### PR TITLE
Re-create the OVN DB with the k8s pod annotation, should it exists.

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -245,19 +245,41 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 	portName := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
 	logrus.Debugf("Creating logical port for %s on switch %s", portName, logicalSwitch)
 
-	out, stderr, err = util.RunOVNNbctl("--wait=sb", "--",
-		"--may-exist", "lsp-add", logicalSwitch, portName,
-		"--", "lsp-set-addresses",
-		portName, "dynamic", "--", "set",
-		"logical_switch_port", portName,
-		"external-ids:namespace="+pod.Namespace,
-		"external-ids:logical_switch="+logicalSwitch,
-		"external-ids:pod=true")
-	if err != nil {
-		logrus.Errorf("Error while creating logical port %s "+
-			"stdout: %q, stderr: %q (%v)",
-			portName, out, stderr, err)
-		return
+	annotation, err := util.UnmarshalPodAnnotation(pod.Annotations["ovn"])
+
+	// If pod already has annotations, just add the lsp with static ip/mac.
+	// Else, create the lsp with dynamic addresses.
+	if err == nil {
+		out, stderr, err = util.RunOVNNbctl("--may-exist", "lsp-add",
+			logicalSwitch, portName, "--", "lsp-set-addresses", portName,
+			fmt.Sprintf("%s %s", annotation.MAC, annotation.IP.IP), "--", "set",
+			"logical_switch_port", portName,
+			"external-ids:namespace="+pod.Namespace,
+			"external-ids:logical_switch="+logicalSwitch,
+			"external-ids:pod=true", "--", "--if-exists",
+			"clear", "logical_switch_port", portName, "dynamic_addresses")
+		if err != nil {
+			logrus.Errorf("Failed to add logical port to switch "+
+				"stdout: %q, stderr: %q (%v)",
+				out, stderr, err)
+			return
+		}
+	} else {
+		out, stderr, err = util.RunOVNNbctl("--wait=sb", "--",
+			"--may-exist", "lsp-add", logicalSwitch, portName,
+			"--", "lsp-set-addresses",
+			portName, "dynamic", "--", "set",
+			"logical_switch_port", portName,
+			"external-ids:namespace="+pod.Namespace,
+			"external-ids:logical_switch="+logicalSwitch,
+			"external-ids:pod=true")
+		if err != nil {
+			logrus.Errorf("Error while creating logical port %s "+
+				"stdout: %q, stderr: %q (%v)",
+				portName, out, stderr, err)
+			return
+		}
+
 	}
 
 	oc.logicalPortCache[portName] = logicalSwitch
@@ -301,7 +323,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		return
 	}
 
-	annotation, err := util.MarshalPodAnnotation(&util.PodAnnotation{
+	marshalledAnnotation, err := util.MarshalPodAnnotation(&util.PodAnnotation{
 		IP:  podCIDR,
 		MAC: podMac,
 		GW:  gatewayIP.IP,
@@ -313,7 +335,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 
 	logrus.Debugf("Annotation values: ip=%s ; mac=%s ; gw=%s\nAnnotation=%s",
 		podCIDR, podMac, gatewayIP, annotation)
-	err = oc.kube.SetAnnotationOnPod(pod, "ovn", annotation)
+	err = oc.kube.SetAnnotationOnPod(pod, "ovn", marshalledAnnotation)
 	if err != nil {
 		logrus.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
 	}

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -73,7 +73,7 @@ func newTPod(nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIP, podMAC, 
 	return
 }
 
-func (p pod) addCmds(fexec *ovntest.FakeExec) {
+func (p pod) addCmds(fexec *ovntest.FakeExec, exists bool) {
 	// node setup
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 get logical_switch " + p.nodeName + " other-config",
@@ -87,9 +87,15 @@ func (p pod) addCmds(fexec *ovntest.FakeExec) {
 		"ovn-nbctl --timeout=15 --may-exist acl-add " + p.nodeName + " to-lport 1001 ip4.src==" + p.nodeMgtIP + " allow-related",
 	})
 	// pod setup
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --wait=sb -- --may-exist lsp-add " + p.nodeName + " " + p.portName + " -- lsp-set-addresses " + p.portName + " dynamic -- set logical_switch_port " + p.portName + " external-ids:namespace=" + p.namespace + " external-ids:logical_switch=" + p.nodeName + " external-ids:pod=true",
-	})
+	if exists {
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			fmt.Sprintf("ovn-nbctl --timeout=15 --may-exist lsp-add %s %s -- lsp-set-addresses %s %s %s -- set logical_switch_port %s external-ids:namespace=namespace external-ids:logical_switch=%s external-ids:pod=true -- --if-exists clear logical_switch_port %s dynamic_addresses", p.nodeName, p.portName, p.portName, p.podMAC, p.podIP, p.portName, p.nodeName, p.portName),
+		})
+	} else {
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --wait=sb -- --may-exist lsp-add " + p.nodeName + " " + p.portName + " -- lsp-set-addresses " + p.portName + " dynamic -- set logical_switch_port " + p.portName + " external-ids:namespace=" + p.namespace + " external-ids:logical_switch=" + p.nodeName + " external-ids:pod=true",
+		})
+	}
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch " + p.nodeName + " external_ids:gateway_ip",
 		Output: fmt.Sprintf("%s/24", p.nodeGWIP),
@@ -101,6 +107,14 @@ func (p pod) addCmds(fexec *ovntest.FakeExec) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 lsp-set-port-security " + p.portName + " " + p.podMAC + " " + p.podIP + "/24",
 	})
+}
+
+func (p pod) addCmdsForNonExistingPod(fexec *ovntest.FakeExec) {
+	p.addCmds(fexec, false)
+}
+
+func (p pod) addCmdsForExistingPod(fexec *ovntest.FakeExec) {
+	p.addCmds(fexec, true)
 }
 
 func (p pod) delCmds(fexec *ovntest.FakeExec) {
@@ -162,7 +176,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				// Assign it and perform the update
 				t.nodeName = "node1"
-				t.addCmds(fExec)
+				t.addCmdsForNonExistingPod(fExec)
 
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(t.namespace).Update(newPod(t.namespace, t.podName, t.nodeName, t.podIP))
 				Expect(err).NotTo(HaveOccurred())
@@ -212,7 +226,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				Expect(pod).To(BeNil())
 				Expect(fExec.CalledMatchesExpected()).To(BeTrue())
 
-				t.addCmds(fExec)
+				t.addCmdsForNonExistingPod(fExec)
 
 				_, err := fakeOvn.fakeClient.CoreV1().Pods(t.namespace).Create(newPod(t.namespace, t.podName, t.nodeName, t.podIP))
 				Expect(err).NotTo(HaveOccurred())
@@ -253,7 +267,7 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: t.portName + "\n",
 				})
 
-				t.addCmds(fExec)
+				t.addCmdsForNonExistingPod(fExec)
 
 				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
@@ -313,7 +327,7 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: t.portName + "\n",
 				})
 
-				t.addCmds(fExec)
+				t.addCmdsForNonExistingPod(fExec)
 
 				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
@@ -401,7 +415,7 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: "\n",
 				})
 
-				t.addCmds(fExec)
+				t.addCmdsForNonExistingPod(fExec)
 
 				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
@@ -449,7 +463,7 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: "\n",
 				})
 
-				t.addCmds(fExec)
+				t.addCmdsForNonExistingPod(fExec)
 
 				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
@@ -472,8 +486,8 @@ var _ = Describe("OVN Pod Operations", func() {
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: "\n",
 				})
-				t.podIP = "10.128.1.9"
-				t.addCmds(fExec)
+
+				t.addCmdsForExistingPod(fExec)
 
 				fakeOvn.restart()
 				fakeOvn.controller.WatchPods()

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -2,13 +2,14 @@ package ovn
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	"k8s.io/client-go/tools/cache"
-	"strings"
 )
 
 func (oc *Controller) syncNetworkPoliciesPortGroup(

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -2,13 +2,14 @@ package ovn
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	"k8s.io/client-go/tools/cache"
-	"strings"
 )
 
 func (oc *Controller) syncNetworkPoliciesOld(networkPolicies []interface{}) {


### PR DESCRIPTION
This had been done previously but was removed with commit https://github.com/ovn-org/ovn-kubernetes/commit/f99a10b1a4b9fa6fefb27e60628cc0960921ca5e 

We however still need this specific behaviour in case the OVN DB is completely destroyed, but the cluster and the corresponding kubernetes objects remain intact (possibly during a roll-out from OVN -> OVN HA). If not we'll have a different state between k8s vs. OVN. 

Test cases updated to test for this behaviour. 