### PR TITLE
remove redundant checks in addLogicalPort()

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -331,7 +331,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 	oc.addPodToNamespace(pod.Namespace, podIP, portName)
 
 	logrus.Debugf("Annotation values: ip=%s ; mac=%s ; gw=%s\nAnnotation=%s",
-		podCIDR, podMac, gatewayIP, annotation)
+		podCIDR, podMac, gatewayIP, marshalledAnnotation)
 	if err = oc.kube.SetAnnotationOnPod(pod, "ovn", marshalledAnnotation); err != nil {
 		return fmt.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
 	}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -234,15 +234,6 @@ func (oc *Controller) waitForNodeLogicalSwitch(nodeName string) error {
 func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 	var out, stderr string
 	var err error
-	if pod.Spec.HostNetwork {
-		return nil
-	}
-
-	logicalSwitch := pod.Spec.NodeName
-	if logicalSwitch == "" {
-		return fmt.Errorf("Failed to find the logical switch for pod %s/%s",
-			pod.Namespace, pod.Name)
-	}
 
 	// Keep track of how long syncs take.
 	start := time.Now()
@@ -250,6 +241,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 		logrus.Infof("[%s/%s] addLogicalPort took %v", pod.Namespace, pod.Name, time.Since(start))
 	}()
 
+	logicalSwitch := pod.Spec.NodeName
 	if err = oc.waitForNodeLogicalSwitch(pod.Spec.NodeName); err != nil {
 		return err
 	}


### PR DESCRIPTION
now that podScheduledAndWantsNetwork() ensures that the pod to which
logical_switch_port is being created is not a HostNetwork pod and that
is already scheduled, there is no need to check the same in
addLogicalPort

@dcbw  @danwinship 