### PR TITLE
scale: waitForNodeLogicalSwitch() should get other-config:subnet itself

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -83,10 +83,6 @@ func (p pod) baseCmds(fexec *ovntest.FakeExec) {
 
 func (p pod) addNodeSetupCmds(fexec *ovntest.FakeExec) {
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 get logical_switch " + p.nodeName + " other-config",
-		Output: `{exclude_ips="10.128.1.2", subnet="` + p.nodeSubnet + `"}`,
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 get logical_switch " + p.nodeName + " other-config:subnet",
 		Output: fmt.Sprintf("%q", p.nodeSubnet),
 	})

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -397,19 +397,7 @@ const (
 	defaultMcastAllowPriority = "1012"
 )
 
-func (oc *Controller) addAllowACLFromNode(logicalSwitch string) error {
-	subnet, stderr, err := util.RunOVNNbctl("get", "logical_switch",
-		logicalSwitch, "other-config:subnet")
-	if err != nil {
-		logrus.Errorf("failed to get the logical_switch %s subnet, "+
-			"stderr: %q (%v)", logicalSwitch, stderr, err)
-		return err
-	}
-
-	if subnet == "" {
-		return fmt.Errorf("logical_switch %q had no subnet", logicalSwitch)
-	}
-
+func (oc *Controller) addAllowACLFromNode(logicalSwitch, subnet string) error {
 	ip, _, err := net.ParseCIDR(subnet)
 	if err != nil {
 		logrus.Errorf("failed to parse subnet %s", subnet)
@@ -423,7 +411,7 @@ func (oc *Controller) addAllowACLFromNode(logicalSwitch string) error {
 	address := ip.String()
 
 	match := fmt.Sprintf("ip4.src==%s", address)
-	_, stderr, err = util.RunOVNNbctl("--may-exist", "acl-add", logicalSwitch,
+	_, stderr, err := util.RunOVNNbctl("--may-exist", "acl-add", logicalSwitch,
 		"to-lport", defaultAllowPriority, match, "allow-related")
 	if err != nil {
 		logrus.Errorf("failed to create the node acl for "+


### PR DESCRIPTION
currently, that function gets other-config to ascertain that the
logcial switch is created for a node and continues. later on, we make
an another call to get other-config:subnet. instead, check for
other-config:subnet itself and avoid an unnecessary call.

@dcbw PTAL