### PR TITLE
use ovs-ofctl dump-aggregate instead of dump-flows

### DIFF
--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -56,8 +56,11 @@ func isOVNControllerReady(name string) (bool, error) {
 	}
 
 	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		flows, _, err := util.RunOVSOfctl("dump-flows", "br-int")
-		return len(flows) > 0, err
+		stdout, _, err := util.RunOVSOfctl("dump-aggregate", "br-int")
+		if err != nil {
+			return false, fmt.Errorf("failed to get aggregate flow statistics: %v", err)
+		}
+		return strings.Index(stdout, "flow_count=0") == -1, nil
 	})
 	if err != nil {
 		return false, fmt.Errorf("timed out dumping br-int flow entries for node %s: %v", name, err)


### PR DESCRIPTION
with the current use of dump-flows to check if there are non-zero flows
in br-int, the log file for ovnkube-node is getting polluted with 1000s
of flows. instead use `dump-aggregate` which returns the flow_count to
determine the same

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>