### PR TITLE
break after successully getting a subnet from the allocator

### DIFF
--- a/go-controller/pkg/cluster/master.go
+++ b/go-controller/pkg/cluster/master.go
@@ -255,6 +255,7 @@ func (cluster *OvnClusterController) addNode(node *kapi.Node) (err error) {
 			return fmt.Errorf("Error allocating network for node %s: %v", node.Name, err)
 		}
 		logrus.Infof("Allocated node %s HostSubnet %s", node.Name, hostsubnet.String())
+		break
 	}
 	if err == netutils.ErrSubnetAllocatorFull {
 		return fmt.Errorf("Error allocating network for node %s: %v", node.Name, err)


### PR DESCRIPTION
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>