### PR TITLE
    Upgrade ovs version in Dockerfile.ubuntu to 2.11

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -34,13 +34,13 @@ RUN INSTALL_PKGS=" \
 # docker build --build-arg rpmArch=ARCH -f Dockerfile.centos -t some_tag .
 # where ARCH can be x86_64 (default), aarch64, or ppc64le
 ARG rpmArch=x86_64
-ARG ovsVer=2.10.1
-ARG ovsSubVer=3.el7
-ARG dpdkVer=17.11
-ARG dpdkSubVer=3.el7
-ARG dpdkRpmUrl=http://cbs.centos.org/kojifiles/packages/dpdk/${dpdkVer}/${dpdkSubVer}/${rpmArch}/dpdk-${dpdkVer}-${dpdkSubVer}.${rpmArch}.rpm
+ARG ovsVer=2.11.0
+ARG ovsSubVer=4.el7
+ARG dpdkVer=18.11.2
+ARG dpdkSubVer=1.el7
+ARG dpdkRpmUrl=http://mirror.centos.org/centos/7/extras/${rpmArch}/Packages/dpdk-${dpdkVer}-${dpdkSubVer}.${rpmArch}.rpm
 
-RUN if [ "$(uname -m)" = "aarch64" ]; then dpdkRpmUrl=https://rpmfind.net/linux/fedora/linux/updates/28/Everything/aarch64/Packages/d/dpdk-17.11.2-1.fc28.aarch64.rpm; fi && rpm -i ${dpdkRpmUrl}
+RUN if [ "$(uname -m)" = "aarch64" ]; then dpdkRpmUrl=http://psw32.psw.net/altarch/7/extras/aarch64/Packages/dpdk-18.11-4.el7_6.aarch64.rpm; fi && rpm -i ${dpdkRpmUrl}
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-common-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
 RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-central-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -8,18 +8,11 @@
 #
 # So this file will change over time.
 
-FROM ubuntu:18.04
+FROM ubuntu:19.04
 
 USER root
 
-RUN apt-get update && apt-get install -y iptables iproute2 curl software-properties-common setpriv
-
-# We do not have much control over the exact version of OVS/OVN that can be
-# obtained from upstream Ubuntu. guru@ovn.org maintains more latest versions of
-# OVS/OVN packages at 3.19.28.122. Please comment out the next 3 lines if
-# you prefer to use upstream Ubuntu packages instead.
-RUN echo "deb http://3.19.28.122/openvswitch/stable /" |  tee /etc/apt/sources.list.d/openvswitch.list
-RUN curl http://3.19.28.122/openvswitch/keyFile |  apt-key add -
+RUN apt-get update && apt-get install -y iptables iproute2 curl software-properties-common util-linux
 
 RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
 RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -46,7 +39,7 @@ COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 COPY git_info /root
 
 LABEL io.k8s.display-name="ovn kubernetes" \
-      io.k8s.description="ovnkube ubuntu image" 
+      io.k8s.description="ovnkube ubuntu image"
 
 WORKDIR /root
 ENTRYPOINT /root/ovnkube.sh


### PR DESCRIPTION
Due to the problems met in issue:
https://github.com/ovn-org/ovn-kubernetes/issues/855
We should use ovs 2.11 instead of 2.10 to fix the problem of using ovn-nbctl in daemon mode(default).

So the ovs version used in the Dockerfile should be promoted
to 2.11 to build a suitable image for daemonset install.
The related changes in Dockerfile.ubuntu are also verified on
aarch64(arm64) platform in addition to amd64(x86_64).
