### PR TITLE
Allow IPv6 Node addresses for geneve tunnels

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -107,16 +107,29 @@ func GetNodeIP(nodeName string) (string, error) {
 			return "", fmt.Errorf("Failed to lookup IP address for node %s: %v", nodeName, err)
 		}
 		for _, addr := range addrs {
-			// Skip loopback and non IPv4 addrs
-			if addr.IsLoopback() || addr.To4() == nil {
-				klog.V(5).Infof("Skipping loopback/non-IPv4 addr: %q for node %s", addr.String(), nodeName)
+			// Skip loopback addrs
+			if addr.IsLoopback() {
+				klog.V(5).Infof("Skipping loopback addr: %q for node %s", addr.String(), nodeName)
+				continue
+			}
+			if config.IPv6Mode && addr.To4() != nil {
+				klog.V(5).Infof("Skipping IPv4 addr: %q for node %s", addr.String(), nodeName)
+				continue
+			} else if !config.IPv6Mode && addr.To4() == nil {
+				klog.V(5).Infof("Skipping IPv6 addr: %q for node %s", addr.String(), nodeName)
 				continue
 			}
 			ip = addr
 			break
 		}
-	} else if ip.IsLoopback() || ip.To4() == nil {
-		klog.V(5).Infof("Skipping loopback/non-IPv4 addr: %q for node %s", ip.String(), nodeName)
+	} else if ip.IsLoopback() {
+		klog.V(5).Infof("Skipping loopback addr: %q for node %s", ip.String(), nodeName)
+		ip = nil
+	} else if config.IPv6Mode && ip.To4() != nil {
+		klog.V(5).Infof("Skipping IPv4 addr: %q for node %s", ip.String(), nodeName)
+		ip = nil
+	} else if !config.IPv6Mode && ip.To4() == nil {
+		klog.V(5).Infof("Skipping IPv6 addr: %q for node %s", ip.String(), nodeName)
 		ip = nil
 	}
 


### PR DESCRIPTION
GetNodeIP is used to determine an IP address for the Node to use as
the address other Nodes will use to create Geneve tunnels to this
Node.  It previously filtered out IPv4 addresses, but that breaks an
environment where the Nodes only have IPv6 addresses.

The code will now adjust between expecting an IPv4 or IPv6 address
based on which mode it is in.

Signed-off-by: Russell Bryant <russell@ovn.org>