### PR TITLE
Add arm64 support for daemonset image build

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -21,6 +21,7 @@ USER root
 ENV PYTHONDONTWRITEBYTECODE yes
 
 COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
+RUN if [ "$(uname -m)" = "aarch64" ]; then sed -i "s/x86_64/aarch64/" /etc/yum.repos.d/kubernetes.repo; fi
 RUN yum install -y  \
 	PyYAML bind-utils \
 	openssl \
@@ -41,14 +42,16 @@ ARG ovsVer=2.10.1
 ARG ovsSubVer=3.el7
 ARG dpdkVer=17.11
 ARG dpdkSubVer=3.el7
-RUN rpm -i http://cbs.centos.org/kojifiles/packages/dpdk/${dpdkVer}/${dpdkSubVer}/${rpmArch}/dpdk-${dpdkVer}-${dpdkSubVer}.${rpmArch}.rpm
+ARG dpdkRpmUrl=http://cbs.centos.org/kojifiles/packages/dpdk/${dpdkVer}/${dpdkSubVer}/${rpmArch}/dpdk-${dpdkVer}-${dpdkSubVer}.${rpmArch}.rpm
+
+RUN if [ "$(uname -m)" = "aarch64" ]; then dpdkRpmUrl=https://rpmfind.net/linux/fedora/linux/updates/28/Everything/aarch64/Packages/d/dpdk-17.11.2-1.fc28.aarch64.rpm; fi && rpm -i ${dpdkRpmUrl}
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-common-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-central-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-host-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-vtep-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-devel-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
-RUN rpm -i http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/containernetworking-cni-0.5.1-1.el7.x86_64.rpm
+RUN rpm -i http://dl.fedoraproject.org/pub/epel/7/${rpmArch}/Packages/c/containernetworking-cni-0.5.1-1.el7.${rpmArch}.rpm
 RUN rm -rf /var/cache/yum
 
 RUN mkdir -p /var/run/openvswitch


### PR DESCRIPTION
Add arm64 support for docker build based on Centos:
1. Add aarch64 support for kubernetes.repo
2. Add/fix the aarch64 suport for dpdk rpm install
3. Add multi-arch support for containernetworking-cni package

The docker build command for aarch64 could be:
docker build --build-arg rpmArch=aarch64 -t some_tag .
The commit would NOT affect the original building work on x86, and had been tested both on x86_64 and aarch64.

Signed-off-by: trevor tao <trevor.tao@arm.com>