### PR TITLE
Check pod annotation on syncPod as to handle pod re-sync correctly

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -26,7 +26,8 @@ func (oc *Controller) syncPods(pods []interface{}) {
 			logrus.Errorf("Spurious object in syncPods: %v", podInterface)
 			continue
 		}
-		if podScheduled(pod) && podWantsNetwork(pod) {
+		_, err := util.UnmarshalPodAnnotation(pod.Annotations)
+		if podScheduled(pod) && podWantsNetwork(pod) && err == nil {
 			logicalPort := podLogicalPortName(pod)
 			expectedLogicalPorts[logicalPort] = true
 		}

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -217,6 +217,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				// Assign it and perform the update
 				t.nodeName = "node1"
+				t.portName = t.namespace + "_" + t.podName
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
 
@@ -312,7 +313,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				fExec := ovntest.NewFakeExec()
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
-					Output: t.portName + "\n",
+					Output: "\n",
 				})
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
@@ -424,6 +425,9 @@ var _ = Describe("OVN Pod Operations", func() {
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: t.portName + "\n",
+				})
+				fExec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --if-exists lsp-del " + t.portName,
 				})
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -550,7 +550,7 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(
 	}
 
 	// Get the logical port name.
-	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+	logicalPort := podLogicalPortName(pod)
 	logicalPortUUID := oc.getLogicalPortUUID(logicalPort)
 	if logicalPortUUID == "" {
 		return
@@ -595,7 +595,7 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 	}
 
 	// Get the logical port name.
-	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+	logicalPort := podLogicalPortName(pod)
 	logicalPortUUID := oc.getLogicalPortUUID(logicalPort)
 
 	np.Lock()

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -372,7 +372,7 @@ func (oc *Controller) deleteAclsPolicyOld(namespace, policy string) {
 func (oc *Controller) localPodAddOrDelACLOld(addDel string,
 	policy *knet.NetworkPolicy, pod *kapi.Pod, gress *gressPolicy,
 	logicalSwitch string) {
-	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+	logicalPort := podLogicalPortName(pod)
 	l3Match := gress.getL3MatchFromAddressSet()
 
 	var lportMatch, cidrMatch string
@@ -536,7 +536,7 @@ func (oc *Controller) handleLocalPodSelectorAddFuncOld(
 	}
 
 	// Get the logical port name.
-	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+	logicalPort := podLogicalPortName(pod)
 
 	np.Lock()
 	defer np.Unlock()
@@ -574,7 +574,7 @@ func (oc *Controller) handleLocalPodSelectorDelFuncOld(
 	}
 
 	// Get the logical port name.
-	logicalPort := fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
+	logicalPort := podLogicalPortName(pod)
 
 	np.Lock()
 	defer np.Unlock()

--- a/go-controller/pkg/ovn/policy_old_test.go
+++ b/go-controller/pkg/ovn/policy_old_test.go
@@ -652,14 +652,14 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.delCmds(fExec, namespace2)
 
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391, $a6953373268003663638} && outport == \\\"namespace1_myPod\\\"\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress external-ids:logical_port=namespace1_myPod",
+					Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391, $a6953373268003663638} && outport == \\\"%s\\\"\" external-ids:namespace=%s external-ids:policy=%s external-ids:Ingress_num=0 external-ids:policy_type=Ingress external-ids:logical_port=%s", nPodTest.portName, networkPolicy.Namespace, networkPolicy.Name, nPodTest.portName),
 					Output: fakeUUID,
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 set acl fake_uuid match=\"ip4.src == {$a10148211500778908391} && outport == \\\"namespace1_myPod\\\"\"",
+					fmt.Sprintf("ovn-nbctl --timeout=15 set acl fake_uuid match=\"ip4.src == {$a10148211500778908391} && outport == \\\"%s\\\"\"", nPodTest.portName),
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a6953373268003663638, $a9824637386382239951} && inport == \\\"namespace1_myPod\\\"\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress external-ids:logical_port=namespace1_myPod",
+					fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a6953373268003663638, $a9824637386382239951} && inport == \\\"%s\\\"\" external-ids:namespace=%s external-ids:policy=%s external-ids:Egress_num=0 external-ids:policy_type=Egress external-ids:logical_port=%s", nPodTest.portName, networkPolicy.Namespace, networkPolicy.Name, nPodTest.portName),
 				})
 
 				err = fakeOvn.fakeClient.CoreV1().Namespaces().Delete(namespace2.Name, metav1.NewDeleteOptions(0))
@@ -948,10 +948,10 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				npTest.delPodCmds(fExec, nPodTest, networkPolicy)
 
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"outport == \\\"namespace2_myPod\\\"\" action=drop external-ids:default-deny-policy-type=Ingress external-ids:namespace=namespace2 external-ids:logical_switch=node1 external-ids:logical_port=namespace2_myPod",
+					fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"outport == \\\"%s\\\"\" action=drop external-ids:default-deny-policy-type=Ingress external-ids:namespace=%s external-ids:logical_switch=%s external-ids:logical_port=%s", nPodTest.portName, nPodTest.namespace, nPodTest.nodeName, nPodTest.portName),
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"inport == \\\"namespace2_myPod\\\"\" action=drop external-ids:default-deny-policy-type=Egress external-ids:namespace=namespace2 external-ids:logical_switch=node1 external-ids:logical_port=namespace2_myPod",
+					fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"inport == \\\"%s\\\"\" action=drop external-ids:default-deny-policy-type=Egress external-ids:namespace=%s external-ids:logical_switch=%s external-ids:logical_port=%s", nPodTest.portName, nPodTest.namespace, nPodTest.nodeName, nPodTest.portName),
 				})
 
 				err = fakeOvn.fakeClient.CoreV1().Pods(nPodTest.namespace).Delete(nPodTest.podName, metav1.NewDeleteOptions(0))


### PR DESCRIPTION
This PR fixes a special corner case which can completely block pod creation from ever happening.  

If the following sequence of events happen, pod creation will be blocked: 

1) We begin by deleting the ovn-kubernetes master, upon which a new leader election is made by k8s (the switch between leaders is not instantaneous of course), 
2) If we happen to have a pod deletion in between the time our last leader has died and the new leader is elected and has his informers initialized, then we loose this delete.
3) If the deleted pod is now re-created on a different node, then: since we never received the last delete, we will still have the old pod in the OVN DB with an associated logical port attached to its old node's logical switch and we subsequently fail to create it's new logical port which should be attached to the new node. 

What I've done to solve the issue is by redefining the `podLogicalPortName` to include the node it's assigned to. In such a case when ovn-kubernetes "syncPods" it will notice that the pod has a stale port, and will thus clear it and re-create it again afterwards. 

View the following bug, for more information: https://bugzilla.redhat.com/show_bug.cgi?id=1781297

@dcbw 