### PR TITLE
pkg/util: nicsToBridge failing to config open file is a warning

### DIFF
--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -132,7 +132,7 @@ func setupDefaultFile() {
 
 	fileContents, err := ioutil.ReadFile(defaultFile)
 	if err != nil {
-		logrus.Errorf("failed to parse file %s (%v)",
+		logrus.Warningf("failed to parse file %s (%v)",
 			defaultFile, err)
 		return
 	}


### PR DESCRIPTION
This only necessary when using shared gateways which is never a valid
scenario for OpenShift. Hence it should never be an error but a warning.

This is important because it's currently breaking some tests suchs as:
https://github.com/ovn-org/ovn-kubernetes/pull/1017#issuecomment-579300124