### PR TITLE
Add multicast support.

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -31,7 +31,16 @@ func defaultFakeExec(nodeSubnet, nodeName string) (*ovntest.FakeExec, string, st
 
 	fexec := ovntest.NewFakeExec()
 	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --columns=_uuid list port_group",
+		"ovn-sbctl --timeout=15 --columns=_uuid list IGMP_Group",
 		"ovn-nbctl --timeout=15 -- --may-exist lr-add ovn_cluster_router -- set logical_router ovn_cluster_router external_ids:k8s-cluster-router=yes",
+		"ovn-nbctl --timeout=15 -- set logical_router ovn_cluster_router options:mcast_relay=\"true\"",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=mcastPortGroupDeny",
+		"ovn-nbctl --timeout=15 create port_group name=mcastPortGroupDeny external-ids:name=mcastPortGroupDeny",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"inport == @mcastPortGroupDeny && ip4.mcast\" action=drop external-ids:default-deny-policy-type=Egress",
+		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=from-lport match=\"inport == @mcastPortGroupDeny && ip4.mcast\" action=drop external-ids:default-deny-policy-type=Egress -- add port_group  acls @acl",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"outport == @mcastPortGroupDeny && ip4.mcast\" action=drop external-ids:default-deny-policy-type=Ingress",
+		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=to-lport match=\"outport == @mcastPortGroupDeny && ip4.mcast\" action=drop external-ids:default-deny-policy-type=Ingress -- add port_group  acls @acl",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
@@ -58,7 +67,6 @@ func defaultFakeExec(nodeSubnet, nodeName string) (*ovntest.FakeExec, string, st
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-ovn_cluster_router -- set logical_switch_port jtor-ovn_cluster_router type=router options:router-port=rtoj-ovn_cluster_router addresses=\"" + joinLRPMAC + "\"",
-		"ovn-nbctl --timeout=15 --columns=_uuid list port_group",
 	})
 
 	// Node-related logical network stuff
@@ -66,6 +74,7 @@ func defaultFakeExec(nodeSubnet, nodeName string) (*ovntest.FakeExec, string, st
 	Expect(err).NotTo(HaveOccurred())
 	cidr.IP = util.NextIP(ip)
 	gwCIDR := cidr.String()
+	gwIP := cidr.IP.String()
 	nodeMgmtPortIP := util.NextIP(cidr.IP).String()
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -79,6 +88,7 @@ func defaultFakeExec(nodeSubnet, nodeName string) (*ovntest.FakeExec, string, st
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --may-exist lrp-add ovn_cluster_router rtos-" + nodeName + " " + lrpMAC + " " + gwCIDR,
 		"ovn-nbctl --timeout=15 -- --may-exist ls-add " + nodeName + " -- set logical_switch " + nodeName + " other-config:subnet=" + nodeSubnet + " other-config:exclude_ips=" + nodeMgmtPortIP + " external-ids:gateway_ip=" + gwCIDR,
+		"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " other-config:mcast_snoop=\"true\" other-config:mcast_querier=\"true\" other-config:mcast_eth_src=\"" + lrpMAC + "\" other-config:mcast_ip4_src=\"" + gwIP + "\"",
 		"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " stor-" + nodeName + " -- set logical_switch_port stor-" + nodeName + " type=router options:router-port=rtos-" + nodeName + " addresses=\"" + lrpMAC + "\"",
 		"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 		"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -46,4 +46,5 @@ func (o *FakeOVN) init() {
 
 	o.controller = NewOvnController(o.fakeClient, o.watcher)
 	o.controller.portGroupSupport = true
+	o.controller.multicastSupport = true
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -12,6 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// Builds the logical switch port name for a given pod.
+func podLogicalPortName(pod *kapi.Pod) string {
+	return pod.Namespace + "_" + pod.Name
+}
+
 func (oc *Controller) syncPods(pods []interface{}) {
 	// get the list of logical switch ports (equivalent to pods)
 	expectedLogicalPorts := make(map[string]bool)
@@ -21,7 +26,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 			logrus.Errorf("Spurious object in syncPods: %v", podInterface)
 			continue
 		}
-		logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+		logicalPort := podLogicalPortName(pod)
 		expectedLogicalPorts[logicalPort] = true
 	}
 
@@ -155,7 +160,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	}
 
 	logrus.Infof("Deleting pod: %s", pod.Name)
-	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+	logicalPort := podLogicalPortName(pod)
 	out, stderr, err := util.RunOVNNbctl("--if-exists", "lsp-del",
 		logicalPort)
 	if err != nil {
@@ -187,7 +192,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		oc.deleteACLDenyOld(pod.Namespace, pod.Spec.NodeName, logicalPort,
 			"Egress")
 	}
-	oc.deletePodFromNamespaceAddressSet(pod.Namespace, podIP)
+	oc.deletePodFromNamespace(pod.Namespace, podIP, logicalPort)
 	return
 }
 
@@ -242,7 +247,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		return
 	}
 
-	portName := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+	portName := podLogicalPortName(pod)
 	logrus.Debugf("Creating logical port for %s on switch %s", portName, logicalSwitch)
 
 	annotation, err := util.UnmarshalPodAnnotation(pod.Annotations["ovn"])
@@ -339,7 +344,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 	if err != nil {
 		logrus.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
 	}
-	oc.addPodToNamespaceAddressSet(pod.Namespace, podIP)
+	oc.addPodToNamespace(pod.Namespace, podIP, portName)
 
 	return
 }

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -371,6 +371,7 @@ func (oc *Controller) handlePeerNamespaceSelector(
 
 const (
 	toLport   = "to-lport"
+	fromLport = "from-lport"
 	addACL    = "add"
 	deleteACL = "delete"
 	noneMatch = "None"
@@ -380,6 +381,10 @@ const (
 	defaultAllowPriority = "1001"
 	// IP Block except deny acl rule priority
 	ipBlockDenyPriority = "1010"
+	// Default multicast deny acl rule priority
+	defaultMcastDenyPriority = "1011"
+	// Default multicast allow acl rule priority
+	defaultMcastAllowPriority = "1012"
 )
 
 func (oc *Controller) addAllowACLFromNode(logicalSwitch string) error {


### PR DESCRIPTION
Enable IGMP Snoop (when supported) and IGMP relay to allow multicast
connectivity across nodes.

Enforce the following network policies for IP multicast traffic:
- a default deny-all network policy is applied to all IP multicast
    traffic. This is implemented with two ACLs:
    a) one ACL dropping egress multicast traffic from all pods:
       this is to protect OVN controller from processing IP multicast
       reports from nodes that are not allowed to receive multicast
       traffic.
    b) one ACL dropping ingress multicast traffic to all pods.
- when multicast is explicitly enabled in the namespace, IP multicast
    traffic is forwarded only to pods in the same namespace. This is done
    by adding:
    a) a port group containing all logical ports associated with the
       namespace.
    b) one "from-lport" ACL allowing egress multicast traffic from the
       in the namespace.
    c) one "to-lport" ACL allowing ingress multicast traffic to pods in
       the namespace. This matches only traffic originated by pods in
       the same namespace (based on the namespace address set).

Add a new namespace annotation to allow enabling of multicast:
"k8s.ovn.org/multicast-enabled".

Signed-off-by: Dumitru Ceara <dceara@redhat.com>