### PR TITLE
exit early if ovn specific pod annotations exists

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -250,37 +250,39 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 	logrus.Debugf("Creating logical port for %s on switch %s", portName, logicalSwitch)
 
 	annotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
-	annotationsSet := (err == nil)
 	// If pod already has annotations, just add the lsp with static ip/mac.
 	// Else, create the lsp with dynamic addresses.
 	if err == nil {
-		out, stderr, err = util.RunOVNNbctl("--may-exist", "lsp-add",
-			logicalSwitch, portName, "--", "lsp-set-addresses", portName,
-			fmt.Sprintf("%s %s", annotation.MAC, annotation.IP.IP), "--", "set",
-			"logical_switch_port", portName,
-			"external-ids:namespace="+pod.Namespace,
-			"external-ids:logical_switch="+logicalSwitch,
-			"external-ids:pod=true", "--", "--if-exists",
-			"clear", "logical_switch_port", portName, "dynamic_addresses")
+		out, stderr, err = util.RunOVNNbctl(
+			"--may-exist", "lsp-add", logicalSwitch, portName,
+			"--", "lsp-set-addresses", portName, fmt.Sprintf("%s %s", annotation.MAC, annotation.IP.IP),
+			"--", "set", "logical_switch_port", portName, "external-ids:namespace="+pod.Namespace,
+			"external-ids:logical_switch="+logicalSwitch, "external-ids:pod=true",
+			"--", "--if-exists", "clear", "logical_switch_port", portName, "dynamic_addresses")
 		if err != nil {
 			return fmt.Errorf("Failed to add logical port to switch "+
-				"stdout: %q, stderr: %q (%v)",
-				out, stderr, err)
+				"stdout: %q, stderr: %q (%v)", out, stderr, err)
 		}
-	} else {
-		out, stderr, err = util.RunOVNNbctl("--wait=sb", "--",
-			"--may-exist", "lsp-add", logicalSwitch, portName,
-			"--", "lsp-set-addresses",
-			portName, "dynamic", "--", "set",
-			"logical_switch_port", portName,
-			"external-ids:namespace="+pod.Namespace,
-			"external-ids:logical_switch="+logicalSwitch,
-			"external-ids:pod=true")
+		// now set the port security for the logical switch port
+		out, stderr, err = util.RunOVNNbctl("lsp-set-port-security", portName,
+			fmt.Sprintf("%s %s", annotation.MAC, annotation.IP))
 		if err != nil {
-			return fmt.Errorf("Error while creating logical port %s "+
-				"stdout: %q, stderr: %q (%v)",
-				portName, out, stderr, err)
+			return fmt.Errorf("error while setting port security for logical port %s "+
+				"stdout: %q, stderr: %q (%v)", portName, out, stderr, err)
 		}
+		oc.logicalPortCache[portName] = logicalSwitch
+		oc.addPodToNamespace(pod.Namespace, annotation.IP.IP, portName)
+		return nil
+	}
+
+	out, stderr, err = util.RunOVNNbctl("--wait=sb",
+		"--", "--may-exist", "lsp-add", logicalSwitch, portName,
+		"--", "lsp-set-addresses", portName, "dynamic",
+		"--", "set", "logical_switch_port", portName, "external-ids:namespace="+pod.Namespace,
+		"external-ids:logical_switch="+logicalSwitch, "external-ids:pod=true")
+	if err != nil {
+		return fmt.Errorf("Error while creating logical port %s stdout: %q, stderr: %q (%v)",
+			portName, out, stderr, err)
 	}
 
 	oc.logicalPortCache[portName] = logicalSwitch
@@ -337,11 +339,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 		return fmt.Errorf("failed to set annotation on pod %s - %v", pod.Name, err)
 	}
 
-	// If we're setting the annotation for the first time, observe the creation
-	// latency metric.
-	if !annotationsSet {
-		recordPodCreated(pod)
-	}
+	// observe the pod creation latency metric.
+	recordPodCreated(pod)
 
 	return nil
 }

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -133,7 +133,13 @@ func (p pod) addCmdsForNonExistingPodGatewayCached(fexec *ovntest.FakeExec) {
 }
 
 func (p pod) addCmdsForExistingPod(fexec *ovntest.FakeExec) {
-	p.addCmds(fexec, true, false, false)
+	// pod setup
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 --may-exist lsp-add %s %s -- lsp-set-addresses %s %s %s -- set logical_switch_port %s external-ids:namespace=namespace external-ids:logical_switch=%s external-ids:pod=true -- --if-exists clear logical_switch_port %s dynamic_addresses", p.nodeName, p.portName, p.portName, p.podMAC, p.podIP, p.portName, p.nodeName, p.portName),
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 lsp-set-port-security " + p.portName + " " + p.podMAC + " " + p.podIP + "/24",
+	})
 }
 
 func (p pod) addCmdsForNonExistingFailedPod(fexec *ovntest.FakeExec) {


### PR DESCRIPTION
currently, if the ovn specific pod annotation exists, then we read
pod interface info from the annotation and re-create the corresponding
logical switch port. this is all good, however we continue further and
get the pod interface info from OVN logical topology and add the
annotation back. this is not required. so, exit early

@dcbw @danwinship  PTAL