### PR TITLE
Factory and testcase cleanups

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -179,7 +179,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		stop := make(chan struct{})
 		wf, err := factory.NewWatchFactory(fakeClient, stop)
 		Expect(err).NotTo(HaveOccurred())
-		defer wf.Shutdown()
+		defer close(stop)
 
 		cluster := OvnClusterController{
 			watchFactory: wf,
@@ -327,7 +327,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			stop := make(chan struct{})
 			wf, err := factory.NewWatchFactory(fakeClient, stop)
 			Expect(err).NotTo(HaveOccurred())
-			defer wf.Shutdown()
+			defer close(stop)
 
 			ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Node Operations", func() {
 			stopChan := make(chan struct{})
 			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
-			defer f.Shutdown()
+			defer close(stopChan)
 
 			cluster := NewClusterController(fakeClient, f)
 			Expect(cluster).NotTo(BeNil())
@@ -246,7 +246,7 @@ var _ = Describe("Node Operations", func() {
 			stopChan := make(chan struct{})
 			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
-			defer f.Shutdown()
+			defer close(stopChan)
 
 			cluster := NewClusterController(fakeClient, f)
 			Expect(cluster).NotTo(BeNil())

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(h).NotTo(BeNil())
 			wf.removeHandler(objType, h)
-			wf.Shutdown()
+			close(stop)
 		}
 
 		It("is called for each existing pod", func() {
@@ -250,7 +250,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(numAdded).To(Equal(2))
 			wf.removeHandler(objType, h)
-			wf.Shutdown()
+			close(stop)
 		}
 
 		It("calls ADD for each existing pod", func() {
@@ -349,7 +349,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.RemovePodHandler(h)
-		wf.Shutdown()
+		close(stop)
 	})
 
 	It("responds to namespace add/update/delete events", func() {
@@ -384,7 +384,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.RemoveNamespaceHandler(h)
-		wf.Shutdown()
+		close(stop)
 	})
 
 	It("responds to node add/update/delete events", func() {
@@ -419,7 +419,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.removeHandler(nodeType, h)
-		wf.Shutdown()
+		close(stop)
 	})
 
 	It("responds to policy add/update/delete events", func() {
@@ -454,7 +454,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.removeHandler(policyType, h)
-		wf.Shutdown()
+		close(stop)
 	})
 
 	It("responds to endpoints add/update/delete events", func() {
@@ -496,7 +496,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.removeHandler(endpointsType, h)
-		wf.Shutdown()
+		close(stop)
 	})
 
 	It("responds to service add/update/delete events", func() {
@@ -531,7 +531,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
 		wf.removeHandler(serviceType, h)
-		wf.Shutdown()
+		close(stop)
 	})
 
 	It("stops processing events after the handler is removed", func() {
@@ -562,7 +562,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		namespaceWatch.Delete(added2)
 		Consistently(func() int { return numDeleted }, 2).Should(Equal(0))
 
-		wf.Shutdown()
+		close(stop)
 	})
 
 	It("filters correctly by label and namespace", func() {
@@ -628,7 +628,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		podWatch.Delete(passesFilter)
 		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
 
-		wf.Shutdown()
+		close(stop)
 	})
 
 	It("correctly handles object updates that cause filter changes", func() {
@@ -681,6 +681,6 @@ var _ = Describe("Watch Factory Operations", func() {
 		Consistently(func() int { return numUpdated }, 2).Should(Equal(0))
 
 		wf.RemovePodHandler(h)
-		wf.Shutdown()
+		close(stop)
 	})
 })

--- a/go-controller/pkg/ovn/endpoints_test.go
+++ b/go-controller/pkg/ovn/endpoints_test.go
@@ -66,15 +66,24 @@ func (e endpoints) delCmds(fexec *ovntest.FakeExec, service v1.Service, endpoint
 }
 
 var _ = Describe("OVN Namespace Operations", func() {
-	var app *cli.App
+	var (
+		app     *cli.App
+		fakeOvn *FakeOVN
+	)
 
 	BeforeEach(func() {
-		//Restore global default values before each testcase
+		// Restore global default values before each testcase
 		config.RestoreDefaultConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		fakeOvn = &FakeOVN{}
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
 	})
 
 	Context("on startup", func() {
@@ -112,7 +121,6 @@ var _ = Describe("OVN Namespace Operations", func() {
 				tExec := ovntest.NewFakeExec()
 				testE.addCmds(tExec, serviceT, endpointsT)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, tExec,
 					&v1.EndpointsList{
 						Items: []v1.Endpoints{
@@ -170,7 +178,6 @@ var _ = Describe("OVN Namespace Operations", func() {
 				tExec := ovntest.NewFakeExec()
 				testE.addCmds(tExec, serviceT, endpointsT)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, tExec,
 					&v1.EndpointsList{
 						Items: []v1.Endpoints{

--- a/go-controller/pkg/ovn/endpoints_test.go
+++ b/go-controller/pkg/ovn/endpoints_test.go
@@ -69,6 +69,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
+		tExec   *ovntest.FakeExec
 	)
 
 	BeforeEach(func() {
@@ -79,7 +80,8 @@ var _ = Describe("OVN Namespace Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = &FakeOVN{}
+		tExec = ovntest.NewFakeExec()
+		fakeOvn = NewFakeOVN(tExec, true)
 	})
 
 	AfterEach(func() {
@@ -118,10 +120,9 @@ var _ = Describe("OVN Namespace Operations", func() {
 					v1.ServiceTypeClusterIP,
 				)
 
-				tExec := ovntest.NewFakeExec()
 				testE.addCmds(tExec, serviceT, endpointsT)
 
-				fakeOvn.start(ctx, tExec,
+				fakeOvn.start(ctx,
 					&v1.EndpointsList{
 						Items: []v1.Endpoints{
 							endpointsT,
@@ -175,10 +176,9 @@ var _ = Describe("OVN Namespace Operations", func() {
 					},
 					v1.ServiceTypeClusterIP,
 				)
-				tExec := ovntest.NewFakeExec()
 				testE.addCmds(tExec, serviceT, endpointsT)
 
-				fakeOvn.start(ctx, tExec,
+				fakeOvn.start(ctx,
 					&v1.EndpointsList{
 						Items: []v1.Endpoints{
 							endpointsT,

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Master Operations", func() {
 			stopChan := make(chan struct{})
 			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
-			defer f.Shutdown()
+			defer close(stopChan)
 
 			clusterController := NewOvnController(fakeClient, f)
 			Expect(clusterController).NotTo(BeNil())
@@ -297,7 +297,7 @@ var _ = Describe("Master Operations", func() {
 			stopChan := make(chan struct{})
 			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
-			defer f.Shutdown()
+			defer close(stopChan)
 
 			clusterController := NewOvnController(fakeClient, f)
 			Expect(clusterController).NotTo(BeNil())
@@ -446,7 +446,7 @@ subnet=%s
 			stopChan := make(chan struct{})
 			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
-			defer f.Shutdown()
+			defer close(stopChan)
 
 			clusterController := NewOvnController(fakeClient, f)
 			Expect(clusterController).NotTo(BeNil())
@@ -667,7 +667,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			stop := make(chan struct{})
 			wf, err := factory.NewWatchFactory(fakeClient, stop)
 			Expect(err).NotTo(HaveOccurred())
-			defer wf.Shutdown()
+			defer close(stop)
 
 			clusterController := NewOvnController(fakeClient, wf)
 			Expect(clusterController).NotTo(BeNil())
@@ -879,7 +879,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			stop := make(chan struct{})
 			wf, err := factory.NewWatchFactory(fakeClient, stop)
 			Expect(err).NotTo(HaveOccurred())
-			defer wf.Shutdown()
+			defer close(stop)
 
 			clusterController := NewOvnController(fakeClient, wf)
 			Expect(clusterController).NotTo(BeNil())

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -76,7 +76,10 @@ func (n namespace) addCmdsWithPods(fexec *ovntest.FakeExec, tP pod, namespace v1
 }
 
 var _ = Describe("OVN Namespace Operations", func() {
-	var app *cli.App
+	var (
+		app     *cli.App
+		fakeOvn *FakeOVN
+	)
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -85,6 +88,12 @@ var _ = Describe("OVN Namespace Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		fakeOvn = &FakeOVN{}
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
 	})
 
 	Context("on startup", func() {
@@ -109,7 +118,6 @@ var _ = Describe("OVN Namespace Operations", func() {
 				test.baseCmds(tExec, namespaceT)
 				test.addCmdsWithPods(tExec, tP, namespaceT)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, tExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -145,7 +153,6 @@ var _ = Describe("OVN Namespace Operations", func() {
 				test.baseCmds(tExec, namespaceT)
 				test.addCmds(tExec, namespaceT)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, tExec, &v1.NamespaceList{
 					Items: []v1.Namespace{
 						namespaceT,
@@ -178,7 +185,6 @@ var _ = Describe("OVN Namespace Operations", func() {
 				test.baseCmds(fExec, namespaceT)
 				test.addCmds(fExec, namespaceT)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.NamespaceList{
 					Items: []v1.Namespace{
 						namespaceT,

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -79,6 +79,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
+		fExec   *ovntest.FakeExec
 	)
 
 	BeforeEach(func() {
@@ -89,7 +90,8 @@ var _ = Describe("OVN Namespace Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = &FakeOVN{}
+		fExec = ovntest.NewFakeExec()
+		fakeOvn = NewFakeOVN(fExec, true)
 	})
 
 	AfterEach(func() {
@@ -114,11 +116,10 @@ var _ = Describe("OVN Namespace Operations", func() {
 					namespaceT.Name,
 				)
 
-				tExec := ovntest.NewFakeExec()
-				test.baseCmds(tExec, namespaceT)
-				test.addCmdsWithPods(tExec, tP, namespaceT)
+				test.baseCmds(fExec, namespaceT)
+				test.addCmdsWithPods(fExec, tP, namespaceT)
 
-				fakeOvn.start(ctx, tExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespaceT,
@@ -134,7 +135,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 
 				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(tExec.CalledMatchesExpected()).To(BeTrue(), tExec.ErrorDesc)
+				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 				return nil
 			}
@@ -149,11 +150,10 @@ var _ = Describe("OVN Namespace Operations", func() {
 				test := namespace{}
 				namespaceT := *newNamespace("namespace1")
 
-				tExec := ovntest.NewFakeExec()
-				test.baseCmds(tExec, namespaceT)
-				test.addCmds(tExec, namespaceT)
+				test.baseCmds(fExec, namespaceT)
+				test.addCmds(fExec, namespaceT)
 
-				fakeOvn.start(ctx, tExec, &v1.NamespaceList{
+				fakeOvn.start(ctx, &v1.NamespaceList{
 					Items: []v1.Namespace{
 						namespaceT,
 					},
@@ -162,7 +162,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 
 				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(tExec.CalledMatchesExpected()).To(BeTrue(), tExec.ErrorDesc)
+				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 				return nil
 			}
@@ -181,11 +181,10 @@ var _ = Describe("OVN Namespace Operations", func() {
 				test := namespace{}
 				namespaceT := *newNamespace("namespace1")
 
-				fExec := ovntest.NewFakeExec()
 				test.baseCmds(fExec, namespaceT)
 				test.addCmds(fExec, namespaceT)
 
-				fakeOvn.start(ctx, fExec, &v1.NamespaceList{
+				fakeOvn.start(ctx, &v1.NamespaceList{
 					Items: []v1.Namespace{
 						namespaceT,
 					},

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -35,8 +35,12 @@ func (o *FakeOVN) start(ctx *cli.Context, fexec *ovntest.FakeExec, objects ...ru
 }
 
 func (o *FakeOVN) restart() {
-	close(o.stopChan)
+	o.shutdown()
 	o.init()
+}
+
+func (o *FakeOVN) shutdown() {
+	close(o.stopChan)
 }
 
 func (o *FakeOVN) init() {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -162,7 +162,10 @@ func (p pod) delFromNamespaceCmds(fexec *ovntest.FakeExec, pod pod, isMulticastE
 }
 
 var _ = Describe("OVN Pod Operations", func() {
-	var app *cli.App
+	var (
+		app     *cli.App
+		fakeOvn *FakeOVN
+	)
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -171,6 +174,12 @@ var _ = Describe("OVN Pod Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		fakeOvn = &FakeOVN{}
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
 	})
 
 	Context("during execution", func() {
@@ -196,7 +205,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: "\n",
 				})
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
@@ -256,7 +264,6 @@ var _ = Describe("OVN Pod Operations", func() {
 				fExec := ovntest.NewFakeExec()
 				t.baseCmds(fExec)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
 					Items: []v1.Pod{},
 				})
@@ -314,7 +321,6 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
@@ -371,7 +377,6 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingFailedPod(fExec)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
@@ -428,7 +433,6 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
@@ -480,7 +484,6 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				t.delCmds(fExec)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec)
 				fakeOvn.controller.WatchPods()
 
@@ -515,7 +518,6 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
@@ -563,7 +565,6 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -165,6 +165,7 @@ var _ = Describe("OVN Pod Operations", func() {
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
+		fExec   *ovntest.FakeExec
 	)
 
 	BeforeEach(func() {
@@ -175,7 +176,8 @@ var _ = Describe("OVN Pod Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = &FakeOVN{}
+		fExec = ovntest.NewFakeExec()
+		fakeOvn = NewFakeOVN(fExec, true)
 	})
 
 	AfterEach(func() {
@@ -199,13 +201,12 @@ var _ = Describe("OVN Pod Operations", func() {
 					"namespace",
 				)
 
-				fExec := ovntest.NewFakeExec()
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: "\n",
 				})
 
-				fakeOvn.start(ctx, fExec, &v1.PodList{
+				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 					},
@@ -261,10 +262,9 @@ var _ = Describe("OVN Pod Operations", func() {
 					"namespace",
 				)
 
-				fExec := ovntest.NewFakeExec()
 				t.baseCmds(fExec)
 
-				fakeOvn.start(ctx, fExec, &v1.PodList{
+				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{},
 				})
 				fakeOvn.controller.WatchPods()
@@ -313,7 +313,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					"namespace",
 				)
 
-				fExec := ovntest.NewFakeExec()
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: "\n",
@@ -321,7 +320,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
 
-				fakeOvn.start(ctx, fExec, &v1.PodList{
+				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 					},
@@ -369,7 +368,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					"namespace",
 				)
 
-				fExec := ovntest.NewFakeExec()
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: "\n",
@@ -377,7 +375,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingFailedPod(fExec)
 
-				fakeOvn.start(ctx, fExec, &v1.PodList{
+				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 					},
@@ -422,7 +420,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					"namespace",
 				)
 
-				fExec := ovntest.NewFakeExec()
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: t.portName + "\n",
@@ -433,7 +430,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
 
-				fakeOvn.start(ctx, fExec, &v1.PodList{
+				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 					},
@@ -476,7 +473,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					"namespace",
 				)
 
-				fExec := ovntest.NewFakeExec()
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: t.portName + "\n",
@@ -484,7 +480,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				t.delCmds(fExec)
 
-				fakeOvn.start(ctx, fExec)
+				fakeOvn.start(ctx)
 				fakeOvn.controller.WatchPods()
 
 				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
@@ -510,7 +506,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					"namespace",
 				)
 
-				fExec := ovntest.NewFakeExec()
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: "\n",
@@ -518,7 +513,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
 
-				fakeOvn.start(ctx, fExec, &v1.PodList{
+				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 					},
@@ -557,7 +552,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					"namespace",
 				)
 
-				fExec := ovntest.NewFakeExec()
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: "\n",
@@ -565,7 +559,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.addNodeSetupCmds(fExec)
 				t.addCmdsForNonExistingPod(fExec)
 
-				fakeOvn.start(ctx, fExec, &v1.PodList{
+				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
 						*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 					},

--- a/go-controller/pkg/ovn/policy_old_test.go
+++ b/go-controller/pkg/ovn/policy_old_test.go
@@ -43,18 +43,15 @@ func newNetworkPolicyOld(name, namespace string, podSelector metav1.LabelSelecto
 }
 
 func (n networkPolicyOld) baseCmds(fexec *ovntest.FakeExec, networkPolicy knet.NetworkPolicy) {
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=external_ids find address_set",
-		Output: "",
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=external_ids find address_set",
 	})
 }
+
 func (n networkPolicyOld) addNamespaceSelectorCmdsForGress(fexec *ovntest.FakeExec, networkPolicy knet.NetworkPolicy, gress string, i int) {
 	hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, gress, i))
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=%s", hashedOVNName),
-		Output: "",
-	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=%s", hashedOVNName),
 		fmt.Sprintf("ovn-nbctl --timeout=15 create address_set name=%s external-ids:name=%s", hashedOVNName, fmt.Sprintf("%s.%s.%s.%v", networkPolicy.Namespace, networkPolicy.Name, gress, i)),
 	})
 }

--- a/go-controller/pkg/ovn/policy_old_test.go
+++ b/go-controller/pkg/ovn/policy_old_test.go
@@ -281,7 +281,10 @@ func (n networkPolicyOld) delLocalPodCmds(fexec *ovntest.FakeExec, pod pod, netw
 }
 
 var _ = Describe("OVN NetworkPolicy Operations", func() {
-	var app *cli.App
+	var (
+		app     *cli.App
+		fakeOvn *FakeOVN
+	)
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -290,6 +293,12 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		fakeOvn = &FakeOVN{}
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
 	})
 
 	Context("on startup", func() {
@@ -336,7 +345,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmds(fExec, namespace1, namespace2)
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -421,7 +429,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addLocalPodSelectorCmds(fExec, nPodTest, networkPolicy)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -523,7 +530,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
 				npTest.addPodAndNamespaceSelectorCmds(fExec, nPodTest, namespace2, networkPolicy)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -620,7 +626,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addLocalPodAndNamespaceSelectorCmds(fExec, nPodTest, networkPolicy, namespace2)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -715,7 +720,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmds(fExec, namespace1, namespace2)
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -806,7 +810,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addLocalPodSelectorCmds(fExec, nPodTest, networkPolicy)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -915,7 +918,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
 				npTest.addPodAndNamespaceSelectorCmds(fExec, nPodTest, namespace2, networkPolicy)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -1020,7 +1022,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addLocalPodSelectorCmds(fExec, nPodTest, networkPolicy)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{

--- a/go-controller/pkg/ovn/policy_old_test.go
+++ b/go-controller/pkg/ovn/policy_old_test.go
@@ -281,6 +281,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
+		fExec   *ovntest.FakeExec
 	)
 
 	BeforeEach(func() {
@@ -291,7 +292,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = &FakeOVN{}
+		fExec = ovntest.NewLooseCompareFakeExec()
+		fakeOvn = NewFakeOVN(fExec, false)
 	})
 
 	AfterEach(func() {
@@ -337,12 +339,11 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nTest.baseCmds(fExec, namespace1, namespace2)
 				nTest.addCmds(fExec, namespace1, namespace2)
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -355,8 +356,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				fakeOvn.controller.portGroupSupport = false
-				fakeOvn.controller.multicastSupport = false
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
 
@@ -418,7 +417,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -426,7 +424,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addLocalPodSelectorCmds(fExec, nPodTest, networkPolicy)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -443,8 +441,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				fakeOvn.controller.portGroupSupport = false
-				fakeOvn.controller.multicastSupport = false
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -518,7 +514,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -527,7 +522,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
 				npTest.addPodAndNamespaceSelectorCmds(fExec, nPodTest, namespace2, networkPolicy)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -545,8 +540,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				fakeOvn.controller.portGroupSupport = false
-				fakeOvn.controller.multicastSupport = false
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -614,7 +607,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -623,7 +615,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addLocalPodAndNamespaceSelectorCmds(fExec, nPodTest, networkPolicy, namespace2)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -641,8 +633,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				fakeOvn.controller.portGroupSupport = false
-				fakeOvn.controller.multicastSupport = false
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -712,12 +702,11 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nTest.baseCmds(fExec, namespace1, namespace2)
 				nTest.addCmds(fExec, namespace1, namespace2)
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -730,8 +719,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				fakeOvn.controller.portGroupSupport = false
-				fakeOvn.controller.multicastSupport = false
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
 
@@ -799,7 +786,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -807,7 +793,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addLocalPodSelectorCmds(fExec, nPodTest, networkPolicy)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -824,8 +810,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				fakeOvn.controller.portGroupSupport = false
-				fakeOvn.controller.multicastSupport = false
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -906,7 +890,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -915,7 +898,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
 				npTest.addPodAndNamespaceSelectorCmds(fExec, nPodTest, namespace2, networkPolicy)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -933,8 +916,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				fakeOvn.controller.portGroupSupport = false
-				fakeOvn.controller.multicastSupport = false
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -1011,7 +992,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -1019,7 +999,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addLocalPodSelectorCmds(fExec, nPodTest, networkPolicy)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -1036,8 +1016,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				fakeOvn.controller.portGroupSupport = false
-				fakeOvn.controller.multicastSupport = false
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -42,13 +42,9 @@ func newNetworkPolicy(name, namespace string, podSelector metav1.LabelSelector, 
 func (n networkPolicy) baseCmds(fexec *ovntest.FakeExec, networkPolicy knet.NetworkPolicy) {
 	readableGroupName := fmt.Sprintf("%s_%s", networkPolicy.Namespace, networkPolicy.Name)
 	hashedGroupName := hashedPortGroup(readableGroupName)
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=external_ids find address_set",
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=%s", hashedGroupName),
-		Output: "",
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=external_ids find address_set",
+		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=%s", hashedGroupName),
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 create port_group name=%s external-ids:name=%s", hashedGroupName, readableGroupName),
@@ -57,11 +53,8 @@ func (n networkPolicy) baseCmds(fexec *ovntest.FakeExec, networkPolicy knet.Netw
 }
 func (n networkPolicy) addNamespaceSelectorCmdsForGress(fexec *ovntest.FakeExec, networkPolicy knet.NetworkPolicy, gress string, i int) {
 	hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, gress, i))
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=%s", hashedOVNName),
-		Output: "",
-	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=%s", hashedOVNName),
 		fmt.Sprintf("ovn-nbctl --timeout=15 create address_set name=%s external-ids:name=%s", hashedOVNName, fmt.Sprintf("%s.%s.%s.%v", networkPolicy.Namespace, networkPolicy.Name, gress, i)),
 	})
 }
@@ -121,35 +114,25 @@ func (n networkPolicy) addNamespaceSelectorCmds(fexec *ovntest.FakeExec, network
 	n.baseCmds(fexec, networkPolicy)
 	for i := range networkPolicy.Spec.Ingress {
 		n.addNamespaceSelectorCmdsForGress(fexec, networkPolicy, "ingress", i)
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Ingress_num=%v external-ids:policy_type=Ingress", networkPolicy.Namespace, networkPolicy.Name, i),
-			Output: "",
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" action=allow-related external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group fake_uuid acls @acl",
-			Output: "",
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Ingress_num=%v external-ids:policy_type=Ingress", networkPolicy.Namespace, networkPolicy.Name, i),
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" action=allow-related external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group fake_uuid acls @acl",
 		})
 		if findAgain {
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
-				Output: "",
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
 			})
 		}
 	}
 	for i := range networkPolicy.Spec.Egress {
 		n.addNamespaceSelectorCmdsForGress(fexec, networkPolicy, "egress", i)
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Egress_num=%v external-ids:policy_type=Egress", networkPolicy.Namespace, networkPolicy.Name, i),
-			Output: "",
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" action=allow external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group fake_uuid acls @acl",
-			Output: "",
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Egress_num=%v external-ids:policy_type=Egress", networkPolicy.Namespace, networkPolicy.Name, i),
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" action=allow external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group fake_uuid acls @acl",
 		})
 		if findAgain {
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
-				Output: "",
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
 			})
 		}
 	}

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -214,7 +214,10 @@ func (n networkPolicy) delPodCmds(fexec *ovntest.FakeExec, networkPolicy knet.Ne
 }
 
 var _ = Describe("OVN NetworkPolicy Operations", func() {
-	var app *cli.App
+	var (
+		app     *cli.App
+		fakeOvn *FakeOVN
+	)
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -223,6 +226,12 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		fakeOvn = &FakeOVN{}
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
 	})
 
 	Context("on startup", func() {
@@ -269,7 +278,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmds(fExec, namespace1, namespace2)
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -353,7 +361,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, true, false)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -454,7 +461,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, false, false)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -551,7 +557,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
 				npTest.addLocalPodCmds(fExec, nPodTest)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -645,7 +650,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmds(fExec, namespace1, namespace2)
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -745,7 +749,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, true, false)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -854,7 +857,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, false, false)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -952,7 +954,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, true, false)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -200,6 +200,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
+		fExec   *ovntest.FakeExec
 	)
 
 	BeforeEach(func() {
@@ -210,7 +211,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = &FakeOVN{}
+		fExec = ovntest.NewLooseCompareFakeExec()
+		fakeOvn = NewFakeOVN(fExec, true)
 	})
 
 	AfterEach(func() {
@@ -256,12 +258,11 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nTest.baseCmds(fExec, namespace1, namespace2)
 				nTest.addCmds(fExec, namespace1, namespace2)
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -336,7 +337,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -344,7 +344,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, true, false)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -435,7 +435,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -444,7 +443,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, false, false)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -530,7 +529,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -540,7 +538,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
 				npTest.addLocalPodCmds(fExec, nPodTest)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -628,12 +626,11 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nTest.baseCmds(fExec, namespace1, namespace2)
 				nTest.addCmds(fExec, namespace1, namespace2)
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -724,7 +721,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -732,7 +728,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, true, false)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -831,7 +827,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -840,7 +835,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, false, false)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,
@@ -929,7 +924,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 						},
 					})
 
-				fExec := ovntest.NewLooseCompareFakeExec()
 				nPodTest.baseCmds(fExec)
 				nPodTest.addNodeSetupCmds(fExec)
 				nPodTest.addCmdsForNonExistingPod(fExec)
@@ -937,7 +931,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, true, false)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespace1,

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -102,7 +102,10 @@ func (s service) delCmds(fexec *ovntest.FakeExec, service v1.Service) {
 }
 
 var _ = Describe("OVN Namespace Operations", func() {
-	var app *cli.App
+	var (
+		app     *cli.App
+		fakeOvn *FakeOVN
+	)
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -111,6 +114,12 @@ var _ = Describe("OVN Namespace Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		fakeOvn = &FakeOVN{}
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
 	})
 
 	Context("on startup", func() {
@@ -132,7 +141,6 @@ var _ = Describe("OVN Namespace Operations", func() {
 				fExec := ovntest.NewFakeExec()
 				test.baseCmds(fExec, service)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.ServiceList{
 						Items: []v1.Service{
@@ -170,7 +178,6 @@ var _ = Describe("OVN Namespace Operations", func() {
 				fExec := ovntest.NewFakeExec()
 				test.baseCmds(fExec, service)
 
-				fakeOvn := FakeOVN{}
 				fakeOvn.start(ctx, fExec,
 					&v1.ServiceList{
 						Items: []v1.Service{

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -105,6 +105,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
+		fExec   *ovntest.FakeExec
 	)
 
 	BeforeEach(func() {
@@ -115,7 +116,8 @@ var _ = Describe("OVN Namespace Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = &FakeOVN{}
+		fExec = ovntest.NewFakeExec()
+		fakeOvn = NewFakeOVN(fExec, true)
 	})
 
 	AfterEach(func() {
@@ -138,10 +140,9 @@ var _ = Describe("OVN Namespace Operations", func() {
 					v1.ServiceTypeClusterIP,
 				)
 
-				fExec := ovntest.NewFakeExec()
 				test.baseCmds(fExec, service)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.ServiceList{
 						Items: []v1.Service{
 							service,
@@ -175,10 +176,9 @@ var _ = Describe("OVN Namespace Operations", func() {
 					v1.ServiceTypeClusterIP,
 				)
 
-				fExec := ovntest.NewFakeExec()
 				test.baseCmds(fExec, service)
 
-				fakeOvn.start(ctx, fExec,
+				fakeOvn.start(ctx,
 					&v1.ServiceList{
 						Items: []v1.Service{
 							service,

--- a/go-controller/pkg/testing/testing.go
+++ b/go-controller/pkg/testing/testing.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	kruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kexec "k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
 )
@@ -16,6 +17,9 @@ func init() {
 	// Gomega's default string diff behavior makes it impossible to figure
 	// out what fake command is failing, so turn it off
 	format.TruncatedDiff = false
+	// SharedInformers and the Kubernetes cache have internal panic
+	// handling that interferes with Gingko. Disable it.
+	kruntime.ReallyCrash = false
 }
 
 // KCmd is a callback spec returning a k8s exec command


### PR DESCRIPTION
Mostly making sure we shut the watcher down more consistently so events don't bleed into subsequent tests.

@girishmg @danwinship 