### PR TITLE
Move node annotation under k8s.ovn.org namespace

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -8,6 +8,7 @@ import (
 	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -106,6 +107,8 @@ func (cluster *OvnClusterController) initGateway(
 			}
 		}
 		return initSharedGateway(nodeName, subnet, gatewayNextHop, gatewayIntf, cluster.watchFactory)
+	case config.GatewayModeDisabled:
+		return map[string]string{ovn.OvnNodeGatewayMode: string(config.GatewayModeDisabled)}, nil, nil
 	}
 
 	return nil, nil, nil

--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -158,7 +158,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 			Annotations: map[string]string{
-				ovn.OvnHostSubnet:            nodeSubnet,
+				ovn.OvnNodeSubnets:           nodeSubnet,
 				ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
 				ovn.OvnNodeGatewayVlanID:     string(gatewayVLANID),
 				ovn.OvnNodeGatewayIfaceID:    gwRouter,
@@ -299,7 +299,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
-					ovn.OvnHostSubnet:            nodeSubnet,
+					ovn.OvnNodeSubnets:           nodeSubnet,
 					ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
 					ovn.OvnNodeGatewayVlanID:     string(0),
 					ovn.OvnNodeGatewayIfaceID:    gwRouter,

--- a/go-controller/pkg/cluster/management-port_linux_test.go
+++ b/go-controller/pkg/cluster/management-port_linux_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Management Port Operations", func() {
 			existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
-					ovn.OvnHostSubnet:                   nodeSubnet,
+					ovn.OvnNodeSubnets:                  nodeSubnet,
 					ovn.OvnNodeManagementPortMacAddress: mgtPortMAC,
 				},
 			}}

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -142,14 +142,12 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	var nodeAnnotations map[string]string
 	var postReady postReadyFn
 
-	// If gateway is enabled, get gateway annotations
-	if config.Gateway.Mode != config.GatewayModeDisabled {
-		nodeAnnotations, postReady, err = cluster.initGateway(node.Name, subnet.String())
-		if err != nil {
-			return err
-		}
-		readyFuncs = append(readyFuncs, GatewayReady)
+	// get gateway annotations
+	nodeAnnotations, postReady, err = cluster.initGateway(node.Name, subnet.String())
+	if err != nil {
+		return err
 	}
+	readyFuncs = append(readyFuncs, GatewayReady)
 
 	// Get management port annotations
 	mgmtPortAnnotations, err := CreateManagementPort(node.Name, subnet, clusterSubnets)

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -139,11 +139,9 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 
 	type readyFunc func(string, string) (bool, error)
 	var readyFuncs []readyFunc
-	var nodeAnnotations map[string]string
-	var postReady postReadyFn
 
 	// get gateway annotations
-	nodeAnnotations, postReady, err = cluster.initGateway(node.Name, subnet.String())
+	gwAnnotations, postReady, err := cluster.initGateway(node.Name, subnet.String())
 	if err != nil {
 		return err
 	}
@@ -154,11 +152,14 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	if err != nil {
 		return err
 	}
-
 	readyFuncs = append(readyFuncs, ManagementPortReady)
 
-	// Combine mgmtPortAnnotations with any existing gwyAnnotations
+	// Combine mgmtPortAnnotations and gwAnnotations into nodeAnnotations
+	nodeAnnotations := make(map[string]interface{})
 	for k, v := range mgmtPortAnnotations {
+		nodeAnnotations[k] = v
+	}
+	for k, v := range gwAnnotations {
 		nodeAnnotations[k] = v
 	}
 

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -21,7 +21,7 @@ type Interface interface {
 	SetAnnotationOnPod(pod *kapi.Pod, key, value string) error
 	SetAnnotationsOnPod(pod *kapi.Pod, annotations map[string]string) error
 	SetAnnotationOnNode(node *kapi.Node, key, value string) error
-	SetAnnotationsOnNode(node *kapi.Node, annotations map[string]string) error
+	SetAnnotationsOnNode(node *kapi.Node, annotations map[string]interface{}) error
 	UpdateNodeStatus(node *kapi.Node) error
 	GetAnnotationsOnPod(namespace, name string) (map[string]string, error)
 	GetPod(namespace, name string) (*kapi.Pod, error)
@@ -95,7 +95,7 @@ func (k *Kube) SetAnnotationOnNode(node *kapi.Node, key, value string) error {
 }
 
 // SetAnnotationsOnNode takes the node object and map of key/value string pairs to set as annotations
-func (k *Kube) SetAnnotationsOnNode(node *kapi.Node, annotations map[string]string) error {
+func (k *Kube) SetAnnotationsOnNode(node *kapi.Node, annotations map[string]interface{}) error {
 	var err error
 	var patchData []byte
 	patch := struct {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Master Operations", func() {
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue())
 			updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedNode.Annotations).To(HaveKeyWithValue(OvnHostSubnet, nodeSubnet))
+			Expect(updatedNode.Annotations[OvnNodeSubnets]).To(MatchJSON(fmt.Sprintf(`{"default": "%s"}`, nodeSubnet)))
 			Expect(updatedNode.Annotations).To(HaveKeyWithValue(OvnNodeManagementPortMacAddress, mgmtMAC))
 			Eventually(func() bool { return fexec.CalledMatchesExpected() }, 2).Should(BeTrue())
 			return nil
@@ -267,7 +267,7 @@ var _ = Describe("Master Operations", func() {
 				Name: nodeName,
 				Annotations: map[string]string{
 					OvnNodeManagementPortMacAddress: mgmtMAC,
-					OvnHostSubnet:                   nodeSubnet,
+					OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
 				},
 			}}
 
@@ -307,7 +307,7 @@ var _ = Describe("Master Operations", func() {
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue())
 			updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedNode.Annotations).To(HaveKeyWithValue(OvnHostSubnet, nodeSubnet))
+			Expect(updatedNode.Annotations[OvnNodeSubnets]).To(MatchJSON(fmt.Sprintf(`{"default": "%s"}`, nodeSubnet)))
 			Expect(updatedNode.Annotations).To(HaveKeyWithValue(OvnNodeManagementPortMacAddress, mgmtMAC))
 			Eventually(func() bool { return fexec.CalledMatchesExpected() }, 2).Should(BeTrue())
 			return nil
@@ -411,7 +411,7 @@ subnet=%s
 				ObjectMeta: metav1.ObjectMeta{
 					Name: masterName,
 					Annotations: map[string]string{
-						OvnHostSubnet:                   masterSubnet,
+						OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, masterSubnet),
 						OvnNodeManagementPortMacAddress: masterMgmtPortMAC,
 					},
 				},
@@ -515,7 +515,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				Name: nodeName,
 				Annotations: map[string]string{
 					OvnNodeManagementPortMacAddress: brLocalnetMAC,
-					OvnHostSubnet:                   nodeSubnet,
+					OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
 					OvnNodeGatewayMode:              string(config.GatewayModeLocal),
 					OvnNodeGatewayVlanID:            string(config.Gateway.VLANID),
 					OvnNodeGatewayIfaceID:           ifaceID,
@@ -758,7 +758,7 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				Name: nodeName,
 				Annotations: map[string]string{
 					OvnNodeManagementPortMacAddress: brLocalnetMAC,
-					OvnHostSubnet:                   nodeSubnet,
+					OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
 					OvnNodeGatewayMode:              string(config.GatewayModeShared),
 					OvnNodeGatewayVlanID:            "1024",
 					OvnNodeGatewayIfaceID:           ifaceID,


### PR DESCRIPTION
The node's subnet information is  under 'ovn_host_subnet' annotation.
We need to move it under 'k8s.ovn.org' namespae.

The new annotation is called 'node-subnets', and it is going to be a
map of 'network_name' to node's subnet allocation from that network.
For example: ("default" refers to the first OVN interface to the Pod)

    k8s.ovn.org/node-subnets: {
       "default": "192.168.10.0/24"
    }

The changes assumes that the master is upgraded first. Since this
annotation is used only in the master the old worker nodes are not
going to be affected by this change. As a result, on master upgarde to
this code we are going to remove the old key and add the new key to
the nodes as part of syncNodes() call.

@dcbw PTAL
