### PR TITLE
ovnkube.sh: add OVNKUBE_SH_VERBOSE for 'set -x' debugging

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-#set -x
 #set -euo pipefail
+
+# Enable verbose shell output if OVNKUBE_SH_VERBOSE is set to 'true'
+if [[ "${OVNKUBE_SH_VERBOSE:-}" == "true" ]]; then
+  set -x
+fi
 
 # This script is the entrypoint to the image.
 # Supports version 3 daemonsets


### PR DESCRIPTION
This allows better debugging of startup/dependency issues in onvkube.sh
from the daemonset/deployment YAML of each container, so that we don't
need to build special container images just for debugging.

@girishmg @shettyg @danwinship @pecameron 