### PR TITLE
Fixes empty services, load balancer creation in OVN

### DIFF
--- a/.github/workflow-templates/test.yml
+++ b/.github/workflow-templates/test.yml
@@ -122,7 +122,7 @@ jobs:
         export NODE_NAMES=${MASTER_NAME}
         
         # all tests that don't have P as their sixth letter after the N
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$) --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity|rejected\swhen\sno\sendpoints)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$) --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
 
     - &step_export_logs
       name: Export logs
@@ -164,7 +164,7 @@ jobs:
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
         # all tests that have P as the sixth letter after the N
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$ --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity|rejected\swhen\sno\sendpoints)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$ --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
 
     - *step_export_logs
     - *step_upload_logs
@@ -192,7 +192,7 @@ jobs:
         export KUBECONFIG=${HOME}/admin.conf
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Ss].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity|rejected\swhen\sno\sendpoints)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Ss].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
 
     - *step_export_logs
     - *step_upload_logs
@@ -220,7 +220,7 @@ jobs:
         export KUBECONFIG=${HOME}/admin.conf
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[^NnSs].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity|rejected\swhen\sno\sendpoints)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[^NnSs].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
 
     - *step_export_logs
     - *step_upload_logs

--- a/.github/workflows/test_generated.yml
+++ b/.github/workflows/test_generated.yml
@@ -147,7 +147,7 @@ jobs:
         export NODE_NAMES=${MASTER_NAME}
 
         # all tests that don't have P as their sixth letter after the N
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$) --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity|rejected\swhen\sno\sendpoints)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$) --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
     - name: Export logs
       if: always()
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}
@@ -225,7 +225,7 @@ jobs:
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
         # all tests that have P as the sixth letter after the N
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$ --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity|rejected\swhen\sno\sendpoints)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$ --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
     - name: Export logs
       if: always()
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}
@@ -302,7 +302,7 @@ jobs:
         export KUBECONFIG=${HOME}/admin.conf
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Ss].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity|rejected\swhen\sno\sendpoints)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[Ss].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
     - name: Export logs
       if: always()
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}
@@ -379,7 +379,7 @@ jobs:
         export KUBECONFIG=${HOME}/admin.conf
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[^NnSs].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity|rejected\swhen\sno\sendpoints)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\]\s[^NnSs].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|hairpin|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]'
     - name: Export logs
       if: always()
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -20,6 +20,7 @@ RUN INSTALL_PKGS=" \
 	PyYAML bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
 	libpcap hostname kubernetes-client \
         ovn ovn-central ovn-host \
+        openvswitch \
 	iptables iproute strace socat \
         " && \
 	dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/json-iterator/go v1.1.8 // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.8.1
 	github.com/prometheus/client_golang v1.2.1

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -3,8 +3,8 @@ package ovn
 import (
 	"fmt"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog"
 )
@@ -65,7 +65,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 			if svcPort.Protocol == kapi.ProtocolTCP && svcPort.Name == svcPortName {
 				if util.ServiceTypeHasNodePort(svc) {
 					klog.V(5).Infof("Creating Gateways IP for NodePort: %d, %v", svcPort.NodePort, ips)
-					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
+					err = ovn.createGatewaysVIP(svcPort.Protocol, svcPort.NodePort, targetPort, ips)
 					if err != nil {
 						klog.Errorf("Error in creating Node Port for svc %s, node port: %d - %v\n", svc.Name, svcPort.NodePort, err)
 						continue
@@ -79,15 +79,14 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 							svcPort.Protocol, err)
 						continue
 					}
-					err = ovn.createLoadBalancerVIP(loadBalancer,
-						svc.Spec.ClusterIP, svcPort.Port, ips, targetPort)
+					err = ovn.createLoadBalancerVIP(loadBalancer, svc.Spec.ClusterIP, svcPort.Port, ips, targetPort)
 					if err != nil {
 						klog.Errorf("Error in creating Cluster IP for svc %s, target port: %d - %v\n", svc.Name, targetPort, err)
 						continue
 					}
 					vip := util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port)
 					ovn.AddServiceVIPToName(vip, svcPort.Protocol, svc.Namespace, svc.Name)
-					ovn.handleExternalIPs(svc, svcPort, ips, targetPort)
+					ovn.handleExternalIPs(svc, svcPort, ips, targetPort, false)
 				}
 			}
 		}
@@ -98,7 +97,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 		for _, svcPort := range svc.Spec.Ports {
 			if svcPort.Protocol == kapi.ProtocolUDP && svcPort.Name == svcPortName {
 				if util.ServiceTypeHasNodePort(svc) {
-					err = ovn.createGatewaysVIP(string(svcPort.Protocol), svcPort.NodePort, targetPort, ips)
+					err = ovn.createGatewaysVIP(svcPort.Protocol, svcPort.NodePort, targetPort, ips)
 					if err != nil {
 						klog.Errorf("Error in creating Node Port for svc %s, node port: %d - %v\n", svc.Name, svcPort.NodePort, err)
 						continue
@@ -112,15 +111,14 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 							svcPort.Protocol, err)
 						continue
 					}
-					err = ovn.createLoadBalancerVIP(loadBalancer,
-						svc.Spec.ClusterIP, svcPort.Port, ips, targetPort)
+					err = ovn.createLoadBalancerVIP(loadBalancer, svc.Spec.ClusterIP, svcPort.Port, ips, targetPort)
 					if err != nil {
 						klog.Errorf("Error in creating Cluster IP for svc %s, target port: %d - %v\n", svc.Name, targetPort, err)
 						continue
 					}
 					vip := util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port)
 					ovn.AddServiceVIPToName(vip, svcPort.Protocol, svc.Namespace, svc.Name)
-					ovn.handleExternalIPs(svc, svcPort, ips, targetPort)
+					ovn.handleExternalIPs(svc, svcPort, ips, targetPort, false)
 				}
 			}
 		}
@@ -166,8 +164,7 @@ func (ovn *Controller) handleNodePortLB(node *kapi.Node) error {
 				targetPort := lbEps.Port
 				for _, svcPort := range svc.Spec.Ports {
 					if svcPort.Protocol == kapi.ProtocolTCP && svcPort.Name == svcPortName {
-						err = ovn.createLoadBalancerVIP(k8sNSLbTCP,
-							physicalIP, svcPort.NodePort, ips, targetPort)
+						err = ovn.createLoadBalancerVIP(k8sNSLbTCP, physicalIP, svcPort.NodePort, ips, targetPort)
 						if err != nil {
 							klog.Errorf("failed to create VIP in load balancer %s - %v", k8sNSLbTCP, err)
 							continue
@@ -180,8 +177,7 @@ func (ovn *Controller) handleNodePortLB(node *kapi.Node) error {
 				targetPort := lbEps.Port
 				for _, svcPort := range svc.Spec.Ports {
 					if svcPort.Protocol == kapi.ProtocolUDP && svcPort.Name == svcPortName {
-						err = ovn.createLoadBalancerVIP(k8sNSLbUDP,
-							physicalIP, svcPort.NodePort, ips, targetPort)
+						err = ovn.createLoadBalancerVIP(k8sNSLbUDP, physicalIP, svcPort.NodePort, ips, targetPort)
 						if err != nil {
 							klog.Errorf("failed to create VIP in load balancer %s - %v", k8sNSLbUDP, err)
 							continue
@@ -194,7 +190,7 @@ func (ovn *Controller) handleNodePortLB(node *kapi.Node) error {
 	return nil
 }
 
-func (ovn *Controller) handleExternalIPsLB() {
+func (ovn *Controller) handleExternalIPsLB(delete bool) {
 	namespaces, err := ovn.watchFactory.GetNamespaces()
 	if err != nil {
 		klog.Errorf("failed to get k8s namespaces: %v", err)
@@ -222,7 +218,7 @@ func (ovn *Controller) handleExternalIPsLB() {
 				targetPort := lbEps.Port
 				for _, svcPort := range svc.Spec.Ports {
 					if svcPort.Protocol == kapi.ProtocolTCP && svcPort.Name == svcPortName {
-						ovn.handleExternalIPs(svc, svcPort, ips, targetPort)
+						ovn.handleExternalIPs(svc, svcPort, ips, targetPort, delete)
 					}
 				}
 			}
@@ -231,7 +227,7 @@ func (ovn *Controller) handleExternalIPsLB() {
 				targetPort := lbEps.Port
 				for _, svcPort := range svc.Spec.Ports {
 					if svcPort.Protocol == kapi.ProtocolUDP && svcPort.Name == svcPortName {
-						ovn.handleExternalIPs(svc, svcPort, ips, targetPort)
+						ovn.handleExternalIPs(svc, svcPort, ips, targetPort, delete)
 					}
 				}
 			}
@@ -239,7 +235,8 @@ func (ovn *Controller) handleExternalIPsLB() {
 	}
 }
 
-func (ovn *Controller) handleExternalIPs(svc *kapi.Service, svcPort kapi.ServicePort, ips []string, targetPort int32) {
+func (ovn *Controller) handleExternalIPs(svc *kapi.Service, svcPort kapi.ServicePort, ips []string, targetPort int32,
+	removeLoadBalancerVIP bool) {
 	klog.V(5).Infof("handling external IPs for svc %v", svc.Name)
 	if len(svc.Spec.ExternalIPs) == 0 {
 		return
@@ -250,18 +247,17 @@ func (ovn *Controller) handleExternalIPs(svc *kapi.Service, svcPort kapi.Service
 			klog.Warningf("No default gateway found for protocol %s\n\tNote: 'nodeport' flag needs to be enabled for default gateway", svcPort.Protocol)
 			continue
 		}
-		err := ovn.createLoadBalancerVIP(lb, extIP, svcPort.Port, ips, targetPort)
-		if err != nil {
-			klog.Errorf("Error in creating external IP for service: %s, externalIP: %s", svc.Name, extIP)
+		if removeLoadBalancerVIP {
+			vip := util.JoinHostPortInt32(extIP, svcPort.Port)
+			klog.V(5).Infof("Removing external VIP: %s from load balancer: %s", vip, lb)
+			ovn.deleteLoadBalancerVIP(lb, vip)
+		} else {
+			err := ovn.createLoadBalancerVIP(lb, extIP, svcPort.Port, ips, targetPort)
+			if err != nil {
+				klog.Errorf("Error in creating external IP for service: %s, externalIP: %s", svc.Name, extIP)
+			}
 		}
 	}
-}
-
-// keepEmptyLB returns true if empty load-balancer events is enabled and if the
-// service was idled.
-func keepEmptyLB(service *kapi.Service) bool {
-	_, ok := service.Annotations[OvnServiceIdledAt]
-	return config.Kubernetes.OVNEmptyLbEvents && ok
 }
 
 func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
@@ -270,8 +266,7 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		// This is not necessarily an error. For e.g when a service is deleted,
 		// you will get endpoint delete event and the call to fetch service
 		// will fail.
-		klog.V(5).Infof("no service found for endpoint %s in namespace %s",
-			ep.Name, ep.Namespace)
+		klog.V(5).Infof("no service found for endpoint %s in namespace %s", ep.Name, ep.Namespace)
 		return nil
 	}
 	if !util.IsClusterIPSet(svc) {
@@ -281,26 +276,27 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		var lb string
 		lb, err = ovn.getLoadBalancer(svcPort.Protocol)
 		if err != nil {
-			klog.Errorf("Failed to get load-balancer for %s (%v)",
-				lb, err)
+			klog.Errorf("Failed to get load-balancer for %s (%v)", lb, err)
 			continue
 		}
 
-		quotedHostPort := "\"" + util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port) + "\""
-		if keepEmptyLB(svc) {
-			key := "vips:" + quotedHostPort + "=\"\""
-			_, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, key)
+		// apply reject ACL if necessary before deleting endpoints (avoids unwanted traffic events hitting OVN/OVS)
+		if ovn.svcQualifiesForReject(svc) {
+			aclUUID, err := ovn.createLoadBalancerRejectACL(lb, svc.Spec.ClusterIP, svcPort.Port, svcPort.Protocol)
 			if err != nil {
-				klog.Errorf("Error in deleting endpoints for lb %s, "+
-					"stderr: %q (%v)", lb, stderr, err)
+				klog.Errorf("Failed to create reject ACL for load balancer: %s, error: %v", lb, err)
 			}
-		} else {
-			_, stderr, err := util.RunOVNNbctl("remove", "load_balancer", lb,
-				"vips", quotedHostPort)
-			if err != nil {
-				klog.Errorf("Error in deleting lb %s, stderr: %q (%v)", lb, stderr, err)
-			}
+			klog.V(5).Infof("Reject ACL created for load balancer: %s, %s", lb, aclUUID)
 		}
+
+		// clear endpoints from the LB
+		err := ovn.configureLoadBalancer(lb, svc.Spec.ClusterIP, svcPort.Port, "")
+
+		if err != nil {
+			klog.Errorf("Error in deleting endpoints for lb %s: %v", lb, err)
+		}
+		vip := util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port)
+		ovn.RemoveServiceEndpoints(lb, vip)
 
 	}
 	return nil

--- a/go-controller/pkg/ovn/endpoints_test.go
+++ b/go-controller/pkg/ovn/endpoints_test.go
@@ -55,7 +55,8 @@ func (e endpoints) delCmds(fexec *ovntest.FakeExec, service v1.Service, endpoint
 	for _, sPort := range service.Spec.Ports {
 		if sPort.Protocol == v1.ProtocolTCP {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				fmt.Sprintf("ovn-nbctl --timeout=15 remove load_balancer %s vips \"%s:%v\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, sPort.Port),
+				fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find Logical_Switch load_balancer{>=}%s", k8sTCPLoadBalancerIP),
+				fmt.Sprintf("ovn-nbctl --timeout=15 set load_balancer %s vips:\"172.124.0.2:8032\"=\"\"", k8sTCPLoadBalancerIP),
 			})
 		} else if sPort.Protocol == v1.ProtocolUDP {
 			fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -3,7 +3,9 @@ package ovn
 import (
 	"strings"
 
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog"
 )
 
@@ -16,8 +18,7 @@ func (ovn *Controller) getOvnGateways() ([]string, string, error) {
 	return strings.Fields(out), stderr, err
 }
 
-func (ovn *Controller) getGatewayPhysicalIP(
-	physicalGateway string) (string, error) {
+func (ovn *Controller) getGatewayPhysicalIP(physicalGateway string) (string, error) {
 	physicalIP, _, err := util.RunOVNNbctl("get", "logical_router",
 		physicalGateway, "external_ids:physical_ip")
 	if err != nil {
@@ -27,9 +28,8 @@ func (ovn *Controller) getGatewayPhysicalIP(
 	return physicalIP, nil
 }
 
-func (ovn *Controller) getGatewayLoadBalancer(physicalGateway,
-	protocol string) (string, error) {
-	externalIDKey := protocol + "_lb_gateway_router"
+func (ovn *Controller) getGatewayLoadBalancer(physicalGateway string, protocol kapi.Protocol) (string, error) {
+	externalIDKey := string(protocol) + "_lb_gateway_router"
 	loadBalancer, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "load_balancer",
 		"external_ids:"+externalIDKey+"="+
@@ -40,7 +40,7 @@ func (ovn *Controller) getGatewayLoadBalancer(physicalGateway,
 	return loadBalancer, nil
 }
 
-func (ovn *Controller) createGatewaysVIP(protocol string, port, targetPort int32, ips []string) error {
+func (ovn *Controller) createGatewaysVIP(protocol kapi.Protocol, port, targetPort int32, ips []string) error {
 
 	klog.V(5).Infof("Creating Gateway VIP - %s, %d, %d, %v", protocol, port, targetPort, ips)
 
@@ -70,12 +70,42 @@ func (ovn *Controller) createGatewaysVIP(protocol string, port, targetPort int32
 		}
 		// With the physical_ip:port as the VIP, add an entry in
 		// 'load_balancer'.
-		err = ovn.createLoadBalancerVIP(loadBalancer,
-			physicalIP, port, ips, targetPort)
+		err = ovn.createLoadBalancerVIP(loadBalancer, physicalIP, port, ips, targetPort)
 		if err != nil {
 			klog.Errorf("Failed to create VIP in load balancer %s - %v", loadBalancer, err)
 			continue
 		}
 	}
 	return nil
+}
+
+func (ovn *Controller) deleteGatewaysVIP(protocol kapi.Protocol, port int32) {
+	klog.V(5).Infof("Searching to remove Gateway VIP - %s, %d", protocol, port)
+	physicalGateways, _, err := ovn.getOvnGateways()
+	if err != nil {
+		klog.Errorf("Error while searching for gateways: %v", err)
+		return
+	}
+
+	for _, physicalGateway := range physicalGateways {
+		loadBalancer, err := ovn.getGatewayLoadBalancer(physicalGateway, protocol)
+		if err != nil {
+			klog.Errorf("physical gateway %s does not have load_balancer "+
+				"(%v)", physicalGateway, err)
+			continue
+		}
+		if loadBalancer == "" {
+			continue
+		}
+		physicalIP, err := ovn.getGatewayPhysicalIP(physicalGateway)
+		if err != nil {
+			klog.Errorf("physical gateway %s does not have physical ip (%v)",
+				physicalGateway, err)
+			continue
+		}
+		// With the physical_ip:port as the VIP, delete an entry in 'load_balancer'.
+		vip := util.JoinHostPortInt32(physicalIP, port)
+		klog.V(5).Infof("Removing gateway VIP: %s from loadbalancer: %s", vip, loadBalancer)
+		ovn.deleteLoadBalancerVIP(loadBalancer, vip)
+	}
 }

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -3,9 +3,11 @@ package ovn
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog"
 )
@@ -82,45 +84,140 @@ func (ovn *Controller) getLoadBalancerVIPS(
 	return raw, nil
 }
 
+// deleteLoadBalancerVIP removes the VIP as well as any reject ACLs associated to the LB
 func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) {
 	vipQuotes := fmt.Sprintf("\"%s\"", vip)
-	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
-		"load_balancer", loadBalancer, "vips", vipQuotes)
+	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove", "load_balancer", loadBalancer, "vips", vipQuotes)
 	if err != nil {
 		klog.Errorf("Error in deleting load balancer vip %s for %s"+
 			"stdout: %q, stderr: %q, error: %v",
 			vip, loadBalancer, stdout, stderr, err)
+		// if we hit an error and fail to remove load balancer, we skip removing the rejectACL
+		return
 	}
+	ovn.RemoveServiceEndpoints(loadBalancer, vip)
+	ovn.deleteLoadBalancerRejectACL(loadBalancer, vip)
+	ovn.RemoveServiceLB(loadBalancer, vip)
 }
 
-func (ovn *Controller) createLoadBalancerVIP(lb string, serviceIP string, port int32, ips []string, targetPort int32) error {
-	klog.V(5).Infof("Creating lb with %s, %s, %d, [%v], %d", lb, serviceIP, port, ips, targetPort)
-
-	// With service_ip:port as a VIP, create an entry in 'load_balancer'
-	// key is of the form "IP:port" (with quotes around)
-	key := fmt.Sprintf(`"%s"`, util.JoinHostPortInt32(serviceIP, port))
-
-	if len(ips) == 0 {
-		_, _, err := util.RunOVNNbctl("remove", "load_balancer", lb,
-			"vips", key)
-		return err
-	}
-
-	var commaSeparatedEndpoints string
-	for i, ep := range ips {
-		comma := ","
-		if i == 0 {
-			comma = ""
-		}
-		commaSeparatedEndpoints += fmt.Sprintf("%s%s", comma, util.JoinHostPortInt32(ep, targetPort))
-	}
-	target := fmt.Sprintf(`vips:"%s"="%s"`, util.JoinHostPortInt32(serviceIP, port), commaSeparatedEndpoints)
+func (ovn *Controller) configureLoadBalancer(lb, serviceIP string, port int32, endpoints string) error {
+	target := fmt.Sprintf(`vips:"%s"="%s"`, util.JoinHostPortInt32(serviceIP, port), endpoints)
 
 	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb,
 		target)
 	if err != nil {
-		klog.Errorf("Error in creating load balancer: %s "+
+		klog.Errorf("Error in configuring load balancer: %s "+
 			"stdout: %q, stderr: %q, error: %v", lb, out, stderr, err)
+		// endpoints are comma separated
+		ovn.SetServiceEndpointsToLB(lb, util.JoinHostPortInt32(serviceIP, port), strings.Split(endpoints, ","))
 	}
 	return err
+}
+
+// createLoadBalancerVIP either creates or updates a load balancer VIP
+// Calls to this method assume that if ips are passed that those endpoints actually exist
+// and thus the reject ACL is removed
+func (ovn *Controller) createLoadBalancerVIP(lb, serviceIP string, port int32, ips []string, targetPort int32) error {
+	klog.V(5).Infof("Creating lb with %s, %s, %d, [%v], %d", lb, serviceIP, port, ips, targetPort)
+
+	var commaSeparatedEndpoints string
+
+	if len(ips) > 0 {
+		for i, ep := range ips {
+			comma := ","
+			if i == 0 {
+				comma = ""
+			}
+			commaSeparatedEndpoints += fmt.Sprintf("%s%s", comma, util.JoinHostPortInt32(ep, targetPort))
+		}
+
+		// ensure the ACL is removed if it exists
+		ovn.deleteLoadBalancerRejectACL(lb, util.JoinHostPortInt32(serviceIP, port))
+	}
+
+	return ovn.configureLoadBalancer(lb, serviceIP, port, commaSeparatedEndpoints)
+}
+
+func (ovn *Controller) getLogicalSwitchesForLoadBalancer(lb string) ([]string, error) {
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "find",
+		"Logical_Switch", fmt.Sprintf("load_balancer{>=}%s", lb))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(out), nil
+}
+
+func (ovn *Controller) createLoadBalancerRejectACL(lb string, serviceIP string, port int32, proto kapi.Protocol) (string, error) {
+
+	switches, err := ovn.getLogicalSwitchesForLoadBalancer(lb)
+	if err != nil {
+		klog.Errorf("Error finding logical switch that contains load balancer %s", lb)
+		return "", err
+	}
+
+	if len(switches) == 0 {
+		klog.Infof("Ignoring creating reject ACL for load balancer %s. It has no logical switches", lb)
+		return "", nil
+	}
+
+	ip := net.ParseIP(serviceIP)
+	if ip == nil {
+		klog.Errorf("Cannot parse IP address %s", serviceIP)
+		return "", fmt.Errorf("cannot create reject ACL, invalid cluster IP: %s", serviceIP)
+	}
+	var aclMatch string
+	var l3Prefix string
+	if ip.To4() != nil {
+		l3Prefix = "ip4"
+	} else {
+		l3Prefix = "ip6"
+	}
+	vip := util.JoinHostPortInt32(serviceIP, port)
+	if eps, ok := ovn.GetServiceLBEndpoints(lb, vip); ok && len(eps) > 0 {
+		klog.Warningf("ACL being applied to Load Balancer with Endpoints: %s, %s", lb, vip)
+	}
+
+	aclMatch = fmt.Sprintf("match=\"%s.dst==%s && %s && %s.dst==%d\"", l3Prefix, serviceIP,
+		strings.ToLower(string(proto)), strings.ToLower(string(proto)), port)
+
+	cmd := []string{"--id=@acl", "create", "acl", "direction=from-lport", "priority=1000", aclMatch, "action=reject"}
+	for _, ls := range switches {
+		cmd = append(cmd, "--", "add", "logical_switch", ls, "acls", "@acl")
+	}
+
+	aclUUID, stderr, err := util.RunOVNNbctl(cmd...)
+	if err != nil {
+		klog.Errorf("Error creating ACL reject rule: %s for load balancer %s: %s", cmd, lb, stderr)
+		return "", err
+	} else {
+		// Associate ACL UUID with load balancer and ip+port so we can remove this ACL if
+		// backends are re-added.
+		ovn.SetServiceACLToLB(lb, util.JoinHostPortInt32(serviceIP, port), aclUUID)
+	}
+	return aclUUID, nil
+}
+
+func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
+	acl, ok := ovn.GetServiceLBACL(lb, vip)
+	if !ok || acl == "" {
+		klog.V(5).Infof("No reject ACL found to remove for load balancer: %s", lb)
+		return
+	}
+
+	switches, err := ovn.getLogicalSwitchesForLoadBalancer(lb)
+	if err != nil {
+		klog.Errorf("Could not retrieve logical switches associated with load balancer %s", lb)
+	}
+	for _, ls := range switches {
+		_, _, err := util.RunOVNNbctl("--if-exists", "remove", "logical_switch", ls, "acl", acl)
+		if err != nil {
+			klog.Errorf("Error while removing ACL: %s, from switch %s, error: %v", acl, ls, err)
+		} else {
+			klog.V(5).Infof("ACL: %s, removed from switch: %s", acl, ls)
+		}
+	}
+
+	ovn.RemoveServiceACL(lb, vip)
+
 }

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -87,6 +87,9 @@ func (s service) baseCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists remove load_balancer udp_load_balancer_id_1 vips \"172.30.0.10:53\"",
 	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find Logical_Switch load_balancer{>=}k8s_tcp_load_balancer"),
+	})
 }
 
 func (s service) addCmds(fexec *ovntest.FakeExec, service v1.Service) {
@@ -96,7 +99,7 @@ func (s service) addCmds(fexec *ovntest.FakeExec, service v1.Service) {
 func (s service) delCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	for _, port := range service.Spec.Ports {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 remove load_balancer %s vips \"%s:%v\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
+			fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"%s:%v\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
 		})
 	}
 }


### PR DESCRIPTION
Changes-Include:
 - Services should always be created in OVN, regardless of endpoints
   being present or not.
 - In order immediately close a connection rather than let it timeout to
   a service with no endpoints, a reject ACL is applied to each service
   containing no endpoints.
 - This ACL is only applied if the service is not idled (we want traffic
   events if the service is idled) or ovn-empty-lb-events is not used.
 - Code refactor to stop using create methods with dummy variables for
   delete actions

 Todo:
   - Need to implement service update. Will do that in follow up patch.
     This only affects a service that is updated and has no endpoints.


Closes: #928

Co-authored-by: Mark Michelson <mmichels@redhat.com>

Signed-off-by: Tim Rozet <trozet@redhat.com>