### PR TITLE
cleanup OVS resources on k8s node upon ovnkube-node pod deletion

### DIFF
--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -84,6 +84,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/root/ovnkube.sh", "cleanup-ovs-server"]
 
 
       # firewall rules for ovn - assumed to be setup
@@ -278,7 +282,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["rm","-f","/etc/cni/net.d/10-ovn-kubernetes.conf"]
+              command: ["/root/ovnkube.sh", "cleanup-ovn-node"]
 
       nodeSelector:
         beta.kubernetes.io/os: "linux"

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -190,10 +190,23 @@ func runOvnKube(ctx *cli.Context) error {
 	netController := ctx.Bool("net-controller")
 	master := ctx.String("init-master")
 	node := ctx.String("init-node")
+	clusterController := ovncluster.NewClusterController(clientset, factory)
+
+	cleanupNode := ctx.String("cleanup-node")
+	if cleanupNode != "" {
+		if master != "" || node != "" {
+			panic("Cannot specify cleanup-node together with 'init-node or 'init-master'.")
+		}
+
+		err = clusterController.CleanupClusterNode(cleanupNode)
+		if err != nil {
+			logrus.Errorf(err.Error())
+			panic(err.Error())
+		}
+		return nil
+	}
 
 	if master != "" || node != "" {
-		clusterController := ovncluster.NewClusterController(clientset, factory)
-
 		clusterController.ClusterIPNet, err = parseClusterSubnetEntries(ctx.String("cluster-subnet"))
 		if err != nil {
 			panic(err.Error())

--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -102,3 +102,15 @@ func (cluster *OvnClusterController) initGateway(
 
 	return err
 }
+
+func (cluster *OvnClusterController) cleanupGateway(nodeName string) error {
+	switch config.Gateway.Mode {
+	case config.GatewayModeLocal:
+		return cleanupLocalnetGateway()
+	case config.GatewayModeSpare:
+		return cleanupSpareGateway(config.Gateway.Interface, nodeName)
+	case config.GatewayModeShared:
+		return cleanupSharedGateway()
+	}
+	return nil
+}

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -313,11 +313,11 @@ func spareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		fexec := ovntest.NewFakeExec()
 		if gatewayVLANID == 0 {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int eth0 -- set interface eth0 external-ids:iface-id=eth0_" + nodeName,
+				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int eth0 -- set interface eth0 external-ids:iface-id=eth0_" + nodeName + " external-ids:physical-ip=" + eth0CIDR,
 			})
 		} else {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int eth0 -- set interface eth0 external-ids:iface-id=eth0_" + nodeName + fmt.Sprintf(" -- set port eth0 tag=%d", gatewayVLANID),
+				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int eth0 -- set interface eth0 external-ids:iface-id=eth0_" + nodeName + " external-ids:physical-ip=" + eth0CIDR + fmt.Sprintf(" -- set port eth0 tag=%d", gatewayVLANID),
 			})
 		}
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -309,3 +309,18 @@ func localnetNodePortWatcher(ipt util.IPTablesHelper, wf *factory.WatchFactory) 
 	}, nil)
 	return err
 }
+
+func cleanupLocalnetGateway() error {
+	// get bridgeName from ovn-bridge-mappings.
+	stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",
+		"external_ids:ovn-bridge-mappings")
+	if err != nil {
+		return fmt.Errorf("Failed to get ovn-bridge-mappings stderr:%s (%v)", stderr, err)
+	}
+	bridgeName := strings.Split(stdout, ":")[1]
+	_, stderr, err = util.RunOVSVsctl("--", "--if-exists", "del-br", bridgeName)
+	if err != nil {
+		return fmt.Errorf("Failed to ovs-vsctl del-br %s stderr:%s (%v)", bridgeName, stderr, err)
+	}
+	return err
+}

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -348,3 +348,20 @@ func initSharedGateway(
 
 	return nil
 }
+
+func cleanupSharedGateway() error {
+	// NicToBridge() may be created before-hand, only delete the patch port here
+	stdout, stderr, err := util.RunOVSVsctl("--columns=name", "--no-heading", "find", "port",
+		"external_ids:ovn-localnet-port!=_")
+	if err != nil {
+		return fmt.Errorf("Failed to get ovn-localnet-port port stderr:%s (%v)", stderr, err)
+	}
+	ports := strings.Fields(strings.Trim(stdout, "\""))
+	for _, port := range ports {
+		_, stderr, err := util.RunOVSVsctl("--if-exists", "del-port", strings.Trim(port, "\""))
+		if err != nil {
+			return fmt.Errorf("Failed to delete port %s stderr:%s (%v)", port, stderr, err)
+		}
+	}
+	return nil
+}

--- a/go-controller/pkg/cluster/gateway_spare_intf.go
+++ b/go-controller/pkg/cluster/gateway_spare_intf.go
@@ -25,7 +25,8 @@ func initSpareGateway(nodeName string, clusterIPSubnet []string,
 	ifaceID := gwIntf + "_" + nodeName
 	addPortCmdArgs := []string{"--", "--may-exist", "add-port",
 		"br-int", gwIntf, "--", "set", "interface",
-		gwIntf, "external-ids:iface-id=" + ifaceID}
+		gwIntf, "external-ids:iface-id=" + ifaceID,
+		"external-ids:physical-ip=" + ipAddress}
 	if config.Gateway.VLANID != 0 {
 		addPortCmdArgs = append(addPortCmdArgs, "--", "set", "port", gwIntf,
 			fmt.Sprintf("tag=%d", config.Gateway.VLANID))
@@ -52,6 +53,28 @@ func initSpareGateway(nodeName string, clusterIPSubnet []string,
 		macAddress, gwNextHop, subnet, false, nil)
 	if err != nil {
 		return fmt.Errorf("failed to init spare interface gateway: %v", err)
+	}
+
+	return nil
+}
+
+func cleanupSpareGateway(physicalInterface, nodeName string) error {
+	ifaceID := physicalInterface + "_" + nodeName
+	stdout, stderr, err := util.RunOVSVsctl("--data=bare", "--columns=name", "--no-heading", "find", "interface",
+		"external-ids:iface-id="+ifaceID)
+	if err != nil {
+		return fmt.Errorf("Failed to get the physical interface %q on br-int stderr:%s (%v)",
+			physicalInterface, stderr, err)
+	}
+	nicIP, stderr, err := util.RunOVSVsctl("--data=bare", "get", "interface", stdout, "external-ids:physical-ip")
+	if err != nil {
+		return fmt.Errorf("Failed to get the IP associated with the physical interface %q, stderr:%s (%v)",
+			stdout, stderr, err)
+	}
+	_, _, err = util.RunIP("addr", "add", nicIP, "dev", physicalInterface)
+	if err != nil {
+		return fmt.Errorf("Failed to add IP address %s back to interface %s, error: %v",
+			nicIP, physicalInterface, err)
 	}
 
 	return nil

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -159,4 +160,31 @@ func (cluster *OvnClusterController) watchConfigEndpoints() error {
 			},
 		}, nil)
 	return err
+}
+
+// CleanupClusterNode cleans up OVS resources on the k8s node on ovnkube-node daemonset deletion.
+// This is going to be a best effort cleanup.
+func (cluster *OvnClusterController) CleanupClusterNode(name string) error {
+	var err error
+	var node *kapi.Node
+	var nodeName string
+
+	node, err = cluster.Kube.GetNode(name)
+	if err != nil {
+		logrus.Errorf("Failed to get kubernetes node %q, error: %v", name, err)
+		return nil
+	}
+	nodeName = strings.ToLower(node.Name)
+	err = cluster.cleanupGateway(nodeName)
+	if err != nil {
+		logrus.Errorf("Failed to cleanup Gateway, error: %v", err)
+	}
+
+	// Make sure br-int is deleted, the management internal port is also deleted at the same time.
+	stdout, stderr, err := util.RunOVSVsctl("--", "--if-exists", "del-br", "br-int")
+	if err != nil {
+		logrus.Errorf("Failed to delete bridge br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+	}
+
+	return nil
 }

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -315,6 +315,10 @@ var CommonFlags = []cli.Flag{
 		Usage: "initialize node, requires the name that node is registered with in kubernetes cluster",
 	},
 	cli.StringFlag{
+		Name:  "cleanup-node",
+		Usage: "cleanup node, requires the name that node is registered with in kubernetes cluster",
+	},
+	cli.StringFlag{
 		Name:  "pidfile",
 		Usage: "Name of file that will hold the ovnkube pid (optional)",
 	},


### PR DESCRIPTION
on each of the k8s node, based on the gateway mode, we create several
OVS resources namely
-- bridges, like br-int, br-local
-- ports, k8s-`hostname`, br-nexthop, patch ports

These resources are not cleaned up on the deletion of the onvkube-node
pod. This change adds a preStop hook to ovn-node and ovs-daemons
containers in the ovnkube-node POD to perform cleanup.

Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>