### PR TITLE
avoid using --wait=sb in ovn-nbctl calls when using ovn-nbctl daemon

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -275,7 +275,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 		return nil
 	}
 
-	out, stderr, err = util.RunOVNNbctl("--wait=sb",
+	out, stderr, err = util.RunOVNNbctl(
 		"--", "--may-exist", "lsp-add", logicalSwitch, portName,
 		"--", "lsp-set-addresses", portName, "dynamic",
 		"--", "set", "logical_switch_port", portName, "external-ids:namespace="+pod.Namespace,

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -99,7 +99,7 @@ func (p pod) addCmds(fexec *ovntest.FakeExec, exists, fail, gatewayCached bool) 
 		})
 	} else {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --wait=sb -- --may-exist lsp-add " + p.nodeName + " " + p.portName + " -- lsp-set-addresses " + p.portName + " dynamic -- set logical_switch_port " + p.portName + " external-ids:namespace=" + p.namespace + " external-ids:logical_switch=" + p.nodeName + " external-ids:pod=true",
+			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + p.nodeName + " " + p.portName + " -- lsp-set-addresses " + p.portName + " dynamic -- set logical_switch_port " + p.portName + " external-ids:namespace=" + p.namespace + " external-ids:logical_switch=" + p.nodeName + " external-ids:pod=true",
 		})
 	}
 	if !gatewayCached {


### PR DESCRIPTION
--wait=sb doesn't play well with ovn-nbctl in daemon mode. when the
client call to the daemon timeouts with SIGALARM (after 15 seconds) the
daemon itself is stuck and any subsequent ovn-nbctl calls will not
succeed until the 1st call completes. so, we need ot avoid using
--wait=sb when using ovn-nbctl daemon mode. instead fall back to the
retry loop

@dcbw @danwinship PTAL