### PR TITLE
do normal processing for all inbound packets that are not tracked

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -125,7 +125,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovs-ofctl add-flow breth0 priority=50, in_port=7, ip, actions=ct(zone=64000, table=1)",
 			"ovs-ofctl add-flow breth0 priority=100, table=1, ct_state=+trk+est, actions=output:5",
 			"ovs-ofctl add-flow breth0 priority=100, table=1, ct_state=+trk+rel, actions=output:5",
-			"ovs-ofctl add-flow breth0 priority=0, table=1, actions=output:LOCAL",
+			"ovs-ofctl add-flow breth0 priority=0, table=1, actions=output:NORMAL",
 		})
 		// nodePortWatcher()
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -235,9 +235,9 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string) error {
 			"error: %v", gwBridge, stderr, err)
 	}
 
-	// table 1, all other connections go to the bridge interface.
+	// table 1, all other connections do normal processing
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
-		"priority=0, table=1, actions=output:LOCAL")
+		"priority=0, table=1, actions=output:NORMAL")
 	if err != nil {
 		return fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)


### PR DESCRIPTION
Say, we share the interface eth0 in the shared gateway mode and that
the ovs-bridge br-eth0 has an additional interface 'vlan100'

    br-eth0(LOCAL)  vlan100    patch_port_to_br_int
              |        |       |
              |        |       |
            +-+--------+-------+---+
            |       br-eth0        |
            +--------+-------------+
                     |
                     |
                   eth0

In the current code, the inbound traffic to vlan100 is always sent to
LOCAL port and therefore services on vlan100 is not reachable. Fix this
by using NORMAL action.

@dcbw @danwinship PTAL