### PR TITLE
add support for log rotation for ovnkube.log and ovnkube-master.log

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/json-iterator/go v1.1.8 // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.7.1
 	github.com/prometheus/client_golang v1.2.1
@@ -32,6 +31,7 @@ require (
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/api v0.0.0-20190606204050-af9c91bd2759
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -244,6 +244,8 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	gcfg "gopkg.in/gcfg.v1"
+	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 
 	kexec "k8s.io/utils/exec"
 )
@@ -998,19 +999,13 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 
 	logrus.SetLevel(logrus.Level(Logging.Level))
 	if Logging.File != "" {
-		var file *os.File
-		if _, err = os.Stat(filepath.Dir(Logging.File)); os.IsNotExist(err) {
-			dir := filepath.Dir(Logging.File)
-			if err = os.MkdirAll(dir, 0755); err != nil {
-				logrus.Errorf("failed to create logfile directory %s (%v). Ignoring..", dir, err)
-			}
-		}
-		file, err = os.OpenFile(Logging.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0660)
-		if err != nil {
-			logrus.Errorf("failed to open logfile %s (%v). Ignoring..", Logging.File, err)
-		} else {
-			logrus.SetOutput(file)
-		}
+		logrus.SetOutput(&lumberjack.Logger{
+			Filename:   Logging.File,
+			MaxSize:    100, // megabytes
+			MaxBackups: 10,
+			MaxAge:     30, // days
+			Compress:   true,
+		})
 	}
 
 	if err = buildDefaultConfig(&cliConfig, &cfg); err != nil {


### PR DESCRIPTION
these files with `debug` enabled are running into several GB over few
days, so add support for log rotation for these files

lumberjack seems very popular and works very well with logrus, so use
it to support log rotation

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>