### PR TITLE
Support multiple networks - minion only

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -123,6 +123,9 @@ func cniRequestToPodRequest(r *http.Request) (*PodRequest, error) {
 		return nil, fmt.Errorf("missing K8S_POD_NAME")
 	}
 
+	req.Mac, _ = cniArgs["MAC"]
+	req.Ip, _ = cniArgs["IP"]
+
 	conf, err := config.ReadCNIConfig(cr.Config)
 	if err != nil {
 		return nil, fmt.Errorf("broken stdin args")

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -35,7 +35,7 @@ func renameLink(curName, newName string) error {
 	return nil
 }
 
-func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, gatewayIP string, mtu int) (*current.Interface, *current.Interface, error) {
+func setupInterface(netns ns.NetNS, hostIfaceName, ifName, macAddress, ipAddress, gatewayIP string, mtu int, isDefaultInterface bool) (*current.Interface, *current.Interface, error) {
 	hostIface := &current.Interface{}
 	contIface := &current.Interface{}
 
@@ -46,6 +46,7 @@ func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, 
 		if err != nil {
 			return err
 		}
+
 		hostIface.Mac = hostVeth.HardwareAddr.String()
 		contIface.Name = containerVeth.Name
 
@@ -65,22 +66,28 @@ func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, 
 		contIface.Mac = macAddress
 		contIface.Sandbox = netns.Path()
 
-		addr, err := netlink.ParseAddr(ipAddress)
-		if err != nil {
-			return err
-		}
-		err = netlink.AddrAdd(link, addr)
-		if err != nil {
-			return fmt.Errorf("failed to add IP addr %s to %s: %v", ipAddress, contIface.Name, err)
+		if ipAddress != "" {
+			addr, err := netlink.ParseAddr(ipAddress)
+			if err != nil {
+				return err
+			}
+			err = netlink.AddrAdd(link, addr)
+			if err != nil {
+				return fmt.Errorf("failed to add IP addr %s to %s: %v", ipAddress, contIface.Name, err)
+			}
 		}
 
-		gw := net.ParseIP(gatewayIP)
-		if gw == nil {
-			return fmt.Errorf("parse ip of gateway failed")
-		}
-		err = ip.AddRoute(nil, gw, link)
-		if err != nil {
-			return err
+		if gatewayIP != "" {
+			gw := net.ParseIP(gatewayIP)
+			if gw == nil {
+				return fmt.Errorf("parse ip of gateway failed")
+			}
+			if gw != nil {
+				err = ip.AddRoute(nil, gw, link)
+				if err != nil {
+					return err
+				}
+			}
 		}
 
 		oldHostVethName = hostVeth.Name
@@ -92,7 +99,7 @@ func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, 
 	}
 
 	// rename the host end of veth pair
-	hostIface.Name = containerID[:15]
+	hostIface.Name = hostIfaceName
 	if err := renameLink(oldHostVethName, hostIface.Name); err != nil {
 		return nil, nil, fmt.Errorf("failed to rename %s to %s: %v", oldHostVethName, hostIface.Name, err)
 	}
@@ -101,47 +108,64 @@ func setupInterface(netns ns.NetNS, containerID, ifName, macAddress, ipAddress, 
 }
 
 // ConfigureInterface sets up the container interface
-func (pr *PodRequest) ConfigureInterface(namespace string, podName string, macAddress string, ipAddress string, gatewayIP string, mtu int, ingress, egress int64) ([]*current.Interface, error) {
+func (pr *PodRequest) ConfigureInterface(namespace string, podName string, networkName string, macAddress string, ipAddress string, gatewayIP string, mtu int, ingress, egress int64) ([]*current.Interface, error) {
 	netns, err := ns.GetNS(pr.Netns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open netns %q: %v", pr.Netns, err)
 	}
 	defer netns.Close()
 
-	hostIface, contIface, err := setupInterface(netns, pr.SandboxID, pr.IfName, macAddress, ipAddress, gatewayIP, mtu)
+	isDefaultInterface := isDefaultInterface(networkName)
+	var ifaceID string
+	var hostIfaceName string
+	if isDefaultInterface {
+		ifaceID = fmt.Sprintf("%s_%s", namespace, podName)
+		hostIfaceName = pr.SandboxID[:15]
+	} else {
+		ifaceID = fmt.Sprintf("%s_%s_%s", namespace, podName, networkName)
+		hostIfaceName, err = ip.RandomVethName()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	hostIface, contIface, err := setupInterface(netns, hostIfaceName, pr.IfName, macAddress, ipAddress, gatewayIP, mtu, isDefaultInterface)
 	if err != nil {
 		return nil, err
 	}
-
-	ifaceID := fmt.Sprintf("%s_%s", namespace, podName)
 
 	ovsArgs := []string{
 		"add-port", "br-int", hostIface.Name, "--", "set",
 		"interface", hostIface.Name,
 		fmt.Sprintf("external_ids:attached_mac=%s", macAddress),
 		fmt.Sprintf("external_ids:iface-id=%s", ifaceID),
-		fmt.Sprintf("external_ids:ip_address=%s", ipAddress),
 		fmt.Sprintf("external_ids:sandbox=%s", pr.SandboxID),
 	}
+	if ipAddress != "" {
+		ovsArgs = append(ovsArgs, fmt.Sprintf("external_ids:ip_address=%s", ipAddress))
+	}
+
 	if out, err := ovsExec(ovsArgs...); err != nil {
 		return nil, fmt.Errorf("failure in plugging pod interface: %v\n  %q", err, out)
 	}
 
-	if err := clearPodBandwidth(pr.SandboxID); err != nil {
-		return nil, err
-	}
-	if ingress > 0 || egress > 0 {
-		l, err := netlink.LinkByName(hostIface.Name)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find host veth interface %s: %v", hostIface.Name, err)
-		}
-		err = netlink.LinkSetTxQLen(l, 1000)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set host veth txqlen: %v", err)
-		}
-
-		if err := setPodBandwidth(pr.SandboxID, hostIface.Name, ingress, egress); err != nil {
+	if isDefaultInterface {
+		if err := clearPodBandwidth(pr.SandboxID); err != nil {
 			return nil, err
+		}
+		if ingress > 0 || egress > 0 {
+			l, err := netlink.LinkByName(hostIface.Name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find host veth interface %s: %v", hostIface.Name, err)
+			}
+			err = netlink.LinkSetTxQLen(l, 1000)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set host veth txqlen: %v", err)
+			}
+
+			if err := setPodBandwidth(pr.SandboxID, hostIface.Name, ingress, egress); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -150,17 +174,39 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, macAd
 
 // PlatformSpecificCleanup deletes the OVS port
 func (pr *PodRequest) PlatformSpecificCleanup() error {
-	ifaceName := pr.SandboxID[:15]
-	ovsArgs := []string{
-		"del-port", "br-int", ifaceName,
-	}
-	out, err := exec.Command("ovs-vsctl", ovsArgs...).CombinedOutput()
-	if err != nil && !strings.Contains(string(out), "no port named") {
-		// DEL should be idempotent; don't return an error just log it
-		logrus.Warningf("failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))
+	networkName := pr.CNIConf.Name
+	var portList []string
+	isDefaultInterface := isDefaultInterface(networkName)
+	if isDefaultInterface {
+		portList = make([]string, 1)
+		portList[0] = pr.SandboxID[:15]
+	} else {
+		var err error
+		ifaceName := fmt.Sprintf("%s_%s_%s", pr.PodNamespace, pr.PodName, networkName)
+		portList, err = ovsFind("interface", "name", fmt.Sprintf("external-ids:iface-id=%s", ifaceName))
+		if err != nil {
+			logrus.Infof("failed to find OVS port with external-ids:iface-id: %s  error: %v", ifaceName, err)
+		}
 	}
 
-	_ = clearPodBandwidth(pr.SandboxID)
+	for _, ifaceName := range portList {
+		ovsArgs := []string{
+			"del-port", "br-int", ifaceName,
+		}
+		out, err := exec.Command("ovs-vsctl", ovsArgs...).CombinedOutput()
+		if err != nil && !strings.Contains(string(out), "no port named") {
+			// DEL should be idempotent; don't return an error just log it
+			logrus.Warningf("failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))
+		}
+	}
+
+	if isDefaultInterface {
+		_ = clearPodBandwidth(pr.SandboxID)
+	}
 
 	return nil
+}
+
+func isDefaultInterface(networkName string) bool {
+	return networkName == "ovn-kubernetes"
 }

--- a/go-controller/pkg/cni/helper_windows.go
+++ b/go-controller/pkg/cni/helper_windows.go
@@ -109,7 +109,11 @@ func deleteHNSEndpoint(endpointName string) error {
 // The fact that CNI add should be idempotent on Windows is stated here:
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/cni/cni_windows.go#L38
 // TODO: add proper MTU config (GetCurrentThreadId/SetCurrentThreadId) or via OVS properties
-func (pr *PodRequest) ConfigureInterface(namespace string, podName string, macAddress string, ipAddress string, gatewayIP string, mtu int, ingress, egress int64) ([]*current.Interface, error) {
+func (pr *PodRequest) ConfigureInterface(namespace string, podName string, networkName string, macAddress string, ipAddress string, gatewayIP string, mtu int, ingress, egress int64) ([]*current.Interface, error) {
+	if networkName != "ovn-kubernetes" {
+		return nil, fmt.Errorf("Cannot add network %s to pod %s. Non-default networks are currently not supported on windows", networkName, podName)
+	}
+
 	conf := pr.CNIConf
 	ipAddr, ipNet, err := net.ParseCIDR(ipAddress)
 	if err != nil {

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -48,6 +48,10 @@ type PodRequest struct {
 	Netns string
 	// Interface name to be configured
 	IfName string
+	// MAC address to be configured
+	Mac string
+	// IP address to be configured
+	Ip string
 	// CNI conf obtained from stdin conf
 	CNIConf *types.NetConf
 	// Channel for returning the operation result to the Server


### PR DESCRIPTION
The purpose of this PR is to extend ovn-kubernetes to support multiple networks.
The secondary networks will be added using multus (or any other solution complies with the
de-facto standard).

It means the pods annotation should contain the required network attachments, MACs and IPs
under -'k8s.v1.cni.cncf.io/networks'.

```apiVersion: v1
kind: Pod
metadata:
  name: pod-with-multiple-ovn-networks
  annotations:
    k8s.v1.cni.cncf.io/networks: '[
            {
             "name": "blue-network-attachment",
             "mac": "0a:00:00:00:00:70",
             "ips": "192.168.0.2/24"
            },
            {
             "name": "red-network-attachment",
             "mac": "0a:00:00:00:00:71",
             "ips": "10.0.0.2/24"
            }
    ]'
...
```

The network attachment CRD should contain the name of the logical switch represents the
logical network in the config section.

```apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: “blue-network-attachment”
spec:
  config: '{
    “name”: “blue-network”
    "cniVersion": "0.3.1",
    "type": "ovn-k8s-cni-overlay",
    "Ipam":{},
    "dns":{}
  }'
```

Once the pod will be started, multus will invoke on the minion the binary 'ovn-k8s-cni-overlay'
per each pod's network attachment with the type 'ovn-k8s-cni-overlay'.

The ovn-kubernetes minion code is changed in the following way -

1. **Multus invokes the 'ovn-k8s-cni-overlay' per each interface** (of course only network
interfaces that are using network attachment with the type - 'ovn-k8s-cni-overlay').
2. **The CNI binary ('ovn-k8s-cni-overlay') reads the name of the network/switch from the
cni.config and the MAC and the IP from the cni.env["CNI_ARGS"].
3. A veth pair is created in the container and then the host end is moved into host netns.
4. **A new port is created on “br-int”** connecting the host-end to the switch **with "
external_ids:iface-id: namespace_podName_logicalSwitchName”** (the logicalSwitchName is
taken from the NetworkAttachment and passed by multus to the minion binary (same as the
other values from the config section of the network attachment).

Notes:
1. Currently multus has two bugs/unimplemented parts -
 - The "ips" addresses specified in the pod network annotation are not passed to the CNI binary.
 - Multus expects the "ips" to be a string although according to the de-facto standard
documentation, it should be an array of strings.
 I will send multus a PR to fix the issues.
2. According to the documentation of the de-facto standard, the subnet is not specified as part
of the "ips".
I need to discuss about it with the maintainers of the standard, but currently in ovn-kubernetes,
I assume the format of each ip is ip/prefix.
3. Although the pod-network annotation is called ips, only one IP is supported (it is passed to
the cni binary on cniRequest["ENV"]["CNI_ARGS"]["IP"]).
4. An external system will be responsible for adding the logical switches/ports/... to the ovn
DB. The name of the ports should be "namespace_podName_logicalSwitchName"
5. The secondary ovn-kubernetes networks can be added whether ovn-kubernetes is the
 primary network or not.
6. Interfaces on the same pod connected to the same network/logical switch are currently not
supported (since the name of logical port is namespace_podName_switchName and we cannot
have multiple ports with the same name).