### PR TITLE
ovnkube.sh: idempotently set endpoints

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -498,8 +498,8 @@ cleanup-ovs-server () {
   /usr/share/openvswitch/scripts/ovs-ctl stop
 }
 
-# create the ovnkube_db endpoint for other pods to query the OVN DB IP
-create_ovnkube_db_ep () {
+# set the ovnkube_db endpoint for other pods to query the OVN DB IP
+set_ovnkube_db_ep () {
   # delete any endpoint by name ovnkube-db
   kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
     delete ep -n ${ovn_kubernetes_namespace} ovnkube-db 2>/dev/null
@@ -507,7 +507,7 @@ create_ovnkube_db_ep () {
   # create a new endpoint for the headless onvkube-db service without selectors
   # using the current host has the endpoint IP
   ovn_db_host=$(getent ahosts $(hostname) | head -1 | awk '{ print $1 }')
-  kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} create -f - << EOF
+  kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} apply -f - << EOF
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -580,7 +580,7 @@ sb-ovsdb () {
   ovn-sbctl set-connection ptcp:${ovn_sb_port} -- set connection . inactivity_probe=0
 
   # create the ovnkube_db endpoint for other pods to query the OVN DB IP
-  create_ovnkube_db_ep
+  set_ovnkube_db_ep
 
   tail --follow=name /var/log/openvswitch/ovsdb-server-sb.log &
   ovn_tail_pid=$!


### PR DESCRIPTION
This was crashing when the daemonset restarted, because it would try and create endpoints that already exist. Change it to "kubectl apply"