### PR TITLE
remove the -net-controller option

### DIFF
--- a/README_MANUAL.md
+++ b/README_MANUAL.md
@@ -124,7 +124,7 @@ uses the hostname.  kubelet allows this name to be overridden with
 --service-cluster-ip-range option. An e.g is 172.16.1.0/24.
 
 ```
- nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -net-controller \
+ nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml \
  -loglevel=4 \
  -k8s-apiserver="http://$CENTRAL_IP:8080" \
  -logfile="/var/log/ovn-kubernetes/ovnkube.log" \

--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -211,7 +211,6 @@
         -cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
         -k8s-service-cidr "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
         -nodeport \
-        -net-controller \
         -k8s-token {{TOKEN}} \
         -k8s-cacert /etc/openvswitch/k8s-ca.crt \
         -k8s-apiserver "https://{{ host_public_ip }}" \

--- a/dist/files/ovn-kubernetes-master.sh
+++ b/dist/files/ovn-kubernetes-master.sh
@@ -10,8 +10,7 @@ function ovn-kubernetes-master() {
   echo "Enable and start ovn-kubernetes master services"
   /usr/bin/ovnkube \
 	--cluster-subnet "${cluster_cidr}" \
-	--init-master `hostname` \
-	--net-controller
+	--init-master `hostname`
 }
 
 ovn-kubernetes-master

--- a/dist/images/ovn-debug.sh
+++ b/dist/images/ovn-debug.sh
@@ -128,8 +128,7 @@ ovn-master () {
            --cluster-subnet "${ovn_cidr}" \
            --init-master ${ovn_host} \
 	   --pidfile /var/run/openvswitch/ovnkube-master.pid \
-	   --logfile /var/log/ovn-kubernetes/ovnkube-master.log \
-           --net-controller &
+	   --logfile /var/log/ovn-kubernetes/ovnkube-master.log &
 	 fi
 	 ;;
   "stop") echo "ovn-master - STOP"

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -632,7 +632,7 @@ ovn-master () {
 
   echo "=============== ovn-master ========== MASTER ONLY"
   /usr/bin/ovnkube \
-    --init-master ${ovn_pod_host} --net-controller \
+    --init-master ${ovn_pod_host} \
     --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
     --nodeport \
@@ -797,7 +797,7 @@ start_ovn () {
 
     echo "=============== start ovn-master ========== MASTER ONLY"
     /usr/bin/ovnkube \
-      --init-master ${ovn_pod_host} --net-controller \
+      --init-master ${ovn_pod_host} \
       --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
       --nodeport \

--- a/docs/INSTALL.SSL.md
+++ b/docs/INSTALL.SSL.md
@@ -163,7 +163,7 @@ Now, when you start the ovnkube utility on master, you should pass the SSL
 certificates to it. For e.g:
 
 ```
-sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -net-controller -loglevel=4 \
+sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -loglevel=4 \
  -k8s-apiserver="http://$CENTRAL_IP:8080" \
  -logfile="/var/log/ovn-kubernetes/ovnkube.log" \
  -init-master="$NODE_NAME" -cluster-subnet=$CLUSTER_IP_SUBNET \

--- a/docs/ha.md
+++ b/docs/ha.md
@@ -86,7 +86,7 @@ IP3="$MASTER3"
 ovn_nb="tcp://$IP1:6641,tcp://$IP2:6641,tcp://$IP3:6641"
 ovn_sb="tcp://$IP1:6642,tcp://$IP2:6642,tcp://$IP3:6642"
 
-nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -net-controller \
+nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml \
  -loglevel=4 \
  -k8s-apiserver="http://$K8S_APISERVER_IP:8080" \
  -logfile="/var/log/openvswitch/ovnkube.log" \

--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -21,11 +21,8 @@ A CIDR notation IP range from which k8s assigns service cluster IPs.
 This should be the same as the one provided for kube-apiserver's
 \fB\--service-cluster-ip-range\fR option.
 .TP
-\fB\--net-controller
-Flag to start the central controller that watches pods/services/policies.
-.TP
 \fB\--init-master\fR string
-Initialize master, requires the hostname as argument.
+Initialize master that acts as a controller that watches pods/services/policies. Requires the hostname as argument.
 .TP
 \fB\--init-node\fR string
 Initialize node, requires the name that node is registered with in kubernetes cluster.

--- a/go-controller/README.md
+++ b/go-controller/README.md
@@ -39,14 +39,12 @@ Usage:
   -cluster-subnet string
      cluster wide IP subnet to use (default: 11.11.0.0/16)
   -init-master string
-     initialize master, requires the hostname as argument
+     initialize master (that watches pods/nodes/services/policies), requires the hostname as argument
   -init-node string
      initialize node, requires the name that node is registered with in kubernetes cluster
   -remove-node string
      remove a node from the OVN cluster. Requires the name that node is
      registered with in kubernetes cluster
-  -net-controller
-     flag to start the central controller that watches pods/services/policies
   -mtu int
      MTU value used for the overlay networks (default: 1400)
   -conntrack-zone int
@@ -157,8 +155,7 @@ ovnkube --init-master <master-host-name> \
 	--k8s-cacert <path to the cacert file> \
 	--k8s-token <token string for authentication with kube apiserver> \
 	--k8s-apiserver <url to the kube apiserver e.g. https://10.11.12.13.8443> \
-	--cluster-subnet <cidr representing the global pod network e.g. 192.168.0.0/16> \
-	--net-controller
+	--cluster-subnet <cidr representing the global pod network e.g. 192.168.0.0/16>
 ```
 
 With the above the master ovnkube controller will initialize the central master logical router and establish the watcher loops for the following:

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -187,7 +187,6 @@ func runOvnKube(ctx *cli.Context) error {
 		panic(err.Error())
 	}
 
-	netController := ctx.Bool("net-controller")
 	master := ctx.String("init-master")
 	node := ctx.String("init-node")
 	clusterController := ovncluster.NewClusterController(clientset, factory)
@@ -222,6 +221,11 @@ func runOvnKube(ctx *cli.Context) error {
 				logrus.Errorf(err.Error())
 				panic(err.Error())
 			}
+			ovnController := ovn.NewOvnController(clientset, factory)
+			if err := ovnController.Run(); err != nil {
+				logrus.Errorf(err.Error())
+				panic(err.Error())
+			}
 		}
 
 		if node != "" {
@@ -235,24 +239,12 @@ func runOvnKube(ctx *cli.Context) error {
 				panic(err.Error())
 			}
 		}
-	}
-	if netController {
-		ovnController := ovn.NewOvnController(clientset, factory)
-		if err := ovnController.Run(); err != nil {
-			logrus.Errorf(err.Error())
-			panic(err.Error())
-		}
-	}
-	if master != "" || netController {
-		// run forever
-		select {}
-	}
-	if node != "" {
+
 		// run forever
 		select {}
 	}
 
-	return nil
+	return fmt.Errorf("need to run ovnkube in either master and/or node mode")
 }
 
 // parseClusterSubnetEntries returns the parsed set of CIDRNetworkEntries passed by the user on the command line

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -302,10 +302,6 @@ var cliConfig config
 //CommonFlags capture general options.
 var CommonFlags = []cli.Flag{
 	// Mode flags
-	cli.BoolFlag{
-		Name:  "net-controller",
-		Usage: "Flag to start the central controller that watches pods/services/policies",
-	},
 	cli.StringFlag{
 		Name:  "init-master",
 		Usage: "initialize master, requires the hostname as argument",

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -203,7 +203,7 @@ if [ "$DAEMONSET" != "true" ]; then
   TOKEN=`kubectl get secret/$SECRET -o yaml |grep "token:" | cut -f2  -d ":" | sed 's/^  *//' | base64 -d`
   echo $TOKEN > /vagrant/token
 
-  nohup sudo ovnkube -net-controller -loglevel=4 \
+  nohup sudo ovnkube -loglevel=4 \
    -k8s-apiserver="https://$OVERLAY_IP:6443" \
    -k8s-cacert=/etc/kubernetes/pki/ca.crt \
    -k8s-token="$TOKEN" \


### PR DESCRIPTION
In this iteration I have just removed the `-net-controller` option. 

In the next iteration, which I am testing, I am going to 
- move some master aspects of cluster.go`OvnClusterController into the ovn.go`Controller and create a single controller called MasterController
- keep the node aspects of cluster.go`OvnClusterController and rename it to NodeController.

So, there will be two controllers -- MasterController (runs in ovnkube-master process) and NodeController (runs in ovnkube-node process).