### PR TITLE
Fix parsing of IPv6 addresses in ovn URLs

### DIFF
--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -982,7 +982,7 @@ mode=shared
 				})
 
 			generateTests("the OVN URL has no port",
-				"Failed to parse OVN address tcp:4.3.2.1",
+				"failed to parse OVN DB host/port \"4.3.2.1\": address 4.3.2.1: missing port in address",
 				func() []string {
 					return []string{
 						"address=tcp://4.3.2.1",


### PR DESCRIPTION
When handling the scheme:address:port URLs given to OVN for
configuring how to reach OVN services, properly handle IPv6 addresses
by not assuming we can just split on ":" across the whole string.

Also use JoinHostPort to properly join a host and port for both IPv4
and IPv6 cases.