### PR TITLE
Allow node --nb-address / --sb-address to be learned 

### DIFF
--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -277,4 +277,88 @@ var _ = Describe("Node Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 	})
+
+	It("test watchConfigEndpoints to learn nb and sb addresses", func() {
+		app.Action = func(ctx *cli.Context) error {
+
+			const (
+				masterAddress1 string = "10.10.2.3"
+				masterAddress2 string = "11.10.2.3"
+				nbPort         int32  = 5678
+				sbPort         int32  = 8765
+			)
+
+			fexec := ovntest.NewFakeExec()
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+					"external_ids:ovn-nb=\"tcp:%s,tcp:%s\"",
+					util.JoinHostPortInt32(masterAddress1, nbPort),
+					util.JoinHostPortInt32(masterAddress2, nbPort)),
+			})
+
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+					"external_ids:ovn-remote=\"tcp:%s,tcp:%s\"",
+					util.JoinHostPortInt32(masterAddress1, sbPort),
+					util.JoinHostPortInt32(masterAddress2, sbPort)),
+			})
+
+			err := util.SetExec(fexec)
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeClient := fake.NewSimpleClientset(&kapi.EndpointsList{
+				Items: []kapi.Endpoints{{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ovn-kubernetes", Name: "ovnkube-db"},
+					Subsets: []kapi.EndpointSubset{
+						{
+							Addresses: []kapi.EndpointAddress{
+								{IP: masterAddress1}, {IP: masterAddress2},
+							},
+							Ports: []kapi.EndpointPort{
+								{
+									Name: "north",
+									Port: nbPort,
+								},
+								{
+									Name: "south",
+									Port: sbPort,
+								},
+							},
+						},
+					},
+				}},
+			})
+			_, err = config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			stopChan := make(chan struct{})
+			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			Expect(err).NotTo(HaveOccurred())
+			defer close(stopChan)
+
+			cluster := NewClusterController(fakeClient, f)
+			Expect(cluster).NotTo(BeNil())
+
+			Expect(config.OvnNorth.Address).To(Equal("watch-endpoint"), "config.OvnNorth.Address does not equal cli arg")
+			Expect(config.OvnSouth.Address).To(Equal("watch-endpoint"), "config.OvnSouth.Address does not equal cli arg")
+			Expect(config.OvnNorth.Scheme).To(Equal(config.OvnDBSchemeTCP))
+			Expect(config.OvnSouth.Scheme).To(Equal(config.OvnDBSchemeTCP))
+
+			err = cluster.watchConfigEndpoints(make(chan bool, 1))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Kubernetes endpoints should eventually propogate to OvnNorth/OvnSouth
+			Eventually(func() string {
+				return config.OvnNorth.Address
+			}).Should(Equal(fmt.Sprintf("tcp:%s,tcp:%s", util.JoinHostPortInt32(masterAddress1, nbPort), util.JoinHostPortInt32(masterAddress2, nbPort))), "Northbound DB Port did not get set by watchConfigEndpoints")
+			Eventually(func() string {
+				return config.OvnSouth.Address
+			}).Should(Equal(fmt.Sprintf("tcp:%s,tcp:%s", util.JoinHostPortInt32(masterAddress1, sbPort), util.JoinHostPortInt32(masterAddress2, sbPort))), "Southbound DBPort did not get set by watchConfigEndpoints")
+
+			return nil
+		}
+		err := app.Run([]string{app.Name, "-nb-address=watch-endpoint", "-sb-address=watch-endpoint", "-manage-db-servers"})
+		Expect(err).NotTo(HaveOccurred())
+
+	})
 })

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1183,6 +1183,20 @@ func buildOvnAuth(exec kexec.Interface, northbound bool, cliAuth, confAuth *OvnA
 		return nil, err
 	}
 
+	// When instructed to watch-endpoint, just set scheme and obtain address(es) from endpoint
+	if address == "watch-endpoint" {
+		if !MasterHA.ManageDBServers {
+			return nil, fmt.Errorf("watch-endpoint requires --manage-db-servers")
+		}
+		// Set scheme and wait for an endpoint update to provide address/port to use
+		if auth.PrivKey != "" || auth.Cert != "" || auth.CACert != "" {
+			auth.Scheme = OvnDBSchemeSSL
+		} else {
+			auth.Scheme = OvnDBSchemeTCP
+		}
+		return auth, nil
+	}
+
 	if address == "" {
 		if auth.PrivKey != "" || auth.Cert != "" || auth.CACert != "" {
 			return nil, fmt.Errorf("certificate or key given; perhaps you mean to use the 'ssl' scheme?")

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -879,6 +879,31 @@ mode=shared
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 		})
+
+		It("configures client northbound and southbound Scheme correctly when watch-endpoint specified", func() {
+
+			fexec := ovntest.NewFakeExec()
+
+			cliConfig := &OvnAuthConfig{
+				Address: "watch-endpoint",
+				PrivKey: keyFile,
+				Cert:    certFile,
+				CACert:  caFile,
+			}
+			MasterHA.ManageDBServers = true
+
+			a, err := buildOvnAuth(fexec, false, cliConfig, &OvnAuthConfig{}, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(a.Scheme).To(Equal(OvnDBSchemeSSL))
+			Expect(a.PrivKey).To(Equal(keyFile))
+			Expect(a.Cert).To(Equal(certFile))
+			Expect(a.CACert).To(Equal(caFile))
+			Expect(a.Address).To(Equal("watch-endpoint"))
+			Expect(a.northbound).To(BeFalse())
+			Expect(a.externalID).To(Equal("ovn-remote"))
+
+			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+		})
 	})
 
 	// This testcase factory function exists only to ensure that 'runType'


### PR DESCRIPTION
Allow node --nb-address / --sb-address addresses to be obtained by watching endpoints

Signed-off-by: Michael Cambria <mcambria@redhat.com>
