### PR TITLE
wait for the ovs integration bridge to be created

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -66,6 +66,10 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 
 		fexec := ovntest.NewFakeExec()
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ovs-vsctl --timeout=15 -- port-to-br eth0",
+			Err: fmt.Errorf(""),
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd: "ovs-vsctl --timeout=15 -- br-exists eth0",
 			Err: fmt.Errorf(""),
 		})

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -157,7 +157,7 @@ func initLocalnetGateway(nodeName string, clusterIPSubnet []string,
 			localnetBridgeNextHop, err)
 	}
 
-	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, localnetBridgeName)
+	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, localnetBridgeName, localnetBridgeName, true)
 	if err != nil {
 		return fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -279,9 +279,17 @@ func initSharedGateway(
 	nodeName string, clusterIPSubnet []string, subnet,
 	gwNextHop, gwIntf string, wf *factory.WatchFactory) error {
 	var bridgeName string
+	var uplinkName string
+	var brCreated bool
+	var err error
 
-	// Check to see whether the interface is OVS bridge.
-	if _, _, err := util.RunOVSVsctl("--", "br-exists", gwIntf); err != nil {
+	if bridgeName, _, err = util.RunOVSVsctl("--", "port-to-br", gwIntf); err == nil {
+		// This is an OVS bridge's internal port
+		uplinkName, err = util.GetNicName(bridgeName)
+		if err != nil {
+			return err
+		}
+	} else if _, _, err := util.RunOVSVsctl("--", "br-exists", gwIntf); err != nil {
 		// This is not a OVS bridge. We need to create a OVS bridge
 		// and add cluster.GatewayIntf as a port of that bridge.
 		bridgeName, err = util.NicToBridge(gwIntf)
@@ -289,27 +297,30 @@ func initSharedGateway(
 			return fmt.Errorf("failed to convert %s to OVS bridge: %v",
 				gwIntf, err)
 		}
+		uplinkName = gwIntf
+		gwIntf = bridgeName
+		brCreated = true
 	} else {
-		intfName, err := getIntfName(gwIntf)
+		// gateway interface is an OVS bridge
+		uplinkName, err = getIntfName(gwIntf)
 		if err != nil {
 			return err
 		}
 		bridgeName = gwIntf
-		gwIntf = intfName
 	}
 
 	// Now, we get IP address from OVS bridge. If IP does not exist,
 	// error out.
-	ipAddress, err := getIPv4Address(bridgeName)
+	ipAddress, err := getIPv4Address(gwIntf)
 	if err != nil {
 		return fmt.Errorf("Failed to get interface details for %s (%v)",
-			bridgeName, err)
+			gwIntf, err)
 	}
 	if ipAddress == "" {
-		return fmt.Errorf("%s does not have a ipv4 address", bridgeName)
+		return fmt.Errorf("%s does not have a ipv4 address", gwIntf)
 	}
 
-	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, bridgeName)
+	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, bridgeName, gwIntf, brCreated)
 	if err != nil {
 		return fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
@@ -335,13 +346,13 @@ func initSharedGateway(
 
 	// Program cluster.GatewayIntf to let non-pod traffic to go to host
 	// stack
-	if err := addDefaultConntrackRules(nodeName, bridgeName, gwIntf); err != nil {
+	if err := addDefaultConntrackRules(nodeName, bridgeName, uplinkName); err != nil {
 		return err
 	}
 
 	if config.Gateway.NodeportEnable {
 		// Program cluster.GatewayIntf to let nodePort traffic to go to pods.
-		if err := nodePortWatcher(nodeName, bridgeName, gwIntf, wf); err != nil {
+		if err := nodePortWatcher(nodeName, bridgeName, uplinkName, wf); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/cluster/helper_linux.go
+++ b/go-controller/pkg/cluster/helper_linux.go
@@ -41,7 +41,10 @@ func getIntfName(gatewayIntf string) (string, error) {
 	// created by us using util.NicToBridge() or it was pre-created by the user.
 
 	// Is intfName a port of gatewayIntf?
-	intfName := util.GetNicName(gatewayIntf)
+	intfName, err := util.GetNicName(gatewayIntf)
+	if err != nil {
+		return "", err
+	}
 	_, stderr, err := util.RunOVSVsctl("--if-exists", "get",
 		"interface", intfName, "ofport")
 	if err != nil {

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -45,6 +45,17 @@ func isOVNControllerReady(name string) (bool, error) {
 	}
 
 	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+		_, _, err := util.RunOVSVsctl("--", "br-exists", "br-int")
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("timed out checking whether br-int exists or not on node %s: %v", name, err)
+	}
+
+	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
 		flows, _, err := util.RunOVSOfctl("dump-flows", "br-int")
 		return len(flows) > 0, err
 	})

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -31,7 +31,7 @@ func isOVNControllerReady(name string) (bool, error) {
 		return false, fmt.Errorf("unknown pid for ovn-controller process: %v", err)
 	}
 
-	err = wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
+	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
 		ctlFile := runDir + fmt.Sprintf("ovn-controller.%s.ctl", strings.TrimSuffix(string(pid), "\n"))
 		ret, _, err := util.RunOVSAppctl("-t", ctlFile, "connection-status")
 		if err == nil {
@@ -44,7 +44,7 @@ func isOVNControllerReady(name string) (bool, error) {
 		return false, fmt.Errorf("timed out waiting sbdb for node %s: %v", name, err)
 	}
 
-	err = wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
+	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
 		flows, _, err := util.RunOVSOfctl("dump-flows", "br-int")
 		return len(flows) > 0, err
 	})


### PR DESCRIPTION
wait for the ovs integration bridge to be created

on our cluster, several ovnkube-nodes had a failed restart due to the
fact that `br-int` was not created yet by ovn-controller. the code in
isOVNControllerRead() checks for Openflow rules in br-int. however, it
could be that br-int is not created yet. as a result
`ovs-ofctl dump-flows br-int` fails and the container restarts.

wait for some time for the br-int to be created and then wait for the
flows to be created on br-int

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>