### PR TITLE
do not assign cluster-admin role for the `ovn` serviceaccount

### DIFF
--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -34,63 +34,87 @@ metadata:
   namespace: ovn-kubernetes
 
 ---
+# for now throw in all the privileges to run a pod. we can fine grain it further later.
+
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: ovn-kubernetes
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65536
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    rbac.authorization.k8s.io/system-only: "true"
-  name: system:ovn-reader
+  name: ovn-kubernetes
 rules:
 - apiGroups:
   - ""
-  - extensions
   resources:
   - pods
   - namespaces
-  - networkpolicies
   - nodes
-  verbs:
-  - get
-  - list
-  - watch
+  - endpoints
+  - services
+  - configmaps
+  verbs: ["get", "list", "watch"]
 - apiGroups:
+  - extensions
   - networking.k8s.io
   resources:
   - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
+  verbs: ["get", "list", "watch"]
 - apiGroups:
   - ""
   resources:
   - events
-  verbs:
-  - create
-  - patch
-  - update
+  - endpoints
+  - configmaps
+  verbs: ["create", "patch", "update"]
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  verbs: ["patch", "update"]
+- apiGroups:
+  - extensions
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - ovn-kubernetes
+  verbs: ["use"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ovn-reader
+  name: ovn-kubernetes
 roleRef:
-  name: system:ovn-reader
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: ovn
-  namespace: ovn-kubernetes
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cluster-admin-0
-roleRef:
-  name: cluster-admin
+  name: ovn-kubernetes
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
 subjects:


### PR DESCRIPTION
the serviceaccount user `ovn` has a cluster-admin role today and can
pretty much do anything in the clsuter. we need to fine grain access
control and pod privileges for this user.

to do this:

1. define a PodSecurityPolicy object that captures minimum required
   security policies to run our deployments and daemonset.
2. define a ClusterRole object that captures all the resources we are
   intersted in and all the actions we need on them. also, this role
   should use the PodSecurityPolicy defined in step 1.
3. bind the above role to `ovn` serviceaccount

Note: this commit adds (1) that provides almost any securityContext to
be set (this can be restricted in future commits)

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>