### PR TITLE
[v2] Allocate gateway router port addresses dynamically

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -48,7 +48,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 	app.Action = func(ctx *cli.Context) error {
 		const (
 			nodeName          string = "node1"
-			lrpMAC            string = "00:00:00:05:46:C3"
+			lrpMAC            string = "00:00:00:05:46:c3"
 			lrpIP             string = "100.64.0.3"
 			lrpCIDR           string = lrpIP + "/16"
 			clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
@@ -106,17 +106,32 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + eth0IP,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-" + gwRouter + " mac",
-			Output: lrpMAC,
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_router_port rtoj-" + gwRouter + " networks",
-			Output: "[" + lrpCIDR + "]",
+			Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+			Output: "",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=\"" + lrpMAC + "\"",
+			"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+			Output: lrpMAC + " " + lrpIP,
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join other-config:subnet",
+			Output: "\"100.64.0.1/16\"",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + lrpMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
+			"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
-			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 100.64.0.2",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
+			Output: fmt.Sprintf(`%s      chassis=%s lb_force_snat_ip=%s
+GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, gwRouter, systemID, lrpIP),
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
 		})
 		addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -139,7 +154,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + eth0GWIP + " rtoe-" + gwRouter,
 			"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat " + eth0IP + " " + clusterCIDR,
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
-			"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -284,7 +298,7 @@ func spareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 	app.Action = func(ctx *cli.Context) error {
 		const (
 			nodeName          string = "node1"
-			lrpMAC            string = "00:00:00:05:46:C3"
+			lrpMAC            string = "00:00:00:05:46:c3"
 			lrpIP             string = "100.64.0.3"
 			lrpCIDR           string = lrpIP + "/16"
 			clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
@@ -310,17 +324,32 @@ func spareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + eth0IP,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-" + gwRouter + " mac",
-			Output: lrpMAC,
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_router_port rtoj-" + gwRouter + " networks",
-			Output: "[" + lrpCIDR + "]",
+			Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+			Output: "",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=\"" + lrpMAC + "\"",
+			"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+			Output: lrpMAC + " " + lrpIP,
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join other-config:subnet",
+			Output: "\"100.64.0.1/16\"",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + lrpMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
+			"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
-			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 100.64.0.2",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
+			Output: fmt.Sprintf(`%s      chassis=%s lb_force_snat_ip=%s
+GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, gwRouter, systemID, lrpIP),
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
 		})
 		addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -347,7 +376,6 @@ func spareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + eth0GWIP + " rtoe-" + gwRouter,
 			"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat " + eth0IP + " " + clusterCIDR,
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
-			"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 		})
 
@@ -440,7 +468,7 @@ var _ = Describe("Gateway Init Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				nodeName          string = "node1"
-				lrpMAC            string = "00:00:00:05:46:C3"
+				lrpMAC            string = "00:00:00:05:46:c3"
 				brLocalnetMAC     string = "11:22:33:44:55:66"
 				lrpIP             string = "100.64.0.3"
 				lrpCIDR           string = lrpIP + "/16"
@@ -476,17 +504,33 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-" + gwRouter + " mac",
-				Output: lrpMAC,
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_router_port rtoj-" + gwRouter + " networks",
-				Output: "[" + lrpCIDR + "]",
+				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+				Output: "",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=\"" + lrpMAC + "\"",
+				"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses",
+				Output: lrpMAC + " " + lrpIP,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join other-config:subnet",
+				Output: "\"100.64.0.1/16\"",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + lrpMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
+				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 100.64.0.2",
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
+				Output: fmt.Sprintf(`GR_openshift-node-2      chassis=5befb1e1-b0b1-4277-bb1d-54e8732a39c6 lb_force_snat_ip=%s
+GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_snat_ip=100.64.0.5
+GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, lrpIP),
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -504,7 +548,6 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 rtoe-" + gwRouter,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
-				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 			})
 

--- a/go-controller/pkg/cluster/master_test.go
+++ b/go-controller/pkg/cluster/master_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Master Operations", func() {
 				Output: udpLBUUID,
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --may-exist ls-add join",
+				"ovn-nbctl --timeout=15 --may-exist ls-add join -- set logical_switch join other-config:subnet=100.64.0.0/16 -- set logical_switch join other-config:exclude_ips=100.64.0.1",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-ovn_cluster_router mac",
@@ -69,11 +69,10 @@ var _ = Describe("Master Operations", func() {
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-ovn_cluster_router -- set logical_switch_port jtor-ovn_cluster_router type=router options:router-port=rtoj-ovn_cluster_router addresses=\"" + joinLRPMAC + "\"",
-				"ovn-nbctl --timeout=15 -- set nb_global . external-ids:gateway-lock=\"\"",
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
 			})
 
-			var (
+			// Node-related logical network stuff
+			const (
 				nodeName       string = "node1"
 				lrpMAC         string = "00:00:00:05:46:C3"
 				nodeSubnet     string = "10.1.0.0/24"
@@ -81,6 +80,9 @@ var _ = Describe("Master Operations", func() {
 				nodeMgmtPortIP string = "10.1.0.2"
 			)
 
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
+			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtos-" + nodeName + " mac",
 				// Return a known MAC; otherwise code autogenerates it

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -42,12 +42,9 @@ func (ovn *Controller) getDefaultGatewayLoadBalancer(protocol kapi.Protocol) str
 		return outStr
 	}
 
-	var gw string
-	gw, _, _ = util.RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=name", "find", "logical_router",
-		"options:lb_force_snat_ip=100.64.0.2")
-	if len(gw) == 0 {
-		logrus.Errorf("Error locating default gateway")
+	gw, _, err := util.GetDefaultGatewayRouterIP()
+	if err != nil {
+		logrus.Errorf(err.Error())
 		return ""
 	}
 

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -283,16 +284,12 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		return
 	}
 
+	var podMac net.HardwareAddr
+	var podIP net.IP
 	count := 30
 	for count > 0 {
-		if isStaticIP {
-			out, stderr, err = util.RunOVNNbctl("get",
-				"logical_switch_port", portName, "addresses")
-		} else {
-			out, stderr, err = util.RunOVNNbctl("get",
-				"logical_switch_port", portName, "dynamic_addresses")
-		}
-		if err == nil && out != "[]" {
+		podMac, podIP, err = util.GetPortAddresses(portName, isStaticIP)
+		if err == nil && podMac != nil && podIP != nil {
 			break
 		}
 		if err != nil {
@@ -309,26 +306,15 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		return
 	}
 
-	// static addresses have format ["0a:00:00:00:00:01 192.168.1.3"], while
-	// dynamic addresses have format "0a:00:00:00:00:01 192.168.1.3".
-	outStr := strings.TrimLeft(out, `[`)
-	outStr = strings.TrimRight(outStr, `]`)
-	outStr = strings.Trim(outStr, `"`)
-	addresses := strings.Split(outStr, " ")
-	if len(addresses) != 2 {
-		logrus.Errorf("Error while obtaining addresses for %s", portName)
-		return
-	}
-
 	if !isStaticIP {
-		annotation = fmt.Sprintf(`{\"ip_address\":\"%s/%s\", \"mac_address\":\"%s\", \"gateway_ip\": \"%s\"}`, addresses[1], mask, addresses[0], gatewayIP)
-		logrus.Debugf("Annotation values: ip=%s/%s ; mac=%s ; gw=%s\nAnnotation=%s", addresses[1], mask, addresses[0], gatewayIP, annotation)
+		annotation = fmt.Sprintf(`{\"ip_address\":\"%s/%s\", \"mac_address\":\"%s\", \"gateway_ip\": \"%s\"}`, podIP.String(), mask, podMac.String(), gatewayIP)
+		logrus.Debugf("Annotation values: ip=%s/%s ; mac=%s ; gw=%s\nAnnotation=%s", podIP.String(), mask, podMac.String(), gatewayIP, annotation)
 		err = oc.kube.SetAnnotationOnPod(pod, "ovn", annotation)
 		if err != nil {
 			logrus.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
 		}
 	}
-	oc.addPodToNamespaceAddressSet(pod.Namespace, addresses[1])
+	oc.addPodToNamespaceAddressSet(pod.Namespace, podIP.String())
 
 	return
 }

--- a/go-controller/pkg/util/gateway-init_test.go
+++ b/go-controller/pkg/util/gateway-init_test.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Gateway Init Operations", func() {
+	It("correctly sorts gateway routers", func() {
+		fexec := ovntest.NewFakeExec()
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
+			Output: `node5      chassis=842fdade-747a-43b8-b40a-d8e8e26379fa lb_force_snat_ip=100.64.0.5
+node2 chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.2
+node1 chassis=d17ddb5a-050d-42ab-ab50-7c6ce79a8f2e lb_force_snat_ip=100.64.0.1
+node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
+		})
+
+		err := SetExec(fexec)
+		Expect(err).NotTo(HaveOccurred())
+
+		name, ip, err := GetDefaultGatewayRouterIP()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("node1"))
+		Expect(ip.String()).To(Equal("100.64.0.1"))
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue())
+	})
+
+	It("ignores malformatted gateway router entires", func() {
+		fexec := ovntest.NewFakeExec()
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
+			Output: `node5      chassis=842fdade-747a-43b8-b40a-d8e8e26379fa lb_force_snat_ip=100.64.0.5
+node2 chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=asdfsadf
+node1 chassis=d17ddb5a-050d-42ab-ab50-7c6ce79a8f2e lb_force_xxxxxxx=100.64.0.1
+node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
+		})
+
+		err := SetExec(fexec)
+		Expect(err).NotTo(HaveOccurred())
+
+		name, ip, err := GetDefaultGatewayRouterIP()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("node4"))
+		Expect(ip.String()).To(Equal("100.64.0.4"))
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue())
+	})
+})

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"math/rand"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -31,4 +32,38 @@ func ipToInt(ip net.IP) *big.Int {
 
 func intToIP(i *big.Int) net.IP {
 	return net.IP(i.Bytes())
+}
+
+// GetPortAddresses returns the MAC and IP of the given logical switch port
+func GetPortAddresses(portName string, isStaticIP bool) (net.HardwareAddr, net.IP, error) {
+	addrType := "dynamic_addresses"
+	if isStaticIP {
+		addrType = "addresses"
+	}
+	out, _, err := RunOVNNbctl("get", "logical_switch_port", portName, addrType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error while obtaining addresses for %s: %v", portName, err)
+	}
+	if out == "[]" {
+		// No addresses
+		return nil, nil, nil
+	}
+
+	// static addresses have format ["0a:00:00:00:00:01 192.168.1.3"], while
+	// dynamic addresses have format "0a:00:00:00:00:01 192.168.1.3".
+	outStr := strings.Trim(out, `[]`)
+	outStr = strings.Trim(outStr, `"`)
+	addresses := strings.Split(outStr, " ")
+	if len(addresses) != 2 {
+		return nil, nil, fmt.Errorf("Error while obtaining addresses for %s", portName)
+	}
+	ip := net.ParseIP(addresses[1])
+	if ip == nil {
+		return nil, nil, fmt.Errorf("failed to parse logical switch port %q IP %q", portName, addresses[1])
+	}
+	mac, err := net.ParseMAC(addresses[0])
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse logical switch port %q MAC %q: %v", portName, addresses[0], err)
+	}
+	return mac, ip, nil
 }

--- a/go-controller/pkg/util/util_suite_test.go
+++ b/go-controller/pkg/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtilSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}


### PR DESCRIPTION
This reverts commit ebe7c729afc4581f8b9e31a288056758f9e8caeb.

Now that OVS 2.11 and 2.10.2 are out we can rely on the IPAM fixes that prevented
PR #503 from being used. Those fixes in upstream OVS are:

branch-2.11/master:
6f5cc61c07f20452955d5278f0771fbd8af1840c
dcad447342ea30d2806d9df063c7cef6a1b0cb1d

branch-2.10:
f01ed924c5f7224d8083a25a7e6b3c3621ba03aa
66b6fff3edae2dc71628997b749a962c80fbec30

Signed-off-by: Dan Williams <dcbw@redhat.com>

@shettyg @girishmg 