### PR TITLE
add support for custom MAC specified in default network-attachment

### DIFF
--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -10,3 +10,17 @@ type NetConf struct {
 	// PciAddrs in case of using sriov
 	DeviceID string `json:"deviceID"`
 }
+
+// NetworkSelectionElement represents one element of the JSON format
+// Network Attachment Selection Annotation as described in section 4.1.2
+// of the CRD specification.
+type NetworkSelectionElement struct {
+	// Name contains the name of the Network object this element selects
+	Name string `json:"name"`
+	// Namespace contains the optional namespace that the network referenced
+	// by Name exists in
+	Namespace string `json:"namespace,omitempty"`
+	// MacRequest contains an optional requested MAC address for this
+	// network attachment
+	MacRequest string `json:"mac,omitempty"`
+}


### PR DESCRIPTION
One can specify the custom MAC off of the annotation on the POD
spec defined like this below:

```
annotations: v1.multus-cni.io/default-network: | [
    {
        "namespace": "kube-system",
        "name": "ovnkube",
        "mac": "aa:bb:cc:dd:ee:ff"
    }
]
```
The OVN interface that gets added to the POD will have that MAC instead
of OVN chosen MAC.

Fixes #776

@dcbw @danwinship PTAL. 

BTW, the net-attach-def client here https://github.com/k8snetworkplumbingwg/network-attachment-definition-client doesn't yet support parsing NetworkSelectionElement for MAC, IPs, and default-route. So, I can't use it in this PR