### PR TITLE
Adding test cases for OVN sync

### DIFF
--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -3,11 +3,12 @@ package ovn
 import (
 	"encoding/json"
 	"fmt"
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/sirupsen/logrus"
 	"hash/fnv"
 	"strconv"
 	"strings"
+
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/sirupsen/logrus"
 )
 
 // hash the provided input to make it a valid addressSet or portGroup name.

--- a/go-controller/pkg/ovn/endpoints_test.go
+++ b/go-controller/pkg/ovn/endpoints_test.go
@@ -1,0 +1,206 @@
+package ovn
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type endpoints struct{}
+
+func newEndpointsMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		UID:       types.UID(name),
+		Name:      name,
+		Namespace: namespace,
+		Labels: map[string]string{
+			"name": name,
+		},
+	}
+}
+
+func newEndpoints(name, namespace string, addresses []v1.EndpointAddress, ports []v1.EndpointPort) *v1.Endpoints {
+	return &v1.Endpoints{
+		ObjectMeta: newEndpointsMeta(name, namespace),
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: addresses,
+				Ports:     ports,
+			},
+		},
+	}
+}
+
+func (e endpoints) addCmds(fexec *ovntest.FakeExec, service v1.Service, endpoint v1.Endpoints) {
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: k8sTCPLoadBalancerIP,
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 set load_balancer %s vips:\"%s:%v\"=\"%s:%v\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, service.Spec.Ports[0].Port, endpoint.Subsets[0].Addresses[0].IP, endpoint.Subsets[0].Ports[0].Port),
+	})
+}
+
+func (e endpoints) delCmds(fexec *ovntest.FakeExec, service v1.Service, endpoint v1.Endpoints) {
+	for _, sPort := range service.Spec.Ports {
+		if sPort.Protocol == v1.ProtocolTCP {
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				fmt.Sprintf("ovn-nbctl --timeout=15 remove load_balancer %s vips \"%s:%v\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, sPort.Port),
+			})
+		} else if sPort.Protocol == v1.ProtocolUDP {
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				fmt.Sprintf("ovn-nbctl --timeout=15 remove load_balancer %s vips \"%s:%v\"", k8sUDPLoadBalancerIP, service.Spec.ClusterIP, sPort.Port),
+			})
+		}
+	}
+}
+
+var _ = Describe("OVN Namespace Operations", func() {
+	var app *cli.App
+
+	BeforeEach(func() {
+		//Restore global default values before each testcase
+		config.RestoreDefaultConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+	})
+
+	Context("on startup", func() {
+
+		It("reconciles existing endpoints", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				testE := endpoints{}
+
+				endpointsT := *newEndpoints("endpoint-service1", "namespace1",
+					[]v1.EndpointAddress{
+						{
+							IP: "10.125.0.2",
+						},
+					},
+					[]v1.EndpointPort{
+						{
+							Name:     "portTcp1",
+							Port:     8080,
+							Protocol: v1.ProtocolTCP,
+						},
+					})
+
+				serviceT := *newService("endpoint-service1", "namespace1", "172.124.0.2",
+					[]v1.ServicePort{
+						{
+							Name:     "portTcp1",
+							Port:     8032,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+				)
+
+				tExec := ovntest.NewFakeExec()
+				testE.addCmds(tExec, serviceT, endpointsT)
+
+				fakeOvn := FakeOVN{}
+				fakeOvn.start(ctx, tExec,
+					&v1.EndpointsList{
+						Items: []v1.Endpoints{
+							endpointsT,
+						},
+					},
+					&v1.ServiceList{
+						Items: []v1.Service{
+							serviceT,
+						},
+					},
+				)
+				fakeOvn.controller.WatchEndpoints()
+
+				_, err := fakeOvn.fakeClient.CoreV1().Endpoints(endpointsT.Namespace).Get(endpointsT.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tExec.CalledMatchesExpected()).To(BeTrue())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("reconciles deleted endpoints", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				testE := endpoints{}
+
+				endpointsT := *newEndpoints("endpoint-service1", "namespace1",
+					[]v1.EndpointAddress{
+						{
+							IP: "10.125.0.2",
+						},
+					},
+					[]v1.EndpointPort{
+						{
+							Name:     "portTcp1",
+							Port:     8080,
+							Protocol: v1.ProtocolTCP,
+						},
+					})
+
+				serviceT := *newService("endpoint-service1", "namespace1", "172.124.0.2",
+					[]v1.ServicePort{
+						{
+							Port:     8032,
+							Protocol: v1.ProtocolTCP,
+							Name:     "portTcp1",
+						},
+					},
+					v1.ServiceTypeClusterIP,
+				)
+				tExec := ovntest.NewFakeExec()
+				testE.addCmds(tExec, serviceT, endpointsT)
+
+				fakeOvn := FakeOVN{}
+				fakeOvn.start(ctx, tExec,
+					&v1.EndpointsList{
+						Items: []v1.Endpoints{
+							endpointsT,
+						},
+					},
+					&v1.ServiceList{
+						Items: []v1.Service{
+							serviceT,
+						},
+					},
+				)
+				fakeOvn.controller.WatchEndpoints()
+
+				_, err := fakeOvn.fakeClient.CoreV1().Endpoints(endpointsT.Namespace).Get(endpointsT.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(tExec.CalledMatchesExpected).Should(BeTrue())
+
+				// Delete the endpoint
+				testE.delCmds(tExec, serviceT, endpointsT)
+
+				err = fakeOvn.fakeClient.CoreV1().Endpoints(endpointsT.Namespace).Delete(endpointsT.Name, metav1.NewDeleteOptions(0))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(tExec.CalledMatchesExpected).Should(BeTrue())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -2,10 +2,11 @@ package ovn
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
-	kapi "k8s.io/api/core/v1"
 	"sync"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	kapi "k8s.io/api/core/v1"
 )
 
 func (oc *Controller) syncNamespaces(namespaces []interface{}) {

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -1,0 +1,197 @@
+package ovn
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type namespace struct{}
+
+func newNamespaceMeta(namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		UID:  types.UID(namespace),
+		Name: namespace,
+		Labels: map[string]string{
+			"name": namespace,
+		},
+	}
+}
+
+func newNamespace(namespace string) *v1.Namespace {
+	return &v1.Namespace{
+		ObjectMeta: newNamespaceMeta(namespace),
+		Spec:       v1.NamespaceSpec{},
+		Status:     v1.NamespaceStatus{},
+	}
+}
+
+func (n namespace) baseCmds(fexec *ovntest.FakeExec, namespace v1.Namespace) {
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=external_ids find address_set",
+		Output: fmt.Sprintf("name=%s\n", namespace.Name),
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=" + hashedAddressSet(namespace.Name),
+		Output: fmt.Sprintf("name=%s\n", namespace.Name),
+	})
+}
+
+func (n namespace) addCmds(fexec *ovntest.FakeExec, namespace v1.Namespace) {
+	n.baseCmds(fexec, namespace)
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedAddressSet(namespace.Name)),
+	})
+}
+
+func (n namespace) delCmds(fexec *ovntest.FakeExec, namespace v1.Namespace) {
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists destroy address_set %s", hashedAddressSet(namespace.Name)),
+	})
+}
+
+func (n namespace) addCmdsWithPods(fexec *ovntest.FakeExec, tP pod, namespace v1.Namespace) {
+	n.baseCmds(fexec, namespace)
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 set address_set %s addresses=%s", hashedAddressSet(namespace.Name), tP.podIP),
+	})
+}
+
+var _ = Describe("OVN Namespace Operations", func() {
+	var app *cli.App
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.RestoreDefaultConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+	})
+
+	Context("on startup", func() {
+
+		It("reconciles an existing namespace with pods", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				test := namespace{}
+				namespaceT := *newNamespace("namespace1")
+				tP := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.4",
+					"11:22:33:44:55:66",
+					namespaceT.Name,
+				)
+
+				tExec := ovntest.NewFakeExec()
+				test.addCmdsWithPods(tExec, tP, namespaceT)
+
+				fakeOvn := FakeOVN{}
+				fakeOvn.start(ctx, tExec,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*newPod(namespaceT.Name, tP.podName, tP.nodeName, tP.podIP),
+						},
+					},
+				)
+				fakeOvn.controller.WatchNamespaces()
+
+				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tExec.CalledMatchesExpected()).To(BeTrue())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("reconciles an existing namespace without pods", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				test := namespace{}
+				namespaceT := *newNamespace("namespace1")
+
+				tExec := ovntest.NewFakeExec()
+				test.addCmds(tExec, namespaceT)
+
+				fakeOvn := FakeOVN{}
+				fakeOvn.start(ctx, tExec, &v1.NamespaceList{
+					Items: []v1.Namespace{
+						namespaceT,
+					},
+				})
+				fakeOvn.controller.WatchNamespaces()
+
+				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tExec.CalledMatchesExpected()).To(BeTrue())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+	})
+
+	Context("during execution", func() {
+
+		It("reconciles a deleted namespace without pods", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				test := namespace{}
+				namespaceT := *newNamespace("namespace1")
+
+				fExec := ovntest.NewFakeExec()
+				test.addCmds(fExec, namespaceT)
+
+				fakeOvn := FakeOVN{}
+				fakeOvn.start(ctx, fExec, &v1.NamespaceList{
+					Items: []v1.Namespace{
+						namespaceT,
+					},
+				})
+				fakeOvn.controller.WatchNamespaces()
+
+				namespace, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(namespace).NotTo(BeNil())
+				Eventually(fExec.CalledMatchesExpected).Should(BeTrue())
+
+				test.delCmds(fExec, namespaceT)
+
+				err = fakeOvn.fakeClient.CoreV1().Namespaces().Delete(namespaceT.Name, metav1.NewDeleteOptions(1))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(fExec.CalledMatchesExpected).Should(BeTrue())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+	})
+})

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -1,6 +1,9 @@
 package ovn
 
 import (
+	"reflect"
+	"sync"
+
 	"github.com/openshift/origin/pkg/util/netutils"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -10,8 +13,6 @@ import (
 	kapisnetworking "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"reflect"
-	"sync"
 )
 
 // Controller structure is the object which holds the controls for starting

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -1,0 +1,49 @@
+package ovn
+
+import (
+	. "github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/urfave/cli"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	k8sTCPLoadBalancerIP = "k8s_tcp_load_balancer"
+	k8sUDPLoadBalancerIP = "k8s_udp_load_balancer"
+)
+
+type FakeOVN struct {
+	fakeClient *fake.Clientset
+	watcher    *factory.WatchFactory
+	controller *Controller
+}
+
+func (o *FakeOVN) start(ctx *cli.Context, fexec *ovntest.FakeExec, objects ...runtime.Object) {
+	err := util.SetExec(fexec)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = config.InitConfig(ctx, fexec, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	o.fakeClient = fake.NewSimpleClientset(objects...)
+	o.init()
+}
+
+func (o *FakeOVN) restart() {
+	o.watcher.Shutdown()
+	o.init()
+}
+
+func (o *FakeOVN) init() {
+	var err error
+
+	o.watcher, err = factory.NewWatchFactory(o.fakeClient, make(chan struct{}))
+	Expect(err).NotTo(HaveOccurred())
+
+	o.controller = NewOvnController(o.fakeClient, o.watcher)
+	o.controller.portGroupSupport = true
+}

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -1,0 +1,203 @@
+package ovn
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/urfave/cli"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type service struct{}
+
+func newServiceMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		UID:       types.UID(namespace),
+		Name:      name,
+		Namespace: namespace,
+		Labels: map[string]string{
+			"name": name,
+		},
+	}
+}
+
+func newService(name, namespace, ip string, ports []v1.ServicePort, serviceType v1.ServiceType) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: newServiceMeta(name, namespace),
+		Spec: v1.ServiceSpec{
+			ClusterIP: ip,
+			Ports:     ports,
+			Type:      serviceType,
+		},
+	}
+}
+
+func (s service) baseCmds(fexec *ovntest.FakeExec, service v1.Service) {
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: k8sTCPLoadBalancerIP,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer %s vips", k8sTCPLoadBalancerIP),
+		Output: "{\"172.30.0.10:53\"=\"10.128.0.18:5353,10.129.0.3:5353\"}",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"172.30.0.10:53\"", k8sTCPLoadBalancerIP),
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+		Output: k8sUDPLoadBalancerIP,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer %s vips", k8sUDPLoadBalancerIP),
+		Output: "{\"172.30.0.10:53\"=\"10.128.0.18:5353,10.129.0.3:5353\"}",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"172.30.0.10:53\"", k8sUDPLoadBalancerIP),
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+		Output: "gateway1",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=gateway1",
+		Output: "tcp_load_balancer_id_1",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer tcp_load_balancer_id_1 vips",
+		Output: "{\"172.30.0.10:53\"=\"10.128.0.18:5353,10.129.0.3:5353\"}",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --if-exists remove load_balancer tcp_load_balancer_id_1 vips \"172.30.0.10:53\"",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=gateway1",
+		Output: "udp_load_balancer_id_1",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer udp_load_balancer_id_1 vips",
+		Output: "{\"172.30.0.10:53\"=\"10.128.0.18:5353,10.129.0.3:5353\"}",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --if-exists remove load_balancer udp_load_balancer_id_1 vips \"172.30.0.10:53\"",
+	})
+}
+
+func (s service) addCmds(fexec *ovntest.FakeExec, service v1.Service) {
+	s.baseCmds(fexec, service)
+}
+
+func (s service) delCmds(fexec *ovntest.FakeExec, service v1.Service) {
+	for _, port := range service.Spec.Ports {
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			fmt.Sprintf("ovn-nbctl --timeout=15 remove load_balancer %s vips \"%s:%v\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
+		})
+	}
+}
+
+var _ = Describe("OVN Namespace Operations", func() {
+	var app *cli.App
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.RestoreDefaultConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+	})
+
+	Context("on startup", func() {
+
+		It("reconciles an existing service", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				test := service{}
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port: 8032,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+				)
+
+				fExec := ovntest.NewFakeExec()
+				test.baseCmds(fExec, service)
+
+				fakeOvn := FakeOVN{}
+				fakeOvn.start(ctx, fExec,
+					&v1.ServiceList{
+						Items: []v1.Service{
+							service,
+						},
+					},
+				)
+				fakeOvn.controller.WatchServices()
+
+				_, err := fakeOvn.fakeClient.CoreV1().Services(service.Namespace).Get(service.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fExec.CalledMatchesExpected()).To(BeTrue())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("reconciles a deleted service", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				test := service{}
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port: 8032,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+				)
+
+				fExec := ovntest.NewFakeExec()
+				test.baseCmds(fExec, service)
+
+				fakeOvn := FakeOVN{}
+				fakeOvn.start(ctx, fExec,
+					&v1.ServiceList{
+						Items: []v1.Service{
+							service,
+						},
+					},
+				)
+				fakeOvn.controller.WatchServices()
+
+				_, err := fakeOvn.fakeClient.CoreV1().Services(service.Namespace).Get(service.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fExec.CalledMatchesExpected()).To(BeTrue())
+
+				test.delCmds(fExec, service)
+				err = fakeOvn.fakeClient.CoreV1().Services(service.Namespace).Delete(service.Name, metav1.NewDeleteOptions(0))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(fExec.CalledMatchesExpected).Should(BeTrue())
+
+				s, err := fakeOvn.fakeClient.CoreV1().Services(service.Namespace).Get(service.Name, metav1.GetOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(s).To(BeNil())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This PR comprises: the testing of the OVN DB re-creation should OVN die during its life-cycle. 

Among other, it increases the `ovn` package's test-covarage from 8 to 25 %. Testing has been abstracted a bit for increased readability. Tests have been added for the resources: `service`, `endpoints` , `pod` and `namespace`. 

These tests are more "integration tests" than any kind of unit-tests, thus the scale of these tests increases. So, please get back to me with any of your modifications on the readability of these tests. 

Please keep in mind that as long as the issue: https://github.com/ovn-org/ovn-kubernetes/issues/743 is not resolved, flaky builds will increase as a result of this PR. 

@dcbw 