### PR TITLE
Restrict address type requirements for tunneling

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -112,24 +112,11 @@ func GetNodeIP(nodeName string) (string, error) {
 				klog.V(5).Infof("Skipping loopback addr: %q for node %s", addr.String(), nodeName)
 				continue
 			}
-			if config.IPv6Mode && addr.To4() != nil {
-				klog.V(5).Infof("Skipping IPv4 addr: %q for node %s", addr.String(), nodeName)
-				continue
-			} else if !config.IPv6Mode && addr.To4() == nil {
-				klog.V(5).Infof("Skipping IPv6 addr: %q for node %s", addr.String(), nodeName)
-				continue
-			}
 			ip = addr
 			break
 		}
 	} else if ip.IsLoopback() {
 		klog.V(5).Infof("Skipping loopback addr: %q for node %s", ip.String(), nodeName)
-		ip = nil
-	} else if config.IPv6Mode && ip.To4() != nil {
-		klog.V(5).Infof("Skipping IPv4 addr: %q for node %s", ip.String(), nodeName)
-		ip = nil
-	} else if !config.IPv6Mode && ip.To4() == nil {
-		klog.V(5).Infof("Skipping IPv6 addr: %q for node %s", ip.String(), nodeName)
 		ip = nil
 	}
 


### PR DESCRIPTION
This is a follow-up based on discussion in PR #1013.

Relax the requirements on address type for tunnels and use whatever IP
we can find that should work.  If this behavior doesn't work in some
environment, the encap IP can be configured explicitly instead by
setting the encap-ip configuration option.  This should be safe
default behavior, because it will only use an IP that can be
determined via DNS for the Node.

Signed-off-by: Russell Bryant <russell@ovn.org>