### PR TITLE
remove TEMP HACK - WORKAROUND verbiage from ovnkube.sh

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -785,11 +785,6 @@ ovn-node () {
   sleep 1
 
   echo "=============== ovn-node   --init-node"
-  # TEMP HACK - WORKAROUND
-  # --gateway-mode=local works around a problem that
-  # results in loss of network connectivity when docker is
-  # restarted or ovs daemonset is deleted.
-  # TEMP HACK - WORKAROUND
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
       --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
@@ -902,11 +897,6 @@ start_ovn () {
 
   # ovn-node - all nodes
   echo  "=============== start ovn-node"
-  # TEMP HACK - WORKAROUND
-  # --gateway-mode=local works around a problem that
-  # results in loss of network connectivity when docker is
-  # restarted or ovs daemonset is deleted.
-  # TEMP HACK - WORKAROUND
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
       --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \


### PR DESCRIPTION
Running "local" gateway mode is not a HACK. It is one of the ways to
achieve North-South traffic (aka traffic external to logical network).

If operators want to run "shared" gateway mode, then it is well
understood that they shouldn't be running ovs-server container in the
ovnkube-node POD. The expectation is that the OVS bridge with
right physical NIC as one of the bridge's port is already created in
the K8s node and that ovs-vswitchd and ovsdb-server processes are
running in the node.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>