### PR TITLE
Wrap IPv6 address in [] before adding port

### DIFF
--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -4,9 +4,11 @@ package cluster
 
 import (
 	"fmt"
-	"k8s.io/client-go/tools/cache"
+	"net"
 	"reflect"
 	"strings"
+
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -194,7 +196,7 @@ func localnetIptRules(svc *kapi.Service) []iptRule {
 			table: "nat",
 			chain: iptableNodePortChain,
 			args: []string{"-p", string(protocol), "--dport", nodePort, "-j", "DNAT", "--to-destination",
-				strings.Split(localnetGatewayIP, "/")[0] + ":" + nodePort},
+				net.JoinHostPort(strings.Split(localnetGatewayIP, "/")[0], nodePort)},
 		})
 		rules = append(rules, iptRule{
 			table: "filter",


### PR DESCRIPTION
This code assumed an IPv4 address.  When the IP address is IPv6, we
must wrap it with square brackets to differentiate the address from
the : that separates the address from the port number.