### PR TITLE
windows: fix build after gateway cleanup changes

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -23,8 +23,8 @@ all build:
 
 windows:
 	export WINDOWS_BUILD="yes"; \
-	hack/build-go.sh cmd/ovnkube/ovnkube.go; \
-	hack/build-go.sh cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go;
+	hack/build-go.sh cmd/ovnkube/ovnkube.go || exit 1; \
+	hack/build-go.sh cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go || exit 1;
 
 check test:
 	hack/test-go.sh ${PKGS}

--- a/go-controller/pkg/cluster/gateway_localnet_windows.go
+++ b/go-controller/pkg/cluster/gateway_localnet_windows.go
@@ -12,3 +12,8 @@ func initLocalnetGateway(nodeName string, clusterIPSubnet []string,
 	// TODO: Implement this
 	return fmt.Errorf("Not implemented yet on Windows")
 }
+
+func cleanupLocalnetGateway() error {
+	// TODO: Implement this
+	return fmt.Errorf("Not implemented yet on Windows")
+}


### PR DESCRIPTION
It seems that chaining the Windows build commands together (to
take advantage of the export WINDOWS_BUILD) wouldn't properly
exit with failure when one of the commands failed. Fix that.

@girishmg @alinbalutoiu 