### PR TITLE
provide a way to specify gateway options for ovnkube-node daemonset

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ git clone https://github.com/ovn-org/ovn-kubernetes
 cd $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/images
 ./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-u:latest \
     --net-cidr=192.168.0.0/16 --svc-cidr=172.16.1.0/24 \
+    --gateway-options="--gateway-local" \
     --k8s-apiserver=https://$MASTER_IP:6443
 ```
 
@@ -68,8 +69,8 @@ cluster.
 ## Manual installation and Vagrant
 
 For Windows, (and to understand what daemonsets run internally), please read
-[MANUAL.md].  For more advanced use cases too (like SSL and HA of databases),
-please read [MANUAL.md].
+[MANUAL.md].  For more advanced use cases too (like SSL, HA of databases, and various
+gateway modes supported), please read [MANUAL.md].
 
 [INSTALL.rst]: http://docs.openvswitch.org/en/latest/intro/install
 [INSTALL.UBUNTU.md]: docs/INSTALL.UBUNTU.md

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -11,7 +11,8 @@ OVN_IMAGE=""
 OVN_IMAGE_PULL_POLICY=""
 OVN_NET_CIDR=""
 OVN_SVC_DIDR=""
-ONV_K8S_APISERVER=""
+OVN_K8S_APISERVER=""
+OVN_GATEWAY_OPTS=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -23,6 +24,9 @@ while [ "$1" != "" ]; do
             ;;
         --image-pull-policy)
             OVN_IMAGE_PULL_POLICY=$VALUE
+            ;;
+        --gateway-options)
+            OVN_GATEWAY_OPTS=$VALUE
             ;;
         --net-cidr)
             OVN_NET_CIDR=$VALUE
@@ -72,11 +76,16 @@ else
 fi
 echo "imagePullPolicy: ${policy}"
 
+ovn_gateway_opts=${OVN_GATEWAY_OPTS}
+echo "ovn_gateway_opts: ${ovn_gateway_opts}"
+
 # Simplified expansion of template 
 image_str="{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
 policy_str="{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+ovn_gateway_opts_repl="{{ ovn_gateway_opts }}"
 
 sed "s,${image_str},${image},
+s,${ovn_gateway_opts_repl},${ovn_gateway_opts},
 s,${policy_str},${policy}," ../templates/ovnkube-node.yaml.j2 > ../yaml/ovnkube-node.yaml
 
 sed "s,${image_str},${image},

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -114,8 +114,9 @@ ovn_controller_opts=${OVN_CONTROLLER_OPTS:-""}
 # set the log level for ovnkube
 ovnkube_loglevel=${OVNKUBE_LOGLEVEL:-4}
 
-#OVN_GATEWAY_OPTS=""
-ovn_gateway_opts=${OVN_GATEWAY_OPTS:-"--gateway-local"}
+# by default it is going to be a shared gateway mode, however this can be overridden to any of the other
+# two gateway modes that we support using `images/daemonset.sh` tool
+ovn_gateway_opts=${OVN_GATEWAY_OPTS:-""}
 
 net_cidr=${OVN_NET_CIDR:-10.128.0.0/14/23}
 svc_cidr=${OVN_SVC_CIDR:-172.30.0.0/16}

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -259,6 +259,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: OVN_GATEWAY_OPTS
+          value: "{{ ovn_gateway_opts }}"
 
         ports:
         - name: healthz

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -230,6 +230,7 @@ else
   pushd $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/images
   ./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-u:latest \
   --net-cidr=192.168.0.0/16 --svc-cidr=172.16.1.0/24 \
+  --gateway-options="--gateway-local" \
   --k8s-apiserver=https://$OVERLAY_IP:6443
   popd
 


### PR DESCRIPTION
daemonset.sh now supports --gateway-options CLI switch using which one
can specify one of the 3 gateway modes that we support. When specified,
the ovnkube-node POD spec will expose an environment variable capturing
the gateway options. The onvkube.sh reads this environment variable and
does the right thing.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>