### PR TITLE
reuse the ofport computed in nodePortWatcher in syncServices as well

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -133,12 +133,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		})
 		// syncServices()
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface eth0 ofport",
-			Output: "11",
-		})
-
-		// syncServices()
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd: "ovs-ofctl dump-flows breth0",
 			Output: `cookie=0x0, duration=8366.605s, table=0, n_packets=0, n_bytes=0, priority=100,ip,in_port="patch-breth0_no" actions=ct(commit,zone=64000),output:eth0
 cookie=0x0, duration=8366.603s, table=0, n_packets=10642, n_bytes=10370438, priority=50,ip,in_port=eth0 actions=ct(table=1,zone=64000)

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -62,16 +62,7 @@ func deleteService(service *kapi.Service, inport, gwBridge string) {
 	}
 }
 
-func syncServices(services []interface{}, gwBridge, gwIntf string) {
-	// Get ofport of physical interface
-	inport, stderr, err := util.RunOVSVsctl("--if-exists", "get",
-		"interface", gwIntf, "ofport")
-	if err != nil {
-		logrus.Errorf("Failed to get ofport of %s, stderr: %q, error: %v",
-			gwIntf, stderr, err)
-		return
-	}
-
+func syncServices(services []interface{}, inport, gwBridge string) {
 	nodePorts := make(map[string]bool)
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*kapi.Service)
@@ -179,7 +170,7 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, wf *factory.WatchFactory
 			deleteService(service, ofportPhys, gwBridge)
 		},
 	}, func(services []interface{}) {
-		syncServices(services, gwBridge, gwIntf)
+		syncServices(services, ofportPhys, gwBridge)
 	})
 
 	return err


### PR DESCRIPTION
We already have ofport obtained in nodePortWatcher() function, however
we obtain it again in syncServices() called from nodePortWatcher(). so,
pass that value into syncServices() instead.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@dcbw @danwinship this is a simple one