### PR TITLE
config: add '-cluster-subnets' CLI and 'cluster-subnets' config file options

### DIFF
--- a/README_MANUAL.md
+++ b/README_MANUAL.md
@@ -129,7 +129,7 @@ uses the hostname.  kubelet allows this name to be overridden with
  -k8s-apiserver="http://$CENTRAL_IP:8080" \
  -logfile="/var/log/ovn-kubernetes/ovnkube.log" \
  -init-master=$NODE_NAME -init-node=$NODE_NAME \
- -cluster-subnet="$CLUSTER_IP_SUBNET" \
+ -cluster-subnets="$CLUSTER_IP_SUBNET" \
  -k8s-service-cidr=$SERVICE_IP_SUBNET \
  -nodeport \
  -init-gateways -gateway-local \
@@ -176,7 +176,7 @@ nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -loglevel=4 \
     -sb-address="tcp://$CENTRAL_IP:6642" -k8s-token="$TOKEN" \
     -init-gateways \
     -k8s-service-cidr=$SERVICE_IP_SUBNET \
-    -cluster-subnet=$CLUSTER_IP_SUBNET 2>&1 &
+    -cluster-subnets=$CLUSTER_IP_SUBNET 2>&1 &
 ```
 
 Note: Make sure to read /var/log/ovn-kubernetes/ovnkube.log to see that there were

--- a/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
+++ b/contrib/roles/linux/kubernetes/tasks/init_gateway.yml
@@ -23,7 +23,7 @@
       [Service]
       ExecStart=/usr/bin/ovnkube \
         -init-node "{{ ansible_hostname }}" \
-        -cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
+        -cluster-subnets "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
         -k8s-token {{TOKEN}} \
         -k8s-cacert /etc/openvswitch/k8s-ca.crt \
         -k8s-apiserver "http://{{ kubernetes_cluster_info.MASTER_IP }}:8080" \

--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -208,7 +208,7 @@
       [Service]
       ExecStart=/usr/bin/ovnkube \
         -init-master "{{ ansible_hostname }}" \
-        -cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
+        -cluster-subnets "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
         -k8s-service-cidr "{{ kubernetes_cluster_info.SERVICE_CLUSTER_IP_RANGE }}" \
         -nodeport \
         -k8s-token {{TOKEN}} \

--- a/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_minion.yml
@@ -138,7 +138,7 @@
           [Service]
           ExecStart=/usr/bin/ovnkube \
             --init-node "{{ ansible_hostname }}" \
-            --cluster-subnet "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
+            --cluster-subnets "{{ kubernetes_cluster_info.CLUSTER_SUBNET }}" \
             --k8s-token {{TOKEN}} \
             --k8s-cacert /etc/openvswitch/k8s-ca.crt \
             --k8s-apiserver "http://{{ kubernetes_cluster_info.MASTER_IP }}:8080" \

--- a/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
+++ b/contrib/roles/windows/kubernetes/tasks/run_minion_init.yml
@@ -30,7 +30,7 @@
       --k8s-token {{ TOKEN }}
       --nb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6641"
       --sb-address "tcp://{{ kubernetes_info.MASTER_IP }}:6642"
-      --cluster-subnet {{ kubernetes_info.CLUSTER_SUBNET }}
+      --cluster-subnets {{ kubernetes_info.CLUSTER_SUBNET }}
       --k8s-service-cidr {{ kubernetes_info.SERVICE_CLUSTER_IP_RANGE }}
       --cni-conf-dir="{{ install_path }}/cni"
       --cni-plugin "ovn-k8s-cni-overlay.exe"

--- a/dist/files/ovn-kubernetes-master.sh
+++ b/dist/files/ovn-kubernetes-master.sh
@@ -9,7 +9,7 @@ source /etc/sysconfig/ovn-kubernetes
 function ovn-kubernetes-master() {
   echo "Enable and start ovn-kubernetes master services"
   /usr/bin/ovnkube \
-	--cluster-subnet "${cluster_cidr}" \
+	--cluster-subnets "${cluster_cidr}" \
 	--init-master `hostname`
 }
 

--- a/dist/files/ovn-kubernetes-node.sh
+++ b/dist/files/ovn-kubernetes-node.sh
@@ -10,7 +10,7 @@ function ovn-kubernetes-node() {
 
   echo "Enable and start ovn-kubernetes node services"
   /usr/bin/ovnkube \
-	--cluster-subnet "${cluster_cidr}" \
+	--cluster-subnets "${cluster_cidr}" \
 	--init-node `hostname`
 }
 

--- a/dist/images/ovn-debug.sh
+++ b/dist/images/ovn-debug.sh
@@ -125,7 +125,7 @@ ovn-master () {
   "start") echo "ovn-master - START"
 	 if [ ! -f /var/run/openvswitch/ovnkube-master.pid ] ; then
 	 /usr/bin/ovnkube \
-           --cluster-subnet "${ovn_cidr}" \
+           --cluster-subnets "${ovn_cidr}" \
            --init-master ${ovn_host} \
 	   --pidfile /var/run/openvswitch/ovnkube-master.pid \
 	   --logfile /var/log/ovn-kubernetes/ovnkube-master.log &
@@ -205,7 +205,7 @@ ovn-node () {
   case $1 in
   "start") echo "ovn-node - START"
 	 /usr/bin/ovnkube \
-        --cluster-subnet "${ovn_cidr}" \
+        --cluster-subnets "${ovn_cidr}" \
         --init-node "${ovn_host}" &
 	 ;;
   "stop") echo "ovn-node - STOP"

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -676,7 +676,7 @@ ovn-master () {
   echo "=============== ovn-master ========== MASTER ONLY"
   /usr/bin/ovnkube \
     --init-master ${ovn_pod_host} \
-    --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
+    --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
     --nodeport \
     --loglevel=${ovnkube_loglevel} \
@@ -751,7 +751,7 @@ ovn-node () {
   # restarted or ovs daemonset is deleted.
   # TEMP HACK - WORKAROUND
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
-      --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
+      --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
       --nodeport \
       --loglevel=${ovnkube_loglevel} \
@@ -842,7 +842,7 @@ start_ovn () {
     echo "=============== start ovn-master ========== MASTER ONLY"
     /usr/bin/ovnkube \
       --init-master ${ovn_pod_host} \
-      --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
+      --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
       --nodeport \
       --loglevel=${ovnkube_loglevel} \
@@ -867,7 +867,7 @@ start_ovn () {
   # restarted or ovs daemonset is deleted.
   # TEMP HACK - WORKAROUND
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
-      --cluster-subnet ${net_cidr} --k8s-service-cidr=${svc_cidr} \
+      --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
       --nodeport \
       --loglevel=${ovnkube_loglevel} \

--- a/docs/INSTALL.SSL.md
+++ b/docs/INSTALL.SSL.md
@@ -166,7 +166,7 @@ certificates to it. For e.g:
 sudo ovnkube -k8s-kubeconfig kubeconfig.yaml -loglevel=4 \
  -k8s-apiserver="http://$CENTRAL_IP:8080" \
  -logfile="/var/log/ovn-kubernetes/ovnkube.log" \
- -init-master="$NODE_NAME" -cluster-subnet=$CLUSTER_IP_SUBNET \
+ -init-master="$NODE_NAME" -cluster-subnets=$CLUSTER_IP_SUBNET \
  -k8s-service-cidr=$SERVICE_IP_SUBNET \
  -nodeport \
  -nb-address="ssl://$CENTRAL_IP:6641" \
@@ -197,7 +197,7 @@ sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -sb-client-cacert /etc/openvswitch/cacert.pem \
     -init-gateways \
     -k8s-service-cidr=$SERVICE_IP_SUBNET \
-    -cluster-subnet=$CLUSTER_IP_SUBNET
+    -cluster-subnets=$CLUSTER_IP_SUBNET
 ```
 
 [README.md]: README.md

--- a/docs/ha.md
+++ b/docs/ha.md
@@ -90,7 +90,7 @@ nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml \
  -loglevel=4 \
  -k8s-apiserver="http://$K8S_APISERVER_IP:8080" \
  -logfile="/var/log/openvswitch/ovnkube.log" \
- -init-master="$NODENAME" -cluster-subnet="$CLUSTER_IP_SUBNET" \
+ -init-master="$NODENAME" -cluster-subnets="$CLUSTER_IP_SUBNET" \
  -init-node="$NODENAME" \
  -k8s-service-cidr="$SERVICE_IP_SUBNET" \
  -k8s-token="$TOKEN" \
@@ -139,5 +139,5 @@ nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -k8s-token="$TOKEN" \
     -init-gateways \
     -k8s-service-cidr= \
-    -cluster-subnet="$SERVICE_IP_SUBNET" 2>&1 &
+    -cluster-subnets="$SERVICE_IP_SUBNET" 2>&1 &
 ```

--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -9,12 +9,13 @@ ovnkube \- ovn utility
 The ovn utility used to confiugre ovn-kubernetes
 .SH GLOBAL OPTIONS
 .TP
-\fB\--cluster-subnet\fR string
-A comma separated set of IP subnets and the associated hostsubnetlengths to use for
+\fB\--cluster-subnets\fR string
+A comma separated set of IP subnets and the associated hostsubnet prefix lengths to use for
 the cluster (eg, "10.128.0.0/14/23,10.0.0.0/14/23").  Each entry is given in the form
-IP address/subnet mask/hostsubnetlength, the hostsubnetlength is optional and if
-unspecified defaults to 24. The hostsubnetlength defines how many IP addresses are
-dedicated to each node. (default "11.11.0.0/16")
+[IP address/prefix-length/hostsubnet-prefix-length] and cannot overlap with other entries.
+The hostsubnet-prefix-length is optional and if unspecified defaults to 24. The
+hostsubnet-prefix-length defines how many IP addresses are dedicated to each node
+and may be different for each entry. (default "10.128.0.0/14/23")
 .TP
 \fB\--k8s-service-cidr\fR value
 A CIDR notation IP range from which k8s assigns service cluster IPs.

--- a/go-controller/README.md
+++ b/go-controller/README.md
@@ -36,7 +36,7 @@ Options specified on the command-line override configuration file options which 
 Usage:
   -config-file string
      configuration file path (default: /etc/openvswitch/ovn_k8s.conf)
-  -cluster-subnet string
+  -cluster-subnets string
      cluster wide IP subnet to use (default: 11.11.0.0/16)
   -init-master string
      initialize master (that watches pods/nodes/services/policies), requires the hostname as argument
@@ -155,7 +155,7 @@ ovnkube --init-master <master-host-name> \
 	--k8s-cacert <path to the cacert file> \
 	--k8s-token <token string for authentication with kube apiserver> \
 	--k8s-apiserver <url to the kube apiserver e.g. https://10.11.12.13.8443> \
-	--cluster-subnet <cidr representing the global pod network e.g. 192.168.0.0/16>
+	--cluster-subnets <cidr representing the global pod network e.g. 192.168.0.0/16>
 ```
 
 With the above the master ovnkube controller will initialize the central master logical router and establish the watcher loops for the following:

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -206,11 +206,6 @@ func runOvnKube(ctx *cli.Context) error {
 	}
 
 	if master != "" || node != "" {
-		clusterController.ClusterIPNet, err = config.ParseClusterSubnetEntries(ctx.String("cluster-subnet"))
-		if err != nil {
-			panic(err.Error())
-		}
-
 		if master != "" {
 			if runtime.GOOS == "windows" {
 				panic("Windows is not supported as master node")

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -55,6 +55,7 @@ GLOBAL OPTIONS:{{range $title, $category := getFlagsByCategory}}
 func getFlagsByCategory() map[string][]cli.Flag {
 	m := map[string][]cli.Flag{}
 	m["Generic Options"] = config.CommonFlags
+	m["CNI Options"] = config.CNIFlags
 	m["K8s-related Options"] = config.K8sFlags
 	m["OVN Northbound DB Options"] = config.OvnNBFlags
 	m["OVN Southbound DB Options"] = config.OvnSBFlags
@@ -92,6 +93,7 @@ func main() {
 	c.Version = config.Version
 	c.CustomAppHelpTemplate = CustomAppHelpTemplate
 	c.Flags = config.CommonFlags
+	c.Flags = append(c.Flags, config.CNIFlags...)
 	c.Flags = append(c.Flags, config.K8sFlags...)
 	c.Flags = append(c.Flags, config.OvnNBFlags...)
 	c.Flags = append(c.Flags, config.OvnSBFlags...)

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -20,8 +20,6 @@ type OvnClusterController struct {
 
 	TCPLoadBalancerUUID string
 	UDPLoadBalancerUUID string
-
-	ClusterIPNet []config.CIDRNetworkEntry
 }
 
 const (

--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -21,13 +21,7 @@ type OvnClusterController struct {
 	TCPLoadBalancerUUID string
 	UDPLoadBalancerUUID string
 
-	ClusterIPNet []CIDRNetworkEntry
-}
-
-// CIDRNetworkEntry is the object that holds the definition for a single network CIDR range
-type CIDRNetworkEntry struct {
-	CIDR             *net.IPNet
-	HostSubnetLength uint32
+	ClusterIPNet []config.CIDRNetworkEntry
 }
 
 const (

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -8,6 +8,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	"github.com/openshift/origin/pkg/util/netutils"
@@ -40,7 +41,7 @@ func (cluster *OvnClusterController) StartClusterMaster(masterNodeName string) e
 	// NewSubnetAllocator is a subnet IPAM, which takes a CIDR (first argument)
 	// and gives out subnets of length 'hostSubnetLength' (second argument)
 	// but omitting any that exist in 'subrange' (third argument)
-	for _, clusterEntry := range cluster.ClusterIPNet {
+	for _, clusterEntry := range config.Default.ClusterSubnets {
 		subrange := make([]string, 0)
 		for _, allocatedRange := range alreadyAllocated {
 			firstAddress, _, err := net.ParseCIDR(allocatedRange)

--- a/go-controller/pkg/cluster/master_test.go
+++ b/go-controller/pkg/cluster/master_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Master Operations", func() {
 
 			_, ipnet, err := net.ParseCIDR(clusterCIDR)
 			Expect(err).NotTo(HaveOccurred())
-			clusterController.ClusterIPNet = append(clusterController.ClusterIPNet, CIDRNetworkEntry{
+			clusterController.ClusterIPNet = append(clusterController.ClusterIPNet, config.CIDRNetworkEntry{
 				CIDR:             ipnet,
 				HostSubnetLength: 24,
 			})

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -30,7 +30,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	var clusterSubnets []string
 	var cidr string
 
-	for _, clusterSubnet := range cluster.ClusterIPNet {
+	for _, clusterSubnet := range config.Default.ClusterSubnets {
 		clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR.String())
 	}
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -214,6 +214,7 @@ func init() {
 	savedOvnSouth = OvnSouth
 	savedGateway = Gateway
 	Flags = append(Flags, CommonFlags...)
+	Flags = append(Flags, CNIFlags...)
 	Flags = append(Flags, K8sFlags...)
 	Flags = append(Flags, OvnNBFlags...)
 	Flags = append(Flags, OvnSBFlags...)
@@ -362,17 +363,8 @@ var CommonFlags = []cli.Flag{
 	},
 }
 
-// K8sFlags capture Kubernetes-related options
-var K8sFlags = []cli.Flag{
-	cli.StringFlag{
-		Name:  "cluster-subnet",
-		Value: "11.11.0.0/16",
-		Usage: "A comma separated set of IP subnets and the associated" +
-			"hostsubnetlengths to use for the cluster (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\"). " +
-			"Each entry is given in the form IP address/subnet mask/hostsubnetlength, " +
-			"the hostsubnetlength is optional and if unspecified defaults to 24. The " +
-			"hostsubnetlength defines how many IP addresses are dedicated to each node.",
-	},
+// CNIFlags capture CNI-related options
+var CNIFlags = []cli.Flag{
 	// CNI options
 	cli.StringFlag{
 		Name:        "cni-conf-dir",
@@ -388,6 +380,19 @@ var K8sFlags = []cli.Flag{
 		Name:        "win-hnsnetwork-id",
 		Usage:       "the ID of the HNS network to which containers will be attached (default: not set)",
 		Destination: &cliConfig.CNI.WinHNSNetworkID,
+	},
+}
+
+// K8sFlags capture Kubernetes-related options
+var K8sFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "cluster-subnet",
+		Value: "11.11.0.0/16",
+		Usage: "A comma separated set of IP subnets and the associated" +
+			"hostsubnetlengths to use for the cluster (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\"). " +
+			"Each entry is given in the form IP address/subnet mask/hostsubnetlength, " +
+			"the hostsubnetlength is optional and if unspecified defaults to 24. The " +
+			"hostsubnetlength defines how many IP addresses are dedicated to each node.",
 	},
 	cli.StringFlag{
 		Name:        "service-cluster-ip-range",

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -28,11 +28,12 @@ var (
 
 	// Default holds parsed config file parameters and command-line overrides
 	Default = DefaultConfig{
-		MTU:             1400,
-		ConntrackZone:   64000,
-		EncapType:       "geneve",
-		EncapIP:         "",
-		InactivityProbe: 100000,
+		MTU:               1400,
+		ConntrackZone:     64000,
+		EncapType:         "geneve",
+		EncapIP:           "",
+		InactivityProbe:   100000,
+		RawClusterSubnets: "10.128.0.0/14/23",
 	}
 
 	// Logging holds logging-related parsed config file parameters and command-line overrides
@@ -88,6 +89,12 @@ type DefaultConfig struct {
 	// Maximum number of milliseconds of idle time on connection that
 	// ovn-controller waits before it will send a connection health probe.
 	InactivityProbe int `gcfg:"inactivity-probe"`
+	// RawClusterSubnets holds the unparsed cluster subnets. Should only be
+	// used inside config module.
+	RawClusterSubnets string `gcfg:"cluster-subnets"`
+	// ClusterSubnets holds parsed cluster subnet entries and may be used
+	// outside the config module.
+	ClusterSubnets []CIDRNetworkEntry
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides
@@ -196,6 +203,8 @@ var (
 
 	// legacy service-cluster-ip-range CLI option
 	serviceClusterIPRange string
+	// legacy cluster-subnet CLI option
+	clusterSubnet string
 	// legacy init-gateways CLI option
 	initGateways bool
 	// legacy gateway-spare-interface CLI option
@@ -349,6 +358,24 @@ var CommonFlags = []cli.Flag{
 			"connection for ovn-controller before it sends a inactivity probe",
 		Destination: &cliConfig.Default.InactivityProbe,
 	},
+	cli.StringFlag{
+		Name:        "cluster-subnet",
+		Usage:       "Deprecated alias for cluster-subnets.",
+		Destination: &clusterSubnet,
+	},
+	cli.StringFlag{
+		Name:  "cluster-subnets",
+		Value: "10.128.0.0/14/23",
+		Usage: "A comma separated set of IP subnets and the associated " +
+			"hostsubnet prefix lengths to use for the cluster (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\"). " +
+			"Each entry is given in the form [IP address/prefix-length/hostsubnet-prefix-length] " +
+			"and cannot overlap with other entries. The hostsubnet-prefix-length " +
+			"is optional and if unspecified defaults to 24. The " +
+			"hostsubnet-prefix-length defines how many IP addresses " +
+			"are dedicated to each node and may be different for each " +
+			"entry.",
+		Destination: &cliConfig.Default.RawClusterSubnets,
+	},
 
 	// Logging options
 	cli.IntFlag{
@@ -385,15 +412,6 @@ var CNIFlags = []cli.Flag{
 
 // K8sFlags capture Kubernetes-related options
 var K8sFlags = []cli.Flag{
-	cli.StringFlag{
-		Name:  "cluster-subnet",
-		Value: "11.11.0.0/16",
-		Usage: "A comma separated set of IP subnets and the associated" +
-			"hostsubnetlengths to use for the cluster (eg, \"10.128.0.0/14/23,10.0.0.0/14/23\"). " +
-			"Each entry is given in the form IP address/subnet mask/hostsubnetlength, " +
-			"the hostsubnetlength is optional and if unspecified defaults to 24. The " +
-			"hostsubnetlength defines how many IP addresses are dedicated to each node.",
-	},
 	cli.StringFlag{
 		Name:        "service-cluster-ip-range",
 		Usage:       "Deprecated alias for k8s-service-cidr.",
@@ -724,6 +742,26 @@ func buildGatewayConfig(ctx *cli.Context, cli, file *config) error {
 	return nil
 }
 
+func buildDefaultConfig(cli, file *config) error {
+	overrideFields(&Default, &file.Default)
+	overrideFields(&Default, &cli.Default)
+
+	// Legacy cluster-subnet CLI option overrides config file or --cluster-subnets
+	if clusterSubnet != "" {
+		Default.RawClusterSubnets = clusterSubnet
+	}
+	if Default.RawClusterSubnets == "" {
+		return fmt.Errorf("cluster subnet is required")
+	}
+
+	var err error
+	Default.ClusterSubnets, err = ParseClusterSubnetEntries(Default.RawClusterSubnets)
+	if err != nil {
+		return fmt.Errorf("cluster subnet invalid: %v", err)
+	}
+	return nil
+}
+
 // getConfigFilePath returns config file path and 'true' if the config file is
 // the fallback path (eg not given by the user), 'false' if given explicitly
 // by the user
@@ -796,8 +834,6 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 	}
 
 	// Build config that needs no special processing
-	overrideFields(&Default, &cfg.Default)
-	overrideFields(&Default, &cliConfig.Default)
 	overrideFields(&CNI, &cfg.CNI)
 	overrideFields(&CNI, &cliConfig.CNI)
 
@@ -819,6 +855,10 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 		} else {
 			logrus.SetOutput(file)
 		}
+	}
+
+	if err = buildDefaultConfig(&cliConfig, &cfg); err != nil {
+		return "", err
 	}
 
 	if err = buildKubernetesConfig(exec, &cliConfig, &cfg, saPath, defaults); err != nil {

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -35,7 +35,7 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 			// the old hardcoded value for backwards compatability
 			parsedClusterEntry.HostSubnetLength = 24
 		} else {
-			return nil, fmt.Errorf("cluster-cidr not formatted properly")
+			return nil, fmt.Errorf("CIDR %q not properly formatted", clusterEntry)
 		}
 
 		var err error
@@ -46,11 +46,10 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 
 		//check to make sure that no cidrs overlap
 		if cidrsOverlap(parsedClusterEntry.CIDR, parsedClusterList) {
-			return nil, fmt.Errorf("CIDR %s overlaps with another cluster network CIDR", parsedClusterEntry.CIDR.String())
+			return nil, fmt.Errorf("CIDR %q overlaps with another cluster network CIDR", clusterEntry)
 		}
 
 		parsedClusterList = append(parsedClusterList, parsedClusterEntry)
-
 	}
 
 	if len(parsedClusterList) == 0 {
@@ -62,7 +61,6 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 
 //cidrsOverlap returns a true if the cidr range overlaps any in the list of cidr ranges
 func cidrsOverlap(cidr *net.IPNet, cidrList []CIDRNetworkEntry) bool {
-
 	for _, clusterEntry := range cidrList {
 		if cidr.Contains(clusterEntry.CIDR.IP) || clusterEntry.CIDR.Contains(cidr.IP) {
 			return true

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// CIDRNetworkEntry is the object that holds the definition for a single network CIDR range
+type CIDRNetworkEntry struct {
+	CIDR             *net.IPNet
+	HostSubnetLength uint32
+}
+
+// ParseClusterSubnetEntries returns the parsed set of CIDRNetworkEntries passed by the user on the command line
+// These entries define the clusters network space by specifying a set of CIDR and netmasks the SDN can allocate
+// addresses from.
+func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, error) {
+	var parsedClusterList []CIDRNetworkEntry
+
+	clusterEntriesList := strings.Split(clusterSubnetCmd, ",")
+
+	for _, clusterEntry := range clusterEntriesList {
+		var parsedClusterEntry CIDRNetworkEntry
+
+		splitClusterEntry := strings.Split(clusterEntry, "/")
+		if len(splitClusterEntry) == 3 {
+			tmp, err := strconv.ParseUint(splitClusterEntry[2], 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			parsedClusterEntry.HostSubnetLength = uint32(tmp)
+		} else if len(splitClusterEntry) == 2 {
+			// the old hardcoded value for backwards compatability
+			parsedClusterEntry.HostSubnetLength = 24
+		} else {
+			return nil, fmt.Errorf("cluster-cidr not formatted properly")
+		}
+
+		var err error
+		_, parsedClusterEntry.CIDR, err = net.ParseCIDR(fmt.Sprintf("%s/%s", splitClusterEntry[0], splitClusterEntry[1]))
+		if err != nil {
+			return nil, err
+		}
+
+		//check to make sure that no cidrs overlap
+		if cidrsOverlap(parsedClusterEntry.CIDR, parsedClusterList) {
+			return nil, fmt.Errorf("CIDR %s overlaps with another cluster network CIDR", parsedClusterEntry.CIDR.String())
+		}
+
+		parsedClusterList = append(parsedClusterList, parsedClusterEntry)
+
+	}
+
+	if len(parsedClusterList) == 0 {
+		return nil, fmt.Errorf("failed to parse any CIDRs from %q", clusterSubnetCmd)
+	}
+
+	return parsedClusterList, nil
+}
+
+//cidrsOverlap returns a true if the cidr range overlaps any in the list of cidr ranges
+func cidrsOverlap(cidr *net.IPNet, cidrList []CIDRNetworkEntry) bool {
+
+	for _, clusterEntry := range cidrList {
+		if cidr.Contains(clusterEntry.CIDR.IP) || clusterEntry.CIDR.Contains(cidr.IP) {
+			return true
+		}
+	}
+	return false
+}

--- a/go-controller/pkg/config/utils_test.go
+++ b/go-controller/pkg/config/utils_test.go
@@ -1,7 +1,6 @@
-package main
+package config
 
 import (
-	ovncluster "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cluster"
 	"net"
 	"testing"
 )
@@ -15,19 +14,19 @@ func TestParseClusterSubnetEntries(t *testing.T) {
 	tests := []struct {
 		name            string
 		cmdLineArg      string
-		clusterNetworks []ovncluster.CIDRNetworkEntry
+		clusterNetworks []CIDRNetworkEntry
 		expectedErr     bool
 	}{
 		{
 			name:            "Single CIDR correctly formatted",
 			cmdLineArg:      "10.132.0.0/26/28",
-			clusterNetworks: []ovncluster.CIDRNetworkEntry{{CIDR: returnIPNetPointers("10.132.0.0/26"), HostSubnetLength: 28}},
+			clusterNetworks: []CIDRNetworkEntry{{CIDR: returnIPNetPointers("10.132.0.0/26"), HostSubnetLength: 28}},
 			expectedErr:     false,
 		},
 		{
 			name:       "Two CIDRs correctly formatted",
 			cmdLineArg: "10.132.0.0/26/28,10.133.0.0/26/28",
-			clusterNetworks: []ovncluster.CIDRNetworkEntry{
+			clusterNetworks: []CIDRNetworkEntry{
 				{CIDR: returnIPNetPointers("10.132.0.0/26"), HostSubnetLength: 28},
 				{CIDR: returnIPNetPointers("10.133.0.0/26"), HostSubnetLength: 28},
 			},
@@ -36,7 +35,7 @@ func TestParseClusterSubnetEntries(t *testing.T) {
 		{
 			name:            "Test that defaulting to hostsubnetlength 8 still works",
 			cmdLineArg:      "10.128.0.0/14",
-			clusterNetworks: []ovncluster.CIDRNetworkEntry{{CIDR: returnIPNetPointers("10.128.0.0/14"), HostSubnetLength: 24}},
+			clusterNetworks: []CIDRNetworkEntry{{CIDR: returnIPNetPointers("10.128.0.0/14"), HostSubnetLength: 24}},
 			expectedErr:     false,
 		},
 		{
@@ -61,7 +60,7 @@ func TestParseClusterSubnetEntries(t *testing.T) {
 
 	for _, tc := range tests {
 
-		parsedList, err := parseClusterSubnetEntries(tc.cmdLineArg)
+		parsedList, err := ParseClusterSubnetEntries(tc.cmdLineArg)
 		if err != nil && !tc.expectedErr {
 			t.Errorf("Test case \"%s\" expected no errors, got %v", tc.name, err)
 		}
@@ -84,7 +83,7 @@ func TestCidrsOverlap(t *testing.T) {
 	tests := []struct {
 		name           string
 		cidr           *net.IPNet
-		cidrList       []ovncluster.CIDRNetworkEntry
+		cidrList       []CIDRNetworkEntry
 		expectedOutput bool
 	}{
 		{
@@ -96,7 +95,7 @@ func TestCidrsOverlap(t *testing.T) {
 		{
 			name: "non-overlapping",
 			cidr: returnIPNetPointers("10.132.0.0/26"),
-			cidrList: []ovncluster.CIDRNetworkEntry{
+			cidrList: []CIDRNetworkEntry{
 				{CIDR: returnIPNetPointers("10.133.0.0/26")},
 			},
 			expectedOutput: false,
@@ -104,7 +103,7 @@ func TestCidrsOverlap(t *testing.T) {
 		{
 			name: "cidr equal to an entry in the list",
 			cidr: returnIPNetPointers("10.132.0.0/26"),
-			cidrList: []ovncluster.CIDRNetworkEntry{
+			cidrList: []CIDRNetworkEntry{
 				{CIDR: returnIPNetPointers("10.132.0.0/26")},
 			},
 			expectedOutput: true,
@@ -112,7 +111,7 @@ func TestCidrsOverlap(t *testing.T) {
 		{
 			name: "proposed cidr is a proper subset of a list entry",
 			cidr: returnIPNetPointers("10.132.0.0/26"),
-			cidrList: []ovncluster.CIDRNetworkEntry{
+			cidrList: []CIDRNetworkEntry{
 				{CIDR: returnIPNetPointers("10.0.0.0/8")},
 			},
 			expectedOutput: true,
@@ -120,7 +119,7 @@ func TestCidrsOverlap(t *testing.T) {
 		{
 			name: "proposed cidr is a proper superset of a list entry",
 			cidr: returnIPNetPointers("10.0.0.0/8"),
-			cidrList: []ovncluster.CIDRNetworkEntry{
+			cidrList: []CIDRNetworkEntry{
 				{CIDR: returnIPNetPointers("10.133.0.0/26")},
 			},
 			expectedOutput: true,
@@ -128,7 +127,7 @@ func TestCidrsOverlap(t *testing.T) {
 		{
 			name: "proposed cidr overlaps a list entry",
 			cidr: returnIPNetPointers("10.1.0.0/14"),
-			cidrList: []ovncluster.CIDRNetworkEntry{
+			cidrList: []CIDRNetworkEntry{
 				{CIDR: returnIPNetPointers("10.0.0.0/15")},
 			},
 			expectedOutput: true,

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -208,7 +208,7 @@ if [ "$DAEMONSET" != "true" ]; then
    -k8s-cacert=/etc/kubernetes/pki/ca.crt \
    -k8s-token="$TOKEN" \
    -logfile="/var/log/ovn-kubernetes/ovnkube.log" \
-   -init-master="k8smaster" -cluster-subnet="192.168.0.0/16" \
+   -init-master="k8smaster" -cluster-subnets="192.168.0.0/16" \
    -init-node="k8smaster" \
    -nodeport \
    -nb-address="$ovn_nb" \

--- a/vagrant/provisioning/setup-minion.sh
+++ b/vagrant/provisioning/setup-minion.sh
@@ -176,7 +176,7 @@ if [ "$DAEMONSET" != "true" ]; then
       -sb-address="$ovn_sb" \
       ${SSL_ARGS} \
       -init-gateways -gateway-interface=enp0s8 -gateway-nexthop="$GW_IP" \
-      -cluster-subnet="192.168.0.0/16" 2>&1 &
+      -cluster-subnets="192.168.0.0/16" 2>&1 &
 fi
 
 sleep 10


### PR DESCRIPTION
To keep moving towards our future use of the config file (and thus ConfigMaps) instead of CLI options, move the cluster-subnet option into config and rename slightly now that we support multiple cluster CIDRs. Provide backwards compatibility for the old '-cluster-subnets' CLI option.
    
@danwinship @pecameron @girishmg @shettyg @squeed 