### PR TITLE
Handle static vs dynamic better in GetPortAddresses()

### DIFF
--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -47,7 +47,7 @@ func GetPortAddresses(portName string) (net.HardwareAddr, net.IP, error) {
 			return nil, nil, fmt.Errorf("Error while obtaining static addresses for %s: %v", portName, err)
 		}
 	}
-	if out == "[]" {
+	if out == "[]" || out == "[dynamic]" {
 		// No addresses
 		return nil, nil, nil
 	}


### PR DESCRIPTION
If dynamic addressing is set up, but there are no addresses assigned, then since commit 11f284c8, you'll see:

```
  /usr/bin/ovn-nbctl --db=tcp:10.0.141.40:9641 --timeout=15 get logical_switch_port jtor-GR_ip-10-0-170-219.us-west-2.compute.internal addresses"
  stdout: \"[dynamic]\\n\""
  stderr: \"\""
  failed to localnet gateway: error while waiting for addresses for gateway switch port
```

whereas the error before was:

```
  failed to localnet gateway: empty addresses for gateway switch port
```

Restore the previous behavior by recognizing that [dynamic] means that no addresses are assigned.