### PR TITLE
ExternalP for ovn-kubernetes  

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -247,7 +247,7 @@ func runOvnKube(ctx *cli.Context) error {
 		// register ovn specific (ovn-controller and ovn-northd) metrics
 		metrics.RegisterOvnMetrics()
 		start := time.Now()
-		n := ovnnode.NewNode(clientset, factory, node, stopChan)
+		n := ovnnode.NewNode(clientset, factory, node, stopChan, util.EventRecorder(clientset))
 		if err := n.Start(); err != nil {
 			return err
 		}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -99,8 +99,10 @@ func (n *OvnNode) initGateway(subnet *net.IPNet, nodeAnnotator kube.Annotator,
 	waiter *startupWaiter) error {
 
 	if config.Gateway.NodeportEnable {
-		err := initLoadBalancerHealthChecker(n.name, n.watchFactory)
-		if err != nil {
+		if err := initLoadBalancerHealthChecker(n.name, n.watchFactory); err != nil {
+			return err
+		}
+		if err := initPortClaimWatcher(n.recorder, n.watchFactory); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -109,7 +109,7 @@ func (n *OvnNode) initGateway(subnet *net.IPNet, nodeAnnotator kube.Annotator,
 	var prFn postWaitFunc
 	switch config.Gateway.Mode {
 	case config.GatewayModeLocal:
-		err = initLocalnetGateway(n.name, subnet, n.watchFactory, nodeAnnotator)
+		err = n.initLocalnetGateway(subnet, nodeAnnotator)
 	case config.GatewayModeShared:
 		gatewayNextHop := net.ParseIP(config.Gateway.NextHop)
 		gatewayIntf := config.Gateway.Interface

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -13,6 +13,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
 
 	. "github.com/onsi/ginkgo"
@@ -184,10 +184,9 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 			wf.Shutdown()
 		}()
 
-		n := NewNode(nil, wf, existingNode.Name, stop)
+		n := NewNode(nil, wf, existingNode.Name, stop, record.NewFakeRecorder(0))
 
-		ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
-		Expect(err).NotTo(HaveOccurred())
+		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 
 		nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &existingNode)
 
@@ -248,10 +247,37 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 
 		expectedTables := map[string]util.FakeTable{
-			"filter": {},
-			"nat":    {},
+			"filter": {
+				"OUTPUT": []string{
+					"-j OVN-KUBE-EXTERNALIP",
+					"-j OVN-KUBE-NODEPORT",
+				},
+				"FORWARD": []string{
+					"-j OVN-KUBE-EXTERNALIP",
+					"-j OVN-KUBE-NODEPORT",
+				},
+				"OVN-KUBE-NODEPORT":   []string{},
+				"OVN-KUBE-EXTERNALIP": []string{},
+			},
+			"nat": {
+				"OUTPUT": []string{
+					"-j OVN-KUBE-EXTERNALIP",
+					"-j OVN-KUBE-NODEPORT",
+				},
+				"PREROUTING": []string{
+					"-j OVN-KUBE-EXTERNALIP",
+					"-j OVN-KUBE-NODEPORT",
+				},
+				"OVN-KUBE-NODEPORT":   []string{},
+				"OVN-KUBE-EXTERNALIP": []string{},
+			},
 		}
-		Expect(ipt.MatchState(expectedTables)).NotTo(HaveOccurred())
+		f4 := iptV4.(*util.FakeIPTables)
+		err = f4.MatchState(expectedTables)
+		Expect(err).NotTo(HaveOccurred())
+		f6 := iptV6.(*util.FakeIPTables)
+		err = f6.MatchState(expectedTables)
+		Expect(err).NotTo(HaveOccurred())
 		return nil
 	}
 
@@ -268,8 +294,13 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 }
 
 var _ = Describe("Gateway Init Operations", func() {
-	var app *cli.App
-	var testNS ns.NetNS
+
+	var (
+		testNS      ns.NetNS
+		app         *cli.App
+		fakeOvnNode *FakeOVNNode
+		fexec       *ovntest.FakeExec
+	)
 
 	BeforeEach(func() {
 		var err error
@@ -283,7 +314,10 @@ var _ = Describe("Gateway Init Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		// Set up a fake br-local & localnetGatewayNextHopPort
+		fexec = ovntest.NewFakeExec()
+		fakeOvnNode = NewFakeOVNNode(fexec)
+
+		// Set up a fake br-local & LocalnetGatewayNextHopPort
 		testNS, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 		err = testNS.Do(func(ns.NetNS) error {
@@ -318,13 +352,12 @@ var _ = Describe("Gateway Init Operations", func() {
 			const (
 				nodeName      string = "node1"
 				brLocalnetMAC string = "11:22:33:44:55:66"
-				brNextHopIp   string = "169.254.33.1"
-				brNextHopCIDR string = brNextHopIp + "/24"
+				brNextHopIP   string = "169.254.33.1"
+				brNextHopCIDR string = brNextHopIP + "/24"
 				systemID      string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 				nodeSubnet    string = "10.1.1.0/24"
 			)
 
-			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovs-vsctl --timeout=15 --may-exist add-br br-local",
 			})
@@ -348,29 +381,33 @@ var _ = Describe("Gateway Init Operations", func() {
 				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 				Output: systemID,
 			})
-
-			err := util.SetExec(fexec)
-			Expect(err).NotTo(HaveOccurred())
-
-			_, err = config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: "ip rule",
+				Output: "0:	from all lookup local\n32766:	from all lookup main\n32767:	from all lookup default\n",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ip rule add from all table " + localnetGatewayExternalIDTable,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ip route list table " + localnetGatewayExternalIDTable,
+			})
 
 			existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 			}}
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{existingNode},
-			})
-			wf, err := factory.NewWatchFactory(fakeClient)
-			Expect(err).NotTo(HaveOccurred())
-			defer wf.Shutdown()
 
-			ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
-			Expect(err).NotTo(HaveOccurred())
-			util.SetIPTablesHelper(iptables.ProtocolIPv4, ipt)
+			fakeOvnNode.start(ctx,
+				&v1.NodeList{
+					Items: []v1.Node{
+						existingNode,
+					},
+				},
+			)
 
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &existingNode)
-			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(nodeSubnet))
+			iptV4, _ := util.SetFakeIPTablesHelpers()
+
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeOvnNode.fakeClient}, &existingNode)
+			err := util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(nodeSubnet))
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -378,7 +415,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			err = testNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				err = initLocalnetGateway(nodeName, ovntest.MustParseIPNet(nodeSubnet), wf, nodeAnnotator)
+				err = fakeOvnNode.node.initLocalnetGateway(ovntest.MustParseIPNet(nodeSubnet), nodeAnnotator)
 				Expect(err).NotTo(HaveOccurred())
 				// Check if IP has been assigned to LocalnetGatewayNextHopPort
 				link, err := netlink.LinkByName(localnetGatewayNextHopPort)
@@ -407,26 +444,33 @@ var _ = Describe("Gateway Init Operations", func() {
 						"-i " + localnetGatewayNextHopPort + " -m comment --comment from OVN to localhost -j ACCEPT",
 					},
 					"FORWARD": []string{
+						"-j OVN-KUBE-EXTERNALIP",
 						"-j OVN-KUBE-NODEPORT",
 						"-o " + localnetGatewayNextHopPort + " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
 						"-i " + localnetGatewayNextHopPort + " -j ACCEPT",
 					},
-					"OVN-KUBE-NODEPORT": []string{},
+					"OVN-KUBE-NODEPORT":   []string{},
+					"OVN-KUBE-EXTERNALIP": []string{},
 				},
 				"nat": {
 					"POSTROUTING": []string{
 						"-s 169.254.33.2 -j MASQUERADE",
 					},
 					"PREROUTING": []string{
+						"-j OVN-KUBE-EXTERNALIP",
 						"-j OVN-KUBE-NODEPORT",
 					},
 					"OUTPUT": []string{
+						"-j OVN-KUBE-EXTERNALIP",
 						"-j OVN-KUBE-NODEPORT",
 					},
-					"OVN-KUBE-NODEPORT": []string{},
+					"OVN-KUBE-NODEPORT":   []string{},
+					"OVN-KUBE-EXTERNALIP": []string{},
 				},
 			}
-			Expect(ipt.MatchState(expectedTables)).NotTo(HaveOccurred())
+			f4 := iptV4.(*util.FakeIPTables)
+			err = f4.MatchState(expectedTables)
+			Expect(err).NotTo(HaveOccurred())
 			return nil
 		}
 

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -1,0 +1,342 @@
+// +build linux
+
+package node
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	utilnet "k8s.io/utils/net"
+)
+
+const (
+	iptableNodePortChain   = "OVN-KUBE-NODEPORT"
+	iptableExternalIPChain = "OVN-KUBE-EXTERNALIP"
+)
+
+type iptRule struct {
+	table    string
+	chain    string
+	args     []string
+	protocol iptables.Protocol
+}
+
+func addIptRules(rules []iptRule) error {
+	for _, r := range rules {
+		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ", r.table, r.chain, strings.Join(r.args, " "), r.protocol)
+		ipt, _ := util.GetIPTablesHelper(r.protocol)
+		if err := ipt.NewChain(r.table, r.chain); err != nil {
+			klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation", r.table, r.chain)
+		}
+		exists, err := ipt.Exists(r.table, r.chain, r.args...)
+		if !exists && err == nil {
+			err = ipt.Insert(r.table, r.chain, 1, r.args...)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to add iptables %s/%s rule %q: %v",
+				r.table, r.chain, strings.Join(r.args, " "), err)
+		}
+	}
+	return nil
+}
+
+func delIptRules(rules []iptRule) error {
+	for _, r := range rules {
+		klog.V(5).Infof("Deleting rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ", r.table, r.chain, strings.Join(r.args, " "), r.protocol)
+		ipt, _ := util.GetIPTablesHelper(r.protocol)
+		err := ipt.Delete(r.table, r.chain, r.args...)
+		if err != nil {
+			return fmt.Errorf("failed to delete iptables %s/%s rule %q: %v",
+				r.table, r.chain, strings.Join(r.args, " "), err)
+		}
+	}
+	return nil
+}
+
+func getSharedGatewayInitRules(chain string, proto iptables.Protocol) []iptRule {
+	return []iptRule{
+		{
+			table:    "nat",
+			chain:    "OUTPUT",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
+		{
+			table:    "nat",
+			chain:    "PREROUTING",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
+		{
+			table:    "filter",
+			chain:    "OUTPUT",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
+		{
+			table:    "filter",
+			chain:    "FORWARD",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
+	}
+}
+
+func getLocalGatewayInitRules(chain string, proto iptables.Protocol) []iptRule {
+	return []iptRule{
+		{
+			table:    "nat",
+			chain:    "PREROUTING",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
+		{
+			table:    "nat",
+			chain:    "OUTPUT",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
+		{
+			table:    "filter",
+			chain:    "FORWARD",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
+	}
+}
+
+func getNodePortIPTRules(svcPort kapi.ServicePort, nodeIP *net.IPNet, gatewayIP string, targetPort int32) []iptRule {
+	var protocol iptables.Protocol
+	if utilnet.IsIPv6String(gatewayIP) {
+		protocol = iptables.ProtocolIPv6
+	} else {
+		protocol = iptables.ProtocolIPv4
+	}
+	var natArgs, filterArgs []string
+	if nodeIP != nil {
+		natArgs = []string{
+			"-p", string(svcPort.Protocol),
+			"-d", nodeIP.IP.String(),
+			"--dport", fmt.Sprintf("%d", svcPort.NodePort),
+			"-j", "DNAT",
+			"--to-destination", util.JoinHostPortInt32(gatewayIP, targetPort),
+		}
+		filterArgs = []string{
+			"-p", string(svcPort.Protocol),
+			"-d", nodeIP.IP.String(),
+			"--dport", fmt.Sprintf("%d", svcPort.NodePort),
+			"-j", "ACCEPT",
+		}
+	} else {
+		natArgs = []string{
+			"-p", string(svcPort.Protocol),
+			"--dport", fmt.Sprintf("%d", svcPort.NodePort),
+			"-j", "DNAT",
+			"--to-destination", util.JoinHostPortInt32(gatewayIP, targetPort),
+		}
+		filterArgs = []string{
+			"-p", string(svcPort.Protocol),
+			"--dport", fmt.Sprintf("%d", svcPort.NodePort),
+			"-j", "ACCEPT",
+		}
+	}
+	return []iptRule{
+		{
+			table:    "nat",
+			chain:    iptableNodePortChain,
+			args:     natArgs,
+			protocol: protocol,
+		},
+		{
+			table:    "filter",
+			chain:    iptableNodePortChain,
+			args:     filterArgs,
+			protocol: protocol,
+		},
+	}
+}
+
+func getExternalIPTRules(svcPort kapi.ServicePort, externalIP, dstIP string) []iptRule {
+	var protocol iptables.Protocol
+	if utilnet.IsIPv6String(externalIP) {
+		protocol = iptables.ProtocolIPv6
+	} else {
+		protocol = iptables.ProtocolIPv4
+	}
+	return []iptRule{
+		{
+			table: "nat",
+			chain: iptableExternalIPChain,
+			args: []string{
+				"-p", string(svcPort.Protocol),
+				"-d", externalIP,
+				"--dport", fmt.Sprintf("%v", svcPort.Port),
+				"-j", "DNAT",
+				"--to-destination", util.JoinHostPortInt32(dstIP, svcPort.Port),
+			},
+			protocol: protocol,
+		},
+		{
+			table: "filter",
+			chain: iptableExternalIPChain,
+			args: []string{
+				"-p", string(svcPort.Protocol),
+				"-d", externalIP,
+				"--dport", fmt.Sprintf("%v", svcPort.Port),
+				"-j", "ACCEPT",
+			},
+			protocol: protocol,
+		},
+	}
+}
+
+func getLocalGatewayNATRules(ifname string, ip net.IP) []iptRule {
+	// Allow packets to/from the gateway interface in case defaults deny
+	var protocol iptables.Protocol
+	if utilnet.IsIPv6(ip) {
+		protocol = iptables.ProtocolIPv6
+	} else {
+		protocol = iptables.ProtocolIPv4
+	}
+	return []iptRule{
+		{
+			table: "filter",
+			chain: "FORWARD",
+			args: []string{
+				"-i", ifname,
+				"-j", "ACCEPT",
+			},
+			protocol: protocol,
+		},
+		{
+			table: "filter",
+			chain: "FORWARD",
+			args: []string{
+				"-o", ifname,
+				"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
+				"-j", "ACCEPT",
+			},
+			protocol: protocol,
+		},
+		{
+			table: "filter",
+			chain: "INPUT",
+			args: []string{
+				"-i", ifname,
+				"-m", "comment", "--comment", "from OVN to localhost",
+				"-j", "ACCEPT",
+			},
+			protocol: protocol,
+		},
+		{
+			table: "nat",
+			chain: "POSTROUTING",
+			args: []string{
+				"-s", ip.String(),
+				"-j", "MASQUERADE",
+			},
+			protocol: protocol,
+		},
+	}
+}
+
+func initLocalGatewayNATRules(ifname string, ip net.IP) error {
+	return addIptRules(getLocalGatewayNATRules(ifname, ip))
+}
+
+func initGatewayIPTTables(genGatewayChainRules func(chain string, proto iptables.Protocol) []iptRule) error {
+	rules := make([]iptRule, 0)
+	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
+		for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
+			ipt, err := util.GetIPTablesHelper(proto)
+			if err != nil {
+				return err
+			}
+			if err := ipt.NewChain("nat", chain); err != nil {
+				klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation", "nat", chain)
+			}
+			if err := ipt.NewChain("filter", chain); err != nil {
+				klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation", "filter", chain)
+			}
+			rules = append(rules, genGatewayChainRules(chain, proto)...)
+		}
+	}
+	if err := addIptRules(rules); err != nil {
+		return fmt.Errorf("failed to add iptables rules %v: %v", rules, err)
+	}
+	return nil
+}
+
+func initSharedGatewayIPTables() error {
+	if err := initGatewayIPTTables(getSharedGatewayInitRules); err != nil {
+		return err
+	}
+	return nil
+}
+
+func initLocalGatewayIPTables() error {
+	if err := initGatewayIPTTables(getLocalGatewayInitRules); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cleanupSharedGatewayIPTChains() {
+	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
+		for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
+			ipt, err := util.GetIPTablesHelper(proto)
+			if err != nil {
+				return
+			}
+			_ = ipt.ClearChain("nat", chain)
+			_ = ipt.ClearChain("filter", chain)
+			_ = ipt.DeleteChain("nat", chain)
+			_ = ipt.DeleteChain("filter", chain)
+		}
+	}
+}
+
+func recreateIPTRules(table, chain string, keepIPTRules []iptRule) {
+	for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
+		ipt, _ := util.GetIPTablesHelper(proto)
+		if err := ipt.ClearChain(table, chain); err != nil {
+			klog.Errorf("Error clearing chain: %s in table: %s, err: %v", chain, table, err)
+		}
+	}
+	if err := addIptRules(keepIPTRules); err != nil {
+		klog.Error(err)
+	}
+}
+
+func getGatewayIPTRules(service *kapi.Service, nodePortTargetIP string, nodeIP *net.IPNet) []iptRule {
+	rules := make([]iptRule, 0)
+	for _, svcPort := range service.Spec.Ports {
+		if util.ServiceTypeHasNodePort(service) {
+			err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort)
+			if err != nil {
+				klog.Errorf("Skipping service: %s, invalid service NodePort: %v", svcPort.Name, err)
+				continue
+			}
+			err = util.ValidatePort(svcPort.Protocol, svcPort.Port)
+			if err != nil {
+				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
+				continue
+			}
+			rules = append(rules, getNodePortIPTRules(svcPort, nodeIP, nodePortTargetIP, svcPort.Port)...)
+		}
+		for _, externalIP := range service.Spec.ExternalIPs {
+			err := util.ValidatePort(svcPort.Protocol, svcPort.Port)
+			if err != nil {
+				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
+				continue
+			}
+			rules = append(rules, getExternalIPTRules(svcPort, externalIP, service.Spec.ClusterIP)...)
+		}
+	}
+	return rules
+}

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -8,15 +8,14 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/klog"
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -36,92 +35,11 @@ const (
 	// fixed MAC address for the br-nexthop interface. the last 4 hex bytes
 	// translates to the br-nexthop's IP address
 	localnetGatewayNextHopMac = "00:00:a9:fe:21:01"
-	iptableNodePortChain      = "OVN-KUBE-NODEPORT"
+	// Routing table for ExternalIP communication
+	localnetGatewayExternalIDTable = "6"
 )
 
-type iptRule struct {
-	table string
-	chain string
-	args  []string
-}
-
-func ensureChain(ipt util.IPTablesHelper, table, chain string) error {
-	chains, err := ipt.ListChains(table)
-	if err != nil {
-		return fmt.Errorf("failed to list iptables chains: %v", err)
-	}
-	for _, ch := range chains {
-		if ch == chain {
-			return nil
-		}
-	}
-
-	return ipt.NewChain(table, chain)
-}
-
-func addIptRules(ipt util.IPTablesHelper, rules []iptRule) error {
-	for _, r := range rules {
-		if err := ensureChain(ipt, r.table, r.chain); err != nil {
-			return fmt.Errorf("failed to ensure %s/%s: %v", r.table, r.chain, err)
-		}
-		exists, err := ipt.Exists(r.table, r.chain, r.args...)
-		if !exists && err == nil {
-			err = ipt.Insert(r.table, r.chain, 1, r.args...)
-		}
-		if err != nil {
-			return fmt.Errorf("failed to add iptables %s/%s rule %q: %v",
-				r.table, r.chain, strings.Join(r.args, " "), err)
-		}
-	}
-
-	return nil
-}
-
-func delIptRules(ipt util.IPTablesHelper, rules []iptRule) {
-	for _, r := range rules {
-		err := ipt.Delete(r.table, r.chain, r.args...)
-		if err != nil {
-			klog.Warningf("Failed to delete iptables %s/%s rule %q: %v", r.table, r.chain,
-				strings.Join(r.args, " "), err)
-		}
-	}
-}
-
-func generateGatewayNATRules(ifname string, ip net.IP) []iptRule {
-	// Allow packets to/from the gateway interface in case defaults deny
-	rules := make([]iptRule, 0)
-	rules = append(rules, iptRule{
-		table: "filter",
-		chain: "FORWARD",
-		args:  []string{"-i", ifname, "-j", "ACCEPT"},
-	})
-	rules = append(rules, iptRule{
-		table: "filter",
-		chain: "FORWARD",
-		args: []string{"-o", ifname, "-m", "conntrack", "--ctstate",
-			"RELATED,ESTABLISHED", "-j", "ACCEPT"},
-	})
-	rules = append(rules, iptRule{
-		table: "filter",
-		chain: "INPUT",
-		args:  []string{"-i", ifname, "-m", "comment", "--comment", "from OVN to localhost", "-j", "ACCEPT"},
-	})
-
-	// NAT for the interface
-	rules = append(rules, iptRule{
-		table: "nat",
-		chain: "POSTROUTING",
-		args:  []string{"-s", ip.String(), "-j", "MASQUERADE"},
-	})
-	return rules
-}
-
-func localnetGatewayNAT(ipt util.IPTablesHelper, ifname string, ip net.IP) error {
-	rules := generateGatewayNATRules(ifname, ip)
-	return addIptRules(ipt, rules)
-}
-
-func initLocalnetGateway(nodeName string, subnet *net.IPNet, wf *factory.WatchFactory, nodeAnnotator kube.Annotator) error {
+func (n *OvnNode) initLocalnetGateway(subnet *net.IPNet, nodeAnnotator kube.Annotator) error {
 	// Create a localnet OVS bridge.
 	localnetBridgeName := "br-local"
 	_, stderr, err := util.RunOVSVsctl("--may-exist", "add-br",
@@ -131,7 +49,7 @@ func initLocalnetGateway(nodeName string, subnet *net.IPNet, wf *factory.WatchFa
 			", stderr:%s (%v)", localnetBridgeName, stderr, err)
 	}
 
-	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, localnetBridgeName, localnetBridgeName,
+	ifaceID, macAddress, err := bridgedGatewayNodeSetup(n.name, localnetBridgeName, localnetBridgeName,
 		util.PhysicalNetworkName, true)
 	if err != nil {
 		return fmt.Errorf("failed to set up shared interface gateway: %v", err)
@@ -208,121 +126,199 @@ func initLocalnetGateway(nodeName string, subnet *net.IPNet, wf *factory.WatchFa
 		}
 	}
 
-	ipt, err := localnetIPTablesHelper(subnet)
-	if err != nil {
-		return err
-	}
-
-	err = localnetGatewayNAT(ipt, localnetGatewayNextHopPort, gatewayIP)
+	err = initLocalGatewayNATRules(localnetGatewayNextHopPort, gatewayIP)
 	if err != nil {
 		return fmt.Errorf("failed to add NAT rules for localnet gateway (%v)", err)
 	}
 
 	if config.Gateway.NodeportEnable {
-		err = localnetNodePortWatcher(ipt, wf, gatewayIP)
+		localAddrSet, err := getLocalAddrs()
+		if err != nil {
+			return err
+		}
+		err = n.watchLocalPorts(
+			newLocalPortWatcherData(gatewayIP, n.recorder, localAddrSet),
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	return err
 }
 
-// localnetIPTablesHelper gets an IPTablesHelper for IPv4 or IPv6 as appropriate
-func localnetIPTablesHelper(subnet *net.IPNet) (util.IPTablesHelper, error) {
-	var ipt util.IPTablesHelper
-	var err error
-	if utilnet.IsIPv6CIDR(subnet) {
-		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv6)
-	} else {
-		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv4)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize iptables: %v", err)
-	}
-	return ipt, nil
+type localPortWatcherData struct {
+	recorder     record.EventRecorder
+	gatewayIP    string
+	localAddrSet map[string]net.IPNet
 }
 
-func localnetIptRules(svc *kapi.Service, gatewayIP string) []iptRule {
-	rules := make([]iptRule, 0)
-	for _, svcPort := range svc.Spec.Ports {
-		protocol, err := util.ValidateProtocol(svcPort.Protocol)
+func newLocalPortWatcherData(gatewayIP net.IP, recorder record.EventRecorder, localAddrSet map[string]net.IPNet) *localPortWatcherData {
+	return &localPortWatcherData{
+		gatewayIP:    gatewayIP.String(),
+		recorder:     recorder,
+		localAddrSet: localAddrSet,
+	}
+}
+
+func getLocalAddrs() (map[string]net.IPNet, error) {
+	localAddrSet := make(map[string]net.IPNet)
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, err
+	}
+	for _, addr := range addrs {
+		ip, ipNet, err := net.ParseCIDR(addr.String())
 		if err != nil {
-			klog.Errorf("Invalid service port %s: %v", svcPort.Name, err)
+			return nil, err
+		}
+		localAddrSet[ip.String()] = *ipNet
+	}
+	klog.V(5).Infof("Node local addresses initialized to: %v", localAddrSet)
+	return localAddrSet, nil
+}
+
+func (npw *localPortWatcherData) networkHasAddress(ip net.IP) bool {
+	for _, net := range npw.localAddrSet {
+		if net.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func (npw *localPortWatcherData) addService(svc *kapi.Service) error {
+	iptRules := []iptRule{}
+	for _, port := range svc.Spec.Ports {
+		if util.ServiceTypeHasNodePort(svc) {
+			if err := util.ValidatePort(port.Protocol, port.NodePort); err != nil {
+				klog.Warningf("Invalid service node port %s, err: %v", port.Name, err)
+				continue
+			}
+			iptRules = append(iptRules, getNodePortIPTRules(port, nil, npw.gatewayIP, port.NodePort)...)
+			klog.V(5).Infof("Will add iptables rule for NodePort: %v and protocol: %v", port.NodePort, port.Protocol)
+		}
+		for _, externalIP := range svc.Spec.ExternalIPs {
+			if err := util.ValidatePort(port.Protocol, port.Port); err != nil {
+				klog.Warningf("Invalid service port %s, err: %v", port.Name, err)
+				break
+			}
+			if _, exists := npw.localAddrSet[externalIP]; exists {
+				if !util.IsClusterIPSet(svc) {
+					serviceRef := kapi.ObjectReference{
+						Kind:      "Service",
+						Namespace: svc.Namespace,
+						Name:      svc.Name,
+					}
+					npw.recorder.Eventf(&serviceRef, kapi.EventTypeWarning, "UnsupportedServiceDefinition", "Unsupported service definition, headless service: %s with a local ExternalIP is not supported by ovn-kubernetes in local gateway mode", svc.Name)
+					klog.Warningf("UnsupportedServiceDefinition event for service %s in namespace %s", svc.Name, svc.Namespace)
+					continue
+				}
+				iptRules = append(iptRules, getExternalIPTRules(port, externalIP, svc.Spec.ClusterIP)...)
+				klog.V(5).Infof("Will add iptables rule for ExternalIP: %s", externalIP)
+			} else if npw.networkHasAddress(net.ParseIP(externalIP)) {
+				klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip setup", externalIP)
+			} else {
+				if stdout, stderr, err := util.RunIP("route", "replace", externalIP, "via", npw.gatewayIP, "dev", localnetGatewayNextHopPort, "table", localnetGatewayExternalIDTable); err != nil {
+					klog.Errorf("Error adding routing table entry for ExternalIP %s: stdout: %s, stderr: %s, err: %v", externalIP, stdout, stderr, err)
+				} else {
+					klog.V(5).Infof("Successfully added route for ExternalIP: %s", externalIP)
+				}
+			}
+		}
+	}
+	klog.V(5).Infof("Adding iptables rules: %v for service: %v", iptRules, svc.Name)
+	return addIptRules(iptRules)
+}
+
+func (npw *localPortWatcherData) deleteService(svc *kapi.Service) error {
+	iptRules := []iptRule{}
+	for _, port := range svc.Spec.Ports {
+		if util.ServiceTypeHasNodePort(svc) {
+			iptRules = append(iptRules, getNodePortIPTRules(port, nil, npw.gatewayIP, port.NodePort)...)
+			klog.V(5).Infof("Will delete iptables rule for NodePort: %v and protocol: %v", port.NodePort, port.Protocol)
+		}
+		for _, externalIP := range svc.Spec.ExternalIPs {
+			if _, exists := npw.localAddrSet[externalIP]; exists {
+				iptRules = append(iptRules, getExternalIPTRules(port, externalIP, svc.Spec.ClusterIP)...)
+				klog.V(5).Infof("Will delete iptables rule for ExternalIP: %s", externalIP)
+			} else if npw.networkHasAddress(net.ParseIP(externalIP)) {
+				klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip cleanup", externalIP)
+			} else {
+				if stdout, stderr, err := util.RunIP("route", "del", externalIP, "via", npw.gatewayIP, "dev", localnetGatewayNextHopPort, "table", localnetGatewayExternalIDTable); err != nil {
+					klog.Errorf("Error delete routing table entry for ExternalIP %s: stdout: %s, stderr: %s, err: %v", externalIP, stdout, stderr, err)
+				} else {
+					klog.V(5).Infof("Successfully deleted route for ExternalIP: %s", externalIP)
+				}
+			}
+		}
+	}
+	klog.V(5).Infof("Deleting iptables rules: %v for service: %v", iptRules, svc.Name)
+	return delIptRules(iptRules)
+}
+
+func (npw *localPortWatcherData) syncServices(serviceInterface []interface{}) {
+	removeStaleRoutes := func(keepRoutes []string) {
+		stdout, stderr, err := util.RunIP("route", "list", "table", localnetGatewayExternalIDTable)
+		if err != nil || stdout == "" {
+			klog.Infof("No routing table entries for ExternalIP table %s: stdout: %s, stderr: %s, err: %v", localnetGatewayExternalIDTable, stdout, stderr, err)
+			return
+		}
+		for _, existingRoute := range strings.Split(stdout, "\n") {
+			isFound := false
+			for _, keepRoute := range keepRoutes {
+				if strings.Contains(existingRoute, keepRoute) {
+					isFound = true
+					break
+				}
+			}
+			if !isFound {
+				klog.V(5).Infof("Deleting stale routing rule: %s", existingRoute)
+				if _, stderr, err := util.RunIP("route", "del", existingRoute, "table", localnetGatewayExternalIDTable); err != nil {
+					klog.Errorf("Error deleting stale routing rule: stderr: %s, err: %v", stderr, err)
+				}
+			}
+		}
+	}
+	keepIPTRules := []iptRule{}
+	keepRoutes := []string{}
+	for _, service := range serviceInterface {
+		svc, ok := service.(*kapi.Service)
+		if !ok {
+			klog.Errorf("Spurious object in syncServices: %v", serviceInterface)
 			continue
 		}
-
-		nodePort := fmt.Sprintf("%d", svcPort.NodePort)
-		rules = append(rules, iptRule{
-			table: "nat",
-			chain: iptableNodePortChain,
-			args: []string{
-				"-p", string(protocol), "--dport", nodePort,
-				"-j", "DNAT", "--to-destination", net.JoinHostPort(gatewayIP, nodePort),
-			},
-		})
-		rules = append(rules, iptRule{
-			table: "filter",
-			chain: iptableNodePortChain,
-			args: []string{
-				"-p", string(protocol), "--dport", nodePort,
-				"-j", "ACCEPT",
-			},
-		})
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, npw.gatewayIP, nil)...)
+		keepRoutes = append(keepRoutes, svc.Spec.ExternalIPs...)
 	}
-	return rules
+	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
+		recreateIPTRules("nat", chain, keepIPTRules)
+		recreateIPTRules("filter", chain, keepIPTRules)
+	}
+	removeStaleRoutes(keepRoutes)
 }
 
-type localnetNodePortWatcherData struct {
-	ipt       util.IPTablesHelper
-	gatewayIP string
-}
-
-func (npw *localnetNodePortWatcherData) addService(svc *kapi.Service) error {
-	if !util.ServiceTypeHasNodePort(svc) {
-		return nil
+func initRoutingRules() error {
+	stdout, stderr, err := util.RunIP("rule")
+	if err != nil {
+		return fmt.Errorf("error listing routing rules, stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 	}
-	rules := localnetIptRules(svc, npw.gatewayIP)
-	klog.V(5).Infof("Add rules %v for service %v", rules, svc.Name)
-	return addIptRules(npw.ipt, rules)
-}
-
-func (npw *localnetNodePortWatcherData) deleteService(svc *kapi.Service) error {
-	if !util.ServiceTypeHasNodePort(svc) {
-		return nil
+	if !strings.Contains(stdout, fmt.Sprintf("from all lookup %s", localnetGatewayExternalIDTable)) {
+		if stdout, stderr, err := util.RunIP("rule", "add", "from", "all", "table", localnetGatewayExternalIDTable); err != nil {
+			return fmt.Errorf("error adding routing rule for ExternalIP table (%s): stdout: %s, stderr: %s, err: %v", localnetGatewayExternalIDTable, stdout, stderr, err)
+		}
 	}
-	rules := localnetIptRules(svc, npw.gatewayIP)
-	klog.V(5).Infof("Delete rules %v for service %v", rules, svc.Name)
-	delIptRules(npw.ipt, rules)
 	return nil
 }
 
-func localnetNodePortWatcher(ipt util.IPTablesHelper, wf *factory.WatchFactory, gatewayIP net.IP) error {
-	// delete all the existing OVN-NODEPORT rules
-	// TODO: Add a localnetSyncService method to remove the stale entries only
-	_ = ipt.ClearChain("nat", iptableNodePortChain)
-	_ = ipt.ClearChain("filter", iptableNodePortChain)
-
-	rules := make([]iptRule, 0)
-	rules = append(rules, iptRule{
-		table: "nat",
-		chain: "PREROUTING",
-		args:  []string{"-j", iptableNodePortChain},
-	})
-	rules = append(rules, iptRule{
-		table: "nat",
-		chain: "OUTPUT",
-		args:  []string{"-j", iptableNodePortChain},
-	})
-	rules = append(rules, iptRule{
-		table: "filter",
-		chain: "FORWARD",
-		args:  []string{"-j", iptableNodePortChain},
-	})
-
-	if err := addIptRules(ipt, rules); err != nil {
+func (n *OvnNode) watchLocalPorts(npw *localPortWatcherData) error {
+	if err := initLocalGatewayIPTables(); err != nil {
 		return err
 	}
-
-	npw := &localnetNodePortWatcherData{ipt: ipt, gatewayIP: gatewayIP.String()}
-	_, err := wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
+	if err := initRoutingRules(); err != nil {
+		return err
+	}
+	_, err := n.watchFactory.AddServiceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			svc := obj.(*kapi.Service)
 			err := npw.addService(svc)
@@ -352,13 +348,11 @@ func localnetNodePortWatcher(ipt util.IPTablesHelper, wf *factory.WatchFactory, 
 				klog.Errorf("Error in deleting service - %v", err)
 			}
 		},
-	}, nil)
+	}, npw.syncServices)
 	return err
 }
 
-// cleanupLocalnetGateway cleans up Localnet Gateway
 func cleanupLocalnetGateway(physnet string) error {
-	// get bridgeName from ovn-bridge-mappings.
 	stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",
 		"external_ids:ovn-bridge-mappings")
 	if err != nil {

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -1,0 +1,781 @@
+package node
+
+import (
+	"fmt"
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/urfave/cli/v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func getFakeLocalAddrs() map[string]net.IPNet {
+	localAddrSet := make(map[string]net.IPNet)
+	for _, network := range []string{"127.0.0.1/32", "10.10.10.1/24"} {
+		ip, ipNet, err := net.ParseCIDR(network)
+		Expect(err).NotTo(HaveOccurred())
+		localAddrSet[ip.String()] = *ipNet
+	}
+	return localAddrSet
+}
+
+func initFakeNodePortWatcher(fakeOvnNode *FakeOVNNode, iptV4, iptV6 util.IPTablesHelper) *localPortWatcherData {
+	initIPTable := map[string]util.FakeTable{
+		"filter": {},
+		"nat":    {},
+	}
+
+	f4 := iptV4.(*util.FakeIPTables)
+	err := f4.MatchState(initIPTable)
+	Expect(err).NotTo(HaveOccurred())
+
+	f6 := iptV6.(*util.FakeIPTables)
+	err = f6.MatchState(initIPTable)
+	Expect(err).NotTo(HaveOccurred())
+
+	fNPW := localPortWatcherData{
+		recorder:     fakeOvnNode.recorder,
+		gatewayIP:    v4localnetGatewayIP,
+		localAddrSet: getFakeLocalAddrs(),
+	}
+	return &fNPW
+}
+
+func newServiceMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		UID:       types.UID(namespace),
+		Name:      name,
+		Namespace: namespace,
+		Labels: map[string]string{
+			"name": name,
+		},
+	}
+}
+
+func newService(name, namespace, ip string, ports []v1.ServicePort, serviceType v1.ServiceType, externalIPs []string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: newServiceMeta(name, namespace),
+		Spec: v1.ServiceSpec{
+			ClusterIP:   ip,
+			Ports:       ports,
+			Type:        serviceType,
+			ExternalIPs: externalIPs,
+		},
+	}
+}
+
+var _ = Describe("Node Operations", func() {
+
+	var (
+		app         *cli.App
+		fakeOvnNode *FakeOVNNode
+		fExec       *ovntest.FakeExec
+	)
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.PrepareTestConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		fExec = ovntest.NewFakeExec()
+		fakeOvnNode = NewFakeOVNNode(fExec)
+	})
+
+	Context("on startup", func() {
+
+		It("inits physical routing rules", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip rule",
+					Output: "0:	from all lookup local\n32766:	from all lookup main\n32767:	from all lookup default\n",
+				})
+				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
+					"ip rule add from all table " + localnetGatewayExternalIDTable,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
+					"ip route list table " + localnetGatewayExternalIDTable,
+				})
+
+				fakeOvnNode.start(ctx)
+				fakeOvnNode.node.watchLocalPorts(fNPW)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {
+						"FORWARD": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+					},
+					"nat": {
+						"PREROUTING": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OUTPUT": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-EXTERNALIP": []string{},
+					},
+				}
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				f6 := iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				fakeOvnNode.shutdown()
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("removes stale physical routing rules while keeping remaining intact", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				externalIP := "1.1.1.1"
+				externalIPPort := int32(8032)
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				// Create some fake routing and iptable rules
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip rule",
+					Output: "0:	from all lookup local\n32766:	from all lookup main\n32767:	from all lookup default\n",
+				})
+				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
+					"ip rule add from all table " + localnetGatewayExternalIDTable,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ip route list table " + localnetGatewayExternalIDTable,
+					Output: fmt.Sprintf("%s via %s dev %s\n9.9.9.9 via %s dev %s\n", externalIP, v4localnetGatewayIP, localnetGatewayNextHopPort, v4localnetGatewayIP, localnetGatewayNextHopPort),
+				})
+				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
+					fmt.Sprintf("ip route del 9.9.9.9 via %s dev %s table %s", v4localnetGatewayIP, localnetGatewayNextHopPort, localnetGatewayExternalIDTable),
+				})
+				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
+					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, localnetGatewayNextHopPort, localnetGatewayExternalIDTable),
+				})
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port:     externalIPPort,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					[]string{externalIP},
+				)
+
+				fakeRules := getExternalIPTRules(service.Spec.Ports[0], externalIP, service.Spec.ClusterIP)
+				addIptRules(fakeRules)
+				fakeRules = getExternalIPTRules(
+					v1.ServicePort{
+						Port:     27000,
+						Protocol: v1.ProtocolUDP,
+						Name:     "This is going to dissapear I hope",
+					},
+					"10.10.10.10",
+					"172.32.0.12",
+				)
+				addIptRules(fakeRules)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p UDP -d 10.10.10.10 --dport 27000 -j ACCEPT"),
+							fmt.Sprintf("-p %s -d %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port),
+						},
+					},
+					"nat": {
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p UDP -d 10.10.10.10 --dport 27000 -j DNAT --to-destination 172.32.0.12:27000"),
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+					},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				fakeOvnNode.start(ctx,
+					&v1.ServiceList{
+						Items: []v1.Service{
+							service,
+						},
+					},
+				)
+				fakeOvnNode.node.watchLocalPorts(fNPW)
+				Expect(fakeOvnNode.fakeExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
+
+				expectedTables = map[string]util.FakeTable{
+					"filter": {
+						"FORWARD": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OVN-KUBE-NODEPORT": []string{},
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port),
+						},
+					},
+					"nat": {
+						"PREROUTING": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OUTPUT": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OVN-KUBE-NODEPORT": []string{},
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+					},
+				}
+
+				f4 = iptV4.(*util.FakeIPTables)
+				err = f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				fakeOvnNode.shutdown()
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("on add", func() {
+
+		It("inits physical routing rules with ExternalIP outside any local network", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				externalIP := "1.1.1.1"
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port:     8032,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					[]string{externalIP},
+				)
+
+				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
+					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, localnetGatewayNextHopPort, localnetGatewayExternalIDTable),
+				})
+
+				fNPW.addService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {},
+					"nat":    {},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				f6 := iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does nothing when ExternalIP on shared network", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				externalIP := "10.10.10.2"
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port:     8032,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					[]string{externalIP},
+				)
+
+				fNPW.addService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {},
+					"nat":    {},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				f6 := iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("inits iptables rules when ExternalIP attached to network interface", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				externalIP := "10.10.10.1"
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port:     8032,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					[]string{externalIP},
+				)
+
+				fNPW.addService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port),
+						},
+					},
+					"nat": {
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+					},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("inits iptables rules with NodePort", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				nodePort := int32(31111)
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							NodePort: nodePort,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeNodePort,
+					nil,
+				)
+
+				fNPW.addService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {
+						"OVN-KUBE-NODEPORT": []string{
+							fmt.Sprintf("-p %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort),
+						},
+					},
+					"nat": {
+						"OVN-KUBE-NODEPORT": []string{
+							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, v4localnetGatewayIP, service.Spec.Ports[0].NodePort),
+						},
+					},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("emits event when ExternalIP attached to network interface with headless service", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				externalIP := "10.10.10.1"
+				externalIPPort := int32(8032)
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "None",
+					[]v1.ServicePort{
+						{
+							Port:     externalIPPort,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					[]string{externalIP},
+				)
+
+				fNPW.addService(&service)
+
+				// Check that event was emitted
+				recordedEvent := <-fakeOvnNode.recorder.Events
+				Expect(recordedEvent).To(ContainSubstring("UnsupportedServiceDefinition"))
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {},
+					"nat":    {},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				f6 := iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("on delete", func() {
+
+		It("deletes physical routing rules with ExternalIP outside any local network", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				externalIP := "1.1.1.1"
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port:     8032,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					[]string{externalIP},
+				)
+
+				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
+					fmt.Sprintf("ip route del %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, localnetGatewayNextHopPort, localnetGatewayExternalIDTable),
+				})
+
+				fNPW.deleteService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {},
+					"nat":    {},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				f6 := iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does nothing when ExternalIP on shared network", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				externalIP := "10.10.10.2"
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port:     8032,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					[]string{externalIP},
+				)
+
+				fNPW.deleteService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {},
+					"nat":    {},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				f6 := iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("deletes iptables rules with ExternalIP attached to network interface", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				externalIP := "10.10.10.1"
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port:     8032,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					[]string{externalIP},
+				)
+
+				fNPW.deleteService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {},
+					"nat":    {},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				f6 := iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("deletes iptables rules for NodePort", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				nodePort := int32(31111)
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							NodePort: nodePort,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeNodePort,
+					nil,
+				)
+
+				fNPW.deleteService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {},
+					"nat":    {},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				f6 := iptV6.(*util.FakeIPTables)
+				err = f6.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("on add and delete", func() {
+
+		It("manages iptables rules with ExternalIP attached to network interface", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				externalIP := "10.10.10.1"
+				externalIPPort := int32(8034)
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							Port:     externalIPPort,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					[]string{externalIP},
+				)
+
+				fNPW.addService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port),
+						},
+					},
+					"nat": {
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+					},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				fNPW.deleteService(&service)
+
+				expectedTables = map[string]util.FakeTable{
+					"filter": {
+						"OVN-KUBE-EXTERNALIP": []string{},
+					},
+					"nat": {
+						"OVN-KUBE-EXTERNALIP": []string{},
+					},
+				}
+
+				f4 = iptV4.(*util.FakeIPTables)
+				err = f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("manages iptables rules for NodePort", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				nodePort := int32(38034)
+
+				iptV4, iptV6 := util.SetFakeIPTablesHelpers()
+				fNPW := initFakeNodePortWatcher(fakeOvnNode, iptV4, iptV6)
+
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							NodePort: nodePort,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+					v1.ServiceTypeNodePort,
+					nil,
+				)
+
+				fNPW.addService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"filter": {
+						"OVN-KUBE-NODEPORT": []string{
+							fmt.Sprintf("-p %s --dport %v -j ACCEPT", service.Spec.Ports[0].Protocol, nodePort),
+						},
+					},
+					"nat": {
+						"OVN-KUBE-NODEPORT": []string{
+							fmt.Sprintf("-p %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, nodePort, v4localnetGatewayIP, service.Spec.Ports[0].NodePort),
+						},
+					},
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				fNPW.deleteService(&service)
+
+				expectedTables = map[string]util.FakeTable{
+					"filter": {
+						"OVN-KUBE-NODEPORT": []string{},
+					},
+					"nat": {
+						"OVN-KUBE-NODEPORT": []string{},
+					},
+				}
+
+				f4 = iptV4.(*util.FakeIPTables)
+				err = f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+	})
+})

--- a/go-controller/pkg/node/gateway_localnet_windows.go
+++ b/go-controller/pkg/node/gateway_localnet_windows.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 )
 
-func initLocalnetGateway(nodeName string, subnet *net.IPNet,
-	wf *factory.WatchFactory, nodeAnnotator kube.Annotator) error {
+func (n *OvnNode) initLocalnetGateway(subnet *net.IPNet, nodeAnnotator kube.Annotator) error {
 	// TODO: Implement this
 	return fmt.Errorf("not implemented yet on Windows")
 }

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -24,25 +24,37 @@ const (
 )
 
 func addService(service *kapi.Service, inport, outport, gwBridge string, nodeIP *net.IPNet) {
-	if !util.ServiceTypeHasNodePort(service) {
+	if !util.ServiceTypeHasNodePort(service) && len(service.Spec.ExternalIPs) == 0 {
 		return
 	}
 
 	for _, svcPort := range service.Spec.Ports {
-		_, err := util.ValidateProtocol(svcPort.Protocol)
-		if err != nil {
-			klog.Errorf("Skipping service add. Invalid service port %s: %v", svcPort.Name, err)
-			continue
-		}
 		protocol := strings.ToLower(string(svcPort.Protocol))
-
-		_, stderr, err := util.RunOVSOfctl("add-flow", gwBridge,
-			fmt.Sprintf("priority=100, in_port=%s, %s, tp_dst=%d, actions=%s",
-				inport, protocol, svcPort.NodePort, outport))
-		if err != nil {
-			klog.Errorf("Failed to add openflow flow on %s for nodePort "+
-				"%d, stderr: %q, error: %v", gwBridge,
-				svcPort.NodePort, stderr, err)
+		if util.ServiceTypeHasNodePort(service) {
+			if err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort); err != nil {
+				klog.Errorf("Skipping service add for svc: %s, err: %v", svcPort.Name, err)
+				continue
+			}
+			_, stderr, err := util.RunOVSOfctl("add-flow", gwBridge,
+				fmt.Sprintf("priority=100, in_port=%s, %s, tp_dst=%d, actions=%s",
+					inport, protocol, svcPort.NodePort, outport))
+			if err != nil {
+				klog.Errorf("Failed to add openflow flow on %s for nodePort: "+
+					"%d, stderr: %q, error: %v", gwBridge, svcPort.NodePort, stderr, err)
+			}
+		}
+		for _, externalIP := range service.Spec.ExternalIPs {
+			if err := util.ValidatePort(svcPort.Protocol, svcPort.Port); err != nil {
+				klog.Errorf("Skipping service add for svc: %s, err: %v", svcPort.Name, err)
+				continue
+			}
+			_, stderr, err := util.RunOVSOfctl("add-flow", gwBridge,
+				fmt.Sprintf("priority=100, in_port=%s, %s, nw_dst=%s, tp_dst=%d, actions=%s",
+					inport, protocol, externalIP, svcPort.Port, outport))
+			if err != nil {
+				klog.Errorf("Failed to add openflow flow on %s for ExternalIP: "+
+					"%s, stderr: %q, error: %v", gwBridge, externalIP, stderr, err)
+			}
 		}
 	}
 
@@ -50,34 +62,45 @@ func addService(service *kapi.Service, inport, outport, gwBridge string, nodeIP 
 }
 
 func deleteService(service *kapi.Service, inport, gwBridge string, nodeIP *net.IPNet) {
-	if !util.ServiceTypeHasNodePort(service) {
+	if !util.ServiceTypeHasNodePort(service) && len(service.Spec.ExternalIPs) == 0 {
 		return
 	}
 
 	for _, svcPort := range service.Spec.Ports {
-		_, err := util.ValidateProtocol(svcPort.Protocol)
-		if err != nil {
-			klog.Errorf("Skipping service delete. Invalid service port %s: %v", svcPort.Name, err)
-			continue
-		}
-
 		protocol := strings.ToLower(string(svcPort.Protocol))
-
-		_, stderr, err := util.RunOVSOfctl("del-flows", gwBridge,
-			fmt.Sprintf("in_port=%s, %s, tp_dst=%d",
-				inport, protocol, svcPort.NodePort))
-		if err != nil {
-			klog.Errorf("Failed to delete openflow flow on %s for nodePort "+
-				"%d, stderr: %q, error: %v", gwBridge,
-				svcPort.NodePort, stderr, err)
+		if util.ServiceTypeHasNodePort(service) {
+			if err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort); err != nil {
+				klog.Errorf("Skipping service delete, for svc: %s, err: %v", svcPort.Name, err)
+				continue
+			}
+			_, stderr, err := util.RunOVSOfctl("del-flows", gwBridge,
+				fmt.Sprintf("in_port=%s, %s, tp_dst=%d",
+					inport, protocol, svcPort.NodePort))
+			if err != nil {
+				klog.Errorf("Failed to delete openflow flow on %s for nodePort: "+
+					"%d, stderr: %q, error: %v", gwBridge, svcPort.NodePort, stderr, err)
+			}
+		}
+		for _, externalIP := range service.Spec.ExternalIPs {
+			if err := util.ValidatePort(svcPort.Protocol, svcPort.Port); err != nil {
+				klog.Errorf("Skipping service delete, for svc: %s, err: %v", svcPort.Name, err)
+				continue
+			}
+			_, stderr, err := util.RunOVSOfctl("del-flows", gwBridge,
+				fmt.Sprintf("in_port=%s, %s, nw_dst=%s, tp_dst=%d",
+					inport, protocol, externalIP, svcPort.Port))
+			if err != nil {
+				klog.Errorf("Failed to delete openflow flow on %s for ExternalIP: "+
+					"%s, stderr: %q, error: %v", gwBridge, externalIP, stderr, err)
+			}
 		}
 	}
 
 	delSharedGatewayIptRules(service, nodeIP)
 }
 
-func syncServices(services []interface{}, inport, gwBridge string) {
-	nodePorts := make(map[string]bool)
+func syncServices(services []interface{}, inport, gwBridge string, nodeIP *net.IPNet) {
+	ports := make(map[string]string)
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*kapi.Service)
 		if !ok {
@@ -86,27 +109,33 @@ func syncServices(services []interface{}, inport, gwBridge string) {
 			continue
 		}
 
-		if !util.ServiceTypeHasNodePort(service) ||
-			len(service.Spec.Ports) == 0 {
+		if !util.ServiceTypeHasNodePort(service) && len(service.Spec.ExternalIPs) == 0 {
 			continue
 		}
 
 		for _, svcPort := range service.Spec.Ports {
-			port := svcPort.NodePort
-			if port == 0 {
-				continue
+			if util.ServiceTypeHasNodePort(service) {
+				if err := util.ValidatePort(svcPort.Protocol, svcPort.NodePort); err != nil {
+					klog.Errorf("syncServices error for service port %s: %v", svcPort.Name, err)
+					continue
+				}
+				protocol := strings.ToLower(string(svcPort.Protocol))
+				nodePortKey := fmt.Sprintf("%s_%d", protocol, svcPort.NodePort)
+				ports[nodePortKey] = ""
 			}
-
-			proto, err := util.ValidateProtocol(svcPort.Protocol)
-			if err != nil {
-				klog.Errorf("syncServices error for service port %s: %v", svcPort.Name, err)
-				continue
+			for _, externalIP := range service.Spec.ExternalIPs {
+				if err := util.ValidatePort(svcPort.Protocol, svcPort.Port); err != nil {
+					klog.Errorf("syncServices error for service port %s: %v", svcPort.Name, err)
+					continue
+				}
+				protocol := strings.ToLower(string(svcPort.Protocol))
+				externalPortKey := fmt.Sprintf("%s_%d", protocol, svcPort.Port)
+				ports[externalPortKey] = externalIP
 			}
-			protocol := strings.ToLower(string(proto))
-			nodePortKey := fmt.Sprintf("%s_%d", protocol, port)
-			nodePorts[nodePortKey] = true
 		}
 	}
+
+	syncSharedGatewayIptRules(services, nodeIP)
 
 	stdout, stderr, err := util.RunOVSOfctl("dump-flows",
 		gwBridge)
@@ -139,17 +168,27 @@ func syncServices(services []interface{}, inport, gwBridge string) {
 			continue
 		}
 
-		if _, ok := nodePorts[key]; !ok {
+		if externalIP, ok := ports[key]; !ok {
 			pair := strings.Split(key, "_")
 			protocol, port := pair[0], pair[1]
-
-			stdout, _, err := util.RunOVSOfctl(
-				"del-flows", gwBridge,
-				fmt.Sprintf("in_port=%s, %s, tp_dst=%s",
-					inport, protocol, port))
-			if err != nil {
-				klog.Errorf("del-flows of %s failed: %q",
-					gwBridge, stdout)
+			if externalIP == "" {
+				stdout, _, err := util.RunOVSOfctl(
+					"del-flows", gwBridge,
+					fmt.Sprintf("in_port=%s, %s, tp_dst=%s",
+						inport, protocol, port))
+				if err != nil {
+					klog.Errorf("del-flows of %s failed: %q",
+						gwBridge, stdout)
+				}
+			} else {
+				stdout, _, err := util.RunOVSOfctl(
+					"del-flows", gwBridge,
+					fmt.Sprintf("in_port=%s, %s, nw_dst=%s, tp_dst=%s",
+						inport, protocol, externalIP, port))
+				if err != nil {
+					klog.Errorf("del-flows of %s failed: %q",
+						gwBridge, stdout)
+				}
 			}
 		}
 	}
@@ -180,8 +219,7 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet, wf 
 	// of the node. If someone on the node is trying to access the NodePort service, those packets
 	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
 	// NodePortIP:NodePort to ClusterServiceIP:Port.
-	err = createNodePortIptableChain()
-	if err != nil {
+	if err := initSharedGatewayIPTables(); err != nil {
 		return err
 	}
 
@@ -204,7 +242,7 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet, wf 
 			deleteService(service, ofportPhys, gwBridge, nodeIP[0])
 		},
 	}, func(services []interface{}) {
-		syncServices(services, ofportPhys, gwBridge)
+		syncServices(services, ofportPhys, gwBridge, nodeIP[0])
 	})
 
 	return err
@@ -430,6 +468,6 @@ func cleanupSharedGateway() error {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", bridgeName, stderr, err)
 	}
 
-	deleteNodePortIptableChain()
+	cleanupSharedGatewayIPTChains()
 	return nil
 }

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
@@ -74,116 +73,32 @@ func setupLocalNodeAccessBridge(nodeName string, subnet *net.IPNet) error {
 	return err
 }
 
-func createNodePortIptableChain() error {
-	for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
-		ipt, err := util.GetIPTablesHelper(proto)
-		if err != nil {
-			return err
-		}
-		// delete all the existing OVN-KUBE-NODEPORT rules
-		_ = ipt.ClearChain("nat", iptableNodePortChain)
-		_ = ipt.ClearChain("filter", iptableNodePortChain)
-
-		rules := make([]iptRule, 0)
-		rules = append(rules, iptRule{
-			table: "nat",
-			chain: "OUTPUT",
-			args:  []string{"-j", iptableNodePortChain},
-		})
-		rules = append(rules, iptRule{
-			table: "nat",
-			chain: "PREROUTING",
-			args:  []string{"-j", iptableNodePortChain},
-		})
-		rules = append(rules, iptRule{
-			table: "filter",
-			chain: "OUTPUT",
-			args:  []string{"-j", iptableNodePortChain},
-		})
-		rules = append(rules, iptRule{
-			table: "filter",
-			chain: "FORWARD",
-			args:  []string{"-j", iptableNodePortChain},
-		})
-
-		if err := addIptRules(ipt, rules); err != nil {
-			return fmt.Errorf("failed to add iptable rules %v: %v", rules, err)
-		}
-	}
-	return nil
-}
-
-func deleteNodePortIptableChain() {
-	for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
-		ipt, err := util.GetIPTablesHelper(proto)
-		if err != nil {
-			return
-		}
-		// delete all the existing OVN-NODEPORT rules
-		_ = ipt.ClearChain("nat", iptableNodePortChain)
-		_ = ipt.ClearChain("filter", iptableNodePortChain)
-		_ = ipt.DeleteChain("nat", iptableNodePortChain)
-		_ = ipt.DeleteChain("filter", iptableNodePortChain)
-	}
-}
-
-func getSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) []iptRule {
-	rules := make([]iptRule, 0)
-
-	for _, svcPort := range service.Spec.Ports {
-		protocol, err := util.ValidateProtocol(svcPort.Protocol)
-		if err != nil {
-			klog.Errorf("Skipping service add. Invalid service port %s: %v", svcPort.Name, err)
-			continue
-		}
-		nodePort := fmt.Sprintf("%d", svcPort.NodePort)
-		port := fmt.Sprintf("%d", svcPort.Port)
-
-		rules = append(rules, iptRule{
-			table: "nat",
-			chain: iptableNodePortChain,
-			args: []string{
-				"-p", string(protocol), "--dport", nodePort, "-d", nodeIP.IP.String(),
-				"-j", "DNAT", "--to-destination", net.JoinHostPort(service.Spec.ClusterIP, port),
-			},
-		})
-		rules = append(rules, iptRule{
-			table: "filter",
-			chain: iptableNodePortChain,
-			args: []string{
-				"-p", string(protocol), "--dport", nodePort, "-d", nodeIP.IP.String(),
-				"-j", "ACCEPT",
-			},
-		})
-	}
-	return rules
-}
-
 func addSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
-	var ipt util.IPTablesHelper
-
-	rules := getSharedGatewayIptRules(service, nodeIP)
-	// we've already checked/created iptableHelper in initNodePortIptableChain, no need to check error here.
-	if utilnet.IsIPv6String(service.Spec.ClusterIP) {
-		ipt, _ = util.GetIPTablesHelper(iptables.ProtocolIPv6)
-	} else {
-		ipt, _ = util.GetIPTablesHelper(iptables.ProtocolIPv4)
-	}
-	if err := addIptRules(ipt, rules); err != nil {
-		klog.Errorf("Failed to set up iptables rules for nodePort service %s/%s: %v",
-			service.Namespace, service.Name, err)
+	rules := getGatewayIPTRules(service, service.Spec.ClusterIP, nodeIP)
+	if err := addIptRules(rules); err != nil {
+		klog.Errorf("Failed to add iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)
 	}
 }
 
 func delSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
-	var ipt util.IPTablesHelper
-
-	rules := getSharedGatewayIptRules(service, nodeIP)
-	// we've already checked/created iptableHelper in initNodePortIptableChain, no need to check error here.
-	if utilnet.IsIPv6String(service.Spec.ClusterIP) {
-		ipt, _ = util.GetIPTablesHelper(iptables.ProtocolIPv6)
-	} else {
-		ipt, _ = util.GetIPTablesHelper(iptables.ProtocolIPv4)
+	rules := getGatewayIPTRules(service, service.Spec.ClusterIP, nodeIP)
+	if err := delIptRules(rules); err != nil {
+		klog.Errorf("Failed to delete iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)
 	}
-	delIptRules(ipt, rules)
+}
+
+func syncSharedGatewayIptRules(services []interface{}, nodeIP *net.IPNet) {
+	keepIPTRules := []iptRule{}
+	for _, service := range services {
+		svc, ok := service.(*kapi.Service)
+		if !ok {
+			klog.Errorf("Spurious object in syncSharedGatewayIptRules: %v", service)
+			continue
+		}
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, svc.Spec.ClusterIP, nodeIP)...)
+	}
+	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
+		recreateIPTRules("nat", chain, keepIPTRules)
+		recreateIPTRules("filter", chain, keepIPTRules)
+	}
 }

--- a/go-controller/pkg/node/gateway_shared_intf_windows.go
+++ b/go-controller/pkg/node/gateway_shared_intf_windows.go
@@ -1,21 +1,25 @@
 package node
 
 import (
-	kapi "k8s.io/api/core/v1"
 	"net"
+
+	kapi "k8s.io/api/core/v1"
 )
 
-func createNodePortIptableChain() error {
+func initSharedGatewayIPTables() error {
 	return nil
 }
 
-func deleteNodePortIptableChain() {
+func cleanupSharedGatewayIPTChains() {
 }
 
 func addSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
 }
 
 func delSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
+}
+
+func syncSharedGatewayIptRules(services []interface{}, nodeIP *net.IPNet) {
 }
 
 func setupLocalNodeAccessBridge(nodeName string, subnet *net.IPNet) error {

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -93,7 +93,8 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 
 	nodeSubnetCIDRs := make([]*net.IPNet, len(configs))
 	mgtPortAddrs := make([]*netlink.Addr, len(configs))
-	fakeipt := make([]*util.FakeIPTables, len(configs))
+
+	iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 	for i, cfg := range configs {
 		nodeSubnetCIDRs[i] = ovntest.MustParseIPNet(cfg.nodeSubnet)
 		mpCIDR := &net.IPNet{
@@ -103,13 +104,17 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 		mgtPortAddrs[i], err = netlink.ParseAddr(mpCIDR.String())
 		Expect(err).NotTo(HaveOccurred())
 
-		fakeipt[i], err = util.NewFakeWithProtocol(cfg.protocol)
-		Expect(err).NotTo(HaveOccurred())
-		util.SetIPTablesHelper(cfg.protocol, fakeipt[i])
-		err = fakeipt[i].NewChain("nat", "POSTROUTING")
-		Expect(err).NotTo(HaveOccurred())
-		err = fakeipt[i].NewChain("nat", "OVN-KUBE-SNAT-MGMTPORT")
-		Expect(err).NotTo(HaveOccurred())
+		if cfg.protocol == iptables.ProtocolIPv4 {
+			err = iptV4.NewChain("nat", "POSTROUTING")
+			Expect(err).NotTo(HaveOccurred())
+			err = iptV4.NewChain("nat", "OVN-KUBE-SNAT-MGMTPORT")
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			err = iptV6.NewChain("nat", "POSTROUTING")
+			Expect(err).NotTo(HaveOccurred())
+			err = iptV6.NewChain("nat", "OVN-KUBE-SNAT-MGMTPORT")
+			Expect(err).NotTo(HaveOccurred())
+		}
 	}
 
 	existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
@@ -192,7 +197,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	err = waiter.Wait()
 	Expect(err).NotTo(HaveOccurred())
 
-	for i, cfg := range configs {
+	for _, cfg := range configs {
 		expectedTables := map[string]util.FakeTable{
 			"filter": {},
 			"nat": {
@@ -204,8 +209,15 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 				},
 			},
 		}
-		err = fakeipt[i].MatchState(expectedTables)
-		Expect(err).NotTo(HaveOccurred())
+		if cfg.protocol == iptables.ProtocolIPv4 {
+			f := iptV4.(*util.FakeIPTables)
+			err = f.MatchState(expectedTables)
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			f := iptV6.(*util.FakeIPTables)
+			err = f.MatchState(expectedTables)
+			Expect(err).NotTo(HaveOccurred())
+		}
 	}
 
 	updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -11,19 +11,18 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/klog"
-
 	honode "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
 )
 
 // OvnNode is the object holder for utilities meant for node management
@@ -32,15 +31,17 @@ type OvnNode struct {
 	Kube         kube.Interface
 	watchFactory *factory.WatchFactory
 	stopChan     chan struct{}
+	recorder     record.EventRecorder
 }
 
 // NewNode creates a new controller for node management
-func NewNode(kubeClient kubernetes.Interface, wf *factory.WatchFactory, name string, stopChan chan struct{}) *OvnNode {
+func NewNode(kubeClient kubernetes.Interface, wf *factory.WatchFactory, name string, stopChan chan struct{}, eventRecorder record.EventRecorder) *OvnNode {
 	return &OvnNode{
 		name:         name,
 		Kube:         &kube.Kube{KClient: kubeClient},
 		watchFactory: wf,
 		stopChan:     stopChan,
+		recorder:     eventRecorder,
 	}
 }
 

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -1,0 +1,59 @@
+package node
+
+import (
+	. "github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+)
+
+type FakeOVNNode struct {
+	node       *OvnNode
+	watcher    *factory.WatchFactory
+	stopChan   chan struct{}
+	recorder   *record.FakeRecorder
+	fakeClient *fake.Clientset
+	fakeExec   *ovntest.FakeExec
+}
+
+func NewFakeOVNNode(fexec *ovntest.FakeExec) *FakeOVNNode {
+	err := util.SetExec(fexec)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &FakeOVNNode{
+		fakeExec: fexec,
+		recorder: record.NewFakeRecorder(1),
+	}
+}
+
+func (o *FakeOVNNode) start(ctx *cli.Context, objects ...runtime.Object) {
+	_, err := config.InitConfig(ctx, o.fakeExec, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	o.fakeClient = fake.NewSimpleClientset(objects...)
+	o.init()
+}
+
+func (o *FakeOVNNode) restart() {
+	o.shutdown()
+	o.init()
+}
+
+func (o *FakeOVNNode) shutdown() {
+	close(o.stopChan)
+}
+
+func (o *FakeOVNNode) init() {
+	var err error
+
+	o.stopChan = make(chan struct{})
+	o.watcher, err = factory.NewWatchFactory(o.fakeClient)
+	Expect(err).NotTo(HaveOccurred())
+
+	o.node = NewNode(o.fakeClient, o.watcher, "node", o.stopChan, o.recorder)
+}

--- a/go-controller/pkg/node/port_claim.go
+++ b/go-controller/pkg/node/port_claim.go
@@ -1,0 +1,193 @@
+package node
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"sync"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+)
+
+type handler func(port int32, protocol kapi.Protocol, svc *kapi.Service) error
+
+type localPort interface {
+	open(port int32, protocol kapi.Protocol, svc *kapi.Service) error
+	close(port int32, protocol kapi.Protocol, svc *kapi.Service) error
+}
+
+var port localPort
+
+type activeSocket interface {
+	Close() error
+}
+
+type portClaimWatcher struct {
+	recorder          record.EventRecorder
+	activeSocketsLock sync.Mutex
+	activeSockets     map[kapi.Protocol]map[int32]activeSocket
+}
+
+func newPortClaimWatcher(recorder record.EventRecorder) localPort {
+	return &portClaimWatcher{
+		recorder:          recorder,
+		activeSocketsLock: sync.Mutex{},
+		activeSockets:     make(map[kapi.Protocol]map[int32]activeSocket),
+	}
+}
+
+func initPortClaimWatcher(recorder record.EventRecorder, wf *factory.WatchFactory) error {
+	port = newPortClaimWatcher(recorder)
+	_, err := wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			svc := obj.(*kapi.Service)
+			if errors := addServicePortClaim(svc); len(errors) > 0 {
+				for _, err := range errors {
+					klog.Errorf("Error claiming port for service: %s/%s: %v", svc.Namespace, svc.Name, err)
+				}
+			}
+		},
+		UpdateFunc: func(old, new interface{}) {
+			oldSvc := old.(*kapi.Service)
+			newSvc := new.(*kapi.Service)
+			if errors := updateServicePortClaim(oldSvc, newSvc); len(errors) > 0 {
+				for _, err := range errors {
+					klog.Errorf("Error updating port claim for service: %s/%s: %v", oldSvc.Namespace, oldSvc.Name, err)
+				}
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			svc := obj.(*kapi.Service)
+			if errors := deleteServicePortClaim(svc); len(errors) > 0 {
+				for _, err := range errors {
+					klog.Errorf("Error removing port claim for service: %s/%s: %v", svc.Namespace, svc.Name, err)
+				}
+			}
+		},
+	}, nil)
+	return err
+}
+
+func addServicePortClaim(svc *kapi.Service) []error {
+	return handleService(svc, port.open)
+}
+
+func deleteServicePortClaim(svc *kapi.Service) []error {
+	return handleService(svc, port.close)
+}
+
+func handleService(svc *kapi.Service, handler handler) []error {
+	errors := []error{}
+	if !util.ServiceTypeHasNodePort(svc) && len(svc.Spec.ExternalIPs) == 0 {
+		return errors
+	}
+	for _, svcPort := range svc.Spec.Ports {
+		if util.ServiceTypeHasNodePort(svc) {
+			if err := handlePort(svc, svcPort.NodePort, svcPort.Protocol, handler); err != nil {
+				errors = append(errors, err)
+			}
+		}
+		if len(svc.Spec.ExternalIPs) > 0 {
+			if err := handlePort(svc, svcPort.Port, svcPort.Protocol, handler); err != nil {
+				errors = append(errors, err)
+			}
+		}
+	}
+	return errors
+}
+
+func handlePort(svc *kapi.Service, port int32, protocol kapi.Protocol, handler handler) error {
+	if err := util.ValidatePort(protocol, port); err != nil {
+		return fmt.Errorf("invalid service port %s, err: %v", svc.Name, err)
+	}
+	if err := handler(port, protocol, svc); err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateServicePortClaim(oldSvc, newSvc *kapi.Service) []error {
+	if reflect.DeepEqual(oldSvc.Spec.ExternalIPs, newSvc.Spec.ExternalIPs) && reflect.DeepEqual(oldSvc.Spec.Ports, newSvc.Spec.Ports) {
+		return nil
+	}
+	errors := []error{}
+	errors = append(errors, deleteServicePortClaim(oldSvc)...)
+	errors = append(errors, addServicePortClaim(newSvc)...)
+	return errors
+}
+
+func (p *portClaimWatcher) open(port int32, protocol kapi.Protocol, svc *kapi.Service) error {
+	klog.V(5).Infof("Opening socket for service: %s/%s and port: %v", svc.Namespace, svc.Name, port)
+	var socket activeSocket
+	var socketError error
+	switch protocol {
+	case kapi.ProtocolTCP:
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			socketError = err
+			break
+		}
+		socket = listener
+	case kapi.ProtocolUDP:
+		addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			socketError = err
+			break
+		}
+		conn, err := net.ListenUDP("udp", addr)
+		if err != nil {
+			socketError = err
+			break
+		}
+		socket = conn
+	case kapi.ProtocolSCTP:
+		// Do not open ports for SCTP, ref: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0015-20180614-SCTP-support.md#the-solution-in-the-kubernetes-sctp-support-implementation
+		return nil
+	default:
+		socketError = fmt.Errorf("unknown protocol %q", protocol)
+	}
+	if socketError != nil {
+		p.emitPortClaimEvent(svc, port, socketError)
+		return socketError
+	}
+	p.activeSocketsLock.Lock()
+	defer p.activeSocketsLock.Unlock()
+	if _, exists := p.activeSockets[protocol]; exists {
+		p.activeSockets[protocol][port] = socket
+	} else {
+		p.activeSockets[protocol] = map[int32]activeSocket{
+			port: socket,
+		}
+	}
+	return nil
+}
+
+func (p *portClaimWatcher) close(port int32, protocol kapi.Protocol, svc *kapi.Service) error {
+	p.activeSocketsLock.Lock()
+	defer p.activeSocketsLock.Unlock()
+	klog.V(5).Infof("Closing socket claimed for service: %s/%s and port: %v", svc.Namespace, svc.Name, port)
+	if socket, exists := p.activeSockets[protocol][port]; exists {
+		if err := socket.Close(); err != nil {
+			return fmt.Errorf("error closing socket for svc: %s/%s on port: %v, err: %v", svc.Namespace, svc.Name, port, err)
+		}
+		delete(p.activeSockets[protocol], port)
+		return nil
+	}
+	return fmt.Errorf("error closing socket for svc: %s/%s on port: %v, port was never opened...?", svc.Namespace, svc.Name, port)
+}
+
+func (p *portClaimWatcher) emitPortClaimEvent(svc *kapi.Service, port int32, err error) {
+	serviceRef := kapi.ObjectReference{
+		Kind:      "Service",
+		Namespace: svc.Namespace,
+		Name:      svc.Name,
+	}
+	p.recorder.Eventf(&serviceRef, kapi.EventTypeWarning,
+		"PortClaim", "Service: %s/%s requires port: %v to be opened on node, but port cannot be opened, err: %v", svc.Namespace, svc.Name, port, err)
+	klog.Warningf("PortClaim for svc: %s/%s on port: %v, err: %v", svc.Namespace, svc.Name, port, err)
+}

--- a/go-controller/pkg/node/port_claim_test.go
+++ b/go-controller/pkg/node/port_claim_test.go
@@ -1,0 +1,525 @@
+package node
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/urfave/cli/v2"
+	kapi "k8s.io/api/core/v1"
+)
+
+type testPortClaimWatcher struct {
+	tPortOpen       []int32
+	tPortClose      []int32
+	tProtocolOpen   []kapi.Protocol
+	tPortOpenCount  int
+	tPortCloseCount int
+	tActiveSockets  map[kapi.Protocol]map[int32]bool
+}
+
+func (p *testPortClaimWatcher) open(port int32, protocol kapi.Protocol, svc *kapi.Service) error {
+	if _, exists := p.tActiveSockets[protocol]; exists {
+		p.tActiveSockets[protocol][port] = true
+	} else {
+		p.tActiveSockets[protocol] = map[int32]bool{
+			port: true,
+		}
+	}
+	Expect(p.tActiveSockets).To(HaveKey(protocol))
+	Expect(p.tActiveSockets[protocol]).To(HaveKey(port))
+	Expect(port).To(Equal(p.tPortOpen[p.tPortOpenCount]))
+	Expect(protocol).To(Equal(p.tProtocolOpen[p.tPortOpenCount]))
+	p.tPortOpenCount++
+	return nil
+}
+
+func (p *testPortClaimWatcher) close(port int32, protocol kapi.Protocol, svc *kapi.Service) error {
+	if _, exists := p.tActiveSockets[protocol][port]; exists {
+		delete(p.tActiveSockets[protocol], port)
+	}
+	Expect(p.tActiveSockets).To(HaveKey(protocol))
+	Expect(p.tActiveSockets[protocol]).ToNot(HaveKey(port))
+	Expect(port).To(Equal(p.tPortClose[p.tPortCloseCount]))
+	p.tPortCloseCount++
+	return nil
+}
+
+var _ = Describe("Node Operations", func() {
+
+	var (
+		app *cli.App
+	)
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.PrepareTestConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+	})
+	Context("on add service", func() {
+
+		It("should open a port for ExternalIP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortOpen:      []int32{8080, 9999},
+					tProtocolOpen:  []kapi.Protocol{kapi.ProtocolTCP, kapi.ProtocolTCP},
+					tActiveSockets: make(map[kapi.Protocol]map[int32]bool),
+				}
+
+				service := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							Port:     8080,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							Port:     9999,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeClusterIP,
+					[]string{"8.8.8.8"},
+				)
+
+				errors := addServicePortClaim(service)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortOpenCount).To(Equal(len(service.Spec.Ports)))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should open a NodePort", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortOpen:      []int32{32222, 31111},
+					tProtocolOpen:  []kapi.Protocol{kapi.ProtocolTCP, kapi.ProtocolTCP},
+					tActiveSockets: make(map[kapi.Protocol]map[int32]bool),
+				}
+
+				service := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							NodePort: 32222,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							NodePort: 31111,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeNodePort,
+					[]string{},
+				)
+
+				errors := addServicePortClaim(service)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortOpenCount).To(Equal(len(service.Spec.Ports)))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should open a NodePort and port for ExternalIP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortOpen:      []int32{32222, 8081, 31111, 8080},
+					tProtocolOpen:  []kapi.Protocol{kapi.ProtocolTCP, kapi.ProtocolTCP, kapi.ProtocolTCP, kapi.ProtocolTCP},
+					tActiveSockets: make(map[kapi.Protocol]map[int32]bool),
+				}
+
+				service := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							NodePort: 32222,
+							Port:     8081,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							NodePort: 31111,
+							Port:     8080,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeNodePort,
+					[]string{"8.8.8.8"},
+				)
+
+				errors := addServicePortClaim(service)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortOpenCount).To(Equal(len(service.Spec.Ports) * 2))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should open per protocol NodePorts and ExternalIPs ports", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortOpen:      []int32{32222, 8081, 32222, 8081},
+					tProtocolOpen:  []kapi.Protocol{kapi.ProtocolTCP, kapi.ProtocolTCP, kapi.ProtocolUDP, kapi.ProtocolUDP},
+					tActiveSockets: make(map[kapi.Protocol]map[int32]bool),
+				}
+
+				service := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							NodePort: 32222,
+							Port:     8081,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							NodePort: 32222,
+							Port:     8081,
+							Protocol: kapi.ProtocolUDP,
+						},
+					},
+					kapi.ServiceTypeNodePort,
+					[]string{"8.8.8.8"},
+				)
+
+				errors := addServicePortClaim(service)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortOpenCount).To(Equal(len(service.Spec.Ports) * 2))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not open a port for ClusterIP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{}
+
+				service := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							Port:     8081,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							Port:     8080,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeClusterIP,
+					[]string{},
+				)
+
+				errors := addServicePortClaim(service)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortOpenCount).To(Equal(0))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("on delete service", func() {
+
+		It("should not do anything ports for ClusterIP updates", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortClose: []int32{8080, 9999},
+				}
+
+				oldService := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							Port:     8080,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							Port:     9999,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeClusterIP,
+					[]string{},
+				)
+				newService := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							Port:     8080,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							Port:     9999,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeClusterIP,
+					[]string{},
+				)
+
+				errors := updateServicePortClaim(oldService, newService)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortOpenCount).To(Equal(0))
+				Expect(fakePort.tPortCloseCount).To(Equal(0))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should only remove ports when ExternalIP -> no ExternalIP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortClose: []int32{8080, 9999},
+					tActiveSockets: map[kapi.Protocol]map[int32]bool{
+						kapi.ProtocolTCP: {
+							8080: true,
+							9999: true,
+						},
+					},
+				}
+
+				oldService := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							Port:     8080,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							Port:     9999,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeClusterIP,
+					[]string{"8.8.8.8"},
+				)
+				newService := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							Port:     8080,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							Port:     9999,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeClusterIP,
+					[]string{},
+				)
+
+				errors := updateServicePortClaim(oldService, newService)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortOpenCount).To(Equal(0))
+				Expect(fakePort.tPortCloseCount).To(Equal(len(oldService.Spec.Ports)))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+	})
+
+	Context("on delete service", func() {
+
+		It("should close ports for ExternalIP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortClose: []int32{8080, 9999},
+					tActiveSockets: map[kapi.Protocol]map[int32]bool{
+						kapi.ProtocolTCP: {
+							8080: true,
+							9999: true,
+						},
+					},
+				}
+
+				service := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							Port:     8080,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							Port:     9999,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeClusterIP,
+					[]string{"8.8.8.8", "10.10.10.10"},
+				)
+
+				errors := deleteServicePortClaim(service)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortCloseCount).To(Equal(len(service.Spec.Ports)))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should close a NodePort and port for ExternalIP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortClose: []int32{32222, 8081, 31111, 8080},
+					tActiveSockets: map[kapi.Protocol]map[int32]bool{
+						kapi.ProtocolTCP: {
+							8080:  true,
+							8081:  true,
+							32222: true,
+							31111: true,
+						},
+					},
+				}
+
+				service := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							NodePort: 32222,
+							Port:     8081,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							NodePort: 31111,
+							Port:     8080,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeNodePort,
+					[]string{"8.8.8.8"},
+				)
+
+				errors := deleteServicePortClaim(service)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortCloseCount).To(Equal(len(service.Spec.Ports) * 2))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should close per protocol for NodePort and ExternalIP ports", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortClose: []int32{32222, 8081, 32222, 8081},
+					tActiveSockets: map[kapi.Protocol]map[int32]bool{
+						kapi.ProtocolTCP: {
+							8081:  true,
+							32222: true,
+						},
+						kapi.ProtocolUDP: {
+							8081:  true,
+							32222: true,
+						},
+					},
+				}
+
+				service := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							NodePort: 32222,
+							Port:     8081,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							NodePort: 32222,
+							Port:     8081,
+							Protocol: kapi.ProtocolUDP,
+						},
+					},
+					kapi.ServiceTypeNodePort,
+					[]string{"8.8.8.8"},
+				)
+
+				errors := deleteServicePortClaim(service)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortCloseCount).To(Equal(len(service.Spec.Ports) * 2))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should close ports for NodePort", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				port = &testPortClaimWatcher{
+					tPortClose: []int32{31100, 32200},
+					tActiveSockets: map[kapi.Protocol]map[int32]bool{
+						kapi.ProtocolTCP: {
+							31100: true,
+							32200: true,
+						},
+					},
+				}
+
+				service := newService("service1", "namespace1", "10.129.0.2",
+					[]kapi.ServicePort{
+						{
+							NodePort: 31100,
+							Protocol: kapi.ProtocolTCP,
+						},
+						{
+							NodePort: 32200,
+							Protocol: kapi.ProtocolTCP,
+						},
+					},
+					kapi.ServiceTypeNodePort,
+					[]string{},
+				)
+
+				errors := deleteServicePortClaim(service)
+				Expect(errors).To(HaveLen(0))
+
+				fakePort := port.(*testPortClaimWatcher)
+				Expect(fakePort.tPortCloseCount).To(Equal(len(service.Spec.Ports)))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -81,7 +81,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 			var loadBalancer string
 			loadBalancer, err = ovn.getLoadBalancer(svcPort.Protocol)
 			if err != nil {
-				klog.Errorf("Failed to get loadbalancer for %s (%v)", svcPort.Protocol, err)
+				klog.Errorf("Failed to get load balancer for %s (%v)", svcPort.Protocol, err)
 				continue
 			}
 			if err = ovn.createLoadBalancerVIPs(loadBalancer, []string{svc.Spec.ClusterIP}, svcPort.Port, lbEps.IPs, lbEps.Port); err != nil {
@@ -98,7 +98,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 				for _, gateway := range gateways {
 					loadBalancer, err := ovn.getGatewayLoadBalancer(gateway, svcPort.Protocol)
 					if err != nil {
-						klog.Errorf("Physical gateway %s does not have load_balancer (%v)", gateway, err)
+						klog.Errorf("Gateway router %s does not have load balancer (%v)", gateway, err)
 						continue
 					}
 					if err = ovn.createLoadBalancerVIPs(loadBalancer, svc.Spec.ExternalIPs, svcPort.Port, lbEps.IPs, lbEps.Port); err != nil {
@@ -112,9 +112,9 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 }
 
 func (ovn *Controller) handleNodePortLB(node *kapi.Node) error {
-	physicalGateway := gwRouterPrefix + node.Name
+	gatewayRouter := gwRouterPrefix + node.Name
 	var physicalIPs []string
-	if physicalIPs, _ = ovn.getGatewayPhysicalIPs(physicalGateway); physicalIPs == nil {
+	if physicalIPs, _ = ovn.getGatewayPhysicalIPs(gatewayRouter); physicalIPs == nil {
 		return fmt.Errorf("gateway physical IP for node %q does not yet exist", node.Name)
 	}
 	namespaces, err := ovn.watchFactory.GetNamespaces()
@@ -141,7 +141,7 @@ func (ovn *Controller) handleNodePortLB(node *kapi.Node) error {
 				if !isFound {
 					continue
 				}
-				k8sNSLb, _ := ovn.getGatewayLoadBalancer(physicalGateway, svcPort.Protocol)
+				k8sNSLb, _ := ovn.getGatewayLoadBalancer(gatewayRouter, svcPort.Protocol)
 				if k8sNSLb == "" {
 					return fmt.Errorf("%s load balancer for node %q does not yet exist", svcPort.Protocol, node.Name)
 				}
@@ -173,7 +173,7 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		var lb string
 		lb, err = ovn.getLoadBalancer(svcPort.Protocol)
 		if err != nil {
-			klog.Errorf("Failed to get load-balancer for %s (%v)", lb, err)
+			klog.Errorf("Failed to get load balancer for %s (%v)", lb, err)
 			continue
 		}
 

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -50,17 +50,15 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 	if err != nil {
 		// This is not necessarily an error. For e.g when there are endpoints
 		// without a corresponding service.
-		klog.V(5).Infof("No service found for endpoint %s in namespace %s",
-			ep.Name, ep.Namespace)
+		klog.V(5).Infof("No service found for endpoint %s in namespace %s", ep.Name, ep.Namespace)
 		return nil
 	}
 	if !util.IsClusterIPSet(svc) {
-		klog.V(5).Infof("Skipping service %s due to clusterIP = %q",
-			svc.Name, svc.Spec.ClusterIP)
+		klog.V(5).Infof("Skipping service %s due to clusterIP = %q", svc.Name, svc.Spec.ClusterIP)
 		return nil
 	}
-	klog.V(5).Infof("Matching service %s found for ep: %s, with cluster IP: %s", svc.Name, ep.Name,
-		svc.Spec.ClusterIP)
+
+	klog.V(5).Infof("Matching service %s found for ep: %s, with cluster IP: %s", svc.Name, ep.Name, svc.Spec.ClusterIP)
 
 	protoPortMap := ovn.getLbEndpoints(ep)
 	klog.V(5).Infof("Matching service %s ports: %v", svc.Name, svc.Spec.Ports)
@@ -74,8 +72,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 			continue
 		}
 		if util.ServiceTypeHasNodePort(svc) {
-			err = ovn.createGatewayVIPs(svcPort.Protocol, svcPort.NodePort, lbEps.IPs, lbEps.Port)
-			if err != nil {
+			if err := ovn.createGatewayVIPs(svcPort.Protocol, svcPort.NodePort, lbEps.IPs, lbEps.Port); err != nil {
 				klog.Errorf("Error in creating Node Port for svc %s, node port: %d - %v\n", svc.Name, svcPort.NodePort, err)
 				continue
 			}
@@ -101,11 +98,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 				for _, gateway := range gateways {
 					loadBalancer, err := ovn.getGatewayLoadBalancer(gateway, svcPort.Protocol)
 					if err != nil {
-						klog.Errorf("Physical gateway %s does not have load_balancer "+
-							"(%v)", gateway, err)
-						continue
-					}
-					if loadBalancer == "" {
+						klog.Errorf("Physical gateway %s does not have load_balancer (%v)", gateway, err)
 						continue
 					}
 					if err = ovn.createLoadBalancerVIPs(loadBalancer, svc.Spec.ExternalIPs, svcPort.Port, lbEps.IPs, lbEps.Port); err != nil {

--- a/go-controller/pkg/ovn/endpoints_test.go
+++ b/go-controller/pkg/ovn/endpoints_test.go
@@ -13,6 +13,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -95,7 +96,26 @@ func (e endpoints) addCmds(fexec *ovntest.FakeExec, service v1.Service, endpoint
 	})
 }
 
-func (e endpoints) delCmds(fexec *ovntest.FakeExec, service v1.Service) {
+func (e endpoints) addExternalIPCmds(fexec *ovntest.FakeExec, loadBalancerIPs []string, service v1.Service, endpoint v1.Endpoints) {
+	gatewayRouters := "GR_1 GR_2"
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+		Output: gatewayRouters,
+	})
+	for idx, gatewayR := range strings.Fields(gatewayRouters) {
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=" + gatewayR,
+			Output: "load_balancer_" + string(idx),
+		})
+		for _, loadBalancerIP := range loadBalancerIPs {
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				fmt.Sprintf("ovn-nbctl --timeout=15 set load_balancer load_balancer_%s vips:\"%s:%v\"=\"%s:%v\"", string(idx), loadBalancerIP, service.Spec.Ports[0].Port, endpoint.Subsets[0].Addresses[0].IP, endpoint.Subsets[0].Ports[0].Port),
+			})
+		}
+	}
+}
+
+func (e endpoints) delCmds(fexec *ovntest.FakeExec, service v1.Service, endpoint v1.Endpoints) {
 	for _, sPort := range service.Spec.Ports {
 		if sPort.Protocol == v1.ProtocolTCP {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -164,8 +184,131 @@ var _ = Describe("OVN Namespace Operations", func() {
 						},
 					},
 					v1.ServiceTypeClusterIP,
+					nil,
 				)
 
+				testE.addCmds(tExec, serviceT, endpointsT)
+
+				fakeOvn.start(ctx,
+					&v1.EndpointsList{
+						Items: []v1.Endpoints{
+							endpointsT,
+						},
+					},
+					&v1.ServiceList{
+						Items: []v1.Service{
+							serviceT,
+						},
+					},
+				)
+				fakeOvn.controller.WatchEndpoints()
+
+				_, err := fakeOvn.fakeClient.CoreV1().Endpoints(endpointsT.Namespace).Get(endpointsT.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tExec.CalledMatchesExpected()).To(BeTrue(), tExec.ErrorDesc)
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("reconciles existing endpoints with ExternalIP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				testE := endpoints{}
+
+				loadBalancerIPs := []string{"1.1.1.1", "192.168.126.11"}
+
+				endpointsT := *newEndpoints("endpoint-service1", "namespace1",
+					[]v1.EndpointAddress{
+						{
+							IP: "10.125.0.2",
+						},
+					},
+					[]v1.EndpointPort{
+						{
+							Name:     "portTcp1",
+							Port:     8080,
+							Protocol: v1.ProtocolTCP,
+						},
+					})
+
+				serviceT := *newService("endpoint-service1", "namespace1", "172.124.0.2",
+					[]v1.ServicePort{
+						{
+							Name:       "portTcp1",
+							Port:       9100,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+					v1.ServiceTypeClusterIP,
+					loadBalancerIPs,
+				)
+
+				testE.addCmds(tExec, serviceT, endpointsT)
+				testE.addExternalIPCmds(tExec, loadBalancerIPs, serviceT, endpointsT)
+
+				fakeOvn.start(ctx,
+					&v1.EndpointsList{
+						Items: []v1.Endpoints{
+							endpointsT,
+						},
+					},
+					&v1.ServiceList{
+						Items: []v1.Service{
+							serviceT,
+						},
+					},
+				)
+				fakeOvn.controller.WatchEndpoints()
+
+				_, err := fakeOvn.fakeClient.CoreV1().Endpoints(endpointsT.Namespace).Get(endpointsT.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tExec.CalledMatchesExpected()).To(BeTrue(), tExec.ErrorDesc)
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("reconciles existing endpoints with NodePort", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				testE := endpoints{}
+
+				endpointsT := *newEndpoints("endpoint-service1", "namespace1",
+					[]v1.EndpointAddress{
+						{
+							IP: "10.125.0.2",
+						},
+					},
+					[]v1.EndpointPort{
+						{
+							Name:     "portTcp1",
+							Port:     8080,
+							Protocol: v1.ProtocolTCP,
+						},
+					})
+
+				serviceT := *newService("endpoint-service1", "namespace1", "172.124.0.2",
+					[]v1.ServicePort{
+						{
+							Name:       "portTcp1",
+							NodePort:   31111,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+					v1.ServiceTypeNodePort,
+					nil,
+				)
+
+				testE.addNodePortPortCmds(tExec, serviceT, endpointsT)
 				testE.addCmds(tExec, serviceT, endpointsT)
 
 				fakeOvn.start(ctx,
@@ -221,6 +364,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 						},
 					},
 					v1.ServiceTypeClusterIP,
+					nil,
 				)
 				testE.addCmds(tExec, serviceT, endpointsT)
 
@@ -243,7 +387,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 				Eventually(tExec.CalledMatchesExpected).Should(BeTrue(), tExec.ErrorDesc)
 
 				// Delete the endpoint
-				testE.delCmds(tExec, serviceT)
+				testE.delCmds(tExec, serviceT, endpointsT)
 
 				err = fakeOvn.fakeClient.CoreV1().Endpoints(endpointsT.Namespace).Delete(endpointsT.Name, metav1.NewDeleteOptions(0))
 				Expect(err).NotTo(HaveOccurred())
@@ -284,6 +428,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 						},
 					},
 					v1.ServiceTypeNodePort,
+					nil,
 				)
 				testE.addNodePortPortCmds(tExec, serviceT, endpointsT)
 				testE.addCmds(tExec, serviceT, endpointsT)
@@ -307,7 +452,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 				Eventually(tExec.CalledMatchesExpected).Should(BeTrue(), tExec.ErrorDesc)
 
 				// Delete the endpoint
-				testE.delCmds(tExec, serviceT)
+				testE.delCmds(tExec, serviceT, endpointsT)
 				testE.delNodePortPortCmds(tExec, serviceT, endpointsT)
 
 				err = fakeOvn.fakeClient.CoreV1().Endpoints(endpointsT.Namespace).Delete(endpointsT.Name, metav1.NewDeleteOptions(0))

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -244,7 +244,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 			"stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 	}
 
-	// Add static routes in GR with physical gateway as the default next hop.
+	// Add static routes in GR with gateway router as the default next hop.
 	for _, nextHop := range l3GatewayConfig.NextHops {
 		var allIPs string
 		if utilnet.IsIPv6(nextHop) {

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -24,12 +24,6 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 
 		err := util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
-
-		name, ip, err := getDefaultGatewayRouterIP()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(name).To(Equal("node1"))
-		Expect(ip.String()).To(Equal("100.64.0.1"))
-		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 	})
 
 	It("ignores malformatted gateway router entires", func() {
@@ -44,12 +38,6 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 
 		err := util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
-
-		name, ip, err := getDefaultGatewayRouterIP()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(name).To(Equal("node4"))
-		Expect(ip.String()).To(Equal("100.64.0.4"))
-		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 	})
 
 	It("creates an IPv4 gateway in OVN", func() {

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -37,7 +37,7 @@ func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string, error) {
 		return "", err
 	}
 	if out == "" {
-		return "", fmt.Errorf("no load-balancer found in the database")
+		return "", fmt.Errorf("no load balancer found in the database")
 	}
 	ovn.loadbalancerClusterCache[protocol] = out
 	return out, nil
@@ -51,7 +51,7 @@ func (ovn *Controller) getLoadBalancerVIPs(loadBalancer string) (map[string]inte
 		return nil, err
 	}
 	if outStr == "" {
-		return nil, fmt.Errorf("loadBalancer vips in OVN DB is an empty string")
+		return nil, fmt.Errorf("load balancer vips in OVN DB is an empty string")
 	}
 	// sample outStr:
 	// - {"192.168.0.1:80"="10.1.1.1:80,10.2.2.2:80"}

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -51,7 +51,7 @@ func (ovn *Controller) getLoadBalancerVIPs(loadBalancer string) (map[string]inte
 		return nil, err
 	}
 	if outStr == "" {
-		return nil, nil
+		return nil, fmt.Errorf("loadBalancer vips in OVN DB is an empty string")
 	}
 	// sample outStr:
 	// - {"192.168.0.1:80"="10.1.1.1:80,10.2.2.2:80"}

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -43,30 +43,6 @@ func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string, error) {
 	return out, nil
 }
 
-// getDefaultGatewayLoadBalancer returns the load balancer for the node with the lowest gateway IP.
-// This is used in the implementation of ExternalIPs
-func (ovn *Controller) getDefaultGatewayLoadBalancer(protocol kapi.Protocol) string {
-	if outStr, ok := ovn.loadbalancerGWCache[protocol]; ok {
-		return outStr
-	}
-
-	gw, _, err := getDefaultGatewayRouterIP()
-	if err != nil {
-		klog.Errorf(err.Error())
-		return ""
-	}
-
-	externalIDKey := string(protocol) + "_lb_gateway_router"
-	lb, _, _ := util.RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=_uuid", "find", "load_balancer",
-		"external_ids:"+externalIDKey+"="+gw)
-	if len(lb) != 0 {
-		ovn.loadbalancerGWCache[protocol] = lb
-		ovn.defGatewayRouter = gw
-	}
-	return lb
-}
-
 // getLoadBalancerVIPs returns a map whose keys are VIPs (IP:port) on loadBalancer
 func (ovn *Controller) getLoadBalancerVIPs(loadBalancer string) (map[string]interface{}, error) {
 	outStr, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
@@ -91,19 +67,19 @@ func (ovn *Controller) getLoadBalancerVIPs(loadBalancer string) (map[string]inte
 }
 
 // deleteLoadBalancerVIP removes the VIP as well as any reject ACLs associated to the LB
-func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) {
+func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) error {
 	vipQuotes := fmt.Sprintf("\"%s\"", vip)
 	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove", "load_balancer", loadBalancer, "vips", vipQuotes)
 	if err != nil {
-		klog.Errorf("Error in deleting load balancer vip %s for %s"+
+		// if we hit an error and fail to remove load balancer, we skip removing the rejectACL
+		return fmt.Errorf("error in deleting load balancer vip %s for %s"+
 			"stdout: %q, stderr: %q, error: %v",
 			vip, loadBalancer, stdout, stderr, err)
-		// if we hit an error and fail to remove load balancer, we skip removing the rejectACL
-		return
 	}
 	ovn.removeServiceEndpoints(loadBalancer, vip)
 	ovn.deleteLoadBalancerRejectACL(loadBalancer, vip)
 	ovn.removeServiceLB(loadBalancer, vip)
+	return nil
 }
 
 // configureLoadBalancer updates the VIP for sourceIP:sourcePort to point to targets (an

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -269,40 +269,40 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 	// Create 3 load-balancers for east-west traffic for UDP, TCP, SCTP
 	oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes")
 	if err != nil {
-		klog.Errorf("Failed to get tcp load-balancer, stderr: %q, error: %v", stderr, err)
+		klog.Errorf("Failed to get tcp load balancer, stderr: %q, error: %v", stderr, err)
 		return err
 	}
 
 	if oc.TCPLoadBalancerUUID == "" {
 		oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes", "protocol=tcp")
 		if err != nil {
-			klog.Errorf("Failed to create tcp load-balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+			klog.Errorf("Failed to create tcp load balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 			return err
 		}
 	}
 
 	oc.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes")
 	if err != nil {
-		klog.Errorf("Failed to get udp load-balancer, stderr: %q, error: %v", stderr, err)
+		klog.Errorf("Failed to get udp load balancer, stderr: %q, error: %v", stderr, err)
 		return err
 	}
 	if oc.UDPLoadBalancerUUID == "" {
 		oc.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes", "protocol=udp")
 		if err != nil {
-			klog.Errorf("Failed to create udp load-balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+			klog.Errorf("Failed to create udp load balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 			return err
 		}
 	}
 
 	oc.SCTPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-sctp=yes")
 	if err != nil {
-		klog.Errorf("Failed to get sctp load-balancer, stderr: %q, error: %v", stderr, err)
+		klog.Errorf("Failed to get sctp load balancer, stderr: %q, error: %v", stderr, err)
 		return err
 	}
 	if oc.SCTPLoadBalancerUUID == "" && oc.SCTPSupport {
 		oc.SCTPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-sctp=yes", "protocol=sctp")
 		if err != nil {
-			klog.Errorf("Failed to create sctp load-balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+			klog.Errorf("Failed to create sctp load balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 			return err
 		}
 	}
@@ -466,13 +466,13 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 		err = oc.handleNodePortLB(node)
 	} else {
 		// nodePort disabled, delete gateway load balancers for this node.
-		physicalGateway := "GR_" + node.Name
+		gatewayRouter := "GR_" + node.Name
 		for _, proto := range []kapi.Protocol{kapi.ProtocolTCP, kapi.ProtocolUDP, kapi.ProtocolSCTP} {
-			lbUUID, _ := oc.getGatewayLoadBalancer(physicalGateway, proto)
+			lbUUID, _ := oc.getGatewayLoadBalancer(gatewayRouter, proto)
 			if lbUUID != "" {
 				_, _, err := util.RunOVNNbctl("--if-exists", "destroy", "load_balancer", lbUUID)
 				if err != nil {
-					klog.Errorf("Failed to destroy %s load balancer for gateway %s: %v", proto, physicalGateway, err)
+					klog.Errorf("Failed to destroy %s load balancer for gateway %s: %v", proto, gatewayRouter, err)
 				}
 			}
 		}
@@ -593,7 +593,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 	}
 	stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch", nodeName, "load_balancer="+oc.TCPLoadBalancerUUID)
 	if err != nil {
-		klog.Errorf("Failed to set logical switch %v's loadbalancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
+		klog.Errorf("Failed to set logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 		return err
 	}
 
@@ -611,7 +611,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 	}
 	stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", oc.UDPLoadBalancerUUID)
 	if err != nil {
-		klog.Errorf("Failed to add logical switch %v's loadbalancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
+		klog.Errorf("Failed to add logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 		return err
 	}
 
@@ -630,7 +630,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 		}
 		stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", oc.SCTPLoadBalancerUUID)
 		if err != nil {
-			klog.Errorf("Failed to add logical switch %v's loadbalancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
+			klog.Errorf("Failed to add logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 			return err
 		}
 

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -292,10 +292,9 @@ func (ovn *Controller) updateService(oldSvc, newSvc *kapi.Service) error {
 }
 
 func (ovn *Controller) deleteService(service *kapi.Service) {
-	if !util.IsClusterIPSet(service) || len(service.Spec.Ports) == 0 {
+	if !util.IsClusterIPSet(service) {
 		return
 	}
-
 	for _, svcPort := range service.Spec.Ports {
 		var port int32
 		if util.ServiceTypeHasNodePort(service) {
@@ -317,7 +316,7 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 			loadBalancer, err := ovn.getLoadBalancer(svcPort.Protocol)
 			if err != nil {
 				klog.Errorf("Failed to get load balancer for %s (%v)", svcPort.Protocol, err)
-				break
+				continue
 			}
 			vip := util.JoinHostPortInt32(service.Spec.ClusterIP, svcPort.Port)
 			if err := ovn.deleteLoadBalancerVIP(loadBalancer, vip); err != nil {

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -27,13 +27,14 @@ func newServiceMeta(name, namespace string) metav1.ObjectMeta {
 	}
 }
 
-func newService(name, namespace, ip string, ports []v1.ServicePort, serviceType v1.ServiceType) *v1.Service {
+func newService(name, namespace, ip string, ports []v1.ServicePort, serviceType v1.ServiceType, externalIPs []string) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: newServiceMeta(name, namespace),
 		Spec: v1.ServiceSpec{
-			ClusterIP: ip,
-			Ports:     ports,
-			Type:      serviceType,
+			ClusterIP:   ip,
+			Ports:       ports,
+			Type:        serviceType,
+			ExternalIPs: externalIPs,
 		},
 	}
 }
@@ -165,6 +166,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 						},
 					},
 					v1.ServiceTypeClusterIP,
+					nil,
 				)
 
 				test.baseCmds(fExec, service)
@@ -202,6 +204,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 						},
 					},
 					v1.ServiceTypeClusterIP,
+					nil,
 				)
 
 				test.baseCmds(fExec, service)

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -21,7 +21,8 @@ type IPTablesHelper interface {
 	ClearChain(string, string) error
 	// DeleteChain deletes the chain in the specified table.
 	DeleteChain(string, string) error
-	// NewChain creates a new chain in the specified table
+	// NewChain creates a new chain in the specified table.
+	// If the chain already exists, it will result in an error.
 	NewChain(string, string) error
 	// Exists checks if given rulespec in specified table/chain exists
 	Exists(string, string, ...string) (bool, error)
@@ -77,17 +78,24 @@ type FakeIPTables struct {
 	tables map[string]*FakeTable
 }
 
-// NewFakeWithProtocol creates a new IPTablesHelper wrapping a mock
-// iptables implementation that can be used in unit tests
-func NewFakeWithProtocol(proto iptables.Protocol) (*FakeIPTables, error) {
+// SetFakeIPTablesHelpers populates `helpers` with FakeIPTablesHelper that can be used in unit tests
+func SetFakeIPTablesHelpers() (IPTablesHelper, IPTablesHelper) {
+	iptV4 := newFakeWithProtocol(iptables.ProtocolIPv4)
+	SetIPTablesHelper(iptables.ProtocolIPv4, iptV4)
+	iptV6 := newFakeWithProtocol(iptables.ProtocolIPv6)
+	SetIPTablesHelper(iptables.ProtocolIPv6, iptV6)
+	return iptV4, iptV6
+}
+
+func newFakeWithProtocol(protocol iptables.Protocol) *FakeIPTables {
 	ipt := &FakeIPTables{
-		proto:  proto,
+		proto:  protocol,
 		tables: make(map[string]*FakeTable),
 	}
 	// Prepopulate some common tables
 	ipt.tables["filter"] = newFakeTable()
 	ipt.tables["nat"] = newFakeTable()
-	return ipt, nil
+	return ipt
 }
 
 func (f *FakeIPTables) getTable(tableName string) (*FakeTable, error) {

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -3,9 +3,10 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
-	"strings"
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -66,12 +67,20 @@ func IsClusterIPSet(service *kapi.Service) bool {
 	return service.Spec.ClusterIP != kapi.ClusterIPNone && service.Spec.ClusterIP != ""
 }
 
-// ValidateProtocol checks if the protocol is a valid kapi.Protocol type (TCP, UDP, or SCTP) or returns an error
-func ValidateProtocol(proto kapi.Protocol) (kapi.Protocol, error) {
-	if proto == kapi.ProtocolTCP || proto == kapi.ProtocolUDP || proto == kapi.ProtocolSCTP {
-		return proto, nil
+// ValidatePort checks if the port is non-zero and port protocol is valid
+func ValidatePort(proto kapi.Protocol, port int32) error {
+	if port <= 0 || port > 65535 {
+		return fmt.Errorf("invalid port number: %v", port)
 	}
-	return "", fmt.Errorf("protocol %s is not a valid protocol", proto)
+	return ValidateProtocol(proto)
+}
+
+// ValidateProtocol checks if the protocol is a valid kapi.Protocol type (TCP, UDP, or SCTP) or returns an error
+func ValidateProtocol(proto kapi.Protocol) error {
+	if proto == kapi.ProtocolTCP || proto == kapi.ProtocolUDP || proto == kapi.ProtocolSCTP {
+		return nil
+	}
+	return fmt.Errorf("protocol %s is not a valid protocol", proto)
 }
 
 // ServiceTypeHasClusterIP checks if the service has an associated ClusterIP or not

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -124,24 +124,22 @@ func TestValidateProtocol(t *testing.T) {
 		expErr bool
 	}{
 		{
-			desc:   "valid protocol SCTP",
-			inp:    v1.ProtocolSCTP,
-			expOut: v1.ProtocolSCTP,
+			desc: "valid protocol SCTP",
+			inp:  v1.ProtocolSCTP,
 		},
 		{
 			desc:   "invalid protocol -> blah",
 			inp:    "blah",
-			expOut: "",
 			expErr: true,
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			res, e := ValidateProtocol(tc.inp)
+			e := ValidateProtocol(tc.inp)
 			if tc.expErr {
 				assert.Error(t, e)
 			} else {
-				assert.Equal(t, tc.expOut, res)
+				assert.NoError(t, e)
 			}
 		})
 	}


### PR DESCRIPTION
Spoiler: _this is a bit of a provocative PR_

Seeing as how the [google group discussion](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/ovn-kubernetes/G8sR1mnpeLo) died out a bit on this topic, I decided to go ahead and implement the solution as to try to move the conversation ahead here in this PR. 

The background to this story is to make `ExternalIP` for services work with ovn-kubernetes. They need to be reachable from any pods in the cluster or any physical node. Today the `ExternalIP` is only reachable from the pods running on the node with the lowest IP in the cluster. This is due to the load balancer item only being attached to that node's logical router. This PR introduces a similar mechanism to what we have for `ClusterIP`, but continues using the logical router as done previously for `ExternalIP`. Besides the OVN logical networking: physical routing is also needed to direct packets going to a destination external IP address through the ovn-kubernetes bridge. 

I know there were concerns concerning performance of this model (@girishmg @shettyg). Maybe we could have a discussion here concerning this and how to move forward. I am open to any suggestion, but I need to try to push this topic forwards as it's been sitting around for quite some time.   

This has been tested against a running cluster, and `ExternalIP` is now reachable from anywhere (all pods & nodes) in a cluster. 

@girishmg @dcbw @squeed 

PS: this has been split into three commits as to ease the code review. If you feel the need to, let me know once finished and I could squash them into one commit. 