### PR TITLE
Fix parsing of gateway-options

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -23,7 +23,7 @@ OVN_MTU="1400"
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`
-    VALUE=`echo $1 | awk -F= '{print $2}'`
+    VALUE=`echo $1 | cut -d= -f2-`
     case $PARAM in
         --image)
             OVN_IMAGE=$VALUE


### PR DESCRIPTION
daemonset.sh uses awk $2 with "=" delimiter so it misses the rest of the options if there is a = in it.
For example: daemonset.sh with --gateway-options="--gateway-interface=eth2 --gateway-nexthop=172.17.20.1"
ends up with: ovn_gateway_opts: --gateway-interface
while it should be:
ovn_gateway_opts: --gateway-interface=eth2 --gateway-nexthop=172.17.20.1
Use cut to take all the variable text.

Signed-off-by: Shahar Klein <sklein@nvidia.com>