### PR TITLE
Upgrade ovs version in Dockerfile to 2.11

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -34,13 +34,13 @@ RUN INSTALL_PKGS=" \
 # docker build --build-arg rpmArch=ARCH -f Dockerfile.centos -t some_tag .
 # where ARCH can be x86_64 (default), aarch64, or ppc64le
 ARG rpmArch=x86_64
-ARG ovsVer=2.10.1
-ARG ovsSubVer=3.el7
-ARG dpdkVer=17.11
-ARG dpdkSubVer=3.el7
-ARG dpdkRpmUrl=http://cbs.centos.org/kojifiles/packages/dpdk/${dpdkVer}/${dpdkSubVer}/${rpmArch}/dpdk-${dpdkVer}-${dpdkSubVer}.${rpmArch}.rpm
+ARG ovsVer=2.11.0
+ARG ovsSubVer=4.el7
+ARG dpdkVer=18.11.2
+ARG dpdkSubVer=1.el7
+ARG dpdkRpmUrl=http://mirror.centos.org/centos/7/extras/${rpmArch}/Packages/dpdk-${dpdkVer}-${dpdkSubVer}.${rpmArch}.rpm
 
-RUN if [ "$(uname -m)" = "aarch64" ]; then dpdkRpmUrl=https://rpmfind.net/linux/fedora/linux/updates/28/Everything/aarch64/Packages/d/dpdk-17.11.2-1.fc28.aarch64.rpm; fi && rpm -i ${dpdkRpmUrl}
+RUN if [ "$(uname -m)" = "aarch64" ]; then dpdkRpmUrl=http://psw32.psw.net/altarch/7/extras/aarch64/Packages/dpdk-18.11-4.el7_6.aarch64.rpm; fi && rpm -i ${dpdkRpmUrl}
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-common-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-central-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm


### PR DESCRIPTION
Due to the problems met in issue:
https://github.com/ovn-org/ovn-kubernetes/issues/855
We should use ovs 2.11 instead of 2.10 to fix the problem
of ovn-nbctl running in daemon mode.

So the ovs version used in the Dockerfile should be promoted
to 2.11 to build a suitable image for daemonset install.
The DPDK library is also updated to 18.11 to satisfy the requirement
of ovs2.11.
The related changes in Dockerfile for rpmArch of aarch64(arm64)
are also given.

Signed-off-by: Trevor Tao <trevor.tao@arm.com>