### PR TITLE
Change the value for selecting the master node

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,10 @@ sudo apt-get install openvswitch-datapath-dkms -y
 
 ## Run daemonsets
 
-On Kubernetes master, label it to run daemonsets. $NODENAME below is master's
-node name.
+On Kubernetes master, label it to run daemonsets.
 
 ```
 kubectl taint nodes --all node-role.kubernetes.io/master-
-kubectl label node $NODENAME node-role.kubernetes.io/master=true --overwrite
 ```
 
 Create OVN daemonset yamls from templates by:

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -189,7 +189,7 @@ spec:
       # end of container
 
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
         beta.kubernetes.io/os: "linux"
       volumes:
       # In bootstrap mode, the host config contains information not easily available

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -246,7 +246,7 @@ spec:
       # end of container
 
       nodeSelector:
-        node-role.kubernetes.io/master: "true"
+        node-role.kubernetes.io/master: ""
         beta.kubernetes.io/os: "linux"
       volumes:
       # In bootstrap mode, the host config contains information not easily available

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -233,9 +233,6 @@ else
   --k8s-apiserver=https://$OVERLAY_IP:6443
   popd
 
-  # label the master node for daemonsets
-  kubectl label node k8smaster node-role.kubernetes.io/master=true --overwrite
-
   # Create OVN namespace, service accounts, ovnkube-db headless service, configmap, and policies
   kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/ovn-setup.yaml
 


### PR DESCRIPTION
For most current Kubernetes master node, the label value of
"node-role.kubernetes.io/master" is just ""(empty), not "true".

So when using the nodeSelector to choose the master of K8s cluster,
we should use just an empty value "" instead of a "true" value, which
means if there is a label "node-role.kubernetes.io/master" set in the node,
it's the desired master node.

If the value of "true" is used, there may be NO approriate node
that can be found to run the pod when deploying the pod.

Signed-off-by: trevor tao <trevor.tao@arm.com>