### PR TITLE
update beta.kubernetes.io/os to kubernetes.io/os

### DIFF
--- a/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
+++ b/contrib/roles/linux/kubernetes/tasks/prepare_master.yml
@@ -282,7 +282,7 @@
         - name: apachetwin
           image: fedora/apache
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
 - name: Create test yamls
   blockinfile:
     path: /root/apache-e-w.yaml
@@ -343,4 +343,4 @@
         - name: nginxtwin
           image: nginx
         nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux

--- a/contrib/roles/windows/kubernetes/tasks/main.yml
+++ b/contrib/roles/windows/kubernetes/tasks/main.yml
@@ -109,7 +109,7 @@
           image: alinbalutoiu/nanoserver-web:{{windows_container_tag}}
           imagePullPolicy: IfNotPresent
         nodeSelector:
-          beta.kubernetes.io/os: windows
+          kubernetes.io/os: windows
           kubernetes.io/hostname: {{ansible_hostname|lower}}
   delegate_to: "{{ item }}"
   with_items: "{{ groups['kube-master'] }}"

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -28,7 +28,7 @@ spec:
         name: ovnkube-db
         component: network
         type: infra
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -29,7 +29,7 @@ spec:
         name: ovnkube-db
         component: network
         type: infra
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -148,7 +148,7 @@ spec:
 
       nodeSelector:
         node-role.kubernetes.io/master: ""
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       volumes:
       - name: host-var-lib-ovs
         hostPath:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -29,7 +29,7 @@ spec:
         name: ovnkube-master
         component: network
         type: infra
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -221,7 +221,7 @@ spec:
 
       nodeSelector:
         node-role.kubernetes.io/master: ""
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       volumes:
       # TODO: Need to check why we need this?
       - name: host-var-run-dbus

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -25,7 +25,7 @@ spec:
         name: ovnkube-node
         component: network
         type: infra
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -238,7 +238,7 @@ spec:
               command: ["/root/ovnkube.sh", "cleanup-ovn-node"]
 
       nodeSelector:
-        beta.kubernetes.io/os: "linux"
+        kubernetes.io/os: "linux"
       volumes:
       - name: host-modules
         hostPath:


### PR DESCRIPTION
According to the official kubernetes documentation, the `beta.kubernetes.io / os` tag has been deprecated, and the new version will use` kubernetes.io / os`

https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#kubernetes-io-os

@danwinship @squeed @JacobTanenbaum @girishmg @alexanderConstantinescu