### PR TITLE
ovn: use hostsubnet from node addition

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -326,7 +326,8 @@ subnet=%s
 				"ovn-nbctl --timeout=15 --may-exist lrp-add ovn_cluster_router rtos-" + masterName + " " + lrpMAC + " " + masterGWCIDR,
 				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + masterName + " -- set logical_switch " + masterName + " other-config:subnet=" + masterSubnet + " other-config:exclude_ips=" + masterMgmtPortIP + " external-ids:gateway_ip=" + masterGWCIDR,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + masterName + " stor-" + masterName + " -- set logical_switch_port stor-" + masterName + " type=router options:router-port=rtos-" + masterName + " addresses=\"" + lrpMAC + "\"",
-
+				"ovn-nbctl --timeout=15 set logical_switch " + masterName + " load_balancer=" + tcpLBUUID,
+				"ovn-nbctl --timeout=15 add logical_switch " + masterName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + masterName + " k8s-" + masterName + " -- lsp-set-addresses " + "k8s-" + masterName + " " + masterMgmtPortMAC + " " + masterMgmtPortIP + " -- --if-exists remove logical_switch " + masterName + " other-config exclude_ips",
 			})
 
@@ -367,6 +368,8 @@ subnet=%s
 
 			clusterController := NewOvnController(fakeClient, f)
 			Expect(clusterController).NotTo(BeNil())
+			clusterController.TCPLoadBalancerUUID = tcpLBUUID
+			clusterController.UDPLoadBalancerUUID = udpLBUUID
 
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -459,11 +459,13 @@ func (oc *Controller) WatchNodes() error {
 		AddFunc: func(obj interface{}) {
 			node := obj.(*kapi.Node)
 			logrus.Debugf("Added event for Node %q", node.Name)
-			err := oc.addNode(node)
+			hostSubnet, err := oc.addNode(node)
 			if err != nil {
 				logrus.Errorf("error creating subnet for node %s: %v", node.Name, err)
+				return
 			}
-			err = oc.syncNodeManagementPort(node)
+
+			err = oc.syncNodeManagementPort(node, hostSubnet)
 			if err != nil {
 				logrus.Errorf("error creating Node Management Port for node %s: %v", node.Name, err)
 			}
@@ -479,7 +481,7 @@ func (oc *Controller) WatchNodes() error {
 			macAddress, _ := node.Annotations[OvnNodeManagementPortMacAddress]
 			logrus.Debugf("Updated event for Node %q", node.Name)
 			if oldMacAddress != macAddress {
-				err := oc.syncNodeManagementPort(node)
+				err := oc.syncNodeManagementPort(node, nil)
 				if err != nil {
 					logrus.Errorf("error update Node Management Port for node %s: %v", node.Name, err)
 				}


### PR DESCRIPTION
During node addition the hostSubnet gets posted to node
annotations but that doesn't set the annotation in the
node object being used in the WatchNodes() AddFunc, so
when the management port handling function tries to
parse the annotation it won't get it.

@girishmg  what about this instead of https://github.com/ovn-org/ovn-kubernetes/pull/909 ? Saves us an unecessary API call because we have the hostsubnet already.