### PR TITLE
scale: use light weight check to ensure OVN DB endpoints are up

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -218,7 +218,7 @@ ready_to_start_node () {
       return 1
   fi
   get_ovn_db_vars
-  ovn-nbctl --db=${ovn_nbdb_test} show > /dev/null 2>&1
+  ovsdb-client list-dbs ${ovn_nbdb_test} > /dev/null 2>&1
   if [[ $? != 0 ]] ; then
       return 1
   fi


### PR DESCRIPTION
in ready_to_start_node() we use `ovn-nbctl show` to check if the DB
endpoints are up. however, they are very expensive at scale as can be
seen below

$ ovn-nbctl -vjsonrpc show >/dev/null 2>/tmp/show
$ ll -lh /tmp/show
-rw-r--r-- 1 root root 4.2M Jan 14 15:49 /tmp/show

so, close to 4.2M amount of data is downloaded and if all the
ovnkube-node restart at the same time, then we have data storm.

instead use `ovsdb-client` and the data exchanged is 227 bytes

$ ovsdb-client -vjsonrpc list-dbs $OVN_NB_DB >/dev/null 2>/tmp/list_dbs
$ ll -lh /tmp/list_dbs
-rw-r--r-- 1 root root 227 Jan 14 15:51 /tmp/list_dbs

@dcbw @danwinship PTAL