### PR TITLE
add SYS_PTRACE capability to ovnkube-node container

### DIFF
--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -164,7 +164,7 @@ spec:
         securityContext:
           runAsUser: 0
           capabilities:
-            add: ["NET_ADMIN", "SYS_ADMIN"]
+            add: ["NET_ADMIN", "SYS_ADMIN", "SYS_PTRACE"]
 
         volumeMounts:
         - mountPath: /var/run/dbus/


### PR DESCRIPTION
For Pod with security context runAsNonRoot, ovnkube-node container will
fail with statfs for NonRoot container's namespace with permission denied.
SYS_PTRACE is the ability to skip the seccomp check.

Signed-off-by: Zhen Wang <zhewang@nvidia.com>