### PR TITLE
node watcher must be called before the pod watcher

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -113,8 +113,8 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory)
 
 // Run starts the actual watching.
 func (oc *Controller) Run() error {
-	for _, f := range []func() error{oc.WatchPods, oc.WatchServices, oc.WatchEndpoints, oc.WatchNamespaces,
-		oc.WatchNetworkPolicy, oc.WatchNodes} {
+	for _, f := range []func() error{oc.WatchNodes, oc.WatchPods, oc.WatchServices, oc.WatchEndpoints,
+		oc.WatchNamespaces, oc.WatchNetworkPolicy} {
 		if err := f(); err != nil {
 			return err
 		}


### PR DESCRIPTION
The commit ac57d2a213e2 changed the order of nodes and pods handler and
as a result the logical port creation is waiting behind the logical
switch creation. Note that all the watch* functions gets serialized on
the initial addObj() calls in sync*() function.

Fixes: ac57d2a213e2 (move master related receivers in
OvnClusterController to Controller)

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>