### PR TITLE
Revert "create br-nexthop OVS internal port with fixed MAC address"

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovs-vsctl --timeout=15 --may-exist add-br br-local",
 				"ip link set br-local up",
-				"ovs-vsctl --timeout=15 --may-exist add-port br-local br-nexthop -- set interface br-nexthop type=internal mtu_request=" + mtu + " mac=00\\:00\\:a9\\:fe\\:21\\:01",
+				"ovs-vsctl --timeout=15 --may-exist add-port br-local br-nexthop -- set interface br-nexthop type=internal mtu_request=" + mtu,
 				"ip link set br-nexthop up",
 				"ip addr flush dev br-nexthop",
 				"ip addr add 169.254.33.1/24 dev br-nexthop",

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -24,10 +24,7 @@ const (
 	localnetGatewayIP            = "169.254.33.2/24"
 	localnetGatewayNextHop       = "169.254.33.1"
 	localnetGatewayNextHopSubnet = "169.254.33.1/24"
-	// fixed MAC address for the br-nexthop interface. the last 4 hex bytes
-	// translates to the br-nexthop's IP address
-	localnetGatewayNextHopMac = "00:00:a9:fe:21:01"
-	iptableNodePortChain      = "OVN-KUBE-NODEPORT"
+	iptableNodePortChain         = "OVN-KUBE-NODEPORT"
 )
 
 type iptRule struct {
@@ -138,8 +135,7 @@ func initLocalnetGateway(nodeName string,
 	_, stderr, err = util.RunOVSVsctl(
 		"--may-exist", "add-port", localnetBridgeName, localnetBridgeNextHop,
 		"--", "set", "interface", localnetBridgeNextHop, "type=internal",
-		"mtu_request="+fmt.Sprintf("%d", config.Default.MTU),
-		fmt.Sprintf("mac=%s", strings.ReplaceAll(localnetGatewayNextHopMac, ":", "\\:")))
+		"mtu_request="+fmt.Sprintf("%d", config.Default.MTU))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create localnet bridge next hop %s"+
 			", stderr:%s (%v)", localnetBridgeNextHop, stderr, err)


### PR DESCRIPTION
This reverts commit 75f836d91e1eeadd984089eb3f650734918972cf.

Turns out this breaks stuff. Not sure why yet, but it somehow
prevents ARP from working correctly on br-local & br-nexthop.

@girishmg here's some tcpdump output on br-nexthop:

```
[root@openshift-node-2 /]# tcpdump -vvvne -i br-nexthop
tcpdump: listening on br-nexthop, link-type EN10MB (Ethernet), capture size 262144 bytes
04:57:45.597403 00:00:a9:fe:21:01 > Broadcast, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Request who-has 169.254.33.1 tell 169.254.33.2, length 28
04:57:45.597425 00:00:a9:fe:21:01 > 00:00:a9:fe:21:01, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Reply 169.254.33.1 is-at 00:00:a9:fe:21:01, length 28
04:57:46.652960 00:00:a9:fe:21:01 > Broadcast, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Request who-has 169.254.33.1 tell 169.254.33.2, length 28
04:57:46.652987 00:00:a9:fe:21:01 > 00:00:a9:fe:21:01, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Reply 169.254.33.1 is-at 00:00:a9:fe:21:01, length 28
04:57:47.686314 00:00:a9:fe:21:01 > Broadcast, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Request who-has 169.254.33.1 tell 169.254.33.2, length 28
04:57:47.686346 00:00:a9:fe:21:01 > 00:00:a9:fe:21:01, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Reply 169.254.33.1 is-at 00:00:a9:fe:21:01, length 28
04:57:48.700959 00:00:a9:fe:21:01 > Broadcast, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Request who-has 169.254.33.1 tell 169.254.33.2, length 28
04:57:48.700984 00:00:a9:fe:21:01 > 00:00:a9:fe:21:01, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Reply 169.254.33.1 is-at 00:00:a9:fe:21:01, length 28
04:57:49.724985 00:00:a9:fe:21:01 > Broadcast, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Request who-has 169.254.33.1 tell 169.254.33.2, length 28
04:57:49.725011 00:00:a9:fe:21:01 > 00:00:a9:fe:21:01, ethertype ARP (0x0806), length 42: Ethernet (len 6), IPv4 (len 4), Reply 169.254.33.1 is-at 00:00:a9:fe:21:01, length 28
```