### PR TITLE
remove unwanted debug log messages in factory.go

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -143,13 +143,11 @@ func (wf *WatchFactory) newFederatedHandler(inf *informer) cache.ResourceEventHa
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			inf.forEachHandler(obj, func(h *Handler) {
-				logrus.Debugf("running %v ADD event for handler %d", inf.oType, h.id)
 				h.OnAdd(obj)
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			inf.forEachHandler(newObj, func(h *Handler) {
-				logrus.Debugf("running %v UPDATE event for handler %d", inf.oType, h.id)
 				h.OnUpdate(oldObj, newObj)
 			})
 		},
@@ -168,7 +166,6 @@ func (wf *WatchFactory) newFederatedHandler(inf *informer) cache.ResourceEventHa
 				}
 			}
 			inf.forEachHandler(obj, func(h *Handler) {
-				logrus.Debugf("running %v DELETE event for handler %d", inf.oType, h.id)
 				h.OnDelete(obj)
 			})
 		},


### PR DESCRIPTION
ovnkube-master.log file, with 290K lines of log messages, had close to
221K lines of '... UPDATE for event handler X' log messages that doesn't
provide any meaningful information. in fact, in that noise we might miss
important log message. so remove these debug messages.

@dcbw @danwinship PTAL