### PR TITLE
scale: current logical topology doesn't scale with large cluster

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -24,6 +24,8 @@ const (
 	OvnHostSubnetLegacy = "ovn_host_subnet"
 	// OvnNodeSubnets is the constant string representing the node subnets annotation key
 	OvnNodeSubnets = "k8s.ovn.org/node-subnets"
+	// OvnNodeJoinSubnets is the constant string representing the node's join switch subnets annotation key
+	OvnNodeJoinSubnets = "k8s.ovn.org/node-join-subnets"
 	// OvnNodeManagementPortMacAddress is the constant string representing the annotation key
 	OvnNodeManagementPortMacAddress = "k8s.ovn.org/node-mgmt-port-mac-address"
 	// OvnNodeChassisID is the systemID of the node needed for creating L3 gateway
@@ -61,6 +63,17 @@ const (
 // TODO: Verify that the cluster was not already called with a different global subnet
 //  If true, then either quit or perform a complete reconfiguration of the cluster (recreate switches/routers with new subnet values)
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
+	// The gateway router need to be connected to the distributed router via a per-node join switch.
+	// We need a subnet allocator that allocates subnet for this per-node join switch. Use the 100.64.0.0/16
+	// or fd98::/64 network range with host bits set to 3. The allocator will start allocating subnet that has upto 6
+	// host IPs)
+	var joinSubnet string
+	if config.IPv6Mode {
+		joinSubnet = "fd98::/64"
+	} else {
+		joinSubnet = "100.64.0.0/16"
+	}
+	_ = oc.joinSubnetAllocator.AddNetworkRange(joinSubnet, 3)
 
 	existingNodes, err := oc.kube.GetNodes()
 	if err != nil {
@@ -77,6 +90,13 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		hostsubnet, _ := parseNodeHostSubnet(&node)
 		if hostsubnet != nil {
 			err := oc.masterSubnetAllocator.MarkAllocatedNetwork(hostsubnet.String())
+			if err != nil {
+				utilruntime.HandleError(err)
+			}
+		}
+		joinsubnet, _ := parseNodeJoinSubnet(&node)
+		if joinsubnet != nil {
+			err := oc.joinSubnetAllocator.MarkAllocatedNetwork(joinsubnet.String())
 			if err != nil {
 				utilruntime.HandleError(err)
 			}
@@ -174,56 +194,73 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 			return err
 		}
 	}
+	return nil
+}
 
-	// Create a logical switch called "join" that will be used to connect gateway routers to the distributed router.
-	// The "join" switch will be allocated IP addresses in the range 100.64.0.0/16 or fd98::/64.
-	var joinSubnet string
-	if config.IPv6Mode {
-		joinSubnet = "fd98::1/64"
-	} else {
-		joinSubnet = "100.64.0.1/16"
-	}
-	joinIP, joinCIDR, _ := net.ParseCIDR(joinSubnet)
-	if config.IPv6Mode {
-		stdout, stderr, err = util.RunOVNNbctl("--may-exist", "ls-add", "join",
-			"--", "set", "logical_switch", "join", fmt.Sprintf("%s=%s", config.OtherConfigSubnet(), joinCIDR.String()))
-	} else {
-		stdout, stderr, err = util.RunOVNNbctl("--may-exist", "ls-add", "join",
-			"--", "set", "logical_switch", "join", fmt.Sprintf("%s=%s", config.OtherConfigSubnet(), joinCIDR.String()),
-			"--", "set", "logical_switch", "join", fmt.Sprintf("other-config:exclude_ips=%s", joinIP.String()))
-	}
-	if err != nil {
-		logrus.Errorf("Failed to create logical switch called \"join\", stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return err
+// annotate the node with the join subnet information assigned to node's join logical switch.
+// the format of the annotation is:
+//
+// k8s.ovn.org/node-join-subnets: {
+//	  "default": "100.64.0.0/29",
+// }
+func (oc *Controller) addNodeJoinSubnetAnnotations(node *kapi.Node, subnet string) error {
+	// nothing to do if the node already has the annotation key
+	_, ok := node.Annotations[OvnNodeJoinSubnets]
+	if ok {
+		return nil
 	}
 
-	// Connect the distributed router to "join".
-	routerMac, stderr, err := util.RunOVNNbctl("--if-exist", "get", "logical_router_port", "rtoj-"+clusterRouter, "mac")
+	bytes, err := json.Marshal(map[string]string{
+		"default": subnet,
+	})
 	if err != nil {
-		logrus.Errorf("Failed to get logical router port rtoj-%v, stderr: %q, error: %v", clusterRouter, stderr, err)
-		return err
+		return fmt.Errorf("failed to marshal node %q annotation %q for subnet %s",
+			node.Name, OvnNodeJoinSubnets, subnet)
 	}
-	if routerMac == "" {
-		routerMac = util.GenerateMac()
-		stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lrp-add", clusterRouter,
-			"rtoj-"+clusterRouter, routerMac, joinSubnet)
+	nodeAnnotations := make(map[string]interface{})
+	nodeAnnotations[OvnNodeJoinSubnets] = string(bytes)
+	err = oc.kube.SetAnnotationsOnNode(node, nodeAnnotations)
+	if err != nil {
+		return fmt.Errorf("failed to set node annotation %q on existing node %s to %q: %v",
+			OvnNodeJoinSubnets, node.Name, subnet, err)
+	}
+	return nil
+}
+
+func (oc *Controller) allocateJoinSubnet(node *kapi.Node) (string, error) {
+	joinSubnet, _ := parseNodeJoinSubnet(node)
+	if joinSubnet != nil {
+		return joinSubnet.String(), nil
+	}
+
+	// Allocate a new network for the join switch
+	joinSubnetStr, err := oc.joinSubnetAllocator.AllocateNetwork()
+	if err != nil {
+		return "", fmt.Errorf("Error allocating subnet for join switch for node  %s: %v", node.Name, err)
+	}
+
+	defer func() {
+		// Release the allocation on error
 		if err != nil {
-			logrus.Errorf("Failed to add logical router port rtoj-%v, stdout: %q, stderr: %q, error: %v",
-				clusterRouter, stdout, stderr, err)
-			return err
+			_ = oc.joinSubnetAllocator.ReleaseNetwork(joinSubnetStr)
 		}
-	}
-
-	// Connect the switch "join" to the router.
-	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", "join", "jtor-"+clusterRouter,
-		"--", "set", "logical_switch_port", "jtor-"+clusterRouter, "type=router",
-		"options:router-port=rtoj-"+clusterRouter, "addresses="+"\""+routerMac+"\"")
+	}()
+	// Set annotation on the node
+	err = oc.addNodeJoinSubnetAnnotations(node, joinSubnetStr)
 	if err != nil {
-		logrus.Errorf("Failed to add router-type logical switch port to join, stdout: %q, stderr: %q, error: %v",
-			stdout, stderr, err)
-		return err
+		return "", err
 	}
 
+	logrus.Infof("Allocated join subnet %q for node %q", node.Name, joinSubnetStr)
+	return joinSubnetStr, nil
+}
+
+func (oc *Controller) deleteNodeJoinSubnet(nodeName string, subnet *net.IPNet) error {
+	err := oc.joinSubnetAllocator.ReleaseNetwork(subnet.String())
+	if err != nil {
+		return fmt.Errorf("Error deleting join subnet %v for node %q: %s", subnet, nodeName, err)
+	}
+	logrus.Infof("Deleted JoinSubnet %v for node %s", subnet, nodeName)
 	return nil
 }
 
@@ -417,7 +454,13 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 		}
 	}
 
-	err = util.GatewayInit(clusterSubnets, systemID, node.Name, ifaceID, ipAddress,
+	// get a subnet for the per-node join switch
+	joinSubnetStr, err := oc.allocateJoinSubnet(node)
+	if err != nil {
+		return err
+	}
+
+	err = util.GatewayInit(clusterSubnets, joinSubnetStr, systemID, node.Name, ifaceID, ipAddress,
 		gwMacAddress, gwNextHop, subnet, nodePortEnable, lspArgs)
 	if err != nil {
 		return fmt.Errorf("failed to init shared interface gateway: %v", err)
@@ -471,6 +514,27 @@ func parseNodeHostSubnet(node *kapi.Node) (*net.IPNet, error) {
 	}
 	if !ok {
 		return nil, fmt.Errorf("node %q has no subnet annotation", node.Name)
+	}
+
+	_, subnet, err := net.ParseCIDR(sub)
+	if err != nil {
+		return nil, fmt.Errorf("Error in parsing hostsubnet - %v", err)
+	}
+
+	return subnet, nil
+}
+
+func parseNodeJoinSubnet(node *kapi.Node) (*net.IPNet, error) {
+	sub, ok := node.Annotations[OvnNodeJoinSubnets]
+	if ok {
+		nodeSubnets := make(map[string]string)
+		if err := json.Unmarshal([]byte(sub), &nodeSubnets); err != nil {
+			return nil, fmt.Errorf("error parsing node-subnets annotation: %v", err)
+		}
+		sub, ok = nodeSubnets["default"]
+	}
+	if !ok {
+		return nil, fmt.Errorf("node %q has no join subnet annotation", node.Name)
 	}
 
 	_, subnet, err := net.ParseCIDR(sub)
@@ -693,11 +757,16 @@ func (oc *Controller) deleteNodeLogicalNetwork(nodeName string) error {
 	return nil
 }
 
-func (oc *Controller) deleteNode(nodeName string, nodeSubnet *net.IPNet) error {
+func (oc *Controller) deleteNode(nodeName string, nodeSubnet, joinSubnet *net.IPNet) error {
 	// Clean up as much as we can but don't hard error
 	if nodeSubnet != nil {
 		if err := oc.deleteNodeHostSubnet(nodeName, nodeSubnet); err != nil {
-			logrus.Errorf("Error deleting node %s HostSubnet: %v", nodeName, err)
+			logrus.Errorf("Error deleting node %s HostSubnet %v: %v", nodeName, nodeSubnet, err)
+		}
+	}
+	if joinSubnet != nil {
+		if err := oc.deleteNodeJoinSubnet(nodeName, joinSubnet); err != nil {
+			logrus.Errorf("Error deleting node %s JoinSubnet %v: %v", nodeName, joinSubnet, err)
 		}
 	}
 
@@ -787,17 +856,25 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 			stderr, err)
 		return
 	}
+
+	type NodeSubnets struct {
+		hostSubnet *net.IPNet
+		joinSubnet *net.IPNet
+	}
+	NodeSubnetsMap := make(map[string]*NodeSubnets)
 	for _, result := range strings.Split(nodeSwitches, "\n\n") {
 		// Split result into name and other-config
 		items := strings.Split(result, "\n")
 		if len(items) != 2 || len(items[0]) == 0 {
 			continue
 		}
-		if items[0] == "join" {
-			// Don't delete the cluster switch
-			continue
+		isJoinSwitch := false
+		nodeName := items[0]
+		if strings.HasPrefix(items[0], "join_") {
+			isJoinSwitch = true
+			nodeName = strings.Split(items[0], "_")[1]
 		}
-		if _, ok := foundNodes[items[0]]; ok {
+		if _, ok := foundNodes[nodeName]; ok {
 			// node still exists, no cleanup to do
 			continue
 		}
@@ -811,8 +888,21 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 				break
 			}
 		}
+		var tmp NodeSubnets
+		nodeSubnets, ok := NodeSubnetsMap[nodeName]
+		if !ok {
+			nodeSubnets = &tmp
+			NodeSubnetsMap[nodeName] = nodeSubnets
+		}
+		if isJoinSwitch {
+			nodeSubnets.joinSubnet = subnet
+		} else {
+			nodeSubnets.hostSubnet = subnet
+		}
+	}
 
-		if err := oc.deleteNode(items[0], subnet); err != nil {
+	for nodeName, nodeSubnets := range NodeSubnetsMap {
+		if err := oc.deleteNode(nodeName, nodeSubnets.hostSubnet, nodeSubnets.joinSubnet); err != nil {
 			logrus.Error(err)
 		}
 	}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -36,10 +36,10 @@ func cleanupGateway(fexec *ovntest.FakeExec, nodeName string, nodeSubnet string,
 
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + nodeName + " networks",
-		Output: "[\"100.64.0.3/16\"]",
+		Output: "[\"100.64.0.1/29\"]",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=\"100.64.0.3\"",
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=\"100.64.0.1\"",
 		Output: node1RouteUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -53,9 +53,10 @@ func cleanupGateway(fexec *ovntest.FakeExec, nodeName string, nodeSubnet string,
 		"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouter + " static_routes " + node1mgtRouteUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exist lsp-del jtor-GR_" + nodeName,
+		"ovn-nbctl --timeout=15 --if-exist ls-del join_" + nodeName,
 		"ovn-nbctl --timeout=15 --if-exist lr-del GR_" + nodeName,
 		"ovn-nbctl --timeout=15 --if-exist ls-del ext_" + nodeName,
+		"ovn-nbctl --timeout=15 --if-exist lrp-del dtoj-" + nodeName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_" + nodeName,
@@ -69,10 +70,9 @@ func cleanupGateway(fexec *ovntest.FakeExec, nodeName string, nodeSubnet string,
 
 func defaultFakeExec(nodeSubnet, nodeName string) (*ovntest.FakeExec, string, string) {
 	const (
-		tcpLBUUID  string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
-		udpLBUUID  string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
-		joinLRPMAC string = "00:00:00:83:25:1C"
-		mgmtMAC    string = "01:02:03:04:05:06"
+		tcpLBUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
+		udpLBUUID string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
+		mgmtMAC   string = "01:02:03:04:05:06"
 	)
 
 	fexec := ovntest.NewFakeExec()
@@ -103,16 +103,6 @@ func defaultFakeExec(nodeSubnet, nodeName string) (*ovntest.FakeExec, string, st
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-udp=yes protocol=udp",
 		Output: udpLBUUID,
-	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --may-exist ls-add join -- set logical_switch join other-config:subnet=100.64.0.0/16 -- set logical_switch join other-config:exclude_ips=100.64.0.1",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-ovn_cluster_router mac",
-		Output: joinLRPMAC,
-	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 -- --may-exist lsp-add join jtor-ovn_cluster_router -- set logical_switch_port jtor-ovn_cluster_router type=router options:router-port=rtoj-ovn_cluster_router addresses=\"" + joinLRPMAC + "\"",
 	})
 
 	// Node-related logical network stuff
@@ -366,10 +356,10 @@ subnet=%s
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_openshift-node-1 networks",
-				Output: "[\"100.64.0.3/16\"]",
+				Output: "[\"100.64.0.1/29\"]",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=\"100.64.0.3\"",
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=\"100.64.0.1\"",
 				Output: node1RouteUUID,
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -383,9 +373,10 @@ subnet=%s
 				"ovn-nbctl --timeout=15 --if-exists remove logical_router " + clusterRouter + " static_routes " + node1mgtRouteUUID,
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --if-exist lsp-del jtor-GR_" + node1Name,
+				"ovn-nbctl --timeout=15 --if-exist ls-del join_" + node1Name,
 				"ovn-nbctl --timeout=15 --if-exist lr-del GR_" + node1Name,
 				"ovn-nbctl --timeout=15 --if-exist ls-del ext_" + node1Name,
+				"ovn-nbctl --timeout=15 --if-exist lrp-del dtoj-" + node1Name,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_" + node1Name,
@@ -454,6 +445,7 @@ subnet=%s
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
+			_ = clusterController.joinSubnetAllocator.AddNetworkRange("100.64.0.0/16", 3)
 
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()
@@ -495,11 +487,13 @@ var _ = Describe("Gateway Init Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				nodeName               string = "node1"
-				gwLRPMAC               string = "00:00:00:05:46:c3"
-				lrpMAC                 string = "0A:58:0A:01:01:01"
+				nodeLRPMAC             string = "0A:58:0A:01:01:01"
+				joinSubnet             string = "100.64.0.0/29"
+				lrpMAC                 string = "0A:58:64:40:00:01"
+				lrpIP                  string = "100.64.0.1"
+				drLrpMAC               string = "0A:58:64:40:00:02"
+				drLrpIP                string = "100.64.0.2"
 				brLocalnetMAC          string = "11:22:33:44:55:66"
-				lrpIP                  string = "100.64.0.3"
-				lrpCIDR                string = lrpIP + "/16"
 				clusterRouter          string = util.OvnClusterRouter
 				systemID               string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 				tcpLBUUID              string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
@@ -536,6 +530,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				Annotations: map[string]string{
 					OvnNodeManagementPortMacAddress: brLocalnetMAC,
 					OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
+					OvnNodeJoinSubnets:              fmt.Sprintf(`{"default": "%s"}`, joinSubnet),
 					OvnNodeL3GatewayConfig:          string(bytes),
 					OvnNodeChassisID:                systemID,
 				},
@@ -557,36 +552,26 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --may-exist lrp-add ovn_cluster_router rtos-" + nodeName + " " + lrpMAC + " " + masterGWCIDR,
+				"ovn-nbctl --timeout=15 --may-exist lrp-add ovn_cluster_router rtos-" + nodeName + " " + nodeLRPMAC + " " + masterGWCIDR,
 				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + nodeName + " -- set logical_switch " + nodeName + " other-config:subnet=" + nodeSubnet + " other-config:exclude_ips=" + masterMgmtPortIP,
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " stor-" + nodeName + " -- set logical_switch_port stor-" + nodeName + " type=router options:router-port=rtos-" + nodeName + " addresses=\"" + lrpMAC + "\"",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " stor-" + nodeName + " -- set logical_switch_port stor-" + nodeName + " type=router options:router-port=rtos-" + nodeName + " addresses=\"" + nodeLRPMAC + "\"",
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " k8s-" + nodeName + " -- lsp-set-addresses " + "k8s-" + nodeName + " " + brLocalnetMAC + " " + masterMgmtPortIP + " -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 				"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + masterMgmtPortIP + " allow-related",
 			})
+			joinSwitch := "join_" + nodeName
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses addresses",
-				Output: "[]" + "\n" + "[]",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses addresses",
-				Output: gwLRPMAC + " " + lrpIP + "\n" + "[]",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join other-config:subnet",
-				Output: "\"100.64.0.1/16\"",
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch + " -- set logical_switch " + joinSwitch + " other-config:subnet=" + joinSubnet,
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtod-" + nodeName + " -- set logical_switch_port jtod-" + nodeName + " type=router options:router-port=dtoj-" + nodeName + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + clusterRouter + " dtoj-" + nodeName + " " + drLrpMAC + " " + drLrpIP + "/29",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + gwLRPMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
 				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " " + drLrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -597,7 +582,6 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoe-" + gwRouter + " -- lrp-add " + gwRouter + " rtoe-" + gwRouter + " " + brLocalnetMAC + " 169.254.33.2/24 -- set logical_router_port rtoe-" + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 rtoe-" + gwRouter,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + lrpIP + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouter + " " + nodeSubnet + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
 			})
@@ -619,26 +603,15 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses addresses",
-				Output: "[]" + "\n" + "[]",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses addresses",
-				Output: gwLRPMAC + " " + lrpIP + "\n" + "[]",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join other-config:subnet",
-				Output: "\"100.64.0.1/16\"",
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch + " -- set logical_switch " + joinSwitch + " other-config:subnet=" + joinSubnet,
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtod-" + nodeName + " -- set logical_switch_port jtod-" + nodeName + " type=router options:router-port=dtoj-" + nodeName + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + clusterRouter + " dtoj-" + nodeName + " " + drLrpMAC + " " + drLrpIP + "/29",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + gwLRPMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
 				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " " + drLrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -649,7 +622,6 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoe-" + gwRouter + " -- lrp-add " + gwRouter + " rtoe-" + gwRouter + " " + brLocalnetMAC + " 169.254.33.2/24 -- set logical_router_port rtoe-" + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 rtoe-" + gwRouter,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + lrpIP + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouter + " " + nodeSubnet + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
 			})
@@ -676,6 +648,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
+			_ = clusterController.joinSubnetAllocator.AddNetworkRange("100.64.0.0/16", 3)
 
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()
@@ -704,10 +677,13 @@ var _ = Describe("Gateway Init Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				nodeName               string = "node1"
-				lrpMAC                 string = "0A:58:0A:01:01:01"
-				gwLRPMAC               string = "00:00:00:05:46:c3"
+				nodeLRPMAC             string = "0A:58:0A:01:01:01"
+				joinSubnet             string = "100.64.0.0/29"
+				lrpMAC                 string = "0A:58:64:40:00:01"
+				lrpIP                  string = "100.64.0.1"
+				drLrpMAC               string = "0A:58:64:40:00:02"
+				drLrpIP                string = "100.64.0.2"
 				physicalBridgeMAC      string = "11:22:33:44:55:66"
-				lrpIP                  string = "100.64.0.3"
 				lrpCIDR                string = lrpIP + "/16"
 				clusterRouter          string = util.OvnClusterRouter
 				systemID               string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
@@ -744,6 +720,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				Annotations: map[string]string{
 					OvnNodeManagementPortMacAddress: nodeMgmtPortMAC,
 					OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
+					OvnNodeJoinSubnets:              fmt.Sprintf(`{"default": "%s"}`, joinSubnet),
 					OvnNodeL3GatewayConfig:          string(bytes),
 					OvnNodeChassisID:                systemID,
 				},
@@ -765,36 +742,26 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --may-exist lrp-add ovn_cluster_router rtos-" + nodeName + " " + lrpMAC + " " + nodeGWIP,
+				"ovn-nbctl --timeout=15 --may-exist lrp-add ovn_cluster_router rtos-" + nodeName + " " + nodeLRPMAC + " " + nodeGWIP,
 				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + nodeName + " -- set logical_switch " + nodeName + " other-config:subnet=" + nodeSubnet + " other-config:exclude_ips=" + nodeMgmtPortIP,
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " stor-" + nodeName + " -- set logical_switch_port stor-" + nodeName + " type=router options:router-port=rtos-" + nodeName + " addresses=\"" + lrpMAC + "\"",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " stor-" + nodeName + " -- set logical_switch_port stor-" + nodeName + " type=router options:router-port=rtos-" + nodeName + " addresses=\"" + nodeLRPMAC + "\"",
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " k8s-" + nodeName + " -- lsp-set-addresses " + "k8s-" + nodeName + " " + nodeMgmtPortMAC + " " + nodeMgmtPortIP + " -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 				"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + nodeMgmtPortIP + " allow-related",
 			})
+			joinSwitch := "join_" + nodeName
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + physicalGatewayIP,
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses addresses",
-				Output: "[]" + "\n" + "[]",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses addresses",
-				Output: gwLRPMAC + " " + lrpIP + "\n" + "[]",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join other-config:subnet",
-				Output: "\"100.64.0.1/16\"",
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch + " -- set logical_switch " + joinSwitch + " other-config:subnet=" + joinSubnet,
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtod-" + nodeName + " -- set logical_switch_port jtod-" + nodeName + " type=router options:router-port=dtoj-" + nodeName + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + clusterRouter + " dtoj-" + nodeName + " " + drLrpMAC + " " + drLrpIP + "/29",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + gwLRPMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
 				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " " + drLrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -805,7 +772,6 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoe-" + gwRouter + " -- lrp-add " + gwRouter + " rtoe-" + gwRouter + " " + physicalBridgeMAC + " " + physicalGatewayIPMask + " -- set logical_router_port rtoe-" + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + physicalBridgeMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + physicalGatewayNextHop + " rtoe-" + gwRouter,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + lrpIP + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouter + " " + nodeSubnet + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat " + physicalGatewayIP + " " + clusterCIDR,
 			})
@@ -828,26 +794,16 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + physicalGatewayIP,
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch + " -- set logical_switch " + joinSwitch + " other-config:subnet=" + joinSubnet,
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtod-" + nodeName + " -- set logical_switch_port jtod-" + nodeName + " type=router options:router-port=dtoj-" + nodeName + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + clusterRouter + " dtoj-" + nodeName + " " + drLrpMAC + " " + drLrpIP + "/29",
 			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses addresses",
-				Output: "[]" + "\n" + "[]",
-			})
+
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --wait=sb --may-exist lsp-add join jtor-GR_" + nodeName + " -- --if-exists clear logical_switch_port jtor-GR_" + nodeName + " dynamic_addresses -- lsp-set-addresses jtor-GR_" + nodeName + " dynamic",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port jtor-" + gwRouter + " dynamic_addresses addresses",
-				Output: gwLRPMAC + " " + lrpIP + "\n" + "[]",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --if-exists get logical_switch join other-config:subnet",
-				Output: "\"100.64.0.1/16\"",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 -- --may-exist lrp-add GR_" + nodeName + " rtoj-GR_" + nodeName + " " + gwLRPMAC + " " + lrpCIDR + " -- set logical_switch_port jtor-GR_" + nodeName + " type=router options:router-port=rtoj-GR_" + nodeName + " addresses=router",
 				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " 100.64.0.1",
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " " + drLrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID)
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -858,7 +814,6 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoe-" + gwRouter + " -- lrp-add " + gwRouter + " rtoe-" + gwRouter + " " + physicalBridgeMAC + " " + physicalGatewayIPMask + " -- set logical_router_port rtoe-" + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_" + nodeName + " etor-" + gwRouter + " -- set logical_switch_port etor-" + gwRouter + " type=router options:router-port=rtoe-" + gwRouter + " addresses=\"" + physicalBridgeMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + physicalGatewayNextHop + " rtoe-" + gwRouter,
-				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + lrpIP + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + clusterRouter + " " + nodeSubnet + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat " + physicalGatewayIP + " " + clusterCIDR,
 			})
@@ -889,6 +844,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
+			_ = clusterController.joinSubnetAllocator.AddNetworkRange("100.64.0.0/16", 3)
 
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -41,6 +41,7 @@ type Controller struct {
 	watchFactory *factory.WatchFactory
 
 	masterSubnetAllocator *allocator.SubnetAllocator
+	joinSubnetAllocator   *allocator.SubnetAllocator
 
 	TCPLoadBalancerUUID string
 	UDPLoadBalancerUUID string
@@ -128,6 +129,7 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory)
 		watchFactory:             wf,
 		masterSubnetAllocator:    allocator.NewSubnetAllocator(),
 		logicalSwitchCache:       make(map[string]*net.IPNet),
+		joinSubnetAllocator:      allocator.NewSubnetAllocator(),
 		logicalPortCache:         make(map[string]string),
 		logicalPortUUIDCache:     make(map[string]string),
 		namespaceAddressSet:      make(map[string]map[string]string),
@@ -555,7 +557,8 @@ func (oc *Controller) WatchNodes() error {
 				"various caches", node.Name)
 
 			nodeSubnet, _ := parseNodeHostSubnet(node)
-			err := oc.deleteNode(node.Name, nodeSubnet)
+			joinSubnet, _ := parseNodeJoinSubnet(node)
+			err := oc.deleteNode(node.Name, nodeSubnet, joinSubnet)
 			if err != nil {
 				logrus.Error(err)
 			}

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -77,52 +77,6 @@ func GetDefaultGatewayRouterIP() (string, net.IP, error) {
 	return routers[0].name, routers[0].ip, nil
 }
 
-func ensureGatewayPortAddress(portName string) (net.HardwareAddr, *net.IPNet, error) {
-	mac, ip, _ := GetPortAddresses(portName)
-	if mac == nil || ip == nil {
-		// Create the gateway switch port in 'join' if it doesn't exist yet
-		stdout, stderr, err := RunOVNNbctl("--wait=sb",
-			"--may-exist", "lsp-add", "join", portName,
-			"--", "--if-exists", "clear", "logical_switch_port", portName, "dynamic_addresses",
-			"--", "lsp-set-addresses", portName, "dynamic")
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to add logical switch "+
-				"port %s, stdout: %q, stderr: %q, error: %v",
-				portName, stdout, stderr, err)
-		}
-		// Should have an address already since we waited for the SB above
-		mac, ip, err = GetPortAddresses(portName)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error while waiting for addresses "+
-				"for gateway switch port %q: %v", portName, err)
-		}
-		if mac == nil || ip == nil {
-			return nil, nil, fmt.Errorf("empty addresses for gateway "+
-				"switch port %q", portName)
-		}
-	}
-
-	// Grab the 'join' switch prefix length to add to our gateway router's IP
-	cidrStr, stderr, err := RunOVNNbctl("--if-exists", "get",
-		"logical_switch", "join", config.OtherConfigSubnet())
-	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to get 'join' switch external-ids: "+
-			"stderr: %q, %v", stderr, err)
-	}
-	_, cidr, err := net.ParseCIDR(cidrStr)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to parse 'join' switch subnet %q: %v",
-			cidrStr, err)
-	}
-	if !cidr.Contains(ip) {
-		return nil, nil, fmt.Errorf("gateway router port %q IP %q not "+
-			"contained in 'join' switch subnet %q", portName, ip, cidrStr)
-	}
-	cidr.IP = ip
-
-	return mac, cidr, nil
-}
-
 // getGatewayLoadBalancers find TCP UDP load-balancers from gateway router.
 func getGatewayLoadBalancers(gatewayRouter string) (string, string, error) {
 	lbTCP, stderr, err := RunOVNNbctl("--data=bare", "--no-heading",
@@ -145,7 +99,7 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, error) {
 }
 
 // GatewayInit creates a gateway router for the local chassis.
-func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, nicMacAddress,
+func GatewayInit(clusterIPSubnet []string, joinSubnetStr, systemID, nodeName, ifaceID, nicIP, nicMacAddress,
 	defaultGW string, rampoutIPSubnet string, nodePortEnable bool, lspArgs []string) error {
 
 	ip, physicalIPNet, err := net.ParseCIDR(nicIP)
@@ -172,23 +126,60 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 			"stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 	}
 
-	gwSwitchPort := "jtor-" + gatewayRouter
-	gwRouterPort := "rtoj-" + gatewayRouter
-	routerMac, routerCIDR, err := ensureGatewayPortAddress(gwSwitchPort)
+	_, joinSubnet, _ := net.ParseCIDR(joinSubnetStr)
+	prefixLen, _ := joinSubnet.Mask.Size()
+	gwLRPIp := NextIP(joinSubnet.IP)
+	drLRPIp := NextIP(gwLRPIp)
+	gwLRPMac := IPAddrToHWAddr(gwLRPIp)
+	drLRPMac := IPAddrToHWAddr(drLRPIp)
+
+	joinSwitch := "join_" + nodeName
+	// create the per-node join switch
+	stdout, stderr, err = RunOVNNbctl(
+		"--", "--may-exist", "ls-add", joinSwitch,
+		"--", "set", "logical_switch", joinSwitch, fmt.Sprintf("%s=%s", config.OtherConfigSubnet(), joinSubnetStr))
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to create logical switch %q, stdout: %q, stderr: %q, error: %v",
+			joinSwitch, stdout, stderr, err)
 	}
 
-	// Must move the IP from the LSP to the LRP and set the LSP addresses
-	// to 'router' in one transaction, because IPAM doesn't consider LSPs that
-	// are attached to routers when checking reserved addresses.
+	gwSwitchPort := "jtor-" + gatewayRouter
+	gwRouterPort := "rtoj-" + gatewayRouter
 	stdout, stderr, err = RunOVNNbctl(
-		"--", "--may-exist", "lrp-add", gatewayRouter, gwRouterPort, routerMac.String(), routerCIDR.String(),
-		"--", "set", "logical_switch_port", gwSwitchPort, "type=router",
-		"options:router-port="+gwRouterPort, "addresses=router")
+		"--", "--may-exist", "lsp-add", joinSwitch, gwSwitchPort,
+		"--", "set", "logical_switch_port", gwSwitchPort, "type=router", "options:router-port="+gwRouterPort,
+		"addresses=router")
 	if err != nil {
-		return fmt.Errorf("failed to add logical port to router, stdout: %q, "+
-			"stderr: %q, error: %v", stdout, stderr, err)
+		return fmt.Errorf("failed to add port %q to logical switch %q, "+
+			"stdout: %q, stderr: %q, error: %v", gwSwitchPort, joinSwitch, stdout, stderr, err)
+	}
+
+	_, stderr, err = RunOVNNbctl(
+		"--", "--may-exist", "lrp-add", gatewayRouter, gwRouterPort, gwLRPMac,
+		fmt.Sprintf("%s/%d", gwLRPIp.String(), prefixLen))
+	if err != nil {
+		return fmt.Errorf("Failed to add logical router port %q, stderr: %q, error: %v", gwRouterPort, stderr, err)
+	}
+
+	// jtod/dtoj - patch ports that connect the per-node join switch to distributed router
+	drSwitchPort := "jtod-" + nodeName
+	drRouterPort := "dtoj-" + nodeName
+
+	// Connect the per-node join switch to the distributed router.
+	stdout, stderr, err = RunOVNNbctl(
+		"--", "--may-exist", "lsp-add", joinSwitch, drSwitchPort,
+		"--", "set", "logical_switch_port", drSwitchPort, "type=router", "options:router-port="+drRouterPort,
+		"addresses=router")
+	if err != nil {
+		return fmt.Errorf("failed to add port %q to logical switch %q, "+
+			"stdout: %q, stderr: %q, error: %v", drSwitchPort, joinSwitch, stdout, stderr, err)
+	}
+
+	_, stderr, err = RunOVNNbctl(
+		"--", "--may-exist", "lrp-add", k8sClusterRouter, drRouterPort, drLRPMac,
+		fmt.Sprintf("%s/%d", drLRPIp.String(), prefixLen))
+	if err != nil {
+		return fmt.Errorf("Failed to add logical router port %q, stderr: %q, error: %v", drRouterPort, stderr, err)
 	}
 
 	// When there are multiple gateway routers (which would be the likely
@@ -196,7 +187,7 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 	// heading to the logical space with the Gateway router's IP so that
 	// return traffic comes back to the same gateway router.
 	stdout, stderr, err = RunOVNNbctl("set", "logical_router",
-		gatewayRouter, "options:lb_force_snat_ip="+routerCIDR.IP.String())
+		gatewayRouter, "options:lb_force_snat_ip="+gwLRPIp.String())
 	if err != nil {
 		return fmt.Errorf("Failed to set logical router, stdout: %q, "+
 			"stderr: %q, error: %v", stdout, stderr, err)
@@ -204,14 +195,8 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 
 	for _, entry := range clusterIPSubnet {
 		// Add a static route in GR with distributed router as the nexthop.
-		var joinAddr string
-		if config.IPv6Mode {
-			joinAddr = "fd98::1"
-		} else {
-			joinAddr = "100.64.0.1"
-		}
 		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
-			gatewayRouter, entry, joinAddr)
+			gatewayRouter, entry, drLRPIp.String())
 		if err != nil {
 			return fmt.Errorf("Failed to add a static route in GR with distributed "+
 				"router as the nexthop, stdout: %q, stderr: %q, error: %v",
@@ -333,17 +318,6 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 		}
 	}
 
-	// We need to add a /32 route to the Gateway router's IP, on the
-	// cluster router, to ensure that the return traffic goes back
-	// to the same gateway router
-	stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
-		k8sClusterRouter, routerCIDR.IP.String(), routerCIDR.IP.String())
-	if err != nil {
-		return fmt.Errorf("Failed to add /32 route to Gateway router's IP of %q "+
-			"on the distributed router, stdout: %q, stderr: %q, error: %v",
-			routerCIDR.IP.String(), stdout, stderr, err)
-	}
-
 	if rampoutIPSubnet != "" {
 		rampoutIPSubnets := strings.Split(rampoutIPSubnet, ",")
 		for _, rampoutIPSubnet = range rampoutIPSubnets {
@@ -356,7 +330,7 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 			// for this gateway router.
 			stdout, stderr, err = RunOVNNbctl("--may-exist",
 				"--policy=src-ip", "lr-route-add", k8sClusterRouter,
-				rampoutIPSubnet, routerCIDR.IP.String())
+				rampoutIPSubnet, gwLRPIp.String())
 			if err != nil {
 				return fmt.Errorf("Failed to add source IP address based "+
 					"routes in distributed router, stdout: %q, "+


### PR DESCRIPTION
In the logical topology we have, the join logical switch connects all
the L3 gateways together on a single L2 broadcast domain. So, with 622
k8s nodes the join logical switch connects 622 L3 gateways and 1
distributed gateway router (ovn_cluster_router). This ends up in
creation of hundreds of thousands of logical flow entries in OVN SB’s
lr_in_arp_resolve table across all of the 623 gateway routers.

These flows add the destination MAC address to the packets bound to
other router ports. Every L3 gateway router has ARP resolve entries in
lr_in_arp_resolve table for 622 other router’s IP address. So, this
results in 622 * 622 entries. Which is 386K entries. Add in IPv6
entries, then it will be 772K entries.

Both ovn-northd and ovsdb-server NB daemon is super busy processing
these flow entries (cursory ltrace says it’s all in string operations).

The solution is to remove the single join logical switch and instead,
introduce a join logical switch per-node.

```
+-------------------+   +-------------------+  +-------------------+
|Node1              |   |Node2              |  |NodeN              |
| .---.             |   | .---.             |  | .---.             |
|(l3GW )            |   |(l3GW )            |  |(l3GW )            |
| `-+-'             |   | `-+-'             |  | `-+-'             |
+---+---------------+   +---+---------------+  +---+---------------+
    |                       |                      |
    |                       |                      |
 +--+-------------+     +---+------------+      +--+--------------+
 | join_node1     |     | join_node2     |      |  join_node3     |
 | 100.64.0.0/29  |     | 100.64.0.4/29  |      |  100.64.0.8/29  |
 +--+-------------+     +---+------------+      +--+--------------+
    |                       |                      |
 .--+-----------------------+----------------------+-------------.
(                       ovn_cluster_router                        )
 `--------+------------------+---------------------------+-------'
          |                  |                           |
          |                  |                           |
        +-+-+              +-+-+                       +-+-+
        |LS1|              |LS2|                       |LS3|
        +---+              +---+                       +---+
```
The L2 broadcast domain is smaller now. Each L3 Gateway router
connects with ovn_cluster_router with a two-port switch.

Fixes #990

@dcbw @danwinship PTAL