### PR TITLE
dist: simplify kubernetes.repo and Dockerfile interaction

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -21,7 +21,6 @@ USER root
 ENV PYTHONDONTWRITEBYTECODE yes
 
 COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
-RUN if [ "$(uname -m)" = "aarch64" ]; then sed -i "s/x86_64/aarch64/" /etc/yum.repos.d/kubernetes.repo; fi
 RUN yum install -y  \
 	PyYAML bind-utils \
 	openssl \

--- a/dist/images/kubernetes.repo
+++ b/dist/images/kubernetes.repo
@@ -1,6 +1,6 @@
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$basearch
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1


### PR DESCRIPTION
Let's just use what yum already does with $basearch rather than doing
magic in the Dockerfile.

Fixes: https://github.com/ovn-org/ovn-kubernetes/pull/721

Signed-off-by: Dan Williams <dcbw@redhat.com>