### PR TITLE
do not annotate test node with subnet information upfront

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -203,7 +203,6 @@ var _ = Describe("Master Operations", func() {
 				Name: nodeName,
 				Annotations: map[string]string{
 					OvnNodeManagementPortMacAddress: mgmtMAC,
-					OvnHostSubnet:                   nodeSubnet,
 				},
 			}}
 


### PR DESCRIPTION
The current test annotates the node upfront and later checks to see if
the node has correct subnet information. This is not right. We need to
start with no subnet annotation and then later check if the node has
subnet annotation.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>