### PR TITLE
do not delete integration bridge as part of ovnkube-node cleanup

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -163,12 +163,6 @@ func CleanupClusterNode(name string) error {
 		logrus.Errorf("Failed to cleanup Gateway, error: %v", err)
 	}
 
-	// Make sure br-int is deleted, the management internal port is also deleted at the same time.
-	stdout, stderr, err := util.RunOVSVsctl("--", "--if-exists", "del-br", "br-int")
-	if err != nil {
-		logrus.Errorf("Failed to delete bridge br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-	}
-
 	// Delete iptable rules for management port on Linux.
 	if runtime.GOOS != "windows" {
 		DelMgtPortIptRules(name)


### PR DESCRIPTION
when we delete ovnkube-node, to say fix some issue or it met a panic,
we delete the integration bridge. this inturn deletes all the POD's
ports on the integration bridge. When the ovnkube-node comes back up,
the integration bridge is created but not the ports on it. as a result
all the PODs are disconnected from network.

@dcbw @danwinship PTAL