### PR TITLE
gateway-init.go: Read chassis ID from OVS, not SBDB.

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -104,7 +104,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: clusterRouterUUID,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + nodeName,
+			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 			Output: systemID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -332,7 +332,7 @@ func spareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: clusterRouterUUID,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + nodeName,
+			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 			Output: systemID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -504,7 +504,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				Output: clusterRouterUUID,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + nodeName,
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 				Output: systemID,
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -34,16 +34,16 @@ func GetK8sClusterRouter() (string, error) {
 	return k8sClusterRouter, nil
 }
 
-func getNodeChassisID(nodeName string) (string, error) {
-	chassisID, stderr, err := RunOVNSbctl("--data=bare", "--no-heading",
-		"--columns=name", "find", "Chassis", "hostname="+nodeName)
+func getNodeChassisID() (string, error) {
+	chassisID, stderr, err := RunOVSVsctl("--if-exists", "get",
+		"Open_vSwitch", ".", "external_ids:system-id")
 	if err != nil {
-		logrus.Errorf("Failed to find Chassis ID for node %s, "+
-			"stderr: %q, error: %v", nodeName, stderr, err)
+		logrus.Errorf("No system-id configured in the local host, "+
+			"stderr: %q, error: %v", stderr, err)
 		return "", err
 	}
 	if chassisID == "" {
-		return "", fmt.Errorf("No chassis ID configured for node %s", nodeName)
+		return "", fmt.Errorf("No system-id configured in the local host")
 	}
 
 	return chassisID, nil
@@ -187,7 +187,7 @@ func GatewayInit(clusterIPSubnet []string, nodeName, ifaceID, nicIP, nicMacAddre
 		return err
 	}
 
-	systemID, err := getNodeChassisID(nodeName)
+	systemID, err := getNodeChassisID()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Revert the part of commit ea0c8916943a19622c82fca9d2e9faf87f2b00d2
that uses sbdb to obtain chassis ID.

Fixes # 791

Signed-off-by: Michael Cambria <mcambria@redhat.com>