### PR TITLE
config: add --k8s-service-cidr config option and deprecate --service-cluster-ip-range

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ uses the hostname.  kubelet allows this name to be overridden with
  -logfile="/var/log/ovn-kubernetes/ovnkube.log" \
  -init-master=$NODE_NAME -init-node=$NODE_NAME \
  -cluster-subnet="$CLUSTER_IP_SUBNET" \
- -service-cluster-ip-range=$SERVICE_IP_SUBNET \
+ -k8s-service-cidr=$SERVICE_IP_SUBNET \
  -nodeport \
  -init-gateways -gateway-local \
  -k8s-token="$TOKEN" \
@@ -175,7 +175,7 @@ nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -loglevel=4 \
     -nb-address="tcp://$CENTRAL_IP:6641" \
     -sb-address="tcp://$CENTRAL_IP:6642" -k8s-token="$TOKEN" \
     -init-gateways \
-    -service-cluster-ip-range=$SERVICE_IP_SUBNET \
+    -k8s-service-cidr=$SERVICE_IP_SUBNET \
     -cluster-subnet=$CLUSTER_IP_SUBNET 2>&1 &
 ```
 

--- a/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
+++ b/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
@@ -27,7 +27,7 @@
         -k8s-token {{TOKEN}} \
         -k8s-cacert /etc/openvswitch/k8s-ca.crt \
         -k8s-apiserver "http://{{ kubernetes_cluster_info.MASTER_IP }}:8080" \
-        -service-cluster-ip-range "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
+        -k8s-service-cidr "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
         -nodeport \
         -init-gateways \
         -gateway-interface={{physical_interface_name}} \

--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -10,7 +10,7 @@
       [Service]
       ExecStart=/usr/bin/kube-apiserver \
         --bind-address=0.0.0.0 \
-        --service-cluster-ip-range={{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }} \
+        --k8s-service-cidr={{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }} \
         --address=0.0.0.0 \
         --etcd-servers=http://127.0.0.1:2379 \
         --v=2 \
@@ -209,7 +209,7 @@
       ExecStart=/usr/bin/ovnkube \
         -init-master "{{ ansible_hostname }}" \
         -cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
-        -service-cluster-ip-range "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
+        -k8s-service-cidr "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
         -nodeport \
         -net-controller \
         -k8s-token {{TOKEN}} \

--- a/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
@@ -133,7 +133,7 @@
             --k8s-token {{TOKEN}} \
             --k8s-cacert /etc/openvswitch/k8s-ca.crt \
             --k8s-apiserver "http://{{ kubernetes_cluster_info.MASTER_IP }}:8080" \
-            --service-cluster-ip-range "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
+            --k8s-service-cidr "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
             --nb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6641 \
             --sb-address tcp://{{ kubernetes_cluster_info.MASTER_IP }}:6642
           Restart=on-failure

--- a/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
+++ b/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
@@ -31,7 +31,7 @@
       --nb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6641"
       --sb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6642"
       --cluster-subnet {{ kubernetes_info.CLUSTER_SUBNET }}
-      --service-cluster-ip-range {{ kubernetes_info.SERVICE_CLUSTER_IP_RANGE }}
+      --k8s-service-cidr {{ kubernetes_info.SERVICE_CLUSTER_IP_RANGE }}
       --cni-conf-dir="{{ install_path }}/cni"
       --cni-plugin "ovn-k8s-cni-overlay.exe"
       --encap-ip="{{ host_internal_ip }}"

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -611,7 +611,7 @@ ovn-master () {
   echo "=============== ovn-master ========== MASTER ONLY"
   /usr/bin/ovnkube \
     --init-master ${ovn_pod_host} --net-controller \
-    --cluster-subnet ${net_cidr} --service-cluster-ip-range=${svc_cidr} \
+    --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --k8s-token=${k8s_token} --k8s-apiserver=${K8S_APISERVER} --k8s-cacert=${K8S_CACERT} \
     --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
     --nodeport \
@@ -687,7 +687,7 @@ ovn-node () {
   # restarted or ovs daemonset is deleted.
   # TEMP HACK - WORKAROUND
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
-      --cluster-subnet ${net_cidr} --service-cluster-ip-range=${svc_cidr} \
+      --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --k8s-token=${k8s_token} --k8s-apiserver=${K8S_APISERVER} --k8s-cacert=${K8S_CACERT} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
       --nodeport \
@@ -753,7 +753,7 @@ start_ovn () {
     echo "=============== start ovn-master ========== MASTER ONLY"
     /usr/bin/ovnkube \
       --init-master ${ovn_pod_host} --net-controller \
-      --cluster-subnet ${net_cidr} --service-cluster-ip-range=${svc_cidr} \
+      --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --k8s-token=${k8s_token} --k8s-apiserver=${K8S_APISERVER} --k8s-cacert=${K8S_CACERT} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
       --nodeport \
@@ -779,7 +779,7 @@ start_ovn () {
   # restarted or ovs daemonset is deleted.
   # TEMP HACK - WORKAROUND
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
-      --cluster-subnet ${net_cidr} --service-cluster-ip-range=${svc_cidr} \
+      --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --k8s-token=${k8s_token} --k8s-apiserver=${K8S_APISERVER} --k8s-cacert=${K8S_CACERT} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
       --nodeport \

--- a/docs/INSTALL.SSL.md
+++ b/docs/INSTALL.SSL.md
@@ -167,7 +167,7 @@ sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -net-controller -loglevel=4 \
  -k8s-apiserver="http://$CENTRAL_IP:8080" \
  -logfile="/var/log/ovn-kubernetes/ovnkube.log" \
  -init-master="$NODE_NAME" -cluster-subnet=$CLUSTER_IP_SUBNET \
- -service-cluster-ip-range=$SERVICE_IP_SUBNET \
+ -k8s-service-cidr=$SERVICE_IP_SUBNET \
  -nodeport \
  -nb-address="ssl://$CENTRAL_IP:6641" \
  -sb-address="ssl://$CENTRAL_IP:6642" \
@@ -196,7 +196,7 @@ sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -sb-client-cert /etc/openvswitch/ovncontroller-cert.pem \
     -sb-client-cacert /etc/openvswitch/cacert.pem \
     -init-gateways \
-    -service-cluster-ip-range=$SERVICE_IP_SUBNET \
+    -k8s-service-cidr=$SERVICE_IP_SUBNET \
     -cluster-subnet=$CLUSTER_IP_SUBNET
 ```
 

--- a/docs/ha.md
+++ b/docs/ha.md
@@ -92,7 +92,7 @@ nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -net-controller \
  -logfile="/var/log/openvswitch/ovnkube.log" \
  -init-master="$NODENAME" -cluster-subnet="$CLUSTER_IP_SUBNET" \
  -init-node="$NODENAME" \
- -service-cluster-ip-range="$SERVICE_IP_SUBNET" \
+ -k8s-service-cidr="$SERVICE_IP_SUBNET" \
  -k8s-token="$TOKEN" \
  -nodeport \
  -nb-address="${ovn_nb}" \
@@ -138,6 +138,6 @@ nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -sb-address="${ovn_sb}" \
     -k8s-token="$TOKEN" \
     -init-gateways \
-    -service-cluster-ip-range= \
+    -k8s-service-cidr= \
     -cluster-subnet="$SERVICE_IP_SUBNET" 2>&1 &
 ```

--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -16,7 +16,7 @@ IP address/subnet mask/hostsubnetlength, the hostsubnetlength is optional and if
 unspecified defaults to 24. The hostsubnetlength defines how many IP addresses are
 dedicated to each node. (default "11.11.0.0/16")
 .TP
-\fB\--service-cluster-ip-range\fR value
+\fB\--k8s-service-cidr\fR value
 A CIDR notation IP range from which k8s assigns service cluster IPs.
 This should be the same as the one provided for kube-apiserver's
 \fB\--service-cluster-ip-range\fR option.

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -207,16 +207,6 @@ func runOvnKube(ctx *cli.Context) error {
 			panic(err.Error())
 		}
 
-		clusterServicesSubnet := ctx.String("service-cluster-ip-range")
-		if clusterServicesSubnet != "" {
-			var servicesSubnet *net.IPNet
-			_, servicesSubnet, err = net.ParseCIDR(
-				clusterServicesSubnet)
-			if err != nil {
-				panic(err.Error())
-			}
-			clusterController.ClusterServicesSubnet = servicesSubnet.String()
-		}
 		clusterController.NodePortEnable = nodePortEnable
 
 		if master != "" {

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -21,8 +21,7 @@ type OvnClusterController struct {
 	TCPLoadBalancerUUID string
 	UDPLoadBalancerUUID string
 
-	ClusterServicesSubnet string
-	ClusterIPNet          []CIDRNetworkEntry
+	ClusterIPNet []CIDRNetworkEntry
 
 	GatewayInit      bool
 	GatewayIntf      string

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -60,8 +60,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		return err
 	}
 
-	err = ovn.CreateManagementPort(node.Name, subnet.String(),
-		config.Kubernetes.ServiceCIDR, clusterSubnets)
+	err = ovn.CreateManagementPort(node.Name, subnet.String(), clusterSubnets)
 	if err != nil {
 		return err
 	}
@@ -116,8 +115,7 @@ func (cluster *OvnClusterController) updateOvnNode(masterIP string,
 	}
 
 	// Recreate logical switch and management port for this node
-	err = ovn.CreateManagementPort(node.Name, subnet,
-		config.Kubernetes.ServiceCIDR, clusterSubnets)
+	err = ovn.CreateManagementPort(node.Name, subnet, clusterSubnets)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -61,8 +61,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	}
 
 	err = ovn.CreateManagementPort(node.Name, subnet.String(),
-		cluster.ClusterServicesSubnet,
-		clusterSubnets)
+		config.Kubernetes.ServiceCIDR, clusterSubnets)
 	if err != nil {
 		return err
 	}
@@ -118,8 +117,7 @@ func (cluster *OvnClusterController) updateOvnNode(masterIP string,
 
 	// Recreate logical switch and management port for this node
 	err = ovn.CreateManagementPort(node.Name, subnet,
-		cluster.ClusterServicesSubnet,
-		clusterSubnets)
+		config.Kubernetes.ServiceCIDR, clusterSubnets)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -17,8 +17,8 @@ const (
 	windowsOS = "windows"
 )
 
-func configureManagementPortWindows(clusterSubnet []string, clusterServicesSubnet,
-	routerIP, interfaceName, interfaceIP string) error {
+func configureManagementPortWindows(clusterSubnet []string, routerIP,
+	interfaceName, interfaceIP string) error {
 	// Up the interface.
 	_, _, err := util.RunPowershell("Enable-NetAdapter", "-IncludeHidden", interfaceName)
 	if err != nil {
@@ -99,43 +99,40 @@ func configureManagementPortWindows(clusterSubnet []string, clusterServicesSubne
 		}
 	}
 
-	if clusterServicesSubnet != "" {
-		clusterServiceIP, clusterServiceIPNet, err := net.ParseCIDR(clusterServicesSubnet)
-		if err != nil {
-			return fmt.Errorf("Failed to parse clusterServicesSubnet %v : %v", clusterServicesSubnet, err)
-		}
-		// Checking if the route already exists, in which case it will not be created again
-		stdout, stderr, err = util.RunRoute("print", "-4", clusterServiceIP.String())
-		if err != nil {
-			logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stderr, err)
-		}
+	clusterServiceIP, clusterServiceIPNet, err := net.ParseCIDR(config.Kubernetes.ServiceCIDR)
+	if err != nil {
+		return fmt.Errorf("Failed to parse clusterServicesSubnet %v : %v", config.Kubernetes.ServiceCIDR, err)
+	}
+	// Checking if the route already exists, in which case it will not be created again
+	stdout, stderr, err = util.RunRoute("print", "-4", clusterServiceIP.String())
+	if err != nil {
+		logrus.Debugf("Failed to run route print, stderr: %q, error: %v", stderr, err)
+	}
 
-		if strings.Contains(stdout, clusterServiceIP.String()) {
-			logrus.Debugf("Route was found, skipping route add")
-		} else {
-			// Windows route command requires the mask to be specified in the IP format
-			clusterServiceMask := net.IP(clusterServiceIPNet.Mask).String()
-			// Create a route for the entire subnet.
-			_, stderr, err = util.RunRoute("-p", "add",
-				clusterServiceIP.String(), "mask", clusterServiceMask,
-				routerIP, "METRIC", "2", "IF", interfaceIndex)
-			if err != nil {
-				logrus.Errorf("failed to run route add, stderr: %q, error: %v", stderr, err)
-				return err
-			}
+	if strings.Contains(stdout, clusterServiceIP.String()) {
+		logrus.Debugf("Route was found, skipping route add")
+	} else {
+		// Windows route command requires the mask to be specified in the IP format
+		clusterServiceMask := net.IP(clusterServiceIPNet.Mask).String()
+		// Create a route for the entire subnet.
+		_, stderr, err = util.RunRoute("-p", "add",
+			clusterServiceIP.String(), "mask", clusterServiceMask,
+			routerIP, "METRIC", "2", "IF", interfaceIndex)
+		if err != nil {
+			logrus.Errorf("failed to run route add, stderr: %q, error: %v", stderr, err)
+			return err
 		}
 	}
 
 	return nil
 }
 
-func configureManagementPort(clusterSubnet []string, clusterServicesSubnet,
-	routerIP, routerMac, interfaceName, interfaceIP string) error {
+func configureManagementPort(clusterSubnet []string, routerIP, routerMac,
+	interfaceName, interfaceIP string) error {
 	if runtime.GOOS == windowsOS {
 		// Return here for Windows, the commands for enabling the interface, setting the IP and adding the
 		// route will be done in the above function
-		return configureManagementPortWindows(clusterSubnet, clusterServicesSubnet,
-			routerIP, interfaceName, interfaceIP)
+		return configureManagementPortWindows(clusterSubnet, routerIP, interfaceName, interfaceIP)
 	}
 
 	// Up the interface.
@@ -170,19 +167,16 @@ func configureManagementPort(clusterSubnet []string, clusterServicesSubnet,
 		}
 	}
 
-	if clusterServicesSubnet != "" {
-		// Flush the route for the services subnet (in case it was added before).
-		_, _, err = util.RunIP("route", "flush", clusterServicesSubnet)
-		if err != nil {
-			return err
-		}
+	// Flush the route for the services subnet (in case it was added before).
+	_, _, err = util.RunIP("route", "flush", config.Kubernetes.ServiceCIDR)
+	if err != nil {
+		return err
+	}
 
-		// Create a route for the services subnet.
-		_, _, err = util.RunIP("route", "add", clusterServicesSubnet,
-			"via", routerIP)
-		if err != nil {
-			return err
-		}
+	// Create a route for the services subnet.
+	_, _, err = util.RunIP("route", "add", config.Kubernetes.ServiceCIDR, "via", routerIP)
+	if err != nil {
+		return err
 	}
 
 	// Add a neighbour entry on the K8s node to map routerIP with routerMAC. This is
@@ -201,8 +195,7 @@ func configureManagementPort(clusterSubnet []string, clusterServicesSubnet,
 // CreateManagementPort creates a management port attached to the node switch
 // that lets the node access its pods via their private IP address. This is used
 // for health checking and other management tasks.
-func CreateManagementPort(nodeName, localSubnet,
-	clusterServicesSubnet string, clusterSubnet []string) error {
+func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) error {
 
 	// Determine the IP of the node switch's logical router port on the cluster router
 	ip, subnet, err := net.ParseCIDR(localSubnet)
@@ -274,7 +267,6 @@ func CreateManagementPort(nodeName, localSubnet,
 			stderr, err)
 		return err
 	}
-	err = configureManagementPort(clusterSubnet, clusterServicesSubnet,
-		routerIP, routerMac, interfaceName, portIPMask)
+	err = configureManagementPort(clusterSubnet, routerIP, routerMac, interfaceName, portIPMask)
 	return err
 }

--- a/go-controller/pkg/ovn/management-port_test.go
+++ b/go-controller/pkg/ovn/management-port_test.go
@@ -63,8 +63,8 @@ var _ = Describe("Management Port Operations", func() {
 				mgtPortCIDR   string = mgtPortIP + "/" + mgtPortPrefix
 				clusterIPNet  string = "10.1.0.0"
 				clusterCIDR   string = clusterIPNet + "/16"
-				serviceIPNet  string = "172.16.0.0"
-				serviceCIDR   string = serviceIPNet + "/16"
+				serviceIPNet  string = "172.16.1.0"
+				serviceCIDR   string = serviceIPNet + "/24"
 				mtu           string = "1400"
 				gwIP          string = "10.1.1.1"
 				lrpMAC        string = "00:00:00:00:00:03"
@@ -133,7 +133,7 @@ var _ = Describe("Management Port Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = CreateManagementPort(nodeName, nodeSubnet, serviceCIDR, []string{clusterCIDR})
+			err = CreateManagementPort(nodeName, nodeSubnet, []string{clusterCIDR})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CommandCalls).To(Equal(len(fakeCmds)))

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -210,7 +210,6 @@ if [ "$DAEMONSET" != "true" ]; then
    -logfile="/var/log/ovn-kubernetes/ovnkube.log" \
    -init-master="k8smaster" -cluster-subnet="192.168.0.0/16" \
    -init-node="k8smaster" \
-   -service-cluster-ip-range=172.16.1.0/24 \
    -nodeport \
    -nb-address="$ovn_nb" \
    -sb-address="$ovn_sb" \

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -176,7 +176,6 @@ if [ "$DAEMONSET" != "true" ]; then
       -sb-address="$ovn_sb" \
       ${SSL_ARGS} \
       -init-gateways -gateway-interface=enp0s8 -gateway-nexthop="$GW_IP" \
-      -service-cluster-ip-range=172.16.1.0/24 \
       -cluster-subnet="192.168.0.0/16" 2>&1 &
 fi
 


### PR DESCRIPTION
The two values do the same thing, and --service-cluster-ip-range wins if present
to maintain backwards compatibility. But there's now config file support for
service-cidr and it now has a default too.

@shettyg @girishmg @pecameron @JacobTanenbaum @danwinship @squeed 