### PR TITLE
OVN HA - Cleanup and small fixes

### DIFF
--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -28,13 +28,6 @@ func NewClusterController(kubeClient kubernetes.Interface, wf *factory.WatchFact
 }
 
 func setupOVNNode(nodeName string) error {
-	// Tell ovn-*bctl how to talk to the database
-	for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
-		if err := auth.SetDBAuth(); err != nil {
-			return err
-		}
-	}
-
 	var err error
 
 	nodeIP := config.Default.EncapIP

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -74,8 +74,30 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	var subnet *net.IPNet
 	var clusterSubnets []string
 	var cidr string
-
 	var wg sync.WaitGroup
+
+	if config.MasterHA.ManageDBServers {
+		var readyChan = make(chan bool, 1)
+
+		err = cluster.watchConfigEndpoints(readyChan)
+		if err != nil {
+			return err
+		}
+		// Hold until we are certain that the endpoint has been setup.
+		// We risk polling an inactive master if we don't wait while a new leader election is on-going
+		<-readyChan
+	} else {
+		for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
+			if err := auth.SetDBAuth(); err != nil {
+				return err
+			}
+		}
+	}
+
+	err = setupOVNNode(name)
+	if err != nil {
+		return err
+	}
 
 	for _, clusterSubnet := range config.Default.ClusterSubnets {
 		clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR.String())
@@ -103,16 +125,6 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	}
 
 	logrus.Infof("Node %s ready for ovn initialization with subnet %s", node.Name, subnet.String())
-
-	err = cluster.watchConfigEndpoints()
-	if err != nil {
-		return err
-	}
-
-	err = setupOVNNode(name)
-	if err != nil {
-		return err
-	}
 
 	if _, err = isOVNControllerReady(name); err != nil {
 		return err
@@ -180,7 +192,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	return err
 }
 
-func updateOVNConfig(ep *kapi.Endpoints) error {
+func updateOVNConfig(ep *kapi.Endpoints, readyChan chan bool) error {
 	masterIPList, southboundDBPort, northboundDBPort, err := util.ExtractDbRemotesFromEndpoint(ep)
 	if err != nil {
 		return err
@@ -195,20 +207,22 @@ func updateOVNConfig(ep *kapi.Endpoints) error {
 		if err := auth.SetDBAuth(); err != nil {
 			return err
 		}
-		logrus.Infof("OVN databases reconfigured, masterIP %s, northbound-db %d, southbound-db %d", ep.Subsets[0].Addresses[0].IP, northboundDBPort, southboundDBPort)
 	}
 
+	logrus.Infof("OVN databases reconfigured, masterIPs %v, northbound-db %v, southbound-db %v", masterIPList, northboundDBPort, southboundDBPort)
+
+	readyChan <- true
 	return nil
 }
 
 //watchConfigEndpoints starts the watching of Endpoint resource and calls back to the appropriate handler logic
-func (cluster *OvnClusterController) watchConfigEndpoints() error {
+func (cluster *OvnClusterController) watchConfigEndpoints(readyChan chan bool) error {
 	_, err := cluster.watchFactory.AddFilteredEndpointsHandler(config.Kubernetes.OVNConfigNamespace,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				ep := obj.(*kapi.Endpoints)
 				if ep.Name == "ovnkube-db" {
-					if err := updateOVNConfig(ep); err != nil {
+					if err := updateOVNConfig(ep, readyChan); err != nil {
 						logrus.Errorf(err.Error())
 					}
 				}
@@ -217,7 +231,7 @@ func (cluster *OvnClusterController) watchConfigEndpoints() error {
 				epNew := new.(*kapi.Endpoints)
 				epOld := old.(*kapi.Endpoints)
 				if !reflect.DeepEqual(epNew.Subsets, epOld.Subsets) && epNew.Name == "ovnkube-db" {
-					if err := updateOVNConfig(epNew); err != nil {
+					if err := updateOVNConfig(epNew, readyChan); err != nil {
 						logrus.Errorf(err.Error())
 					}
 				}

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(config.OvnNorth.Address).To(Equal("tcp:1.1.1.1:6641"), "config.OvnNorth.Address does not equal cli arg")
 			Expect(config.OvnSouth.Address).To(Equal("tcp:1.1.1.1:6642"), "config.OvnSouth.Address does not equal cli arg")
 
-			err = cluster.watchConfigEndpoints()
+			err = cluster.watchConfigEndpoints(make(chan bool, 1))
 			Expect(err).NotTo(HaveOccurred())
 
 			// Kubernetes endpoints should eventually propogate to OvnNorth/OvnSouth
@@ -185,6 +185,7 @@ var _ = Describe("Node Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 	})
+
 	It("test watchConfigEndpoints multiple IPs", func() {
 		app.Action = func(ctx *cli.Context) error {
 
@@ -249,7 +250,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(config.OvnNorth.Address).To(Equal("tcp:1.1.1.1:6641"), "config.OvnNorth.Address does not equal cli arg")
 			Expect(config.OvnSouth.Address).To(Equal("tcp:1.1.1.1:6642"), "config.OvnSouth.Address does not equal cli arg")
 
-			err = cluster.watchConfigEndpoints()
+			err = cluster.watchConfigEndpoints(make(chan bool, 1))
 			Expect(err).NotTo(HaveOccurred())
 
 			// Kubernetes endpoints should eventually propogate to OvnNorth/OvnSouth


### PR DESCRIPTION
This PR cleans up the work done in https://github.com/ovn-org/ovn-kubernetes/pull/881 a bit. Specifically it changes the following:

* It makes sure that when ovnkube-node starts up, that the endpoint is configured properly as to avoid targeting an empty IP or incorrect ovnkube-master. 
* It does a `CreateManagementPort` (which sets up `br-int` in case it does not exist) before doing a `isOVNControllerReady` which dumps all flows on `br-int`. This usually fails for the first run of the container when `br-int` does not exist.
* It makes sure the `ovnkube-db` endpoint only has one master defined. If we have more than one, it's bad. 
* It simplifies the methods of the leader election process 


