### PR TITLE
 move the node gateway annotations to map[string]map[string]string format

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -4,6 +4,7 @@ package cluster
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net"
 	"syscall"
@@ -155,16 +156,21 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		_, err = config.InitConfig(ctx, fexec, nil)
 		Expect(err).NotTo(HaveOccurred())
 
+		l3GatewayConfig := map[string]string{
+			ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
+			ovn.OvnNodeGatewayVlanID:     string(gatewayVLANID),
+			ovn.OvnNodeGatewayIfaceID:    gwRouter,
+			ovn.OvnNodeGatewayMacAddress: lrpMAC,
+			ovn.OvnNodeGatewayIP:         lrpIP,
+			//ovn.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+		}
+		byteArr, err := json.Marshal(map[string]map[string]string{ovn.OvnDefaultNetworkGateway: l3GatewayConfig})
+		Expect(err).NotTo(HaveOccurred())
 		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 			Annotations: map[string]string{
-				ovn.OvnNodeSubnets:           nodeSubnet,
-				ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
-				ovn.OvnNodeGatewayVlanID:     string(gatewayVLANID),
-				ovn.OvnNodeGatewayIfaceID:    gwRouter,
-				ovn.OvnNodeGatewayMacAddress: lrpMAC,
-				ovn.OvnNodeGatewayIP:         lrpIP,
-				//ovn.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+				ovn.OvnNodeSubnets:         nodeSubnet,
+				ovn.OvnNodeL3GatewayConfig: string(byteArr),
 			},
 		}}
 		fakeClient := fake.NewSimpleClientset(&v1.NodeList{
@@ -296,16 +302,21 @@ var _ = Describe("Gateway Init Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
+			l3GatewayConfig := map[string]string{
+				ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
+				ovn.OvnNodeGatewayVlanID:     string(0),
+				ovn.OvnNodeGatewayIfaceID:    gwRouter,
+				ovn.OvnNodeGatewayMacAddress: lrpMAC,
+				ovn.OvnNodeGatewayIP:         lrpIP,
+				//ovn.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+			}
+			byteArr, err := json.Marshal(map[string]map[string]string{ovn.OvnDefaultNetworkGateway: l3GatewayConfig})
+			Expect(err).NotTo(HaveOccurred())
 			existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
-					ovn.OvnNodeSubnets:           nodeSubnet,
-					ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
-					ovn.OvnNodeGatewayVlanID:     string(0),
-					ovn.OvnNodeGatewayIfaceID:    gwRouter,
-					ovn.OvnNodeGatewayMacAddress: lrpMAC,
-					ovn.OvnNodeGatewayIP:         lrpIP,
-					//ovn.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+					ovn.OvnNodeSubnets:         nodeSubnet,
+					ovn.OvnNodeL3GatewayConfig: string(byteArr),
 				},
 			}}
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -110,7 +110,7 @@ func localnetGatewayNAT(ipt util.IPTablesHelper, ifname, ip string) error {
 }
 
 func initLocalnetGateway(nodeName string,
-	subnet string, wf *factory.WatchFactory) (map[string]string, error) {
+	subnet string, wf *factory.WatchFactory) (map[string]map[string]string, error) {
 	ipt, err := util.GetIPTablesHelper(iptables.ProtocolIPv4)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize iptables: %v", err)
@@ -165,13 +165,16 @@ func initLocalnetGateway(nodeName string,
 		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
 
-	annotations := map[string]string{
+	l3GatewayConfig := map[string]string{
 		ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
 		ovn.OvnNodeGatewayVlanID:     fmt.Sprintf("%d", config.Gateway.VLANID),
 		ovn.OvnNodeGatewayIfaceID:    ifaceID,
 		ovn.OvnNodeGatewayMacAddress: macAddress,
 		ovn.OvnNodeGatewayIP:         localnetGatewayIP,
 		ovn.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+	}
+	annotations := map[string]map[string]string{
+		ovn.OvnDefaultNetworkGateway: l3GatewayConfig,
 	}
 
 	err = localnetGatewayNAT(ipt, localnetBridgeNextHop, localnetGatewayIP)

--- a/go-controller/pkg/cluster/gateway_localnet_windows.go
+++ b/go-controller/pkg/cluster/gateway_localnet_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 func initLocalnetGateway(nodeName string,
-	subnet string, wf *factory.WatchFactory) (map[string]string, error) {
+	subnet string, wf *factory.WatchFactory) (map[string]map[string]string, error) {
 	// TODO: Implement this
 	return nil, fmt.Errorf("Not implemented yet on Windows")
 }

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -254,8 +254,8 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string) error {
 	return nil
 }
 
-func initSharedGateway(
-	nodeName string, subnet, gwNextHop, gwIntf string, wf *factory.WatchFactory) (map[string]string, postReadyFn, error) {
+func initSharedGateway(nodeName string, subnet, gwNextHop, gwIntf string,
+	wf *factory.WatchFactory) (map[string]map[string]string, postReadyFn, error) {
 	var bridgeName string
 	var uplinkName string
 	var brCreated bool
@@ -303,13 +303,16 @@ func initSharedGateway(
 		return nil, nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
 
-	annotations := map[string]string{
+	l3GatewayConfig := map[string]string{
 		ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
 		ovn.OvnNodeGatewayVlanID:     fmt.Sprintf("%d", config.Gateway.VLANID),
 		ovn.OvnNodeGatewayIfaceID:    ifaceID,
 		ovn.OvnNodeGatewayMacAddress: macAddress,
 		ovn.OvnNodeGatewayIP:         ipAddress,
 		ovn.OvnNodeGatewayNextHop:    gwNextHop,
+	}
+	annotations := map[string]map[string]string{
+		ovn.OvnDefaultNetworkGateway: l3GatewayConfig,
 	}
 
 	return annotations, func() error {


### PR DESCRIPTION
Currently, the node gateway annotations are in map[string]string format.
As in,

    annotations:
      k8s.ovn.org/node-gateway-iface-id: breno1_sdn-test1
      k8s.ovn.org/node-gateway-ip: 10.8.51.51/22
      k8s.ovn.org/node-gateway-mac-address: ac:1f:6b:59:97:34
      k8s.ovn.org/node-gateway-mode: shared
      k8s.ovn.org/node-gateway-next-hop: 10.8.48.1
      k8s.ovn.org/node-gateway-vlan-id: "0"

However, in order to support multiple OVN interfaces we would like
those annotations to be map[string]map[string]string. For example:

    annotations
      k8s.ovn.org/l3-gateway-config: {
            "default" : {
                  "interface-id": "breno1_sdn-test1,
                  "ip-address": "10.8.51.51/22",
                  "mac-address": "ac:1f:6b:59:97:34",
                  "mode": "shared",
                  "next-hop": "10.8.48.1",
                  "vlan-id": "0",
             }
       }

The key "default" above represents the default network attachment to
the pod which is the first OVN interface to the pod.

@dcbw @danwinship PTAL