### PR TITLE
Change the prometheus port numbers to values allocated for ovn-k8s

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -676,7 +676,7 @@ ovn-master () {
     --loglevel=${ovnkube_loglevel} \
     --pidfile /var/run/openvswitch/ovnkube-master.pid \
     --logfile /var/log/ovn-kubernetes/ovnkube-master.log \
-    --metrics-bind-address "0.0.0.0:9102" &
+    --metrics-bind-address "0.0.0.0:9409" &
   echo "=============== ovn-master ========== running"
   wait_for_event attempts=3 process_ready ovnkube-master
   sleep 1
@@ -752,7 +752,7 @@ ovn-node () {
       --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts}  \
       --pidfile /var/run/openvswitch/ovnkube.pid \
       --logfile /var/log/ovn-kubernetes/ovnkube.log \
-      --metrics-bind-address "0.0.0.0:9101" &
+      --metrics-bind-address "0.0.0.0:9410" &
 
   wait_for_event attempts=3 process_ready ovnkube
   setup_cni

--- a/dist/templates/ovnkube-monitor.yaml.j2
+++ b/dist/templates/ovnkube-monitor.yaml.j2
@@ -36,9 +36,9 @@ spec:
   clusterIP: None
   ports:
   - name: http-metrics
-    port: 9102
+    port: 9409
     protocol: TCP
-    targetPort: 9102
+    targetPort: 9409
 ---
 
 apiVersion: monitoring.coreos.com/v1
@@ -76,6 +76,6 @@ spec:
   clusterIP: None
   ports:
   - name: http-metrics
-    port: 9101
+    port: 9410
     protocol: TCP
-    targetPort: 9101
+    targetPort: 9410


### PR DESCRIPTION
So, we have registered 9409 and 9410 port numbers for ovnkube-master
and ovnkube-node here:

https://github.com/prometheus/prometheus/wiki/Default-port-allocations

Change the current port numbers to use the reserved port numbers.
Furthermore, with the current port numbers -- 9101 and 9102 -- the
node_exporter daemonset is crashing because it uses one of the
above ports.

@dcbw @danwinship @squeed PTAL