### PR TITLE
Ensure addresses are quoted for address set

### DIFF
--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -72,7 +72,7 @@ func (oc *Controller) setAddressSet(hashName string, addresses []string) {
 		return
 	}
 
-	ips := strings.Join(addresses, " ")
+	ips := `"` + strings.Join(addresses, `" "`) + `"`
 	_, stderr, err := util.RunOVNNbctl("set", "address_set",
 		hashName, fmt.Sprintf("addresses=%s", ips))
 	if err != nil {
@@ -104,7 +104,7 @@ func (oc *Controller) createAddressSet(name string, hashName string,
 		return
 	}
 
-	ips := strings.Join(addresses, " ")
+	ips := `"` + strings.Join(addresses, `" "`) + `"`
 
 	// An addressSet has already been created. Just set addresses.
 	if addressSet != "" {

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -63,7 +63,7 @@ func (n namespace) delCmds(fexec *ovntest.FakeExec, namespace v1.Namespace) {
 func (n namespace) addCmdsWithPods(fexec *ovntest.FakeExec, tP pod, namespace v1.Namespace) {
 	n.baseCmds(fexec, namespace)
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf("ovn-nbctl --timeout=15 set address_set %s addresses=%s", hashedAddressSet(namespace.Name), tP.podIP),
+		fmt.Sprintf(`ovn-nbctl --timeout=15 set address_set %s addresses="%s"`, hashedAddressSet(namespace.Name), tP.podIP),
 	})
 }
 


### PR DESCRIPTION
When setting the value of the "addresses" column of an address_set,
each IP address should be quoted.  Otherwise, ovn-nbctl will emit an
error when parsing an IPv6 address like this one:

level=error msg="failed to set address_set, stderr: \"ovn-nbctl: fd01::58e2:7aff:fe00:13: unexpected \\\":\\\" parsing set of strings\\n\" (OVN command '/usr/bin/ovn-nbctl --timeout=15 set address_set a4065017480316135312 addresses=fd01::58e2:7aff:fe00:13' failed: exit status 1)"

Signed-off-by: Russell Bryant <russell@ovn.org>