### PR TITLE
Run yum update in centos Dockerfile

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -27,8 +27,9 @@ RUN INSTALL_PKGS=" \
 	iptables iproute strace socat \
 	unbound-libs \
         " && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-	yum clean all && rm -rf /var/cache/yum/*
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
+
+RUN yum -y update && yum clean all && rm -rf /var/cache/yum/*
 
 # Get a reasonable version of openvswitch (2.9.2 or higher)
 # docker build --build-arg rpmArch=ARCH -f Dockerfile.centos -t some_tag .


### PR DESCRIPTION
The centos image gets a lot of vulnerabilities warnings at quay.io.
Running yum update cures them all.

Signed-off-by: Shahar Klein <sklein@nvidia.com>