### PR TITLE
load balancer entries are not getting cleaned up on node deletion, this commit fixes it.

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -29,12 +29,12 @@ func addNodeportLBs(nodeName, tcpLBUUID, udpLBUUID string, fakeCmds []fakeexec.F
 	fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_" + nodeName,
 	})
+	fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_" + nodeName,
+	})
 	fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:TCP_lb_gateway_router=GR_" + nodeName + " protocol=tcp",
 		Output: tcpLBUUID,
-	})
-	fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_" + nodeName,
 	})
 	fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_" + nodeName + " protocol=udp",

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -509,7 +509,7 @@ func (cluster *OvnClusterController) deleteNode(nodeName string, nodeSubnet *net
 		logrus.Errorf("Error deleting node %s logical network: %v", nodeName, err)
 	}
 
-	if err := util.GatewayCleanup(nodeName); err != nil {
+	if err := util.GatewayCleanup(nodeName, cluster.NodePortEnable); err != nil {
 		return fmt.Errorf("Failed to clean up node %s gateway: (%v)", nodeName, err)
 	}
 


### PR DESCRIPTION


When nodeport enabled for the cluster node, there are two load balancers
created for north-south traffic, one handles UDP and another handles
TCP, add the missing clean up code. So there should be corresponding code
in gateway clean up logic.

Signed-off-by: Zhen Wang <zhewang@nvidia.com>