### PR TITLE
Add unidling support.

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -225,7 +225,7 @@ func runOvnKube(ctx *cli.Context) error {
 		ovn.RegisterMetrics()
 
 		// run the HA master controller to init the master
-		ovnHAController := ovn.NewHAMasterController(clientset, factory, master)
+		ovnHAController := ovn.NewHAMasterController(clientset, factory, master, stopChan)
 		if err := ovnHAController.StartHAMasterController(); err != nil {
 			return err
 		}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -144,6 +144,7 @@ type KubernetesConfig struct {
 	ServiceCIDR        string `gcfg:"service-cidr"`
 	OVNConfigNamespace string `gcfg:"ovn-config-namespace"`
 	MetricsBindAddress string `gcfg:"metrics-bind-address"`
+	OVNEmptyLbEvents   bool   `gcfg:"ovn-empty-lb-events"`
 }
 
 // GatewayMode holds the node gateway mode
@@ -497,6 +498,14 @@ var K8sFlags = []cli.Flag{
 		Name:        "metrics-bind-address",
 		Usage:       "The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces)",
 		Destination: &cliConfig.Kubernetes.MetricsBindAddress,
+	},
+	cli.BoolFlag{
+		Name: "ovn-empty-lb-events",
+		Usage: "If set, then load balancers do not get deleted when all backends are removed. " +
+			"Instead, ovn-kubernetes monitors the OVN southbound database for empty lb backends " +
+			"controller events. If one arrives, then a NeedPods event is sent so that Kubernetes " +
+			"will spin up pods for the load balancer to send traffic to.",
+		Destination: &cliConfig.Kubernetes.OVNEmptyLbEvents,
 	},
 }
 

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	kv1core "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 // Interface represents the exported methods for dealing with getting/setting
@@ -30,6 +31,7 @@ type Interface interface {
 	GetService(namespace, name string) (*kapi.Service, error)
 	GetEndpoints(namespace string) (*kapi.EndpointsList, error)
 	GetNamespaces() (*kapi.NamespaceList, error)
+	Events() kv1core.EventInterface
 }
 
 // Kube is the structure object upon which the Interface is implemented
@@ -148,4 +150,9 @@ func (k *Kube) GetEndpoints(namespace string) (*kapi.EndpointsList, error) {
 // GetNamespaces returns all Namespace resource from kubernetes apiserver
 func (k *Kube) GetNamespaces() (*kapi.NamespaceList, error) {
 	return k.KClient.CoreV1().Namespaces().List(metav1.ListOptions{})
+}
+
+// Events returns events to use when creating an EventSinkImpl
+func (k *Kube) Events() kv1core.EventInterface {
+	return k.KClient.CoreV1().Events("")
 }

--- a/go-controller/pkg/ovn/ha_master.go
+++ b/go-controller/pkg/ovn/ha_master.go
@@ -25,11 +25,12 @@ type HAMasterController struct {
 	nodeName      string
 	isLeader      bool
 	leaderElector *leaderelection.LeaderElector
+	stopChan      chan struct{}
 }
 
 // NewHAMasterController creates a new HA Master controller
 func NewHAMasterController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
-	nodeName string) *HAMasterController {
+	nodeName string, stopChan chan struct{}) *HAMasterController {
 	ovnController := NewOvnController(kubeClient, wf)
 	return &HAMasterController{
 		kubeClient:    kubeClient,
@@ -37,6 +38,7 @@ func NewHAMasterController(kubeClient kubernetes.Interface, wf *factory.WatchFac
 		nodeName:      nodeName,
 		isLeader:      false,
 		leaderElector: nil,
+		stopChan:      stopChan,
 	}
 }
 
@@ -120,5 +122,5 @@ func (hacontroller *HAMasterController) ConfigureAsActive(masterNodeName string)
 		return err
 	}
 
-	return hacontroller.ovnController.Run()
+	return hacontroller.ovnController.Run(hacontroller.stopChan)
 }

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -1,19 +1,36 @@
 package ovn
 
 import (
+	"encoding/json"
+	"errors"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/openshift/origin/pkg/util/netutils"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	kapisnetworking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	kv1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 )
+
+// ServiceVIPKey is used for looking up service namespace information for a
+// particular load balancer
+type ServiceVIPKey struct {
+	// Load balancer VIP in the form "ip:port"
+	vip string
+	// Protocol used by the load balancer
+	protocol kapi.Protocol
+}
 
 // Controller structure is the object which holds the controls for starting
 // and reacting upon the watched resources (e.g. pods, endpoints)
@@ -82,6 +99,11 @@ type Controller struct {
 
 	// supports port_group?
 	portGroupSupport bool
+
+	// Map of load balancers to service namespace
+	serviceVIPToName map[ServiceVIPKey]types.NamespacedName
+
+	serviceVIPToNameLock sync.Mutex
 }
 
 const (
@@ -112,11 +134,13 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory)
 		gatewayCache:             make(map[string]string),
 		loadbalancerClusterCache: make(map[string]string),
 		loadbalancerGWCache:      make(map[string]string),
+		serviceVIPToName:         make(map[ServiceVIPKey]types.NamespacedName),
+		serviceVIPToNameLock:     sync.Mutex{},
 	}
 }
 
 // Run starts the actual watching.
-func (oc *Controller) Run() error {
+func (oc *Controller) Run(stopChan chan struct{}) error {
 	startOvnUpdater()
 
 	// WatchNodes must be started first so that its initial Add will
@@ -132,7 +156,165 @@ func (oc *Controller) Run() error {
 			return err
 		}
 	}
+
+	if config.Kubernetes.OVNEmptyLbEvents {
+		go oc.ovnControllerEventChecker(stopChan)
+	}
+
 	return nil
+}
+
+type eventRecord struct {
+	Data     [][]interface{} `json:"Data"`
+	Headings []string        `json:"Headings"`
+}
+
+type emptyLBBackendEvent struct {
+	vip      string
+	protocol kapi.Protocol
+	uuid     string
+}
+
+func extractEmptyLBBackendsEvents(out []byte) ([]emptyLBBackendEvent, error) {
+	events := make([]emptyLBBackendEvent, 0, 4)
+
+	var f eventRecord
+	err := json.Unmarshal(out, &f)
+	if err != nil {
+		return events, err
+	}
+	if len(f.Data) == 0 {
+		return events, nil
+	}
+
+	var eventInfoIndex int
+	var eventTypeIndex int
+	var uuidIndex int
+	for idx, val := range f.Headings {
+		switch val {
+		case "event_info":
+			eventInfoIndex = idx
+		case "event_type":
+			eventTypeIndex = idx
+		case "_uuid":
+			uuidIndex = idx
+		}
+	}
+
+	for _, val := range f.Data {
+		if len(val) <= eventTypeIndex {
+			return events, errors.New("Mismatched Data and Headings in controller event")
+		}
+		if val[eventTypeIndex] != "empty_lb_backends" {
+			continue
+		}
+
+		uuidArray, ok := val[uuidIndex].([]interface{})
+		if !ok {
+			return events, errors.New("Unexpected '_uuid' data in controller event")
+		}
+		if len(uuidArray) < 2 {
+			return events, errors.New("Malformed UUID presented in controller event")
+		}
+		uuid, ok := uuidArray[1].(string)
+		if !ok {
+			return events, errors.New("Failed to parse UUID in controller event")
+		}
+
+		// Unpack the data. There's probably a better way to do this.
+		info, ok := val[eventInfoIndex].([]interface{})
+		if !ok {
+			return events, errors.New("Unexpected 'event_info' data in controller event")
+		}
+		if len(info) < 2 {
+			return events, errors.New("Malformed event_info in controller event")
+		}
+		eventMap, ok := info[1].([]interface{})
+		if !ok {
+			return events, errors.New("'event_info' data is not the expected type")
+		}
+
+		var vip string
+		var protocol kapi.Protocol
+		for _, x := range eventMap {
+			tuple, ok := x.([]interface{})
+			if !ok {
+				return events, errors.New("event map item failed to parse")
+			}
+			if len(tuple) < 2 {
+				return events, errors.New("event map contains malformed data")
+			}
+			switch tuple[0] {
+			case "vip":
+				vip, ok = tuple[1].(string)
+				if !ok {
+					return events, errors.New("Failed to parse vip in controller event")
+				}
+			case "protocol":
+				prot, ok := tuple[1].(string)
+				if !ok {
+					return events, errors.New("Failed to parse protocol in controller event")
+				}
+				if prot == "udp" {
+					protocol = kapi.ProtocolUDP
+				} else {
+					protocol = kapi.ProtocolTCP
+				}
+			}
+		}
+		events = append(events, emptyLBBackendEvent{vip, protocol, uuid})
+	}
+
+	return events, nil
+}
+
+func (oc *Controller) ovnControllerEventChecker(stopChan chan struct{}) {
+	ticker := time.NewTicker(5 * time.Second)
+
+	_, _, err := util.RunOVNNbctl("set", "nb_global", ".", "options:controller_event=true")
+	if err != nil {
+		logrus.Error("Unable to enable controller events. Unidling not possible")
+		return
+	}
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(&kv1core.EventSinkImpl{Interface: oc.kube.Events()})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, kapi.EventSource{Component: "kube-proxy"})
+
+	for {
+		select {
+		case <-ticker.C:
+			out, _, err := util.RunOVNSbctl("--format=json", "list", "controller_event")
+			if err != nil {
+				continue
+			}
+
+			events, err := extractEmptyLBBackendsEvents([]byte(out))
+			if err != nil || len(events) == 0 {
+				continue
+			}
+
+			for _, event := range events {
+				_, _, err := util.RunOVNSbctl("destroy", "controller_event", event.uuid)
+				if err != nil {
+					// Don't unidle until we are able to remove the controller event
+					logrus.Errorf("Unable to remove controller event %s", event.uuid)
+					continue
+				}
+				if serviceName, ok := oc.GetServiceVIPToName(event.vip, event.protocol); ok {
+					serviceRef := kapi.ObjectReference{
+						Kind:      "Service",
+						Namespace: serviceName.Namespace,
+						Name:      serviceName.Name,
+					}
+					logrus.Debugf("Sending a NeedPods event for service %s in namespace %s.", serviceName.Name, serviceName.Namespace)
+					recorder.Eventf(&serviceRef, kapi.EventTypeNormal, "NeedPods", "The service %s needs pods", serviceName.Name)
+				}
+			}
+		case <-stopChan:
+			return
+		}
+	}
 }
 
 // WatchPods starts the watching of Pod resource and calls back the appropriate handler logic
@@ -325,4 +507,19 @@ func (oc *Controller) WatchNodes() error {
 		},
 	}, oc.syncNodes)
 	return err
+}
+
+// AddServiceVIPToName associates a k8s service name with a load balancer VIP
+func (oc *Controller) AddServiceVIPToName(vip string, protocol kapi.Protocol, namespace, name string) {
+	oc.serviceVIPToNameLock.Lock()
+	defer oc.serviceVIPToNameLock.Unlock()
+	oc.serviceVIPToName[ServiceVIPKey{vip, protocol}] = types.NamespacedName{namespace, name}
+}
+
+// GetServiceVIPToName retrieves the associated k8s service name for a load balancer VIP
+func (oc *Controller) GetServiceVIPToName(vip string, protocol kapi.Protocol) (types.NamespacedName, bool) {
+	oc.serviceVIPToNameLock.Lock()
+	defer oc.serviceVIPToNameLock.Unlock()
+	namespace, ok := oc.serviceVIPToName[ServiceVIPKey{vip, protocol}]
+	return namespace, ok
 }


### PR DESCRIPTION
When all pods for a service VIP are removed, this used to result in the
load balancer for the VIP being removed from OVN.

With this change, we instead leave the VIP configured, but have the
backends in the OVN load balancer empty.

We also enable the controller_event northbound option. Now, with empty
load balancer backends, if OVN receives traffic for a load balancer VIP,
it will raise an empty_lb_backends event in the southbound database.

This patch adds an EventChecker method for the Controller that polls the
southbound database every 5 seconds to find if there are any unhandled
empty_lb_backend events. If there are any, then the event is parsed and
we send an event to kubernetes to request pods.

The use case for this is OpenShift's unidling. OpenShift will
automatically spin up pods if traffic is received on idled services.
This patchset allows for this behavior to work when using ovn-kubernetes
with OpenShift.

Signed-off-by: Lorenzo Bianconi <lorenzo.bianconi@redhat.com>
Signed-off-by: Mark Michelson <mmichels@redhat.com>