### PR TITLE
Get git info from git commands

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -70,9 +70,7 @@ COPY ovn-debug.sh /root/
 COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 
 # copy git commit number into image
-RUN mkdir -p /root/.git/ /root/.git/refs/heads/
-COPY .git/HEAD /root/.git/HEAD
-COPY .git/refs/heads/ /root/.git/refs/heads/
+COPY git_info /root
 
 
 LABEL io.k8s.display-name="ovn kubernetes" \

--- a/dist/images/Dockerfile-ovndb-vip.ubuntu
+++ b/dist/images/Dockerfile-ovndb-vip.ubuntu
@@ -31,9 +31,7 @@ RUN mkdir -p /var/run/openvswitch
 COPY ovndb-vip.sh /root/
 
 # copy git commit number into image
-RUN mkdir -p /root/.git/ /root/.git/refs/heads/
-COPY .git/HEAD /root/.git/HEAD
-COPY .git/refs/heads/ /root/.git/refs/heads/
+COPY git_info /root
 
 
 LABEL io.k8s.display-name="ovn kubernetes" \

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -41,9 +41,7 @@ COPY ovnkube /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 
 # copy git commit number into image
-RUN mkdir -p /root/.git/ /root/.git/refs/heads/
-COPY .git/HEAD /root/.git/HEAD
-COPY .git/refs/heads/ /root/.git/refs/heads/
+COPY git_info /root
 
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -45,10 +45,7 @@ COPY ovn-debug.sh /root/
 COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 
 # copy git commit number into image
-RUN mkdir -p /root/.git/ /root/.git/refs/heads/
-COPY .git/HEAD /root/.git/HEAD
-COPY .git/refs/heads/ /root/.git/refs/heads/
-
+COPY git_info /root
 
 LABEL io.k8s.display-name="ovn kubernetes" \
       io.k8s.description="ovnkube ubuntu image" 

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -48,9 +48,8 @@ daemonsetyaml:
 ../../go-controller/_output/go/bin/ovnkube:
 	cd ../../go-controller ; make
 
+BRANCH = $(shell git rev-parse  --symbolic-full-name HEAD)
+COMMIT = $(shell git rev-parse  HEAD)
 bld: ../../go-controller/_output/go/bin/ovnkube
 	cp ../../go-controller/_output/go/bin/* .
-	mkdir -p .git/ .git/refs/heads/
-	cp ../../.git/HEAD .git/HEAD
-	cp ../../.git/refs/heads/* .git/refs/heads/
-
+	echo "ref: ${BRANCH}  commit: ${COMMIT}" > git_info

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -336,18 +336,11 @@ setup_cni () {
 display_version () {
   echo " =================== hostname: ${ovn_pod_host}"
   echo " =================== daemonset version ${ovn_daemonset_version}"
-  if [[ -f /root/.git/HEAD ]]
+  if [[ -f /root/git_info ]]
   then
-    commit=$(awk '{ print $1 }' /root/.git/HEAD )
-    if [[ ${commit} == "ref:" ]]
-    then
-      head=$(awk '{ print $2 }' /root/.git/HEAD )
-      commit=$(cat /root/.git/${head} )
-    else
-      head="master"
-      commit=$(cat /root/.git/HEAD)
-    fi
-    echo " =================== Image built from ovn-kubernetes ref: ${head}  commit: ${commit}"
+	disp_ver=$(cat /root/git_info)
+	echo " =================== Image built from ovn-kubernetes ${disp_ver}"
+	return
   fi
 }
 


### PR DESCRIPTION
Currently this info is parsed from files that are not guarnteed to be there.
For example in the case of git-pack-refs.

Signed-off-by: Shahar Klein <sklein@nvidia.com>