### PR TITLE
create NodePort related LB rules only for nodes for which it is enabled

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -668,7 +668,6 @@ ovn-master () {
     --init-master ${ovn_pod_host} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
-    --nodeport \
     --nbctl-daemon-mode \
     --loglevel=${ovnkube_loglevel} \
     --pidfile /var/run/openvswitch/ovnkube-master.pid \

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -177,6 +177,7 @@ func initLocalnetGateway(nodeName string,
 		ovn.OvnNodeGatewayMacAddress: macAddress,
 		ovn.OvnNodeGatewayIP:         localnetGatewayIP,
 		ovn.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+		ovn.OvnNodePortEnable:        fmt.Sprintf("%t", config.Gateway.NodeportEnable),
 	}
 	annotations := map[string]map[string]string{
 		ovn.OvnDefaultNetworkGateway: l3GatewayConfig,

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -301,6 +301,7 @@ func initSharedGateway(nodeName string, subnet, gwNextHop, gwIntf string,
 		ovn.OvnNodeGatewayMacAddress: macAddress,
 		ovn.OvnNodeGatewayIP:         ipAddress,
 		ovn.OvnNodeGatewayNextHop:    gwNextHop,
+		ovn.OvnNodePortEnable:        fmt.Sprintf("%t", config.Gateway.NodeportEnable),
 	}
 	annotations := map[string]map[string]string{
 		ovn.OvnDefaultNetworkGateway: l3GatewayConfig,

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -62,7 +62,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 		targetPort := lbEps.Port
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == kapi.ProtocolTCP && svcPort.Name == svcPortName {
-				if util.ServiceTypeHasNodePort(svc) && config.Gateway.NodeportEnable {
+				if util.ServiceTypeHasNodePort(svc) {
 					logrus.Debugf("Creating Gateways IP for NodePort: %d, %v", svcPort.NodePort, ips)
 					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
 					if err != nil {
@@ -96,7 +96,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 		targetPort := lbEps.Port
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == kapi.ProtocolUDP && svcPort.Name == svcPortName {
-				if util.ServiceTypeHasNodePort(svc) && config.Gateway.NodeportEnable {
+				if util.ServiceTypeHasNodePort(svc) {
 					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
 					if err != nil {
 						logrus.Errorf("Error in creating Node Port for svc %s, node port: %d - %v\n", svc.Name, svcPort.NodePort, err)

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -52,13 +52,6 @@ func (ovn *Controller) createGatewaysVIP(protocol string, port, targetPort int32
 	}
 
 	for _, physicalGateway := range physicalGateways {
-		physicalIP, err := ovn.getGatewayPhysicalIP(physicalGateway)
-		if err != nil {
-			logrus.Errorf("physical gateway %s does not have physical ip (%v)",
-				physicalGateway, err)
-			continue
-		}
-
 		loadBalancer, err := ovn.getGatewayLoadBalancer(physicalGateway,
 			protocol)
 		if err != nil {
@@ -69,7 +62,12 @@ func (ovn *Controller) createGatewaysVIP(protocol string, port, targetPort int32
 		if loadBalancer == "" {
 			continue
 		}
-
+		physicalIP, err := ovn.getGatewayPhysicalIP(physicalGateway)
+		if err != nil {
+			logrus.Errorf("physical gateway %s does not have physical ip (%v)",
+				physicalGateway, err)
+			continue
+		}
 		// With the physical_ip:port as the VIP, add an entry in
 		// 'load_balancer'.
 		err = ovn.createLoadBalancerVIP(loadBalancer,

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -66,6 +66,14 @@ func cleanupGateway(fexec *ovntest.FakeExec, nodeName string, nodeSubnet string,
 		"ovn-nbctl --timeout=15 --if-exist lr-del GR_" + nodeName,
 		"ovn-nbctl --timeout=15 --if-exist ls-del ext_" + nodeName,
 	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_" + nodeName,
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_" + nodeName,
+		Output: "",
+	})
 }
 
 func defaultFakeExec(nodeSubnet, nodeName string) (*ovntest.FakeExec, string, string) {
@@ -395,6 +403,14 @@ subnet=%s
 				"ovn-nbctl --timeout=15 --if-exist lr-del GR_" + node1Name,
 				"ovn-nbctl --timeout=15 --if-exist ls-del ext_" + node1Name,
 			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_" + node1Name,
+				Output: "",
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_" + node1Name,
+				Output: "",
+			})
 
 			// Expect the code to re-add the master node (which still exists)
 			// when the factory watch begins and enumerates all existing
@@ -526,6 +542,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				OvnNodeGatewayMacAddress: brLocalnetMAC,
 				OvnNodeGatewayIP:         localnetGatewayIP,
 				OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+				OvnNodePortEnable:        "true",
 			}
 			bytes, err := json.Marshal(map[string]map[string]string{"default": l3GatewayConfig})
 			Expect(err).NotTo(HaveOccurred())
@@ -758,6 +775,7 @@ GR_openshift-master-node chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_s
 				OvnNodeGatewayMacAddress: brLocalnetMAC,
 				OvnNodeGatewayIP:         localnetGatewayIP,
 				OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+				OvnNodePortEnable:        "true",
 			}
 			bytes, err := json.Marshal(map[string]map[string]string{"default": l3GatewayConfig})
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
@@ -191,7 +190,7 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 
 		// targetPort can be anything, the deletion logic does not use it
 		var targetPort int32
-		if util.ServiceTypeHasNodePort(service) && config.Gateway.NodeportEnable {
+		if util.ServiceTypeHasNodePort(service) {
 			// Delete the 'NodePort' service from a load-balancer instantiated in gateways.
 			err := ovn.createGatewaysVIP(string(protocol), port, targetPort, ips)
 			if err != nil {

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -7,8 +7,6 @@ import (
 	"net"
 	"sort"
 	"strings"
-
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 )
 
 const (
@@ -145,7 +143,7 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, error) {
 
 // GatewayInit creates a gateway router for the local chassis.
 func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, nicMacAddress,
-	defaultGW string, rampoutIPSubnet string, lspArgs []string) error {
+	defaultGW string, rampoutIPSubnet string, nodePortEnable bool, lspArgs []string) error {
 
 	ip, physicalIPNet, err := net.ParseCIDR(nicIP)
 	if err != nil {
@@ -225,7 +223,7 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 			stdout, stderr, err)
 	}
 
-	if config.Gateway.NodeportEnable {
+	if nodePortEnable {
 		// Create 2 load-balancers for north-south traffic for each gateway
 		// router.  One handles UDP and another handles TCP.
 		var k8sNSLbTCP, k8sNSLbUDP string

--- a/vagrant/provisioning/setup-master.sh
+++ b/vagrant/provisioning/setup-master.sh
@@ -210,7 +210,6 @@ if [ "$DAEMONSET" != "true" ]; then
    -logfile="/var/log/ovn-kubernetes/ovnkube.log" \
    -init-master="k8smaster" -cluster-subnets="192.168.0.0/16" \
    -init-node="k8smaster" \
-   -nodeport \
    -nb-address="$ovn_nb" \
    -sb-address="$ovn_sb" \
    -init-gateways -gateway-local \


### PR DESCRIPTION
After we migrated the gateway related logical resources creation to
master, the master is now creating LB rules for NodePort services for
all of the nodes irrespective of the fact whether the NodePort feature
is enabled or not on the node.

Each node through l3-gateway-config`node-port-enabled annotation will
specify if the NodePort must be enabled or not. The master acts on this
annotation to create LB rules for specific nodes.

@dcbw @danwinship PTAL