### PR TITLE
Fixes specifying geneve port

### DIFF
--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -61,7 +61,15 @@ func setupOVNNode(nodeName string) error {
 		if err != nil {
 			return err
 		}
-		_, stderr, errSet := util.RunOVNSbctl("set", "encap", systemID,
+		uuid, _, err := util.RunOVNSbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "Encap",
+			fmt.Sprintf("chassis_name=%s", systemID))
+		if err != nil {
+			return err
+		}
+		if len(uuid) == 0 {
+			return fmt.Errorf("unable to find encap uuid to set geneve port for chassis %s", systemID)
+		}
+		_, stderr, errSet := util.RunOVNSbctl("set", "encap", uuid,
 			fmt.Sprintf("options:dst_port=%d", config.Default.EncapPort),
 		)
 		if errSet != nil {

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Node Operations", func() {
 				interval    int    = 100000
 				ofintval    int    = 180
 				chassisUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
+				encapUUID   string = "e4437094-0094-4223-9f14-995d98d5fff8"
 			)
 
 			fexec := ovntest.NewFakeExec()
@@ -90,8 +91,13 @@ var _ = Describe("Node Operations", func() {
 				Output: chassisUUID,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovn-sbctl --timeout=15 --data=bare --no-heading --columns=_uuid find "+
+					"Encap chassis_name=%s", chassisUUID),
+				Output: encapUUID,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: fmt.Sprintf("ovn-sbctl --timeout=15 set encap "+
-					"%s options:dst_port=%d", chassisUUID, encapPort),
+					"%s options:dst_port=%d", encapUUID, encapPort),
 			})
 
 			err := util.SetExec(fexec)


### PR DESCRIPTION
The configuration was attempting to use the chassis name rather than the
uuid in the Encap table.

Signed-off-by: Tim Rozet <trozet@redhat.com>