### PR TITLE
Bandwidth: Actual egress bandwidth might be much lower than configured.

### DIFF
--- a/go-controller/pkg/cni/bandwidth.go
+++ b/go-controller/pkg/cni/bandwidth.go
@@ -47,7 +47,14 @@ func setPodBandwidth(sandboxID, ifname string, ingressBPS, egressBPS int64) erro
 	}
 	if egressBPS > 0 {
 		// ingress_policing_rate is in Kbps
-		err := ovsSet("interface", ifname, fmt.Sprintf("ingress_policing_rate=%d", egressBPS/1000))
+		egressKBPS := egressBPS / 1000
+		err := ovsSet("interface", ifname, fmt.Sprintf("ingress_policing_rate=%d", egressKBPS))
+		if err != nil {
+			return err
+		}
+		// Set the ingress_policing_burst too per recommendation in ovsdb schema, i.e
+		// 10% of the rate
+		err = ovsSet("interface", ifname, fmt.Sprintf("ingress_policing_burst=%d", (egressKBPS/10)))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
For egress network bandwidth, we configure ingress_policying_rate,
but, by itself, it might end up allowing less than the rate (e.g.
iperf TCP with a rate of 4Gbps gives < 1Gbps). OVSDB schema has
this to say about ingress_policying_burst:

"
Specifying a larger burst size lets the algorithm be more forgiving,
which is important for protocols like TCP that react severely to
dropped packets. The burst size should be at least the size of the
interface’s MTU. Specifying a value that is numerically at least as
large as 10% of ingress_policing_rate helps TCP come closer to
achieving the full rate
"

Set ingress_policying_burst to 10% of ingress_policying_rate.

Additionally, for a SR-IOV VF we also need to configure its
max_tx_rate using the egress value in Mbps.

Tested by configuring egress-bandwidth for a pod and using iperf.
Tested the VF setting by giving a VF as OVN interface to the pod,
with egress-bandwidth configured.

Signed-off-by: venu iyer  <venugopali@nvidia.com>