### PR TITLE
ovnkube support for ovs offload

### DIFF
--- a/docs/ovs_offload.md
+++ b/docs/ovs_offload.md
@@ -1,0 +1,215 @@
+# OVS Hardware Offload
+
+The OVS software based solution is CPU intensive, affecting system performance
+and preventing fully utilizing available bandwidth. OVS 2.8 and above support
+new feature called OVS Hardware Offload which improves performance significantly. 
+This feature allows to offload the OVS data-plane to the NIC while maintaining 
+OVS control-plane unmodified. It is using SR-IOV technology with VF representor
+host net-device. The VF representor plays the same role as TAP devices
+in Para-Virtual (PV) setup. A packet sent through the VF representor on the host
+arrives to the VF, and a packet sent through the VF is received by its representor.
+
+## Supported Ethernet controllers
+
+The following manufacturers are known to work:
+
+- Mellanox ConnectX-4 Lx/ConnectX-5 NICs
+
+## Prerequisites
+
+- Linux Kernel >= 4.13
+- Open vSwitch >= 2.8
+- iproute >= 4.12
+- sriov-device-plugin
+- multus-cni
+
+## Worker Node SR-IOV Configuration
+
+In order to enable Open vSwitch hardware offloading, the following steps
+are required. Please make sure you have root privileges to run the commands
+below.
+
+Check the Number of VF Supported on the NIC
+
+```
+cat /sys/class/net/enp3s0f0/device/sriov_totalvfs
+8
+```
+
+Create the VFs
+
+```
+echo '4' > /sys/class/net/enp3s0f0/device/sriov_numvfs
+```
+
+Verfiy the VFs are created
+
+```
+ip link show enp3s0f0
+8: enp3s0f0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT qlen 1000
+   link/ether a0:36:9f:8f:3f:b8 brd ff:ff:ff:ff:ff:ff
+   vf 0 MAC 00:00:00:00:00:00, spoof checking on, link-state auto
+   vf 1 MAC 00:00:00:00:00:00, spoof checking on, link-state auto
+   vf 2 MAC 00:00:00:00:00:00, spoof checking on, link-state auto
+   vf 3 MAC 00:00:00:00:00:00, spoof checking on, link-state auto
+```
+
+Setup the PF to be up
+
+```
+ip link set enp3s0f0 up
+```
+
+Unbind the VFs from the driver
+
+```
+echo 0000:03:00.2 > /sys/bus/pci/drivers/mlx5_core/unbind
+echo 0000:03:00.3 > /sys/bus/pci/drivers/mlx5_core/unbind
+echo 0000:03:00.4 > /sys/bus/pci/drivers/mlx5_core/unbind
+echo 0000:03:00.5 > /sys/bus/pci/drivers/mlx5_core/unbind
+```
+
+Configure SR-IOV VFs to switchdev mode
+
+```
+devlink dev eswitch set pci/0000:03:00.0 mode switchdev
+ethtool -K enp3s0f0 hw-tc-offload on
+```
+
+Bind the VFs to the driver
+
+```
+echo 0000:03:00.2 > /sys/bus/pci/drivers/mlx5_core/bind
+echo 0000:03:00.3 > /sys/bus/pci/drivers/mlx5_core/bind
+echo 0000:03:00.4 > /sys/bus/pci/drivers/mlx5_core/bind
+echo 0000:03:00.5 > /sys/bus/pci/drivers/mlx5_core/bind
+```
+
+Set hw-offload=true restart Open vSwitch
+
+```
+systemctl enable openvswitch.service
+ovs-vsctl set Open_vSwitch . other_config:hw-offload=true
+systemctl restart openvswitch.service
+```
+
+## Worker Node SR-IOV network device plugin configuration
+
+This plugin creates device plugin endpoints based on the configurations given in file `/etc/pcidp/config.json`.
+This configuration file is in json format as shown below:
+
+```json
+{
+    "resourceList": [{
+            "resourceName": "cx4lx_sriov_switchdev",
+            "selectors": {
+                "vendors": ["15b3"],
+                "devices": ["1016"],
+            },
+            "resourceName": "cx5_sriov_switchdev",
+            "selectors": {
+                "vendors": ["15b3"],
+                "devices": ["1018"],
+            }
+        }
+    ]
+}
+```
+
+Deploy SR-IOV network device plugin as daemonset see https://github.com/intel/sriov-network-device-plugin
+
+## Worker Node Multus CNI configuration
+
+Multus Config
+```json
+{
+  "name": "multus-cni-network",
+  "type": "multus",
+  "clusterNetwork": "default",
+  "defaultNetworks":[],
+  "kubeconfig": "/etc/kubernetes/node-kubeconfig.yaml"
+}
+```
+
+Deploy multus CNI as daemonset see https://github.com/intel/multus-cni
+
+Create NetworkAttachementDefinition CRD with OVN CNI config
+
+```yaml
+Kubernetes Network CRD Spec:
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: mellanox.com/cx5_sriov_switchdev
+spec:
+  Config: '{"cniVersion":"0.3.1","name":"ovn-kubernetes","type":"ovn-k8s-cni-overlay","ipam":{},"dns":{}}'
+```
+
+## Deploy POD with OVS hardware-offload
+
+Create POD spec and
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ovs-offload-pod1
+  annotations:
+    v1.multus-cni.io/default-network: default
+spec:
+  containers:
+  - name: appcntr1
+    image: centos/tools
+    resources:
+      requests:
+        mellanox.com/cx5_sriov_switchdev: '1'
+      limits:
+        mellanox.com/cx5_sriov_switchdev: '1'
+```
+
+## Verify Hardware-Offload is working
+
+Lookup VF representor, in this example it is e5a1c8fcef0f327
+
+```
+$ ip link show enp3s0f0
+6: enp3s0f0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master ovs-system state UP mode DEFAULT group default qlen 1000
+   link/ether ec:0d:9a:46:9e:84 brd ff:ff:ff:ff:ff:ff
+   vf 0 MAC 00:00:00:00:00:00, spoof checking off, link-state enable, trust off, query_rss off
+   vf 1 MAC 00:00:00:00:00:00, spoof checking off, link-state enable, trust off, query_rss off
+   vf 2 MAC 00:00:00:00:00:00, spoof checking off, link-state enable, trust off, query_rss off
+   vf 3 MAC fa:16:3e:b9:b8:ce, vlan 57, spoof checking on, link-state enable, trust off, query_rss off
+
+compute_node2# ls -l /sys/class/net/
+lrwxrwxrwx 1 root root 0 Sep 11 10:54 eth0 -> ../../devices/virtual/net/eth0
+lrwxrwxrwx 1 root root 0 Sep 11 10:54 eth1 -> ../../devices/virtual/net/eth1
+lrwxrwxrwx 1 root root 0 Sep 11 10:54 eth2 -> ../../devices/virtual/net/eth2
+lrwxrwxrwx 1 root root 0 Sep 11 10:54 e5a1c8fcef0f327 -> ../../devices/virtual/net/e5a1c8fcef0f327
+```
+
+Access the POD
+
+```
+kubectl exec -it ovs-offload-pod1 -- /bin/bash
+```
+
+Ping other POD on second worker node
+```
+ping ovs-offload-pod2
+```
+
+Check traffic on the VF representor port. Verify that only the first ICMP packet appears
+```
+tcpdump -nnn -i e5a1c8fcef0f327
+
+tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+17:12:41.260487 IP 172.0.0.13 > 172.0.0.10: ICMP echo request, id 1263, seq 1, length 64
+17:12:41.260778 IP 172.0.0.10 > 172.0.0.13: ICMP echo reply, id 1263, seq 1, length 64
+17:12:46.268951 ARP, Request who-has 172.0.0.13 tell 172.0.0.10, length 42
+17:12:46.271771 ARP, Reply 172.0.0.13 is-at fa:16:3e:1a:10:05, length 46
+17:12:55.354737 IP6 fe80::f816:3eff:fe29:8118 > ff02::1: ICMP6, router advertisement, length 64
+17:12:56.106705 IP 0.0.0.0.68 > 255.255.255.255.67: BOOTP/DHCP, Request from 62:21:f0:89:40:73, length 30
+```
+

--- a/go-controller/pkg/cni/helper_windows.go
+++ b/go-controller/pkg/cni/helper_windows.go
@@ -111,6 +111,10 @@ func deleteHNSEndpoint(endpointName string) error {
 // TODO: add proper MTU config (GetCurrentThreadId/SetCurrentThreadId) or via OVS properties
 func (pr *PodRequest) ConfigureInterface(namespace string, podName string, macAddress string, ipAddress string, gatewayIP string, mtu int, ingress, egress int64) ([]*current.Interface, error) {
 	conf := pr.CNIConf
+
+	if conf.DeviceID != "" {
+		return nil, fmt.Errorf("failure OVS-Offload is not supported in Windows")
+	}
 	ipAddr, ipNet, err := net.ParseCIDR(ipAddress)
 	if err != nil {
 		return nil, err

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -3,7 +3,7 @@ package cni
 import (
 	"net/http"
 
-	"github.com/containernetworking/cni/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 )
 
 // serverRunDir is the default directory for CNIServer runtime files

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -1,0 +1,12 @@
+package types
+
+import (
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+// NetConf is CNI NetConf with DeviceID
+type NetConf struct {
+	types.NetConf
+	// PciAddrs in case of using sriov
+	DeviceID string `json:"deviceID"`
+}

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 
 	"github.com/containernetworking/cni/pkg/types"
+
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 )
 
 // WriteCNIConfig writes a CNI JSON config file to directory given by global config
@@ -50,8 +52,8 @@ func WriteCNIConfig(ConfDir string, fileName string) error {
 }
 
 // ReadCNIConfig unmarshals a CNI JSON config into an NetConf structure
-func ReadCNIConfig(bytes []byte) (*types.NetConf, error) {
-	conf := &types.NetConf{}
+func ReadCNIConfig(bytes []byte) (*ovntypes.NetConf, error) {
+	conf := &ovntypes.NetConf{}
 	if err := json.Unmarshal(bytes, conf); err != nil {
 		return nil, err
 	}

--- a/go-controller/vendor/github.com/Mellanox/sriovnet/LICENSE
+++ b/go-controller/vendor/github.com/Mellanox/sriovnet/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/go-controller/vendor/github.com/Mellanox/sriovnet/README.md
+++ b/go-controller/vendor/github.com/Mellanox/sriovnet/README.md
@@ -1,0 +1,53 @@
+# sriovnet
+Go library to configure SRIOV networking devices
+
+Local build and test
+
+You can use go get command:
+```
+go get github.com/Mellanox/sriovnet.git
+```
+
+Example:
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/Mellanox/sriovnet"
+)
+
+func main() {
+	var vfList[10] *sriovnet.VfObj
+
+	err1 := sriovnet.EnableSriov("ib0")
+	if err1 != nil {
+		return
+	}
+
+	handle, err2 := sriovnet.GetPfNetdevHandle("ib0")
+	if err2 != nil {
+		return
+	}
+	err3 := sriovnet.ConfigVfs(handle, false)
+	if err3 != nil {
+		return
+	}
+	for i := 0; i < 10; i++ {
+		vfList[i], _ = sriovnet.AllocateVf(handle)
+	}
+	for _, vf := range handle.List {
+		fmt.Printf("after allocation vf = %v\n", vf)
+	}
+	for i := 0; i < 10; i++ {
+		if vfList[i] == nil {
+			continue
+		}
+		sriovnet.FreeVf(handle, vfList[i])
+	}
+	for _, vf := range handle.List {
+		fmt.Printf("after free vf = %v\n", vf)
+	}
+}
+```

--- a/go-controller/vendor/github.com/Mellanox/sriovnet/file_access.go
+++ b/go-controller/vendor/github.com/Mellanox/sriovnet/file_access.go
@@ -1,0 +1,139 @@
+package sriovnet
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+type fileObject struct {
+	Path string
+	File *os.File
+}
+
+func (attrib *fileObject) Exists() bool {
+	return fileExists(attrib.Path)
+}
+
+func (attrib *fileObject) Open() (err error) {
+	attrib.File, err = os.OpenFile(attrib.Path, os.O_RDWR|syscall.O_NONBLOCK, 0660)
+	return err
+}
+
+func (attrib *fileObject) OpenRO() (err error) {
+	attrib.File, err = os.OpenFile(attrib.Path, os.O_RDONLY, 0444)
+	return err
+}
+
+func (attrib *fileObject) OpenWO() (err error) {
+	attrib.File, err = os.OpenFile(attrib.Path, os.O_WRONLY, 0444)
+	return err
+}
+
+func (attrib *fileObject) Close() (err error) {
+	err = attrib.File.Close()
+	attrib.File = nil
+	return err
+}
+
+func (attrib *fileObject) Read() (str string, err error) {
+	if attrib.File == nil {
+		err = attrib.OpenRO()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	_, err = attrib.File.Seek(0, io.SeekStart)
+	if err != nil {
+		return "", err
+	}
+	data, err := ioutil.ReadAll(attrib.File)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (attrib *fileObject) Write(value string) (err error) {
+	if attrib.File == nil {
+		err = attrib.OpenWO()
+		if err != nil {
+			return
+		}
+		defer func() {
+			e := attrib.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+	}
+	_, err = attrib.File.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+	_, err = attrib.File.WriteString(value)
+	return err
+}
+
+func (attrib *fileObject) ReadInt() (value int, err error) {
+	s, err := attrib.Read()
+	if err != nil {
+		return 0, err
+	}
+	s = strings.Trim(s, "\n")
+	value, err = strconv.Atoi(s)
+	if err != nil {
+		return 0, err
+	}
+
+	return value, err
+}
+
+func (attrib *fileObject) WriteInt(value int) (err error) {
+	return attrib.Write(strconv.Itoa(value))
+}
+
+func lsFilesWithPrefix(dir string, filePrefix string, ignoreDir bool) ([]string, error) {
+	var desiredFiles []string
+
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	fileInfos, err := f.Readdir(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range fileInfos {
+		if ignoreDir && fileInfos[i].IsDir() {
+			continue
+		}
+
+		if filePrefix == "" ||
+			strings.Contains(fileInfos[i].Name(), filePrefix) {
+			desiredFiles = append(desiredFiles, fileInfos[i].Name())
+		}
+	}
+	return desiredFiles, nil
+}
+
+func dirExists(dirname string) bool {
+	info, err := os.Stat(dirname)
+	return err == nil && info.IsDir()
+}
+
+func fileExists(dirname string) bool {
+	info, err := os.Stat(dirname)
+	return err == nil && !info.IsDir()
+}

--- a/go-controller/vendor/github.com/Mellanox/sriovnet/mofed_ib_helper.go
+++ b/go-controller/vendor/github.com/Mellanox/sriovnet/mofed_ib_helper.go
@@ -1,0 +1,55 @@
+package sriovnet
+
+import (
+	"net"
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	ibSriovCfgDir               = "sriov"
+	ibSriovNodeFile             = "node"
+	ibSriovPortFile             = "port"
+	ibSriovPortAdminFile        = "policy"
+	ibSriovPortAdminStateFollow = "Follow"
+)
+
+func ibGetPortAdminState(pfNetdevName string, vfIndex int) (string, error) {
+	path := filepath.Join(NetSysDir, pfNetdevName, pcidevPrefix, ibSriovCfgDir, strconv.Itoa(vfIndex), ibSriovPortAdminFile)
+	adminStateFile := fileObject{
+		Path: path,
+	}
+
+	state, err := adminStateFile.Read()
+	if err != nil {
+		return "", err
+	}
+	return state, nil
+}
+
+func ibSetPortAdminState(pfNetdevName string, vfIndex int, newState string) error {
+	path := filepath.Join(NetSysDir, pfNetdevName, pcidevPrefix, ibSriovCfgDir, strconv.Itoa(vfIndex), ibSriovPortAdminFile)
+	adminStateFile := fileObject{
+		Path: path,
+	}
+
+	return adminStateFile.Write(newState)
+}
+
+func ibSetNodeGuid(pfNetdevName string, vfIndex int, guid net.HardwareAddr) error {
+	path := filepath.Join(NetSysDir, pfNetdevName, pcidevPrefix, ibSriovCfgDir, strconv.Itoa(vfIndex), ibSriovNodeFile)
+	nodeGuidFile := fileObject{
+		Path: path,
+	}
+	kernelGuidFormat := guid.String()
+	return nodeGuidFile.Write(kernelGuidFormat)
+}
+
+func ibSetPortGuid(pfNetdevName string, vfIndex int, guid net.HardwareAddr) error {
+	path := filepath.Join(NetSysDir, pfNetdevName, pcidevPrefix, ibSriovCfgDir, strconv.Itoa(vfIndex), ibSriovPortFile)
+	portGuidFile := fileObject{
+		Path: path,
+	}
+	kernelGuidFormat := guid.String()
+	return portGuidFile.Write(kernelGuidFormat)
+}

--- a/go-controller/vendor/github.com/Mellanox/sriovnet/sriovnet.go
+++ b/go-controller/vendor/github.com/Mellanox/sriovnet/sriovnet.go
@@ -1,0 +1,436 @@
+package sriovnet
+
+import (
+	"fmt"
+	"github.com/satori/go.uuid"
+	"github.com/vishvananda/netlink"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var virtFnRe = regexp.MustCompile(`virtfn(\d+)`)
+
+type VfObj struct {
+	Index      int
+	PciAddress string
+	Bound      bool
+	Allocated  bool
+}
+
+type PfNetdevHandle struct {
+	PfNetdevName string
+	pfLinkHandle netlink.Link
+
+	List []*VfObj
+}
+
+func SetPFLinkUp(pfNetdevName string) error {
+	handle, err := netlink.LinkByName(pfNetdevName)
+	if err != nil {
+		return err
+	}
+
+	return netlink.LinkSetUp(handle)
+}
+
+func IsSriovSupported(netdevName string) bool {
+
+	maxvfs, err := getMaxVfCount(netdevName)
+	if maxvfs == 0 || err != nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func IsSriovEnabled(netdevName string) bool {
+
+	curvfs, err := getCurrentVfCount(netdevName)
+	if curvfs == 0 || err != nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func EnableSriov(pfNetdevName string) error {
+	var maxVfCount int
+	var err error
+
+	devDirName := netDevDeviceDir(pfNetdevName)
+
+	devExist := dirExists(devDirName)
+	if !devExist {
+		return fmt.Errorf("device %s not found", pfNetdevName)
+	}
+
+	maxVfCount, err = getMaxVfCount(pfNetdevName)
+	if err != nil {
+		log.Println("Fail to read max vf count of PF", pfNetdevName)
+		return err
+	}
+
+	if maxVfCount == 0 {
+		return fmt.Errorf("sriov unsupported for device: %s", pfNetdevName)
+	}
+
+	curVfCount, err2 := getCurrentVfCount(pfNetdevName)
+	if err2 != nil {
+		log.Println("Fail to read current vf count of PF", pfNetdevName)
+		return err
+	}
+	if curVfCount == 0 {
+		return setMaxVfCount(pfNetdevName, maxVfCount)
+	}
+	return nil
+}
+
+func DisableSriov(pfNetdevName string) error {
+	devDirName := netDevDeviceDir(pfNetdevName)
+
+	devExist := dirExists(devDirName)
+	if !devExist {
+		return fmt.Errorf("device %s not found", pfNetdevName)
+	}
+
+	return setMaxVfCount(pfNetdevName, 0)
+}
+
+func GetPfNetdevHandle(pfNetdevName string) (*PfNetdevHandle, error) {
+
+	pfLinkHandle, err := netlink.LinkByName(pfNetdevName)
+	if err != nil {
+		return nil, err
+	}
+
+	handle := PfNetdevHandle{
+		PfNetdevName: pfNetdevName,
+		pfLinkHandle: pfLinkHandle,
+	}
+
+	list, err := GetVfPciDevList(pfNetdevName)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vfDir := range list {
+		vfIndexStr := strings.TrimPrefix(vfDir, netDevVfDevicePrefix)
+		vfIndex, _ := strconv.Atoi(vfIndexStr)
+		vfNetdevName := vfNetdevNameFromParent(pfNetdevName, vfIndex)
+		pciAddress, err := vfPCIDevNameFromVfIndex(pfNetdevName, vfIndex)
+		if err != nil {
+			log.Printf("Failed to read PCI Address for VF %v from PF %v: %v\n",
+				vfNetdevName, pfNetdevName, err)
+			continue
+		}
+		vfObj := VfObj{
+			Index:      vfIndex,
+			PciAddress: pciAddress,
+		}
+		if vfNetdevName != "" {
+			vfObj.Bound = true
+		} else {
+			vfObj.Bound = false
+		}
+		vfObj.Allocated = false
+		handle.List = append(handle.List, &vfObj)
+	}
+	return &handle, nil
+}
+
+func UnbindVf(handle *PfNetdevHandle, vf *VfObj) error {
+	cmdFile := filepath.Join(NetSysDir, handle.PfNetdevName, netdevDriverDir, netdevUnbindFile)
+	cmdFileObj := fileObject{
+		Path: cmdFile,
+	}
+	err := cmdFileObj.Write(vf.PciAddress)
+	if err != nil {
+		vf.Bound = false
+	}
+	return err
+}
+
+func BindVf(handle *PfNetdevHandle, vf *VfObj) error {
+	cmdFile := filepath.Join(NetSysDir, handle.PfNetdevName, netdevDriverDir, netdevBindFile)
+	cmdFileObj := fileObject{
+		Path: cmdFile,
+	}
+	err := cmdFileObj.Write(vf.PciAddress)
+	if err != nil {
+		vf.Bound = true
+	}
+	return err
+}
+
+func GetVfDefaultMacAddr(vfNetdevName string) (string, error) {
+
+	ethHandle, err1 := netlink.LinkByName(vfNetdevName)
+	if err1 != nil {
+		return "", err1
+	}
+
+	ethAttr := ethHandle.Attrs()
+	return ethAttr.HardwareAddr.String(), nil
+}
+
+func SetVfDefaultMacAddress(handle *PfNetdevHandle, vf *VfObj) error {
+
+	netdevName := vfNetdevNameFromParent(handle.PfNetdevName, vf.Index)
+	ethHandle, err1 := netlink.LinkByName(netdevName)
+	if err1 != nil {
+		return err1
+	}
+	ethAttr := ethHandle.Attrs()
+	return netlink.LinkSetVfHardwareAddr(handle.pfLinkHandle, vf.Index, ethAttr.HardwareAddr)
+}
+
+func SetVfVlan(handle *PfNetdevHandle, vf *VfObj, vlan int) error {
+	return netlink.LinkSetVfVlan(handle.pfLinkHandle, vf.Index, vlan)
+}
+
+func setVfNodeGuid(handle *PfNetdevHandle, vf *VfObj, guid []byte) error {
+	var err error
+
+	nodeGuidHwAddr := net.HardwareAddr(guid)
+
+	err = ibSetNodeGuid(handle.PfNetdevName, vf.Index, nodeGuidHwAddr)
+	if err == nil {
+		return nil
+	}
+	err = netlink.LinkSetVfNodeGUID(handle.pfLinkHandle, vf.Index, guid)
+	return err
+}
+
+func setVfPortGuid(handle *PfNetdevHandle, vf *VfObj, guid []byte) error {
+	var err error
+
+	portGuidHwAddr := net.HardwareAddr(guid)
+
+	err = ibSetPortGuid(handle.PfNetdevName, vf.Index, portGuidHwAddr)
+	if err == nil {
+		return nil
+	}
+	err = netlink.LinkSetVfPortGUID(handle.pfLinkHandle, vf.Index, guid)
+	return err
+}
+
+func SetVfDefaultGUID(handle *PfNetdevHandle, vf *VfObj) error {
+
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		return err
+	}
+	guid := uuid[0:8]
+	guid[7] = byte(vf.Index)
+
+	err = setVfNodeGuid(handle, vf, guid)
+	if err != nil {
+		return err
+	}
+
+	err = setVfPortGuid(handle, vf, guid)
+	return err
+}
+
+func SetVfPrivileged(handle *PfNetdevHandle, vf *VfObj, privileged bool) error {
+
+	var spoofChk bool
+	var trusted bool
+
+	ethAttr := handle.pfLinkHandle.Attrs()
+	if ethAttr.EncapType != "ether" {
+		return nil
+	}
+	//Only ether type is supported
+	if privileged {
+		spoofChk = false
+		trusted = true
+	} else {
+		spoofChk = true
+		trusted = false
+	}
+
+	/* do not check for error status as older kernels doesn't
+	 * have support for it.
+	 * golangci-lint complains on missing error check. ignore it
+	 * with nolint comment until we update the code to ignore ENOTSUP error
+	 */
+	netlink.LinkSetVfTrust(handle.pfLinkHandle, vf.Index, trusted)     //nolint
+	netlink.LinkSetVfSpoofchk(handle.pfLinkHandle, vf.Index, spoofChk) //nolint
+	return nil
+}
+
+func setDefaultHwAddr(handle *PfNetdevHandle, vf *VfObj) error {
+	var err error
+
+	ethAttr := handle.pfLinkHandle.Attrs()
+	if ethAttr.EncapType == "ether" {
+		err = SetVfDefaultMacAddress(handle, vf)
+	} else if ethAttr.EncapType == "infiniband" {
+		err = SetVfDefaultGUID(handle, vf)
+	}
+	return err
+}
+
+func setPortAdminState(handle *PfNetdevHandle, vf *VfObj) error {
+	ethAttr := handle.pfLinkHandle.Attrs()
+	if ethAttr.EncapType == "infiniband" {
+		state, err2 := ibGetPortAdminState(handle.PfNetdevName, vf.Index)
+		// Ignore the error where this file is not available
+		if err2 != nil {
+			return nil
+		}
+		log.Printf("Admin state = %v", state)
+		err2 = ibSetPortAdminState(handle.PfNetdevName, vf.Index, ibSriovPortAdminStateFollow)
+		if err2 != nil {
+			//If file exist, we must be able to write
+			log.Printf("Admin state setting error = %v", err2)
+			return err2
+		}
+	}
+	return nil
+}
+
+func ConfigVfs(handle *PfNetdevHandle, privileged bool) error {
+	var err error
+
+	for _, vf := range handle.List {
+		log.Printf("vf = %v\n", vf)
+		err = setPortAdminState(handle, vf)
+		if err != nil {
+			break
+		}
+		// skip VFs in another namespace
+		netdevName := vfNetdevNameFromParent(handle.PfNetdevName, vf.Index)
+		if _, err = netlink.LinkByName(netdevName); err != nil {
+			continue
+		}
+		err = setDefaultHwAddr(handle, vf)
+		if err != nil {
+			break
+		}
+		_ = SetVfPrivileged(handle, vf, privileged)
+	}
+	if err != nil {
+		return err
+	}
+	for _, vf := range handle.List {
+		if vf.Bound {
+			err = UnbindVf(handle, vf)
+			if err != nil {
+				log.Printf("Fail to unbind err=%v\n", err)
+				break
+			}
+			err = BindVf(handle, vf)
+			if err != nil {
+				log.Printf("Fail to bind err=%v\n", err)
+				break
+			}
+			log.Printf("vf = %v unbind/bind completed", vf)
+		}
+	}
+	return nil
+}
+
+func AllocateVf(handle *PfNetdevHandle) (*VfObj, error) {
+	for _, vf := range handle.List {
+		if vf.Allocated {
+			continue
+		}
+		vf.Allocated = true
+		log.Printf("Allocated vf = %v\n", *vf)
+		return vf, nil
+	}
+	return nil, fmt.Errorf("All Vfs for %v are allocated.", handle.PfNetdevName)
+}
+
+func AllocateVfByMacAddress(handle *PfNetdevHandle, vfMacAddress string) (*VfObj, error) {
+	for _, vf := range handle.List {
+		if vf.Allocated {
+			continue
+		}
+
+		netdevName := vfNetdevNameFromParent(handle.PfNetdevName, vf.Index)
+		macAddr, _ := GetVfDefaultMacAddr(netdevName)
+		if macAddr != vfMacAddress {
+			continue
+		}
+		vf.Allocated = true
+		log.Printf("Allocated vf by mac = %v\n", *vf)
+		return vf, nil
+	}
+	return nil, fmt.Errorf("All Vfs for %v are allocated for mac address %v.",
+		handle.PfNetdevName, vfMacAddress)
+}
+
+func FreeVf(handle *PfNetdevHandle, vf *VfObj) {
+	vf.Allocated = false
+	log.Printf("Free vf = %v\n", *vf)
+}
+
+func FreeVfByNetdevName(handle *PfNetdevHandle, vfIndex int) error {
+	vfNetdevName := fmt.Sprintf("%s%v", netDevVfDevicePrefix, vfIndex)
+	for _, vf := range handle.List {
+		netdevName := vfNetdevNameFromParent(handle.PfNetdevName, vf.Index)
+		if vf.Allocated && netdevName == vfNetdevName {
+			vf.Allocated = true
+			return nil
+		}
+	}
+	return fmt.Errorf("vf netdev %v not found", vfNetdevName)
+}
+
+func GetVfNetdevName(handle *PfNetdevHandle, vf *VfObj) string {
+	return vfNetdevNameFromParent(handle.PfNetdevName, vf.Index)
+}
+
+// GetVfIndexByPciAddress gets a VF PCI address (e.g '0000:03:00.4') and
+// returns the correlate VF index.
+func GetVfIndexByPciAddress(vfPciAddress string) (int, error) {
+	vfPath := filepath.Join(PciSysDir, vfPciAddress, "physfn/virtfn*")
+	matches, err := filepath.Glob(vfPath)
+	if err != nil {
+		return -1, err
+	}
+	for _, match := range matches {
+		tmp, err := os.Readlink(match)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(tmp, vfPciAddress) {
+			result := virtFnRe.FindStringSubmatch(match)
+			vfIndex, err := strconv.Atoi(result[1])
+			if err != nil {
+				continue
+			}
+			return vfIndex, nil
+		}
+	}
+	return -1, fmt.Errorf("vf index for %s not found", vfPciAddress)
+}
+
+// GetNetDevicesFromPci gets a PCI address (e.g '0000:03:00.1') and
+// returns the correlate list of netdevices
+func GetNetDevicesFromPci(pciAddress string) ([]string, error) {
+	var netDevices []string
+	pciDir := filepath.Join(PciSysDir, pciAddress, "net")
+	_, err := os.Lstat(pciDir)
+	if err != nil {
+		return netDevices, fmt.Errorf("cannot get a network device with pci address %v %v", pciAddress, err)
+	}
+
+	netDevicesFiles, err := ioutil.ReadDir(pciDir)
+	if err != nil {
+		return netDevices, fmt.Errorf("failed to get network device name in %v %v", pciDir, err)
+	}
+	for _, netDeviceFile := range netDevicesFiles {
+		netDevices = append(netDevices, strings.TrimSpace(netDeviceFile.Name()))
+    }
+	return netDevices, nil
+}

--- a/go-controller/vendor/github.com/Mellanox/sriovnet/sriovnet_helper.go
+++ b/go-controller/vendor/github.com/Mellanox/sriovnet/sriovnet_helper.go
@@ -1,0 +1,133 @@
+package sriovnet
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+const (
+	NetSysDir        = "/sys/class/net"
+	PciSysDir        = "/sys/bus/pci/devices"
+	pcidevPrefix     = "device"
+	netdevDriverDir  = "device/driver"
+	netdevUnbindFile = "unbind"
+	netdevBindFile   = "bind"
+
+	netDevMaxVfCountFile     = "sriov_totalvfs"
+	netDevCurrentVfCountFile = "sriov_numvfs"
+	netDevVfDevicePrefix     = "virtfn"
+)
+
+type VfObject struct {
+	NetdevName string
+	PCIDevName string
+}
+
+func netDevDeviceDir(netDevName string) string {
+	devDirName := filepath.Join(NetSysDir, netDevName, pcidevPrefix)
+	return devDirName
+}
+
+func getMaxVfCount(pfNetdevName string) (int, error) {
+	devDirName := netDevDeviceDir(pfNetdevName)
+
+	maxDevFile := fileObject{
+		Path: filepath.Join(devDirName, netDevMaxVfCountFile),
+	}
+
+	maxVfs, err := maxDevFile.ReadInt()
+	if err != nil {
+		return 0, err
+	} else {
+		log.Println("max_vfs = ", maxVfs)
+		return maxVfs, nil
+	}
+}
+
+func setMaxVfCount(pfNetdevName string, maxVfs int) error {
+	devDirName := netDevDeviceDir(pfNetdevName)
+
+	maxDevFile := fileObject{
+		Path: filepath.Join(devDirName, netDevCurrentVfCountFile),
+	}
+
+	return maxDevFile.WriteInt(maxVfs)
+}
+
+func getCurrentVfCount(pfNetdevName string) (int, error) {
+	devDirName := netDevDeviceDir(pfNetdevName)
+
+	maxDevFile := fileObject{
+		Path: filepath.Join(devDirName, netDevCurrentVfCountFile),
+	}
+
+	curVfs, err := maxDevFile.ReadInt()
+	if err != nil {
+		return 0, err
+	} else {
+		log.Println("cur_vfs = ", curVfs)
+		return curVfs, nil
+	}
+}
+
+func vfNetdevNameFromParent(pfNetdevName string, vfIndex int) string {
+
+	devDirName := netDevDeviceDir(pfNetdevName)
+	vfNetdev, _ := lsFilesWithPrefix(fmt.Sprintf("%s/%s%v/net", devDirName,
+		netDevVfDevicePrefix, vfIndex), "", false)
+	if len(vfNetdev) <= 0 {
+		return ""
+	} else {
+		return vfNetdev[0]
+	}
+}
+
+func readPCIsymbolicLink(symbolicLink string) (string, error) {
+	pciDevDir, err := os.Readlink(symbolicLink)
+	if len(pciDevDir) <= 3 {
+		return "", fmt.Errorf("could not find PCI Address")
+	}
+
+	return pciDevDir[3:], err
+}
+func vfPCIDevNameFromVfIndex(pfNetdevName string, vfIndex int) (string, error) {
+	symbolicLink := filepath.Join(NetSysDir, pfNetdevName, pcidevPrefix, fmt.Sprintf("%s%v",
+		netDevVfDevicePrefix, vfIndex))
+	pciAddress, err := readPCIsymbolicLink(symbolicLink)
+	if err != nil {
+		err = fmt.Errorf("%v for VF %s%v of PF %s", err,
+			netDevVfDevicePrefix, vfIndex, pfNetdevName)
+	}
+	return pciAddress, err
+}
+
+func getPCIFromDeviceName(netdevName string) (string, error) {
+	symbolicLink := filepath.Join(NetSysDir, netdevName, pcidevPrefix)
+	pciAddress, err := readPCIsymbolicLink(symbolicLink)
+	if err != nil {
+		err = fmt.Errorf("%v for netdevice %s", err, netdevName)
+	}
+	return pciAddress, err
+
+}
+
+func GetVfPciDevList(pfNetdevName string) ([]string, error) {
+	var vfDirList []string
+	var i int
+	devDirName := netDevDeviceDir(pfNetdevName)
+
+	virtFnDirs, err := lsFilesWithPrefix(devDirName, netDevVfDevicePrefix, true)
+
+	if err != nil {
+		return nil, err
+	}
+
+	i = 0
+	for _, vfDir := range virtFnDirs {
+		vfDirList = append(vfDirList, vfDir)
+		i++
+	}
+	return vfDirList, nil
+}

--- a/go-controller/vendor/github.com/Mellanox/sriovnet/sriovnet_switchdev.go
+++ b/go-controller/vendor/github.com/Mellanox/sriovnet/sriovnet_switchdev.go
@@ -1,0 +1,120 @@
+package sriovnet
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	netdevPhysSwitchID = "phys_switch_id"
+	netdevPhysPortName = "phys_port_name"
+)
+
+var physPortRe = regexp.MustCompile(`pf(\d+)vf(\d+)`)
+
+func parsePortName(physPortName string) (pfRepIndex int, vfRepIndex int, err error) {
+
+	pfRepIndex = -1
+	vfRepIndex = -1
+
+	// old kernel syntax of phys_port_name is vf index
+	physPortName = strings.TrimSpace(physPortName)
+	physPortNameInt, err := strconv.Atoi(physPortName)
+	if err == nil {
+		vfRepIndex = physPortNameInt
+	} else {
+		// new kernel syntax of phys_port_name pfXVfY
+		matches := physPortRe.FindStringSubmatch(physPortName)
+		if len(matches) != 3 {
+			err = fmt.Errorf("Failed to parse physPortName %s", physPortName)
+		} else {
+			pfRepIndex, err = strconv.Atoi(matches[1])
+			if err == nil {
+				vfRepIndex, err = strconv.Atoi(matches[2])
+			}
+		}
+
+	}
+	return pfRepIndex, vfRepIndex, err
+}
+
+func isSwitchdev(netdevice string) bool {
+	swIDFile := filepath.Join(NetSysDir, netdevice, netdevPhysSwitchID)
+	physSwitchID, err := ioutil.ReadFile(swIDFile)
+	if err != nil {
+		return false
+	}
+	if physSwitchID != nil && string(physSwitchID) != "" {
+		return true
+	}
+	return false
+}
+
+// GetUplinkRepresentor gets a VF PCI address (e.g '0000:03:00.4') and
+// returns the uplink represntor netdev name for that VF.
+func GetUplinkRepresentor(vfPciAddress string) (string, error) {
+	devicePath := filepath.Join(PciSysDir, vfPciAddress, "physfn/net")
+	devices, err := ioutil.ReadDir(devicePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup %s: %v", vfPciAddress, err)
+	}
+	for _, device := range devices {
+		if isSwitchdev(device.Name()) {
+			return device.Name(), nil
+		}
+	}
+	return "", fmt.Errorf("uplink for %s not found", vfPciAddress)
+}
+
+func GetVfRepresentor(uplink string, vfIndex int) (string, error) {
+	swIDFile := filepath.Join(NetSysDir, uplink, netdevPhysSwitchID)
+	physSwitchID, err := ioutil.ReadFile(swIDFile)
+	if err != nil || string(physSwitchID) == "" {
+		return "", fmt.Errorf("cant get uplink %s switch id", uplink)
+	}
+
+	pfSubsystemPath := filepath.Join(NetSysDir, uplink, "subsystem")
+	devices, err := ioutil.ReadDir(pfSubsystemPath)
+	if err != nil {
+		return "", err
+	}
+	for _, device := range devices {
+		devicePath := filepath.Join(NetSysDir, device.Name())
+		deviceSwIDFile := filepath.Join(devicePath, netdevPhysSwitchID)
+		deviceSwID, err := ioutil.ReadFile(deviceSwIDFile)
+		if err != nil || string(deviceSwID) != string(physSwitchID) {
+			continue
+		}
+		devicePortNameFile := filepath.Join(devicePath, netdevPhysPortName)
+		_, err = os.Stat(devicePortNameFile)
+		if os.IsNotExist(err) {
+			continue
+		}
+		physPortName, err := ioutil.ReadFile(devicePortNameFile)
+		if err != nil {
+			continue
+		}
+		physPortNameStr := string(physPortName)
+		pfRepIndex, vfRepIndex, _ := parsePortName(physPortNameStr)
+		if pfRepIndex != -1 {
+			pfPCIAddress, err := getPCIFromDeviceName(uplink)
+			if err != nil {
+				continue
+			}
+			PCIFuncAddress, err := strconv.Atoi(string((pfPCIAddress[len(pfPCIAddress)-1])))
+			if pfRepIndex != PCIFuncAddress || err != nil {
+				continue
+			}
+		}
+		// At this point we're confident we have a representor.
+		if vfRepIndex == vfIndex {
+			return device.Name(), nil
+		}
+	}
+	return "", fmt.Errorf("failed to find VF representor for uplink %s", uplink)
+}

--- a/go-controller/vendor/github.com/satori/go.uuid/LICENSE
+++ b/go-controller/vendor/github.com/satori/go.uuid/LICENSE
@@ -1,0 +1,20 @@
+Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/go-controller/vendor/github.com/satori/go.uuid/README.md
+++ b/go-controller/vendor/github.com/satori/go.uuid/README.md
@@ -1,0 +1,75 @@
+# UUID package for Go language
+
+[![Build Status](https://travis-ci.org/satori/go.uuid.svg?branch=master)](https://travis-ci.org/satori/go.uuid)
+[![Coverage Status](https://coveralls.io/repos/github/satori/go.uuid/badge.svg?branch=master)](https://coveralls.io/github/satori/go.uuid)
+[![GoDoc](http://godoc.org/github.com/satori/go.uuid?status.svg)](http://godoc.org/github.com/satori/go.uuid)
+
+This package provides pure Go implementation of Universally Unique Identifier (UUID). Supported both creation and parsing of UUIDs.
+
+With 100% test coverage and benchmarks out of box.
+
+Supported versions:
+* Version 1, based on timestamp and MAC address (RFC 4122)
+* Version 2, based on timestamp, MAC address and POSIX UID/GID (DCE 1.1)
+* Version 3, based on MD5 hashing (RFC 4122)
+* Version 4, based on random numbers (RFC 4122)
+* Version 5, based on SHA-1 hashing (RFC 4122)
+
+## Installation
+
+Use the `go` command:
+
+	$ go get github.com/satori/go.uuid
+
+## Requirements
+
+UUID package tested against Go >= 1.6.
+
+## Example
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/satori/go.uuid"
+)
+
+func main() {
+	// Creating UUID Version 4
+	// panic on error
+	u1 := uuid.Must(uuid.NewV4())
+	fmt.Printf("UUIDv4: %s\n", u1)
+
+	// or error handling
+	u2, err := uuid.NewV4()
+	if err != nil {
+		fmt.Printf("Something went wrong: %s", err)
+		return
+	}
+	fmt.Printf("UUIDv4: %s\n", u2)
+
+	// Parsing UUID from string input
+	u2, err := uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	if err != nil {
+		fmt.Printf("Something went wrong: %s", err)
+		return
+	}
+	fmt.Printf("Successfully parsed: %s", u2)
+}
+```
+
+## Documentation
+
+[Documentation](http://godoc.org/github.com/satori/go.uuid) is hosted at GoDoc project.
+
+## Links
+* [RFC 4122](http://tools.ietf.org/html/rfc4122)
+* [DCE 1.1: Authentication and Security Services](http://pubs.opengroup.org/onlinepubs/9696989899/chap5.htm#tagcjh_08_02_01_01)
+
+## Copyright
+
+Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>.
+
+UUID package released under MIT License.
+See [LICENSE](https://github.com/satori/go.uuid/blob/master/LICENSE) for details.

--- a/go-controller/vendor/github.com/satori/go.uuid/codec.go
+++ b/go-controller/vendor/github.com/satori/go.uuid/codec.go
@@ -1,0 +1,206 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+)
+
+// FromBytes returns UUID converted from raw byte slice input.
+// It will return error if the slice isn't 16 bytes long.
+func FromBytes(input []byte) (u UUID, err error) {
+	err = u.UnmarshalBinary(input)
+	return
+}
+
+// FromBytesOrNil returns UUID converted from raw byte slice input.
+// Same behavior as FromBytes, but returns a Nil UUID on error.
+func FromBytesOrNil(input []byte) UUID {
+	uuid, err := FromBytes(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// FromString returns UUID parsed from string input.
+// Input is expected in a form accepted by UnmarshalText.
+func FromString(input string) (u UUID, err error) {
+	err = u.UnmarshalText([]byte(input))
+	return
+}
+
+// FromStringOrNil returns UUID parsed from string input.
+// Same behavior as FromString, but returns a Nil UUID on error.
+func FromStringOrNil(input string) UUID {
+	uuid, err := FromString(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The encoding is the same as returned by String.
+func (u UUID) MarshalText() (text []byte, err error) {
+	text = []byte(u.String())
+	return
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// Following formats are supported:
+//   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+//   "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+//   "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+//   "6ba7b8109dad11d180b400c04fd430c8"
+// ABNF for supported UUID text representation follows:
+//   uuid := canonical | hashlike | braced | urn
+//   plain := canonical | hashlike
+//   canonical := 4hexoct '-' 2hexoct '-' 2hexoct '-' 6hexoct
+//   hashlike := 12hexoct
+//   braced := '{' plain '}'
+//   urn := URN ':' UUID-NID ':' plain
+//   URN := 'urn'
+//   UUID-NID := 'uuid'
+//   12hexoct := 6hexoct 6hexoct
+//   6hexoct := 4hexoct 2hexoct
+//   4hexoct := 2hexoct 2hexoct
+//   2hexoct := hexoct hexoct
+//   hexoct := hexdig hexdig
+//   hexdig := '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' |
+//             'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
+//             'A' | 'B' | 'C' | 'D' | 'E' | 'F'
+func (u *UUID) UnmarshalText(text []byte) (err error) {
+	switch len(text) {
+	case 32:
+		return u.decodeHashLike(text)
+	case 36:
+		return u.decodeCanonical(text)
+	case 38:
+		return u.decodeBraced(text)
+	case 41:
+		fallthrough
+	case 45:
+		return u.decodeURN(text)
+	default:
+		return fmt.Errorf("uuid: incorrect UUID length: %s", text)
+	}
+}
+
+// decodeCanonical decodes UUID string in format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8".
+func (u *UUID) decodeCanonical(t []byte) (err error) {
+	if t[8] != '-' || t[13] != '-' || t[18] != '-' || t[23] != '-' {
+		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+	}
+
+	src := t[:]
+	dst := u[:]
+
+	for i, byteGroup := range byteGroups {
+		if i > 0 {
+			src = src[1:] // skip dash
+		}
+		_, err = hex.Decode(dst[:byteGroup/2], src[:byteGroup])
+		if err != nil {
+			return
+		}
+		src = src[byteGroup:]
+		dst = dst[byteGroup/2:]
+	}
+
+	return
+}
+
+// decodeHashLike decodes UUID string in format
+// "6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodeHashLike(t []byte) (err error) {
+	src := t[:]
+	dst := u[:]
+
+	if _, err = hex.Decode(dst, src); err != nil {
+		return err
+	}
+	return
+}
+
+// decodeBraced decodes UUID string in format
+// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}" or in format
+// "{6ba7b8109dad11d180b400c04fd430c8}".
+func (u *UUID) decodeBraced(t []byte) (err error) {
+	l := len(t)
+
+	if t[0] != '{' || t[l-1] != '}' {
+		return fmt.Errorf("uuid: incorrect UUID format %s", t)
+	}
+
+	return u.decodePlain(t[1 : l-1])
+}
+
+// decodeURN decodes UUID string in format
+// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in format
+// "urn:uuid:6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodeURN(t []byte) (err error) {
+	total := len(t)
+
+	urn_uuid_prefix := t[:9]
+
+	if !bytes.Equal(urn_uuid_prefix, urnPrefix) {
+		return fmt.Errorf("uuid: incorrect UUID format: %s", t)
+	}
+
+	return u.decodePlain(t[9:total])
+}
+
+// decodePlain decodes UUID string in canonical format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in hash-like format
+// "6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodePlain(t []byte) (err error) {
+	switch len(t) {
+	case 32:
+		return u.decodeHashLike(t)
+	case 36:
+		return u.decodeCanonical(t)
+	default:
+		return fmt.Errorf("uuid: incorrrect UUID length: %s", t)
+	}
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (u UUID) MarshalBinary() (data []byte, err error) {
+	data = u.Bytes()
+	return
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+// It will return error if the slice isn't 16 bytes long.
+func (u *UUID) UnmarshalBinary(data []byte) (err error) {
+	if len(data) != Size {
+		err = fmt.Errorf("uuid: UUID must be exactly 16 bytes long, got %d bytes", len(data))
+		return
+	}
+	copy(u[:], data)
+
+	return
+}

--- a/go-controller/vendor/github.com/satori/go.uuid/generator.go
+++ b/go-controller/vendor/github.com/satori/go.uuid/generator.go
@@ -1,0 +1,265 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// Difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
+const epochStart = 122192928000000000
+
+type epochFunc func() time.Time
+type hwAddrFunc func() (net.HardwareAddr, error)
+
+var (
+	global = newRFC4122Generator()
+
+	posixUID = uint32(os.Getuid())
+	posixGID = uint32(os.Getgid())
+)
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func NewV1() (UUID, error) {
+	return global.NewV1()
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func NewV2(domain byte) (UUID, error) {
+	return global.NewV2(domain)
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func NewV3(ns UUID, name string) UUID {
+	return global.NewV3(ns, name)
+}
+
+// NewV4 returns random generated UUID.
+func NewV4() (UUID, error) {
+	return global.NewV4()
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func NewV5(ns UUID, name string) UUID {
+	return global.NewV5(ns, name)
+}
+
+// Generator provides interface for generating UUIDs.
+type Generator interface {
+	NewV1() (UUID, error)
+	NewV2(domain byte) (UUID, error)
+	NewV3(ns UUID, name string) UUID
+	NewV4() (UUID, error)
+	NewV5(ns UUID, name string) UUID
+}
+
+// Default generator implementation.
+type rfc4122Generator struct {
+	clockSequenceOnce sync.Once
+	hardwareAddrOnce  sync.Once
+	storageMutex      sync.Mutex
+
+	rand io.Reader
+
+	epochFunc     epochFunc
+	hwAddrFunc    hwAddrFunc
+	lastTime      uint64
+	clockSequence uint16
+	hardwareAddr  [6]byte
+}
+
+func newRFC4122Generator() Generator {
+	return &rfc4122Generator{
+		epochFunc:  time.Now,
+		hwAddrFunc: defaultHWAddrFunc,
+		rand:       rand.Reader,
+	}
+}
+
+// NewV1 returns UUID based on current timestamp and MAC address.
+func (g *rfc4122Generator) NewV1() (UUID, error) {
+	u := UUID{}
+
+	timeNow, clockSeq, err := g.getClockSequence()
+	if err != nil {
+		return Nil, err
+	}
+	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+
+	hardwareAddr, err := g.getHardwareAddr()
+	if err != nil {
+		return Nil, err
+	}
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(V1)
+	u.SetVariant(VariantRFC4122)
+
+	return u, nil
+}
+
+// NewV2 returns DCE Security UUID based on POSIX UID/GID.
+func (g *rfc4122Generator) NewV2(domain byte) (UUID, error) {
+	u, err := g.NewV1()
+	if err != nil {
+		return Nil, err
+	}
+
+	switch domain {
+	case DomainPerson:
+		binary.BigEndian.PutUint32(u[:], posixUID)
+	case DomainGroup:
+		binary.BigEndian.PutUint32(u[:], posixGID)
+	}
+
+	u[9] = domain
+
+	u.SetVersion(V2)
+	u.SetVariant(VariantRFC4122)
+
+	return u, nil
+}
+
+// NewV3 returns UUID based on MD5 hash of namespace UUID and name.
+func (g *rfc4122Generator) NewV3(ns UUID, name string) UUID {
+	u := newFromHash(md5.New(), ns, name)
+	u.SetVersion(V3)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// NewV4 returns random generated UUID.
+func (g *rfc4122Generator) NewV4() (UUID, error) {
+	u := UUID{}
+	if _, err := io.ReadFull(g.rand, u[:]); err != nil {
+		return Nil, err
+	}
+	u.SetVersion(V4)
+	u.SetVariant(VariantRFC4122)
+
+	return u, nil
+}
+
+// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+func (g *rfc4122Generator) NewV5(ns UUID, name string) UUID {
+	u := newFromHash(sha1.New(), ns, name)
+	u.SetVersion(V5)
+	u.SetVariant(VariantRFC4122)
+
+	return u
+}
+
+// Returns epoch and clock sequence.
+func (g *rfc4122Generator) getClockSequence() (uint64, uint16, error) {
+	var err error
+	g.clockSequenceOnce.Do(func() {
+		buf := make([]byte, 2)
+		if _, err = io.ReadFull(g.rand, buf); err != nil {
+			return
+		}
+		g.clockSequence = binary.BigEndian.Uint16(buf)
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+
+	g.storageMutex.Lock()
+	defer g.storageMutex.Unlock()
+
+	timeNow := g.getEpoch()
+	// Clock didn't change since last UUID generation.
+	// Should increase clock sequence.
+	if timeNow <= g.lastTime {
+		g.clockSequence++
+	}
+	g.lastTime = timeNow
+
+	return timeNow, g.clockSequence, nil
+}
+
+// Returns hardware address.
+func (g *rfc4122Generator) getHardwareAddr() ([]byte, error) {
+	var err error
+	g.hardwareAddrOnce.Do(func() {
+		if hwAddr, err := g.hwAddrFunc(); err == nil {
+			copy(g.hardwareAddr[:], hwAddr)
+			return
+		}
+
+		// Initialize hardwareAddr randomly in case
+		// of real network interfaces absence.
+		if _, err = io.ReadFull(g.rand, g.hardwareAddr[:]); err != nil {
+			return
+		}
+		// Set multicast bit as recommended by RFC 4122
+		g.hardwareAddr[0] |= 0x01
+	})
+	if err != nil {
+		return []byte{}, err
+	}
+	return g.hardwareAddr[:], nil
+}
+
+// Returns difference in 100-nanosecond intervals between
+// UUID epoch (October 15, 1582) and current time.
+func (g *rfc4122Generator) getEpoch() uint64 {
+	return epochStart + uint64(g.epochFunc().UnixNano()/100)
+}
+
+// Returns UUID based on hashing of namespace UUID and name.
+func newFromHash(h hash.Hash, ns UUID, name string) UUID {
+	u := UUID{}
+	h.Write(ns[:])
+	h.Write([]byte(name))
+	copy(u[:], h.Sum(nil))
+
+	return u
+}
+
+// Returns hardware address.
+func defaultHWAddrFunc() (net.HardwareAddr, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return []byte{}, err
+	}
+	for _, iface := range ifaces {
+		if len(iface.HardwareAddr) >= 6 {
+			return iface.HardwareAddr, nil
+		}
+	}
+	return []byte{}, fmt.Errorf("uuid: no HW address found")
+}

--- a/go-controller/vendor/github.com/satori/go.uuid/sql.go
+++ b/go-controller/vendor/github.com/satori/go.uuid/sql.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package uuid
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Value implements the driver.Valuer interface.
+func (u UUID) Value() (driver.Value, error) {
+	return u.String(), nil
+}
+
+// Scan implements the sql.Scanner interface.
+// A 16-byte slice is handled by UnmarshalBinary, while
+// a longer byte slice or a string is handled by UnmarshalText.
+func (u *UUID) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		if len(src) == Size {
+			return u.UnmarshalBinary(src)
+		}
+		return u.UnmarshalText(src)
+
+	case string:
+		return u.UnmarshalText([]byte(src))
+	}
+
+	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
+}
+
+// NullUUID can be used with the standard sql package to represent a
+// UUID value that can be NULL in the database
+type NullUUID struct {
+	UUID  UUID
+	Valid bool
+}
+
+// Value implements the driver.Valuer interface.
+func (u NullUUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+	// Delegate to UUID Value function
+	return u.UUID.Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (u *NullUUID) Scan(src interface{}) error {
+	if src == nil {
+		u.UUID, u.Valid = Nil, false
+		return nil
+	}
+
+	// Delegate to UUID Scan function
+	u.Valid = true
+	return u.UUID.Scan(src)
+}

--- a/go-controller/vendor/github.com/satori/go.uuid/uuid.go
+++ b/go-controller/vendor/github.com/satori/go.uuid/uuid.go
@@ -1,0 +1,161 @@
+// Copyright (C) 2013-2018 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package uuid provides implementation of Universally Unique Identifier (UUID).
+// Supported versions are 1, 3, 4 and 5 (as specified in RFC 4122) and
+// version 2 (as specified in DCE 1.1).
+package uuid
+
+import (
+	"bytes"
+	"encoding/hex"
+)
+
+// Size of a UUID in bytes.
+const Size = 16
+
+// UUID representation compliant with specification
+// described in RFC 4122.
+type UUID [Size]byte
+
+// UUID versions
+const (
+	_ byte = iota
+	V1
+	V2
+	V3
+	V4
+	V5
+)
+
+// UUID layout variants.
+const (
+	VariantNCS byte = iota
+	VariantRFC4122
+	VariantMicrosoft
+	VariantFuture
+)
+
+// UUID DCE domains.
+const (
+	DomainPerson = iota
+	DomainGroup
+	DomainOrg
+)
+
+// String parse helpers.
+var (
+	urnPrefix  = []byte("urn:uuid:")
+	byteGroups = []int{8, 4, 4, 4, 12}
+)
+
+// Nil is special form of UUID that is specified to have all
+// 128 bits set to zero.
+var Nil = UUID{}
+
+// Predefined namespace UUIDs.
+var (
+	NamespaceDNS  = Must(FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceURL  = Must(FromString("6ba7b811-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceOID  = Must(FromString("6ba7b812-9dad-11d1-80b4-00c04fd430c8"))
+	NamespaceX500 = Must(FromString("6ba7b814-9dad-11d1-80b4-00c04fd430c8"))
+)
+
+// Equal returns true if u1 and u2 equals, otherwise returns false.
+func Equal(u1 UUID, u2 UUID) bool {
+	return bytes.Equal(u1[:], u2[:])
+}
+
+// Version returns algorithm version used to generate UUID.
+func (u UUID) Version() byte {
+	return u[6] >> 4
+}
+
+// Variant returns UUID layout variant.
+func (u UUID) Variant() byte {
+	switch {
+	case (u[8] >> 7) == 0x00:
+		return VariantNCS
+	case (u[8] >> 6) == 0x02:
+		return VariantRFC4122
+	case (u[8] >> 5) == 0x06:
+		return VariantMicrosoft
+	case (u[8] >> 5) == 0x07:
+		fallthrough
+	default:
+		return VariantFuture
+	}
+}
+
+// Bytes returns bytes slice representation of UUID.
+func (u UUID) Bytes() []byte {
+	return u[:]
+}
+
+// Returns canonical string representation of UUID:
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func (u UUID) String() string {
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], u[0:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
+}
+
+// SetVersion sets version bits.
+func (u *UUID) SetVersion(v byte) {
+	u[6] = (u[6] & 0x0f) | (v << 4)
+}
+
+// SetVariant sets variant bits.
+func (u *UUID) SetVariant(v byte) {
+	switch v {
+	case VariantNCS:
+		u[8] = (u[8]&(0xff>>1) | (0x00 << 7))
+	case VariantRFC4122:
+		u[8] = (u[8]&(0xff>>2) | (0x02 << 6))
+	case VariantMicrosoft:
+		u[8] = (u[8]&(0xff>>3) | (0x06 << 5))
+	case VariantFuture:
+		fallthrough
+	default:
+		u[8] = (u[8]&(0xff>>3) | (0x07 << 5))
+	}
+}
+
+// Must is a helper that wraps a call to a function returning (UUID, error)
+// and panics if the error is non-nil. It is intended for use in variable
+// initializations such as
+//	var packageUUID = uuid.Must(uuid.FromString("123e4567-e89b-12d3-a456-426655440000"));
+func Must(u UUID, err error) UUID {
+	if err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/go-controller/vendor/vendor.json
+++ b/go-controller/vendor/vendor.json
@@ -105,6 +105,12 @@
 			"revisionTime": "2019-06-20T21:17:52Z"
 		},
 		{
+			"checksumSHA1": "pBmaTjNo279YtPKnLPtakPY97sI=",
+			"path": "github.com/Mellanox/sriovnet",
+			"revision": "73402dc8fcaa26a2aa195ff12245bd2bafd1494f",
+			"revisionTime": "2019-05-13T20:44:09Z"
+		},
+		{
 			"checksumSHA1": "LvjTFR2Am01kquJNDnfISncPfRw=",
 			"path": "github.com/containernetworking/cni/pkg/skel",
 			"revision": "909fe7d10d98ab99b9990966796316249c83b263",

--- a/go-controller/vendor/vendor.json
+++ b/go-controller/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test appengine",
 	"package": [
 		{
+			"checksumSHA1": "pBmaTjNo279YtPKnLPtakPY97sI=",
+			"path": "github.com/Mellanox/sriovnet",
+			"revision": "73402dc8fcaa26a2aa195ff12245bd2bafd1494f",
+			"revisionTime": "2019-05-13T20:44:09Z"
+		},
+		{
 			"checksumSHA1": "7CZFKc5GTJHTnrvclrIfPzALGys=",
 			"path": "github.com/Microsoft/go-winio",
 			"revision": "12afdbf8b879f9ce020255d4dea63525b16518f5",
@@ -535,6 +541,12 @@
 			"path": "github.com/pkg/errors",
 			"revision": "27936f6d90f9c8e1145f11ed52ffffbfdb9e0af7",
 			"revisionTime": "2019-02-27T00:00:51Z"
+		},
+		{
+			"checksumSHA1": "Tutue3nEgM/87jitUcYv6ODwyNE=",
+			"path": "github.com/satori/go.uuid",
+			"revision": "b2ce2384e17bbe0c6d34077efa39dbab3e09123b",
+			"revisionTime": "2018-10-28T12:50:25Z"
 		},
 		{
 			"checksumSHA1": "F/VVrVmpuEMaCWZ+2Vvzf5vnj0E=",


### PR DESCRIPTION
The current OVS supported is OVS running in Linux Kernel. Mellanox Accelerated Switching And Packet Processing (ASAP2 ) technology allows OVS offloading by handling OVS data-plane in Mellanox ConnectX-4 Lx onwards NIC hardware (Mellanox Embedded Switch or eSwitch) while maintaining OVS control-plane unmodified. OVS hardware offload is using SR-IOV technology with VF representor host net-device. The VF representor plays the same role as TAP devices in Para-Virtual (PV) setup. A packet sent through the VF representor on the host arrives to the VF, and a packet sent through the VF is received by its representor.

This proposal provide a mechanism to enable OVS hardware offload with OVN Kubernetes. 

More information can be found on Design Proposal for OVS Offload Support for OVN CNI [1]

[1] - https://docs.google.com/document/d/11uBezjSZg5b2g6VNs2mugGrgK5ZX9c-Xirj6XL_acjM/edit?usp=sharing

Co-authored-by: mamduhala mamduhala@mellanox.com
Signed-off-by: Moshe Levi <moshele@mellanox.com>