### PR TITLE
a way to specify the encap-ip for a k8s worker node

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -775,12 +775,20 @@ ovn-node () {
   wait_for_event process_ready ovn-controller
   sleep 1
 
+  OVN_ENCAP_IP=""
+  ovn_encap_ip=`ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-encap-ip | tr -d '\"'`
+  if [[ $? == 0 && "${ovn_encap_ip}" != "" ]]; then
+    OVN_ENCAP_IP=$(echo --encap-ip=${ovn_encap_ip})
+  fi
+
+
   echo "=============== ovn-node   --init-node"
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
       --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
       --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
       --nodeport \
       --mtu=${mtu} \
+      ${OVN_ENCAP_IP} \
       --loglevel=${ovnkube_loglevel} \
       --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts}  \
       --pidfile ${OVN_RUNDIR}/ovnkube.pid \


### PR DESCRIPTION
it could be that the IP that the hostname resolves to is not the
intended ip for Geneve VTEP. provide a way for ovnkube.sh to get to
know about the actual encap IP to be used on the node.

the assumption here is that some entity sets up the
external_ids:ovn-encap-ip with the right vtep ip and ovnkube.sh scraps
that info and passes it to onvkube through --encap-ip option.

@danwinship @dcbw PTAL
