### PR TITLE
make use of GetNodeWellKnownAddresses() in createManagementPortGeneric()

### DIFF
--- a/go-controller/pkg/cluster/management-port_linux.go
+++ b/go-controller/pkg/cluster/management-port_linux.go
@@ -4,6 +4,7 @@ package cluster
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
@@ -21,7 +22,7 @@ const (
 // CreateManagementPort creates a management port attached to the node switch
 // that lets the node access its pods via their private IP address. This is used
 // for health checking and other management tasks.
-func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) (map[string]string, error) {
+func CreateManagementPort(nodeName string, localSubnet *net.IPNet, clusterSubnet []string) (map[string]string, error) {
 	interfaceName, interfaceIP, macAddress, routerIP, routerMAC, err :=
 		createManagementPortGeneric(nodeName, localSubnet)
 	if err != nil {

--- a/go-controller/pkg/cluster/management-port_linux_test.go
+++ b/go-controller/pkg/cluster/management-port_linux_test.go
@@ -4,6 +4,7 @@ package cluster
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -132,7 +133,8 @@ var _ = Describe("Management Port Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			macAddress, err := CreateManagementPort(nodeName, nodeSubnet, []string{clusterCIDR})
+			_, nodeSubnetCIDR, _ := net.ParseCIDR(nodeSubnet)
+			macAddress, err := CreateManagementPort(nodeName, nodeSubnetCIDR, []string{clusterCIDR})
 			Expect(err).NotTo(HaveOccurred())
 			i := 0
 			for k, v := range macAddress {

--- a/go-controller/pkg/cluster/management-port_windows.go
+++ b/go-controller/pkg/cluster/management-port_windows.go
@@ -17,7 +17,7 @@ import (
 // CreateManagementPort creates a management port attached to the node switch
 // that lets the node access its pods via their private IP address. This is used
 // for health checking and other management tasks.
-func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) (map[string]string, error) {
+func CreateManagementPort(nodeName string, localSubnet *net.IPNet, clusterSubnet []string) (map[string]string, error) {
 	interfaceName, interfaceIP, macAddress, routerIP, _, err :=
 		createManagementPortGeneric(nodeName, localSubnet)
 	if err != nil {

--- a/go-controller/pkg/cluster/management-port_windows_test.go
+++ b/go-controller/pkg/cluster/management-port_windows_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Management Port Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = CreateManagementPort(nodeName, nodeSubnet, []string{clusterCIDR})
+			_, err = CreateManagementPort(nodeName, nodeSubnet, []string{clusterCIDR})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue())

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -129,7 +129,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	type readyFunc func(string) (bool, error)
 	var readyFuncs []readyFunc
 
-	mgmtPortAnnotations, err := CreateManagementPort(node.Name, subnet.String(), clusterSubnets)
+	mgmtPortAnnotations, err := CreateManagementPort(node.Name, subnet, clusterSubnets)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -95,16 +95,10 @@ func GetOVSPortMACAddress(portName string) (string, error) {
 	return macAddress, nil
 }
 
-// GetNodeWellKnownAddresses returns routerIP, Management Port IP and subnet mask
+// GetNodeWellKnownAddresses returns routerIP, Management Port IP and prefix len
 // for a given subnet
-func GetNodeWellKnownAddresses(subnet *net.IPNet) (string, string, int) {
-
-	ip := NextIP(subnet.IP)
-	prefixlen, _ := subnet.Mask.Size()
-	routerIP := fmt.Sprintf("%s/%d", ip.String(), prefixlen)
-
-	ip = NextIP(ip)
-	mgmtIP := ip.String()
-
-	return routerIP, mgmtIP, prefixlen
+func GetNodeWellKnownAddresses(subnet *net.IPNet) (*net.IPNet, *net.IPNet) {
+	routerIP := NextIP(subnet.IP)
+	return &net.IPNet{IP: routerIP, Mask: subnet.Mask},
+		&net.IPNet{IP: NextIP(routerIP), Mask: subnet.Mask}
 }


### PR DESCRIPTION
GetNodeWellKnownAddresses() returns RotuerIP, ManagementPortIP, and PrefixLen. However, the RouterIP is returned ad RouterIP/PrefixLen whilst ManagementPortIP is returned without PrefixLen.

So, I changed the code to just return IPs. With that the callers can use PrefixLen if they want to construct an IP with mask. This also allowed me to use this Function at one other place in the codebase.