### PR TITLE
Fixes for NodePort and LoadBalancer services

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -68,6 +68,14 @@ loop:
 
 func (cluster *OvnClusterController) initGateway(
 	nodeName string, clusterIPSubnet []string, subnet string) error {
+
+	if config.Gateway.NodeportEnable {
+		err := initLoadBalancerHealthChecker(nodeName, cluster.watchFactory)
+		if err != nil {
+			return err
+		}
+	}
+
 	if config.Gateway.Mode == config.GatewayModeLocal {
 		return initLocalnetGateway(nodeName, clusterIPSubnet, subnet,
 			cluster.watchFactory)

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -591,6 +591,9 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 					"PREROUTING": []string{
 						"-j OVN-KUBE-NODEPORT",
 					},
+					"OUTPUT": []string{
+						"-j OVN-KUBE-NODEPORT",
+					},
 					"OVN-KUBE-NODEPORT": []string{},
 				},
 			}

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -267,6 +267,11 @@ func localnetNodePortWatcher(ipt util.IPTablesHelper, wf *factory.WatchFactory) 
 		args:  []string{"-j", iptableNodePortChain},
 	})
 	rules = append(rules, iptRule{
+		table: "nat",
+		chain: "OUTPUT",
+		args:  []string{"-j", iptableNodePortChain},
+	})
+	rules = append(rules, iptRule{
 		table: "filter",
 		chain: "FORWARD",
 		args:  []string{"-j", iptableNodePortChain},

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -187,7 +187,7 @@ func initLocalnetGatewayInternal(nodeName string, clusterIPSubnet []string,
 
 // AddService adds service and creates corresponding resources in OVN
 func localnetAddService(svc *kapi.Service) error {
-	if svc.Spec.Type != kapi.ServiceTypeNodePort {
+	if !util.ServiceTypeHasNodePort(svc) {
 		return nil
 	}
 	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
@@ -220,7 +220,7 @@ func localnetAddService(svc *kapi.Service) error {
 }
 
 func localnetDeleteService(svc *kapi.Service) error {
-	if svc.Spec.Type != kapi.ServiceTypeNodePort {
+	if !util.ServiceTypeHasNodePort(svc) {
 		return nil
 	}
 	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -15,7 +15,7 @@ import (
 )
 
 func addService(service *kapi.Service, inport, outport, gwBridge string) {
-	if service.Spec.Type != kapi.ServiceTypeNodePort {
+	if !util.ServiceTypeHasNodePort(service) {
 		return
 	}
 
@@ -38,7 +38,7 @@ func addService(service *kapi.Service, inport, outport, gwBridge string) {
 }
 
 func deleteService(service *kapi.Service, inport, gwBridge string) {
-	if service.Spec.Type != kapi.ServiceTypeNodePort {
+	if !util.ServiceTypeHasNodePort(service) {
 		return
 	}
 
@@ -80,7 +80,7 @@ func syncServices(services []interface{}, gwBridge, gwIntf string) {
 			continue
 		}
 
-		if service.Spec.Type != kapi.ServiceTypeNodePort ||
+		if !util.ServiceTypeHasNodePort(service) ||
 			len(service.Spec.Ports) == 0 {
 			continue
 		}

--- a/go-controller/pkg/cluster/healthcheck.go
+++ b/go-controller/pkg/cluster/healthcheck.go
@@ -1,0 +1,85 @@
+package cluster
+
+import (
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/healthcheck"
+
+	kapi "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+)
+
+// initLoadBalancerHealthChecker initializes the health check server for
+// ServiceTypeLoadBalancer services
+func initLoadBalancerHealthChecker(nodeName string, wf *factory.WatchFactory) error {
+	server := healthcheck.NewServer(nodeName, nil, nil, nil)
+	services := make(map[ktypes.NamespacedName]uint16)
+	endpoints := make(map[ktypes.NamespacedName]int)
+
+	_, err := wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			svc := obj.(*kapi.Service)
+			if svc.Spec.HealthCheckNodePort != 0 {
+				name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
+				services[name] = uint16(svc.Spec.HealthCheckNodePort)
+				_ = server.SyncServices(services)
+			}
+		},
+		UpdateFunc: func(old, new interface{}) {
+			// HealthCheckNodePort can't be changed on update
+		},
+		DeleteFunc: func(obj interface{}) {
+			svc := obj.(*kapi.Service)
+			if svc.Spec.HealthCheckNodePort != 0 {
+				name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
+				delete(services, name)
+				delete(endpoints, name)
+				_ = server.SyncServices(services)
+			}
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = wf.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			ep := obj.(*kapi.Endpoints)
+			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
+			if _, exists := services[name]; exists {
+				endpoints[name] = countLocalEndpoints(ep, nodeName)
+				_ = server.SyncEndpoints(endpoints)
+			}
+		},
+		UpdateFunc: func(old, new interface{}) {
+			ep := new.(*kapi.Endpoints)
+			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
+			if _, exists := services[name]; exists {
+				endpoints[name] = countLocalEndpoints(ep, nodeName)
+				_ = server.SyncEndpoints(endpoints)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			ep := obj.(*kapi.Endpoints)
+			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
+			delete(endpoints, name)
+			_ = server.SyncEndpoints(endpoints)
+		},
+	}, nil)
+	return err
+}
+
+func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {
+	num := 0
+	for i := range ep.Subsets {
+		ss := &ep.Subsets[i]
+		for i := range ss.Addresses {
+			addr := &ss.Addresses[i]
+			if addr.NodeName != nil && *addr.NodeName == nodeName {
+				num++
+			}
+		}
+	}
+	return num
+}

--- a/go-controller/pkg/kube/healthcheck/healthcheck.go
+++ b/go-controller/pkg/kube/healthcheck/healthcheck.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+)
+
+// Server serves HTTP endpoints for each service name, with results
+// based on the endpoints.  If there are 0 endpoints for a service, it returns a
+// 503 "Service Unavailable" error (telling LBs not to use this node).  If there
+// are 1 or more endpoints, it returns a 200 "OK".
+type Server interface {
+	// Make the new set of services be active.  Services that were open before
+	// will be closed.  Services that are new will be opened.  Service that
+	// existed and are in the new set will be left alone.  The value of the map
+	// is the healthcheck-port to listen on.
+	SyncServices(newServices map[types.NamespacedName]uint16) error
+	// Make the new set of endpoints be active.  Endpoints for services that do
+	// not exist will be dropped.  The value of the map is the number of
+	// endpoints the service has on this node.
+	SyncEndpoints(newEndpoints map[types.NamespacedName]int) error
+}
+
+// Listener allows for testing of Server.  If the Listener argument
+// to NewServer() is nil, the real net.Listen function will be used.
+type Listener interface {
+	// Listen is very much like net.Listen, except the first arg (network) is
+	// fixed to be "tcp".
+	Listen(addr string) (net.Listener, error)
+}
+
+// HTTPServerFactory allows for testing of Server.  If the
+// HTTPServerFactory argument to NewServer() is nil, the real
+// http.Server type will be used.
+type HTTPServerFactory interface {
+	// New creates an instance of a type satisfying HTTPServer.  This is
+	// designed to include http.Server.
+	New(addr string, handler http.Handler) HTTPServer
+}
+
+// HTTPServer allows for testing of Server.
+type HTTPServer interface {
+	// Server is designed so that http.Server satisfies this interface,
+	Serve(listener net.Listener) error
+}
+
+// NewServer allocates a new healthcheck server manager.  If either
+// of the injected arguments are nil, defaults will be used.
+func NewServer(hostname string, recorder record.EventRecorder, listener Listener, httpServerFactory HTTPServerFactory) Server {
+	if listener == nil {
+		listener = stdNetListener{}
+	}
+	if httpServerFactory == nil {
+		httpServerFactory = stdHTTPServerFactory{}
+	}
+	return &server{
+		hostname:    hostname,
+		recorder:    recorder,
+		listener:    listener,
+		httpFactory: httpServerFactory,
+		services:    map[types.NamespacedName]*hcInstance{},
+	}
+}
+
+// Implement Listener in terms of net.Listen.
+type stdNetListener struct{}
+
+func (stdNetListener) Listen(addr string) (net.Listener, error) {
+	return net.Listen("tcp", addr)
+}
+
+var _ Listener = stdNetListener{}
+
+// Implement HTTPServerFactory in terms of http.Server.
+type stdHTTPServerFactory struct{}
+
+func (stdHTTPServerFactory) New(addr string, handler http.Handler) HTTPServer {
+	return &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+}
+
+var _ HTTPServerFactory = stdHTTPServerFactory{}
+
+type server struct {
+	hostname    string
+	recorder    record.EventRecorder // can be nil
+	listener    Listener
+	httpFactory HTTPServerFactory
+
+	lock     sync.RWMutex
+	services map[types.NamespacedName]*hcInstance
+}
+
+func (hcs *server) SyncServices(newServices map[types.NamespacedName]uint16) error {
+	hcs.lock.Lock()
+	defer hcs.lock.Unlock()
+
+	// Remove any that are not needed any more.
+	for nsn, svc := range hcs.services {
+		if port, found := newServices[nsn]; !found || port != svc.port {
+			logrus.Infof("Closing healthcheck %q on port %d", nsn.String(), svc.port)
+			if err := svc.listener.Close(); err != nil {
+				logrus.Errorf("Close(%v): %v", svc.listener.Addr(), err)
+			}
+			delete(hcs.services, nsn)
+		}
+	}
+
+	// Add any that are needed.
+	for nsn, port := range newServices {
+		if hcs.services[nsn] != nil {
+			logrus.Debugf("Existing healthcheck %q on port %d", nsn.String(), port)
+			continue
+		}
+
+		logrus.Infof("Opening healthcheck %q on port %d", nsn.String(), port)
+		svc := &hcInstance{port: port}
+		addr := fmt.Sprintf(":%d", port)
+		svc.server = hcs.httpFactory.New(addr, hcHandler{name: nsn, hcs: hcs})
+		var err error
+		svc.listener, err = hcs.listener.Listen(addr)
+		if err != nil {
+			msg := fmt.Sprintf("node %s failed to start healthcheck %q on port %d: %v", hcs.hostname, nsn.String(), port, err)
+
+			if hcs.recorder != nil {
+				hcs.recorder.Eventf(
+					&v1.ObjectReference{
+						Kind:      "Service",
+						Namespace: nsn.Namespace,
+						Name:      nsn.Name,
+						UID:       types.UID(nsn.String()),
+					}, v1.EventTypeWarning, "FailedToStartServiceHealthcheck", msg)
+			}
+			logrus.Error(msg)
+			continue
+		}
+		hcs.services[nsn] = svc
+
+		go func(nsn types.NamespacedName, svc *hcInstance) {
+			// Serve() will exit when the listener is closed.
+			logrus.Debugf("Starting goroutine for healthcheck %q on port %d", nsn.String(), svc.port)
+			if err := svc.server.Serve(svc.listener); err != nil {
+				logrus.Debugf("Healthcheck %q closed: %v", nsn.String(), err)
+				return
+			}
+			logrus.Debugf("Healthcheck %q closed", nsn.String())
+		}(nsn, svc)
+	}
+	return nil
+}
+
+type hcInstance struct {
+	port      uint16
+	listener  net.Listener
+	server    HTTPServer
+	endpoints int // number of local endpoints for a service
+}
+
+type hcHandler struct {
+	name types.NamespacedName
+	hcs  *server
+}
+
+var _ http.Handler = hcHandler{}
+
+func (h hcHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	h.hcs.lock.RLock()
+	svc, ok := h.hcs.services[h.name]
+	if !ok || svc == nil {
+		h.hcs.lock.RUnlock()
+		logrus.Errorf("Received request for closed healthcheck %q", h.name.String())
+		return
+	}
+	count := svc.endpoints
+	h.hcs.lock.RUnlock()
+
+	resp.Header().Set("Content-Type", "application/json")
+	if count == 0 {
+		resp.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		resp.WriteHeader(http.StatusOK)
+	}
+	fmt.Fprintf(resp, `{ "service": { "namespace": %q, "name": %q }, "localEndpoints": %d }`,
+		h.name.Namespace, h.name.Name, count)
+}
+
+func (hcs *server) SyncEndpoints(newEndpoints map[types.NamespacedName]int) error {
+	hcs.lock.Lock()
+	defer hcs.lock.Unlock()
+
+	for nsn, count := range newEndpoints {
+		if hcs.services[nsn] == nil {
+			logrus.Debugf("Not saving endpoints for unknown healthcheck %q", nsn.String())
+			continue
+		}
+		logrus.Debugf("Reporting %d endpoints for healthcheck %q", count, nsn.String())
+		hcs.services[nsn].endpoints = count
+	}
+	for nsn, hci := range hcs.services {
+		if _, found := newEndpoints[nsn]; !found {
+			hci.endpoints = 0
+		}
+	}
+	return nil
+}

--- a/go-controller/pkg/kube/healthcheck/healthcheck_test.go
+++ b/go-controller/pkg/kube/healthcheck/healthcheck_test.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type fakeListener struct {
+	openPorts sets.String
+}
+
+func newFakeListener() *fakeListener {
+	return &fakeListener{
+		openPorts: sets.String{},
+	}
+}
+
+func (fake *fakeListener) hasPort(addr string) bool {
+	return fake.openPorts.Has(addr)
+}
+
+func (fake *fakeListener) Listen(addr string) (net.Listener, error) {
+	fake.openPorts.Insert(addr)
+	return &fakeNetListener{
+		parent: fake,
+		addr:   addr,
+	}, nil
+}
+
+type fakeNetListener struct {
+	parent *fakeListener
+	addr   string
+}
+
+func (fake *fakeNetListener) Accept() (net.Conn, error) {
+	// Not implemented
+	return nil, nil
+}
+
+func (fake *fakeNetListener) Close() error {
+	fake.parent.openPorts.Delete(fake.addr)
+	return nil
+}
+
+func (fake *fakeNetListener) Addr() net.Addr {
+	// Not implemented
+	return nil
+}
+
+type fakeHTTPServerFactory struct{}
+
+func newFakeHTTPServerFactory() *fakeHTTPServerFactory {
+	return &fakeHTTPServerFactory{}
+}
+
+func (fake *fakeHTTPServerFactory) New(addr string, handler http.Handler) HTTPServer {
+	return &fakeHTTPServer{
+		addr:    addr,
+		handler: handler,
+	}
+}
+
+type fakeHTTPServer struct {
+	addr    string
+	handler http.Handler
+}
+
+func (fake *fakeHTTPServer) Serve(listener net.Listener) error {
+	return nil // Cause the goroutine to return
+}
+
+func mknsn(ns, name string) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}
+}
+
+type hcPayload struct {
+	Service struct {
+		Namespace string
+		Name      string
+	}
+	LocalEndpoints int
+}
+
+type healthzPayload struct {
+	LastUpdated string
+	CurrentTime string
+}
+
+func TestServer(t *testing.T) {
+	listener := newFakeListener()
+	httpFactory := newFakeHTTPServerFactory()
+
+	hcsi := NewServer("hostname", nil, listener, httpFactory)
+	hcs := hcsi.(*server)
+	if len(hcs.services) != 0 {
+		t.Errorf("expected 0 services, got %d", len(hcs.services))
+	}
+
+	// sync nothing
+	hcs.SyncServices(nil)
+	if len(hcs.services) != 0 {
+		t.Errorf("expected 0 services, got %d", len(hcs.services))
+	}
+	hcs.SyncEndpoints(nil)
+	if len(hcs.services) != 0 {
+		t.Errorf("expected 0 services, got %d", len(hcs.services))
+	}
+
+	// sync unknown endpoints, should be dropped
+	hcs.SyncEndpoints(map[types.NamespacedName]int{mknsn("a", "b"): 93})
+	if len(hcs.services) != 0 {
+		t.Errorf("expected 0 services, got %d", len(hcs.services))
+	}
+
+	// sync a real service
+	nsn := mknsn("a", "b")
+	hcs.SyncServices(map[types.NamespacedName]uint16{nsn: 9376})
+	if len(hcs.services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn].endpoints != 0 {
+		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn].endpoints)
+	}
+	if len(listener.openPorts) != 1 {
+		t.Errorf("expected 1 open port, got %d\n%#v", len(listener.openPorts), listener.openPorts)
+	}
+	if !listener.hasPort(":9376") {
+		t.Errorf("expected port :9376 to be open\n%#v", listener.openPorts)
+	}
+	// test the handler
+	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
+
+	// sync an endpoint
+	hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 18})
+	if len(hcs.services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn].endpoints != 18 {
+		t.Errorf("expected 18 endpoints, got %d", hcs.services[nsn].endpoints)
+	}
+	// test the handler
+	testHandler(hcs, nsn, http.StatusOK, 18, t)
+
+	// sync zero endpoints
+	hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 0})
+	if len(hcs.services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn].endpoints != 0 {
+		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn].endpoints)
+	}
+	// test the handler
+	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
+
+	// put the endpoint back
+	hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 11})
+	if len(hcs.services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn].endpoints != 11 {
+		t.Errorf("expected 18 endpoints, got %d", hcs.services[nsn].endpoints)
+	}
+	// sync nil endpoints
+	hcs.SyncEndpoints(nil)
+	if len(hcs.services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn].endpoints != 0 {
+		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn].endpoints)
+	}
+	// test the handler
+	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
+
+	// put the endpoint back
+	hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 18})
+	if len(hcs.services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn].endpoints != 18 {
+		t.Errorf("expected 18 endpoints, got %d", hcs.services[nsn].endpoints)
+	}
+	// delete the service
+	hcs.SyncServices(nil)
+	if len(hcs.services) != 0 {
+		t.Errorf("expected 0 services, got %d", len(hcs.services))
+	}
+
+	// sync multiple services
+	nsn1 := mknsn("a", "b")
+	nsn2 := mknsn("c", "d")
+	nsn3 := mknsn("e", "f")
+	nsn4 := mknsn("g", "h")
+	hcs.SyncServices(map[types.NamespacedName]uint16{
+		nsn1: 9376,
+		nsn2: 12909,
+		nsn3: 11113,
+	})
+	if len(hcs.services) != 3 {
+		t.Errorf("expected 3 service, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn1].endpoints != 0 {
+		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn1].endpoints)
+	}
+	if hcs.services[nsn2].endpoints != 0 {
+		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn2].endpoints)
+	}
+	if hcs.services[nsn3].endpoints != 0 {
+		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn3].endpoints)
+	}
+	if len(listener.openPorts) != 3 {
+		t.Errorf("expected 3 open ports, got %d\n%#v", len(listener.openPorts), listener.openPorts)
+	}
+	// test the handlers
+	testHandler(hcs, nsn1, http.StatusServiceUnavailable, 0, t)
+	testHandler(hcs, nsn2, http.StatusServiceUnavailable, 0, t)
+	testHandler(hcs, nsn3, http.StatusServiceUnavailable, 0, t)
+
+	// sync endpoints
+	hcs.SyncEndpoints(map[types.NamespacedName]int{
+		nsn1: 9,
+		nsn2: 3,
+		nsn3: 7,
+	})
+	if len(hcs.services) != 3 {
+		t.Errorf("expected 3 services, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn1].endpoints != 9 {
+		t.Errorf("expected 9 endpoints, got %d", hcs.services[nsn1].endpoints)
+	}
+	if hcs.services[nsn2].endpoints != 3 {
+		t.Errorf("expected 3 endpoints, got %d", hcs.services[nsn2].endpoints)
+	}
+	if hcs.services[nsn3].endpoints != 7 {
+		t.Errorf("expected 7 endpoints, got %d", hcs.services[nsn3].endpoints)
+	}
+	// test the handlers
+	testHandler(hcs, nsn1, http.StatusOK, 9, t)
+	testHandler(hcs, nsn2, http.StatusOK, 3, t)
+	testHandler(hcs, nsn3, http.StatusOK, 7, t)
+
+	// sync new services
+	hcs.SyncServices(map[types.NamespacedName]uint16{
+		//nsn1: 9376, // remove it
+		nsn2: 12909, // leave it
+		nsn3: 11114, // change it
+		nsn4: 11878, // add it
+	})
+	if len(hcs.services) != 3 {
+		t.Errorf("expected 3 service, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn2].endpoints != 3 {
+		t.Errorf("expected 3 endpoints, got %d", hcs.services[nsn2].endpoints)
+	}
+	if hcs.services[nsn3].endpoints != 0 {
+		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn3].endpoints)
+	}
+	if hcs.services[nsn4].endpoints != 0 {
+		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn4].endpoints)
+	}
+	// test the handlers
+	testHandler(hcs, nsn2, http.StatusOK, 3, t)
+	testHandler(hcs, nsn3, http.StatusServiceUnavailable, 0, t)
+	testHandler(hcs, nsn4, http.StatusServiceUnavailable, 0, t)
+
+	// sync endpoints
+	hcs.SyncEndpoints(map[types.NamespacedName]int{
+		nsn1: 9,
+		nsn2: 3,
+		nsn3: 7,
+		nsn4: 6,
+	})
+	if len(hcs.services) != 3 {
+		t.Errorf("expected 3 services, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn2].endpoints != 3 {
+		t.Errorf("expected 3 endpoints, got %d", hcs.services[nsn2].endpoints)
+	}
+	if hcs.services[nsn3].endpoints != 7 {
+		t.Errorf("expected 7 endpoints, got %d", hcs.services[nsn3].endpoints)
+	}
+	if hcs.services[nsn4].endpoints != 6 {
+		t.Errorf("expected 6 endpoints, got %d", hcs.services[nsn4].endpoints)
+	}
+	// test the handlers
+	testHandler(hcs, nsn2, http.StatusOK, 3, t)
+	testHandler(hcs, nsn3, http.StatusOK, 7, t)
+	testHandler(hcs, nsn4, http.StatusOK, 6, t)
+
+	// sync endpoints, missing nsn2
+	hcs.SyncEndpoints(map[types.NamespacedName]int{
+		nsn3: 7,
+		nsn4: 6,
+	})
+	if len(hcs.services) != 3 {
+		t.Errorf("expected 3 services, got %d", len(hcs.services))
+	}
+	if hcs.services[nsn2].endpoints != 0 {
+		t.Errorf("expected 0 endpoints, got %d", hcs.services[nsn2].endpoints)
+	}
+	if hcs.services[nsn3].endpoints != 7 {
+		t.Errorf("expected 7 endpoints, got %d", hcs.services[nsn3].endpoints)
+	}
+	if hcs.services[nsn4].endpoints != 6 {
+		t.Errorf("expected 6 endpoints, got %d", hcs.services[nsn4].endpoints)
+	}
+	// test the handlers
+	testHandler(hcs, nsn2, http.StatusServiceUnavailable, 0, t)
+	testHandler(hcs, nsn3, http.StatusOK, 7, t)
+	testHandler(hcs, nsn4, http.StatusOK, 6, t)
+}
+
+func testHandler(hcs *server, nsn types.NamespacedName, status int, endpoints int, t *testing.T) {
+	handler := hcs.services[nsn].server.(*fakeHTTPServer).handler
+	req, err := http.NewRequest("GET", "/healthz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != status {
+		t.Errorf("expected status code %v, got %v", status, resp.Code)
+	}
+	var payload hcPayload
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Service.Name != nsn.Name || payload.Service.Namespace != nsn.Namespace {
+		t.Errorf("expected payload name %q, got %v", nsn.String(), payload.Service)
+	}
+	if payload.LocalEndpoints != endpoints {
+		t.Errorf("expected %d endpoints, got %d", endpoints, payload.LocalEndpoints)
+	}
+}
+
+func testHealthzHandler(server HTTPServer, status int, t *testing.T) {
+	handler := server.(*fakeHTTPServer).handler
+	req, err := http.NewRequest("GET", "/healthz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != status {
+		t.Errorf("expected status code %v, got %v", status, resp.Code)
+	}
+	var payload healthzPayload
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -52,7 +52,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 			ep.Name, ep.Namespace)
 		return nil
 	}
-	if !util.IsServiceIPSet(svc) {
+	if !util.IsClusterIPSet(svc) {
 		logrus.Debugf("Skipping service %s due to clusterIP = %q",
 			svc.Name, svc.Spec.ClusterIP)
 		return nil
@@ -65,7 +65,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 		targetPort := lbEps.Port
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == kapi.ProtocolTCP && svcPort.Name == svcPortName {
-				if svc.Spec.Type == kapi.ServiceTypeNodePort && config.Gateway.NodeportEnable {
+				if util.ServiceTypeHasNodePort(svc) && config.Gateway.NodeportEnable {
 					logrus.Debugf("Creating Gateways IP for NodePort: %d, %v", svcPort.NodePort, ips)
 					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
 					if err != nil {
@@ -73,7 +73,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 						continue
 					}
 				}
-				if svc.Spec.Type == kapi.ServiceTypeClusterIP || svc.Spec.Type == kapi.ServiceTypeNodePort {
+				if util.ServiceTypeHasClusterIP(svc) {
 					var loadBalancer string
 					loadBalancer, err = ovn.getLoadBalancer(svcPort.Protocol)
 					if err != nil {
@@ -97,14 +97,14 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 		targetPort := lbEps.Port
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == kapi.ProtocolUDP && svcPort.Name == svcPortName {
-				if svc.Spec.Type == kapi.ServiceTypeNodePort && config.Gateway.NodeportEnable {
+				if util.ServiceTypeHasNodePort(svc) && config.Gateway.NodeportEnable {
 					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
 					if err != nil {
 						logrus.Errorf("Error in creating Node Port for svc %s, node port: %d - %v\n", svc.Name, svcPort.NodePort, err)
 						continue
 					}
 				}
-				if svc.Spec.Type == kapi.ServiceTypeNodePort || svc.Spec.Type == kapi.ServiceTypeClusterIP {
+				if util.ServiceTypeHasClusterIP(svc) {
 					var loadBalancer string
 					loadBalancer, err = ovn.getLoadBalancer(svcPort.Protocol)
 					if err != nil {
@@ -161,7 +161,7 @@ func (ovn *Controller) handleNodePortLB(node *kapi.Node) {
 			if err != nil {
 				continue
 			}
-			if svc.Spec.Type != kapi.ServiceTypeNodePort {
+			if !util.ServiceTypeHasNodePort(svc) {
 				continue
 			}
 			tcpPortMap := make(map[string]lbEndpoints)
@@ -227,7 +227,7 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 			ep.Name, ep.Namespace)
 		return nil
 	}
-	if !util.IsServiceIPSet(svc) {
+	if !util.IsClusterIPSet(svc) {
 		return nil
 	}
 	for _, svcPort := range svc.Spec.Ports {

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -48,4 +49,19 @@ func NewClientset(conf *config.KubernetesConfig) (*kubernetes.Clientset, error) 
 	}
 
 	return kubernetes.NewForConfig(kconfig)
+}
+
+// IsClusterIPSet checks if the service is an headless service or not
+func IsClusterIPSet(service *kapi.Service) bool {
+	return service.Spec.ClusterIP != kapi.ClusterIPNone && service.Spec.ClusterIP != ""
+}
+
+// ServiceTypeHasClusterIP checks if the service has an associated ClusterIP or not
+func ServiceTypeHasClusterIP(service *kapi.Service) bool {
+	return service.Spec.Type == kapi.ServiceTypeClusterIP || service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
+}
+
+// ServiceTypeHasNodePort checks if the service has an associated NodePort or not
+func ServiceTypeHasNodePort(service *kapi.Service) bool {
+	return service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
 }

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	kapi "k8s.io/api/core/v1"
 	"os/exec"
 	"strings"
 
@@ -31,11 +30,6 @@ func FetchIfMacWindows(interfaceName string) (string, error) {
 	macAddress := strings.Replace(strings.TrimSpace(fmt.Sprintf("%s", stdoutStderr)), "-", ":", -1)
 
 	return strings.ToLower(macAddress), nil
-}
-
-// IsServiceIPSet checks if the service is an headless service or not
-func IsServiceIPSet(service *kapi.Service) bool {
-	return service.Spec.ClusterIP != kapi.ClusterIPNone && service.Spec.ClusterIP != ""
 }
 
 // GetK8sMgmtIntfName returns the correct length interface name to be used


### PR DESCRIPTION
A few fixes to get NodePort and LoadBalancer services fully working.

The first patch fixes an edge case: connecting from a node to a NodePort service on the same node, when using `GatewayModeLocal`. (The bug is pretty specific to the localnet implementation; I don't think any corresponding fix is needed to the other modes.)

The second patch fixes LoadBalancer services that don't have health checks, by treating them the same as NodePort.

The third patch fixes LoadBalancer services *with* health checks, by copying in the kube-proxy service health check code and running health check servers for the services that need them. This code probably should be moved somewhere outside of kubernetes itself so we can vendor it, but for now I just copied it over. The changes from upstream are minimal (90% is just klog->logrus); if you want I can add in an extra dummy commit importing the clean code and then fix it in the followup commit. Also if you want I can delete the unused second half of the file (which implements kube-proxy's own health server which is separate from the per-service health server, and which we're not using).

/cc @dcbw 