### PR TITLE
OVN CNI Network configuration should come from configmap

### DIFF
--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -130,3 +130,13 @@ data:
   net_cidr:      "{{ net_cidr | default('10.128.0.0/14/23') }}"
   svc_cidr:      "{{ svc_cidr | default('172.30.0.0/16') }}"
   k8s_apiserver: "{{ k8s_apiserver.stdout }}"
+
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    { 
+      "cniVersion": "0.3.1",
+      "name": "ovn-kubernetes",
+      "type": "ovn-k8s-cni-overlay",
+      "ipam": {},
+      "dns": {}
+    }

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -13,14 +13,17 @@ import (
 )
 
 // WriteCNIConfig writes a CNI JSON config file to directory given by global config
-func WriteCNIConfig(ConfDir string, fileName string) error {
-	bytes, err := json.Marshal(&types.NetConf{
-		CNIVersion: "0.3.1",
-		Name:       "ovn-kubernetes",
-		Type:       CNI.Plugin,
-	})
+func WriteCNIConfig(ConfDir, fileName, cniConfig string) error {
+	conf := &types.NetConf{}
+	bytes := []byte(cniConfig)
+
+	err := json.Unmarshal(bytes, conf)
 	if err != nil {
-		return fmt.Errorf("failed to marshal CNI config JSON: %v", err)
+		return fmt.Errorf("invalid OVN CNI config json string %s: %v", cniConfig, err)
+	}
+
+	if conf.CNIVersion == "" || conf.Name == "" || conf.Type == "" {
+		return fmt.Errorf("OVN CNI config json string %s is missing mandatory field(s)", cniConfig)
 	}
 
 	// Install the CNI config file after all initialization is done

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -24,6 +24,7 @@ type Interface interface {
 	GetNodes() (*kapi.NodeList, error)
 	GetNode(name string) (*kapi.Node, error)
 	GetService(namespace, name string) (*kapi.Service, error)
+	GetConfigMap(namespace, name string) (*kapi.ConfigMap, error)
 	GetEndpoints(namespace string) (*kapi.EndpointsList, error)
 	GetNamespaces() (*kapi.NamespaceList, error)
 }
@@ -95,6 +96,11 @@ func (k *Kube) GetNode(name string) (*kapi.Node, error) {
 // GetService returns the Service resource from kubernetes apiserver, given its name and namespace
 func (k *Kube) GetService(namespace, name string) (*kapi.Service, error) {
 	return k.KClient.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+}
+
+// GetConfigMap returns the ConfigMap resource from kubernetes apiserver, given its name and namespace
+func (k *Kube) GetConfigMap(namespace, name string) (*kapi.ConfigMap, error) {
+	return k.KClient.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
 }
 
 // GetEndpoints returns all the Endpoint resources from kubernetes

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -65,3 +65,9 @@ func ServiceTypeHasClusterIP(service *kapi.Service) bool {
 func ServiceTypeHasNodePort(service *kapi.Service) bool {
 	return service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
 }
+
+// GetConfigMapStringData gets the value of a specific key in the configmap
+func GetConfigMapStringData(configMap *kapi.ConfigMap, key string) string {
+	value, _ := configMap.Data[key]
+	return value
+}


### PR DESCRIPTION
Currently the OVN CNI network configuration is hardcoded to the
following JSON.

{
    "cniVersion": "0.3.1",
    "dns": {},
    "ipam": {},
    "name": "ovn-kubernetes",
    "type": "ovn-k8s-cni-overlay"
}

This shouldn't be the case. It should come from the configmap so that
deployers can choose DNS servers and such.

Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>