### PR TITLE
HA: fix assignment to nil endpoints annotation map

### DIFF
--- a/go-controller/pkg/ovn/ha_master.go
+++ b/go-controller/pkg/ovn/ha_master.go
@@ -159,7 +159,13 @@ func (hacontroller *HAMasterController) StartHAMasterController() error {
 
 	go hacontroller.leaderElector.Run(context.Background())
 
-	return hacontroller.WatchOvnDbEndpoints()
+	if hacontroller.manageDBServers {
+		if err = hacontroller.WatchOvnDbEndpoints(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // ConfigureAsActive configures the node as active.
@@ -264,6 +270,9 @@ func (hacontroller *HAMasterController) updateOvnDbEndpoints(ep *kapi.Endpoints,
 		logrus.Debugf("updateOvnDbEndpoints : Updating the endpoint")
 		ovndbEp := ep.DeepCopy()
 		ovndbEp.Subsets = epSubsets
+		if ovndbEp.Annotations == nil {
+			ovndbEp.Annotations = make(map[string]string)
+		}
 		ovndbEp.Annotations[haMasterLeader] = hacontroller.nodeName
 		_, err := hacontroller.ovnController.kube.UpdateEndpoint(config.Kubernetes.OVNConfigNamespace, ovndbEp)
 		if err != nil {


### PR DESCRIPTION
I don't think we should be running WatchOvnDbEndpoints() if we
aren't managing the DB servers? Endpoints map nil is not directly
related, but is likely why this gets called and panics.

```
E1109 05:52:57.673238       1 runtime.go:69] Observed a panic: "assignment to entry in nil map" (assignment to entry in nil map)
/go-controller/_output/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:76
/go-controller/_output/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/go-controller/_output/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/panic.go:522
/usr/local/go/src/runtime/map_faststr.go:204
/go-controller/_output/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ha_master.go:257
/go-controller/_output/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ha_master.go:368
/go-controller/_output/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ha_master.go:387
/go-controller/_output/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:202
/go-controller/_output/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:236
```

@numansiddique @girishmg @danwinship @alexanderConstantinescu 