### PR TITLE
fix parsing error in onvkube-node.yaml post changes for kind

### DIFF
--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -293,5 +293,6 @@ spec:
         hostPath:
           path: /var/run/netns
       {% endif %}
+
       tolerations:
       - operator: "Exists"


### PR DESCRIPTION
i am seeing the following error while applying ovnkube-node.yaml,

 error: error parsing ovnkube-node.yaml: error converting YAML to JSON:
 yaml: line 231: mapping values are not allowed in this context

the issue is that `tolerations` got indented incorrectly

      - name: host-config-openvswitch
        hostPath:
          path: /etc/origin/openvswitch
          tolerations:
      - operator: "Exists"

Fixes: 3b6d22cad910 (Make KIND specific yaml rendered)

@trozet FYI