### PR TITLE
do not copy over loopback CNI plugin from the onvkube-node container

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -323,12 +323,7 @@ display () {
 }
 
 setup_cni () {
-  # Take over network functions on the node
   cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /opt/cni/bin/ovn-k8s-cni-overlay
-  if [[ ! -f /opt/cni/bin/loopback ]]
-  then
-    cp -f /usr/libexec/cni/loopback /opt/cni/bin/loopback
-  fi
 }
 
 display_version () {


### PR DESCRIPTION
all of the docker images for ovnkube-node container doesn't have
loopback CNI plugin installed, so there is no point in trying to copy
over this binary as it will result in an error.

furthermore, the `looopback` CNI plugin will need to be installed by
the deployer on each of the kubernetes node as part of the node bring
up. this is one of the requirements of kubernetes. (See Kubernetes
CNI network plugin requirements on kubernetes.io)

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>