### PR TITLE
skip adding default gateway for OVN interface in certain cases

### DIFF
--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/containernetworking/cni/pkg/types"
+	"net"
 )
 
 // NetConf is CNI NetConf with DeviceID
@@ -23,4 +24,6 @@ type NetworkSelectionElement struct {
 	// MacRequest contains an optional requested MAC address for this
 	// network attachment
 	MacRequest string `json:"mac,omitempty"`
+	// GatewayRequest contains default route IP address for the pod
+	GatewayRequest []net.IP `json:"default-route,omitempty"`
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
@@ -227,6 +228,37 @@ func waitForPodAddresses(portName string) (net.HardwareAddr, net.IP, error) {
 	return podMac, podIP, nil
 }
 
+func getRoutesGatewayIP(pod *kapi.Pod, gatewayIPnet *net.IPNet) ([]util.PodRoute, net.IP, error) {
+	// if there are other network attachments for the pod, then check if those network-attachment's
+	// annotation has default-route key. If present, then we need to skip adding default route for
+	// OVN interface
+	networks, err := util.GetPodNetSelAnnotation(pod, util.NetworkAttachmentAnnotation)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error while getting network attachment definition for [%s/%s]: %v",
+			pod.Namespace, pod.Name, err)
+	}
+	otherDefaultRoute := false
+	for _, network := range networks {
+		if len(network.GatewayRequest) != 0 && network.GatewayRequest[0] != nil {
+			otherDefaultRoute = true
+			break
+		}
+	}
+	var gatewayIP net.IP
+	routes := make([]util.PodRoute, 0)
+	if otherDefaultRoute {
+		for _, clusterSubnet := range config.Default.ClusterSubnets {
+			var route util.PodRoute
+			route.Dest = clusterSubnet.CIDR
+			route.NextHop = gatewayIPnet.IP
+			routes = append(routes, route)
+		}
+	} else {
+		gatewayIP = gatewayIPnet.IP
+	}
+	return routes, gatewayIP, nil
+}
+
 func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 	var out, stderr string
 	var err error
@@ -292,14 +324,14 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 
 	oc.logicalPortCache[portName] = logicalSwitch
 
-	gatewayIP, _ := util.GetNodeWellKnownAddresses(nodeSubnet)
+	gatewayIPnet, _ := util.GetNodeWellKnownAddresses(nodeSubnet)
 
 	podMac, podIP, err := waitForPodAddresses(portName)
 	if err != nil {
 		return err
 	}
 
-	podCIDR := &net.IPNet{IP: podIP, Mask: gatewayIP.Mask}
+	podCIDR := &net.IPNet{IP: podIP, Mask: gatewayIPnet.Mask}
 
 	// now set the port security for the logical switch port
 	out, stderr, err = util.RunOVNNbctl("lsp-set-port-security", portName,
@@ -309,10 +341,15 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 			"stdout: %q, stderr: %q (%v)", portName, out, stderr, err)
 	}
 
+	routes, gatewayIP, err := getRoutesGatewayIP(pod, gatewayIPnet)
+	if err != nil {
+		return err
+	}
 	marshalledAnnotation, err := util.MarshalPodAnnotation(&util.PodAnnotation{
-		IP:  podCIDR,
-		MAC: podMac,
-		GW:  gatewayIP.IP,
+		IP:     podCIDR,
+		MAC:    podMac,
+		GW:     gatewayIP,
+		Routes: routes,
 	})
 	if err != nil {
 		return fmt.Errorf("error creating pod network annotation: %v", err)

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -131,6 +131,9 @@ func GetNodeIP(nodeName string) (string, error) {
 const (
 	// DefNetworkAnnotation is the pod annotation for the cluster-wide default network
 	DefNetworkAnnotation = "v1.multus-cni.io/default-network"
+
+	// NetworkAttachmentAnnotation is the pod annotation for network-attachment-definition
+	NetworkAttachmentAnnotation = "k8s.v1.cni.cncf.io/networks"
 )
 
 // GetPodNetSelAnnotation returns the pod's Network Attachment Selection Annotation either for


### PR DESCRIPTION
It’s generally expected that the the cluster-wide default network
attachment sets a default route. This default route may be overridden
using the “default-route” key in the Network Attachment Selection
Annotation (see 4.1.2.1.9) on another attachments. In that case, we
should skip adding default route on the OVN interface and instead just
add cluster subnet routes for the OVN interface.

Consider the set of annotations below on a pod:

```
  annotations:
          v1.multus-cni.io/default-network: ovn-kubernetes
          k8s.v1.cni.cncf.io/networks: |
            [
              {
                "name":"sriov-storage-net",
                "default-route": ["10.1.32.2"]
              }
            ]
```
The first interface to the pod is provided by ovn-kubernetes and the
second interface is through SRIOV CNI. The default route for that
pod should be through the second interface. So, the routes should be
something like this:

$ ip ro
default via 10.1.32.2 dev net1
10.1.32.0/19 dev net1 proto kernel scope link src 10.1.32.142
192.168.0.0/24 dev eth0 proto kernel scope link src 192.168.0.5
192.168.0.0/16 via 192.168.0.1 dev eth0

192.168.0.0/16 is the OVN Kubernetes Cluster Subnet for which the POD
will have a route through OVN's interface (aka eth0)

@dcbw @danwinship PTAL (Note this PR is based on top of Custom MAC PR 997)