### PR TITLE
Add stdout and stderr to more error logs

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/sirupsen/logrus"
 	"net"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
@@ -150,7 +151,7 @@ func GatewayReady(nodeName string, portName string) (bool, error) {
 	gatewayRouter := "GR_" + nodeName
 	stdout, stderr, err := util.RunOVNNbctl("lsp-get-addresses", "etor-"+gatewayRouter)
 	if err != nil {
-		logrus.Errorf("Error while obtaining gateway router addresses for %s - %v", nodeName, err)
+		logrus.Errorf("Error while obtaining gateway router addresses for %s, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 		return false, nil
 	}
 	// Did master create etor-GR_nodeName port on ls?

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -38,14 +38,14 @@ func intToIP(i *big.Int) net.IP {
 
 // GetPortAddresses returns the MAC and IP of the given logical switch port
 func GetPortAddresses(portName string) (net.HardwareAddr, net.IP, error) {
-	out, _, err := RunOVNNbctl("get", "logical_switch_port", portName, "dynamic_addresses")
+	out, stderr, err := RunOVNNbctl("get", "logical_switch_port", portName, "dynamic_addresses")
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error while obtaining dynamic addresses for %s: %v", portName, err)
+		return nil, nil, fmt.Errorf("Error while obtaining dynamic addresses for %s: stdout: %q, stderr: %q, error: %v", portName, out, stderr, err)
 	}
 	if out == "[]" {
-		out, _, err = RunOVNNbctl("get", "logical_switch_port", portName, "addresses")
+		out, stderr, err = RunOVNNbctl("get", "logical_switch_port", portName, "addresses")
 		if err != nil {
-			return nil, nil, fmt.Errorf("Error while obtaining static addresses for %s: %v", portName, err)
+			return nil, nil, fmt.Errorf("Error while obtaining static addresses for %s: stdout: %q, stderr: %q, error: %v", portName, out, stderr, err)
 		}
 	}
 	if out == "[]" || out == "[dynamic]" {


### PR DESCRIPTION
Most error logs as the result of a failed ovn-nbctl / ovs-vsctl / etc
included stdout and stderr, but I got a couple in my logs that didn't.
I've added them here to help with debugging these conditions.