### PR TITLE
[WIP] add kube e2e network policy tests to integration testing

### DIFF
--- a/test/integration/build/kubernetes.yml
+++ b/test/integration/build/kubernetes.yml
@@ -1,0 +1,15 @@
+
+---
+
+- name: clone kubernetes repo
+  git:
+    repo: "https://github.com/kubernetes/kubernetes.git"
+    dest: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes/kubernetes"
+    force: "{{ force_clone | default(False) | bool}}"
+
+- name: build kube e2e
+  make:
+    target: all
+    params: 
+        WHAT: test/e2e/e2e.test
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes/kubernetes"

--- a/test/integration/main.yml
+++ b/test/integration/main.yml
@@ -16,6 +16,9 @@
     - name: clone build and install openshift 
       include: "build/openshift.yml"
 
+    - name: clone build and install kubernetes
+      include: "build/kubernetes.yml"
+
 - hosts: all
   vars_files:
     - "{{ playbook_dir }}/vars.yml"
@@ -24,5 +27,7 @@
   tasks:
     - name: clone build and install ovn-kubernetes
       include: "build/ovnkube.yml"
+    - name: clone build and install kubernetes
+      include: "build/kubernetes.yml"
     - name: run openshift-dind tests
       include: "openshift-dind-test.yml"

--- a/test/integration/main.yml
+++ b/test/integration/main.yml
@@ -11,7 +11,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-        version: "1.9.1"
+        version: "1.10.2"
 
     - name: clone build and install openshift 
       include: "build/openshift.yml"

--- a/test/integration/openshift-dind-test.yml
+++ b/test/integration/openshift-dind-test.yml
@@ -17,6 +17,11 @@
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/openshift/origin/test/extended"
 
+- name: run kube e2e tests
+  shell: "./_output/local/go/bin/e2e.test --provider=local --kubeconfig={{ openshift_dind_kubeconfig }} --ginkgo.focus=\"NetworkPolicy\" --ginkgo.skip=\"access on one named port\" &> {{ artifacts }}/kube_e2e_test.log"
+  args:
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes/kubernetes"
+
 - name: cleanup after integration tests
   shell: "./hack/dind-cluster.sh stop"
   args:


### PR DESCRIPTION
Attempt to pull in kube e2e network policy tests as part of integration testing. They have been made to pass locally, so this is just automating the stuff.

This is a work in progress, until the tag is removed.

Signed-off-by: Rajat Chopra <rchopra@redhat.com>