### PR TITLE
[Contrib] Add Ubuntu 18.04 support

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -35,7 +35,7 @@ ansible-playbook ovn-kubernetes-cluster.yml
 ```
 
 Currently supported Linux nodes:
-- Ubuntu 14.04 and 16.04
+- Ubuntu 16.04 and 18.04
 
 Currently supported Windows nodes:
 - Windows Server 2016 build version 1709 (OS Version 10.0.16299.0)
@@ -76,7 +76,7 @@ The following ports need to be opened if we access the cluster machines via the 
 
 - Support for hybrid cluster with master/minion nodes on different cloud providers.
 
-- Different Linux versions support (currently only Ubuntu 14.04 and 16.04 supported)
+- Different Linux versions support (currently only Ubuntu 16.04 and 18.04 supported)
 
 ### Known issues
 

--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -128,7 +128,7 @@
       with_items: "{{ groups['kube-master'] }}"
 
 # TODO(ionutbalutoiu):
-# Remove below workaround when this is fixed: https://github.com/openvswitch/ovn-kubernetes/issues/531
+# Remove below workaround when this is fixed: https://github.com/ovn-org/ovn-kubernetes/issues/531
 # Right now, the CoreDNS pods will never reach "running" state. We need to kill the existing pods and
 # new ones will be successfully created.
 - hosts: kube-master

--- a/contrib/ovn-kubernetes-cluster.yml
+++ b/contrib/ovn-kubernetes-cluster.yml
@@ -97,7 +97,7 @@
         # to install the MSI in unattended mode
         # Setting install_beta_ovs to false will install the latest stable OVS
         install_custom_ovs: true
-        custom_ovs_link: "https://cloudbase.it/downloads/openvswitch-hyperv-installer-beta.msi"
+        custom_ovs_link: "https://cloudbase.it/downloads/openvswitch-hyperv-installer-beta-2.10.msi"
         # This is useful for dev purposes and when using custom MSI which is not signed
         bcdedit_needed: false
         # ovs_certs_link: ""  # link to certificates for OVS if required

--- a/contrib/roles/linux/docker/vars/ubuntu.yml
+++ b/contrib/roles/linux/docker/vars/ubuntu.yml
@@ -2,19 +2,19 @@
 docker_package_info:
   pkg_mgr: apt
   pkgs:
-    - name: "docker-engine"
+    - name: "docker-ce"
       force: yes
 
 docker_repo_key_info:
   pkg_key: apt_key
-  url: https://apt.dockerproject.org/gpg
+  url: https://download.docker.com/linux/ubuntu/gpg
   repo_keys:
-    - 58118E89F3A912897C070ADBF76221572C52609D
+    - 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 docker_repo_info:
   pkg_repo: apt_repository
   repos:
     - >
-       deb https://apt.dockerproject.org/repo
-       {{ ansible_distribution|lower }}-{{ ansible_distribution_release|lower }}
-       main
+       deb https://download.docker.com/linux/{{ ansible_distribution|lower }}
+       {{ ansible_distribution_release|lower }}
+       stable

--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -204,7 +204,7 @@
     block: |
       [Unit]
       Description=OVN watches the Kubernetes API
-      Documentation=https://github.com/openvswitch/ovn-kubernetes#watchers-on-master-node
+      Documentation=https://github.com/ovn-org/ovn-kubernetes#watchers-on-master-node
       [Service]
       ExecStart=/usr/bin/ovnkube \
         -init-master "{{ ansible_hostname }}" \

--- a/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
@@ -112,9 +112,18 @@
     remote_src: yes
 
 - name: Kubernetes Minion | Set default "init_gateway" fact if not already defined
-  set_fact:
-    init_gateway: true
+  block:
+  - set_fact:
+      init_gateway: true
+    when: ansible_distribution_version == '16.04'
+  - set_fact:
+      init_gateway: false
+    when: ansible_distribution_version == '18.04'
   when: init_gateway is not defined
+
+- fail:
+    msg: "Gateway not supported yet on Ubuntu 18.04"
+  when: init_gateway == true and ansible_distribution_version == '18.04'
 
 - name: Kubernetes Minion | Setup OVN Kube service
   block:

--- a/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
@@ -125,7 +125,7 @@
         block: |
           [Unit]
           Description=OVN Kube Systemd Daemon
-          Documentation=https://github.com/openvswitch/ovn-kubernetes
+          Documentation=https://github.com/ovn-org/ovn-kubernetes
           [Service]
           ExecStart=/usr/bin/ovnkube \
             --init-node "{{ ansible_hostname }}" \

--- a/contrib/roles/linux/openvswitch/tasks/build_install_release_ovs.yml
+++ b/contrib/roles/linux/openvswitch/tasks/build_install_release_ovs.yml
@@ -39,24 +39,11 @@
   args:
     chdir: "{{ ovs_info.build_path }}/{{ ovs_info.release_name }}"
 
-- name: OVS | install debs
-  apt: deb="{{ ovs_info.build_path }}/{{item}}_{{ ovs_info.pkg_build_version }}_amd64.deb"
-  with_items:
-    - libopenvswitch
-    - openvswitch-common
-    - openvswitch-switch
-    - ovn-common
-    - ovn-host
-
-- name: OVS | install additional debs
+- name: OVS | install datapath debs
   apt: deb="{{ ovs_info.build_path }}/{{item}}_{{ ovs_info.pkg_build_version }}_all.deb"
   with_items:
     - openvswitch-datapath-dkms
     - python-openvswitch
-
-- name: OVS | install controller deb if applicable
-  apt: deb="{{ ovs_info.build_path }}/ovn-central_{{ ovs_info.pkg_build_version }}_amd64.deb"
-  when: controller
 
 - name: OVS | add modules
   lineinfile:
@@ -77,6 +64,7 @@
   with_items:
     - openvswitch
     - vport-geneve
+    - vport-stt
 
 - name: OVS | add modprobe
   modprobe:
@@ -85,6 +73,20 @@
   with_items:
     - openvswitch
     - vport-geneve
+    - vport-stt
+
+- name: OVS | install debs
+  apt: deb="{{ ovs_info.build_path }}/{{item}}_{{ ovs_info.pkg_build_version }}_amd64.deb"
+  with_items:
+    - libopenvswitch
+    - openvswitch-common
+    - openvswitch-switch
+    - ovn-common
+    - ovn-host
+
+- name: OVS | install controller deb if applicable
+  apt: deb="{{ ovs_info.build_path }}/ovn-central_{{ ovs_info.pkg_build_version }}_amd64.deb"
+  when: controller
 
 # TODO: .deb packages are not creating services, we need this for ovnkube
 # when it tries to start/restart services

--- a/contrib/roles/linux/openvswitch/tasks/download_install_packages.yml
+++ b/contrib/roles/linux/openvswitch/tasks/download_install_packages.yml
@@ -15,24 +15,11 @@
     dest: "{{ ovs_info.prebuilt_packages_download_path }}"
     remote_src: yes
 
-- name: OVS | install debs
-  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/{{item}}_{{ ovs_info.prebuilt_version }}_amd64.deb"
-  with_items:
-    - libopenvswitch
-    - openvswitch-common
-    - openvswitch-switch
-    - ovn-common
-    - ovn-host
-
-- name: OVS | install additional debs
+- name: OVS | install datapath debs
   apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/{{item}}_{{ ovs_info.prebuilt_version }}_all.deb"
   with_items:
     - openvswitch-datapath-dkms
     - python-openvswitch
-
-- name: OVS | install controller deb if applicable
-  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/ovn-central_{{ ovs_info.prebuilt_version }}_amd64.deb"
-  when: controller
 
 - name: OVS | add modules
   lineinfile:
@@ -53,6 +40,7 @@
   with_items:
     - openvswitch
     - vport-geneve
+    - vport-stt
 
 - name: OVS | add modprobe
   modprobe:
@@ -61,6 +49,20 @@
   with_items:
     - openvswitch
     - vport-geneve
+    - vport-stt
+
+- name: OVS | install debs
+  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/{{item}}_{{ ovs_info.prebuilt_version }}_amd64.deb"
+  with_items:
+    - libopenvswitch
+    - openvswitch-common
+    - openvswitch-switch
+    - ovn-common
+    - ovn-host
+
+- name: OVS | install controller deb if applicable
+  apt: deb="{{ ovs_info.prebuilt_packages_download_path }}/ovn-central_{{ ovs_info.prebuilt_version }}_amd64.deb"
+  when: controller
 
 # TODO: make this better
 - name: OVS | Mock OVS services

--- a/contrib/roles/linux/openvswitch/vars/ubuntu.yml
+++ b/contrib/roles/linux/openvswitch/vars/ubuntu.yml
@@ -9,6 +9,7 @@ ovs_package_info:
     - name: "automake"
     - name: "bzip2"
     - name: "libssl-dev"
+    - name: "libunbound-dev"
     - name: "openssl"
     - name: "graphviz"
     - name: "python-all"

--- a/contrib/roles/linux/openvswitch/vars/ubuntu.yml
+++ b/contrib/roles/linux/openvswitch/vars/ubuntu.yml
@@ -27,13 +27,13 @@ ovs_info:
   git_url: https://github.com/openvswitch/ovs.git
   build_path: /tmp
   modules_file_path: /etc/modules-load.d/modules.conf
-  branch: branch-2.9
+  branch: branch-2.10
   service_path: /etc/systemd/system/openvswitch.service
-  release_link: http://openvswitch.org/releases/openvswitch-2.9.2.tar.gz
-  release_name: openvswitch-2.9.2
-  pkg_build_version: 2.9.2-1
+  release_link: https://www.openvswitch.org/releases/openvswitch-2.10.2.tar.gz
+  release_name: openvswitch-2.10.2
+  pkg_build_version: 2.10.2-1
   # Prebuilt packages info and download link
   install_prebuilt_packages: "{{ovs_install_prebuilt_packages | default(false)}}"
   prebuilt_packages_download_path: /tmp
-  prebuilt_version: "2.9.2-1"
+  prebuilt_version: "2.10.2-1"
   debs_targz_link: "replace_me"

--- a/contrib/roles/linux/ovn-kubernetes/vars/ubuntu.yml
+++ b/contrib/roles/linux/ovn-kubernetes/vars/ubuntu.yml
@@ -2,7 +2,7 @@
 ovn_kubernetes_info:
   install_path: /usr/bin
   # ovn-kubernetes build info
-  git_url: https://github.com/openvswitch/ovn-kubernetes
+  git_url: https://github.com/ovn-org/ovn-kubernetes
   build_path: /tmp
   branch: master
 

--- a/contrib/roles/linux/version_check/tasks/main.yml
+++ b/contrib/roles/linux/version_check/tasks/main.yml
@@ -7,4 +7,4 @@
 - name: version check | Checking if distro version is supported by this playbook
   fail:
     msg: "Distribution version {{ ansible_distribution_version }} not supported by this playbook"
-  when: ansible_distribution_version != '16.04' and ansible_distribution_version != '14.04'
+  when: ansible_distribution_version != '18.04' and ansible_distribution_version != '16.04'


### PR DESCRIPTION
This PR updates the OVS/OVN versions to 2.10, adds support for Ubuntu 18.04, deprecates support for Ubuntu 14.04.

Unfortunately Ubuntu 18.04 comes with `netplan` builtin. This causes issues when deploying it as a gateway, because the DNS settings are not copied from the physical interface to the OVS bridge. Until support is added, 18.04 minions will be forced with a gateway configuration.

This PR contains the following commits:
-   [ansible] Switch to ovn-org links
-   [contrib] Bump OVS linux version to 2.10
-   [contrib] Add 18.04 to the supported list and deprecate 14.04
-   [contrib] Bump OVS installer to 2.10 on Windows
-   [contrib] Linux add new dependency needed to compile OVS
-   [contrib] Change order when installing debs
-   [contrib] Set init_gateway to false by default on Ubuntu 18.04 nodes

CC: @ionutbalutoiu @alinbalutoiu 