### PR TITLE
ovn-controller: Set ovn-openflow-probe-interval

### DIFF
--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -48,6 +48,8 @@ func setupOVNNode(nodeName string) error {
 		fmt.Sprintf("external_ids:ovn-encap-ip=%s", nodeIP),
 		fmt.Sprintf("external_ids:ovn-remote-probe-interval=%d",
 			config.Default.InactivityProbe),
+		fmt.Sprintf("external_ids:ovn-openflow-probe-interval=%d",
+			config.Default.OpenFlowProbe),
 		fmt.Sprintf("external_ids:hostname=\"%s\"", nodeName),
 	)
 	if err != nil {

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Node Operations", func() {
 			const (
 				nodeName string = "1.2.5.6"
 				interval int    = 100000
+				ofintval int    = 180
 			)
 
 			fexec := ovntest.NewFakeExec()
@@ -42,8 +43,9 @@ var _ = Describe("Node Operations", func() {
 					"external_ids:ovn-encap-type=geneve "+
 					"external_ids:ovn-encap-ip=%s "+
 					"external_ids:ovn-remote-probe-interval=%d "+
+					"external_ids:ovn-openflow-probe-interval=%d "+
 					"external_ids:hostname=\"%s\"",
-					nodeName, interval, nodeName),
+					nodeName, interval, ofintval, nodeName),
 			})
 
 			err := util.SetExec(fexec)
@@ -68,6 +70,7 @@ var _ = Describe("Node Operations", func() {
 				nodeName    string = "1.2.5.6"
 				encapPort   uint   = 666
 				interval    int    = 100000
+				ofintval    int    = 180
 				chassisUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
 			)
 
@@ -77,8 +80,9 @@ var _ = Describe("Node Operations", func() {
 					"external_ids:ovn-encap-type=geneve "+
 					"external_ids:ovn-encap-ip=%s "+
 					"external_ids:ovn-remote-probe-interval=%d "+
+					"external_ids:ovn-openflow-probe-interval=%d "+
 					"external_ids:hostname=\"%s\"",
-					nodeName, interval, nodeName),
+					nodeName, interval, ofintval, nodeName),
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 " +

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -39,7 +39,8 @@ var (
 		EncapType:         "geneve",
 		EncapIP:           "",
 		EncapPort:         DefaultEncapPort,
-		InactivityProbe:   100000,
+		InactivityProbe:   100000, // in Milliseconds
+		OpenFlowProbe:     180,    // in Seconds
 		RawClusterSubnets: "10.128.0.0/14/23",
 	}
 
@@ -118,6 +119,9 @@ type DefaultConfig struct {
 	// Maximum number of milliseconds of idle time on connection that
 	// ovn-controller waits before it will send a connection health probe.
 	InactivityProbe int `gcfg:"inactivity-probe"`
+	// Maximum number of seconds of idle time on the OpenFlow connection
+	// that ovn-controller will wait before it sends a connection health probe
+	OpenFlowProbe int `gcfg:"openflow-probe"`
 	// RawClusterSubnets holds the unparsed cluster subnets. Should only be
 	// used inside config module.
 	RawClusterSubnets string `gcfg:"cluster-subnets"`
@@ -405,6 +409,12 @@ var CommonFlags = []cli.Flag{
 		Usage: "Maximum number of milliseconds of idle time on " +
 			"connection for ovn-controller before it sends a inactivity probe",
 		Destination: &cliConfig.Default.InactivityProbe,
+	},
+	cli.IntFlag{
+		Name: "openflow-probe",
+		Usage: "Maximum number of seconds of idle time on the openflow " +
+			"connection for ovn-controller before it sends a inactivity probe",
+		Destination: &cliConfig.Default.OpenFlowProbe,
 	},
 	cli.StringFlag{
 		Name:        "cluster-subnet",


### PR DESCRIPTION
ovn-kubernetes was already setting ovn-remote-probe-interval.  This
patch follows the same pattern for ovn-openflow-probe-interval, and
does it for the same reasons.
    
The default value for this option is 5 seconds. On a large cluster,
this can cause excessive CPU consumption in ovn-controller.  If it
takes ovn-controller 5 seconds to do a full state computation, then
you'll see ovn-controller end up in effectively a busy loop, because
it isn't able to keep up with this probe interval.
    
The openflow probe is even less interesting than the OVSDB
remote probe.  At least the ovsdb connection is to something remote.
The openflow connection is always local, so this is unlikely to be a
problem.  We now set it to 3 minutes by default, just in case, instead
of disabling it completely.

Signed-off-by: Russell Bryant <russell@ovn.org>