### PR TITLE
PodSecurityPolicy should be apiVersion: policy/v1beta1

### DIFF
--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -34,7 +34,7 @@ metadata:
 ---
 # for now throw in all the privileges to run a pod. we can fine grain it further later.
 
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: ovn-kubernetes


### PR DESCRIPTION
extensions/v1beta1 is no longer supported in 1.16.
PodSecurityPolicy apiVersion should be policy/v1beta1 and
is back supported to 1.10