### PR TITLE
update the default route when the next hop node is deleted

### DIFF
--- a/go-controller/pkg/cluster/master_test.go
+++ b/go-controller/pkg/cluster/master_test.go
@@ -254,6 +254,10 @@ subnet=%s
 				Output: "[\"100.64.0.3/16\"]",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route ip_prefix=0.0.0.0/0 nexthop=100.64.0.3",
+				Output: "",
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=100.64.0.3",
 				Output: node1RouteUUID,
 			})

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -54,6 +54,7 @@ func (ovn *Controller) getDefaultGatewayLoadBalancer(protocol kapi.Protocol) str
 		"external_ids:"+externalIDKey+"="+gw)
 	if len(lb) != 0 {
 		ovn.loadbalancerGWCache[string(protocol)] = lb
+		ovn.defGatewayRouter = gw
 	}
 	return lb
 }

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -28,6 +28,7 @@ type Controller struct {
 	// For TCP and UDP type traffice, cache OVN load balancer that exists on the
 	// default gateway
 	loadbalancerGWCache map[string]string
+	defGatewayRouter    string
 
 	// A cache of all logical switches seen by the watcher
 	logicalSwitchCache map[string]bool
@@ -278,6 +279,12 @@ func (oc *Controller) WatchNodes() error {
 			delete(oc.logicalSwitchCache, node.Name)
 			oc.lsMutex.Unlock()
 			delete(gatewaysHandled, node.Name)
+			if oc.defGatewayRouter == "GR_"+node.Name {
+				delete(oc.loadbalancerGWCache, TCP)
+				delete(oc.loadbalancerGWCache, UDP)
+				oc.defGatewayRouter = ""
+				oc.handleExternalIPsLB()
+			}
 		},
 	}, nil)
 	return err

--- a/go-controller/pkg/util/gateway-cleanup.go
+++ b/go-controller/pkg/util/gateway-cleanup.go
@@ -21,7 +21,7 @@ func GatewayCleanup(nodeName, nodeSubnet string) error {
 	gatewayRouter := fmt.Sprintf("GR_%s", nodeName)
 
 	// Get the gateway router port's IP address (connected to join switch)
-	var routerIP, mgtPortIP string
+	var routerIP, mgtPortIP, defRouteUUID string
 	var nextHops []string
 	routerIPNetwork, stderr, err := RunOVNNbctl("--if-exist", "get",
 		"logical_router_port", "rtoj-"+gatewayRouter, "networks")
@@ -38,6 +38,9 @@ func GatewayCleanup(nodeName, nodeSubnet string) error {
 	}
 	if routerIP != "" {
 		nextHops = append(nextHops, routerIP)
+		defRouteUUID, _, _ = RunOVNNbctl("--data=bare", "--no-heading",
+			"--columns=_uuid", "find", "logical_router_static_route",
+			"ip_prefix=0.0.0.0/0", "nexthop="+routerIP)
 	}
 	mgtPortIP = getMgtPortIP(nodeSubnet)
 	if mgtPortIP != "" {
@@ -67,6 +70,23 @@ func GatewayCleanup(nodeName, nodeSubnet string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to delete external switch %s, stderr: %q, "+
 			"error: %v", externalSwitch, stderr, err)
+	}
+
+	if routerIP != "" && defRouteUUID != "" {
+		// need update the default GW route since the node will be deleted.
+		_, defGatewayIP, err := GetDefaultGatewayRouterIP()
+		if err != nil {
+			logrus.Errorf("failed to get default route for the distributed router "+
+				"with first GR as the nexthop, error: %v", err)
+		} else {
+			_, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
+				clusterRouter, "0.0.0.0/0", defGatewayIP.String())
+			if err != nil {
+				logrus.Errorf("failed to add a default route in distributed router "+
+					"with first GR as the nexthop, stderr: %q, error: %v",
+					stderr, err)
+			}
+		}
 	}
 
 	if config.Gateway.NodeportEnable {


### PR DESCRIPTION
We add a default route to ovn_cluster_router that points to a L3
gateway router as the next hop. When the node that hosts the L3 gateway
router is deleted from the cluster, the default route still points to
the same l3 gateway router chassis. We also need to move all the
External IPs related Load Balancer rules to a different default gateway
router.

Signed-off-by: Zhen Wang <zhewang@nvidia.com>