### PR TITLE
enable port security on the pod's logical switch port

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -120,6 +120,9 @@ var _ = Describe("OVN Pod Operations", func() {
 					Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + portName + " dynamic_addresses",
 					Output: `"` + podMAC + " " + podIP + `"`,
 				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 lsp-set-port-security " + portName + " " + podMAC + " " + podIP + "/24",
+				})
 
 				err := util.SetExec(fexec)
 				Expect(err).NotTo(HaveOccurred())
@@ -229,6 +232,9 @@ var _ = Describe("OVN Pod Operations", func() {
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + portName + " dynamic_addresses",
 					Output: `"` + podMAC + " " + podIP + `"`,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 lsp-set-port-security " + portName + " " + podMAC + " " + podIP + "/24",
 				})
 
 				err := util.SetExec(fexec)


### PR DESCRIPTION
The port security is currently disabled. This means that the packets
with any ip/mac can be received/sent by the pod. A pod can do both MAC
and IP spoofing. However, by enabling port security we can limit the
addresses from which a logical port may send packets and to which it
may receive packets. This can be enabled by setting the
logical_switch_port's port_security column to the port's (MAC, IP)
address.

We cannot enable port security on K8s management logical switch port
since packets meant for local k8s node are forwarded through that port.
So, it receives packets with destination IP address that does not
belong to it.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>