### PR TITLE
gateway: split local vswitch and OVN operations

### DIFF
--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -89,6 +89,7 @@ func setupOVNNode(nodeName string) error {
 		fmt.Sprintf("external_ids:ovn-encap-ip=%s", nodeIP),
 		fmt.Sprintf("external_ids:ovn-remote-probe-interval=%d",
 			config.Default.InactivityProbe),
+		fmt.Sprintf("external_ids:hostname=\"%s\"", nodeName),
 	)
 	if err != nil {
 		return fmt.Errorf("error setting OVS external IDs: %v\n  %q", err, stderr)

--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -1,8 +1,41 @@
 package cluster
 
 import (
+	"fmt"
 	"net"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
+
+// bridgedGatewayNodeSetup makes the bridge's MAC address permanent, sets up
+// the physical network name mappings for the bridge, and returns an ifaceID
+// created from the bridge name and the node name
+func bridgedGatewayNodeSetup(nodeName, bridgeInterface string) (string, string, error) {
+	// A OVS bridge's mac address can change when ports are added to it.
+	// We cannot let that happen, so make the bridge mac address permanent.
+	macAddress, err := util.GetOVSPortMACAddress(bridgeInterface)
+	if err != nil {
+		return "", "", err
+	}
+	stdout, stderr, err := util.RunOVSVsctl("set", "bridge",
+		bridgeInterface, "other-config:hwaddr="+macAddress.String())
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to set bridge, stdout: %q, stderr: %q, "+
+			"error: %v", stdout, stderr, err)
+	}
+
+	// ovn-bridge-mappings maps a physical network name to a local ovs bridge
+	// that provides connectivity to that network.
+	_, stderr, err = util.RunOVSVsctl("set", "Open_vSwitch", ".",
+		fmt.Sprintf("external_ids:ovn-bridge-mappings=%s:%s", util.PhysicalNetworkName, bridgeInterface))
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to set ovn-bridge-mappings for ovs bridge %s"+
+			", stderr:%s (%v)", bridgeInterface, stderr, err)
+	}
+
+	ifaceID := bridgeInterface + "_" + nodeName
+	return ifaceID, macAddress.String(), nil
+}
 
 // getIPv4Address returns the ipv4 address for the network interface 'iface'.
 func getIPv4Address(iface string) (string, error) {

--- a/go-controller/pkg/cluster/gateway_spare_intf.go
+++ b/go-controller/pkg/cluster/gateway_spare_intf.go
@@ -19,8 +19,36 @@ func initSpareGateway(nodeName string, clusterIPSubnet []string,
 	if ipAddress == "" {
 		return fmt.Errorf("%s does not have a ipv4 address", gwIntf)
 	}
-	err = util.GatewayInit(clusterIPSubnet, nodeName, ipAddress,
-		gwIntf, "", gwNextHop, subnet, gwVLANId, nodeportEnable)
+
+	// Connect physical interface to br-int. Get its mac address.
+	ifaceID := gwIntf + "_" + nodeName
+	addPortCmdArgs := []string{"--", "--may-exist", "add-port",
+		"br-int", gwIntf, "--", "set", "interface",
+		gwIntf, "external-ids:iface-id=" + ifaceID}
+	if gwVLANId != 0 {
+		addPortCmdArgs = append(addPortCmdArgs, "--", "set", "port", gwIntf,
+			fmt.Sprintf("tag=%d", gwVLANId))
+	}
+	stdout, stderr, err := util.RunOVSVsctl(addPortCmdArgs...)
+	if err != nil {
+		return fmt.Errorf("Failed to add port to br-int, stdout: %q, "+
+			"stderr: %q, error: %v", stdout, stderr, err)
+	}
+	macAddress, stderr, err := util.RunOVSVsctl("--if-exists", "get",
+		"interface", gwIntf, "mac_in_use")
+	if err != nil {
+		return fmt.Errorf("Failed to get macAddress, stderr: %q, error: %v",
+			stderr, err)
+	}
+
+	// Flush the IP address of the physical interface.
+	_, _, err = util.RunIP("addr", "flush", "dev", gwIntf)
+	if err != nil {
+		return err
+	}
+
+	err = util.GatewayInit(clusterIPSubnet, nodeName, ifaceID, ipAddress,
+		macAddress, gwNextHop, subnet, false, 0, nodeportEnable)
 	if err != nil {
 		return fmt.Errorf("failed to init spare interface gateway: %v", err)
 	}

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -41,8 +41,9 @@ var _ = Describe("Node Operations", func() {
 				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
 					"external_ids:ovn-encap-type=geneve "+
 					"external_ids:ovn-encap-ip=%s "+
-					"external_ids:ovn-remote-probe-interval=%d",
-					nodeName, interval),
+					"external_ids:ovn-remote-probe-interval=%d "+
+					"external_ids:hostname=\"%s\"",
+					nodeName, interval, nodeName),
 			})
 
 			err := util.SetExec(fexec)

--- a/go-controller/pkg/testing/testing.go
+++ b/go-controller/pkg/testing/testing.go
@@ -52,9 +52,12 @@ func (f *FakeExec) AddFakeCmd(expected *ExpectedCmd) {
 	f.CommandScript = append(f.CommandScript, func(cmd string, args ...string) kexec.Cmd {
 		parts := strings.Split(expected.Cmd, " ")
 		gomega.Expect(len(parts)).To(gomega.BeNumerically(">=", 2))
-		gomega.Expect(cmd).To(gomega.Equal("/fake-bin/" + parts[0]))
+
+		executedCommandline := cmd + " " + strings.Join(args, " ")
+		expectedCommandline := "/fake-bin/" + strings.Join(parts, " ")
 		// Expect the incoming 'args' to equal the fake/expected command 'parts'
-		gomega.Expect(strings.Join(args, " ")).To(gomega.Equal(strings.Join(parts[1:], " ")), "Called command doesn't match expected fake command")
+		gomega.Expect(executedCommandline).To(gomega.Equal(expectedCommandline), "Called command doesn't match expected fake command")
+
 		return &fakeexec.FakeCmd{
 			Argv: parts[1:],
 			CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"net"
-	"runtime"
 	"sort"
 	"strings"
 )
@@ -33,19 +32,19 @@ func GetK8sClusterRouter() (string, error) {
 	return k8sClusterRouter, nil
 }
 
-func getLocalSystemID() (string, error) {
-	localSystemID, stderr, err := RunOVSVsctl("--if-exists", "get",
-		"Open_vSwitch", ".", "external_ids:system-id")
+func getNodeChassisID(nodeName string) (string, error) {
+	chassisID, stderr, err := RunOVNSbctl("--data=bare", "--no-heading",
+		"--columns=name", "find", "Chassis", "hostname="+nodeName)
 	if err != nil {
-		logrus.Errorf("No system-id configured in the local host, "+
-			"stderr: %q, error: %v", stderr, err)
+		logrus.Errorf("Failed to find Chassis ID for node %s, "+
+			"stderr: %q, error: %v", nodeName, stderr, err)
 		return "", err
 	}
-	if localSystemID == "" {
-		return "", fmt.Errorf("No system-id configured in the local host")
+	if chassisID == "" {
+		return "", fmt.Errorf("No chassis ID configured for node %s", nodeName)
 	}
 
-	return localSystemID, nil
+	return chassisID, nil
 }
 
 // GetDefaultGatewayRouterIP returns the first gateway logical router name
@@ -165,8 +164,8 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, error) {
 }
 
 // GatewayInit creates a gateway router for the local chassis.
-func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
-	bridgeInterface, defaultGW, rampoutIPSubnet string, gatewayVLANId uint,
+func GatewayInit(clusterIPSubnet []string, nodeName, ifaceID, nicIP, nicMacAddress,
+	defaultGW string, rampoutIPSubnet string, localnet bool, gatewayVLANId uint,
 	gatewayLBEnable bool) error {
 
 	ip, physicalIPNet, err := net.ParseCIDR(nicIP)
@@ -187,7 +186,7 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 		return err
 	}
 
-	systemID, err := getLocalSystemID()
+	systemID, err := getNodeChassisID(nodeName)
 	if err != nil {
 		return err
 	}
@@ -311,75 +310,20 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 			"stderr: %q, error: %v", stdout, stderr, err)
 	}
 
-	var ifaceID, macAddress string
-	var localNetArgs = []string{}
-	if physicalInterface != "" {
-		// Connect physical interface to br-int. Get its mac address.
-		ifaceID = physicalInterface + "_" + nodeName
-		addPortCmdArgs := []string{"--", "--may-exist", "add-port",
-			"br-int", physicalInterface, "--", "set", "interface",
-			physicalInterface, "external-ids:iface-id=" + ifaceID}
-		if gatewayVLANId != 0 {
-			addPortCmdArgs = append(addPortCmdArgs, "--", "set", "port", physicalInterface,
-				fmt.Sprintf("tag=%d", gatewayVLANId))
-		}
-		stdout, stderr, err = RunOVSVsctl(addPortCmdArgs...)
-		if err != nil {
-			return fmt.Errorf("Failed to add port to br-int, stdout: %q, "+
-				"stderr: %q, error: %v", stdout, stderr, err)
-		}
-		macAddress, stderr, err = RunOVSVsctl("--if-exists", "get",
-			"interface", physicalInterface, "mac_in_use")
-		if err != nil {
-			return fmt.Errorf("Failed to get macAddress, stderr: %q, error: %v",
-				stderr, err)
-		}
-
-		// Flush the IP address of the physical interface.
-		_, _, err = RunIP("addr", "flush", "dev", physicalInterface)
-		if err != nil {
-			return err
-		}
-	} else {
-		// A OVS bridge's mac address can change when ports are added to it.
-		// We cannot let that happen, so make the bridge mac address permanent.
-		macAddress, stderr, err = RunOVSVsctl("--if-exists", "get",
-			"interface", bridgeInterface, "mac_in_use")
-		if err != nil {
-			return fmt.Errorf("Failed to get macAddress, stderr: %q, error: %v",
-				stderr, err)
-		}
-		if macAddress == "" {
-			return fmt.Errorf("No mac_address found for the bridge-interface")
-		}
-		if runtime.GOOS == windowsOS && macAddress == "00:00:00:00:00:00" {
-			macAddress, err = FetchIfMacWindows(bridgeInterface)
-			if err != nil {
-				return err
-			}
-		}
-		stdout, stderr, err = RunOVSVsctl("set", "bridge",
-			bridgeInterface, "other-config:hwaddr="+macAddress)
-		if err != nil {
-			return fmt.Errorf("Failed to set bridge, stdout: %q, stderr: %q, "+
-				"error: %v", stdout, stderr, err)
-		}
-		ifaceID = bridgeInterface + "_" + nodeName
-		localNetArgs = []string{"--", "lsp-set-type", ifaceID, "localnet",
-			"--", "lsp-set-options", ifaceID,
-			fmt.Sprintf("network_name=%s", PhysicalNetworkName)}
-		if gatewayVLANId != 0 {
-			localNetArgs = append(localNetArgs, "--", "set", "logical_switch_port",
-				ifaceID, fmt.Sprintf("tag_request=%d", gatewayVLANId))
-		}
-	}
-
 	// Add external interface as a logical port to external_switch.
 	// This is a learning switch port with "unknown" address. The external
 	// world is accessed via this port.
 	cmdArgs := []string{"--", "--may-exist", "lsp-add", externalSwitch, ifaceID,
 		"--", "lsp-set-addresses", ifaceID, "unknown"}
-	cmdArgs = append(cmdArgs, localNetArgs...)
+	if localnet {
+		cmdArgs = append(cmdArgs, "--", "lsp-set-type", ifaceID,
+			"localnet", "--", "lsp-set-options", ifaceID,
+			"network_name="+PhysicalNetworkName)
+	}
+	if gatewayVLANId != 0 {
+		cmdArgs = append(cmdArgs, "--", "set", "logical_switch_port",
+			ifaceID, fmt.Sprintf("tag_request=%d", gatewayVLANId))
+	}
 	stdout, stderr, err = RunOVNNbctl(cmdArgs...)
 	if err != nil {
 		return fmt.Errorf("Failed to add logical port to switch, stdout: %q, "+
@@ -389,7 +333,7 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 	// Connect GR to external_switch with mac address of external interface
 	// and that IP address.
 	stdout, stderr, err = RunOVNNbctl("--", "--may-exist", "lrp-add",
-		gatewayRouter, "rtoe-"+gatewayRouter, macAddress, physicalIPMask,
+		gatewayRouter, "rtoe-"+gatewayRouter, nicMacAddress, physicalIPMask,
 		"--", "set", "logical_router_port", "rtoe-"+gatewayRouter,
 		"external-ids:gateway-physical-ip=yes")
 	if err != nil {
@@ -402,7 +346,7 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 		externalSwitch, "etor-"+gatewayRouter, "--", "set",
 		"logical_switch_port", "etor-"+gatewayRouter, "type=router",
 		"options:router-port=rtoe-"+gatewayRouter,
-		"addresses="+"\""+macAddress+"\"")
+		"addresses="+"\""+nicMacAddress+"\"")
 	if err != nil {
 		return fmt.Errorf("Failed to add logical port to router, stdout: %q, "+
 			"stderr: %q, error: %v", stdout, stderr, err)


### PR DESCRIPTION
Move all vswitch, MAC retrieval, and IP operations out of the common gateway code in pkg/util. This will allow us to run the local operations only on the nodes but all the logical network operations on the master in the near future.

@girishmg @shettyg @squeed @danwinship @pecameron @rcarrillocruz 