### PR TITLE
Allow protobuf in client

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -48,6 +48,9 @@ func NewClientset(conf *config.KubernetesConfig) (*kubernetes.Clientset, error) 
 		return nil, err
 	}
 
+	kconfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	kconfig.ContentType = "application/vnd.kubernetes.protobuf"
+
 	return kubernetes.NewForConfig(kconfig)
 }
 


### PR DESCRIPTION
A quick profiling session showed that decoding json is 50% of the CPU usage of ovnkube-master. There's no need to waste that time; switch to protobuf.