### PR TITLE
add kind for clusterRoleBinding

### DIFF
--- a/dist/yaml/ovn-namespace.yaml
+++ b/dist/yaml/ovn-namespace.yaml
@@ -10,5 +10,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    openshift.io/node-selector: ""        
   name: ovn-kubernetes
 

--- a/dist/yaml/ovn-policy.yaml
+++ b/dist/yaml/ovn-policy.yaml
@@ -60,6 +60,7 @@ metadata:
   name: ovn-cluster-reader
 roleRef:
   name: cluster-reader
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: ovn
@@ -75,6 +76,7 @@ metadata:
   name: ovn-reader
 roleRef:
   name: system:ovn-reader
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: ovn
@@ -90,6 +92,7 @@ metadata:
   name: cluster-admin-0
 roleRef:
   name: cluster-admin
+  kind: ClusterRole
 subjects:
 - kind: ServiceAccount
   name: ovn


### PR DESCRIPTION
1. Met errors when creating the 'ClusterRoleBinding'
```
Error from server (Invalid): error when creating "dist/yaml/ovn-policy.yaml": ClusterRoleBinding.rbac.authorization.k8s.io "ovn-cluster-reader" is invalid: roleRef.kind: Unsupported value: "": supported values: "ClusterRole"
Error from server (Invalid): error when creating "dist/yaml/ovn-policy.yaml": ClusterRoleBinding.rbac.authorization.k8s.io "ovn-reader" is invalid: roleRef.kind: Unsupported value: "": supported values: "ClusterRole"
Error from server (Invalid): error when creating "dist/yaml/ovn-policy.yaml": ClusterRoleBinding.rbac.authorization.k8s.io "cluster-admin-0" is invalid: roleRef.kind: Unsupported value: "": supported values: "Cl
```
So added related kind
2. Added node-selector to ovn-kubernetes namespaces, otherwise the ovn related pods can only deployed on `compute` node.
```
  annotations:
    openshift.io/node-selector: ""
```
@pecameron  please help check this

Signed-off-by: zzhao@redhat.com