### PR TITLE
[daemonset] enable support for non-default CNI directories

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,16 @@
+# OVN Kubernetes CNI FAQ
+
+Q: How do I configure a non-default location for CNI configuration and bin directory?
+
+By default the CNI configuration directory is set to /etc/cni/net.d and the
+CNI bin directory is set to /opt/cni/bin. One can change these default locations by
+passing the new directory locations to `kubelet` using --cni-conf-dir and --cni-bin-dir
+option. If non-default directory location is used in a K8s deployment, then OVN CNI
+need to be made aware of it by following the instructions below.
+
+1. Define volumes, for both configuration and bin, in the ovnkube-node pod spec with
+   `hostPath` set to the CNI directory on the host machine.
+2. Define volumeMounts for CNI configuration directory in the ovnkube-node container
+   spec with mountPath set to '/etc/cni/net.d'.
+3. Define volumeMounts for CNI bin directory in the ovnkube-node container spec with
+   mountPath set to '/opt/cni/bin'

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -50,8 +50,6 @@ RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsS
 RUN rm -rf /var/cache/yum
 
 RUN mkdir -p /var/run/openvswitch
-RUN mkdir -p /etc/cni/net.d
-RUN mkdir -p /opt/cni/bin
 
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the rpm

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -26,8 +26,6 @@ RUN INSTALL_PKGS=" \
 	dnf clean all && rm -rf /var/cache/dnf/*
 
 RUN mkdir -p /var/run/openvswitch && \
-    mkdir -p /etc/cni/net.d && \
-    mkdir -p /opt/cni/bin && \
     mkdir -p /usr/libexec/cni/
 
 COPY ovnkube /usr/bin/

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -28,8 +28,6 @@ RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add 
 RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host kubectl
 
 RUN mkdir -p /var/run/openvswitch
-RUN mkdir -p /etc/cni/net.d
-RUN mkdir -p /opt/cni/bin
 
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the pkg

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -320,11 +320,10 @@ display () {
 
 setup_cni () {
   # Take over network functions on the node
-  # rm -f /etc/cni/net.d/*
-  cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /host/opt/cni/bin/ovn-k8s-cni-overlay
-  if [[ ! -f /host/opt/cni/bin/loopback ]]
+  cp -f /usr/libexec/cni/ovn-k8s-cni-overlay /opt/cni/bin/ovn-k8s-cni-overlay
+  if [[ ! -f /opt/cni/bin/loopback ]]
   then
-    cp -f /usr/libexec/cni/loopback /host/opt/cni/bin/loopback
+    cp -f /usr/libexec/cni/loopback /opt/cni/bin/loopback
   fi
 }
 

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -178,7 +178,7 @@ spec:
         - mountPath: /var/run/ovn-kubernetes
           name: host-var-run-ovn-kubernetes
         # CNI related mounts which we take over
-        - mountPath: /host/opt/cni/bin
+        - mountPath: /opt/cni/bin
           name: host-opt-cni-bin
         - mountPath: /etc/cni/net.d
           name: host-etc-cni-netd


### PR DESCRIPTION
Currently, the CNI configuration and bin directories are not
configurable when using daemonsets. They are hardcoded to
/etc/cni/net.d and /opt/cni/bin respectively. This commit
adds support for using non-default locations using volumes
and volumeMounts field of the pod specification.

Added a FAQ file, and an entry within the FAQ file to capture the
steps required to enable non-default CNI directories.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>