### PR TITLE
ci: use consistent kind cluster name and fix artifact retrieval

### DIFF
--- a/.github/workflow-templates/test.yml
+++ b/.github/workflow-templates/test.yml
@@ -4,6 +4,7 @@ name: Go
 'on': [push, pull_request]
 env:
   K8S_VERSION: v1.16.4
+  KIND_CLUSTER_NAME: ovn
 jobs:
   build:
     name: Build
@@ -77,13 +78,15 @@ jobs:
         pushd $GOPATH/src/k8s.io/kubernetes/
         export KUBERNETES_CONFORMANCE_TEST=y
         export KUBECONFIG=${HOME}/admin.conf
-        kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\].*Conformance --disable-log-dump=false --ginkgo.skip=\[Serial\]'
-        kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\].*NetworkPolicy --disable-log-dump=false --ginkgo.skip=ingress\saccess|multiple\segress\spolicies|allow\segress\saccess|\[Serial\]'
+        export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
+        export NODE_NAMES=${MASTER_NAME}
+        kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\].*Conformance --disable-log-dump=false --ginkgo.skip=\[Serial\]'
+        kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\].*NetworkPolicy --disable-log-dump=false --ginkgo.skip=ingress\saccess|multiple\segress\spolicies|allow\segress\saccess|\[Serial\]'
     
     - name: Export logs on failure
       run: |
         mkdir -p /tmp/kind/logs 
-        kind export logs /tmp/kind/logs
+        kind export logs --name ${KIND_CLUSTER_NAME} /tmp/kind/logs
       working-directory: ${{ env.WORKDIR }}
       if: failure()
     - name: Upload logs

--- a/.github/workflows/test_generated.yml
+++ b/.github/workflows/test_generated.yml
@@ -7,6 +7,7 @@ name: Go
 - pull_request
 env:
   K8S_VERSION: v1.16.4
+  KIND_CLUSTER_NAME: ovn
 jobs:
   build:
     name: Build
@@ -85,10 +86,13 @@ jobs:
         pushd $GOPATH/src/k8s.io/kubernetes/
         export KUBERNETES_CONFORMANCE_TEST=y
         export KUBECONFIG=${HOME}/admin.conf
-        kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\].*Conformance --disable-log-dump=false --ginkgo.skip=\[Serial\]'
-        kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--ginkgo.focus=\[sig-network\].*NetworkPolicy --disable-log-dump=false --ginkgo.skip=ingress\saccess|multiple\segress\spolicies|allow\segress\saccess|\[Serial\]'
+        export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
+        export NODE_NAMES=${MASTER_NAME}
+        kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\].*Conformance --disable-log-dump=false --ginkgo.skip=\[Serial\]'
+        kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\].*NetworkPolicy --disable-log-dump=false --ginkgo.skip=ingress\saccess|multiple\segress\spolicies|allow\segress\saccess|\[Serial\]'
     - name: Export logs on failure
-      run: "mkdir -p /tmp/kind/logs \nkind export logs /tmp/kind/logs\n"
+      run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}
+        /tmp/kind/logs\n"
       working-directory: "${{ env.WORKDIR }}"
       if: failure()
     - name: Upload logs

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -14,7 +14,8 @@ fi
 sed -i "s/apiServerAddress.*/apiServerAddress: ${API_IP}/" kind.yaml
 
 # Create KIND cluster
-kind create cluster --name ovn --kubeconfig ${HOME}/admin.conf --image kindest/node:${K8S_VERSION} --config=./kind.yaml
+CLUSTER_NAME=${CLUSTER_NAME:-ovn}
+kind create cluster --name ${CLUSTER_NAME} --kubeconfig ${HOME}/admin.conf --image kindest/node:${K8S_VERSION} --config=./kind.yaml
 export KUBECONFIG=${HOME}/admin.conf
 mkdir -p /tmp/kind
 sudo chmod 777 /tmp/kind
@@ -40,13 +41,14 @@ echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse 
 docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
 ./daemonset.sh --image=docker.io/library/ovn-daemonset-f:dev --net-cidr=10.244.0.0/16 --svc-cidr=10.96.0.0/12 --gateway-mode="local" --k8s-apiserver=https://${API_IP}:11337 --kind
 popd
-kind load docker-image ovn-daemonset-f:dev --name ovn
+kind load docker-image ovn-daemonset-f:dev --name ${CLUSTER_NAME}
 pushd ../dist/yaml
 kubectl create -f ovn-setup.yaml
 kubectl create -f ovnkube-db.yaml
 kubectl create -f ovnkube-master.yaml
 kubectl create -f ovnkube-node.yaml
 popd
-
+kind get clusters
+kind get nodes --name ${CLUSTER_NAME}
 
 


### PR DESCRIPTION
Instead of a mix of 'ovn' and 'kind-ovn' just use 'ovn'. Also fix the node name so that log dumping works and we get artifacts.