### PR TITLE
master: don't set connection in ovsdb

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -81,22 +81,8 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	return nil
 }
 
-func setupOVNMaster(nodeName string) error {
-	// Configure both server and client of OVN databases, since master uses both
-	for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
-		if err := auth.SetDBAuth(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // SetupMaster creates the central router and load-balancers for the network
 func (oc *Controller) SetupMaster(masterNodeName string) error {
-	if err := setupOVNMaster(masterNodeName); err != nil {
-		return err
-	}
-
 	// Create a single common distributed router for the cluster.
 	stdout, stderr, err := util.RunOVNNbctl("--", "--may-exist", "lr-add", OvnClusterRouter,
 		"--", "set", "logical_router", OvnClusterRouter, "external_ids:k8s-cluster-router=yes")

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -358,10 +358,6 @@ subnet=%s
 			clusterController := NewOvnController(fakeClient, f)
 			Expect(clusterController).NotTo(BeNil())
 
-			// Initialize OVS/OVN connection methods
-			err = setupOVNMaster(masterNode.Name)
-			Expect(err).NotTo(HaveOccurred())
-
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
While this is useful for the nodes, it doesn't really make sense for the master process to be connecting to ovsdb and setting connection information (ovsdbs or nodes). So, remove that.