### PR TITLE
define prometheus ServiceMonitor and Service resource for OVN components

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -178,4 +178,6 @@ s,${svc_cidr_repl},${svc_cidr},
 s,${mtu_repl},${OVN_MTU},
 s,${k8s_apiserver_repl},${k8s_apiserver}," ../templates/ovn-setup.yaml.j2 > ../yaml/ovn-setup.yaml
 
+cp ../templates/ovnkube-monitor.yaml.j2 ../yaml/ovnkube-monitor.yaml
+
 exit 0

--- a/dist/templates/ovnkube-monitor.yaml.j2
+++ b/dist/templates/ovnkube-monitor.yaml.j2
@@ -1,0 +1,81 @@
+# define ServiceMontior and Service resources for ovnkube-master
+# and ovnkube-node (required for prometheus monitoring)
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: ovnkube-master
+  name: monitor-ovnkube-master
+  namespace: ovn-kubernetes
+spec:
+  endpoints:
+  - interval: 30s
+    port: http-metrics
+    scheme: http
+    path: /metrics
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - ovn-kubernetes
+  selector:
+    matchLabels:
+      k8s-app: ovnkube-master
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: ovnkube-master
+  name: ovn-kubernetes-master-prometheus-discovery
+  namespace: ovn-kubernetes
+spec:
+  selector:
+    name: ovnkube-master
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 9102
+    protocol: TCP
+    targetPort: 9102
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: ovnkube-node
+  name: monitor-ovnkube-node
+  namespace: ovn-kubernetes
+spec:
+  endpoints:
+  - interval: 30s
+    port: http-metrics
+    path: /metrics
+    scheme: http
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - ovn-kubernetes
+  selector:
+    matchLabels:
+      k8s-app: ovnkube-node
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: ovnkube-node
+  name: ovn-kubernetes-node-prometheus-discovery
+  namespace: ovn-kubernetes
+spec:
+  selector:
+    name: ovnkube-node
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 9101
+    protocol: TCP
+    targetPort: 9101

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -22,6 +22,7 @@ spec:
     metadata:
       labels:
         app: ovnkube-node
+        name: ovnkube-node
         component: network
         type: infra
         openshift.io/component: network

--- a/dist/yaml/.gitignore
+++ b/dist/yaml/.gitignore
@@ -4,3 +4,5 @@ ovn-setup.yaml
 ovnkube-db-vip.yaml
 ovnkube-db.yaml
 ovnkube-node.yaml
+ovnkube-monitor.yaml
+


### PR DESCRIPTION
with the prometheus monitoring scaffolding in ovn-kubernetes, we need
to add a way to enable prometheus to discover these endpoints and
scrape data out of it. to enable this we need to define a ServiceMonitor
resource and a corresponding Service resource that points to the
endpoint exposing metrics.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>