### PR TITLE
running ovn-kube-util shouldn't require binaries that it doesn't use

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
+++ b/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
@@ -20,7 +20,7 @@ var NicsToBridgeCommand = cli.Command{
 			return fmt.Errorf("Please specify list of nic interfaces")
 		}
 
-		if err := util.SetExec(kexec.New()); err != nil {
+		if err := util.SetSpecificExec(kexec.New(), "ovs-vsctl"); err != nil {
 			return err
 		}
 
@@ -46,7 +46,7 @@ var BridgesToNicCommand = cli.Command{
 			return fmt.Errorf("Please specify list of bridges")
 		}
 
-		if err := util.SetExec(kexec.New()); err != nil {
+		if err := util.SetSpecificExec(kexec.New(), "ovs-vsctl"); err != nil {
 			return err
 		}
 

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -149,6 +149,26 @@ func SetExec(exec kexec.Interface) error {
 	return nil
 }
 
+// SetSpecificExec validates executable paths for selected commands. It also saves the given
+// exec interface to be used for running selected commands
+func SetSpecificExec(exec kexec.Interface, commands ...string) error {
+	var err error
+
+	runner = &execHelper{exec: exec}
+	for _, command := range commands {
+		switch command {
+		case ovsVsctlCommand:
+			runner.vsctlPath, err = exec.LookPath(ovsVsctlCommand)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown command: %q", command)
+		}
+	}
+	return nil
+}
+
 // GetExec returns the exec interface which can be used for running commands directly.
 // Only use for passing an exec interface into pkg/config which cannot call this
 // function directly because this module imports pkg/config already.


### PR DESCRIPTION
While executing ovn-kube-util on a host to bring a NIC under an OVS
bridge, it fails with `ovn-nbctl` command not found. The subcommand
only needs `ovs-vsctl` to run, but expects a whole plethora of utilities
to be present. This commit validates only the required CLI binaries to
be present for ovn-kube-util to succeed.

@dcbw @danwinship  PTAL