### PR TITLE
Update metric service to include not-ready endpoints

### DIFF
--- a/dist/templates/ovnkube-monitor.yaml.j2
+++ b/dist/templates/ovnkube-monitor.yaml.j2
@@ -34,6 +34,7 @@ spec:
     name: ovnkube-master
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
   - name: http-metrics
     port: 9409
@@ -74,6 +75,7 @@ spec:
     name: ovnkube-node
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
   - name: http-metrics
     port: 9410


### PR DESCRIPTION
Though we don't have readiness probes right now, it's a best practice to scrape not-ready endpoints for daemonsets.