### PR TITLE
Remove sb_db lock file on startup

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -564,6 +564,7 @@ nb-ovsdb () {
 sb-ovsdb () {
   trap 'kill $(jobs -p); exit 0' TERM
   check_ovn_daemonset_version "3"
+  rm -f /etc/openvswitch/.ovnsb_db.db.~lock~
   rm -f /var/run/openvswitch/ovnsb_db.pid
 
   # Make sure /var/lib/openvswitch exists


### PR DESCRIPTION
When the ovnkube master pod is deleted and recreated, sb-db
container cannot start due to lock hanging around from previous
run, showing error like:

WARN|/etc/openvswitch/.ovnsb_db.db.~lock~: cannot lock file because it is already locked by pid FOO