### PR TITLE
remove incorrect default value for OVN_NORTHD_OPTS

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -95,7 +95,7 @@ fi
 K8S_CACERT=${K8S_CACERT:-/var/run/secrets/kubernetes.io/serviceaccount/ca.crt}
 
 # ovn-northd - /etc/sysconfig/ovn-northd
-ovn_northd_opts=${OVN_NORTHD_OPTS:-"--db-nb-sock=/var/run/openvswitch/ovnnb_db.sock --db-sb-sock=/var/run/openvswitch/ovnsb_db.sock"}
+ovn_northd_opts=${OVN_NORTHD_OPTS:-""}
 
 # ovn-controller
 ovn_controller_opts=${OVN_CONTROLLER_OPTS:-""}


### PR DESCRIPTION
The NB/SB DB address is already captured in --ovn-northd-nb-db and
--ovn-northd-sb-db CLI options passed to ovn-ctl. This options captures
the address as set in ovnkube-db service. This itself should suffice.
However, the current code also passes the UNIX sock file path to ovn-ctl.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>