### PR TITLE
use ovs-appctl to check for process readiness and health

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -201,16 +201,21 @@ get_ovn_db_vars () {
   ovn_nbdb_test=$(echo ${ovn_nbdb} | sed 's;//;;')
 }
 
-# ovs must be up before ovn comes up
-# This waits for ovs to come up
+# OVS must be up before OVN comes up.
+# This checks if OVS is up and running
 ovs_ready () {
-  /usr/share/openvswitch/scripts/ovs-ctl status &>/dev/null
-  if [[ $? != 0 ]] ; then
+  for daemon in `echo ovsdb-server ovs-vswitchd` ; do
+    pidfile=/var/run/openvswitch/${daemon}.pid
+    if [[ -f ${pidfile} ]] ; then
+      check_health $daemon $(cat $pidfile)
+      if [[ $? == 0 ]] ; then
+        continue
+      fi
+    fi
     return 1
-  fi
+  done
   return 0
 }
-#wait_for_event ovs_ready
 
 # version 1 daemonset compatibility
 # ovn must be up and initialized before ovn-controller, init-node, and init-master
@@ -225,30 +230,29 @@ northd_ready () {
 #wait_for_event northd_ready
 
 
-# wait for the pid file to appear (daemon is up)
-# verify the pid is running
-# $1 is the pid file name
-pid_ready () {
-  pidfile=/var/run/openvswitch/${1}
+# Verify that the process is running either by checking for the PID in `ps` output
+# or by using `ovs-appctl` utility for the processes that support it.
+# $1 is the name of the process
+process_ready () {
+  pidfile=/var/run/openvswitch/${1}.pid
   if [[ -f ${pidfile} ]] ; then
-    pid=$(cat ${pidfile})
-    pidTest=$(ps ax | awk '{ print $1 }' | grep "^${pid:-XX}$")
-    if [[ ${pid:-XX} == ${pidTest} ]] ; then
+    check_health $1 $(cat $pidfile)
+    if [[ $? == 0 ]] ; then
       return 0
     fi
   fi
   return 1
 }
-#wait_for_event pid_ready $1
 
 
-# check process health, exit if process terminates
-# $1 is the pid file fqn
-pid_health () {
-  pid=$(cat $1)
+# continously checks if process is healthy. Exits if process terminates.
+# $1 is the name of the process
+# $2 is the pid of an another process to kill before exiting
+process_healthy () {
+  pid=$(cat /var/run/openvswitch/${1}.pid)
   while true; do
-    pidTest=$(ps ax | awk '{ print $1 }' | grep "^${pid:-XX}$")
-    if [[ ${pid:-XX} != ${pidTest} ]] ; then
+    check_health $1 ${pid}
+    if [[ $? != 0 ]] ; then
       echo "=============== pid ${pid} terminated ========== "
       # kill the tail -f
       kill $2
@@ -256,6 +260,44 @@ pid_health () {
     fi
     sleep 15
   done
+}
+
+# checks for the health of the process either using `ps` or `ovs-appctl`
+# $1 is the name of the process
+# $2 is the process pid
+check_health () {
+  ctl_file=""
+  case ${1} in
+    "ovnkube"|"ovnkube-master")
+    ;;
+    "ovnnb_db"|"ovnsb_db")
+    ctl_file=/var/run/openvswitch/${1}.ctl
+    ;;
+    "ovn-northd"|"ovn-controller"|"ovsdb-server"|"ovs-vswitchd")
+    ctl_file=/var/run/openvswitch/${1}.${2}.ctl
+    ;;
+    *)
+    echo "Unknown service ${1} specified. Exiting.. "
+    exit 1
+    ;;
+  esac
+
+  if [[ ${ctl_file} == "" ]] ; then
+    # no control file, so just do the PID check
+    pid=${2}
+    pidTest=$(ps ax | awk '{ print $1 }' | grep "^${pid:-XX}$")
+    if [[ ${pid:-XX} == ${pidTest} ]] ; then
+      return 0
+    fi
+  else
+    # use ovs-appctl to do the check
+    ovs-appctl -t ${ctl_file} version &>/dev/null
+    if [[ $? == 0 ]] ; then
+        return 0
+    fi
+  fi
+
+  return 1
 }
 
 display_file () {
@@ -498,7 +540,7 @@ nb-ovsdb () {
   /usr/share/openvswitch/scripts/ovn-ctl run_nb_ovsdb --no-monitor \
   --ovn-nb-logfile=${ovn_nb_log_file} --ovn-nb-log="${ovn_log_nb}" &
 
-  wait_for_event pid_ready ovnnb_db.pid
+  wait_for_event process_ready ovnnb_db
   echo "=============== nb-ovsdb ========== RUNNING"
   sleep 3
   ovn-nbctl set-connection ptcp:6641 -- set connection . inactivity_probe=0
@@ -506,7 +548,7 @@ nb-ovsdb () {
   tail --follow=name ${ovn_nb_log_file} &
   ovn_tail_pid=$!
 
-  pid_health /var/run/openvswitch/ovnnb_db.pid ${ovn_tail_pid}
+  process_healthy ovnnb_db ${ovn_tail_pid}
   echo "=============== run nb_ovsdb ========== terminated"
 }
 
@@ -526,7 +568,7 @@ sb-ovsdb () {
   /usr/share/openvswitch/scripts/ovn-ctl run_sb_ovsdb --no-monitor \
   --ovn-sb-logfile=${ovn_sb_log_file} --ovn-sb-log="${ovn_log_sb}" &
 
-  wait_for_event pid_ready ovnsb_db.pid
+  wait_for_event process_ready ovnsb_db
   echo "=============== sb-ovsdb ========== RUNNING"
   sleep 3
   ovn-sbctl set-connection ptcp:6642 -- set connection . inactivity_probe=0
@@ -537,7 +579,7 @@ sb-ovsdb () {
   tail --follow=name ${ovn_sb_log_file} &
   ovn_tail_pid=$!
 
-  pid_health /var/run/openvswitch/ovnsb_db.pid ${ovn_tail_pid}
+  process_healthy ovnsb_db ${ovn_tail_pid}
   echo "=============== run sb_ovsdb ========== terminated"
 }
 
@@ -571,7 +613,7 @@ run-ovn-northd () {
     --ovn-northd-log="${ovn_log_northd}" \
     ${ovn_northd_opts}
 
-  wait_for_event pid_ready ovn-northd.pid
+  wait_for_event process_ready ovn-northd
   echo "=============== run_ovn_northd ========== RUNNING"
   sleep 1
 
@@ -579,7 +621,7 @@ run-ovn-northd () {
   ovn_tail_pid=$!
 
 
-  pid_health /var/run/openvswitch/ovn-northd.pid ${ovn_tail_pid}
+  process_healthy ovn-northd ${ovn_tail_pid}
   exit 8
 }
 
@@ -623,7 +665,7 @@ ovn-master () {
   echo "ovn_nbdb ${ovn_nbdb}   ovn_sbdb ${ovn_sbdb}"
 
   # wait for northd to start
-  wait_for_event pid_ready ovn-northd.pid
+  wait_for_event process_ready ovn-northd
   sleep 5
 
   # wait for ovs-servers to start since ovn-master sets some fields in OVS DB
@@ -640,13 +682,13 @@ ovn-master () {
     --pidfile /var/run/openvswitch/ovnkube-master.pid \
     --logfile /var/log/ovn-kubernetes/ovnkube-master.log &
   echo "=============== ovn-master ========== running"
-  wait_for_event pid_ready ovnkube-master.pid
+  wait_for_event process_ready ovnkube-master
   sleep 1
 
   tail --follow=name /var/log/ovn-kubernetes/ovnkube-master.log &
   kube_tail_pid=$!
 
-  pid_health /var/run/openvswitch/ovnkube-master.pid ${kube_tail_pid}
+  process_healthy ovnkube-master ${kube_tail_pid}
   exit 9
 }
 
@@ -670,14 +712,14 @@ ovn-controller () {
   /usr/share/openvswitch/scripts/ovn-ctl --no-monitor start_controller \
     --ovn-controller-log="${ovn_log_controller}" ${ovn_controller_opts}
 
-  wait_for_event pid_ready ovn-controller.pid
+  wait_for_event process_ready ovn-controller
   echo "=============== ovn-controller ========== running"
 
   sleep 4
   tail --follow=name /var/log/openvswitch/ovn-controller.log &
   controller_tail_pid=$!
 
-  pid_health /var/run/openvswitch/ovn-controller.pid ${controller_tail_pid}
+  process_healthy ovn-controller ${controller_tail_pid}
   exit 10
 }
 
@@ -698,7 +740,7 @@ ovn-node () {
   echo "ovn_nbdb ${ovn_nbdb}   ovn_sbdb ${ovn_sbdb}  ovn_nbdb_test ${ovn_nbdb_test}"
 
   echo "=============== ovn-node - (ovn-node  wait for ovn-controller.pid)"
-  wait_for_event pid_ready ovn-controller.pid
+  wait_for_event process_ready ovn-controller
   sleep 1
 
   echo "=============== ovn-node   --init-node"
@@ -716,7 +758,7 @@ ovn-node () {
       --pidfile /var/run/openvswitch/ovnkube.pid \
       --logfile /var/log/ovn-kubernetes/ovnkube.log &
 
-  wait_for_event pid_ready ovnkube.pid
+  wait_for_event process_ready ovnkube
   setup_cni
   echo "=============== ovn-node ========== running"
 
@@ -724,7 +766,7 @@ ovn-node () {
   tail --follow=name /var/log/ovn-kubernetes/ovnkube.log &
   node_tail_pid=$!
 
-  pid_health /var/run/openvswitch/ovnkube.pid ${node_tail_pid}
+  process_healthy ovnkube ${node_tail_pid}
   exit 7
 }
 
@@ -737,7 +779,7 @@ cleanup-ovn-node () {
   echo "=============== time: $(date +%d-%m-%H:%M:%S:%N) cleanup-ovn-node - (wait for ovn-controller to exit)"
   retries=0
   while [[ ${retries} -lt 80 ]]; do
-    pid_ready ovn-controller.pid
+    process_ready ovn-controller
     if [[ $? != 0 ]] ; then
       break
     fi


### PR DESCRIPTION
For those processes (ovsdb-server, ovs-vswitchd, ovn-northd,
ovsdb-server-nb, ovsdb-server-sb, and ovn-controller) that support
ovs-appctl to control it, use the same utility to check for process
health and readiness.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>