### PR TITLE
gateway: pick the first IP address from the interface

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -16,12 +16,16 @@ func getIPv4Address(iface string) (string, error) {
 	if err != nil {
 		return ipAddress, err
 	}
-
+loop:
 	for _, addr := range addrs {
 		switch ip := addr.(type) {
 		case *net.IPNet:
 			if ip.IP.To4() != nil {
 				ipAddress = ip.String()
+			}
+			// get the first ip address
+			if ipAddress != "" {
+				break loop
 			}
 		}
 	}


### PR DESCRIPTION
it is possible that the IP interface can have more than one IP address
and we end up picking up the wrong address.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>