### PR TITLE
config: add gateway options as full config options

### DIFF
--- a/docs/ovn_k8s.conf.5
+++ b/docs/ovn_k8s.conf.5
@@ -114,6 +114,27 @@ The port, by default, is 6442. E.g., ssl://1.2.3.4:6642
 .TP
 \fBserver-cacert\fR=
 
+.SH [Gateway]
+.TP
+\fBmode\fR=shared
+This is the node gateway mode. It can be left empty (disable gateway functionality),
+or set to "shared" (share a network interface), "spare" (take over a network interface),
+or "local" (use a NAT-ed virtual interface).
+.TP
+\fBinterface\fR=eth1
+This interface will be used as the gateway interface in "shared" or "spare" mode. If not
+specified the interface with the default route will be used.
+.TP
+\fBnext-hop\fR=1.2.3.4
+This is the gateway IP address of \fBinterface\fR to which traffic exiting the
+OVN logical network should be sent in "shared" or "spare" mode. If not specified
+the next-hop of the default route will be used.
+\fBvlan-id\fR=0
+This is the VLAN tag to apply to traffic exiting the OVN logical network in
+"shared" or "spare" mode. A value of 0 means traffic should be untagged.
+\fBnodeport\fR=true
+When set to true Kubernetes NodePort services will be supported.
+
 .SH "SEE ALso"
 .BR ovnkube (1),
 .BR ovn-kube-util (1).

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -190,23 +190,14 @@ func runOvnKube(ctx *cli.Context) error {
 	netController := ctx.Bool("net-controller")
 	master := ctx.String("init-master")
 	node := ctx.String("init-node")
-	nodePortEnable := ctx.Bool("nodeport")
 
 	if master != "" || node != "" {
 		clusterController := ovncluster.NewClusterController(clientset, factory)
-		clusterController.GatewayInit = ctx.Bool("init-gateways")
-		clusterController.GatewayIntf = ctx.String("gateway-interface")
-		clusterController.GatewayNextHop = ctx.String("gateway-nexthop")
-		clusterController.GatewaySpareIntf = ctx.Bool("gateway-spare-interface")
-		clusterController.LocalnetGateway = ctx.Bool("gateway-local")
-		clusterController.GatewayVLANID = ctx.Uint("gateway-vlanid")
 
 		clusterController.ClusterIPNet, err = parseClusterSubnetEntries(ctx.String("cluster-subnet"))
 		if err != nil {
 			panic(err.Error())
 		}
-
-		clusterController.NodePortEnable = nodePortEnable
 
 		if master != "" {
 			if runtime.GOOS == "windows" {
@@ -233,7 +224,7 @@ func runOvnKube(ctx *cli.Context) error {
 		}
 	}
 	if netController {
-		ovnController := ovn.NewOvnController(clientset, factory, nodePortEnable)
+		ovnController := ovn.NewOvnController(clientset, factory)
 		if err := ovnController.Run(); err != nil {
 			logrus.Errorf(err.Error())
 			panic(err.Error())

--- a/go-controller/etc/ovn_k8s.conf
+++ b/go-controller/etc/ovn_k8s.conf
@@ -21,3 +21,6 @@ address=tcp://ovn_master_ip:6641
 [OvnSouth]
 address=tcp://ovn_master_ip:6642
 
+[gateway]
+mode=shared
+nodeport=true

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -22,14 +22,6 @@ type OvnClusterController struct {
 	UDPLoadBalancerUUID string
 
 	ClusterIPNet []CIDRNetworkEntry
-
-	GatewayInit      bool
-	GatewayIntf      string
-	GatewayNextHop   string
-	GatewaySpareIntf bool
-	GatewayVLANID    uint
-	NodePortEnable   bool
-	LocalnetGateway  bool
 }
 
 // CIDRNetworkEntry is the object that holds the definition for a single network CIDR range

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -25,7 +25,6 @@ type OvnClusterController struct {
 
 	GatewayInit      bool
 	GatewayIntf      string
-	GatewayBridge    string
 	GatewayNextHop   string
 	GatewaySpareIntf bool
 	GatewayVLANID    uint

--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -94,13 +94,12 @@ func (cluster *OvnClusterController) initGateway(
 			cluster.NodePortEnable)
 	}
 
-	bridge, gwIntf, err := initSharedGateway(nodeName, clusterIPSubnet, subnet,
+	gwIntf, err := initSharedGateway(nodeName, clusterIPSubnet, subnet,
 		cluster.GatewayNextHop, cluster.GatewayIntf, cluster.GatewayVLANID,
 		cluster.NodePortEnable, cluster.watchFactory)
 	if err != nil {
 		return err
 	}
-	cluster.GatewayBridge = bridge
 	cluster.GatewayIntf = gwIntf
 	return nil
 }

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -239,13 +239,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		defer wf.Shutdown()
 
 		cluster := OvnClusterController{
-			watchFactory:     wf,
-			GatewayInit:      true,
-			GatewayIntf:      eth0Name,
-			GatewaySpareIntf: false,
-			NodePortEnable:   true,
-			LocalnetGateway:  false,
-			GatewayVLANID:    gatewayVLANID,
+			watchFactory: wf,
 		}
 
 		ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
@@ -288,7 +282,13 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		return nil
 	}
 
-	err := app.Run([]string{app.Name})
+	err := app.Run([]string{
+		app.Name,
+		"--init-gateways",
+		"--gateway-interface=" + eth0Name,
+		"--nodeport",
+		"--gateway-vlanid=" + fmt.Sprintf("%d", gatewayVLANID),
+	})
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -391,13 +391,7 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 		defer wf.Shutdown()
 
 		cluster := OvnClusterController{
-			watchFactory:     wf,
-			GatewayInit:      true,
-			GatewayIntf:      eth0Name,
-			GatewaySpareIntf: true,
-			NodePortEnable:   true,
-			LocalnetGateway:  false,
-			GatewayVLANID:    gatewayVLANID,
+			watchFactory: wf,
 		}
 
 		ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
@@ -438,7 +432,14 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 		return nil
 	}
 
-	err := app.Run([]string{app.Name})
+	err := app.Run([]string{
+		app.Name,
+		"--init-gateways",
+		"--gateway-interface=" + eth0Name,
+		"--gateway-spare-interface",
+		"--nodeport",
+		"--gateway-vlanid=" + fmt.Sprintf("%d", gatewayVLANID),
+	})
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -566,7 +567,7 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 
 			ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
 			Expect(err).NotTo(HaveOccurred())
-			err = initLocalnetGatewayInternal(nodeName, []string{clusterCIDR}, nodeSubnet, ipt, true, wf)
+			err = initLocalnetGatewayInternal(nodeName, []string{clusterCIDR}, nodeSubnet, ipt, wf)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue())
@@ -597,7 +598,12 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 			return nil
 		}
 
-		err := app.Run([]string{app.Name})
+		err := app.Run([]string{
+			app.Name,
+			"--init-gateways",
+			"--gateway-local",
+			"--nodeport",
+		})
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/go-controller/pkg/cluster/gateway_localnet_windows.go
+++ b/go-controller/pkg/cluster/gateway_localnet_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 func initLocalnetGateway(nodeName string, clusterIPSubnet []string,
-	subnet string, nodePortEnable bool, wf *factory.WatchFactory) error {
+	subnet string, wf *factory.WatchFactory) error {
 	// TODO: Implement this
 	return fmt.Errorf("Not implemented yet on Windows")
 }

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -277,8 +277,7 @@ func addStaticRouteToHost(nodeName, nicIP string) error {
 
 func initSharedGateway(
 	nodeName string, clusterIPSubnet []string, subnet,
-	gwNextHop, gwIntf string, gwVLANId uint, nodeportEnable bool,
-	wf *factory.WatchFactory) (string, error) {
+	gwNextHop, gwIntf string, wf *factory.WatchFactory) error {
 	var bridgeName string
 
 	// Check to see whether the interface is OVS bridge.
@@ -287,13 +286,13 @@ func initSharedGateway(
 		// and add cluster.GatewayIntf as a port of that bridge.
 		bridgeName, err = util.NicToBridge(gwIntf)
 		if err != nil {
-			return "", fmt.Errorf("failed to convert %s to OVS bridge: %v",
+			return fmt.Errorf("failed to convert %s to OVS bridge: %v",
 				gwIntf, err)
 		}
 	} else {
 		intfName, err := getIntfName(gwIntf)
 		if err != nil {
-			return "", err
+			return err
 		}
 		bridgeName = gwIntf
 		gwIntf = intfName
@@ -303,43 +302,49 @@ func initSharedGateway(
 	// error out.
 	ipAddress, err := getIPv4Address(bridgeName)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get interface details for %s (%v)",
+		return fmt.Errorf("Failed to get interface details for %s (%v)",
 			bridgeName, err)
 	}
 	if ipAddress == "" {
-		return "", fmt.Errorf("%s does not have a ipv4 address", bridgeName)
+		return fmt.Errorf("%s does not have a ipv4 address", bridgeName)
 	}
 
 	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, bridgeName)
 	if err != nil {
-		return "", fmt.Errorf("failed to set up shared interface gateway: %v", err)
+		return fmt.Errorf("failed to set up shared interface gateway: %v", err)
+	}
+
+	var lspArgs []string
+	if config.Gateway.VLANID > 0 {
+		lspArgs = []string{"--", "set", "logical_switch_port",
+			ifaceID, fmt.Sprintf("tag_request=%d", config.Gateway.VLANID)}
 	}
 
 	err = util.GatewayInit(clusterIPSubnet, nodeName, ifaceID, ipAddress,
-		macAddress, gwNextHop, subnet, true, gwVLANId, nodeportEnable)
+		macAddress, gwNextHop, subnet, true, lspArgs)
 	if err != nil {
-		return "", fmt.Errorf("failed to init shared interface gateway: %v", err)
+		return fmt.Errorf("failed to init shared interface gateway: %v", err)
 	}
 
 	// Add static routes to OVN Cluster Router to enable pods on this Node to
 	// reach the host IP
 	err = addStaticRouteToHost(nodeName, ipAddress)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	// Program cluster.GatewayIntf to let non-pod traffic to go to host
 	// stack
 	if err := addDefaultConntrackRules(nodeName, bridgeName, gwIntf); err != nil {
-		return "", err
+		return err
 	}
 
-	if nodeportEnable {
+	if config.Gateway.NodeportEnable {
 		// Program cluster.GatewayIntf to let nodePort traffic to go to pods.
 		if err := nodePortWatcher(nodeName, bridgeName, gwIntf, wf); err != nil {
-			return "", err
+			return err
 		}
 	}
 
-	return gwIntf, nil
+	return nil
 }

--- a/go-controller/pkg/cluster/gateway_spare_intf.go
+++ b/go-controller/pkg/cluster/gateway_spare_intf.go
@@ -3,11 +3,12 @@ package cluster
 import (
 	"fmt"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 func initSpareGateway(nodeName string, clusterIPSubnet []string,
-	subnet, gwNextHop, gwIntf string, gwVLANId uint, nodeportEnable bool) error {
+	subnet, gwNextHop, gwIntf string) error {
 
 	// Now, we get IP address from physical interface. If IP does not
 	// exists error out.
@@ -25,9 +26,9 @@ func initSpareGateway(nodeName string, clusterIPSubnet []string,
 	addPortCmdArgs := []string{"--", "--may-exist", "add-port",
 		"br-int", gwIntf, "--", "set", "interface",
 		gwIntf, "external-ids:iface-id=" + ifaceID}
-	if gwVLANId != 0 {
+	if config.Gateway.VLANID != 0 {
 		addPortCmdArgs = append(addPortCmdArgs, "--", "set", "port", gwIntf,
-			fmt.Sprintf("tag=%d", gwVLANId))
+			fmt.Sprintf("tag=%d", config.Gateway.VLANID))
 	}
 	stdout, stderr, err := util.RunOVSVsctl(addPortCmdArgs...)
 	if err != nil {
@@ -48,7 +49,7 @@ func initSpareGateway(nodeName string, clusterIPSubnet []string,
 	}
 
 	err = util.GatewayInit(clusterIPSubnet, nodeName, ifaceID, ipAddress,
-		macAddress, gwNextHop, subnet, false, 0, nodeportEnable)
+		macAddress, gwNextHop, subnet, false, nil)
 	if err != nil {
 		return fmt.Errorf("failed to init spare interface gateway: %v", err)
 	}

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -331,7 +331,7 @@ func (cluster *OvnClusterController) deleteNode(nodeName string, nodeSubnet *net
 		logrus.Errorf("Error deleting node %s logical network: %v", nodeName, err)
 	}
 
-	if err := util.GatewayCleanup(nodeName, cluster.NodePortEnable); err != nil {
+	if err := util.GatewayCleanup(nodeName); err != nil {
 		return fmt.Errorf("Failed to clean up node %s gateway: (%v)", nodeName, err)
 	}
 

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -72,7 +72,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		return err
 	}
 
-	if cluster.GatewayInit {
+	if config.Gateway.Mode != config.GatewayModeDisabled {
 		err = cluster.initGateway(node.Name, clusterSubnets, subnet.String())
 		if err != nil {
 			return err

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -161,6 +161,13 @@ address=ssl://1.2.3.4:6642
 client-privkey=/path/to/sb-client-private.key
 client-cert=/path/to/sb-client.crt
 client-cacert=/path/to/sb-client-ca.crt
+
+[gateway]
+mode=shared
+interface=eth1
+next-hop=1.3.4.5
+vlan-id=10
+nodeport=false
 `
 
 	var newData string
@@ -465,6 +472,12 @@ var _ = Describe("Config Operations", func() {
 			Expect(OvnSouth.CACert).To(Equal("/path/to/sb-client-ca.crt"))
 			Expect(OvnSouth.Address).To(Equal("ssl:1.2.3.4:6642"))
 
+			Expect(Gateway.Mode).To(Equal(GatewayModeShared))
+			Expect(Gateway.Interface).To(Equal("eth1"))
+			Expect(Gateway.NextHop).To(Equal("1.3.4.5"))
+			Expect(Gateway.VLANID).To(Equal(uint(10)))
+			Expect(Gateway.NodeportEnable).To(BeFalse())
+
 			return nil
 		}
 		err = app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
@@ -513,6 +526,11 @@ var _ = Describe("Config Operations", func() {
 			Expect(OvnSouth.CACert).To(Equal("/client/cacert2"))
 			Expect(OvnSouth.Address).To(Equal("ssl:6.5.4.1:6652"))
 
+			Expect(Gateway.Mode).To(Equal(GatewayModeSpare))
+			Expect(Gateway.Interface).To(Equal("eth5"))
+			Expect(Gateway.NextHop).To(Equal("1.3.5.6"))
+			Expect(Gateway.VLANID).To(Equal(uint(100)))
+			Expect(Gateway.NodeportEnable).To(BeTrue())
 			return nil
 		}
 		cliArgs := []string{
@@ -537,6 +555,12 @@ var _ = Describe("Config Operations", func() {
 			"-sb-client-privkey=/client/privkey2",
 			"-sb-client-cert=/client/cert2",
 			"-sb-client-cacert=/client/cacert2",
+			"-init-gateways",
+			"-gateway-interface=eth5",
+			"-gateway-nexthop=1.3.5.6",
+			"-gateway-spare-interface",
+			"-gateway-vlanid=100",
+			"-nodeport",
 		}
 		err = app.Run(cliArgs)
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
@@ -64,7 +65,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 		targetPort := lbEps.Port
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == kapi.ProtocolTCP && svcPort.Name == svcPortName {
-				if svc.Spec.Type == kapi.ServiceTypeNodePort && ovn.nodePortEnable {
+				if svc.Spec.Type == kapi.ServiceTypeNodePort && config.Gateway.NodeportEnable {
 					logrus.Debugf("Creating Gateways IP for NodePort: %d, %v", svcPort.NodePort, ips)
 					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
 					if err != nil {
@@ -96,7 +97,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 		targetPort := lbEps.Port
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == kapi.ProtocolUDP && svcPort.Name == svcPortName {
-				if svc.Spec.Type == kapi.ServiceTypeNodePort && ovn.nodePortEnable {
+				if svc.Spec.Type == kapi.ServiceTypeNodePort && config.Gateway.NodeportEnable {
 					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
 					if err != nil {
 						logrus.Errorf("Error in creating Node Port for svc %s, node port: %d - %v\n", svc.Name, svcPort.NodePort, err)

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
@@ -191,7 +192,7 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 
 		// targetPort can be anything, the deletion logic does not use it
 		var targetPort int32
-		if service.Spec.Type == kapi.ServiceTypeNodePort && ovn.nodePortEnable {
+		if service.Spec.Type == kapi.ServiceTypeNodePort && config.Gateway.NodeportEnable {
 			// Delete the 'NodePort' service from a load-balancer instantiated in gateways.
 			err := ovn.createGatewaysVIP(string(protocol), port, targetPort, ips)
 			if err != nil {

--- a/go-controller/pkg/util/gateway-cleanup.go
+++ b/go-controller/pkg/util/gateway-cleanup.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 )
 
 // GatewayCleanup removes all the NB DB objects created for a node's gateway
-func GatewayCleanup(nodeName string, gatewayLBEnable bool) error {
+func GatewayCleanup(nodeName string) error {
 	// Get the cluster router
 	clusterRouter, err := GetK8sClusterRouter()
 	if err != nil {
@@ -84,7 +86,7 @@ func GatewayCleanup(nodeName string, gatewayLBEnable bool) error {
 			"error: %v", externalSwitch, stderr, err)
 	}
 
-	if gatewayLBEnable {
+	if config.Gateway.NodeportEnable {
 		//Remove the TCP, UDP load-balancers created for north-south traffic for gateway router.
 		k8sNSLbTCP, k8sNSLbUDP, err := getGatewayLoadBalancers(gatewayRouter)
 		if err != nil {

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"sort"
 	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 )
 
 const (
@@ -165,8 +167,7 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, error) {
 
 // GatewayInit creates a gateway router for the local chassis.
 func GatewayInit(clusterIPSubnet []string, nodeName, ifaceID, nicIP, nicMacAddress,
-	defaultGW string, rampoutIPSubnet string, localnet bool, gatewayVLANId uint,
-	gatewayLBEnable bool) error {
+	defaultGW string, rampoutIPSubnet string, localnet bool, lspArgs []string) error {
 
 	ip, physicalIPNet, err := net.ParseCIDR(nicIP)
 	if err != nil {
@@ -255,7 +256,7 @@ func GatewayInit(clusterIPSubnet []string, nodeName, ifaceID, nicIP, nicMacAddre
 			stdout, stderr, err)
 	}
 
-	if gatewayLBEnable {
+	if config.Gateway.NodeportEnable {
 		// Create 2 load-balancers for north-south traffic for each gateway
 		// router.  One handles UDP and another handles TCP.
 		var k8sNSLbTCP, k8sNSLbUDP string
@@ -320,10 +321,7 @@ func GatewayInit(clusterIPSubnet []string, nodeName, ifaceID, nicIP, nicMacAddre
 			"localnet", "--", "lsp-set-options", ifaceID,
 			"network_name="+PhysicalNetworkName)
 	}
-	if gatewayVLANId != 0 {
-		cmdArgs = append(cmdArgs, "--", "set", "logical_switch_port",
-			ifaceID, fmt.Sprintf("tag_request=%d", gatewayVLANId))
-	}
+	cmdArgs = append(cmdArgs, lspArgs...)
 	stdout, stderr, err = RunOVNNbctl(cmdArgs...)
 	if err != nil {
 		return fmt.Errorf("Failed to add logical port to switch, stdout: %q, "+


### PR DESCRIPTION
Allows their use in the config file, rather than just on the command-line. Girish and I had discussed moving more option processing out of the ovnkube.sh script and into a configmap that would be used as a config file, so that ovnkube.sh is less complicated and config options are easier to change without having to update ovnkube.sh itself.

@girishmg @shettyg @pecameron @danwinship @ovn-org/ovn-kubernetes-committers @JacobTanenbaum @squeed 