### PR TITLE
set other_config:hwaaddr on br-local before you add br-nexthop

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -282,11 +282,6 @@ var _ = Describe("Gateway Init Operations", func() {
 			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovs-vsctl --timeout=15 --may-exist add-br br-local",
-				"ip link set br-local up",
-				"ovs-vsctl --timeout=15 --may-exist add-port br-local br-nexthop -- set interface br-nexthop type=internal mtu_request=" + mtu + " mac=00\\:00\\:a9\\:fe\\:21\\:01",
-				"ip link set br-nexthop up",
-				"ip addr flush dev br-nexthop",
-				"ip addr add 169.254.33.1/24 dev br-nexthop",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface br-local mac_in_use",
@@ -295,6 +290,11 @@ var _ = Describe("Gateway Init Operations", func() {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovs-vsctl --timeout=15 set bridge br-local other-config:hwaddr=" + brLocalnetMAC,
 				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + util.PhysicalNetworkName + ":br-local",
+				"ip link set br-local up",
+				"ovs-vsctl --timeout=15 --may-exist add-port br-local br-nexthop -- set interface br-nexthop type=internal mtu_request=" + mtu + " mac=00\\:00\\:a9\\:fe\\:21\\:01",
+				"ip link set br-nexthop up",
+				"ip addr flush dev br-nexthop",
+				"ip addr add 169.254.33.1/24 dev br-nexthop",
 			})
 
 			err := util.SetExec(fexec)

--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -128,6 +128,11 @@ func initLocalnetGateway(nodeName string,
 			", stderr:%s (%v)", localnetBridgeName, stderr, err)
 	}
 
+	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, localnetBridgeName, localnetBridgeName, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
+	}
+
 	_, _, err = util.RunIP("link", "set", localnetBridgeName, "up")
 	if err != nil {
 		return nil, fmt.Errorf("failed to up %s (%v)", localnetBridgeName, err)
@@ -163,11 +168,6 @@ func initLocalnetGateway(nodeName string,
 	if err != nil {
 		return nil, fmt.Errorf("failed to assign ip address to %s (%v)",
 			localnetBridgeNextHop, err)
-	}
-
-	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, localnetBridgeName, localnetBridgeName, true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
 
 	l3GatewayConfig := map[string]string{


### PR DESCRIPTION
The issue is that br-local was inheriting the lowest MAC from its
port and in this case it was br-nexthop. So, change the order in
which the mac address is fixed for br-local bridge. First, create the
br-local bridge and set other_config:hwaddr with mac_in_use value. Next,
create the br-nexthop interface with fixed mac address.

Fixes: 75f836d91e1e (create br-nexthop OVS internal port with fixed MAC
address)

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>