### PR TITLE
Fix kubetest to enable conformance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ jobs:
         - pushd $GOPATH/src/k8s.io/kubernetes/
         - export KUBERNETES_CONFORMANCE_TEST=y
         - export KUBECONFIG=${HOME}/admin.conf
-        - kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus="\[sig-network\].*Conformance|\[sig-network\].*NetworkPolicy --disable-log-dump=false --ginkgo.skip=ingress\saccess|multiple\segress\spolicies|allow\segress\saccess|\[Serial\]'
+        - kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\].*Conformance --disable-log-dump=false --ginkgo.skip=\[Serial\]'
+        - kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\].*NetworkPolicy --disable-log-dump=false --ginkgo.skip=ingress\saccess|multiple\segress\spolicies|allow\segress\saccess|\[Serial\]'
       after_failure:
         - kind export logs /tmp/kind/logs
         - tar -czvf e2e-kind-ovn-${TRAVIS_COMMIT}-${TRAVIS_JOB_NUMBER}.tar.gz -C /tmp/kind/logs/ ./


### PR DESCRIPTION
Regexp for conformance test was not matching. Move conformance test to
its own kubetest execution, as it seems as running conformance in
parallel with network policy causes some tests to be flaky.

Signed-off-by: Tim Rozet <trozet@redhat.com>