### PR TITLE
node processes should get their connections via a Service

### DIFF
--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -55,6 +57,11 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 
 	logrus.Infof("Node %s ready for ovn initialization with subnet %s", node.Name, subnet.String())
 
+	err = cluster.watchConfigEndpoints()
+	if err != nil {
+		return err
+	}
+
 	err = setupOVNNode(name)
 	if err != nil {
 		return err
@@ -81,11 +88,6 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		}
 	}
 
-	if cluster.OvnHA {
-		err = cluster.watchNamespaceUpdate(node, subnet.String())
-		return err
-	}
-
 	// start the cni server
 	cniServer := cni.NewCNIServer("")
 	err = cniServer.Start(cni.HandleCNIRequest)
@@ -93,62 +95,67 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	return err
 }
 
-// If default namespace MasterOverlayIP annotation has been chaged, update
-// config.OvnNorth and config.OvnSouth auth with new ovn-nb and ovn-remote
-// IP address
-func (cluster *OvnClusterController) updateOvnNode(masterIP string,
-	node *kapi.Node, subnet string) error {
-	err := config.UpdateOvnNodeAuth(masterIP)
-	if err != nil {
-		return err
-	}
-	err = setupOVNNode(node.Name)
-	if err != nil {
-		logrus.Errorf("Failed to setup OVN node (%v)", err)
-		return err
+func validateOVNConfigEndpoint(ep *kapi.Endpoints) bool {
+	if len(ep.Subsets) == 1 && len(ep.Subsets[0].Ports) == 2 {
+		return true
 	}
 
-	var clusterSubnets []string
+	return false
 
-	for _, clusterSubnet := range cluster.ClusterIPNet {
-		clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR.String())
-	}
-
-	// Recreate logical switch and management port for this node
-	err = ovn.CreateManagementPort(node.Name, subnet, clusterSubnets)
-	if err != nil {
-		return err
-	}
-
-	// Reinit Gateway for this node if the --init-gateways flag is set
-	if cluster.GatewayInit {
-		err = cluster.initGateway(node.Name, clusterSubnets, subnet)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
-// watchNamespaceUpdate starts watching namespace resources and calls back
-// the update handler logic if there is any namspace update event
-func (cluster *OvnClusterController) watchNamespaceUpdate(node *kapi.Node,
-	subnet string) error {
-	_, err := cluster.watchFactory.AddNamespaceHandler(
+func updateOVNConfig(ep *kapi.Endpoints) {
+	if !validateOVNConfigEndpoint(ep) {
+		logrus.Errorf("endpoint %s is not in the right format to configure OVN", ep.Name)
+		return
+	}
+	var southboundDBPort string
+	var northboundDBPort string
+	var masterIPList []string
+	for _, ovnDB := range ep.Subsets[0].Ports {
+		if ovnDB.Name == "south" {
+			southboundDBPort = strconv.Itoa(int(ovnDB.Port))
+		}
+		if ovnDB.Name == "north" {
+			northboundDBPort = strconv.Itoa(int(ovnDB.Port))
+		}
+	}
+	for _, address := range ep.Subsets[0].Addresses {
+		masterIPList = append(masterIPList, address.IP)
+	}
+	err := config.UpdateOVNNodeAuth(masterIPList, southboundDBPort, northboundDBPort)
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return
+	}
+	for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
+		if err := auth.SetDBAuth(); err != nil {
+			logrus.Errorf(err.Error())
+			return
+		}
+		logrus.Infof("OVN databases reconfigured, masterIP %s, northbound-db %s, southbound-db %s", ep.Subsets[0].Addresses[0].IP, northboundDBPort, southboundDBPort)
+	}
+
+}
+
+//watchConfigEndpoints starts the watching of Endpoint resource and calls back to the appropriate handler logic
+func (cluster *OvnClusterController) watchConfigEndpoints() error {
+	_, err := cluster.watchFactory.AddFilteredEndpointsHandler(config.Kubernetes.OVNConfigNamespace,
 		cache.ResourceEventHandlerFuncs{
-			UpdateFunc: func(old, newer interface{}) {
-				oldNs := old.(*kapi.Namespace)
-				oldMasterIP := oldNs.Annotations[MasterOverlayIP]
-				newNs := newer.(*kapi.Namespace)
-				newMasterIP := newNs.Annotations[MasterOverlayIP]
-				if newMasterIP != oldMasterIP {
-					err := cluster.updateOvnNode(newMasterIP, node, subnet)
-					if err != nil {
-						logrus.Errorf("Failed to update OVN node with new "+
-							"masterIP %s: %v", newMasterIP, err)
-					}
+			AddFunc: func(obj interface{}) {
+				ep := obj.(*kapi.Endpoints)
+				if ep.Name == "ovnkube-db" {
+					updateOVNConfig(ep)
+					return
 				}
+			},
+			UpdateFunc: func(old, new interface{}) {
+				epNew := new.(*kapi.Endpoints)
+				epOld := old.(*kapi.Endpoints)
+				if !reflect.DeepEqual(epNew.Subsets, epOld.Subsets) && epNew.Name == "ovnkube-db" {
+					updateOVNConfig(epNew)
+				}
+
 			},
 		}, nil)
 	return err

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -4,10 +4,14 @@ import (
 	"fmt"
 
 	"github.com/urfave/cli"
+	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -56,5 +60,269 @@ var _ = Describe("Node Operations", func() {
 
 		err := app.Run([]string{app.Name})
 		Expect(err).NotTo(HaveOccurred())
+	})
+	It("test validateOVNConfigEndpoint()", func() {
+
+		type testcase struct {
+			name           string
+			subsets        []kapi.EndpointSubset
+			expectedResult bool
+		}
+
+		testcases := []testcase{
+			{
+				name: "valid endpoint",
+				subsets: []kapi.EndpointSubset{
+					{
+						Addresses: []kapi.EndpointAddress{
+							{IP: "10.1.2.3"},
+						},
+						Ports: []kapi.EndpointPort{
+							{
+								Name: "north",
+								Port: 1234,
+							},
+							{
+								Name: "south",
+								Port: 4321,
+							},
+						},
+					},
+				},
+				expectedResult: true,
+			},
+			{
+				name: "valid endpoint, multiple IPs",
+				subsets: []kapi.EndpointSubset{
+					{
+						Addresses: []kapi.EndpointAddress{
+							{IP: "10.1.2.3"}, {IP: "11.1.2.3"},
+						},
+						Ports: []kapi.EndpointPort{
+							{
+								Name: "north",
+								Port: 1234,
+							},
+							{
+								Name: "south",
+								Port: 4321,
+							},
+						},
+					},
+				},
+				expectedResult: true,
+			},
+			{
+				name: "invalid endpoint two few ports",
+				subsets: []kapi.EndpointSubset{
+					{
+						Addresses: []kapi.EndpointAddress{
+							{IP: "10.1.2.3"},
+						},
+						Ports: []kapi.EndpointPort{
+							{
+								Name: "north",
+								Port: 1234,
+							},
+						},
+					},
+				},
+				expectedResult: false,
+			},
+			{
+				name: "invalid endpoint too many ports",
+				subsets: []kapi.EndpointSubset{
+					{
+						Addresses: []kapi.EndpointAddress{
+							{IP: "10.1.2.3"},
+						},
+						Ports: []kapi.EndpointPort{
+							{
+								Name: "north",
+								Port: 1234,
+							},
+							{
+								Name: "south",
+								Port: 4321,
+							},
+							{
+								Name: "east",
+								Port: 7654,
+							},
+						},
+					},
+				},
+				expectedResult: false,
+			},
+			{
+				name:           "invalid endpoint no subsets",
+				subsets:        []kapi.EndpointSubset{},
+				expectedResult: false,
+			},
+		}
+
+		for _, tc := range testcases {
+			test := kapi.Endpoints{
+				Subsets: tc.subsets,
+			}
+			Expect(validateOVNConfigEndpoint(&test)).To(Equal(tc.expectedResult), " test case \"%s\" returned %t instead of %t", tc.name, !tc.expectedResult, tc.expectedResult)
+		}
+	})
+	It("test watchConfigEndpoints single IP", func() {
+		app.Action = func(ctx *cli.Context) error {
+
+			const (
+				masterAddress string = "10.1.2.3"
+				nbPort        int32  = 1234
+				sbPort        int32  = 4321
+			)
+
+			fexec := ovntest.NewFakeExec()
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+					"external_ids:ovn-nb=\"tcp:%s:%d\"",
+					masterAddress, nbPort),
+			})
+
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+					"external_ids:ovn-remote=\"tcp:%s:%d\"",
+					masterAddress, sbPort),
+			})
+
+			err := util.SetExec(fexec)
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeClient := fake.NewSimpleClientset(&kapi.EndpointsList{
+				Items: []kapi.Endpoints{{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ovn-kubernetes", Name: "ovnkube-db"},
+					Subsets: []kapi.EndpointSubset{
+						{
+							Addresses: []kapi.EndpointAddress{
+								{IP: masterAddress},
+							},
+							Ports: []kapi.EndpointPort{
+								{
+									Name: "north",
+									Port: nbPort,
+								},
+								{
+									Name: "south",
+									Port: sbPort,
+								},
+							},
+						},
+					},
+				}},
+			})
+			_, err = config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			stopChan := make(chan struct{})
+			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			Expect(err).NotTo(HaveOccurred())
+			defer f.Shutdown()
+
+			cluster := NewClusterController(fakeClient, f)
+			Expect(cluster).NotTo(BeNil())
+
+			Expect(config.OvnNorth.Address).To(Equal("tcp:1.1.1.1:6641"), "config.OvnNorth.Address does not equal cli arg")
+			Expect(config.OvnSouth.Address).To(Equal("tcp:1.1.1.1:6642"), "config.OvnSouth.Address does not equal cli arg")
+
+			err = cluster.watchConfigEndpoints()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Kubernetes endpoints should eventually propogate to OvnNorth/OvnSouth
+			Eventually(func() string {
+				return config.OvnNorth.Address
+			}).Should(Equal(fmt.Sprintf("tcp:%s:%d", masterAddress, nbPort)), "Northbound DB Port did not get set by watchConfigEndpoints")
+			Eventually(func() string {
+				return config.OvnSouth.Address
+			}).Should(Equal(fmt.Sprintf("tcp:%s:%d", masterAddress, sbPort)), "Southbound DBPort did not get set by watchConfigEndpoints")
+
+			return nil
+		}
+		err := app.Run([]string{app.Name, "-nb-address=tcp://1.1.1.1:6641", "-sb-address=tcp://1.1.1.1:6642"})
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+	It("test watchConfigEndpoints multiple IPs", func() {
+		app.Action = func(ctx *cli.Context) error {
+
+			const (
+				masterAddress1 string = "10.1.2.3"
+				masterAddress2 string = "11.1.2.3"
+				nbPort         int32  = 1234
+				sbPort         int32  = 4321
+			)
+
+			fexec := ovntest.NewFakeExec()
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+					"external_ids:ovn-nb=\"tcp:%s:%d,tcp:%s:%d\"",
+					masterAddress1, nbPort, masterAddress2, nbPort),
+			})
+
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+					"external_ids:ovn-remote=\"tcp:%s:%d,tcp:%s:%d\"",
+					masterAddress1, sbPort, masterAddress2, sbPort),
+			})
+
+			err := util.SetExec(fexec)
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeClient := fake.NewSimpleClientset(&kapi.EndpointsList{
+				Items: []kapi.Endpoints{{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ovn-kubernetes", Name: "ovnkube-db"},
+					Subsets: []kapi.EndpointSubset{
+						{
+							Addresses: []kapi.EndpointAddress{
+								{IP: masterAddress1}, {IP: masterAddress2},
+							},
+							Ports: []kapi.EndpointPort{
+								{
+									Name: "north",
+									Port: nbPort,
+								},
+								{
+									Name: "south",
+									Port: sbPort,
+								},
+							},
+						},
+					},
+				}},
+			})
+			_, err = config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			stopChan := make(chan struct{})
+			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			Expect(err).NotTo(HaveOccurred())
+			defer f.Shutdown()
+
+			cluster := NewClusterController(fakeClient, f)
+			Expect(cluster).NotTo(BeNil())
+
+			Expect(config.OvnNorth.Address).To(Equal("tcp:1.1.1.1:6641"), "config.OvnNorth.Address does not equal cli arg")
+			Expect(config.OvnSouth.Address).To(Equal("tcp:1.1.1.1:6642"), "config.OvnSouth.Address does not equal cli arg")
+
+			err = cluster.watchConfigEndpoints()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Kubernetes endpoints should eventually propogate to OvnNorth/OvnSouth
+			Eventually(func() string {
+				return config.OvnNorth.Address
+			}).Should(Equal(fmt.Sprintf("tcp:%s:%d,tcp:%s:%d", masterAddress1, nbPort, masterAddress2, nbPort)), "Northbound DB Port did not get set by watchConfigEndpoints")
+			Eventually(func() string {
+				return config.OvnSouth.Address
+			}).Should(Equal(fmt.Sprintf("tcp:%s:%d,tcp:%s:%d", masterAddress1, sbPort, masterAddress2, sbPort)), "Southbound DBPort did not get set by watchConfigEndpoints")
+
+			return nil
+		}
+		err := app.Run([]string{app.Name, "-nb-address=tcp://1.1.1.1:6641", "-sb-address=tcp://1.1.1.1:6642"})
+		Expect(err).NotTo(HaveOccurred())
+
 	})
 })

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -331,6 +331,11 @@ func (wf *WatchFactory) AddEndpointsHandler(handlerFuncs cache.ResourceEventHand
 	return wf.addHandler(endpointsType, "", nil, handlerFuncs, processExisting)
 }
 
+// AddFilteredEndpointsHandler adds a handler function that will be executed when Endpoint objects that match the given filters change
+func (wf *WatchFactory) AddFilteredEndpointsHandler(namespace string, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
+	return wf.addHandler(endpointsType, namespace, nil, handlerFuncs, processExisting)
+}
+
 // RemoveEndpointsHandler removes a Endpoints object event handler function
 func (wf *WatchFactory) RemoveEndpointsHandler(handler *Handler) error {
 	return wf.removeHandler(endpointsType, handler)


### PR DESCRIPTION
Rather than distributing the database urls via ConfigMaps, they should be obtained via a Service/Endpoint. As endpoints change, the ovn-kube process can update ovn and openvswitch accordingly

[SDN-295](https://jira.coreos.com/browse/SDN-295)