### PR TITLE
Fix formatting of IPv6 LB VIPs

### DIFF
--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -226,14 +226,14 @@ var _ = Describe("Node Operations", func() {
 			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
-					"external_ids:ovn-nb=\"tcp:%s:%d\"",
-					masterAddress, nbPort),
+					"external_ids:ovn-nb=\"tcp:%s\"",
+					util.JoinHostPortInt32(masterAddress, nbPort)),
 			})
 
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
-					"external_ids:ovn-remote=\"tcp:%s:%d\"",
-					masterAddress, sbPort),
+					"external_ids:ovn-remote=\"tcp:%s\"",
+					util.JoinHostPortInt32(masterAddress, sbPort)),
 			})
 
 			err := util.SetExec(fexec)
@@ -281,10 +281,10 @@ var _ = Describe("Node Operations", func() {
 			// Kubernetes endpoints should eventually propogate to OvnNorth/OvnSouth
 			Eventually(func() string {
 				return config.OvnNorth.Address
-			}).Should(Equal(fmt.Sprintf("tcp:%s:%d", masterAddress, nbPort)), "Northbound DB Port did not get set by watchConfigEndpoints")
+			}).Should(Equal(fmt.Sprintf("tcp:%s", util.JoinHostPortInt32(masterAddress, nbPort))), "Northbound DB Port did not get set by watchConfigEndpoints")
 			Eventually(func() string {
 				return config.OvnSouth.Address
-			}).Should(Equal(fmt.Sprintf("tcp:%s:%d", masterAddress, sbPort)), "Southbound DBPort did not get set by watchConfigEndpoints")
+			}).Should(Equal(fmt.Sprintf("tcp:%s", util.JoinHostPortInt32(masterAddress, sbPort))), "Southbound DBPort did not get set by watchConfigEndpoints")
 
 			return nil
 		}
@@ -305,14 +305,16 @@ var _ = Describe("Node Operations", func() {
 			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
-					"external_ids:ovn-nb=\"tcp:%s:%d,tcp:%s:%d\"",
-					masterAddress1, nbPort, masterAddress2, nbPort),
+					"external_ids:ovn-nb=\"tcp:%s,tcp:%s\"",
+					util.JoinHostPortInt32(masterAddress1, nbPort),
+					util.JoinHostPortInt32(masterAddress2, nbPort)),
 			})
 
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
-					"external_ids:ovn-remote=\"tcp:%s:%d,tcp:%s:%d\"",
-					masterAddress1, sbPort, masterAddress2, sbPort),
+					"external_ids:ovn-remote=\"tcp:%s,tcp:%s\"",
+					util.JoinHostPortInt32(masterAddress1, sbPort),
+					util.JoinHostPortInt32(masterAddress2, sbPort)),
 			})
 
 			err := util.SetExec(fexec)
@@ -360,10 +362,10 @@ var _ = Describe("Node Operations", func() {
 			// Kubernetes endpoints should eventually propogate to OvnNorth/OvnSouth
 			Eventually(func() string {
 				return config.OvnNorth.Address
-			}).Should(Equal(fmt.Sprintf("tcp:%s:%d,tcp:%s:%d", masterAddress1, nbPort, masterAddress2, nbPort)), "Northbound DB Port did not get set by watchConfigEndpoints")
+			}).Should(Equal(fmt.Sprintf("tcp:%s,tcp:%s", util.JoinHostPortInt32(masterAddress1, nbPort), util.JoinHostPortInt32(masterAddress2, nbPort))), "Northbound DB Port did not get set by watchConfigEndpoints")
 			Eventually(func() string {
 				return config.OvnSouth.Address
-			}).Should(Equal(fmt.Sprintf("tcp:%s:%d,tcp:%s:%d", masterAddress1, sbPort, masterAddress2, sbPort)), "Southbound DBPort did not get set by watchConfigEndpoints")
+			}).Should(Equal(fmt.Sprintf("tcp:%s,tcp:%s", util.JoinHostPortInt32(masterAddress1, sbPort), util.JoinHostPortInt32(masterAddress2, sbPort))), "Southbound DBPort did not get set by watchConfigEndpoints")
 
 			return nil
 		}

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -1,9 +1,6 @@
 package ovn
 
 import (
-	"net"
-	"strconv"
-
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -86,7 +83,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 						logrus.Errorf("Error in creating Cluster IP for svc %s, target port: %d - %v\n", svc.Name, targetPort, err)
 						continue
 					}
-					vip := net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(int(svcPort.Port)))
+					vip := util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port)
 					ovn.AddServiceVIPToName(vip, svcPort.Protocol, svc.Namespace, svc.Name)
 					ovn.handleExternalIPs(svc, svcPort, ips, targetPort)
 				}
@@ -119,7 +116,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 						logrus.Errorf("Error in creating Cluster IP for svc %s, target port: %d - %v\n", svc.Name, targetPort, err)
 						continue
 					}
-					vip := net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(int(svcPort.Port)))
+					vip := util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port)
 					ovn.AddServiceVIPToName(vip, svcPort.Protocol, svc.Namespace, svc.Name)
 					ovn.handleExternalIPs(svc, svcPort, ips, targetPort)
 				}
@@ -284,7 +281,7 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 			continue
 		}
 
-		quotedHostPort := "\"" + net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(int(svcPort.Port))) + "\""
+		quotedHostPort := "\"" + util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port) + "\""
 		if config.Kubernetes.OVNEmptyLbEvents {
 			key := "vips:" + quotedHostPort + "=\"\""
 			_, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, key)

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -101,4 +102,9 @@ func GetNodeWellKnownAddresses(subnet *net.IPNet) (*net.IPNet, *net.IPNet) {
 	routerIP := NextIP(subnet.IP)
 	return &net.IPNet{IP: routerIP, Mask: subnet.Mask},
 		&net.IPNet{IP: NextIP(routerIP), Mask: subnet.Mask}
+}
+
+// JoinHostPortInt32 is like net.JoinHostPort(), but with an int32 for the port
+func JoinHostPortInt32(host string, port int32) string {
+	return net.JoinHostPort(host, strconv.Itoa(int(port)))
 }


### PR DESCRIPTION
I encountered the following error in an ovn-controller log:

019-11-04T14:15:02Z|00025|lflow|WARN|error parsing actions "ct_lb(2600:1f16:d2d:3003:9dbc:39cc:ef6c:6dbb:6443);": Invalid numeric constant.

The root cause is that the IPv6 address was not wrapped in square
brackets when ovn-kubernetes configured the VIPs for a load balancer.

This patch fixes this issue, along with a number of other places where
net.JoinHostPort() needs to be used instead of performing the same
operation manually in a way that works for IPv4 only.