### PR TITLE
cmd: add --metrics-enable-pprof option to serve pprof on metrics port

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -206,7 +206,7 @@ func runOvnKube(ctx *cli.Context) error {
 
 	// start the prometheus server
 	if config.Kubernetes.MetricsBindAddress != "" {
-		ovncluster.StartMetricsServer(config.Kubernetes.MetricsBindAddress)
+		util.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof)
 	}
 
 	// Set up a watch on our config file; if it changes, we exit -

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -153,6 +153,7 @@ type KubernetesConfig struct {
 	ServiceCIDR        string `gcfg:"service-cidr"`
 	OVNConfigNamespace string `gcfg:"ovn-config-namespace"`
 	MetricsBindAddress string `gcfg:"metrics-bind-address"`
+	MetricsEnablePprof bool   `gcfg:"metrics-enable-pprof"`
 	OVNEmptyLbEvents   bool   `gcfg:"ovn-empty-lb-events"`
 	PodIP              string `gcfg:"pod-ip"`
 }
@@ -515,6 +516,11 @@ var K8sFlags = []cli.Flag{
 		Name:        "metrics-bind-address",
 		Usage:       "The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces)",
 		Destination: &cliConfig.Kubernetes.MetricsBindAddress,
+	},
+	cli.BoolFlag{
+		Name:        "metrics-enable-pprof",
+		Usage:       "If true, then also accept pprof requests on the metrics port.",
+		Destination: &cliConfig.Kubernetes.MetricsEnablePprof,
 	},
 	cli.BoolFlag{
 		Name: "ovn-empty-lb-events",

--- a/go-controller/pkg/util/metrics.go
+++ b/go-controller/pkg/util/metrics.go
@@ -1,8 +1,9 @@
-package cluster
+package util
 
 import (
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -12,9 +13,18 @@ import (
 )
 
 // StartMetricsServer runs the prometheus listner so that metrics can be collected
-func StartMetricsServer(bindAddress string) {
+func StartMetricsServer(bindAddress string, enablePprof bool) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
+
+	if enablePprof {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
+
 	go utilwait.Until(func() {
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {


### PR DESCRIPTION
pprof is a useful tool for profiling and finding hot spots. Make it easy to enable.