### PR TITLE
Correct networkpolicy operation when using pod and namespace selector 

### DIFF
--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -27,6 +27,7 @@ type Interface interface {
 	GetPod(namespace, name string) (*kapi.Pod, error)
 	GetPods(namespace string) (*kapi.PodList, error)
 	GetPodsByLabels(namespace string, selector labels.Selector) (*kapi.PodList, error)
+	GetPodsByLabelSelector(namespace string, selector *metav1.LabelSelector) (*kapi.PodList, error)
 	GetNodes() (*kapi.NodeList, error)
 	GetNode(name string) (*kapi.Node, error)
 	GetService(namespace, name string) (*kapi.Service, error)
@@ -154,6 +155,15 @@ func (k *Kube) GetPods(namespace string) (*kapi.PodList, error) {
 func (k *Kube) GetPodsByLabels(namespace string, selector labels.Selector) (*kapi.PodList, error) {
 	options := metav1.ListOptions{}
 	options.LabelSelector = selector.String()
+	return k.KClient.CoreV1().Pods(namespace).List(options)
+}
+
+// GetPodsByLabelSelector obtains Pod resources from the kubernetes apiserver
+// given the namesoace and a LabelSelector
+func (k *Kube) GetPodsByLabelSelector(namespace string, selector *metav1.LabelSelector) (*kapi.PodList, error) {
+	options := metav1.ListOptions{}
+	sel, _ := metav1.LabelSelectorAsSelector(selector)
+	options.LabelSelector = sel.String()
 	return k.KClient.CoreV1().Pods(namespace).List(options)
 }
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -650,7 +650,7 @@ func (oc *Controller) handleLocalPodSelector(
 		return
 	}
 
-	np.podHandlerList = append(np.podHandlerList, h)
+	np.podHandlerMap[np.namespace] = h
 }
 
 func (oc *Controller) handlePeerNamespaceSelectorModify(
@@ -707,7 +707,7 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 	np.namespace = policy.Namespace
 	np.ingressPolicies = make([]*gressPolicy, 0)
 	np.egressPolicies = make([]*gressPolicy, 0)
-	np.podHandlerList = make([]*factory.Handler, 0)
+	np.podHandlerMap = make(map[string]*factory.Handler)
 	np.nsHandlerList = make([]*factory.Handler, 0)
 	np.localPods = make(map[string]bool)
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -707,6 +707,7 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 	np.namespace = policy.Namespace
 	np.ingressPolicies = make([]*gressPolicy, 0)
 	np.egressPolicies = make([]*gressPolicy, 0)
+	np.podIPMap = make(map[string]map[string]string)
 	np.podHandlerMap = make(map[string]*factory.Handler)
 	np.nsHandlerList = make([]*factory.Handler, 0)
 	np.localPods = make(map[string]bool)

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -686,6 +686,7 @@ func (oc *Controller) addNetworkPolicyOld(policy *knet.NetworkPolicy) {
 	np.namespace = policy.Namespace
 	np.ingressPolicies = make([]*gressPolicy, 0)
 	np.egressPolicies = make([]*gressPolicy, 0)
+	np.podIPMap = make(map[string]map[string]string)
 	np.podHandlerMap = make(map[string]*factory.Handler)
 	np.nsHandlerList = make([]*factory.Handler, 0)
 	np.localPods = make(map[string]bool)

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -626,7 +626,7 @@ func (oc *Controller) handleLocalPodSelectorOld(
 		return
 	}
 
-	np.podHandlerList = append(np.podHandlerList, h)
+	np.podHandlerMap[np.namespace] = h
 
 }
 
@@ -686,7 +686,7 @@ func (oc *Controller) addNetworkPolicyOld(policy *knet.NetworkPolicy) {
 	np.namespace = policy.Namespace
 	np.ingressPolicies = make([]*gressPolicy, 0)
 	np.egressPolicies = make([]*gressPolicy, 0)
-	np.podHandlerList = make([]*factory.Handler, 0)
+	np.podHandlerMap = make(map[string]*factory.Handler)
 	np.nsHandlerList = make([]*factory.Handler, 0)
 	np.localPods = make(map[string]bool)
 


### PR DESCRIPTION
currently when using namespace and pod selector once a pod is added to
the list of peer pods changing the label of the namespace to something
other then a valid namespace selector will not remove the pod from the
list of pods allowed.

Correct this error and correctly clean up the podhandlers

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1752220