### PR TITLE
gateway/local: stop double-NAT-ing

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -548,7 +548,6 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoe-" + gwRouter + " " + brLocalnetMAC + " 169.254.33.2/24 -- set logical_router_port rtoe-" + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 rtoe-" + gwRouter,
-				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
 			})
@@ -586,7 +585,7 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				},
 				"nat": {
 					"POSTROUTING": []string{
-						"-s 169.254.33.2/24 -j MASQUERADE",
+						"-s " + clusterCIDR + " -j MASQUERADE",
 					},
 					"PREROUTING": []string{
 						"-j OVN-KUBE-NODEPORT",

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -321,7 +321,7 @@ func initSharedGateway(
 	}
 
 	err = util.GatewayInit(clusterIPSubnet, nodeName, ifaceID, ipAddress,
-		macAddress, gwNextHop, subnet, true, lspArgs)
+		macAddress, gwNextHop, subnet, true, true, lspArgs)
 	if err != nil {
 		return fmt.Errorf("failed to init shared interface gateway: %v", err)
 	}

--- a/go-controller/pkg/cluster/gateway_spare_intf.go
+++ b/go-controller/pkg/cluster/gateway_spare_intf.go
@@ -50,7 +50,7 @@ func initSpareGateway(nodeName string, clusterIPSubnet []string,
 	}
 
 	err = util.GatewayInit(clusterIPSubnet, nodeName, ifaceID, ipAddress,
-		macAddress, gwNextHop, subnet, false, nil)
+		macAddress, gwNextHop, subnet, false, true, nil)
 	if err != nil {
 		return fmt.Errorf("failed to init spare interface gateway: %v", err)
 	}

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -167,7 +167,7 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, error) {
 
 // GatewayInit creates a gateway router for the local chassis.
 func GatewayInit(clusterIPSubnet []string, nodeName, ifaceID, nicIP, nicMacAddress,
-	defaultGW string, rampoutIPSubnet string, localnet bool, lspArgs []string) error {
+	defaultGW string, rampoutIPSubnet string, localnet, snat bool, lspArgs []string) error {
 
 	ip, physicalIPNet, err := net.ParseCIDR(nicIP)
 	if err != nil {
@@ -362,13 +362,15 @@ func GatewayInit(clusterIPSubnet []string, nodeName, ifaceID, nicIP, nicMacAddre
 		}
 	}
 
-	// Default SNAT rules.
-	for _, entry := range clusterIPSubnet {
-		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-nat-add",
-			gatewayRouter, "snat", physicalIP, entry)
-		if err != nil {
-			return fmt.Errorf("Failed to create default SNAT rules, stdout: %q, "+
-				"stderr: %q, error: %v", stdout, stderr, err)
+	if snat {
+		// Default SNAT rules.
+		for _, entry := range clusterIPSubnet {
+			stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-nat-add",
+				gatewayRouter, "snat", physicalIP, entry)
+			if err != nil {
+				return fmt.Errorf("Failed to create default SNAT rules, stdout: %q, "+
+					"stderr: %q, error: %v", stdout, stderr, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Turns out we can just rely on the host's iptables/nftables for NAT-ing
outgoing gateway traffic, stop NAT-ing in the OVN node gateway, and
things appear to work fine.

@danwinship @girishmg @shettyg 