### PR TITLE
master, node: add pod operation latency metrics, make metric names consistent

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -21,6 +21,8 @@ import (
 // DefaultEncapPort number used if not supplied
 const DefaultEncapPort = 6081
 
+const MetricNamespace = "ovnkube"
+
 // The following are global config parameters that other modules may access directly
 var (
 	// ovn-kubernetes version, to be changed with every release


### PR DESCRIPTION
Add two metrics:
- the delta between pod schedule time and setting the annotations on the control plane
- the time spent on the node waiting for annotations to be set
    
Make metric names more consistent:
- All master metrics start with ovn_master_
- All node metrics start with ovn_node_
