### PR TITLE
determine whether we are running in IPv6 mode once at the start time

### DIFF
--- a/go-controller/pkg/cluster/gateway_localnet.go
+++ b/go-controller/pkg/cluster/gateway_localnet.go
@@ -40,21 +40,21 @@ type iptRule struct {
 }
 
 func localnetGatewayIP() string {
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		return v6localnetGatewayIP
 	}
 	return v4localnetGatewayIP
 }
 
 func localnetGatewayNextHop() string {
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		return v6localnetGatewayNextHop
 	}
 	return v4localnetGatewayNextHop
 }
 
 func localnetGatewayNextHopSubnet() string {
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		return v6localnetGatewayNextHopSubnet
 	}
 	return v4localnetGatewayNextHopSubnet
@@ -207,7 +207,7 @@ func initLocalnetGateway(nodeName string,
 		ovn.OvnDefaultNetworkGateway: l3GatewayConfig,
 	}
 
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		// TODO - IPv6 hack ... for some reason neighbor discovery isn't working here, so hard code a
 		// MAC binding for the gateway IP address for now - need to debug this further
 		_, _, _ = util.RunIP("-6", "neigh", "del", "fd99::2", "dev", "br-nexthop")
@@ -260,7 +260,7 @@ func localnetIptRules(svc *kapi.Service) []iptRule {
 func localnetIPTablesHelper() (util.IPTablesHelper, error) {
 	var ipt util.IPTablesHelper
 	var err error
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv6)
 	} else {
 		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv4)

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Config Operations", func() {
 			Expect(Default.ClusterSubnets).To(Equal([]CIDRNetworkEntry{
 				{mustParseCIDR("10.128.0.0/14"), 23},
 			}))
-			Expect(UseIPv6()).To(Equal(false))
+			Expect(IPv6Mode).To(Equal(false))
 
 			for _, a := range []OvnAuthConfig{OvnNorth, OvnSouth} {
 				Expect(a.Scheme).To(Equal(OvnDBSchemeUnix))
@@ -631,7 +631,7 @@ cluster-subnets=172.18.0.0/24
 			Expect(Default.ClusterSubnets).To(Equal([]CIDRNetworkEntry{
 				{mustParseCIDR("fd02::/64"), 24},
 			}))
-			Expect(UseIPv6()).To(Equal(true))
+			Expect(IPv6Mode).To(Equal(true))
 			return nil
 		}
 		cliArgs := []string{

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -100,7 +100,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 				"Disabling Multicast Support")
 			oc.multicastSupport = false
 		}
-		if config.UseIPv6() {
+		if config.IPv6Mode {
 			logrus.Warningf("Multicast support enabled, but can not be used along with IPv6. Disabling Multicast Support")
 			oc.multicastSupport = false
 		}
@@ -178,13 +178,13 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 	// Create a logical switch called "join" that will be used to connect gateway routers to the distributed router.
 	// The "join" switch will be allocated IP addresses in the range 100.64.0.0/16 or fd98::/64.
 	var joinSubnet string
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		joinSubnet = "fd98::1/64"
 	} else {
 		joinSubnet = "100.64.0.1/16"
 	}
 	joinIP, joinCIDR, _ := net.ParseCIDR(joinSubnet)
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		stdout, stderr, err = util.RunOVNNbctl("--may-exist", "ls-add", "join",
 			"--", "set", "logical_switch", "join", fmt.Sprintf("%s=%s", config.OtherConfigSubnet(), joinCIDR.String()))
 	} else {
@@ -270,7 +270,7 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, subnet *net.IPNet)
 
 	// Create this node's management logical port on the node switch
 	var stdout, stderr string
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		stdout, stderr, err = util.RunOVNNbctl(
 			"--", "--may-exist", "lsp-add", node.Name, "k8s-"+node.Name,
 			"--", "lsp-set-addresses", "k8s-"+node.Name, macAddress+" "+portIP.IP.String())
@@ -495,7 +495,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 
 	// Create a logical switch and set its subnet.
 	var stdout string
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "ls-add", nodeName,
 			"--", "set", "logical_switch", nodeName, config.OtherConfigSubnet()+"="+hostsubnet.String(),
 			"external-ids:gateway_ip="+firstIP.String())

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -93,7 +93,7 @@ func (gp *gressPolicy) addIPBlock(ipblockJSON *knet.IPBlock) {
 }
 
 func ipMatch() string {
-	if config.UseIPv6() {
+	if config.IPv6Mode {
 		return "ip6"
 	}
 	return "ip4"

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -205,7 +205,7 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 	for _, entry := range clusterIPSubnet {
 		// Add a static route in GR with distributed router as the nexthop.
 		var joinAddr string
-		if config.UseIPv6() {
+		if config.IPv6Mode {
 			joinAddr = "fd98::1"
 		} else {
 			joinAddr = "100.64.0.1"
@@ -318,7 +318,7 @@ func GatewayInit(clusterIPSubnet []string, systemID, nodeName, ifaceID, nicIP, n
 	// Add a static route in GR with physical gateway as the default next hop.
 	if defaultGW != "" {
 		var allIPs string
-		if config.UseIPv6() {
+		if config.IPv6Mode {
 			allIPs = "::/0"
 		} else {
 			allIPs = "0.0.0.0/0"


### PR DESCRIPTION
IPv6 mode or not is a deployment time thing and is going to be that way
till the cluster is torn down and brought up in the other mode. So,
figure out the mode in the beginning instead of determining
the mode in every call to UseIPv6().

@russellb @dcbw PTAL