### PR TITLE
factory: parallelize Node events

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -18,7 +18,6 @@ import (
 	kapi "k8s.io/api/core/v1"
 	kapisnetworking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	kv1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -339,7 +338,7 @@ func podScheduled(pod *kapi.Pod) bool {
 
 // WatchPods starts the watching of Pod resource and calls back the appropriate handler logic
 func (oc *Controller) WatchPods() error {
-	retryPods := sets.String{}
+	var retryPods sync.Map
 	_, err := oc.watchFactory.AddPodHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
@@ -350,11 +349,11 @@ func (oc *Controller) WatchPods() error {
 			if podScheduled(pod) {
 				if err := oc.addLogicalPort(pod); err != nil {
 					logrus.Errorf(err.Error())
-					retryPods.Insert(string(pod.UID))
+					retryPods.Store(pod.UID, true)
 				}
 			} else {
 				// Handle unscheduled pods later in UpdateFunc
-				retryPods.Insert(string(pod.UID))
+				retryPods.Store(pod.UID, true)
 			}
 		},
 		UpdateFunc: func(old, newer interface{}) {
@@ -363,18 +362,19 @@ func (oc *Controller) WatchPods() error {
 				return
 			}
 
-			if podScheduled(pod) && retryPods.Has(string(pod.UID)) {
+			_, retry := retryPods.Load(pod.UID)
+			if podScheduled(pod) && retry {
 				if err := oc.addLogicalPort(pod); err != nil {
 					logrus.Errorf(err.Error())
 				} else {
-					retryPods.Delete(string(pod.UID))
+					retryPods.Delete(pod.UID)
 				}
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
 			oc.deleteLogicalPort(pod)
-			retryPods.Delete(string(pod.UID))
+			retryPods.Delete(pod.UID)
 		},
 	}, oc.syncPods)
 	return err
@@ -500,7 +500,7 @@ func (oc *Controller) syncNodeGateway(node *kapi.Node, subnet *net.IPNet) error 
 // WatchNodes starts the watching of node resource and calls
 // back the appropriate handler logic
 func (oc *Controller) WatchNodes() error {
-	gatewaysFailed := make(map[string]bool)
+	var gatewaysFailed sync.Map
 	macAddressFailed := make(map[string]bool)
 	_, err := oc.watchFactory.AddNodeHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -519,8 +519,8 @@ func (oc *Controller) WatchNodes() error {
 			}
 
 			if err := oc.syncNodeGateway(node, hostSubnet); err != nil {
-				gatewaysFailed[node.Name] = true
 				logrus.Errorf(err.Error())
+				gatewaysFailed.Store(node.Name, true)
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
@@ -539,12 +539,14 @@ func (oc *Controller) WatchNodes() error {
 
 			oc.clearInitialNodeNetworkUnavailableCondition(oldNode, node)
 
-			if gatewaysFailed[node.Name] || gatewayChanged(oldNode, node) {
-				if err := oc.syncNodeGateway(node, nil); err != nil {
-					gatewaysFailed[node.Name] = true
+			_, failed := gatewaysFailed.Load(node.Name)
+			if failed || gatewayChanged(oldNode, node) {
+				err := oc.syncNodeGateway(node, nil)
+				if err != nil {
 					logrus.Errorf(err.Error())
+					gatewaysFailed.Store(node.Name, true)
 				} else {
-					delete(gatewaysFailed, node.Name)
+					gatewaysFailed.Delete(node.Name)
 				}
 			}
 		},
@@ -562,7 +564,7 @@ func (oc *Controller) WatchNodes() error {
 			delete(oc.gatewayCache, node.Name)
 			delete(oc.logicalSwitchCache, node.Name)
 			oc.lsMutex.Unlock()
-			delete(gatewaysFailed, node.Name)
+			gatewaysFailed.Delete(node.Name)
 			if oc.defGatewayRouter == "GR_"+node.Name {
 				delete(oc.loadbalancerGWCache, TCP)
 				delete(oc.loadbalancerGWCache, UDP)


### PR DESCRIPTION
Add infrastructure for parallel event handlers and make Node events
use it.

@squeed @danwinship @girishmg 

Alternate take on https://github.com/ovn-org/ovn-kubernetes/pull/913 that hashes into a set number of event queues, rather than queue-per-object, per Casey's suggestion in 913.