### PR TITLE
Unified port cache

### DIFF
--- a/go-controller/pkg/ovn/ha_master.go
+++ b/go-controller/pkg/ovn/ha_master.go
@@ -44,7 +44,7 @@ type HAMasterController struct {
 // NewHAMasterController creates a new HA Master controller
 func NewHAMasterController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
 	nodeName string, stopChan chan struct{}) *HAMasterController {
-	ovnController := NewOvnController(kubeClient, wf)
+	ovnController := NewOvnController(kubeClient, wf, stopChan)
 	return &HAMasterController{
 		kubeClient:      kubeClient,
 		ovnController:   ovnController,

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -216,7 +216,7 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
-			clusterController := NewOvnController(fakeClient, f)
+			clusterController := NewOvnController(fakeClient, f, stopChan)
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -290,7 +290,7 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
-			clusterController := NewOvnController(fakeClient, f)
+			clusterController := NewOvnController(fakeClient, f, stopChan)
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -441,7 +441,7 @@ subnet=%s
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
-			clusterController := NewOvnController(fakeClient, f)
+			clusterController := NewOvnController(fakeClient, f, stopChan)
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -644,7 +644,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stop)
 
-			clusterController := NewOvnController(fakeClient, wf)
+			clusterController := NewOvnController(fakeClient, wf, stop)
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -840,7 +840,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stop)
 
-			clusterController := NewOvnController(fakeClient, wf)
+			clusterController := NewOvnController(fakeClient, wf, stop)
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -76,7 +76,7 @@ func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
 	// If multicast is allowed and enabled for the namespace, add the port
 	// to the allow policy.
 	if oc.multicastSupport && oc.multicastEnabled[ns] {
-		if err := oc.podAddAllowMulticastPolicy(ns, portInfo); err != nil {
+		if err := podAddAllowMulticastPolicy(ns, portInfo); err != nil {
 			return err
 		}
 	}
@@ -101,7 +101,7 @@ func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) error 
 
 	// Remove the port from the multicast allow policy.
 	if oc.multicastSupport && oc.multicastEnabled[ns] {
-		if err := oc.podDeleteAllowMulticastPolicy(ns, portInfo); err != nil {
+		if err := podDeleteAllowMulticastPolicy(ns, portInfo); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -2,7 +2,6 @@ package ovn
 
 import (
 	"fmt"
-	"net"
 	"sync"
 	"time"
 
@@ -54,7 +53,7 @@ func (oc *Controller) waitForNamespaceEvent(namespace string) error {
 	return nil
 }
 
-func (oc *Controller) addPodToNamespace(ns string, ip net.IP, logicalPort string) error {
+func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
 	mutex := oc.getNamespaceLock(ns)
 	if mutex == nil {
 		return nil
@@ -66,18 +65,18 @@ func (oc *Controller) addPodToNamespace(ns string, ip net.IP, logicalPort string
 	}
 
 	// If pod has already been added, nothing to do.
-	address := ip.String()
+	address := portInfo.ip.String()
 	if oc.namespaceAddressSet[ns][address] != "" {
 		return nil
 	}
 
-	oc.namespaceAddressSet[ns][address] = logicalPort
+	oc.namespaceAddressSet[ns][address] = portInfo.name
 	addToAddressSet(hashedAddressSet(ns), address)
 
 	// If multicast is allowed and enabled for the namespace, add the port
 	// to the allow policy.
 	if oc.multicastSupport && oc.multicastEnabled[ns] {
-		if err := oc.podAddAllowMulticastPolicy(ns, logicalPort); err != nil {
+		if err := oc.podAddAllowMulticastPolicy(ns, portInfo); err != nil {
 			return err
 		}
 	}
@@ -85,18 +84,14 @@ func (oc *Controller) addPodToNamespace(ns string, ip net.IP, logicalPort string
 	return nil
 }
 
-func (oc *Controller) deletePodFromNamespace(ns string, ip net.IP, logicalPort string) error {
-	if ip == nil {
-		return nil
-	}
-
+func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) error {
 	mutex := oc.getNamespaceLock(ns)
 	if mutex == nil {
 		return nil
 	}
 	defer mutex.Unlock()
 
-	address := ip.String()
+	address := portInfo.ip.String()
 	if oc.namespaceAddressSet[ns][address] == "" {
 		return nil
 	}
@@ -106,7 +101,7 @@ func (oc *Controller) deletePodFromNamespace(ns string, ip net.IP, logicalPort s
 
 	// Remove the port from the multicast allow policy.
 	if oc.multicastSupport && oc.multicastEnabled[ns] {
-		if err := oc.podDeleteAllowMulticastPolicy(ns, logicalPort); err != nil {
+		if err := oc.podDeleteAllowMulticastPolicy(ns, portInfo); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/urfave/cli"
 
@@ -154,6 +155,8 @@ var _ = Describe("OVN Namespace Operations", func() {
 						},
 					},
 				)
+				podMAC, _ := net.ParseMAC("11:22:33:44:55:66")
+				fakeOvn.controller.logicalPortCache.add(tP.nodeName, tP.portName, fakeUUID, podMAC, net.ParseIP(tP.podIP))
 				fakeOvn.controller.WatchNamespaces()
 
 				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -60,12 +60,8 @@ type Controller struct {
 	// A cache of all logical switches seen by the watcher and their subnets
 	logicalSwitchCache map[string]*net.IPNet
 
-	// A cache of all logical ports seen by the watcher and
-	// its corresponding logical switch
-	logicalPortCache map[string]string
-
-	// A cache of all logical ports and its corresponding uuids.
-	logicalPortUUIDCache map[string]string
+	// A cache of all logical ports known to the controller
+	logicalPortCache *portCache
 
 	// For each namespace, a map from pod IP address to logical port name
 	// for all pods in that namespace.
@@ -125,15 +121,14 @@ const (
 
 // NewOvnController creates a new OVN controller for creating logical network
 // infrastructure and policy
-func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory) *Controller {
+func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory, stopChan <-chan struct{}) *Controller {
 	return &Controller{
 		kube:                     &kube.Kube{KClient: kubeClient},
 		watchFactory:             wf,
 		masterSubnetAllocator:    allocator.NewSubnetAllocator(),
 		logicalSwitchCache:       make(map[string]*net.IPNet),
 		joinSubnetAllocator:      allocator.NewSubnetAllocator(),
-		logicalPortCache:         make(map[string]string),
-		logicalPortUUIDCache:     make(map[string]string),
+		logicalPortCache:         newPortCache(stopChan),
 		namespaceAddressSet:      make(map[string]map[string]string),
 		namespacePolicies:        make(map[string]map[string]*namespacePolicy),
 		namespaceMutex:           make(map[string]*sync.Mutex),

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -59,7 +59,7 @@ func (o *FakeOVN) init() {
 	o.watcher, err = factory.NewWatchFactory(o.fakeClient, o.stopChan)
 	Expect(err).NotTo(HaveOccurred())
 
-	o.controller = NewOvnController(o.fakeClient, o.watcher)
+	o.controller = NewOvnController(o.fakeClient, o.watcher, o.stopChan)
 	o.controller.portGroupSupport = o.portGroups
 	// Multicast depends on port groups
 	o.controller.multicastSupport = o.portGroups

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -124,7 +124,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 
 	// Remove the port from the default deny multicast policy
 	if oc.multicastSupport {
-		if err := oc.podDeleteDefaultDenyMulticastPolicy(portInfo); err != nil {
+		if err := podDeleteDefaultDenyMulticastPolicy(portInfo); err != nil {
 			klog.Errorf(err.Error())
 		}
 	}
@@ -346,7 +346,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 
 	// Enforce the default deny multicast policy
 	if oc.multicastSupport {
-		if err := oc.podAddDefaultDenyMulticastPolicy(portInfo); err != nil {
+		if err := podAddDefaultDenyMulticastPolicy(portInfo); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -107,26 +107,6 @@ func (oc *Controller) deletePodAcls(logicalPort string) {
 	}
 }
 
-func (oc *Controller) getLogicalPortUUID(logicalPort string) (string, error) {
-	if oc.logicalPortUUIDCache[logicalPort] != "" {
-		return oc.logicalPortUUIDCache[logicalPort], nil
-	}
-
-	out, stderr, err := util.RunOVNNbctl("--if-exists", "get",
-		"logical_switch_port", logicalPort, "_uuid")
-	if err != nil {
-		return "", fmt.Errorf("Error while getting uuid for logical_switch_port "+
-			"%s, stderr: %q, err: %v", logicalPort, stderr, err)
-	}
-
-	if out == "" {
-		return "", fmt.Errorf("empty uuid for logical_switch_port %s", logicalPort)
-	}
-
-	oc.logicalPortUUIDCache[logicalPort] = out
-	return oc.logicalPortUUIDCache[logicalPort], nil
-}
-
 func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	if pod.Spec.HostNetwork {
 		return
@@ -134,42 +114,33 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 
 	podDesc := pod.Namespace + "/" + pod.Name
 	klog.Infof("Deleting pod: %s", podDesc)
+
 	logicalPort := podLogicalPortName(pod)
-	out, stderr, err := util.RunOVNNbctl("--if-exists", "lsp-del",
-		logicalPort)
+	portInfo, err := oc.logicalPortCache.get(logicalPort)
+	if err != nil {
+		klog.Errorf(err.Error())
+		return
+	}
+
+	// Remove the port from the default deny multicast policy
+	if oc.multicastSupport {
+		if err := oc.podDeleteDefaultDenyMulticastPolicy(portInfo); err != nil {
+			klog.Errorf(err.Error())
+		}
+	}
+
+	if err := oc.deletePodFromNamespace(pod.Namespace, portInfo); err != nil {
+		klog.Errorf(err.Error())
+	}
+
+	out, stderr, err := util.RunOVNNbctl("--if-exists", "lsp-del", logicalPort)
 	if err != nil {
 		klog.Errorf("Error in deleting pod %s logical port "+
 			"stdout: %q, stderr: %q, (%v)",
 			podDesc, out, stderr, err)
 	}
 
-	var podIP net.IP
-	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
-	if err != nil {
-		klog.V(5).Infof("failed to read pod %s annotation when deleting "+
-			"logical port; falling back to PodIP %s: %v",
-			podDesc, pod.Status.PodIP, err)
-		podIP = net.ParseIP(pod.Status.PodIP)
-	} else {
-		podIP = podAnnotation.IP.IP
-	}
-
-	delete(oc.logicalPortCache, logicalPort)
-
-	oc.lspMutex.Lock()
-	delete(oc.logicalPortUUIDCache, logicalPort)
-	oc.lspMutex.Unlock()
-
-	// Remove the port from the default deny multicast policy
-	if oc.multicastSupport {
-		if err := oc.podDeleteDefaultDenyMulticastPolicy(logicalPort); err != nil {
-			klog.Errorf(err.Error())
-		}
-	}
-
-	if err := oc.deletePodFromNamespace(pod.Namespace, podIP, logicalPort); err != nil {
-		klog.Errorf(err.Error())
-	}
+	oc.logicalPortCache.remove(logicalPort)
 }
 
 func (oc *Controller) waitForNodeLogicalSwitch(nodeName string) (*net.IPNet, error) {
@@ -283,103 +254,131 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 	portName := podLogicalPortName(pod)
 	klog.V(5).Infof("Creating logical port for %s on switch %s", portName, logicalSwitch)
 
-	annotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
-	// If pod already has annotations, just add the lsp with static ip/mac.
-	// Else, create the lsp with dynamic addresses.
-	if err == nil {
-		out, stderr, err = util.RunOVNNbctl(
-			"--may-exist", "lsp-add", logicalSwitch, portName,
-			"--", "lsp-set-addresses", portName, fmt.Sprintf("%s %s", annotation.MAC, annotation.IP.IP),
-			"--", "set", "logical_switch_port", portName, "external-ids:namespace="+pod.Namespace,
-			"external-ids:logical_switch="+logicalSwitch, "external-ids:pod=true",
-			"--", "--if-exists", "clear", "logical_switch_port", portName, "dynamic_addresses")
-		if err != nil {
-			return fmt.Errorf("Failed to add logical port to switch "+
-				"stdout: %q, stderr: %q (%v)", out, stderr, err)
-		}
-		// now set the port security for the logical switch port
-		out, stderr, err = util.RunOVNNbctl("lsp-set-port-security", portName,
-			fmt.Sprintf("%s %s", annotation.MAC, annotation.IP))
-		if err != nil {
-			return fmt.Errorf("error while setting port security for logical port %s "+
-				"stdout: %q, stderr: %q (%v)", portName, out, stderr, err)
-		}
-		oc.logicalPortCache[portName] = logicalSwitch
-		return oc.addPodToNamespace(pod.Namespace, annotation.IP.IP, portName)
-	}
+	var podMac net.HardwareAddr
+	var podCIDR *net.IPNet
+	var gatewayCIDR *net.IPNet
+	var args []string
 
-	addressStr := "dynamic"
-	networks, err := util.GetPodNetSelAnnotation(pod, util.DefNetworkAnnotation)
-	if err != nil || (networks != nil && len(networks) != 1) {
-		return fmt.Errorf("error while getting custom MAC config for port %q from "+
-			"default-network's network-attachment: %v", portName, err)
-	} else if networks != nil && networks[0].MacRequest != "" {
-		klog.V(5).Infof("Pod %s/%s requested custom MAC: %s", pod.Namespace, pod.Name, networks[0].MacRequest)
-		addressStr = networks[0].MacRequest + " dynamic"
+	annotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
+	if err == nil {
+		podMac = annotation.MAC
+		podCIDR = annotation.IP
+		gatewayCIDR = &net.IPNet{IP: annotation.GW, Mask: annotation.IP.Mask}
+
+		// Check if the pod's logical switch port already exists. If it
+		// does don't re-add the port to OVN as this will change its
+		// UUID and and the port cache, address sets, and port groups
+		// will still have the old UUID.
+		out, _, err = util.RunOVNNbctl("--if-exists", "get", "logical_switch_port", portName, "_uuid")
+		if err != nil || !strings.Contains(out, "-") {
+			// Pod's logical switch port does not yet exist
+			args = []string{"lsp-add", logicalSwitch, portName}
+		}
+
+		// If the pod already has annotations use the existing static
+		// IP/MAC from the annotation.
+		args = append(args,
+			"--", "lsp-set-addresses", portName, fmt.Sprintf("%s %s", podMac, annotation.IP.IP),
+			"--", "--if-exists", "clear", "logical_switch_port", portName, "dynamic_addresses",
+		)
+	} else {
+		gatewayCIDR, _ = util.GetNodeWellKnownAddresses(nodeSubnet)
+
+		addresses := "dynamic"
+		networks, err := util.GetPodNetSelAnnotation(pod, util.DefNetworkAnnotation)
+		if err != nil || (networks != nil && len(networks) != 1) {
+			return fmt.Errorf("error while getting custom MAC config for port %q from "+
+				"default-network's network-attachment: %v", portName, err)
+		} else if networks != nil && networks[0].MacRequest != "" {
+			klog.V(5).Infof("Pod %s/%s requested custom MAC: %s", pod.Namespace, pod.Name, networks[0].MacRequest)
+			addresses = networks[0].MacRequest + " dynamic"
+		}
+
+		// If it has no annotations, let OVN assign it IP and MAC addresses
+		args = []string{
+			"--may-exist", "lsp-add", logicalSwitch, portName,
+			"--", "lsp-set-addresses", portName, addresses,
+		}
 	}
-	out, stderr, err = util.RunOVNNbctl(
-		"--", "--may-exist", "lsp-add", logicalSwitch, portName,
-		"--", "lsp-set-addresses", portName, addressStr,
-		"--", "set", "logical_switch_port", portName, "external-ids:namespace="+pod.Namespace,
-		"external-ids:logical_switch="+logicalSwitch, "external-ids:pod=true")
+	args = append(args, "--", "set", "logical_switch_port", portName, "external-ids:namespace="+pod.Namespace, "external-ids:pod=true")
+
+	out, stderr, err = util.RunOVNNbctl(args...)
 	if err != nil {
 		return fmt.Errorf("Error while creating logical port %s stdout: %q, stderr: %q (%v)",
 			portName, out, stderr, err)
 	}
 
-	oc.logicalPortCache[portName] = logicalSwitch
-
-	gatewayIPnet, _ := util.GetNodeWellKnownAddresses(nodeSubnet)
-
-	podMac, podIP, err := waitForPodAddresses(portName)
-	if err != nil {
-		return err
+	// If the pod has not already been assigned addresses, read them now
+	if podMac == nil || podCIDR == nil {
+		var podIP net.IP
+		podMac, podIP, err = waitForPodAddresses(portName)
+		if err != nil {
+			return err
+		}
+		podCIDR = &net.IPNet{IP: podIP, Mask: nodeSubnet.Mask}
 	}
 
-	podCIDR := &net.IPNet{IP: podIP, Mask: gatewayIPnet.Mask}
+	// UUID must be retrieved separately from the lsp-add transaction since
+	// (as of OVN 2.12) a bogus UUID is returned if they are part of the same
+	// transaction.
+	// FIXME: move to the lsp-add transaction once https://bugzilla.redhat.com/show_bug.cgi?id=1806788
+	// is resolved.
+	var uuid string
+	uuid, _, err = util.RunOVNNbctl("get", "logical_switch_port", portName, "_uuid")
+	if err != nil {
+		return fmt.Errorf("error while getting UUID for logical port %s "+
+			"stdout: %q, stderr: %q (%v)", portName, uuid, stderr, err)
+	}
+	if !strings.Contains(uuid, "-") {
+		return fmt.Errorf("invalid logical port %s uuid %q", portName, uuid)
+	}
 
-	// now set the port security for the logical switch port
-	out, stderr, err = util.RunOVNNbctl("lsp-set-port-security", portName,
-		fmt.Sprintf("%s %s", podMac, podCIDR))
+	// Add the pod's logical switch port to the port cache
+	portInfo := oc.logicalPortCache.add(logicalSwitch, portName, uuid, podMac, podCIDR.IP)
+
+	// Set the port security for the logical switch port
+	addresses := fmt.Sprintf("%s %s", podMac, podCIDR.IP)
+	out, stderr, err = util.RunOVNNbctl("lsp-set-port-security", portName, addresses)
 	if err != nil {
 		return fmt.Errorf("error while setting port security for logical port %s "+
 			"stdout: %q, stderr: %q (%v)", portName, out, stderr, err)
 	}
 
-	routes, gatewayIP, err := getRoutesGatewayIP(pod, gatewayIPnet)
-	if err != nil {
-		return err
-	}
-	marshalledAnnotation, err := util.MarshalPodAnnotation(&util.PodAnnotation{
-		IP:     podCIDR,
-		MAC:    podMac,
-		GW:     gatewayIP,
-		Routes: routes,
-	})
-	if err != nil {
-		return fmt.Errorf("error creating pod network annotation: %v", err)
-	}
-
 	// Enforce the default deny multicast policy
 	if oc.multicastSupport {
-		if err := oc.podAddDefaultDenyMulticastPolicy(portName); err != nil {
+		if err := oc.podAddDefaultDenyMulticastPolicy(portInfo); err != nil {
 			return err
 		}
 	}
 
-	if err := oc.addPodToNamespace(pod.Namespace, podIP, portName); err != nil {
+	if err := oc.addPodToNamespace(pod.Namespace, portInfo); err != nil {
 		return err
 	}
 
-	klog.V(5).Infof("Annotation values: ip=%s ; mac=%s ; gw=%s\nAnnotation=%s",
-		podCIDR, podMac, gatewayIP, marshalledAnnotation)
-	err = oc.kube.SetAnnotationsOnPod(pod, marshalledAnnotation)
-	if err != nil {
-		return fmt.Errorf("failed to set annotation on pod %s - %v", pod.Name, err)
-	}
+	if annotation == nil {
+		routes, gwIP, err := getRoutesGatewayIP(pod, gatewayCIDR)
+		if err != nil {
+			return err
+		}
+		marshalledAnnotation, err := util.MarshalPodAnnotation(&util.PodAnnotation{
+			IP:     podCIDR,
+			MAC:    podMac,
+			GW:     gwIP,
+			Routes: routes,
+		})
+		if err != nil {
+			return fmt.Errorf("error creating pod network annotation: %v", err)
+		}
 
-	// observe the pod creation latency metric.
-	recordPodCreated(pod)
+		klog.V(5).Infof("Annotation values: ip=%s ; mac=%s ; gw=%s\nAnnotation=%s",
+			podCIDR, podMac, gwIP, marshalledAnnotation)
+		if err = oc.kube.SetAnnotationsOnPod(pod, marshalledAnnotation); err != nil {
+			return fmt.Errorf("failed to set annotation on pod %s: %v", pod.Name, err)
+		}
+
+		// observe the pod creation latency metric.
+		recordPodCreated(pod)
+	}
 
 	return nil
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -234,33 +234,23 @@ func deleteACLPortGroup(portGroupName, direction, priority, match, action string
 	return nil
 }
 
-func (oc *Controller) addToPortGroup(portGroup, logicalPort string) error {
-	logicalPortUUID, err := oc.getLogicalPortUUID(logicalPort)
-	if err != nil {
-		return err
-	}
-
+func (oc *Controller) addToPortGroup(portGroup string, portInfo *lpInfo) error {
 	_, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
-		"port_group", portGroup, "ports", logicalPortUUID, "--",
-		"add", "port_group", portGroup, "ports", logicalPortUUID)
+		"port_group", portGroup, "ports", portInfo.uuid, "--",
+		"add", "port_group", portGroup, "ports", portInfo.uuid)
 	if err != nil {
 		return fmt.Errorf("failed to add logicalPort %s to portGroup %s "+
-			"stderr: %q (%v)", logicalPort, portGroup, stderr, err)
+			"stderr: %q (%v)", portInfo.name, portGroup, stderr, err)
 	}
 	return nil
 }
 
-func (oc *Controller) deleteFromPortGroup(portGroup, logicalPort string) error {
-	logicalPortUUID, err := oc.getLogicalPortUUID(logicalPort)
-	if err != nil {
-		return err
-	}
-
+func (oc *Controller) deleteFromPortGroup(portGroup string, portInfo *lpInfo) error {
 	_, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
-		"port_group", portGroup, "ports", logicalPortUUID)
+		"port_group", portGroup, "ports", portInfo.uuid)
 	if err != nil {
 		return fmt.Errorf("failed to delete logicalPort %s to portGroup %s "+
-			"stderr: %q (%v)", logicalPort, portGroup, stderr, err)
+			"stderr: %q (%v)", portInfo.name, portGroup, stderr, err)
 	}
 	return nil
 }
@@ -400,7 +390,9 @@ func (oc *Controller) createMulticastAllowPolicy(ns string) error {
 
 	// Add all ports from this namespace to the multicast allow group.
 	for _, portName := range oc.namespaceAddressSet[ns] {
-		if err := oc.podAddAllowMulticastPolicy(ns, portName); err != nil {
+		if portInfo, err := oc.logicalPortCache.get(portName); err != nil {
+			klog.Errorf(err.Error())
+		} else if err := oc.podAddAllowMulticastPolicy(ns, portInfo); err != nil {
 			klog.Warningf("failed to add port %s to port group ACL: %v", portName, err)
 		}
 	}
@@ -466,32 +458,32 @@ func createDefaultDenyMulticastPolicy() error {
 	return nil
 }
 
-func (oc *Controller) podAddDefaultDenyMulticastPolicy(logicalPort string) error {
-	if err := oc.addToPortGroup("mcastPortGroupDeny", logicalPort); err != nil {
-		return fmt.Errorf("failed to add port %s to default multicast deny ACL: %v", logicalPort, err)
+func (oc *Controller) podAddDefaultDenyMulticastPolicy(portInfo *lpInfo) error {
+	if err := oc.addToPortGroup("mcastPortGroupDeny", portInfo); err != nil {
+		return fmt.Errorf("failed to add port %s to default multicast deny ACL: %v", portInfo.name, err)
 	}
 	return nil
 }
 
-func (oc *Controller) podDeleteDefaultDenyMulticastPolicy(logicalPort string) error {
-	if err := oc.deleteFromPortGroup("mcastPortGroupDeny", logicalPort); err != nil {
-		return fmt.Errorf("failed to delete port %s from default multicast deny ACL: %v", logicalPort, err)
+func (oc *Controller) podDeleteDefaultDenyMulticastPolicy(portInfo *lpInfo) error {
+	if err := oc.deleteFromPortGroup("mcastPortGroupDeny", portInfo); err != nil {
+		return fmt.Errorf("failed to delete port %s from default multicast deny ACL: %v", portInfo.name, err)
 	}
 	return nil
 }
 
-func (oc *Controller) podAddAllowMulticastPolicy(ns, logicalPort string) error {
+func (oc *Controller) podAddAllowMulticastPolicy(ns string, portInfo *lpInfo) error {
 	_, portGroupHash := getMulticastPortGroup(ns)
-	return oc.addToPortGroup(portGroupHash, logicalPort)
+	return oc.addToPortGroup(portGroupHash, portInfo)
 }
 
-func (oc *Controller) podDeleteAllowMulticastPolicy(ns, logicalPort string) error {
+func (oc *Controller) podDeleteAllowMulticastPolicy(ns string, portInfo *lpInfo) error {
 	_, portGroupHash := getMulticastPortGroup(ns)
-	return oc.deleteFromPortGroup(portGroupHash, logicalPort)
+	return oc.deleteFromPortGroup(portGroupHash, portInfo)
 }
 
 func (oc *Controller) localPodAddDefaultDeny(
-	policy *knet.NetworkPolicy, logicalPort string) {
+	policy *knet.NetworkPolicy, portInfo *lpInfo) {
 	oc.lspMutex.Lock()
 	defer oc.lspMutex.Unlock()
 
@@ -519,37 +511,37 @@ func (oc *Controller) localPodAddDefaultDeny(
 
 	// Handle condition 1 above.
 	if !(len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) {
-		if oc.lspIngressDenyCache[logicalPort] == 0 {
-			if err := oc.addToPortGroup(oc.portGroupIngressDeny, logicalPort); err != nil {
-				klog.Warningf("failed to add port %s to ingress deny ACL: %v", logicalPort, err)
+		if oc.lspIngressDenyCache[portInfo.name] == 0 {
+			if err := oc.addToPortGroup(oc.portGroupIngressDeny, portInfo); err != nil {
+				klog.Warningf("failed to add port %s to ingress deny ACL: %v", portInfo.name, err)
 			}
 		}
-		oc.lspIngressDenyCache[logicalPort]++
+		oc.lspIngressDenyCache[portInfo.name]++
 	}
 
 	// Handle condition 2 above.
 	if (len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) ||
 		len(policy.Spec.Egress) > 0 || len(policy.Spec.PolicyTypes) == 2 {
-		if oc.lspEgressDenyCache[logicalPort] == 0 {
-			if err := oc.addToPortGroup(oc.portGroupEgressDeny, logicalPort); err != nil {
-				klog.Warningf("failed to add port %s to egress deny ACL: %v", logicalPort, err)
+		if oc.lspEgressDenyCache[portInfo.name] == 0 {
+			if err := oc.addToPortGroup(oc.portGroupEgressDeny, portInfo); err != nil {
+				klog.Warningf("failed to add port %s to egress deny ACL: %v", portInfo.name, err)
 			}
 		}
-		oc.lspEgressDenyCache[logicalPort]++
+		oc.lspEgressDenyCache[portInfo.name]++
 	}
 }
 
 func (oc *Controller) localPodDelDefaultDeny(
-	policy *knet.NetworkPolicy, logicalPort string) {
+	policy *knet.NetworkPolicy, portInfo *lpInfo) {
 	oc.lspMutex.Lock()
 	defer oc.lspMutex.Unlock()
 
 	if !(len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) {
-		if oc.lspIngressDenyCache[logicalPort] > 0 {
-			oc.lspIngressDenyCache[logicalPort]--
-			if oc.lspIngressDenyCache[logicalPort] == 0 {
-				if err := oc.deleteFromPortGroup(oc.portGroupIngressDeny, logicalPort); err != nil {
-					klog.Warningf("failed to remove port %s from ingress deny ACL: %v", logicalPort, err)
+		if oc.lspIngressDenyCache[portInfo.name] > 0 {
+			oc.lspIngressDenyCache[portInfo.name]--
+			if oc.lspIngressDenyCache[portInfo.name] == 0 {
+				if err := oc.deleteFromPortGroup(oc.portGroupIngressDeny, portInfo); err != nil {
+					klog.Warningf("failed to remove port %s from ingress deny ACL: %v", portInfo.name, err)
 				}
 			}
 		}
@@ -557,11 +549,11 @@ func (oc *Controller) localPodDelDefaultDeny(
 
 	if (len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) ||
 		len(policy.Spec.Egress) > 0 || len(policy.Spec.PolicyTypes) == 2 {
-		if oc.lspEgressDenyCache[logicalPort] > 0 {
-			oc.lspEgressDenyCache[logicalPort]--
-			if oc.lspEgressDenyCache[logicalPort] == 0 {
-				if err := oc.deleteFromPortGroup(oc.portGroupEgressDeny, logicalPort); err != nil {
-					klog.Warningf("failed to remove port %s from egress deny ACL: %v", logicalPort, err)
+		if oc.lspEgressDenyCache[portInfo.name] > 0 {
+			oc.lspEgressDenyCache[portInfo.name]--
+			if oc.lspEgressDenyCache[portInfo.name] == 0 {
+				if err := oc.deleteFromPortGroup(oc.portGroupEgressDeny, portInfo); err != nil {
+					klog.Warningf("failed to remove port %s from egress deny ACL: %v", portInfo.name, err)
 				}
 			}
 		}
@@ -573,17 +565,13 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(
 	obj interface{}) {
 	pod := obj.(*kapi.Pod)
 
-	if _, err := util.UnmarshalPodAnnotation(pod.Annotations); err != nil {
-		return
-	}
-
 	if pod.Spec.NodeName == "" {
 		return
 	}
 
-	// Get the logical port name.
+	// Get the logical port info
 	logicalPort := podLogicalPortName(pod)
-	logicalPortUUID, err := oc.getLogicalPortUUID(logicalPort)
+	portInfo, err := oc.logicalPortCache.get(logicalPort)
 	if err != nil {
 		klog.Errorf(err.Error())
 		return
@@ -596,25 +584,25 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(
 		return
 	}
 
-	if np.localPods[logicalPort] {
+	if _, ok := np.localPods[logicalPort]; ok {
 		return
 	}
 
-	oc.localPodAddDefaultDeny(policy, logicalPort)
+	oc.localPodAddDefaultDeny(policy, portInfo)
 
 	if np.portGroupUUID == "" {
 		return
 	}
 
 	_, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
-		"port_group", np.portGroupUUID, "ports", logicalPortUUID, "--",
-		"add", "port_group", np.portGroupUUID, "ports", logicalPortUUID)
+		"port_group", np.portGroupUUID, "ports", portInfo.uuid, "--",
+		"add", "port_group", np.portGroupUUID, "ports", portInfo.uuid)
 	if err != nil {
 		klog.Errorf("Failed to add logicalPort %s to portGroup %s "+
 			"stderr: %q (%v)", logicalPort, np.portGroupUUID, stderr, err)
 	}
 
-	np.localPods[logicalPort] = true
+	np.localPods[logicalPort] = portInfo
 }
 
 func (oc *Controller) handleLocalPodSelectorDelFunc(
@@ -626,8 +614,13 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 		return
 	}
 
-	// Get the logical port name.
+	// Get the logical port info
 	logicalPort := podLogicalPortName(pod)
+	portInfo, err := oc.logicalPortCache.get(logicalPort)
+	if err != nil {
+		klog.Errorf(err.Error())
+		return
+	}
 
 	np.Lock()
 	defer np.Unlock()
@@ -636,31 +629,26 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 		return
 	}
 
-	if !np.localPods[logicalPort] {
+	if _, ok := np.localPods[logicalPort]; !ok {
 		return
 	}
 	delete(np.localPods, logicalPort)
-	oc.localPodDelDefaultDeny(policy, logicalPort)
+	oc.localPodDelDefaultDeny(policy, portInfo)
 
 	oc.lspMutex.Lock()
 	delete(oc.lspIngressDenyCache, logicalPort)
 	delete(oc.lspEgressDenyCache, logicalPort)
 	oc.lspMutex.Unlock()
 
-	logicalPortUUID, err := oc.getLogicalPortUUID(logicalPort)
-	if err != nil {
-		klog.Errorf(err.Error())
-		return
-	}
 	if np.portGroupUUID == "" {
 		return
 	}
 
 	_, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
-		"port_group", np.portGroupUUID, "ports", logicalPortUUID)
+		"port_group", np.portGroupUUID, "ports", portInfo.uuid)
 	if err != nil {
 		klog.Errorf("Failed to delete logicalPort %s from portGroup %s "+
-			"stderr: %q (%v)", logicalPort, np.portGroupUUID, stderr, err)
+			"stderr: %q (%v)", portInfo.uuid, np.portGroupUUID, stderr, err)
 	}
 }
 
@@ -912,8 +900,8 @@ func (oc *Controller) deleteNetworkPolicyPortGroup(
 	// We should now stop all the handlers go routines.
 	oc.shutdownHandlers(np)
 
-	for logicalPort := range np.localPods {
-		oc.localPodDelDefaultDeny(policy, logicalPort)
+	for _, portInfo := range np.localPods {
+		oc.localPodDelDefaultDeny(policy, portInfo)
 	}
 
 	// Delete the port group

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -25,8 +25,8 @@ type namespacePolicy struct {
 	egressPolicies  []*gressPolicy
 	podHandlerList  []*factory.Handler
 	nsHandlerList   []*factory.Handler
-	localPods       map[string]bool //pods effected by this policy
-	portGroupUUID   string          //uuid for OVN port_group
+	localPods       map[string]*lpInfo //pods effected by this policy
+	portGroupUUID   string             //uuid for OVN port_group
 	portGroupName   string
 	deleted         bool //deleted policy
 }
@@ -39,7 +39,7 @@ func NewNamespacePolicy(policy *knet.NetworkPolicy) *namespacePolicy {
 		egressPolicies:  make([]*gressPolicy, 0),
 		podHandlerList:  make([]*factory.Handler, 0),
 		nsHandlerList:   make([]*factory.Handler, 0),
-		localPods:       make(map[string]bool),
+		localPods:       make(map[string]*lpInfo),
 	}
 	return np
 }

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -520,17 +520,17 @@ func (oc *Controller) handleLocalPodSelectorAddFuncOld(
 	obj interface{}) {
 	pod := obj.(*kapi.Pod)
 
-	if _, err := util.UnmarshalPodAnnotation(pod.Annotations); err != nil {
+	if pod.Spec.NodeName == "" {
 		return
 	}
 
-	logicalSwitch := pod.Spec.NodeName
-	if logicalSwitch == "" {
-		return
-	}
-
-	// Get the logical port name.
+	// Get the logical port info
 	logicalPort := podLogicalPortName(pod)
+	portInfo, err := oc.logicalPortCache.get(logicalPort)
+	if err != nil {
+		klog.Errorf(err.Error())
+		return
+	}
 
 	np.Lock()
 	defer np.Unlock()
@@ -539,22 +539,22 @@ func (oc *Controller) handleLocalPodSelectorAddFuncOld(
 		return
 	}
 
-	if np.localPods[logicalPort] {
+	if _, ok := np.localPods[logicalPort]; ok {
 		return
 	}
 
-	oc.localPodAddDefaultDenyOld(policy, logicalPort, logicalSwitch)
+	oc.localPodAddDefaultDenyOld(policy, logicalPort, portInfo.logicalSwitch)
 
 	// For each ingress rule, add a ACL
 	for _, ingress := range np.ingressPolicies {
-		localPodAddOrDelACLOld(addACL, policy, pod, ingress, logicalSwitch)
+		localPodAddOrDelACLOld(addACL, policy, pod, ingress, portInfo.logicalSwitch)
 	}
 	// For each egress rule, add a ACL
 	for _, egress := range np.egressPolicies {
-		localPodAddOrDelACLOld(addACL, policy, pod, egress, logicalSwitch)
+		localPodAddOrDelACLOld(addACL, policy, pod, egress, portInfo.logicalSwitch)
 	}
 
-	np.localPods[logicalPort] = true
+	np.localPods[logicalPort] = portInfo
 }
 
 func (oc *Controller) handleLocalPodSelectorDelFuncOld(
@@ -562,13 +562,17 @@ func (oc *Controller) handleLocalPodSelectorDelFuncOld(
 	obj interface{}) {
 	pod := obj.(*kapi.Pod)
 
-	logicalSwitch := pod.Spec.NodeName
-	if logicalSwitch == "" {
+	if pod.Spec.NodeName == "" {
 		return
 	}
 
-	// Get the logical port name.
+	// Get the logical port info
 	logicalPort := podLogicalPortName(pod)
+	portInfo, err := oc.logicalPortCache.get(logicalPort)
+	if err != nil {
+		klog.Errorf(err.Error())
+		return
+	}
 
 	np.Lock()
 	defer np.Unlock()
@@ -577,11 +581,11 @@ func (oc *Controller) handleLocalPodSelectorDelFuncOld(
 		return
 	}
 
-	if !np.localPods[logicalPort] {
+	if _, ok := np.localPods[logicalPort]; !ok {
 		return
 	}
 	delete(np.localPods, logicalPort)
-	oc.localPodDelDefaultDenyOld(policy, logicalPort, logicalSwitch)
+	oc.localPodDelDefaultDenyOld(policy, logicalPort, portInfo.logicalSwitch)
 
 	oc.lspMutex.Lock()
 	delete(oc.lspIngressDenyCache, logicalPort)
@@ -590,11 +594,11 @@ func (oc *Controller) handleLocalPodSelectorDelFuncOld(
 
 	// For each ingress rule, remove the ACL
 	for _, ingress := range np.ingressPolicies {
-		localPodAddOrDelACLOld(deleteACL, policy, pod, ingress, logicalSwitch)
+		localPodAddOrDelACLOld(deleteACL, policy, pod, ingress, portInfo.logicalSwitch)
 	}
 	// For each egress rule, remove the ACL
 	for _, egress := range np.egressPolicies {
-		localPodAddOrDelACLOld(deleteACL, policy, pod, egress, logicalSwitch)
+		localPodAddOrDelACLOld(deleteACL, policy, pod, egress, portInfo.logicalSwitch)
 	}
 }
 
@@ -797,27 +801,6 @@ func (oc *Controller) addNetworkPolicyOld(policy *knet.NetworkPolicy) {
 	oc.handleLocalPodSelectorOld(policy, np)
 }
 
-func (oc *Controller) getLogicalSwitchForLogicalPort(
-	logicalPort string) string {
-	if oc.logicalPortCache[logicalPort] != "" {
-		return oc.logicalPortCache[logicalPort]
-	}
-
-	logicalSwitch, stderr, err := util.RunOVNNbctl("get",
-		"logical_switch_port", logicalPort, "external-ids:logical_switch")
-	if err != nil {
-		klog.Errorf("Error obtaining logical switch for %s, stderr: %q (%v)",
-			logicalPort, stderr, err)
-		return ""
-	}
-	if logicalSwitch == "" {
-		klog.Errorf("Error obtaining logical switch for %s",
-			logicalPort)
-		return ""
-	}
-	return logicalSwitch
-}
-
 func (oc *Controller) deleteNetworkPolicyOld(
 	policy *knet.NetworkPolicy) {
 	klog.Infof("Deleting network policy %s in namespace %s",
@@ -858,10 +841,8 @@ func (oc *Controller) deleteNetworkPolicyOld(
 	// We should now stop all the handlers go routines.
 	oc.shutdownHandlers(np)
 
-	for logicalPort := range np.localPods {
-		logicalSwitch := oc.getLogicalSwitchForLogicalPort(
-			logicalPort)
-		oc.localPodDelDefaultDenyOld(policy, logicalPort, logicalSwitch)
+	for _, portInfo := range np.localPods {
+		oc.localPodDelDefaultDenyOld(policy, portInfo.name, portInfo.logicalSwitch)
 	}
 	oc.namespacePolicies[policy.Namespace][policy.Name] = nil
 

--- a/go-controller/pkg/ovn/policy_old_test.go
+++ b/go-controller/pkg/ovn/policy_old_test.go
@@ -17,7 +17,7 @@ import (
 
 type networkPolicyOld struct{}
 
-var fakeUUID = "fake_uuid"
+var fakeUUID = "8a86f6d8-7972-4253-b0bd-ddbef66e9303"
 var fakeLogicalSwitch = "fake_ls"
 
 func newNetworkPolicyOldMeta(name, namespace string) metav1.ObjectMeta {
@@ -648,7 +648,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 					Output: fakeUUID,
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ovn-nbctl --timeout=15 set acl fake_uuid match=\"ip4.src == {$a10148211500778908391} && outport == \\\"%s\\\"\"", nPodTest.portName),
+					fmt.Sprintf("ovn-nbctl --timeout=15 set acl %s match=\"ip4.src == {$a10148211500778908391} && outport == \\\"%s\\\"\"", fakeUUID, nPodTest.portName),
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
 					fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a6953373268003663638, $a9824637386382239951} && inport == \\\"%s\\\"\" external-ids:namespace=%s external-ids:policy=%s external-ids:Egress_num=0 external-ids:policy_type=Egress external-ids:logical_port=%s", nPodTest.portName, networkPolicy.Namespace, networkPolicy.Name, nPodTest.portName),

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -61,10 +61,6 @@ func (n networkPolicy) addNamespaceSelectorCmdsForGress(fexec *ovntest.FakeExec,
 
 func (n networkPolicy) addLocalPodCmds(fexec *ovntest.FakeExec, pod pod) {
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists get logical_switch_port %s _uuid", pod.portName),
-		Output: fakeUUID,
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=ingressDefaultDeny",
 		Output: fakeUUID,
 	})
@@ -89,13 +85,13 @@ func (n networkPolicy) addLocalPodCmds(fexec *ovntest.FakeExec, pod pod) {
 		Output: fakeUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove port_group fake_uuid ports fake_uuid -- add port_group fake_uuid ports fake_uuid",
+		"ovn-nbctl --timeout=15 --if-exists remove port_group " + fakeUUID + " ports " + fakeUUID + " -- add port_group " + fakeUUID + " ports " + fakeUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove port_group fake_uuid ports fake_uuid -- add port_group fake_uuid ports fake_uuid",
+		"ovn-nbctl --timeout=15 --if-exists remove port_group " + fakeUUID + " ports " + fakeUUID + " -- add port_group " + fakeUUID + " ports " + fakeUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove port_group fake_uuid ports fake_uuid -- add port_group fake_uuid ports fake_uuid",
+		"ovn-nbctl --timeout=15 --if-exists remove port_group " + fakeUUID + " ports " + fakeUUID + " -- add port_group " + fakeUUID + " ports " + fakeUUID,
 	})
 }
 
@@ -124,7 +120,7 @@ func (n networkPolicy) addNamespaceSelectorCmds(fexec *ovntest.FakeExec, network
 		n.addNamespaceSelectorCmdsForGress(fexec, networkPolicy, "ingress", i)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Ingress_num=%v external-ids:policy_type=Ingress", networkPolicy.Namespace, networkPolicy.Name, i),
-			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" action=allow-related external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group fake_uuid acls @acl",
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" action=allow-related external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group " + fakeUUID + " acls @acl",
 		})
 		if findAgain {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -136,7 +132,7 @@ func (n networkPolicy) addNamespaceSelectorCmds(fexec *ovntest.FakeExec, network
 		n.addNamespaceSelectorCmdsForGress(fexec, networkPolicy, "egress", i)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Egress_num=%v external-ids:policy_type=Egress", networkPolicy.Namespace, networkPolicy.Name, i),
-			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" action=allow external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group fake_uuid acls @acl",
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" action=allow external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group " + fakeUUID + " acls @acl",
 		})
 		if findAgain {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -161,10 +157,10 @@ func (n networkPolicy) delCmds(fexec *ovntest.FakeExec, pod pod, networkPolicy k
 	}
 	if withLocal {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --if-exists remove port_group fake_uuid ports fake_uuid",
+			"ovn-nbctl --timeout=15 --if-exists remove port_group " + fakeUUID + " ports " + fakeUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --if-exists remove port_group fake_uuid ports fake_uuid",
+			"ovn-nbctl --timeout=15 --if-exists remove port_group " + fakeUUID + " ports " + fakeUUID,
 		})
 	}
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -193,13 +189,13 @@ func (n networkPolicy) delPodCmds(fexec *ovntest.FakeExec, networkPolicy knet.Ne
 	}
 	if withLocal {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --if-exists remove port_group fake_uuid ports fake_uuid",
+			"ovn-nbctl --timeout=15 --if-exists remove port_group " + fakeUUID + " ports " + fakeUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --if-exists remove port_group fake_uuid ports fake_uuid",
+			"ovn-nbctl --timeout=15 --if-exists remove port_group " + fakeUUID + " ports " + fakeUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --if-exists remove port_group fake_uuid ports fake_uuid",
+			"ovn-nbctl --timeout=15 --if-exists remove port_group " + fakeUUID + " ports " + fakeUUID,
 		})
 	}
 }
@@ -274,20 +270,20 @@ func (p multicastPolicy) disableCmds(fExec *ovntest.FakeExec, ns string) {
 	})
 }
 
-func (p multicastPolicy) addPodCmds(fExec *ovntest.FakeExec, ns, portUUID string) {
+func (p multicastPolicy) addPodCmds(fExec *ovntest.FakeExec, ns string) {
 	_, pg_hash := getMulticastPortGroup(ns)
 	fExec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 " +
-			"--if-exists remove port_group " + pg_hash + " ports " + portUUID + " " +
-			"-- add port_group " + pg_hash + " ports " + portUUID,
+			"--if-exists remove port_group " + pg_hash + " ports " + fakeUUID + " " +
+			"-- add port_group " + pg_hash + " ports " + fakeUUID,
 	})
 }
 
-func (p multicastPolicy) delPodCmds(fExec *ovntest.FakeExec, ns, portUUID string) {
+func (p multicastPolicy) delPodCmds(fExec *ovntest.FakeExec, ns string) {
 	_, pg_hash := getMulticastPortGroup(ns)
 	fExec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 " +
-			"--if-exists remove port_group " + pg_hash + " ports " + portUUID,
+			"--if-exists remove port_group " + pg_hash + " ports " + fakeUUID,
 	})
 }
 
@@ -436,7 +432,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nPodTest.addCmdsForNonExistingPod(fExec)
 				nTest.baseCmds(fExec, namespace1)
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
-				nPodTest.addPodDenyMcast(fExec, true)
+				nPodTest.addPodDenyMcast(fExec)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, true, false)
 
 				fakeOvn.start(ctx,
@@ -536,7 +532,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.baseCmds(fExec, namespace1, namespace2)
 				nTest.addCmds(fExec, namespace1)
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
-				nPodTest.addPodDenyMcast(fExec, false)
+				nPodTest.addPodDenyMcast(fExec)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, false, false)
 
 				fakeOvn.start(ctx,
@@ -631,7 +627,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.baseCmds(fExec, namespace1, namespace2)
 				nTest.addCmds(fExec, namespace2)
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
-				nPodTest.addPodDenyMcast(fExec, true)
+				nPodTest.addPodDenyMcast(fExec)
 				npTest.addNamespaceSelectorCmds(fExec, networkPolicy, true)
 				npTest.addLocalPodCmds(fExec, nPodTest)
 
@@ -670,7 +666,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 					Output: fakeUUID,
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 set acl fake_uuid match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\"",
+					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\"",
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
 					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a6953373268003663638, $a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
@@ -755,7 +751,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 					Output: fakeUUID,
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 set acl fake_uuid match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\"",
+					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\"",
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
 					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a6953373268003663638, $a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
@@ -823,7 +819,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nPodTest.addCmdsForNonExistingPod(fExec)
 				nTest.baseCmds(fExec, namespace1)
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
-				nPodTest.addPodDenyMcast(fExec, true)
+				nPodTest.addPodDenyMcast(fExec)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, true, false)
 
 				fakeOvn.start(ctx,
@@ -931,7 +927,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nTest.baseCmds(fExec, namespace1, namespace2)
 				nTest.addCmds(fExec, namespace1)
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace2)
-				nPodTest.addPodDenyMcast(fExec, false)
+				nPodTest.addPodDenyMcast(fExec)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, false, false)
 
 				fakeOvn.start(ctx,
@@ -1028,7 +1024,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nPodTest.addCmdsForNonExistingPod(fExec)
 				nTest.baseCmds(fExec, namespace1)
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
-				nPodTest.addPodDenyMcast(fExec, true)
+				nPodTest.addPodDenyMcast(fExec)
 				npTest.addPodSelectorCmds(fExec, nPodTest, networkPolicy, true, false)
 
 				fakeOvn.start(ctx,
@@ -1137,7 +1133,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nPodTest.addCmdsForNonExistingPod(fExec)
 				nTest.baseCmds(fExec, namespace1)
 				nTest.addCmdsWithPods(fExec, nPodTest, namespace1)
-				nPodTest.addPodDenyMcast(fExec, false)
+				nPodTest.addPodDenyMcast(fExec)
 				fakeOvn.start(ctx,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
@@ -1163,7 +1159,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				mcastPolicy := multicastPolicy{}
 				mcastPolicy.enableCmds(fExec, namespace1.Name)
 				// The pod should be added to the multicast allow port group.
-				mcastPolicy.addPodCmds(fExec, namespace1.Name, "fake_uuid")
+				mcastPolicy.addPodCmds(fExec, namespace1.Name)
 				ns.Annotations[nsMulticastAnnotation] = "true"
 				_, err = fakeOvn.fakeClient.CoreV1().Namespaces().Update(ns)
 				Expect(err).NotTo(HaveOccurred())
@@ -1219,11 +1215,11 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				nPodTest.addCmdsForNonExistingPod(fExec)
-				nPodTest.addPodDenyMcast(fExec, false)
+				nPodTest.addPodDenyMcast(fExec)
 				nTest.addPodCmds(fExec, nPodTest, namespace1, false)
 
 				// The pod should be added to the multicast allow group.
-				mcastPolicy.addPodCmds(fExec, namespace1.Name, "fake_uuid")
+				mcastPolicy.addPodCmds(fExec, namespace1.Name)
 
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(nPodTest.namespace).Create(newPod(
 					nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP))
@@ -1231,10 +1227,10 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
 				// Delete the pod from the namespace.
-				mcastPolicy.delPodCmds(fExec, namespace1.Name, "fake_uuid")
+				mcastPolicy.delPodCmds(fExec, namespace1.Name)
 				// The pod should be removed from the multicasts default deny
 				// group and from the multicast allow group.
-				nPodTest.delPodDenyMcast(fExec, false)
+				nPodTest.delPodDenyMcast(fExec)
 				nTest.delPodCmds(fExec, nPodTest, namespace1, false)
 				nPodTest.delCmds(fExec)
 

--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -1,0 +1,92 @@
+package ovn
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"k8s.io/klog"
+)
+
+type portCache struct {
+	sync.RWMutex
+	stopChan <-chan struct{}
+	cache    map[string]*lpInfo
+}
+
+type lpInfo struct {
+	name          string
+	uuid          string
+	logicalSwitch string
+	ip            net.IP
+	mac           net.HardwareAddr
+	// expires, if non-nil, indicates that this object is scheduled to be
+	// removed at the given time
+	expires time.Time
+}
+
+func newPortCache(stopChan <-chan struct{}) *portCache {
+	return &portCache{
+		stopChan: stopChan,
+		cache:    make(map[string]*lpInfo),
+	}
+}
+
+func (c *portCache) get(logicalPort string) (*lpInfo, error) {
+	c.RLock()
+	defer c.RUnlock()
+	if info, ok := c.cache[logicalPort]; ok {
+		return info, nil
+	}
+	return nil, fmt.Errorf("logical port %s not found in cache", logicalPort)
+}
+
+func (c *portCache) add(logicalSwitch, logicalPort, uuid string, mac net.HardwareAddr, ip net.IP) *lpInfo {
+	c.Lock()
+	defer c.Unlock()
+	portInfo := &lpInfo{
+		logicalSwitch: logicalSwitch,
+		name:          logicalPort,
+		uuid:          uuid,
+		ip:            ip,
+		mac:           mac,
+	}
+	klog.V(5).Infof("port-cache(%s): added port %+v", logicalPort, portInfo)
+	c.cache[logicalPort] = portInfo
+	return portInfo
+}
+
+func (c *portCache) remove(logicalPort string) {
+	c.Lock()
+	defer c.Unlock()
+	info, ok := c.cache[logicalPort]
+	if !ok || !info.expires.IsZero() {
+		klog.V(5).Infof("port-cache(%s): port not found in cache or already marked for removal", logicalPort)
+		return
+	}
+	info.expires = time.Now().Add(time.Minute)
+	klog.V(5).Infof("port-cache(%s): scheduling port for removal at %v", logicalPort, info.expires)
+
+	// Removal must be deferred since, for example, NetworkPolicy pod handlers
+	// may run after the main pod handler and look for items in the cache
+	// on delete events.
+	go func() {
+		select {
+		case <-time.After(time.Minute):
+			c.Lock()
+			defer c.Unlock()
+			// remove the port info if its expiration time has elapsed.
+			// This makes sure that we don't prematurely remove a port
+			// that was deleted and re-added before the timer expires.
+			if info, ok := c.cache[logicalPort]; ok && !info.expires.IsZero() {
+				if time.Now().After(info.expires) {
+					klog.V(5).Infof("port-cache(%s): removing port", logicalPort)
+					delete(c.cache, logicalPort)
+				}
+			}
+		case <-c.stopChan:
+			break
+		}
+	}()
+}

--- a/go-controller/pkg/testing/testing.go
+++ b/go-controller/pkg/testing/testing.go
@@ -72,7 +72,10 @@ func (f *FakeExec) ErrorDesc() string {
 	if len(f.executedCommands) == len(f.expectedCommands) {
 		return ""
 	}
+	return f.internalErrorDesc()
+}
 
+func (f *FakeExec) internalErrorDesc() string {
 	desc := "Executed commands do not match expected commands!\n"
 	if f.looseCompare {
 		// For loose compare, mark expected commands that were not
@@ -165,7 +168,7 @@ func (f *FakeExec) Command(cmd string, args ...string) kexec.Cmd {
 	// Fail if the command being executed could not be found in the
 	// expected command list, or if the expected command list has been
 	// completely used and we are executing more commands
-	Expect(expected).NotTo(BeNil(), "Unexpected command: %s", executed)
+	Expect(expected).NotTo(BeNil(), "Unexpected command: %s\n\n%s", executed, f.internalErrorDesc())
 
 	return &fakeexec.FakeCmd{
 		Argv: strings.Split(expected.Cmd, " ")[1:],


### PR DESCRIPTION
Instead of having separate UUID and logical switch caches, consolidate them into one cache. We'll also use this later to store pod labels for network policy matching.

@danwinship @girishmg 