### PR TITLE
ovn-nbctl daemon mode until we get golang OVSDB bindings

### DIFF
--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -136,6 +136,51 @@ spec:
         lifecycle:
       # end of container
 
+      - name: run-nbctld
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "run-nbctld"]
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        volumeMounts:
+        - mountPath: /var/run
+          name: host-var-run
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+
+        ports:
+        - name: healthz
+          containerPort: 10260
+        # TODO: Temporarily disabled until we determine how to wait for clean default
+        # config
+        # livenessProbe:
+        #   initialDelaySeconds: 10
+        #   httpGet:
+        #     path: /healthz
+        #     port: 10258
+        #     scheme: HTTP
+        lifecycle:
+
       - name: ovnkube-master
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -64,6 +64,9 @@ var (
 
 	// Gateway holds node gateway-related parsed config file parameters and command-line overrides
 	Gateway GatewayConfig
+
+	// NbctlDaemon enables ovn-nbctl to run in daemon mode
+	NbctlDaemonMode bool
 )
 
 const (
@@ -375,6 +378,11 @@ var CommonFlags = []cli.Flag{
 			"are dedicated to each node and may be different for each " +
 			"entry.",
 		Destination: &cliConfig.Default.RawClusterSubnets,
+	},
+	cli.BoolFlag{
+		Name:        "nbctl-daemon-mode",
+		Usage:       "Run ovn-nbctl in daemon mode to improve performance in large clusters",
+		Destination: &NbctlDaemonMode,
 	},
 
 	// Logging options


### PR DESCRIPTION
Every invocation of ovn-nbctl command connects to northbound database
running on a remote server, retrieves a partial copy of the database
that is complete enough to do its work, sends a transaction request to
the server, and receives and processes the server’s reply. In common
interactive use, this is fine, but if the database is large, then the
command takes a long time to complete and yields poor performance.

The solution to this problem is to use golang OVSDB bindings. However,
In the absence of the bindings the next best solution is to use
ovn-ncbtl in the daemon mode.

In a "daemon mode", the user first starts ovn-nbctl running in the
background and afterward uses the daemon to execute operations. The
client needs to use the control socket and set the path to the control
socket in environment variable OVN_NB_DAEMON.

Changes have been made such that it can be used in non-daemonset mode as
well.

Also, this will be used for ovn-nbctl invocations in ovnkube --master
mode only.

Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>