### PR TITLE
[WIP] dist: Remove k8s_apiserver parameter for containerized ovnkube

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ git clone https://github.com/ovn-org/ovn-kubernetes
 cd $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/images
 ./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-u:latest \
     --net-cidr=192.168.0.0/16 --svc-cidr=172.16.1.0/24 \
-    --gateway-mode="local" \
-    --k8s-apiserver=https://$MASTER_IP:6443
+    --gateway-mode="local"
 ```
 
 Apply OVN daemonset and deployment yamls.

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -11,7 +11,6 @@ OVN_IMAGE=""
 OVN_IMAGE_PULL_POLICY=""
 OVN_NET_CIDR=""
 OVN_SVC_DIDR=""
-OVN_K8S_APISERVER=""
 OVN_GATEWAY_MODE=""
 OVN_GATEWAY_OPTS=""
 # In the future we will have RAFT based HA support.
@@ -41,9 +40,6 @@ while [ "$1" != "" ]; do
             ;;
         --svc-cidr)
             OVN_SVC_CIDR=$VALUE
-            ;;
-        --k8s-apiserver)
-            OVN_K8S_APISERVER=$VALUE
             ;;
         --db-vip-image)
             OVN_DB_VIP_IMAGE=$VALUE
@@ -156,8 +152,6 @@ then
 else
     svc_cidr=$OVN_SVC_CIDR
 fi
-
-k8s_apiserver=${OVN_K8S_APISERVER:-10.0.2.16:6443}
 
 net_cidr_repl="{{ net_cidr | default('10.128.0.0/14/23') }}"
 svc_cidr_repl="{{ svc_cidr | default('172.30.0.0/16') }}"

--- a/dist/images/ovndb-vip.sh
+++ b/dist/images/ovndb-vip.sh
@@ -14,7 +14,6 @@
 # ====================
 # Environment variables are used to customize operation
 # Required:
-# K8S_APISERVER - hostname:port (URL)of the real apiserver, not the service address
 # OVN_DB_VIP - the virtual IP address to be used by ovn-controller, ovn-northd,
 #                 and other OVN client-side utilities to connect to the OVN DB.
 #
@@ -65,12 +64,12 @@ check_ovn_daemonset_version () {
 # create the ovnkube_db endpoint for other pods to query the OVN DB IP
 create_ovnkube_db_ep () {
   # delete any endpoint by name ovnkube-db
-  kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+  kubectl --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
     delete ep -n ${ovn_kubernetes_namespace} ovnkube-db 2>/dev/null
 
   # create a new endpoint for the headless onvkube-db service without selectors
   # using the provided VIP
-  kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} apply -f - << EOF
+  kubectl --token=${k8s_token} --certificate-authority=${K8S_CACERT} apply -f - << EOF
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -126,7 +125,7 @@ crm_node_status () {
 
 config_corosync () {
   # get all the nodes that are participating in hosting the OVN DBs
-  cluster_nodes=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+  cluster_nodes=$(kubectl --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
     get nodes --selector=openvswitch.org/ovnkube-db=true \
     -o=jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null)
   nnodes=$(echo $cluster_nodes |wc -w)

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -29,7 +29,6 @@
 
 # ====================
 # Environment variables are used to customize operation
-# K8S_APISERVER - hostname:port (URL)of the real apiserver, not the service address - v3
 # OVN_NET_CIDR - the network cidr - v3
 # OVN_SVC_CIDR - the cluster-service-cidr - v3
 # OVN_KUBERNETES_NAMESPACE - k8s namespace - v3
@@ -172,7 +171,7 @@ wait_for_event () {
 ready_to_start_node () {
 
   # See if ep is available ...
-  ovn_db_host=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+  ovn_db_host=$(kubectl --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
     get ep -n ${ovn_kubernetes_namespace} ovnkube-db 2>/dev/null | grep 6642 | sed 's/:/ /' | awk '/ovnkube-db/{ print $2 }')
   if [[ ${ovn_db_host} == "" ]] ; then
       return 1
@@ -351,7 +350,6 @@ echo OVN_GATEWAY_MODE ${ovn_gateway_mode}
 echo OVN_GATEWAY_OPTS ${ovn_gateway_opts}
 echo OVN_NET_CIDR ${net_cidr}
 echo OVN_SVC_CIDR ${svc_cidr}
-echo K8S_APISERVER ${K8S_APISERVER}
 echo OVNKUBE_LOGLEVEL ${ovnkube_loglevel}
 echo OVN_DAEMONSET_VERSION ${ovn_daemonset_version}
 echo ovnkube.sh version ${ovnkube_version}
@@ -487,13 +485,13 @@ cleanup-ovs-server () {
 # create the ovnkube_db endpoint for other pods to query the OVN DB IP
 create_ovnkube_db_ep () {
   # delete any endpoint by name ovnkube-db
-  kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+  kubectl --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
     delete ep -n ${ovn_kubernetes_namespace} ovnkube-db 2>/dev/null
 
   # create a new endpoint for the headless onvkube-db service without selectors
   # using the current host has the endpoint IP
   ovn_db_host=$(getent ahosts $(hostname) | head -1 | awk '{ print $1 }')
-  kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} create -f - << EOF
+  kubectl --token=${k8s_token} --certificate-authority=${K8S_CACERT} create -f - << EOF
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -768,7 +766,7 @@ cleanup-ovn-node () {
 
   echo "=============== time: $(date +%d-%m-%H:%M:%S:%N) cleanup-ovn-node --cleanup-node"
   /usr/bin/ovnkube --cleanup-node ${K8S_NODE} --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
-      --k8s-token=${k8s_token} --k8s-apiserver=${K8S_APISERVER} --k8s-cacert=${K8S_CACERT} \
+      --k8s-token=${k8s_token} --k8s-cacert=${K8S_CACERT} \
       --loglevel=${ovnkube_loglevel} \
       --logfile /var/log/ovn-kubernetes/ovnkube.log
 

--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -129,4 +129,3 @@ metadata:
 data:
   net_cidr:      "{{ net_cidr | default('10.128.0.0/14/23') }}"
   svc_cidr:      "{{ svc_cidr | default('172.30.0.0/16') }}"
-  k8s_apiserver: "{{ k8s_apiserver.stdout }}"

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -93,11 +93,6 @@ spec:
           value: "3"
         - name: OVN_LOG_NB
           value: "-vconsole:info -vfile:info"
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
         - name: OVN_KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -72,11 +72,6 @@ spec:
           value: "3"
         - name: OVN_LOG_NB
           value: "-vconsole:info -vfile:info"
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
         - name: OVN_KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
@@ -124,11 +119,6 @@ spec:
           value: "3"
         - name: OVN_LOG_SB
           value: "-vconsole:info -vfile:info"
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
         - name: OVN_KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -82,11 +82,6 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:
@@ -131,11 +126,6 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
 
         ports:
         - name: healthz
@@ -188,11 +178,6 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -79,11 +79,6 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
         lifecycle:
           preStop:
             exec:
@@ -128,11 +123,6 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:
@@ -202,11 +192,6 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: svc_cidr
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
         - name: K8S_NODE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
When ovnkube is running in containers inside the Kubernetes cluster, it
doesn't have to be aware of the kubeapi-server address. Kubernetes
client should work with the in-cluster config and kubectl inside pods
should work out of the box.

Hardcoding the kubeapi-server IP might be problematic if master nodes
get changed, redeployed or if the network configuration of Kubernetes
nodes gets changed.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>