### PR TITLE
scale: clearInitialNodeNetworkUnavailableCondition() is very expensive

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -427,6 +427,9 @@ subnet=%s
 						OvnNodeL3GatewayConfig:          getDisabledGwModeAnnotation(),
 					},
 				},
+				Spec: v1.NodeSpec{
+					ProviderID: "gce://openshift-gce-devel-ci/us-east1-b/ci-op-tbtpp-m-0",
+				},
 				Status: v1.NodeStatus{
 					Conditions: []v1.NodeCondition{
 						{

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -534,9 +534,7 @@ func (oc *Controller) WatchNodes() error {
 				}
 			}
 
-			if !reflect.DeepEqual(oldNode.Status.Conditions, node.Status.Conditions) {
-				oc.clearInitialNodeNetworkUnavailableCondition(node)
-			}
+			oc.clearInitialNodeNetworkUnavailableCondition(oldNode, node)
 
 			if gatewaysFailed[node.Name] || gatewayChanged(oldNode, node) {
 				if err := oc.syncNodeGateway(node, nil); err != nil {


### PR DESCRIPTION
clearInitialNodeNetworkUnavailableCondition() called from Node
UpdateFunc() is very expensive. In our 600-node cluster, the
updateFunc() is called almost every second. We are spending lot of CPU
cycles in that funciton due to DeepCopy and such. call this function if
the node is part of a cloud provider (Node.Spec.ProviderID is set)

@dcbw @danwinship @alexanderConstantinescu PTAL