### PR TITLE
remove other-config:exclude_ips key once that IP address is allocated

### DIFF
--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -250,12 +250,16 @@ func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) 
 		}
 	}
 
-	// Create this node's management logical port on the node switch
+	// Create this node's management logical port on the node switch. Now that the second subnet IP is
+	// statically allocated to the management logical port, we can safely remove the other_config:exclude_ips
+	// in the same transaction to avoid "Duplicate IP set" warning messages in ovn-northd.
 	ip = util.NextIP(ip)
 	portIP := ip.String()
 	n, _ := subnet.Mask.Size()
 	portIPMask := fmt.Sprintf("%s/%d", portIP, n)
-	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", nodeName, "k8s-"+nodeName, "--", "lsp-set-addresses", "k8s-"+nodeName, macAddress+" "+portIP)
+	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", nodeName, "k8s-"+nodeName,
+		"--", "lsp-set-addresses", "k8s-"+nodeName, macAddress+" "+portIP,
+		"--", "--if-exists", "remove", "logical_switch", nodeName, "other-config", "exclude_ips")
 	if err != nil {
 		logrus.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err

--- a/go-controller/pkg/ovn/management-port_test.go
+++ b/go-controller/pkg/ovn/management-port_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Management Port Operations", func() {
 				Output: mgtPortMAC,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP,
+				Cmd: "ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP + " -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 lsp-get-addresses stor-" + nodeName,


### PR DESCRIPTION
ovn-northd complains with a warning message "Duplicate IP set" when the
IP address set in logical switch's other_config:exclude_ips key is
statically allocated to a logical switch port. To eliminate that
warnings we'd need to remove the exclude_ips configuration in the same
transaction as the creation of the management port.

Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>