### PR TITLE
pkg/util: make GetNodeIP get the ip address from Kubernetes API

### DIFF
--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -123,7 +123,10 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		}
 	}
 
-	err = setupOVNNode(name)
+	if node, err = cluster.Kube.GetNode(name); err != nil {
+		return fmt.Errorf("error retrieving node %s: %v", name, err)
+	}
+	err = setupOVNNode(node)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -32,10 +32,25 @@ var _ = Describe("Node Operations", func() {
 	It("sets correct OVN external IDs", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
-				nodeName string = "1.2.5.6"
+				nodeIP   string = "1.2.5.6"
+				nodeName string = "cannot.be.resolv.ed"
 				interval int    = 100000
 				ofintval int    = 180
 			)
+			node := kapi.Node{
+				Status: kapi.NodeStatus{
+					Addresses: []kapi.NodeAddress{
+						{
+							Type:    kapi.NodeHostName,
+							Address: nodeName,
+						},
+						{
+							Type:    kapi.NodeExternalIP,
+							Address: nodeIP,
+						},
+					},
+				},
+			}
 
 			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -45,7 +60,7 @@ var _ = Describe("Node Operations", func() {
 					"external_ids:ovn-remote-probe-interval=%d "+
 					"external_ids:ovn-openflow-probe-interval=%d "+
 					"external_ids:hostname=\"%s\"",
-					nodeName, interval, ofintval, nodeName),
+					nodeIP, interval, ofintval, nodeName),
 			})
 
 			err := util.SetExec(fexec)
@@ -54,7 +69,7 @@ var _ = Describe("Node Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = setupOVNNode(nodeName)
+			err = setupOVNNode(&node)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
@@ -67,12 +82,27 @@ var _ = Describe("Node Operations", func() {
 	It("sets non-default OVN encap port", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
-				nodeName    string = "1.2.5.6"
+				nodeIP      string = "1.2.5.6"
+				nodeName    string = "cannot.be.resolv.ed"
 				encapPort   uint   = 666
 				interval    int    = 100000
 				ofintval    int    = 180
 				chassisUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
 			)
+			node := kapi.Node{
+				Status: kapi.NodeStatus{
+					Addresses: []kapi.NodeAddress{
+						{
+							Type:    kapi.NodeHostName,
+							Address: nodeName,
+						},
+						{
+							Type:    kapi.NodeExternalIP,
+							Address: nodeIP,
+						},
+					},
+				},
+			}
 
 			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -82,7 +112,7 @@ var _ = Describe("Node Operations", func() {
 					"external_ids:ovn-remote-probe-interval=%d "+
 					"external_ids:ovn-openflow-probe-interval=%d "+
 					"external_ids:hostname=\"%s\"",
-					nodeName, interval, ofintval, nodeName),
+					nodeIP, interval, ofintval, nodeName),
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 " +
@@ -101,7 +131,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			config.Default.EncapPort = encapPort
 
-			err = setupOVNNode(nodeName)
+			err = setupOVNNode(&node)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)


### PR DESCRIPTION
Previously OVN Kubernetes assumed the node's name in kubernetes was the node's
FQDN, which isn't necessarily true, with this change we read it from the
kubernetes API, which is more reliable.