### PR TITLE
Update LB VIPs for nodeport service on adding new node

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -252,7 +252,13 @@ func (oc *Controller) WatchNamespaces() error {
 // back the appropriate handler logic
 func (oc *Controller) WatchNodes() error {
 	_, err := oc.watchFactory.AddNodeHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) {},
+		AddFunc: func(obj interface{}) {
+			if !oc.nodePortEnable {
+				return
+			}
+			node := obj.(*kapi.Node)
+			oc.handleNodePortLB(node)
+		},
 		UpdateFunc: func(old, new interface{}) {},
 		DeleteFunc: func(obj interface{}) {
 			node := obj.(*kapi.Node)


### PR DESCRIPTION
For NodePort enabled endpoints, each node will have VIPs added to the
gateway router load balancers. But if new node add after endpoints
added, there is missed logic to add the VIPs to the new node's
load balancers. This commit fixes this problem.

Fixes #316

Signed-off-by: Zhen Wang <zhewang@nvidia.com>