### PR TITLE
ovnkube-master and ovnkube-db pods shouldn't have hostPID set to true

### DIFF
--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -37,7 +37,6 @@ spec:
       # as all pods.
       serviceAccountName: ovn
       hostNetwork: true
-      hostPID: true
       # required to be scheduled on node with openvswitch.org/ovnkube-db=true label but can
       # only have one instance per node
       affinity:
@@ -78,8 +77,6 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/log/openvswitch/
           name: host-var-log-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
         - mountPath: /etc/corosync
           name: host-etc-corosync
         - mountPath: /var/log/corosync
@@ -128,9 +125,6 @@ spec:
       - name: host-var-log-ovs
         hostPath:
           path: /var/log/openvswitch
-      - name: host-var-run-ovs
-        hostPath:
-          path: /var/run/openvswitch
       - name: host-var-log-corosync
         hostPath:
           path: /var/log/corosync

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -38,7 +38,6 @@ spec:
       # as all pods.
       serviceAccountName: ovn
       hostNetwork: true
-      hostPID: true
       containers:
       # firewall rules for ovn - assumed to be setup
       # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
@@ -63,8 +62,6 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/log/openvswitch/
           name: host-var-log-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
 
         resources:
           requests:
@@ -117,8 +114,6 @@ spec:
           name: host-var-lib-ovs
         - mountPath: /var/log/openvswitch/
           name: host-var-log-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
 
         resources:
           requests:
@@ -162,8 +157,5 @@ spec:
       - name: host-var-log-ovs
         hostPath:
           path: /var/log/openvswitch
-      - name: host-var-run-ovs
-        hostPath:
-          path: /var/run/openvswitch
       tolerations:
       - operator: "Exists"

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -38,7 +38,6 @@ spec:
       # as all pods.
       serviceAccountName: ovn
       hostNetwork: true
-      hostPID: true
 
       containers:
 


### PR DESCRIPTION
Currently, those two pods have hostPID set to true. So, this means that
they can see all the processes in host process namespace. This is not
good from the security perspective.

Commit 59c345931f9d (use ovs-appctl to check for process readiness and
health) added support to check process readiness and health using
a control socket instead of a PID.

ovnkube-node pod cannot be yet moved to hostPID:false since we open
network namespace (PID in host process namespace) from within the pod
while adding an interface to the pod. so, this pod will be tackled in
a separate commit.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>