### PR TITLE
Add iptable rules to enable access to K8s API server from master node

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -215,6 +215,15 @@ func runOvnKube(ctx *cli.Context) error {
 			if runtime.GOOS == "windows" {
 				panic("Windows is not supported as master node")
 			}
+
+			// provide the workaround to allow access to kubernetes service cluster ip from the
+			// master node and from the HostNetwork Pods on the master node. See:
+			// https://github.com/ovn-org/ovn-kubernetes/issues/758 for more details.
+			if err := clusterController.AddWARToAccessAPIServer(); err != nil {
+				logrus.Errorf(err.Error())
+				panic(err.Error())
+			}
+
 			// run the cluster controller to init the master
 			err := clusterController.StartClusterMaster(master)
 			if err != nil {

--- a/go-controller/pkg/cluster/helper_linux.go
+++ b/go-controller/pkg/cluster/helper_linux.go
@@ -6,7 +6,12 @@ import (
 	"fmt"
 	"syscall"
 
+	kapi "k8s.io/api/core/v1"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/sirupsen/logrus"
 
 	"github.com/vishvananda/netlink"
 )
@@ -49,4 +54,64 @@ func getIntfName(gatewayIntf string) (string, error) {
 			intfName, stderr, err)
 	}
 	return intfName, nil
+}
+
+func addWARToAccessAPIServer(kube kube.Interface) error {
+	// first get the kubernetes service's cluster IP and port
+	svc, err := kube.GetService(kapi.NamespaceDefault, "kubernetes")
+	if err != nil {
+		return fmt.Errorf("failed to get service 'kubernetes' in namespace %q",
+			kapi.NamespaceDefault)
+	}
+
+	clusterIP := svc.Spec.ClusterIP
+	clusterPort := fmt.Sprintf("%d", svc.Spec.Ports[0].Port)
+
+	// next get the kubernetes service's endpoint IPs and port
+	ep, err := kube.GetEndpoint(kapi.NamespaceDefault, "kubernetes")
+	if err != nil {
+		return fmt.Errorf("failed to get the endpoints and port for 'kubernetes' service")
+	}
+
+	epIPPorts := make([]string, 0)
+	for _, subset := range ep.Subsets {
+		for _, ip := range subset.Addresses {
+			for _, port := range subset.Ports {
+				epIPPorts = append(epIPPorts, fmt.Sprintf("%s:%d", ip.IP, port.Port))
+			}
+		}
+	}
+
+	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+	if err != nil {
+		return fmt.Errorf("failed to initialize iptables: %v", err)
+	}
+	// delete all the existing OVN-KUBE-APIACCESS rules
+	_ = ipt.ClearChain("nat", "OVN-KUBE-APIACCESS")
+
+	rules := make([]iptRule, 0)
+	rules = append(rules, iptRule{
+		table: "nat",
+		chain: "OUTPUT",
+		args:  []string{"-j", "OVN-KUBE-APIACCESS"},
+	})
+	for i, epIPPort := range epIPPorts {
+		ruleArgs := []string{"-p", "tcp", "-d", clusterIP, "--dport", clusterPort, "-j", "DNAT",
+			"--to-destination", epIPPort}
+		// if there are more than one master, then use a round robin approach to distribute the connections
+		// across various master
+		if i != 0 {
+			ruleArgs = append(ruleArgs, "-m", "statistic", "--mode", "nth", "--every", fmt.Sprintf("%d", i+1))
+		}
+
+		rules = append(rules, iptRule{
+			table: "nat",
+			chain: "OVN-KUBE-APIACCESS",
+			args:  ruleArgs,
+		})
+	}
+
+	logrus.Debugf("Add rules %v to access K8s API Server through K8s service cluster IP %s:%s",
+		rules, clusterIP, clusterPort)
+	return addIptRules(ipt, rules)
 }

--- a/go-controller/pkg/cluster/helper_windows.go
+++ b/go-controller/pkg/cluster/helper_windows.go
@@ -4,6 +4,7 @@ package cluster
 
 import (
 	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -29,4 +30,8 @@ func getIntfName(gatewayIntf string) (string, error) {
 			intfName, stderr, err)
 	}
 	return intfName, nil
+}
+
+func addWARToAccessAPIServer(kube kube.Interface) error {
+	return fmt.Errorf("Not required to be run on Windows")
 }

--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -14,6 +14,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// AddWARToAccessAPIServer adds a workaround (WAR) to allow access to kubernetes service
+// cluster ip from the master node and from the HostNetwork Pods on the master node. It does
+// so by adding iptable rules in the host stack and by completely avoid OVS pipeline for K8s API
+// server access. This is done only for the Master node and only for the HostNetwork Pods and
+// the K8s node itself.
+func (cluster *OvnClusterController) AddWARToAccessAPIServer() error {
+	return addWARToAccessAPIServer(cluster.Kube)
+}
+
 // StartClusterMaster runs a subnet IPAM and a controller that watches arrival/departure
 // of nodes in the cluster
 // On an addition to the cluster (node create), a new subnet is created for it that will translate

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -24,6 +24,7 @@ type Interface interface {
 	GetNodes() (*kapi.NodeList, error)
 	GetNode(name string) (*kapi.Node, error)
 	GetService(namespace, name string) (*kapi.Service, error)
+	GetEndpoint(namespace, name string) (*kapi.Endpoints, error)
 	GetEndpoints(namespace string) (*kapi.EndpointsList, error)
 	GetNamespaces() (*kapi.NamespaceList, error)
 }
@@ -95,6 +96,11 @@ func (k *Kube) GetNode(name string) (*kapi.Node, error) {
 // GetService returns the Service resource from kubernetes apiserver, given its name and namespace
 func (k *Kube) GetService(namespace, name string) (*kapi.Service, error) {
 	return k.KClient.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+}
+
+// GetEndpoint returns the endpoint resource from kubernetes apiserver, given its name and namespace
+func (k *Kube) GetEndpoint(namespace, name string) (*kapi.Endpoints, error) {
+	return k.KClient.CoreV1().Endpoints(namespace).Get(name, metav1.GetOptions{})
 }
 
 // GetEndpoints returns all the Endpoint resources from kubernetes


### PR DESCRIPTION
Connection to K8s API server from the HostNetwork pods on the K8s master
is timing out. The path packets take through the OVS pipeline results
in a particular OpenFlow flow being added twice to the same conntrack
zone. As a result, that particular flow is getting dropped as invalid.

The workaround for now is to use iptable rules in the host stack and
completely avoid OVS pipeline for K8s API server access. This is
done only for the Master node and only for the HostNetwork Pods and the
K8s node itself.

See issue #758 for more information.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>