### PR TITLE
[contrib] Fix kube-apiserver service ip argument

### DIFF
--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -10,7 +10,7 @@
       [Service]
       ExecStart=/usr/bin/kube-apiserver \
         --bind-address=0.0.0.0 \
-        --k8s-service-cidr={{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }} \
+        --service-cluster-ip-range={{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }} \
         --address=0.0.0.0 \
         --etcd-servers=http://127.0.0.1:2379 \
         --v=2 \


### PR DESCRIPTION
`--k8s-service-cidr` is ovnkube specific.

Switch to `service-cluster-ip-range` as per:
https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>