### PR TITLE
node: don't return error from isOVNControllerReady() flow check

### DIFF
--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -60,7 +60,7 @@ func isOVNControllerReady(name string) (bool, error) {
 	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
 		stdout, _, err := util.RunOVSOfctl("dump-aggregate", "br-int")
 		if err != nil {
-			return false, fmt.Errorf("failed to get aggregate flow statistics: %v", err)
+			return false, nil
 		}
 		return !strings.Contains(stdout, "flow_count=0"), nil
 	})


### PR DESCRIPTION
As with all the other Poll*() functions, don't return an error if
all we want to do is just check again at the next interval.

@danwinship @girishmg @squeed @pecameron 