### PR TITLE
Clear kubelet's NodeUnavailable status

### DIFF
--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -18,6 +18,7 @@ import (
 type Interface interface {
 	SetAnnotationOnPod(pod *kapi.Pod, key, value string) error
 	SetAnnotationOnNode(node *kapi.Node, key, value string) error
+	UpdateNodeStatus(node *kapi.Node) error
 	GetAnnotationsOnPod(namespace, name string) (map[string]string, error)
 	GetPod(namespace, name string) (*kapi.Pod, error)
 	GetPods(namespace string) (*kapi.PodList, error)
@@ -54,6 +55,16 @@ func (k *Kube) SetAnnotationOnNode(node *kapi.Node, key, value string) error {
 	_, err := k.KClient.CoreV1().Nodes().Patch(node.Name, types.MergePatchType, []byte(patchData))
 	if err != nil {
 		logrus.Errorf("Error in setting annotation on node %s: %v", node.Name, err)
+	}
+	return err
+}
+
+// UpdateNodeStatus takes the node object and sets the provided update status
+func (k *Kube) UpdateNodeStatus(node *kapi.Node) error {
+	logrus.Infof("Updating status on node %s", node.Name)
+	_, err := k.KClient.CoreV1().Nodes().UpdateStatus(node)
+	if err != nil {
+		logrus.Errorf("Error in updating status on node %s: %v", node.Name, err)
 	}
 	return err
 }


### PR DESCRIPTION
This is a work-around needed as to be able to create clusters using an OVN network plugin on GCP.

The kubelet sets `NodeNetworkUnavailable` on GCP node startup's, see [this](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cloud/node_controller.go#L237) which will lead to problems for network plugins. Have a look at a previous discussion here: https://github.com/kubernetes/kubernetes/pull/34398

This PR introduces an overwrite of this condition once OVN starts so that it can proceed with the networking setup.   

@danwinship @dcbw 