### PR TITLE
Validates host subnet prefix length and default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,19 @@ kubectl taint nodes --all node-role.kubernetes.io/master-
 
 Create OVN daemonset and deployment yamls from templates by running the commands below:
 (The $MASTER_IP below is the IP address of the machine where kube-apiserver is
-running)
+running). Note, when specifying the pod CIDR to the command below, daemonset.sh will
+generate a /24 subnet prefix to create per-node CIDRs. Ensure your pod subnet is has a
+prefix less than 24, or edit hte  generated ovn-setup.yaml and specify a host subnet
+prefix. For example, providing a net-cidr of "129.168.1.0/24" would require modifying
+ovn-setup.yaml with a host subnet prefix as follows:
+
+```
+data:
+  net_cidr:      "192.168.1.0/24/25"
+```
+
+Where "/25" is just chosen for this example, but may be any legitimate prefix value greater
+than 24.
 
 ```
 # Clone ovn-kubernetes repo

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/json-iterator/go v1.1.8 // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.8.1
 	github.com/prometheus/client_golang v1.2.1

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -619,7 +619,7 @@ service-cidr=172.18.0.0/24
 
 	It("overrides config file and defaults with CLI legacy cluster-subnet option", func() {
 		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[default]
-cluster-subnets=172.18.0.0/24
+cluster-subnets=172.18.0.0/23
 `), 0644)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -629,15 +629,15 @@ cluster-subnets=172.18.0.0/24
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfgPath).To(Equal(cfgFile.Name()))
 			Expect(Default.ClusterSubnets).To(Equal([]CIDRNetworkEntry{
-				{mustParseCIDR("fd02::/64"), 24},
+				{mustParseCIDR("172.15.0.0/23"), 24},
 			}))
-			Expect(IPv6Mode).To(Equal(true))
+			Expect(IPv6Mode).To(Equal(false))
 			return nil
 		}
 		cliArgs := []string{
 			app.Name,
 			"-config-file=" + cfgFile.Name(),
-			"-cluster-subnet=fd02::/64",
+			"-cluster-subnet=172.15.0.0/23",
 		}
 		err = app.Run(cliArgs)
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/config/utils_test.go
+++ b/go-controller/pkg/config/utils_test.go
@@ -56,6 +56,36 @@ func TestParseClusterSubnetEntries(t *testing.T) {
 			clusterNetworks: nil,
 			expectedErr:     true,
 		},
+		{
+			name:            "HostSubnetLength smaller than cluster subnet",
+			cmdLineArg:      "10.132.0.0/26/24",
+			clusterNetworks: nil,
+			expectedErr:     true,
+		},
+		{
+			name:            "Cluster Subnet length too large",
+			cmdLineArg:      "10.132.0.0/25",
+			clusterNetworks: nil,
+			expectedErr:     true,
+		},
+		{
+			name:            "Cluster Subnet length same as host subnet length",
+			cmdLineArg:      "10.132.0.0/24/24",
+			clusterNetworks: nil,
+			expectedErr:     true,
+		},
+		{
+			name:            "Test that defaulting to hostsubnetlength with 24 bit cluster prefix fails",
+			cmdLineArg:      "10.128.0.0/24",
+			clusterNetworks: nil,
+			expectedErr:     true,
+		},
+		{
+			name:            "Test that legacy behavior does not work for IPv6",
+			cmdLineArg:      "fda6:78cc:acf2:a039::/64",
+			clusterNetworks: nil,
+			expectedErr:     true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Previously if not provided, the per host subnet prefix length was set to
24. This presents an issue if the cluster subnet provided by the user is
also 24. This patch adds the following:

 - Validations on the value when host subnet length is provided
 - When host subnet length is not provided, validation is done to ensure
   there are a minimum of number of bits left to subnet out the per-host
   subnets
 - The new default host subnet length is set to cluster mask + 3 bits
   (8 per-host subnet) when possible. Otherwise it is set to the maximum
   possible value while still preserving enough room for host
   addressing.

Signed-off-by: Tim Rozet <trozet@redhat.com>