### PR TITLE
Add an option for CNI shim to create and configure the pod interface

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -120,39 +120,22 @@ func (pr *PodRequest) cmdAdd() *PodResult {
 		logrus.Errorf("failed to parse bandwidth request: %v", err)
 		return nil
 	}
-
-	var interfacesArray []*current.Interface
-	interfacesArray, err = pr.ConfigureInterface(namespace, podName, macAddress, ipAddress, gatewayIP, config.Default.MTU, ingress, egress)
-	if err != nil {
-		logrus.Errorf("Failed to configure interface in pod: %v", err)
-		return nil
+	podInterfaceInfo := &PodInterfaceInfo{
+		MTU:        config.Default.MTU,
+		MacAddress: macAddress,
+		IPAddress:  ipAddress,
+		GatewayIP:  gatewayIP,
+		Ingress:    ingress,
+		Egress:     egress,
 	}
-
-	// Build the result structure to pass back to the runtime
-	addr, addrNet, err := net.ParseCIDR(ipAddress)
-	if err != nil {
-		logrus.Errorf("failed to parse IP address %q: %v", ipAddress, err)
-		return nil
-	}
-	ipVersion := "6"
-	if addr.To4() != nil {
-		ipVersion = "4"
-	}
-	result := &current.Result{
-		Interfaces: interfacesArray,
-		IPs: []*current.IPConfig{
-			{
-				Version:   ipVersion,
-				Interface: current.Int(1),
-				Address:   net.IPNet{IP: addr, Mask: addrNet.Mask},
-				Gateway:   net.ParseIP(gatewayIP),
-			},
-		},
-	}
-
 	podResult := &PodResult{}
-	//versionedResult, _ := result.GetAsVersion(pr.CNIConf.CNIVersion)
-	podResult.Response, _ = json.Marshal(result)
+	response := &Response{}
+	if !config.UnprivilegedMode {
+		response.Result = pr.getCNIResult(podInterfaceInfo)
+	} else {
+		response.PodIFInfo = podInterfaceInfo
+	}
+	podResult.Response, _ = json.Marshal(response)
 	return podResult
 }
 
@@ -183,4 +166,38 @@ func HandleCNIRequest(request *PodRequest) ([]byte, error) {
 	}
 	logrus.Infof("Returning pod network request %v, result %s err %v", request, string(result.Response), result.Err)
 	return result.Response, result.Err
+}
+
+// getCNIResult get result from pod interface info.
+func (pr *PodRequest) getCNIResult(podInterfaceInfo *PodInterfaceInfo) *current.Result {
+	var interfacesArray []*current.Interface
+	ipAddress := podInterfaceInfo.IPAddress
+	gatewayIP := podInterfaceInfo.GatewayIP
+	interfacesArray, err := pr.ConfigureInterface(pr.PodNamespace, pr.PodName, podInterfaceInfo.MacAddress, ipAddress, gatewayIP, podInterfaceInfo.MTU, podInterfaceInfo.Ingress, podInterfaceInfo.Egress)
+	if err != nil {
+		logrus.Errorf("Failed to configure interface in pod: %v", err)
+		return nil
+	}
+
+	// Build the result structure to pass back to the runtime
+	addr, addrNet, err := net.ParseCIDR(ipAddress)
+	if err != nil {
+		logrus.Errorf("Failed to parse IP address %q: %v", ipAddress, err)
+		return nil
+	}
+	ipVersion := "6"
+	if addr.To4() != nil {
+		ipVersion = "4"
+	}
+	return &current.Result{
+		Interfaces: interfacesArray,
+		IPs: []*current.IPConfig{
+			{
+				Version:   ipVersion,
+				Interface: current.Int(1),
+				Address:   net.IPNet{IP: addr, Mask: addrNet.Mask},
+				Gateway:   net.ParseIP(gatewayIP),
+			},
+		},
+	}
 }

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -77,12 +77,7 @@ func gatherCNIArgs(env map[string]string) (map[string]string, error) {
 	return mapArgs, nil
 }
 
-func cniRequestToPodRequest(r *http.Request) (*PodRequest, error) {
-	var cr Request
-	b, _ := ioutil.ReadAll(r.Body)
-	if err := json.Unmarshal(b, &cr); err != nil {
-		return nil, fmt.Errorf("JSON unmarshal error: %v", err)
-	}
+func cniRequestToPodRequest(cr *Request) (*PodRequest, error) {
 
 	cmd, ok := cr.Env["CNI_COMMAND"]
 	if !ok {
@@ -134,7 +129,13 @@ func cniRequestToPodRequest(r *http.Request) (*PodRequest, error) {
 // Dispatch a pod request to the request handler and return the result to the
 // CNI server client
 func (s *Server) handleCNIRequest(w http.ResponseWriter, r *http.Request) {
-	req, err := cniRequestToPodRequest(r)
+	var cr Request
+	b, _ := ioutil.ReadAll(r.Body)
+	if err := json.Unmarshal(b, &cr); err != nil {
+		http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+		return
+	}
+	req, err := cniRequestToPodRequest(&cr)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
 		return

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -3,6 +3,7 @@ package cni
 import (
 	"net/http"
 
+	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 )
 
@@ -12,6 +13,16 @@ const serverRunDir string = "/var/run/ovn-kubernetes/cni/"
 const serverSocketName string = "ovn-cni-server.sock"
 const serverSocketPath string = serverRunDir + "/" + serverSocketName
 const serverTCPAddress string = "127.0.0.1:3996"
+
+// PodInterfaceInfo consists of interface info result from cni server if cni client configure's interface
+type PodInterfaceInfo struct {
+	MTU        int    `json:"mtu"`
+	MacAddress string `json:"macAddress"`
+	IPAddress  string `json:"ipAddress"`
+	GatewayIP  string `json:"gatewayIP"`
+	Ingress    int64  `json:"ingress"`
+	Egress     int64  `json:"egress"`
+}
 
 // Explicit type for CNI commands the server handles
 type command string
@@ -31,6 +42,12 @@ type Request struct {
 	Env map[string]string `json:"env,omitempty"`
 	// CNI configuration passed via stdin to the CNI plugin
 	Config []byte `json:"config,omitempty"`
+}
+
+// Response sent to the OVN CNI plugin by the Server
+type Response struct {
+	Result    *current.Result
+	PodIFInfo *PodInterfaceInfo
 }
 
 // PodRequest structure built from Request which is passed to the

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -71,6 +71,9 @@ var (
 
 	// NbctlDaemon enables ovn-nbctl to run in daemon mode
 	NbctlDaemonMode bool
+
+	// UnprivilegedMode allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
+	UnprivilegedMode bool
 )
 
 const (
@@ -395,6 +398,11 @@ var CommonFlags = []cli.Flag{
 		Name:        "nbctl-daemon-mode",
 		Usage:       "Run ovn-nbctl in daemon mode to improve performance in large clusters",
 		Destination: &NbctlDaemonMode,
+	},
+	cli.BoolFlag{
+		Name:        "unprivileged-mode",
+		Usage:       "Run ovnkube-node container in unprivileged mode. Valid only with --init-node option.",
+		Destination: &UnprivilegedMode,
 	},
 
 	// Logging options


### PR DESCRIPTION
Currently we use client/server design to create and configure the pod
interface. The client being the ovn-k8s-cni-overlay and server
being the ovnkube-node container. The ovnkube-node creates and
configures the pod interface. This requires It to be running with
SYS_ADMIN capability and this is undesirable.

To make ovnkube-node to run with least capabilities as possible, the idea
is to create and configure the pod interface in the client itself (i.e., in
ovn-k8s-cni-overlay running on the host). In this approach, the deployer
explicity asks for unpriivelged ovnkube-node using a CLI option. The
server returns to client all the pod interface information (ip, mac, gateway,
MTU, ingresss, egress bandwidth, and so on). The client then creates
and sets up the pod interface.

Signed-off-by: Zhen Wang <zhewang@nvidia.com>