### PR TITLE
IPv6 single-stack support

### DIFF
--- a/go-controller/pkg/cluster/management-port_linux.go
+++ b/go-controller/pkg/cluster/management-port_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -28,6 +29,8 @@ func CreateManagementPort(nodeName string, localSubnet *net.IPNet, clusterSubnet
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO - Migrate to using netlink.
 
 	// Up the interface.
 	_, _, err = util.RunIP("link", "set", interfaceName, "up")
@@ -55,9 +58,14 @@ func CreateManagementPort(nodeName string, localSubnet *net.IPNet, clusterSubnet
 		}
 
 		// Create a route for the entire subnet.
-		_, _, err = util.RunIP("route", "add", subnet, "via", routerIP)
+		_, stderr, err := util.RunIP("route", "add", subnet, "via", routerIP)
 		if err != nil {
-			return nil, err
+			if strings.HasPrefix(stderr, "RTNETLINK answers: File exists") {
+				logrus.Debugf("Ignoring error %s from 'route add %s via %s' - already added via IPv6 RA?",
+					strings.TrimSpace(stderr), subnet, routerIP)
+			} else {
+				return nil, fmt.Errorf("Failed to add route for %s via %s: %s", subnet, routerIP, err)
+			}
 		}
 	}
 
@@ -68,9 +76,14 @@ func CreateManagementPort(nodeName string, localSubnet *net.IPNet, clusterSubnet
 	}
 
 	// Create a route for the services subnet.
-	_, _, err = util.RunIP("route", "add", config.Kubernetes.ServiceCIDR, "via", routerIP)
+	_, stderr, err := util.RunIP("route", "add", config.Kubernetes.ServiceCIDR, "via", routerIP)
 	if err != nil {
-		return nil, err
+		if strings.HasPrefix(stderr, "RTNETLINK answers: File exists") {
+			logrus.Debugf("Ignoring error %s from 'route add %s via %s' - already added via IPv6 RA?",
+				strings.TrimSpace(stderr), config.Kubernetes.ServiceCIDR, routerIP)
+		} else {
+			return nil, fmt.Errorf("Failed to add route for %s via %s: %s", config.Kubernetes.ServiceCIDR, routerIP, err)
+		}
 	}
 
 	// Add a neighbour entry on the K8s node to map routerIP with routerMAC. This is

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -946,6 +946,15 @@ func UseIPv6() bool {
 	return true
 }
 
+// OtherConfigSubnet returns "other-config:subnet" for IPv4 clusers, and
+// "other-config:ipv6_prefix" for IPv6 clusters
+func OtherConfigSubnet() string {
+	if UseIPv6() {
+		return "other-config:ipv6_prefix"
+	}
+	return "other-config:subnet"
+}
+
 // getConfigFilePath returns config file path and 'true' if the config file is
 // the fallback path (eg not given by the user), 'false' if given explicitly
 // by the user

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -934,6 +934,18 @@ func buildDefaultConfig(cli, file *config) error {
 	return nil
 }
 
+// UseIPv6 returns true if ovn-kubernetes is configured in IPv6 mode, false for IPv4
+func UseIPv6() bool {
+	if len(Default.ClusterSubnets) < 1 {
+		logrus.Warningf("Unable to determine IPv4 vs IPv6 because no cluster subnets configured")
+		return false
+	}
+	if Default.ClusterSubnets[0].CIDR.IP.To4() != nil {
+		return false
+	}
+	return true
+}
+
 // getConfigFilePath returns config file path and 'true' if the config file is
 // the fallback path (eg not given by the user), 'false' if given explicitly
 // by the user

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -244,6 +244,7 @@ var _ = Describe("Config Operations", func() {
 			Expect(Default.ClusterSubnets).To(Equal([]CIDRNetworkEntry{
 				{mustParseCIDR("10.128.0.0/14"), 23},
 			}))
+			Expect(UseIPv6()).To(Equal(false))
 
 			for _, a := range []OvnAuthConfig{OvnNorth, OvnSouth} {
 				Expect(a.Scheme).To(Equal(OvnDBSchemeUnix))
@@ -628,14 +629,15 @@ cluster-subnets=172.18.0.0/24
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfgPath).To(Equal(cfgFile.Name()))
 			Expect(Default.ClusterSubnets).To(Equal([]CIDRNetworkEntry{
-				{mustParseCIDR("172.15.0.0/24"), 24},
+				{mustParseCIDR("fd02::/64"), 24},
 			}))
+			Expect(UseIPv6()).To(Equal(true))
 			return nil
 		}
 		cliArgs := []string{
 			app.Name,
 			"-config-file=" + cfgFile.Name(),
-			"-cluster-subnet=172.15.0.0/24",
+			"-cluster-subnet=fd02::/64",
 		}
 		err = app.Run(cliArgs)
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -100,6 +100,10 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 				"Disabling Multicast Support")
 			oc.multicastSupport = false
 		}
+		if config.UseIPv6() {
+			logrus.Warningf("Multicast support enabled, but can not be used along with IPv6. Disabling Multicast Support")
+			oc.multicastSupport = false
+		}
 	}
 
 	if err := oc.SetupMaster(masterNodeName); err != nil {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -128,11 +128,11 @@ func (oc *Controller) addIPBlockACLDeny(np *namespacePolicy,
 	direction = toLport
 	if policyType == knet.PolicyTypeIngress {
 		lportMatch = fmt.Sprintf("outport == @%s", np.portGroupName)
-		l3Match = fmt.Sprintf("ip4.src == %s", except)
+		l3Match = fmt.Sprintf("%s.src == %s", ipMatch(), except)
 		match = fmt.Sprintf("match=\"%s && %s\"", lportMatch, l3Match)
 	} else {
 		lportMatch = fmt.Sprintf("inport == @%s", np.portGroupName)
-		l3Match = fmt.Sprintf("ip4.dst == %s", except)
+		l3Match = fmt.Sprintf("%s.dst == %s", ipMatch(), except)
 		match = fmt.Sprintf("match=\"%s && %s\"", lportMatch, l3Match)
 	}
 

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -91,6 +92,13 @@ func (gp *gressPolicy) addIPBlock(ipblockJSON *knet.IPBlock) {
 	gp.ipBlockExcept = append(gp.ipBlockExcept, ipblockJSON.Except...)
 }
 
+func ipMatch() string {
+	if config.UseIPv6() {
+		return "ip6"
+	}
+	return "ip4"
+}
+
 func (gp *gressPolicy) getL3MatchFromAddressSet() string {
 	var l3Match, addresses string
 	for _, addressSet := range gp.sortedPeerAddressSets {
@@ -101,12 +109,12 @@ func (gp *gressPolicy) getL3MatchFromAddressSet() string {
 		addresses = fmt.Sprintf("%s, $%s", addresses, addressSet)
 	}
 	if addresses == "" {
-		l3Match = "ip4"
+		l3Match = ipMatch()
 	} else {
 		if gp.policyType == knet.PolicyTypeIngress {
-			l3Match = fmt.Sprintf("ip4.src == {%s}", addresses)
+			l3Match = fmt.Sprintf("%s.src == {%s}", ipMatch(), addresses)
 		} else {
-			l3Match = fmt.Sprintf("ip4.dst == {%s}", addresses)
+			l3Match = fmt.Sprintf("%s.dst == {%s}", ipMatch(), addresses)
 		}
 	}
 	return l3Match
@@ -117,19 +125,19 @@ func (gp *gressPolicy) getMatchFromIPBlock(lportMatch, l4Match string) string {
 	ipBlockCidr := fmt.Sprintf("{%s}", strings.Join(gp.ipBlockCidr, ", "))
 	if gp.policyType == knet.PolicyTypeIngress {
 		if l4Match == noneMatch {
-			match = fmt.Sprintf("match=\"ip4.src == %s && %s\"",
-				ipBlockCidr, lportMatch)
+			match = fmt.Sprintf("match=\"%s.src == %s && %s\"",
+				ipMatch(), ipBlockCidr, lportMatch)
 		} else {
-			match = fmt.Sprintf("match=\"ip4.src == %s && %s && %s\"",
-				ipBlockCidr, l4Match, lportMatch)
+			match = fmt.Sprintf("match=\"%s.src == %s && %s && %s\"",
+				ipMatch(), ipBlockCidr, l4Match, lportMatch)
 		}
 	} else {
 		if l4Match == noneMatch {
-			match = fmt.Sprintf("match=\"ip4.dst == %s && %s\"",
-				ipBlockCidr, lportMatch)
+			match = fmt.Sprintf("match=\"%s.dst == %s && %s\"",
+				ipMatch(), ipBlockCidr, lportMatch)
 		} else {
-			match = fmt.Sprintf("match=\"ip4.dst == %s && %s && %s\"",
-				ipBlockCidr, l4Match, lportMatch)
+			match = fmt.Sprintf("match=\"%s.dst == %s && %s && %s\"",
+				ipMatch(), ipBlockCidr, l4Match, lportMatch)
 		}
 	}
 	return match
@@ -408,7 +416,7 @@ func (oc *Controller) addAllowACLFromNode(logicalSwitch, subnet string) error {
 	ip = util.NextIP(util.NextIP(ip))
 	address := ip.String()
 
-	match := fmt.Sprintf("ip4.src==%s", address)
+	match := fmt.Sprintf("%s.src==%s", ipMatch(), address)
 	_, stderr, err := util.RunOVNNbctl("--may-exist", "acl-add", logicalSwitch,
 		"to-lport", defaultAllowPriority, match, "allow-related")
 	if err != nil {

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -404,10 +404,8 @@ func (oc *Controller) addAllowACLFromNode(logicalSwitch, subnet string) error {
 		return err
 	}
 
-	// K8s only supports IPv4 right now. The second IP address of the
-	// network is the node IP address.
-	ip = ip.To4()
-	ip[3] = ip[3] + 2
+	// The second IP address of the network is the node IP address.
+	ip = util.NextIP(util.NextIP(ip))
 	address := ip.String()
 
 	match := fmt.Sprintf("ip4.src==%s", address)

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -3,10 +3,13 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net"
 	"sort"
 	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 )
 
 const (
@@ -101,7 +104,7 @@ func ensureGatewayPortAddress(portName string) (net.HardwareAddr, *net.IPNet, er
 
 	// Grab the 'join' switch prefix length to add to our gateway router's IP
 	cidrStr, stderr, err := RunOVNNbctl("--if-exists", "get",
-		"logical_switch", "join", "other-config:subnet")
+		"logical_switch", "join", config.OtherConfigSubnet())
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to get 'join' switch external-ids: "+
 			"stderr: %q, %v", stderr, err)

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -204,8 +204,14 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 
 	for _, entry := range clusterIPSubnet {
 		// Add a static route in GR with distributed router as the nexthop.
+		var joinAddr string
+		if config.UseIPv6() {
+			joinAddr = "fd98::1"
+		} else {
+			joinAddr = "100.64.0.1"
+		}
 		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
-			gatewayRouter, entry, "100.64.0.1")
+			gatewayRouter, entry, joinAddr)
 		if err != nil {
 			return fmt.Errorf("Failed to add a static route in GR with distributed "+
 				"router as the nexthop, stdout: %q, stderr: %q, error: %v",
@@ -311,8 +317,14 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 
 	// Add a static route in GR with physical gateway as the default next hop.
 	if defaultGW != "" {
+		var allIPs string
+		if config.UseIPv6() {
+			allIPs = "::/0"
+		} else {
+			allIPs = "0.0.0.0/0"
+		}
 		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
-			gatewayRouter, "0.0.0.0/0", defaultGW,
+			gatewayRouter, allIPs, defaultGW,
 			fmt.Sprintf("rtoe-%s", gatewayRouter))
 		if err != nil {
 			return fmt.Errorf("Failed to add a static route in GR with physical "+


### PR DESCRIPTION
I think this PR includes all of the changes needed in a fork to get ovn-kubernetes working with IPv6.  Much of this was reworked from hard-coded IPv6 support to conditional, so it should not change any behavior by default unless configured with IPv6 subnets.

There are a couple of workarounds included here which could use more investigation, but they make things work for now.