### PR TITLE
Add support for MAC attribute in CNI_ARGS

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -118,6 +118,8 @@ func cniRequestToPodRequest(r *http.Request) (*PodRequest, error) {
 		return nil, fmt.Errorf("missing K8S_POD_NAMESPACE")
 	}
 
+	req.MAC, _ = cniArgs["MAC"]
+
 	req.PodName, ok = cniArgs["K8S_POD_NAME"]
 	if !ok {
 		return nil, fmt.Errorf("missing K8S_POD_NAME")

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -48,6 +48,8 @@ type PodRequest struct {
 	Netns string
 	// Interface name to be configured
 	IfName string
+	// custom mac
+	MAC string
 	// CNI conf obtained from stdin conf
 	CNIConf *types.NetConf
 	// Channel for returning the operation result to the Server

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -15,7 +15,7 @@ import (
 // Interface represents the exported methods for dealing with getting/setting
 // kubernetes resources
 type Interface interface {
-	SetAnnotationOnPod(pod *kapi.Pod, key, value string) error
+	SetAnnotationOnPod(namespace, name, key, value string) error
 	SetAnnotationOnNode(node *kapi.Node, key, value string) error
 	GetAnnotationsOnPod(namespace, name string) (map[string]string, error)
 	GetPod(namespace, name string) (*kapi.Pod, error)
@@ -33,13 +33,13 @@ type Kube struct {
 	KClient kubernetes.Interface
 }
 
-// SetAnnotationOnPod takes the pod object and key/value string pair to set it as an annotation
-func (k *Kube) SetAnnotationOnPod(pod *kapi.Pod, key, value string) error {
-	logrus.Infof("Setting annotations %s=%s on pod %s", key, value, pod.Name)
+// SetAnnotationOnPod takes the pod namespace/name and key/value string pair to set it as an annotation
+func (k *Kube) SetAnnotationOnPod(namespace, name, key, value string) error {
+	logrus.Infof("Setting annotations %s=%s on pod %s/%s", key, value, namespace, name)
 	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, key, value)
-	_, err := k.KClient.CoreV1().Pods(pod.Namespace).Patch(pod.Name, types.MergePatchType, []byte(patchData))
+	_, err := k.KClient.CoreV1().Pods(namespace).Patch(name, types.MergePatchType, []byte(patchData))
 	if err != nil {
-		logrus.Errorf("Error in setting annotation on pod %s/%s: %v", pod.Name, pod.Namespace, err)
+		logrus.Errorf("Error in setting annotation on pod %s/%s: %v", namespace, name, err)
 	}
 	return err
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -295,7 +295,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		podIP.String(), mask, podMac.String(), gatewayIP)
 	logrus.Debugf("Annotation values: ip=%s/%s ; mac=%s ; gw=%s\nAnnotation=%s",
 		podIP.String(), mask, podMac.String(), gatewayIP, annotation)
-	err = oc.kube.SetAnnotationOnPod(pod, "ovn", annotation)
+	err = oc.kube.SetAnnotationOnPod(pod.Namespace, pod.Name, "ovn", annotation)
 	if err != nil {
 		logrus.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
 	}


### PR DESCRIPTION
The MAC attribute can be can be passed via CNI_ARGS into the
ovn-kubernetes CNI plugin. If it's passed, then the plugin is supposed
to enforce it and that is not the case with OVN CNI plugin. This commit
fixes the issue.

The multus-CNI reads the custom MAC off of the annotation on the POD
spec defined like this below:
```
annotations: v1.multus-cni.io/default-network: | [
    {
        "namespace": "kube-system",
        "name": "ovnkube",
        "mac": "aa:bb:cc:dd:ee:ff"

    }
]
```

The OVN interface that gets added to the POD will have that MAC instead
of OVN chosen MAC.

Fixes #776

Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>