### PR TITLE
provide a way to modify the MTU of the default cluster network

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -18,6 +18,7 @@ OVN_GATEWAY_OPTS=""
 OVN_DB_VIP_IMAGE=""
 OVN_DB_VIP=""
 OVN_DB_REPLICAS=""
+OVN_MTU="1400"
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -53,6 +54,9 @@ while [ "$1" != "" ]; do
             ;;
         --db-vip)
             OVN_DB_VIP=$VALUE
+            ;;
+        --mtu)
+            OVN_MTU=$VALUE
             ;;
         *)
             echo "WARNING: unknown parameter \"$PARAM\""
@@ -162,13 +166,16 @@ k8s_apiserver=${OVN_K8S_APISERVER:-10.0.2.16:6443}
 net_cidr_repl="{{ net_cidr | default('10.128.0.0/14/23') }}"
 svc_cidr_repl="{{ svc_cidr | default('172.30.0.0/16') }}"
 k8s_apiserver_repl="{{ k8s_apiserver.stdout }}"
+mtu_repl="{{ mtu_value }}"
 
 echo "net_cidr: ${net_cidr}"
 echo "svc_cidr: ${svc_cidr}"
 echo "k8s_apiserver: ${k8s_apiserver}"
+echo "mtu: ${OVN_MTU}"
 
 sed "s,${net_cidr_repl},${net_cidr},
 s,${svc_cidr_repl},${svc_cidr},
+s,${mtu_repl},${OVN_MTU},
 s,${k8s_apiserver_repl},${k8s_apiserver}," ../templates/ovn-setup.yaml.j2 > ../yaml/ovn-setup.yaml
 
 exit 0

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -113,6 +113,7 @@ ovn_gateway_opts=${OVN_GATEWAY_OPTS:-""}
 
 net_cidr=${OVN_NET_CIDR:-10.128.0.0/14/23}
 svc_cidr=${OVN_SVC_CIDR:-172.30.0.0/16}
+mtu=${OVN_MTU:-1400}
 
 ovn_kubernetes_namespace=${OVN_KUBERNETES_NAMESPACE:-ovn-kubernetes}
 
@@ -745,6 +746,7 @@ ovn-node () {
       --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
       --nodeport \
+      --mtu=${mtu} \
       --loglevel=${ovnkube_loglevel} \
       --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts}  \
       --pidfile /var/run/openvswitch/ovnkube.pid \

--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -130,3 +130,4 @@ data:
   net_cidr:      "{{ net_cidr | default('10.128.0.0/14/23') }}"
   svc_cidr:      "{{ svc_cidr | default('172.30.0.0/16') }}"
   k8s_apiserver: "{{ k8s_apiserver.stdout }}"
+  mtu:           "{{ mtu_value }}"

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -207,6 +207,11 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: mtu
         - name: K8S_NODE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
the custom MTU value will be captured in ovn-config's new key 'mtu'
along side with svc_cidr and net_cidr keys.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>