### PR TITLE
management-port: clean up from move to master

### DIFF
--- a/go-controller/pkg/cluster/management-port.go
+++ b/go-controller/pkg/cluster/management-port.go
@@ -54,12 +54,8 @@ func createManagementPortGeneric(nodeName, localSubnet string) (string, string, 
 		return "", "", "", "", "", err
 	}
 
-	// Create this node's management logical port on the node switch.
-	_, portIP, n, err := util.GetNodeWellKnownAddresses(subnet)
-	if err != nil {
-		logrus.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return "", "", "", "", "", err
-	}
+	// The management port is assigned the second IP in the subnet.
+	_, portIP, n := util.GetNodeWellKnownAddresses(subnet)
 	portIPMask := fmt.Sprintf("%s/%d", portIP, n)
 
 	// switch-to-router ports only have MAC address and nothing else.

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -213,11 +213,7 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node) error {
 		return err
 	}
 
-	_, portIP, _, err := util.GetNodeWellKnownAddresses(subnet)
-	if err != nil {
-		logrus.Errorf("Failed to obtain management port IP address, error: %v", err)
-		return err
-	}
+	_, portIP, _ := util.GetNodeWellKnownAddresses(subnet)
 
 	// Create this node's management logical port on the node switch
 	stdout, stderr, err := util.RunOVNNbctl(
@@ -250,11 +246,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 
 	// Get firstIP for gateway.  Skip the second address of the LogicalSwitch's
 	// subnet since we set it aside for the management port on that node.
-	firstIP, secondIP, _, err := util.GetNodeWellKnownAddresses(hostsubnet)
-	if err != nil {
-		logrus.Errorf("Failed to obtain well known IP addresses, error: %v", err)
-		return err
-	}
+	firstIP, secondIP, _ := util.GetNodeWellKnownAddresses(hostsubnet)
 
 	nodeLRPMac, stderr, err := util.RunOVNNbctl("--if-exist", "get", "logical_router_port", "rtos-"+nodeName, "mac")
 	if err != nil {

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -97,7 +97,7 @@ func GetOVSPortMACAddress(portName string) (string, error) {
 
 // GetNodeWellKnownAddresses returns routerIP, Management Port IP and subnet mask
 // for a given subnet
-func GetNodeWellKnownAddresses(subnet *net.IPNet) (string, string, int, error) {
+func GetNodeWellKnownAddresses(subnet *net.IPNet) (string, string, int) {
 
 	ip := NextIP(subnet.IP)
 	prefixlen, _ := subnet.Mask.Size()
@@ -106,5 +106,5 @@ func GetNodeWellKnownAddresses(subnet *net.IPNet) (string, string, int, error) {
 	ip = NextIP(ip)
 	mgmtIP := ip.String()
 
-	return routerIP, mgmtIP, prefixlen, nil
+	return routerIP, mgmtIP, prefixlen
 }


### PR DESCRIPTION
Commit 0c0aa45d moved the creation of the management lsp to the master, but the comment and error message createManagementPortGeneric() doesn't reflect this.

Also, util.GetNodeWellKnownAddresses() never returns an error, so let's remove the return value and the error handling from callers.

(Just noticed this while reviewing #767)

