### PR TITLE
on node addition we fail to create management logical_switch_port

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -463,9 +463,15 @@ func (oc *Controller) WatchNodes() error {
 			if err != nil {
 				logrus.Errorf("error creating subnet for node %s: %v", node.Name, err)
 			}
-			err = oc.syncNodeManagementPort(node)
+			// get the node with the updated annotation set
+			newNode, err := oc.kube.GetNode(node.Name)
 			if err != nil {
-				logrus.Errorf("error creating Node Management Port for node %s: %v", node.Name, err)
+				logrus.Errorf("failed to get the node %s: %v", node.Name, err)
+			} else {
+				err = oc.syncNodeManagementPort(newNode)
+				if err != nil {
+					logrus.Errorf("error creating Node Management Port for node %s: %v", node.Name, err)
+				}
 			}
 			if !config.Gateway.NodeportEnable {
 				return


### PR DESCRIPTION
on node addition we annotate the node with ovn_host_subnet=a.b.c.d/y.
immediately after we try to retrieve this node annotation to get the
management port IP. however, we are retrieving it from a cached copy of
the node and we will not find it.

Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>