### PR TITLE
Update Fedora docker image to get ovn/ovs 2.12

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -9,7 +9,7 @@
 # are built locally and included in the image (instead of the rpm)
 #
 
-FROM fedora:29
+FROM fedora:31
 
 USER root
 

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -51,5 +51,5 @@ daemonsetyaml:
 BRANCH = $(shell git rev-parse  --symbolic-full-name HEAD)
 COMMIT = $(shell git rev-parse  HEAD)
 bld: ../../go-controller/_output/go/bin/ovnkube
-	cp ../../go-controller/_output/go/bin/* .
+	cp -r ../../go-controller/_output/go/bin/* .
 	echo "ref: ${BRANCH}  commit: ${COMMIT}" > git_info


### PR DESCRIPTION
Signed-off-by: Tim Rozet <trozet@redhat.com>