### PR TITLE
unidling: only keep empty LB for service when it has been idled

### DIFF
--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -259,6 +259,13 @@ func (ovn *Controller) handleExternalIPs(svc *kapi.Service, svcPort kapi.Service
 	}
 }
 
+// keepEmptyLB returns true if empty load-balancer events is enabled and if the
+// service was idled.
+func keepEmptyLB(service *kapi.Service) bool {
+	_, ok := service.Annotations[OvnServiceIdledAt]
+	return config.Kubernetes.OVNEmptyLbEvents && ok
+}
+
 func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 	svc, err := ovn.kube.GetService(ep.Namespace, ep.Name)
 	if err != nil {
@@ -282,7 +289,7 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		}
 
 		quotedHostPort := "\"" + util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port) + "\""
-		if config.Kubernetes.OVNEmptyLbEvents {
+		if keepEmptyLB(svc) {
 			key := "vips:" + quotedHostPort + "=\"\""
 			_, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, key)
 			if err != nil {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -23,6 +23,9 @@ const (
 	OvnClusterRouter = "ovn_cluster_router"
 	// OvnNodeManagementPortMacAddress is the constant string representing the annotation key
 	OvnNodeManagementPortMacAddress = "k8s.ovn.org/node-mgmt-port-mac-address"
+	// OvnServiceIdledAt is a constant string representing the Service annotation key
+	// whose value indicates the time stamp in RFC3339 format when a Service was idled
+	OvnServiceIdledAt = "k8s.ovn.org/idled-at"
 )
 
 // StartClusterMaster runs a subnet IPAM and a controller that watches arrival/departure


### PR DESCRIPTION
Service annotations indicate when the service has been idled, so
only keep the empty LB for those services. Otherwise services with
no endpoints time out rather than have requests rejected as expected.

Fixes failures of the OpenShift/Kubernetes e2e test for:

[sig-network] Services should be rejected when no endpoints exist

@putnopvut @danwinship @knobunc @squeed @girishmg 