### PR TITLE
build gateway config only for ovnkube in node mode

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -285,6 +285,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 	err := app.Run([]string{
 		app.Name,
 		"--init-gateways",
+		"--init-node=node1",
 		"--gateway-interface=" + eth0Name,
 		"--nodeport",
 		"--gateway-vlanid=" + fmt.Sprintf("%d", gatewayVLANID),
@@ -435,6 +436,7 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 	err := app.Run([]string{
 		app.Name,
 		"--init-gateways",
+		"--init-node=node1",
 		"--gateway-interface=" + eth0Name,
 		"--gateway-spare-interface",
 		"--nodeport",
@@ -601,6 +603,7 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 		err := app.Run([]string{
 			app.Name,
 			"--init-gateways",
+			"--init-node=node1",
 			"--gateway-local",
 			"--nodeport",
 		})

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -792,10 +792,12 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 		return "", err
 	}
 
-	if err = buildGatewayConfig(ctx, &cliConfig, &cfg); err != nil {
-		return "", err
+	if ctx.String("init-node") != "" {
+		// build gateway configuration only if we are running as a node
+		if err = buildGatewayConfig(ctx, &cliConfig, &cfg); err != nil {
+			return "", err
+		}
 	}
-
 	tmpAuth, err := buildOvnAuth(exec, true, &cliConfig.OvnNorth, &cfg.OvnNorth, defaults.OvnNorthAddress)
 	if err != nil {
 		return "", err

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -480,7 +480,7 @@ var _ = Describe("Config Operations", func() {
 
 			return nil
 		}
-		err = app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
+		err = app.Run([]string{app.Name, "-config-file=" + cfgFile.Name(), "-init-node=node1", "-init-gateways"})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -555,6 +555,7 @@ var _ = Describe("Config Operations", func() {
 			"-sb-client-privkey=/client/privkey2",
 			"-sb-client-cert=/client/cert2",
 			"-sb-client-cacert=/client/cacert2",
+			"-init-node=node1",
 			"-init-gateways",
 			"-gateway-interface=eth5",
 			"-gateway-nexthop=1.3.5.6",


### PR DESCRIPTION
With the recent changes, the gateway config is being build for
onvkube-master as well and it fails with following error:

"gateway nodeport enable option not allowed when gateway is disabled"

As a result, the ovnkube-master doesn't come up and the cluster is hosed.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>