### PR TITLE
Change debian source repository's IP address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ the kernel module package by:
 
 ```
 sudo apt-get install apt-transport-https
-echo "deb http://18.191.116.101/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
-wget -O - http://18.191.116.101/openvswitch/keyFile |  sudo apt-key add -
+echo "deb http://3.19.28.122/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
+wget -O - http://3.19.28.122/openvswitch/keyFile |  sudo apt-key add -
 sudo apt-get update
 sudo apt-get build-dep dkms
 sudo apt-get install openvswitch-datapath-dkms -y

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -16,10 +16,10 @@ RUN apt-get update && apt-get install -y iptables iproute2 curl software-propert
 
 # We do not have much control over the exact version of OVS/OVN that can be
 # obtained from upstream Ubuntu. guru@ovn.org maintains more latest versions of
-# OVS/OVN packages at 18.191.116.101. Please comment out the next 3 lines if
+# OVS/OVN packages at 3.19.28.122. Please comment out the next 3 lines if
 # you prefer to use upstream Ubuntu packages instead.
-RUN echo "deb http://18.191.116.101/openvswitch/stable /" |  tee /etc/apt/sources.list.d/openvswitch.list
-RUN curl http://18.191.116.101/openvswitch/keyFile |  apt-key add -
+RUN echo "deb http://3.19.28.122/openvswitch/stable /" |  tee /etc/apt/sources.list.d/openvswitch.list
+RUN curl http://3.19.28.122/openvswitch/keyFile |  apt-key add -
 
 RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
 RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -

--- a/docs/INSTALL.UBUNTU.md
+++ b/docs/INSTALL.UBUNTU.md
@@ -8,8 +8,8 @@ To install packages from there, you can run:
 
 ```
 sudo apt-get install apt-transport-https
-echo "deb http://18.191.116.101/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
-wget -O - http://18.191.116.101/openvswitch/keyFile |  sudo apt-key add -
+echo "deb http://3.19.28.122/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
+wget -O - http://3.19.28.122/openvswitch/keyFile |  sudo apt-key add -
 sudo apt-get update
 ```
 

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -58,8 +58,8 @@ sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates
 echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" |  sudo tee /etc/apt/sources.list.d/kubernetes.list
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-echo "deb http://18.191.116.101/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
-wget -O - http://18.191.116.101/openvswitch/keyFile |  sudo apt-key add -
+echo "deb http://3.19.28.122/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
+wget -O - http://3.19.28.122/openvswitch/keyFile |  sudo apt-key add -
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sudo su -c "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" >> /etc/apt/sources.list.d/docker.list"
 sudo apt-get update

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -60,8 +60,8 @@ sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates
 echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" |  sudo tee /etc/apt/sources.list.d/kubernetes.list
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-echo "deb http://18.191.116.101/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
-wget -O - http://18.191.116.101/openvswitch/keyFile |  sudo apt-key add -
+echo "deb http://3.19.28.122/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
+wget -O - http://3.19.28.122/openvswitch/keyFile |  sudo apt-key add -
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 sudo su -c "echo \"deb https://apt.dockerproject.org/repo ubuntu-xenial main\" >> /etc/apt/sources.list.d/docker.list"
 sudo apt-get update


### PR DESCRIPTION
We maintain a Debian source repository for ease of use to
keep openvswitch/OVN packages. Amazon had a outage yesterday
and a restart of the VM gave it a new IP address.

Signed-off-by: Gurucharan Shetty <guru@ovn.org>