### PR TITLE
pods: only track failed pods for retry-on-Update

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -26,7 +26,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 			logrus.Errorf("Spurious object in syncPods: %v", podInterface)
 			continue
 		}
-		if podScheduledAndWantsNetwork(pod) {
+		if podScheduled(pod) && podWantsNetwork(pod) {
 			logicalPort := podLogicalPortName(pod)
 			expectedLogicalPorts[logicalPort] = true
 		}


### PR DESCRIPTION
Suggested by Girish.

@danwinship @squeed @girishmg 