### PR TITLE
fix for iptables issue in CentOS 8

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -68,6 +68,14 @@ COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 # copy git commit number into image
 COPY git_info /root
 
+# iptables wrappers
+COPY ./iptables-scripts/iptables /usr/sbin/
+COPY ./iptables-scripts/iptables-save /usr/sbin/
+COPY ./iptables-scripts/iptables-restore /usr/sbin/
+COPY ./iptables-scripts/ip6tables /usr/sbin/
+COPY ./iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
+COPY ./iptables-scripts/iptables /usr/sbin/
 
 LABEL io.k8s.display-name="ovn kubernetes" \
       io.k8s.description="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -12,7 +12,7 @@ FROM ubuntu:18.04
 
 USER root
 
-RUN apt-get update && apt-get install -y iptables iproute2 curl software-properties-common setpriv
+RUN apt-get update && apt-get install -y iproute2 curl software-properties-common setpriv
 
 # We do not have much control over the exact version of OVS/OVN that can be
 # obtained from upstream Ubuntu. guru@ovn.org maintains more latest versions of
@@ -44,6 +44,15 @@ COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 
 # copy git commit number into image
 COPY git_info /root
+
+# iptables wrappers
+COPY ./iptables-scripts/iptables /usr/sbin/
+COPY ./iptables-scripts/iptables-save /usr/sbin/
+COPY ./iptables-scripts/iptables-restore /usr/sbin/
+COPY ./iptables-scripts/ip6tables /usr/sbin/
+COPY ./iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
+COPY ./iptables-scripts/iptables /usr/sbin/
 
 LABEL io.k8s.display-name="ovn kubernetes" \
       io.k8s.description="ovnkube ubuntu image" 

--- a/dist/images/iptables-scripts/ip6tables
+++ b/dist/images/iptables-scripts/ip6tables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables "$@"

--- a/dist/images/iptables-scripts/ip6tables-restore
+++ b/dist/images/iptables-scripts/ip6tables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-restore "$@"

--- a/dist/images/iptables-scripts/ip6tables-save
+++ b/dist/images/iptables-scripts/ip6tables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-save "$@"

--- a/dist/images/iptables-scripts/iptables
+++ b/dist/images/iptables-scripts/iptables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables "$@"

--- a/dist/images/iptables-scripts/iptables-restore
+++ b/dist/images/iptables-scripts/iptables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-restore "$@"

--- a/dist/images/iptables-scripts/iptables-save
+++ b/dist/images/iptables-scripts/iptables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-save "$@"

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -174,6 +174,10 @@ spec:
           {% endif %}
 
         volumeMounts:
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
         - mountPath: /var/run/dbus/
           name: host-var-run-dbus
           readOnly: true
@@ -285,6 +289,9 @@ spec:
       - name: host-etc-cni-netd
         hostPath:
           path: /etc/cni/net.d
+      - name: host-slash
+        hostPath:
+          path: /
       - name: host-config-openvswitch
         hostPath:
           path: /etc/origin/openvswitch


### PR DESCRIPTION
CentOS 8 doesn't have iptables. It instead has nftables. Our code uses
iptables, so we need a way to translate our iptables call into nftables.

On the CentOS host, the ip{6}tables CLI utilties  are symbolic links to
to xtables-nft-multi.

$ file /usr/sbin/iptables
  /usr/sbin/iptables: symbolic link to xtables-nft-multi

That particular binary does the right thing. In our case, we don't want
to install iptables in our ovnkube containers. Instead we need to run
the iptable (xtables-nft-multi) utility in the host. This is done
using the iptable-wrapper scripts and some volume mount tricks.

@dcbw @danwinship something that you guys use and that we talked about during the kubecon. We ave started using this internally as our hosts are CentOS 8. PTAL