### PR TITLE
disable privileged mode for OVN containers

### DIFF
--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -67,8 +67,6 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
 
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -52,8 +52,6 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
 
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
@@ -104,8 +102,6 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
 
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -50,8 +50,6 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
 
         volumeMounts:
         # Run directories where we need to be able to access sockets
@@ -117,8 +115,6 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
 
         volumeMounts:
         - mountPath: /var/log/openvswitch/
@@ -160,8 +156,6 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
 
         volumeMounts:
         # Run directories where we need to be able to access sockets

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -97,8 +97,6 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
 
         volumeMounts:
         - mountPath: /var/run/dbus/
@@ -163,8 +161,8 @@ spec:
 
         securityContext:
           runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
+          capabilities:
+            add: ["NET_ADMIN", "SYS_ADMIN"]
 
         volumeMounts:
         - mountPath: /var/run/dbus/


### PR DESCRIPTION
Currently, all the containers in ovn pods set privileged mode to true.
This is not good from security perspective. This commit only leaves ovs-daemons
container in privileged mode since it needs to probe openvswitch kernel module
and support ovs_user_id for ovsdb-server. The ovn-node container needs to support
setting network link attributes and to manipulate networking namespace,
so two capabilities -- NET_ADMIN and SYS_ADMIN -- are required.

Signed-off-by: Zhen Wang <zhewang@nvidia.com>
Acked-by: Girish Moodalbail <gmoodalbail@nvidia.com>