### PR TITLE
OVN 'extensions'

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -6,7 +6,7 @@ CNIBINDIR ?= ${DESTDIR}/opt/cni/bin
 GCFLAGS ?=
 export GCFLAGS
 
-.PHONY: all build check test
+.PHONY: all build extensions check test
 
 # Example:
 #   make
@@ -25,6 +25,9 @@ windows:
 	export WINDOWS_BUILD="yes"; \
 	hack/build-go.sh cmd/ovnkube/ovnkube.go; \
 	hack/build-go.sh cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go;
+
+extensions:
+	hack/build-go.sh extensions/cmd/hybrid-sdn/hybrid-sdn.go
 
 check test:
 	hack/test-go.sh ${PKGS}

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -28,6 +28,8 @@ windows:
 
 extensions:
 	hack/build-go.sh extensions/cmd/hybrid-sdn/hybrid-sdn.go
+	export WINDOWS_BUILD="yes"; \
+	hack/build-go.sh extensions/cmd/hybrid-sdn/hybrid-sdn.go
 
 check test:
 	hack/test-go.sh ${PKGS}

--- a/go-controller/extensions/cmd/hybrid-sdn/hybrid-sdn.go
+++ b/go-controller/extensions/cmd/hybrid-sdn/hybrid-sdn.go
@@ -71,11 +71,11 @@ func runHybridSDN(ctx *cli.Context) error {
 
 	if master {
 		mastercontroller.HybridClusterSubnet = ctx.String("hybrid-cluster-subnet")
-		common.RunMaster(clientset, stopChan)
+		err = common.RunMaster(clientset, stopChan)
 	}
 	if node {
-		common.RunNode(clientset, stopChan)
+		err = common.RunNode(clientset, stopChan)
 	}
 
-	return nil
+	return err
 }

--- a/go-controller/extensions/cmd/hybrid-sdn/hybrid-sdn.go
+++ b/go-controller/extensions/cmd/hybrid-sdn/hybrid-sdn.go
@@ -63,7 +63,7 @@ func runHybridSDN(ctx *cli.Context) error {
 		panic(err.Error())
 	}
 
-	// TODO: expose the stop channel to user?
+	// TODO: expose the stop channel to user? (trap etc)
 	stopChan := make(chan struct{})
 
 	master := ctx.Bool("master")

--- a/go-controller/extensions/cmd/hybrid-sdn/hybrid-sdn.go
+++ b/go-controller/extensions/cmd/hybrid-sdn/hybrid-sdn.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/common"
+	mastercontroller "github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/master"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/config"
+	util "github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
+
+	kexec "k8s.io/utils/exec"
+)
+
+func main() {
+	c := cli.NewApp()
+	c.Name = "hybrid-sdn"
+	c.Usage = "a controller to integrate disparate networks within kubernetes with VxLAN routes"
+	c.Version = config.Version
+	c.Flags = append([]cli.Flag{
+		// Kubernetes-related options
+		cli.StringFlag{
+			Name:  "cluster-subnet",
+			Value: "10.128.0.0/16",
+			Usage: "A comma separated set of IP subnets and the associated with the main kubernetes cluster",
+		},
+		cli.StringFlag{
+			Name:  "hybrid-cluster-subnet",
+			Value: "11.128.0.0/16",
+			Usage: "A comma separated set of IP subnets and the associated with the extended hybrid network",
+		},
+
+		// Mode flags
+		cli.BoolFlag{
+			Name:  "master",
+			Usage: "Run in master mode, where subnets are assigned to in-coming non-native nodes",
+		},
+		cli.BoolFlag{
+			Name:  "node",
+			Usage: "Run in node mode, where actual actions are performed to integrate with rest of the network",
+		},
+	}, config.Flags...)
+	c.Action = func(c *cli.Context) error {
+		return runHybridSDN(c)
+	}
+
+	if err := c.Run(os.Args); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func runHybridSDN(ctx *cli.Context) error {
+	exec := kexec.New()
+	_, err := config.InitConfig(ctx, exec, nil)
+	if err != nil {
+		return err
+	}
+
+	clientset, err := util.NewClientset(&config.Kubernetes)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// TODO: expose the stop channel to user?
+	stopChan := make(chan struct{})
+
+	master := ctx.Bool("master")
+	node := ctx.Bool("node")
+
+	if master {
+		mastercontroller.HybridClusterSubnet = ctx.String("hybrid-cluster-subnet")
+		common.RunMaster(clientset, stopChan)
+	}
+	if node {
+		common.RunNode(clientset, stopChan)
+	}
+
+	return nil
+}

--- a/go-controller/extensions/pkg/common/common.go
+++ b/go-controller/extensions/pkg/common/common.go
@@ -25,17 +25,19 @@ var (
 	nodeType reflect.Type = reflect.TypeOf(&kapi.Node{})
 )
 
-func RunNode(clientset *kubernetes.Clientset, stopChan chan struct{}) error {
+// RunNode is the top level function to run hybrid-sdn in node mode
+func RunNode(clientset kubernetes.Interface, stopChan chan struct{}) error {
 	h := node.NewNodeHandler(clientset)
 	return watch(clientset, stopChan, h)
 }
 
-func RunMaster(clientset *kubernetes.Clientset, stopChan chan struct{}) error {
+// RunMaster is the top level function to run hybrid-sdn in master mode
+func RunMaster(clientset kubernetes.Interface, stopChan chan struct{}) error {
 	h := master.NewNodeHandler(clientset)
 	return watch(clientset, stopChan, h)
 }
 
-func watch(clientset *kubernetes.Clientset, stopChan chan struct{}, h types.NodeHandler) error {
+func watch(clientset kubernetes.Interface, stopChan chan struct{}, h types.NodeHandler) error {
 	// create factory and start the node informer
 	factory := informerfactory.NewSharedInformerFactory(clientset, resyncInterval)
 	inf := factory.Core().V1().Nodes().Informer()

--- a/go-controller/extensions/pkg/common/common.go
+++ b/go-controller/extensions/pkg/common/common.go
@@ -1,0 +1,94 @@
+package common
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/master"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/node"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/types"
+
+	kapi "k8s.io/api/core/v1"
+	informerfactory "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	resyncInterval = 12 * time.Hour
+)
+
+var (
+	nodeType reflect.Type = reflect.TypeOf(&kapi.Node{})
+)
+
+func RunNode(clientset *kubernetes.Clientset, stopChan chan struct{}) error {
+	h := node.NewNodeHandler(clientset)
+	return watch(clientset, stopChan, h)
+}
+
+func RunMaster(clientset *kubernetes.Clientset, stopChan chan struct{}) error {
+	h := master.NewNodeHandler(clientset)
+	return watch(clientset, stopChan, h)
+}
+
+func watch(clientset *kubernetes.Clientset, stopChan chan struct{}, h types.NodeHandler) error {
+	// create factory and start the node informer
+	factory := informerfactory.NewSharedInformerFactory(clientset, resyncInterval)
+	inf := factory.Core().V1().Nodes().Informer()
+	factory.Start(stopChan)
+	res := factory.WaitForCacheSync(stopChan)
+	for _, synced := range res {
+		if !synced {
+			return fmt.Errorf("Failed to sync node informer")
+		}
+	}
+
+	// synced, so set the handler
+	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			node, ok := obj.(*kapi.Node)
+			if !ok {
+				logrus.Errorf("Event ADD got an unexpected object of type %v", reflect.TypeOf(obj))
+				return
+			}
+			logrus.Debugf("running %v ADD event", nodeType)
+			h.Add(node)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldNode, ok := oldObj.(*kapi.Node)
+			if !ok {
+				logrus.Errorf("Event UPDATE got an unexpected object of type %v", reflect.TypeOf(oldObj))
+				return
+			}
+			newNode, ok := newObj.(*kapi.Node)
+			if !ok {
+				logrus.Errorf("Event UPDATE got an unexpected object of type %v", reflect.TypeOf(newObj))
+				return
+			}
+			logrus.Debugf("running %v UPDATE event", nodeType)
+			h.Update(oldNode, newNode)
+		},
+		DeleteFunc: func(obj interface{}) {
+			if reflect.TypeOf(obj) != nodeType {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					logrus.Errorf("couldn't get object from tombstone: %+v", obj)
+					return
+				}
+				obj = tombstone.Obj
+				objType := reflect.TypeOf(obj)
+				if nodeType != objType {
+					logrus.Errorf("expected tombstone object resource type %v but got %v", nodeType, objType)
+					return
+				}
+			}
+			logrus.Debugf("running %v DELETE event", nodeType)
+			h.Delete(obj.(*kapi.Node))
+		},
+	})
+	return nil
+}

--- a/go-controller/extensions/pkg/master/master.go
+++ b/go-controller/extensions/pkg/master/master.go
@@ -1,10 +1,21 @@
 package master
 
 import (
-	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/types"
+	"net"
 
+	"github.com/sirupsen/logrus"
+
+	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/types"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/kube"
+
+	"github.com/openshift/origin/pkg/util/netutils"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	ExtensionHostSubnet = "hybrid-sdn.extensions.ovn.kubernets.io/hostsubnet"
+	KubeOSKey           = "beta.kubernetes.io/os"
 )
 
 var (
@@ -12,15 +23,59 @@ var (
 )
 
 type masterController struct {
-	clientset *kubernetes.Clientset
+	kube                  *kube.Kube
+	masterSubnetAllocator *netutils.SubnetAllocator
 }
 
-func NewNodeHandler(clientset *kubernetes.Clientset) types.NodeHandler {
-	return &masterController{clientset: clientset}
+func NewNodeHandler(clientset kubernetes.Interface) types.NodeHandler {
+	m := &masterController{
+		kube: &kube.Kube{KClient: clientset},
+	}
+	// TODO: init subrange with all existing windows node
+	// for the case when this software is restarted
+	subrange := make([]string, 0)
+	subnetAllocator, err := netutils.NewSubnetAllocator(HybridClusterSubnet, 8, subrange)
+	if err != nil {
+		logrus.Errorf("Error initializing allocator, Is subnet %s good enough? (%v)", HybridClusterSubnet, err)
+		return nil
+	}
+	m.masterSubnetAllocator = subnetAllocator
+	return m
 }
 
 func (m *masterController) Add(node *kapi.Node) {
-	return
+	// check if this is a node that we care about
+	// for the hybrid-sdn case, we care about it only if its a windows node
+	osPlatform, ok := node.Annotations[KubeOSKey]
+	if !ok || osPlatform != "Windows" {
+		return
+	}
+
+	// Do not create a subnet if the node already has a subnet
+	hostsubnet, ok := node.Annotations[ExtensionHostSubnet]
+	if ok {
+		// double check if the hostsubnet looks valid
+		_, _, err := net.ParseCIDR(hostsubnet)
+		if err == nil {
+			return
+		}
+	}
+
+	// Create new subnet
+	sn, err := m.masterSubnetAllocator.GetNetwork()
+	if err != nil {
+		logrus.Errorf("Error allocating network for node %s: %v", node.Name, err)
+		return
+	} else {
+		err = m.kube.SetAnnotationOnNode(node, ExtensionHostSubnet, sn.String())
+		if err != nil {
+			_ = m.masterSubnetAllocator.ReleaseNetwork(sn)
+			logrus.Errorf("Error creating subnet %s for node %s: %v", sn.String(), node.Name, err)
+			return
+		}
+		logrus.Infof("Created HostSubnet %s", sn.String())
+		return
+	}
 }
 
 func (m *masterController) Update(oldNode, newNode *kapi.Node) {
@@ -28,5 +83,23 @@ func (m *masterController) Update(oldNode, newNode *kapi.Node) {
 }
 
 func (m *masterController) Delete(node *kapi.Node) {
+	sub, ok := node.Annotations[ExtensionHostSubnet]
+	if !ok {
+		logrus.Errorf("Error in obtaining host subnet for node %q for deletion", node.Name)
+		return
+	}
+
+	_, subnet, err := net.ParseCIDR(sub)
+	if err != nil {
+		logrus.Errorf("Error in parsing hostsubnet - %v", err)
+		return
+	}
+	err = m.masterSubnetAllocator.ReleaseNetwork(subnet)
+	if err == nil {
+		logrus.Infof("Deleted HostSubnet %s for node %s", sub, node.Name)
+		return
+	}
+	logrus.Errorf("Error deleting subnet %v for node %q: subnet not found in any CIDR range or already available", sub, node.Name)
+
 	return
 }

--- a/go-controller/extensions/pkg/master/master.go
+++ b/go-controller/extensions/pkg/master/master.go
@@ -1,0 +1,32 @@
+package master
+
+import (
+	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/types"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	HybridClusterSubnet string
+)
+
+type MasterController struct {
+	clientset *kubernetes.Clientset
+}
+
+func NewNodeHandler(clientset *kubernetes.Clientset) types.NodeHandler {
+	return &MasterController{clientset: clientset}
+}
+
+func (m *MasterController) Add(node *kapi.Node) {
+	return
+}
+
+func (m *MasterController) Update(oldNode, newNode *kapi.Node) {
+	return
+}
+
+func (m *MasterController) Delete(node *kapi.Node) {
+	return
+}

--- a/go-controller/extensions/pkg/master/master.go
+++ b/go-controller/extensions/pkg/master/master.go
@@ -11,22 +11,22 @@ var (
 	HybridClusterSubnet string
 )
 
-type MasterController struct {
+type masterController struct {
 	clientset *kubernetes.Clientset
 }
 
 func NewNodeHandler(clientset *kubernetes.Clientset) types.NodeHandler {
-	return &MasterController{clientset: clientset}
+	return &masterController{clientset: clientset}
 }
 
-func (m *MasterController) Add(node *kapi.Node) {
+func (m *masterController) Add(node *kapi.Node) {
 	return
 }
 
-func (m *MasterController) Update(oldNode, newNode *kapi.Node) {
+func (m *masterController) Update(oldNode, newNode *kapi.Node) {
 	return
 }
 
-func (m *MasterController) Delete(node *kapi.Node) {
+func (m *masterController) Delete(node *kapi.Node) {
 	return
 }

--- a/go-controller/extensions/pkg/node/node.go
+++ b/go-controller/extensions/pkg/node/node.go
@@ -1,0 +1,28 @@
+package node
+
+import (
+	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/types"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type NodeController struct {
+	clientset *kubernetes.Clientset
+}
+
+func NewNodeHandler(clientset *kubernetes.Clientset) types.NodeHandler {
+	return &NodeController{clientset: clientset}
+}
+
+func (n *NodeController) Add(node *kapi.Node) {
+	return
+}
+
+func (n *NodeController) Update(oldNode, newNode *kapi.Node) {
+	return
+}
+
+func (n *NodeController) Delete(node *kapi.Node) {
+	return
+}

--- a/go-controller/extensions/pkg/node/node.go
+++ b/go-controller/extensions/pkg/node/node.go
@@ -2,17 +2,20 @@ package node
 
 import (
 	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/types"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/kube"
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 type nodeController struct {
-	clientset *kubernetes.Clientset
+	kube *kube.Kube
 }
 
-func NewNodeHandler(clientset *kubernetes.Clientset) types.NodeHandler {
-	return &nodeController{clientset: clientset}
+func NewNodeHandler(clientset kubernetes.Interface) types.NodeHandler {
+	return &nodeController{
+		kube: &kube.Kube{KClient: clientset},
+	}
 }
 
 func (n *nodeController) Add(node *kapi.Node) {

--- a/go-controller/extensions/pkg/node/node.go
+++ b/go-controller/extensions/pkg/node/node.go
@@ -7,22 +7,22 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type NodeController struct {
+type nodeController struct {
 	clientset *kubernetes.Clientset
 }
 
 func NewNodeHandler(clientset *kubernetes.Clientset) types.NodeHandler {
-	return &NodeController{clientset: clientset}
+	return &nodeController{clientset: clientset}
 }
 
-func (n *NodeController) Add(node *kapi.Node) {
+func (n *nodeController) Add(node *kapi.Node) {
 	return
 }
 
-func (n *NodeController) Update(oldNode, newNode *kapi.Node) {
+func (n *nodeController) Update(oldNode, newNode *kapi.Node) {
 	return
 }
 
-func (n *NodeController) Delete(node *kapi.Node) {
+func (n *nodeController) Delete(node *kapi.Node) {
 	return
 }

--- a/go-controller/extensions/pkg/node/node_linux.go
+++ b/go-controller/extensions/pkg/node/node_linux.go
@@ -12,6 +12,8 @@ type nodeController struct {
 	kube *kube.Kube
 }
 
+// NewNodeHandler returns an implementation of NodeHandler interface
+// so that Add/Update/Delete events are appropriately handled
 func NewNodeHandler(clientset kubernetes.Interface) types.NodeHandler {
 	n := &nodeController{
 		kube: &kube.Kube{KClient: clientset},
@@ -26,6 +28,7 @@ func NewNodeHandler(clientset kubernetes.Interface) types.NodeHandler {
 // and then programming the VxLAN gateway for the VTEP routes based on hostsubnet
 // For a windows node, this means watching for all nodes and programming the routing
 func (n *nodeController) Add(node *kapi.Node) {
+	// check if OVN has initialized a gateway for this node or not
 	return
 }
 

--- a/go-controller/extensions/pkg/node/node_linux.go
+++ b/go-controller/extensions/pkg/node/node_linux.go
@@ -1,0 +1,45 @@
+package node
+
+import (
+	"github.com/openvswitch/ovn-kubernetes/go-controller/extensions/pkg/types"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/kube"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type nodeController struct {
+	kube *kube.Kube
+}
+
+func NewNodeHandler(clientset kubernetes.Interface) types.NodeHandler {
+	n := &nodeController{
+		kube: &kube.Kube{KClient: clientset},
+	}
+	// initialize self
+	n.InitSelf()
+	return n
+}
+
+// Add function learns about a new node being added to the cluster
+// For a linux node, this means watching for other windows nodes
+// and then programming the VxLAN gateway for the VTEP routes based on hostsubnet
+// For a windows node, this means watching for all nodes and programming the routing
+func (n *nodeController) Add(node *kapi.Node) {
+	return
+}
+
+func (n *nodeController) Update(oldNode, newNode *kapi.Node) {
+	return
+}
+
+func (n *nodeController) Delete(node *kapi.Node) {
+	return
+}
+
+// InitSelf initializes the node it is currently running on.
+// On Linux, this means:
+//  1. Setting up a VxLAN gateway and hooking to the OVN gateway
+//  2. Setting back annotations about its VTEP and gateway MAC address to its own object
+func (n *nodeController) InitSelf() {
+}

--- a/go-controller/extensions/pkg/node/node_windows.go
+++ b/go-controller/extensions/pkg/node/node_windows.go
@@ -13,11 +13,16 @@ type nodeController struct {
 }
 
 func NewNodeHandler(clientset kubernetes.Interface) types.NodeHandler {
-	return &nodeController{
+	n := &nodeController{
 		kube: &kube.Kube{KClient: clientset},
 	}
+	// initialize self
+	n.InitSelf()
+	return n
 }
 
+// Add function learns about a new node being added to the cluster
+// For a windows node, this means watching for all nodes and programming the routing
 func (n *nodeController) Add(node *kapi.Node) {
 	return
 }
@@ -28,4 +33,11 @@ func (n *nodeController) Update(oldNode, newNode *kapi.Node) {
 
 func (n *nodeController) Delete(node *kapi.Node) {
 	return
+}
+
+// InitSelf initializes the node it is currently running on.
+// On Windows, this means:
+//  1. Setting up this node and its VxLAN extension for talking to other nodes
+//  2. Setting back annotations about its VTEP and gateway MAC address to its own node object
+func (n *nodeController) InitSelf() {
 }

--- a/go-controller/extensions/pkg/types/types.go
+++ b/go-controller/extensions/pkg/types/types.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	kapi "k8s.io/api/core/v1"
+)
+
+// NodeHandler interface respresents the three functions that get called by the informer upon respective events
+type NodeHandler interface {
+
+	// Add is called when a new object is created
+	Add(obj *kapi.Node)
+
+	// Update is called when an object is updated, both old and new ones are passed along
+	Update(oldObj *kapi.Node, newObj *kapi.Node)
+
+	// Delete is called when an object is deleted
+	Delete(obj *kapi.Node)
+}


### PR DESCRIPTION
This PR introduces 'extensions' to the OVN network. We have two feature requests that this PR begins to address:
1. Make Windows nodes join an OVN based kubernetes network where OVN does not run on Windows but it gets connected to the OVN network through a VxLAN tunnel.
2. Make external devices like F5 join an OVN kubernetes network where a VxLAN tunnel is used to shunt traffic to and from the F5 devies.

The extensions is the place where we could keep the code that creates the extensions to OVN network (extending the OVN node gateways e.g.), and hopefully only minimal code is checked in for the connecting external devices (Windows/F5 etc).
