### PR TITLE
pkg/cluster: add an end-to-end timestamp and metric

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -222,6 +222,8 @@ func runOvnKube(ctx *cli.Context) error {
 			return fmt.Errorf("Windows is not supported as master node")
 		}
 
+		ovn.RegisterMetrics()
+
 		// run the HA master controller to init the master
 		ovnHAController := ovn.NewHAMasterController(clientset, factory, master)
 		if err := ovnHAController.StartHAMasterController(); err != nil {

--- a/go-controller/pkg/ovn/metrics.go
+++ b/go-controller/pkg/ovn/metrics.go
@@ -1,0 +1,73 @@
+package ovn
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+// metricE2ETimestamp is a timestamp value we have persisted to nbdb. We will
+// also export a metric with the same column in sbdb. We will also bump this
+// every 30 seconds, so we can detect a hung northd.
+var metricE2ETimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "ovn_nb_e2e_timestamp",
+	Help: "The current e2e-timestamp value as written to the northbound database"})
+
+var registerMetricsOnce sync.Once
+var startUpdaterOnce sync.Once
+
+// RegisterMetrics registers some ovn-controller metrics with the Prometheus
+// registry
+func RegisterMetrics() {
+	registerMetricsOnce.Do(func() {
+		prometheus.MustRegister(metricE2ETimestamp)
+
+		prometheus.MustRegister(prometheus.NewCounterFunc(
+			prometheus.CounterOpts{
+				Name: "ovn_sb_e2e_timestamp",
+				Help: "The current e2e-timestamp value as observed in the southbound database",
+			}, scrapeOvnTimestamp))
+	})
+}
+
+func scrapeOvnTimestamp() float64 {
+	output, stderr, err := util.RunOVNSbctl("--if-exists",
+		"get", "SB_Global", ".", "options:e2e_timestamp")
+	if err != nil {
+		logrus.Errorf("failed to scrape timestamp: %s (%v)", stderr, err)
+		return 0
+	}
+
+	out, err := strconv.ParseFloat(output, 64)
+	if err != nil {
+		logrus.Errorf("failed to parse timestamp %s: %v", output, err)
+		return 0
+	}
+	return out
+}
+
+// startOvnUpdater adds a goroutine that updates a "timestamp" value in the
+// nbdb every 30 seconds. This is so we can determine freshness of the database
+func startOvnUpdater() {
+	startUpdaterOnce.Do(func() {
+		go func() {
+			for {
+				t := time.Now().Unix()
+				_, stderr, err := util.RunOVNNbctl("set", "NB_Global", ".",
+					fmt.Sprintf(`options:e2e_timestamp="%d"`, t))
+				if err != nil {
+					logrus.Errorf("failed to bump timestamp: %s (%v)", stderr, err)
+				} else {
+					metricE2ETimestamp.Set(float64(t))
+				}
+				time.Sleep(30 * time.Second)
+			}
+		}()
+	})
+}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -117,6 +117,7 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory)
 
 // Run starts the actual watching.
 func (oc *Controller) Run() error {
+	startOvnUpdater()
 	for _, f := range []func() error{oc.WatchNodes, oc.WatchPods, oc.WatchServices, oc.WatchEndpoints,
 		oc.WatchNamespaces, oc.WatchNetworkPolicy} {
 		if err := f(); err != nil {


### PR DESCRIPTION
This adds a simple end-to-end test to determine that northd is working correctly. It periodically updates a value in NB_Global options, and exposes that same value, but from SB_Global.

It also adds some basic metrics plumbing.

cc @JacobTanenbaum @dcbw @girishmg 