### PR TITLE
rename run-ovn-northd and run-nbctld container names

### DIFF
--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -41,8 +41,8 @@ spec:
 
       containers:
 
-      # run-ovn-northd - v3
-      - name: run-ovn-northd
+      # ovn-northd - v3
+      - name: ovn-northd
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
 
@@ -109,7 +109,7 @@ spec:
         lifecycle:
       # end of container
 
-      - name: run-nbctld
+      - name: nbctl-daemon
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
 


### PR DESCRIPTION
-- changed run-ovn-northd to ovn-northd
-- changed run-nbctld to nbctl-daemon

the container names for the rest of the OVN/OVS components seem to
be meaningful to me

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>