### PR TITLE
Change the source repo of containernetwork-cni

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -50,7 +50,7 @@ RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsS
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-host-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-vtep-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-devel-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
-RUN rpm -i http://dl.fedoraproject.org/pub/epel/7/${rpmArch}/Packages/c/containernetworking-cni-0.5.1-1.el7.${rpmArch}.rpm
+RUN rpm -i http://ftp.vcu.edu/pub/gnu_linux/epel/7Server/${rpmArch}/Packages/c/containernetworking-cni-0.5.1-1.el7.${rpmArch}.rpm
 RUN rm -rf /var/cache/yum
 
 RUN mkdir -p /var/run/openvswitch

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -189,7 +189,7 @@ spec:
       # end of container
 
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
         beta.kubernetes.io/os: "linux"
       volumes:
       # In bootstrap mode, the host config contains information not easily available

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -1,4 +1,5 @@
 # ovnkube-master
+    - "bar.remote"
 # daemonset version 3
 # starts master daemons, each in a separate container
 # it is run on the master node(s)
@@ -246,7 +247,7 @@ spec:
       # end of container
 
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
         beta.kubernetes.io/os: "linux"
       volumes:
       # In bootstrap mode, the host config contains information not easily available


### PR DESCRIPTION
It seems the containernetwork-cni rpm package had been
removed from the official fedoraproject repo which leads to
an error when building the image.
Now we turn to a 3rd party repo to get that package and
make the building process work.

Signed-off-by: trevor tao <trevor.tao@arm.com>