### PR TITLE
GetK8sClusterRouter() function is expensive when it doesn't need to be

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -24,7 +24,7 @@ func cleanupGateway(fexec *ovntest.FakeExec, nodeName string, nodeSubnet string,
 	const (
 		lrpMAC                 string = "00:00:00:05:46:c3"
 		brLocalnetMAC          string = "11:22:33:44:55:66"
-		clusterRouterUUID      string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
+		clusterRouter          string = util.OvnClusterRouter
 		systemID               string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 		tcpLBUUID              string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
 		udpLBUUID              string = "12832f14-eb0f-44d4-b8db-4cccbc73c792"
@@ -39,10 +39,6 @@ func cleanupGateway(fexec *ovntest.FakeExec, nodeName string, nodeSubnet string,
 	)
 
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
-		Output: clusterRouterUUID,
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + nodeName + " networks",
 		Output: "[\"100.64.0.3/16\"]",
 	})
@@ -55,14 +51,14 @@ func cleanupGateway(fexec *ovntest.FakeExec, nodeName string, nodeSubnet string,
 		Output: node1RouteUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouterUUID + " static_routes " + node1RouteUUID,
+		"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouter + " static_routes " + node1RouteUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=" + nextHop,
 		Output: node1mgtRouteUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouterUUID + " static_routes " + node1mgtRouteUUID,
+		"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouter + " static_routes " + node1mgtRouteUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exist lsp-del jtor-GR_" + nodeName,
@@ -327,7 +323,7 @@ var _ = Describe("Master Operations", func() {
 			const (
 				tcpLBUUID         string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
 				udpLBUUID         string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
-				clusterRouterUUID string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
+				clusterRouter     string = util.OvnClusterRouter
 				node1Name         string = "openshift-node-1"
 				node1Subnet       string = "10.128.0.0/24"
 				node1RouteUUID    string = "0cac12cf-3e0f-4682-b028-5ea2e0001962"
@@ -357,11 +353,6 @@ subnet=%s
 				"ovn-nbctl --timeout=15 --if-exist ls-del " + node1Name,
 				"ovn-nbctl --timeout=15 --if-exist lrp-del rtos-" + node1Name,
 			})
-
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
-				Output: clusterRouterUUID,
-			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_openshift-node-1 networks",
 				Output: "[\"100.64.0.3/16\"]",
@@ -375,14 +366,14 @@ subnet=%s
 				Output: node1RouteUUID,
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouterUUID + " static_routes " + node1RouteUUID,
+				"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouter + " static_routes " + node1RouteUUID,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=10.128.0.2",
 				Output: node1mgtRouteUUID,
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouterUUID + " static_routes " + node1mgtRouteUUID,
+				"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouter + " static_routes " + node1mgtRouteUUID,
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 --if-exist lsp-del jtor-GR_" + node1Name,
@@ -493,7 +484,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				brLocalnetMAC          string = "11:22:33:44:55:66"
 				lrpIP                  string = "100.64.0.3"
 				lrpCIDR                string = lrpIP + "/16"
-				clusterRouterUUID      string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
+				clusterRouter          string = util.OvnClusterRouter
 				systemID               string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 				tcpLBUUID              string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
 				udpLBUUID              string = "12832f14-eb0f-44d4-b8db-4cccbc73c792"
@@ -555,11 +546,6 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " k8s-" + nodeName + " -- lsp-set-addresses " + "k8s-" + nodeName + " " + brLocalnetMAC + " " + masterMgmtPortIP + " -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 			})
-
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
-				Output: clusterRouterUUID,
-			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + nodeName,
 				Output: systemID,
@@ -594,7 +580,7 @@ GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_s
 GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, lrpIP),
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " 0.0.0.0/0 " + lrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -606,8 +592,8 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 rtoe-" + gwRouter,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
-				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + lrpIP + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouter + " " + nodeSubnet + " " + lrpIP,
 			})
 
 			//fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -626,10 +612,6 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				Output: "169.254.33.2",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
-				Output: clusterRouterUUID,
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + nodeName,
 				Output: systemID,
 			})
@@ -663,7 +645,7 @@ GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_s
 GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, lrpIP),
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " 0.0.0.0/0 " + lrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -675,8 +657,8 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 rtoe-" + gwRouter,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
-				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + lrpIP + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouter + " " + nodeSubnet + " " + lrpIP,
 			})
 
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -728,17 +710,17 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 	It("sets up a shared gateway", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
-				nodeName          string = "node1"
-				lrpMAC            string = "00:00:00:05:46:c3"
-				brLocalnetMAC     string = "11:22:33:44:55:66"
-				lrpIP             string = "100.64.0.3"
-				lrpCIDR           string = lrpIP + "/16"
-				clusterRouterUUID string = "5cedba03-679f-41f3-b00e-b8ed7437bc6c"
-				systemID          string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
-				tcpLBUUID         string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
-				udpLBUUID         string = "12832f14-eb0f-44d4-b8db-4cccbc73c792"
-				nodeSubnet        string = "10.1.1.0/24"
-				nextHop           string = "10.1.1.2"
+				nodeName      string = "node1"
+				lrpMAC        string = "00:00:00:05:46:c3"
+				brLocalnetMAC string = "11:22:33:44:55:66"
+				lrpIP         string = "100.64.0.3"
+				lrpCIDR       string = lrpIP + "/16"
+				clusterRouter string = util.OvnClusterRouter
+				systemID      string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
+				tcpLBUUID     string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
+				udpLBUUID     string = "12832f14-eb0f-44d4-b8db-4cccbc73c792"
+				nodeSubnet    string = "10.1.1.0/24"
+				nextHop       string = "10.1.1.2"
 				//nextHop                string = "10.64.0.2"
 				gwRouter     string = "GR_" + nodeName
 				clusterIPNet string = "10.1.0.0"
@@ -798,11 +780,6 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " k8s-" + nodeName + " -- lsp-set-addresses " + "k8s-" + nodeName + " " + brLocalnetMAC + " " + masterMgmtPortIP + " -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 			})
-
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
-				Output: clusterRouterUUID,
-			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + nodeName,
 				Output: systemID,
@@ -837,7 +814,7 @@ GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_s
 GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, lrpIP),
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " 0.0.0.0/0 " + lrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -849,16 +826,12 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 100.64.0.1 rtoe-" + gwRouter,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 100.64.0.3 " + clusterCIDR,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
-				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + lrpIP + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouter + " " + nodeSubnet + " " + lrpIP,
 			})
 
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
-				Output: clusterRouterUUID,
-			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + "100.64.0.3/32" + " " + nextHop,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + "100.64.0.3/32" + " " + nextHop,
 			})
 
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -874,11 +847,6 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				Output: "169.254.33.2",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
-				Output: clusterRouterUUID,
-			})
-
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + nodeName,
 				Output: systemID,
 			})
@@ -912,7 +880,7 @@ GR_openshift-node-1      chassis=0861e85c-5060-42fd-839e-8c463c7da378 lb_force_s
 GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.4`, lrpIP),
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " 0.0.0.0/0 " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " 0.0.0.0/0 " + lrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -924,16 +892,12 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 100.64.0.1 rtoe-" + gwRouter,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 100.64.0.3 " + clusterCIDR,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + lrpIP + " " + lrpIP,
-				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouterUUID + " " + nodeSubnet + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + lrpIP + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouter + " " + nodeSubnet + " " + lrpIP,
 			})
 
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router external_ids:k8s-cluster-router=yes",
-				Output: clusterRouterUUID,
-			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouterUUID + " " + "100.64.0.3/32" + " " + nextHop,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + "100.64.0.3/32" + " " + nextHop,
 			})
 
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/util/gateway-cleanup.go
+++ b/go-controller/pkg/util/gateway-cleanup.go
@@ -13,11 +13,7 @@ import (
 // GatewayCleanup removes all the NB DB objects created for a node's gateway
 func GatewayCleanup(nodeName string, nodeSubnet *net.IPNet) error {
 	// Get the cluster router
-	clusterRouter, err := GetK8sClusterRouter()
-	if err != nil {
-		return fmt.Errorf("failed to get cluster router")
-	}
-
+	clusterRouter := GetK8sClusterRouter()
 	gatewayRouter := fmt.Sprintf("GR_%s", nodeName)
 
 	// Get the gateway router port's IP address (connected to join switch)

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -15,23 +15,16 @@ const (
 	// PhysicalNetworkName is the name that maps to an OVS bridge that provides
 	// access to physical/external network
 	PhysicalNetworkName = "physnet"
+	// OvnClusterRouter is the name of the distributed router
+	OvnClusterRouter = "ovn_cluster_router"
 )
 
-// GetK8sClusterRouter returns back the OVN distibuted router
-func GetK8sClusterRouter() (string, error) {
-	k8sClusterRouter, stderr, err := RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=_uuid", "find", "logical_router",
-		"external_ids:k8s-cluster-router=yes")
-	if err != nil {
-		logrus.Errorf("Failed to get k8s cluster router, stderr: %q, "+
-			"error: %v", stderr, err)
-		return "", err
-	}
-	if k8sClusterRouter == "" {
-		return "", fmt.Errorf("Failed to get k8s cluster router")
-	}
-
-	return k8sClusterRouter, nil
+// GetK8sClusterRouter returns back the OVN distributed router. This is meant to be used on the
+// master alone. If the worker nodes need to know about distributed cluster router (which they
+// don't need to), then they need to use ovn-nbctl call and shouldn't make any assumption on
+// how the distributed router is named.
+func GetK8sClusterRouter() string {
+	return OvnClusterRouter
 }
 
 // GetDefaultGatewayRouterIP returns the first gateway logical router name
@@ -167,11 +160,7 @@ func GatewayInit(clusterIPSubnet []string, nodeName, ifaceID, nicIP, nicMacAddre
 		defaultGW = defaultgwByte.String()
 	}
 
-	k8sClusterRouter, err := GetK8sClusterRouter()
-	if err != nil {
-		return err
-	}
-
+	k8sClusterRouter := GetK8sClusterRouter()
 	systemID, err := getNodeChassisIDFromSB(nodeName)
 	if err != nil {
 		return err


### PR DESCRIPTION
GetK8sClusterRouter() returns the OVN distributed router in the K8s
OVN topology. In a 400-node cluster, that function searches through
801 routers to find the distributed cluster router (the one with
external_ids:k8s-cluster-router set to yes). Initially, it was written
for use by clients such as ovnkube-node.

However, after the gateway creation move to master there is no need for
that function since the master already knows the name of the distributed
cluster router since it created it. So, remove that function and
directly use the constant that captures the name of the distributed
router.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>