### PR TITLE
Remove the installation of containernetwork-cni

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -50,7 +50,6 @@ RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsS
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-host-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-vtep-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-devel-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
-RUN rpm -i http://dl.fedoraproject.org/pub/epel/7/${rpmArch}/Packages/c/containernetworking-cni-0.5.1-1.el7.${rpmArch}.rpm
 RUN rm -rf /var/cache/yum
 
 RUN mkdir -p /var/run/openvswitch


### PR DESCRIPTION
It seems the containernetwork-cni rpm package had been
removed from the official fedoraproject repo which leads to
an error when building the image.
Now we just remove that package installation since
containernetworking-cni is not needed to build the image.

Do it to the comments of PR727:
https://github.com/ovn-org/ovn-kubernetes/pull/727

Signed-off-by: trevor tao <trevor.tao@arm.com>