### PR TITLE
Iptables followup

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -75,7 +75,6 @@ COPY ./iptables-scripts/iptables-restore /usr/sbin/
 COPY ./iptables-scripts/ip6tables /usr/sbin/
 COPY ./iptables-scripts/ip6tables-save /usr/sbin/
 COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
-COPY ./iptables-scripts/iptables /usr/sbin/
 
 LABEL io.k8s.display-name="ovn kubernetes" \
       io.k8s.description="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -24,7 +24,7 @@ COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 RUN INSTALL_PKGS=" \
 	PyYAML bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
 	libpcap kubectl \
-	iptables iproute strace socat \
+	iproute strace socat \
 	unbound-libs \
         " && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -52,7 +52,6 @@ COPY ./iptables-scripts/iptables-restore /usr/sbin/
 COPY ./iptables-scripts/ip6tables /usr/sbin/
 COPY ./iptables-scripts/ip6tables-save /usr/sbin/
 COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
-COPY ./iptables-scripts/iptables /usr/sbin/
 
 LABEL io.k8s.display-name="ovn kubernetes" \
       io.k8s.description="ovnkube ubuntu image" 

--- a/dist/images/iptables-scripts/ip6tables
+++ b/dist/images/iptables-scripts/ip6tables
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/ip6tables "$@"
+exec chroot /host /sbin/ip6tables "$@"

--- a/dist/images/iptables-scripts/ip6tables-restore
+++ b/dist/images/iptables-scripts/ip6tables-restore
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/ip6tables-restore "$@"
+exec chroot /host /sbin/ip6tables-restore "$@"

--- a/dist/images/iptables-scripts/ip6tables-save
+++ b/dist/images/iptables-scripts/ip6tables-save
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/ip6tables-save "$@"
+exec chroot /host /sbin/ip6tables-save "$@"

--- a/dist/images/iptables-scripts/iptables
+++ b/dist/images/iptables-scripts/iptables
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/iptables "$@"
+exec chroot /host /sbin/iptables "$@"

--- a/dist/images/iptables-scripts/iptables-restore
+++ b/dist/images/iptables-scripts/iptables-restore
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/iptables-restore "$@"
+exec chroot /host /sbin/iptables-restore "$@"

--- a/dist/images/iptables-scripts/iptables-save
+++ b/dist/images/iptables-scripts/iptables-save
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/iptables-save "$@"
+exec chroot /host /sbin/iptables-save "$@"


### PR DESCRIPTION
iptables binary is in /sbin on all distro so use that path

Ideally, iptables should be in /usr/sbin. this is true for CentOS, RHEL,
and Fedora. However, ubuntu has this binary in /sbin.

All the distros have this binary (or symbolic link) in /sbin. So use it.
