### PR TITLE
Add OVN-KUBE-SNAT-MGMTPORT chain in iptables nat table

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -2,10 +2,13 @@ package cluster
 
 import (
 	"fmt"
+	"runtime"
+
 	"github.com/sirupsen/logrus"
 	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -126,6 +129,11 @@ func CleanupClusterNode(name string) error {
 	stdout, stderr, err := util.RunOVSVsctl("--", "--if-exists", "del-br", "br-int")
 	if err != nil {
 		logrus.Errorf("Failed to delete bridge br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+	}
+
+	// Delete iptable rules for management port on Linux.
+	if runtime.GOOS != "windows" {
+		ovn.DelMgtPortIptRules(name)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/management-port_linux_test.go
+++ b/go-controller/pkg/ovn/management-port_linux_test.go
@@ -109,6 +109,8 @@ var _ = Describe("Management Port Operations", func() {
 			util.SetIPTablesHelper(iptables.ProtocolIPv4, fakeipt)
 			err = fakeipt.NewChain("nat", "POSTROUTING")
 			Expect(err).NotTo(HaveOccurred())
+			err = fakeipt.NewChain("nat", "OVN-KUBE-SNAT-MGMTPORT")
+			Expect(err).NotTo(HaveOccurred())
 
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -122,7 +124,10 @@ var _ = Describe("Management Port Operations", func() {
 				"filter": {},
 				"nat": {
 					"POSTROUTING": []string{
-						"-o " + mgtPort + " -j SNAT --to-source " + mgtPortIP,
+						"-o " + mgtPort + " -j OVN-KUBE-SNAT-MGMTPORT",
+					},
+					"OVN-KUBE-SNAT-MGMTPORT": []string{
+						"-o " + mgtPort + " -j SNAT --to-source " + mgtPortIP + " -m comment --comment OVN SNAT to Management Port",
 					},
 				},
 			}

--- a/go-controller/pkg/ovn/management-port_windows.go
+++ b/go-controller/pkg/ovn/management-port_windows.go
@@ -132,3 +132,6 @@ func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) 
 
 	return nil
 }
+
+func DelMgtPortIptRules(nodeName string) {
+}

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -17,6 +17,8 @@ type IPTablesHelper interface {
 	// ClearChain removes all rules in the specified table/chain.
 	// If the chain does not exist, a new one will be created
 	ClearChain(string, string) error
+	// DeleteChain deletes the chain in the specified table.
+	DeleteChain(string, string) error
 	// NewChain creates a new chain in the specified table
 	NewChain(string, string) error
 	// Exists checks if given rulespec in specified table/chain exists
@@ -134,6 +136,12 @@ func (f *FakeIPTables) ClearChain(tableName, chainName string) error {
 		return nil
 	}
 	return f.NewChain(tableName, chainName)
+}
+
+// DeleteChain deletes the chain in the specified table.
+// The chain must be empty
+func (f *FakeIPTables) DeleteChain(tableName, chainName string) error {
+	return f.DeleteChain(tableName, chainName)
 }
 
 // Exists checks if given rulespec in specified table/chain exists


### PR DESCRIPTION
Packets entering the OVN pipeline from the host or hostNetwork pods are
now SNAT'ed to management port IP. This is done so that the response
packets come back through the management port IP itself. However, the
rule is now just added to POSTROUTING chain. This fix moves the SNAT
rule to its own chain called OVN-KUBE-SNAT-MGMTPORT and delete the
chain on node deletion.

Signed-off-by: Zhen Wang <zhewang@nvidia.com>