### PR TITLE
remove logical static route on node deletion

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -322,7 +322,7 @@ func (cluster *OvnClusterController) deleteNode(nodeName string, nodeSubnet *net
 		logrus.Errorf("Error deleting node %s logical network: %v", nodeName, err)
 	}
 
-	if err := util.GatewayCleanup(nodeName); err != nil {
+	if err := util.GatewayCleanup(nodeName, nodeSubnet.String()); err != nil {
 		return fmt.Errorf("Failed to clean up node %s gateway: (%v)", nodeName, err)
 	}
 

--- a/go-controller/pkg/cluster/master_test.go
+++ b/go-controller/pkg/cluster/master_test.go
@@ -219,6 +219,7 @@ var _ = Describe("Master Operations", func() {
 				node1Name         string = "openshift-node-1"
 				node1Subnet       string = "10.128.0.0/24"
 				node1RouteUUID    string = "0cac12cf-3e0f-4682-b028-5ea2e0001962"
+				node1mgtRouteUUID string = "0cac12cf-3e0f-4682-b028-5ea2e0001963"
 				masterName        string = "openshift-master-node"
 				masterSubnet      string = "10.128.2.0/24"
 				masterGWCIDR      string = "10.128.2.1/24"
@@ -258,6 +259,15 @@ subnet=%s
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouterUUID + " static_routes " + node1RouteUUID,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=10.128.0.2",
+				Output: node1mgtRouteUUID,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouterUUID + " static_routes " + node1mgtRouteUUID,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 --if-exist lsp-del jtor-GR_" + node1Name,
 				"ovn-nbctl --timeout=15 --if-exist lr-del GR_" + node1Name,
 				"ovn-nbctl --timeout=15 --if-exist ls-del ext_" + node1Name,


### PR DESCRIPTION

For a given node, we add a logical_static_route to ovn_cluster_router that routes the packets to the local k8s node through the node's management port. Now, when the node is deleted we need to remove that static route from ovn_cluster_router.