### PR TITLE
 Bind OVN DB ports to the node IP instead of INADDR_ANY 

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -549,7 +549,9 @@ nb-ovsdb () {
   wait_for_event attempts=3 process_ready ovnnb_db
   echo "=============== nb-ovsdb ========== RUNNING"
   sleep 3
-  ovn-nbctl set-connection ptcp:${ovn_nb_port} -- set connection . inactivity_probe=0
+
+  ovn_db_host=$(getent ahosts $(hostname) | head -1 | awk '{ print $1 }')
+  ovn-nbctl set-connection ptcp:${ovn_nb_port}:${ovn_db_host} -- set connection . inactivity_probe=0
 
   tail --follow=name /var/log/openvswitch/ovsdb-server-nb.log &
   ovn_tail_pid=$!
@@ -577,7 +579,9 @@ sb-ovsdb () {
   wait_for_event attempts=3 process_ready ovnsb_db
   echo "=============== sb-ovsdb ========== RUNNING"
   sleep 3
-  ovn-sbctl set-connection ptcp:${ovn_sb_port} -- set connection . inactivity_probe=0
+
+  ovn_db_host=$(getent ahosts $(hostname) | head -1 | awk '{ print $1 }')
+  ovn-sbctl set-connection ptcp:${ovn_sb_port}:${ovn_db_host} -- set connection . inactivity_probe=0
 
   # create the ovnkube_db endpoint for other pods to query the OVN DB IP
   create_ovnkube_db_ep


### PR DESCRIPTION
We currently have an issue where-in one can access OVN NB and SB DBs
from within the user's PODs. This commit resolves this issue by:

- opening passive connection at port 6641/6442 bound to the node IP
  instead of INADDR_ANY
- adds a bunch of iptable rules to OVN-KUBE-OVNDB to drop the packets
  from the cluster subnet CIDR

Fixes #624 

Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>