### PR TITLE
remove the unnecessary annotation from the ovn-kubernetes namespace

### DIFF
--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -11,8 +11,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations:
-    openshift.io/node-selector: "beta.kubernetes.io/os=linux"
   name: ovn-kubernetes
 
 ---


### PR DESCRIPTION
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>