### PR TITLE
hack: don't try to run "go test" in dirs with no tests

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -9,7 +9,7 @@ pushd ${GOPATH}/src/${OVN_KUBE_GO_PACKAGE}
 
 if [ -z "$PKGS" ]; then
   # by default, test everything that's not in vendor
-  PKGS="$(go list ./... | grep -v vendor | xargs echo)"
+  PKGS="$(go list -f '{{if len .TestGoFiles}} {{.ImportPath}} {{end}}' ./... | xargs echo)"
 fi
 
 # Work around sudo's PATH handling since Travis puts in Go in the travis user's homedir


### PR DESCRIPTION
Gets rid of the lines like:

    ?   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube   [no test files]

in the "make check" output.

(The "`grep -v vendor`" in the original version may have been necessary with older versions of `go`, but `go list` knows to skip vendor itself these days.)

@dcbw @girishmg 