### PR TITLE
scale: fixed MAC address for the logical router ports

### DIFF
--- a/go-controller/pkg/cluster/management-port.go
+++ b/go-controller/pkg/cluster/management-port.go
@@ -13,6 +13,7 @@ import (
 func createManagementPortGeneric(nodeName string, localSubnet *net.IPNet) (string, string, string, string, string, error) {
 	// Retrieve the routerIP and mangementPortIP for a given localSubnet
 	routerIP, portIP := util.GetNodeWellKnownAddresses(localSubnet)
+	routerMac := util.IPAddrToHWAddr(routerIP.IP)
 
 	// Kubernetes emits events when pods are created. The event will contain
 	// only lowercase letters of the hostname even though the kubelet is
@@ -54,13 +55,6 @@ func createManagementPortGeneric(nodeName string, localSubnet *net.IPNet) (strin
 	if err != nil {
 		logrus.Errorf("failed to persist MAC address %q for %q: stderr:%s (%v)", macAddress,
 			interfaceName, stderr, err)
-		return "", "", "", "", "", err
-	}
-	// switch-to-router ports only have MAC address and nothing else.
-	routerMac, stderr, err := util.RunOVNNbctl("lsp-get-addresses", "stor-"+nodeName)
-	if err != nil {
-		logrus.Errorf("Failed to retrieve the MAC address of the logical port, stderr: %q, error: %v",
-			stderr, err)
 		return "", "", "", "", "", err
 	}
 

--- a/go-controller/pkg/cluster/management-port_linux_test.go
+++ b/go-controller/pkg/cluster/management-port_linux_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Management Port Operations", func() {
 				serviceCIDR   string = serviceIPNet + "/24"
 				mtu           string = "1400"
 				gwIP          string = "10.1.1.1"
-				lrpMAC        string = "00:00:00:00:00:03"
+				lrpMAC        string = "0A:58:0A:01:01:01"
 			)
 
 			fexec := ovntest.NewFakeExec()
@@ -91,10 +91,6 @@ var _ = Describe("Management Port Operations", func() {
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovs-vsctl --timeout=15 set interface k8s-node1 " + fmt.Sprintf("mac=%s", strings.ReplaceAll(mgtPortMAC, ":", "\\:")),
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 lsp-get-addresses stor-" + nodeName,
-				Output: lrpMAC,
 			})
 
 			// linux-specific setup

--- a/go-controller/pkg/cluster/management-port_windows_test.go
+++ b/go-controller/pkg/cluster/management-port_windows_test.go
@@ -82,10 +82,6 @@ var _ = Describe("Management Port Operations", func() {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: "ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP + " -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 lsp-get-addresses stor-" + nodeName,
-				Output: lrpMAC,
-			})
 
 			// windows-specific setup
 			fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -460,19 +460,11 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 	// Get firstIP for gateway.  Skip the second address of the LogicalSwitch's
 	// subnet since we set it aside for the management port on that node.
 	firstIP, secondIP := util.GetNodeWellKnownAddresses(hostsubnet)
-
-	nodeLRPMac, stderr, err := util.RunOVNNbctl("--if-exist", "get", "logical_router_port", "rtos-"+nodeName, "mac")
-	if err != nil {
-		logrus.Errorf("Failed to get logical router port,stderr: %q, error: %v", stderr, err)
-		return err
-	}
-	if nodeLRPMac == "" {
-		nodeLRPMac = util.GenerateMac()
-	}
-
+	nodeLRPMac := util.IPAddrToHWAddr(firstIP.IP)
 	clusterRouter := util.GetK8sClusterRouter()
+
 	// Create a router port and provide it the first address on the node's host subnet
-	_, stderr, err = util.RunOVNNbctl("--may-exist", "lrp-add", clusterRouter, "rtos-"+nodeName,
+	_, stderr, err := util.RunOVNNbctl("--may-exist", "lrp-add", clusterRouter, "rtos-"+nodeName,
 		nodeLRPMac, firstIP.String())
 	if err != nil {
 		logrus.Errorf("Failed to add logical port to router, stderr: %q, error: %v", stderr, err)

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -110,3 +110,10 @@ func GetNodeWellKnownAddresses(subnet *net.IPNet) (*net.IPNet, *net.IPNet) {
 func JoinHostPortInt32(host string, port int32) string {
 	return net.JoinHostPort(host, strconv.Itoa(int(port)))
 }
+
+// IPAddrToHWAddr takes the four octets of IPv4 address (aa.bb.cc.dd, for example) and uses them in creating
+// a MAC address (0A:58:AA:BB:CC:DD)
+func IPAddrToHWAddr(ip net.IP) string {
+	// safe to use private MAC prefix: 0A:58
+	return fmt.Sprintf("0A:58:%02X:%02X:%02X:%02X", ip[0], ip[1], ip[2], ip[3])
+}


### PR DESCRIPTION
currently, the MAC address for the logical_router_port on the
distributed_router that connects to node logical_switch is generated
randomly. that by itself is not an issue. however, we depend on this
MAC address on each of the node. each of the ovnkube-node deamon does

   routerMAC=`ovn-nbctl lsp-get-addresses stor-node1`

the above call doesn't scale with large number of nodes, and the above
command times out.

instead of creating a random MAC address, use a fixed MAC address that
is formed using the octets of gateway IP address. we already make an
assumption that the 1st IP of the node subnet is the gateway address,
and therefore we can easily derive at the MAC address on the node
without making a ovn-nbctl call.

@dcbw PTAL