### PR TITLE
gcp - Delete node annotation to permit workers to come up

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -285,6 +285,11 @@ func (oc *Controller) WatchNodes() error {
 					logrus.Errorf("error update Node Management Port for node %s: %v", node.Name, err)
 				}
 			}
+
+			if !reflect.DeepEqual(oldNode.Status.Conditions, node.Status.Conditions) {
+				oc.clearInitialNodeNetworkUnavailableCondition(node)
+			}
+
 			if !config.Gateway.NodeportEnable {
 				return
 			}


### PR DESCRIPTION
SDN-637 - OVN doesn't work on GCP
https://jira.coreos.com/browse/SDN-637

Bug 1748162
[GCP]Failed to install cluster with OVN network type
https://bugzilla.redhat.com/show_bug.cgi?id=1748162

Signed-off-by: Phil Cameron <pcameron@redhat.com>