### PR TITLE
persist the mac address associated with the node management port

### DIFF
--- a/go-controller/pkg/cluster/management-port.go
+++ b/go-controller/pkg/cluster/management-port.go
@@ -48,7 +48,14 @@ func createManagementPortGeneric(nodeName string, localSubnet *net.IPNet) (strin
 		logrus.Errorf("Failed to get management port MAC address: %v", err)
 		return "", "", "", "", "", err
 	}
-
+	// persist the MAC address so that upon node reboot we get back the same mac address.
+	_, stderr, err = util.RunOVSVsctl("set", "interface", interfaceName,
+		fmt.Sprintf("mac=%s", strings.ReplaceAll(macAddress, ":", "\\:")))
+	if err != nil {
+		logrus.Errorf("failed to persist MAC address %q for %q: stderr:%s (%v)", macAddress,
+			interfaceName, stderr, err)
+		return "", "", "", "", "", err
+	}
 	// switch-to-router ports only have MAC address and nothing else.
 	routerMac, stderr, err := util.RunOVNNbctl("lsp-get-addresses", "stor-"+nodeName)
 	if err != nil {

--- a/go-controller/pkg/cluster/management-port_linux_test.go
+++ b/go-controller/pkg/cluster/management-port_linux_test.go
@@ -3,10 +3,12 @@
 package cluster
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/urfave/cli"
@@ -86,6 +88,9 @@ var _ = Describe("Management Port Operations", func() {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface " + mgtPort + " mac_in_use",
 				Output: mgtPortMAC,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 set interface k8s-node1 " + fmt.Sprintf("mac=%s", strings.ReplaceAll(mgtPortMAC, ":", "\\:")),
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 lsp-get-addresses stor-" + nodeName,


### PR DESCRIPTION
the MAC address for node's management port is randomly chosen. this
address is then added to node's annotation. the master reads the
address and creates a corresponding logical switch port using this
address.

now when node reboots, the mac address of the management port on the
node changes. this changed address is then reflected on node's
annotation and then in the UpdateFunc callback handler for the node
resource, we update the MAC address of the logical switch port.

this is all unnecessary complexity, so better way is to just
persist the initial MAC for the management port in the interface's
MAC column

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>