### PR TITLE
yaml: ovnkube-db and ovnkbue-master need not be on the same k8s node

### DIFF
--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -39,17 +39,7 @@ spec:
       serviceAccountName: ovn
       hostNetwork: true
       hostPID: true
-      # TODO: For now always place ovnkube-master POD in the same node as ovnkube-db POD till will fix #644
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: name
-                  operator: In
-                  values:
-                    - ovnkube-db
-            topologyKey: kubernetes.io/hostname
+
       containers:
 
       # run-ovn-northd - v3


### PR DESCRIPTION
Now that we don't make the assumption that the OVN DBs and its clients
OVN northd and ovnkube-master are on the same k8s node, remove the
limitation in the ovnkube-master POD yaml that restricts both ovnkube-db
and ovnkube-master to be on the same node.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>