### PR TITLE
wait for the ovs integration bridge to be created

### DIFF
--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -45,6 +45,17 @@ func isOVNControllerReady(name string) (bool, error) {
 	}
 
 	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+		_, _, err := util.RunOVSVsctl("--", "br-exists", "br-int")
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("timed out checking whether br-int exists or not on node %s: %v", name, err)
+	}
+
+	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
 		flows, _, err := util.RunOVSOfctl("dump-flows", "br-int")
 		return len(flows) > 0, err
 	})

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -31,7 +31,7 @@ func isOVNControllerReady(name string) (bool, error) {
 		return false, fmt.Errorf("unknown pid for ovn-controller process: %v", err)
 	}
 
-	err = wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
+	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
 		ctlFile := runDir + fmt.Sprintf("ovn-controller.%s.ctl", strings.TrimSuffix(string(pid), "\n"))
 		ret, _, err := util.RunOVSAppctl("-t", ctlFile, "connection-status")
 		if err == nil {
@@ -44,7 +44,7 @@ func isOVNControllerReady(name string) (bool, error) {
 		return false, fmt.Errorf("timed out waiting sbdb for node %s: %v", name, err)
 	}
 
-	err = wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
+	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
 		flows, _, err := util.RunOVSOfctl("dump-flows", "br-int")
 		return len(flows) > 0, err
 	})


### PR DESCRIPTION
on our cluster, several ovnkube-nodes had a failed restart due to the
fact that `br-int` was not created yet by ovn-controller. the code in
isOVNControllerRead() checks for Openflow rules in br-int. however, it
could be that br-int is not created yet. as a result
`ovs-ofctl dump-flows br-int` fails and the container restarts.

wait for some time for the br-int to be created and then wait for the
flows to be created on br-int

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>
