### PR TITLE
factory: fix race between queued informer initial add and other events

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -58,21 +58,15 @@ func (h *Handler) kill() error {
 	return nil
 }
 
-type eventKind int
-
-const (
-	addEvent eventKind = iota
-	updateEvent
-	deleteEvent
-)
-
 type event struct {
-	obj    interface{}
-	oldObj interface{}
-	kind   eventKind
+	obj     interface{}
+	oldObj  interface{}
+	process func(*event)
 }
 
 type listerInterface interface{}
+
+type initialAddFn func(*Handler, []interface{})
 
 type informer struct {
 	sync.RWMutex
@@ -81,6 +75,9 @@ type informer struct {
 	handlers map[uint64]*Handler
 	events   []chan *event
 	lister   listerInterface
+	// initialAddFunc will be called to deliver the initial list of objects
+	// when a handler is added
+	initialAddFunc initialAddFn
 }
 
 func (i *informer) forEachQueuedHandler(f func(h *Handler)) {
@@ -97,8 +94,8 @@ func (i *informer) forEachQueuedHandler(f func(h *Handler)) {
 }
 
 func (i *informer) forEachHandler(obj interface{}, f func(h *Handler)) {
-	i.Lock()
-	defer i.Unlock()
+	i.RLock()
+	defer i.RUnlock()
 
 	objType := reflect.TypeOf(obj)
 	if objType != i.oType {
@@ -111,10 +108,7 @@ func (i *informer) forEachHandler(obj interface{}, f func(h *Handler)) {
 	}
 }
 
-func (i *informer) addHandler(id uint64, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler) *Handler {
-	i.Lock()
-	defer i.Unlock()
-
+func (i *informer) addHandler(id uint64, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler, existingItems []interface{}) *Handler {
 	handler := &Handler{
 		cache.FilteringResourceEventHandler{
 			FilterFunc: filterFunc,
@@ -123,6 +117,12 @@ func (i *informer) addHandler(id uint64, filterFunc func(obj interface{}) bool, 
 		id,
 		handlerAlive,
 	}
+
+	// Send existing items to the handler's add function; informers usually
+	// do this but since we share informers, it's long-since happened so
+	// we must emulate that here
+	i.initialAddFunc(handler, existingItems)
+
 	i.handlers[id] = handler
 	return handler
 }
@@ -156,31 +156,18 @@ func (i *informer) processEvents(events chan *event, stopChan <-chan struct{}) {
 			if !ok {
 				return
 			}
-			switch e.kind {
-			case addEvent:
-				i.forEachQueuedHandler(func(h *Handler) {
-					h.OnAdd(e.obj)
-				})
-			case updateEvent:
-				i.forEachQueuedHandler(func(h *Handler) {
-					h.OnUpdate(e.oldObj, e.obj)
-				})
-			case deleteEvent:
-				i.forEachQueuedHandler(func(h *Handler) {
-					h.OnDelete(e.obj)
-				})
-			}
+			e.process(e)
 		case <-stopChan:
 			return
 		}
 	}
 }
 
-func (i *informer) enqueueEvent(oldObj, obj interface{}, kind eventKind) {
-	meta, err := getObjectMeta(i.oType, obj)
+func getQueueNum(oType reflect.Type, obj interface{}) uint32 {
+	meta, err := getObjectMeta(oType, obj)
 	if err != nil {
 		logrus.Errorf("object has no meta: %v", err)
-		return
+		return 0
 	}
 
 	// Distribute the object to an event queue based on a hash of its
@@ -192,15 +179,20 @@ func (i *informer) enqueueEvent(oldObj, obj interface{}, kind eventKind) {
 		_, _ = h.Write([]byte("/"))
 	}
 	_, _ = h.Write([]byte(meta.Name))
-	queueIdx := h.Sum32() % uint32(numEventQueues)
+	return h.Sum32() % uint32(numEventQueues)
+}
 
+// enqueueEvent adds an event to the queue. Caller must hold at least a read lock
+// on the informer.
+func (i *informer) enqueueEvent(oldObj, obj interface{}, processFunc func(*event)) {
 	i.RLock()
 	defer i.RUnlock()
+	queueIdx := getQueueNum(i.oType, obj)
 	if i.events[queueIdx] != nil {
 		i.events[queueIdx] <- &event{
-			obj:    obj,
-			oldObj: oldObj,
-			kind:   kind,
+			obj:     obj,
+			oldObj:  oldObj,
+			process: processFunc,
 		}
 	}
 }
@@ -224,10 +216,18 @@ func ensureObjectOnDelete(obj interface{}, expectedType reflect.Type) (interface
 func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			i.enqueueEvent(nil, obj, addEvent)
+			i.enqueueEvent(nil, obj, func(e *event) {
+				i.forEachQueuedHandler(func(h *Handler) {
+					h.OnAdd(e.obj)
+				})
+			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			i.enqueueEvent(oldObj, newObj, updateEvent)
+			i.enqueueEvent(oldObj, newObj, func(e *event) {
+				i.forEachQueuedHandler(func(h *Handler) {
+					h.OnUpdate(e.oldObj, e.obj)
+				})
+			})
 		},
 		DeleteFunc: func(obj interface{}) {
 			realObj, err := ensureObjectOnDelete(obj, i.oType)
@@ -235,7 +235,11 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				logrus.Errorf(err.Error())
 				return
 			}
-			i.enqueueEvent(nil, realObj, deleteEvent)
+			i.enqueueEvent(nil, realObj, func(e *event) {
+				i.forEachQueuedHandler(func(h *Handler) {
+					h.OnDelete(e.obj)
+				})
+			})
 		},
 	}
 }
@@ -319,7 +323,11 @@ func newInformer(oType reflect.Type, sharedInformer cache.SharedIndexInformer) (
 	if err != nil {
 		return nil, err
 	}
-
+	i.initialAddFunc = func(h *Handler, items []interface{}) {
+		for _, item := range items {
+			h.OnAdd(item)
+		}
+	}
 	i.inf.AddEventHandler(i.newFederatedHandler())
 	return i, nil
 }
@@ -333,6 +341,38 @@ func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 	for j := range i.events {
 		i.events[j] = make(chan *event, 1)
 		go i.processEvents(i.events[j], stopChan)
+	}
+	i.initialAddFunc = func(h *Handler, items []interface{}) {
+		// Make a handler-specific channel array across which the
+		// initial add events will be distributed.
+		adds := make([]chan interface{}, numEventQueues)
+		queueWg := &sync.WaitGroup{}
+		queueWg.Add(len(adds))
+		for j := range adds {
+			adds[j] = make(chan interface{}, 1)
+			go func(addChan chan interface{}) {
+				defer queueWg.Done()
+				for {
+					obj, ok := <-addChan
+					if !ok {
+						return
+					}
+					h.OnAdd(obj)
+				}
+			}(adds[j])
+		}
+		// Distribute the existing items into the handler-specific
+		// channel array.
+		for _, obj := range items {
+			queueIdx := getQueueNum(i.oType, obj)
+			adds[queueIdx] <- obj
+		}
+		// Close all the channels
+		for j := range adds {
+			close(adds[j])
+		}
+		// Wait until all the object additions have been processed
+		queueWg.Wait()
 	}
 	i.inf.AddEventHandler(i.newFederatedQueuedHandler())
 	return i, nil
@@ -499,30 +539,24 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, lsel 
 		return true
 	}
 
-	// Process existing items as a set so the caller can clean up
-	// after a restart or whatever
-	existingItems := inf.inf.GetStore().List()
-	if processExisting != nil {
-		items := make([]interface{}, 0)
-		for _, obj := range existingItems {
-			if filterFunc(obj) {
-				items = append(items, obj)
-			}
+	inf.Lock()
+	defer inf.Unlock()
+
+	items := make([]interface{}, 0)
+	for _, obj := range inf.inf.GetStore().List() {
+		if filterFunc(obj) {
+			items = append(items, obj)
 		}
+	}
+	if processExisting != nil {
+		// Process existing items as a set so the caller can clean up
+		// after a restart or whatever
 		processExisting(items)
 	}
 
 	handlerID := atomic.AddUint64(&wf.handlerCounter, 1)
-	handler := inf.addHandler(handlerID, filterFunc, funcs)
+	handler := inf.addHandler(handlerID, filterFunc, funcs, items)
 	logrus.Debugf("added %v event handler %d", objType, handler.id)
-
-	// Send existing items to the handler's add function; informers usually
-	// do this but since we share informers, it's long-since happened so
-	// we must emulate that here
-	for _, obj := range existingItems {
-		handler.OnAdd(obj)
-	}
-
 	return handler, nil
 }
 

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -3,6 +3,8 @@ package factory
 import (
 	"fmt"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -103,6 +105,24 @@ func objSetup(c *fake.Clientset, objType string, listFn func(core.Action) (bool,
 	return w
 }
 
+type handlerCalls struct {
+	added   int32
+	updated int32
+	deleted int32
+}
+
+func (c *handlerCalls) getAdded() int {
+	return int(atomic.LoadInt32(&c.added))
+}
+
+func (c *handlerCalls) getUpdated() int {
+	return int(atomic.LoadInt32(&c.updated))
+}
+
+func (c *handlerCalls) getDeleted() int {
+	return int(atomic.LoadInt32(&c.deleted))
+}
+
 var _ = Describe("Watch Factory Operations", func() {
 	var (
 		fakeClient                                *fake.Clientset
@@ -115,7 +135,6 @@ var _ = Describe("Watch Factory Operations", func() {
 		endpoints                                 []*v1.Endpoints
 		services                                  []*v1.Service
 		stop                                      chan struct{}
-		numAdded, numUpdated, numDeleted          int
 	)
 
 	BeforeEach(func() {
@@ -175,10 +194,10 @@ var _ = Describe("Watch Factory Operations", func() {
 			}
 			return true, obj, nil
 		})
+	})
 
-		numAdded = 0
-		numUpdated = 0
-		numDeleted = 0
+	AfterEach(func() {
+		close(stop)
 	})
 
 	Context("when a processExisting is given", func() {
@@ -188,12 +207,12 @@ var _ = Describe("Watch Factory Operations", func() {
 			h, err := wf.addHandler(objType, namespace, lsel,
 				cache.ResourceEventHandlerFuncs{},
 				func(objs []interface{}) {
+					defer GinkgoRecover()
 					Expect(len(objs)).To(Equal(1))
 				})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(h).NotTo(BeNil())
 			wf.removeHandler(objType, h)
-			close(stop)
 		}
 
 		It("is called for each existing pod", func() {
@@ -240,18 +259,18 @@ var _ = Describe("Watch Factory Operations", func() {
 		testExisting := func(objType reflect.Type) {
 			wf, err := NewWatchFactory(fakeClient, stop)
 			Expect(err).NotTo(HaveOccurred())
+			var addCalls int32
 			h, err := wf.addHandler(objType, "", nil,
 				cache.ResourceEventHandlerFuncs{
 					AddFunc: func(obj interface{}) {
-						numAdded++
+						atomic.AddInt32(&addCalls, 1)
 					},
 					UpdateFunc: func(old, new interface{}) {},
 					DeleteFunc: func(obj interface{}) {},
 				}, nil)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(numAdded).To(Equal(2))
+			Expect(int(addCalls)).To(Equal(2))
 			wf.removeHandler(objType, h)
-			close(stop)
 		}
 
 		It("calls ADD for each existing pod", func() {
@@ -291,30 +310,31 @@ var _ = Describe("Watch Factory Operations", func() {
 		})
 	})
 
-	addFilteredHandler := func(wf *WatchFactory, objType reflect.Type, namespace string, lsel *metav1.LabelSelector, funcs cache.ResourceEventHandlerFuncs) *Handler {
+	addFilteredHandler := func(wf *WatchFactory, objType reflect.Type, namespace string, lsel *metav1.LabelSelector, funcs cache.ResourceEventHandlerFuncs) (*Handler, *handlerCalls) {
+		calls := handlerCalls{}
 		h, err := wf.addHandler(objType, namespace, lsel, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				defer GinkgoRecover()
-				numAdded++
+				atomic.AddInt32(&calls.added, 1)
 				funcs.AddFunc(obj)
 			},
 			UpdateFunc: func(old, new interface{}) {
 				defer GinkgoRecover()
-				numUpdated++
+				atomic.AddInt32(&calls.updated, 1)
 				funcs.UpdateFunc(old, new)
 			},
 			DeleteFunc: func(obj interface{}) {
 				defer GinkgoRecover()
-				numDeleted++
+				atomic.AddInt32(&calls.deleted, 1)
 				funcs.DeleteFunc(obj)
 			},
 		}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(h).NotTo(BeNil())
-		return h
+		return h, &calls
 	}
 
-	addHandler := func(wf *WatchFactory, objType reflect.Type, funcs cache.ResourceEventHandlerFuncs) *Handler {
+	addHandler := func(wf *WatchFactory, objType reflect.Type, funcs cache.ResourceEventHandlerFuncs) (*Handler, *handlerCalls) {
 		return addFilteredHandler(wf, objType, "", nil, funcs)
 	}
 
@@ -323,7 +343,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		added := newPod("pod1", "default")
-		h := addHandler(wf, podType, cache.ResourceEventHandlerFuncs{
+		h, c := addHandler(wf, podType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				pod := obj.(*v1.Pod)
 				Expect(reflect.DeepEqual(pod, added)).To(BeTrue())
@@ -341,16 +361,15 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		pods = append(pods, added)
 		podWatch.Add(added)
-		Eventually(func() int { return numAdded }, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(1))
 		added.Spec.NodeName = "foobar"
 		podWatch.Modify(added)
-		Eventually(func() int { return numUpdated }, 2).Should(Equal(1))
+		Eventually(c.getUpdated, 2).Should(Equal(1))
 		pods = pods[:0]
 		podWatch.Delete(added)
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
+		Eventually(c.getDeleted, 2).Should(Equal(1))
 
 		wf.RemovePodHandler(h)
-		close(stop)
 	})
 
 	It("responds to multiple pod add/update/delete events", func() {
@@ -372,7 +391,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			testPods[name] = &opTest{pod: pod}
 		}
 
-		h := addHandler(wf, podType, cache.ResourceEventHandlerFuncs{
+		h, c := addHandler(wf, podType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				pod := obj.(*v1.Pod)
 				ot, ok := testPods[pod.Name]
@@ -411,17 +430,16 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		// Ensure total number of each operation is 10; and each
 		// node's individual operation count is 2
-		Eventually(func() int { return numAdded }, 2).Should(Equal(10))
-		Eventually(func() int { return numUpdated }, 2).Should(Equal(10))
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(10))
+		Eventually(c.getAdded, 2).Should(Equal(10))
+		Eventually(c.getUpdated, 2).Should(Equal(10))
+		Eventually(c.getDeleted, 2).Should(Equal(10))
 		for _, ot := range testPods {
 			Expect(ot.added).Should(Equal(2))
 			Expect(ot.updated).Should(Equal(2))
 			Expect(ot.deleted).Should(Equal(2))
 		}
 
-		wf.removeHandler(podType, h)
-		close(stop)
+		wf.RemovePodHandler(h)
 	})
 
 	It("responds to namespace add/update/delete events", func() {
@@ -429,7 +447,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		added := newNamespace("default")
-		h := addHandler(wf, namespaceType, cache.ResourceEventHandlerFuncs{
+		h, c := addHandler(wf, namespaceType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				ns := obj.(*v1.Namespace)
 				Expect(reflect.DeepEqual(ns, added)).To(BeTrue())
@@ -447,16 +465,15 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		namespaces = append(namespaces, added)
 		namespaceWatch.Add(added)
-		Eventually(func() int { return numAdded }, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(1))
 		added.Status.Phase = v1.NamespaceTerminating
 		namespaceWatch.Modify(added)
-		Eventually(func() int { return numUpdated }, 2).Should(Equal(1))
+		Eventually(c.getUpdated, 2).Should(Equal(1))
 		namespaces = namespaces[:0]
 		namespaceWatch.Delete(added)
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
+		Eventually(c.getDeleted, 2).Should(Equal(1))
 
 		wf.RemoveNamespaceHandler(h)
-		close(stop)
 	})
 
 	It("responds to node add/update/delete events", func() {
@@ -464,7 +481,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		added := newNode("mynode")
-		h := addHandler(wf, nodeType, cache.ResourceEventHandlerFuncs{
+		h, c := addHandler(wf, nodeType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				node := obj.(*v1.Node)
 				Expect(reflect.DeepEqual(node, added)).To(BeTrue())
@@ -482,16 +499,15 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		nodes = append(nodes, added)
 		nodeWatch.Add(added)
-		Eventually(func() int { return numAdded }, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(1))
 		added.Status.Phase = v1.NodeTerminated
 		nodeWatch.Modify(added)
-		Eventually(func() int { return numUpdated }, 2).Should(Equal(1))
+		Eventually(c.getUpdated, 2).Should(Equal(1))
 		nodes = nodes[:0]
 		nodeWatch.Delete(added)
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
+		Eventually(c.getDeleted, 2).Should(Equal(1))
 
-		wf.removeHandler(nodeType, h)
-		close(stop)
+		wf.RemoveNodeHandler(h)
 	})
 
 	It("responds to multiple node add/update/delete events", func() {
@@ -512,7 +528,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			testNodes[name] = &opTest{node: node}
 		}
 
-		h := addHandler(wf, nodeType, cache.ResourceEventHandlerFuncs{
+		h, c := addHandler(wf, nodeType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				node := obj.(*v1.Node)
 				ot, ok := testNodes[node.Name]
@@ -551,17 +567,162 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		// Ensure total number of each operation is 10; and each
 		// node's individual operation count is 2
-		Eventually(func() int { return numAdded }, 2).Should(Equal(10))
-		Eventually(func() int { return numUpdated }, 2).Should(Equal(10))
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(10))
+		Eventually(c.getAdded, 2).Should(Equal(10))
+		Eventually(c.getUpdated, 2).Should(Equal(10))
+		Eventually(c.getDeleted, 2).Should(Equal(10))
 		for _, ot := range testNodes {
 			Expect(ot.added).Should(Equal(2))
 			Expect(ot.updated).Should(Equal(2))
 			Expect(ot.deleted).Should(Equal(2))
 		}
 
-		wf.removeHandler(nodeType, h)
-		close(stop)
+		wf.RemoveNodeHandler(h)
+	})
+
+	It("correctly orders queued informer initial add events and subsequent update events", func() {
+		type opTest struct {
+			node    *v1.Node
+			added   int
+			updated int
+		}
+		testNodes := make(map[string]*opTest)
+
+		for i := 0; i < 600; i++ {
+			name := fmt.Sprintf("mynode-%d", i)
+			node := newNode(name)
+			testNodes[name] = &opTest{node: node}
+			// Add all nodes to the initial list
+			nodes = append(nodes, node)
+		}
+
+		wf, err := NewWatchFactory(fakeClient, stop)
+		Expect(err).NotTo(HaveOccurred())
+
+		startWg := sync.WaitGroup{}
+		startWg.Add(1)
+		doneWg := sync.WaitGroup{}
+		doneWg.Add(1)
+		go func() {
+			startWg.Done()
+			// Send an update event for each node
+			for _, n := range nodes {
+				n.Status.Phase = v1.NodeTerminated
+				nodeWatch.Modify(n)
+			}
+			doneWg.Done()
+		}()
+		startWg.Wait()
+
+		h, c := addHandler(wf, nodeType, cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				node := obj.(*v1.Node)
+				ot, ok := testNodes[node.Name]
+				Expect(ok).To(BeTrue())
+				Expect(ot.added).To(Equal(0), "add for node %s already run", node.Name)
+				ot.added++
+			},
+			UpdateFunc: func(old, new interface{}) {
+				defer GinkgoRecover()
+				newNode := new.(*v1.Node)
+				ot, ok := testNodes[newNode.Name]
+				Expect(ok).To(BeTrue())
+				// Expect updates to be processed after Add
+				Expect(ot.added).To(Equal(1), "update for node %s processed before initial add!", newNode.Name)
+				Expect(ot.updated).To(Equal(0))
+				ot.updated++
+				Expect(newNode.Status.Phase).To(Equal(v1.NodeTerminated))
+			},
+			DeleteFunc: func(obj interface{}) {},
+		})
+		doneWg.Wait()
+
+		// Adds are done synchronously at handler addition time
+		for _, ot := range testNodes {
+			Expect(ot.added).To(Equal(1), "missing add for node %s", ot.node.Name)
+		}
+		Expect(c.getAdded()).To(Equal(len(testNodes)))
+
+		// Updates are async and may take a bit longer to finish
+		Eventually(c.getUpdated, 10).Should(Equal(len(testNodes)))
+		for _, ot := range testNodes {
+			Expect(ot.updated).To(Equal(1), "missing update for node %s", ot.node.Name)
+		}
+
+		wf.RemoveNodeHandler(h)
+	})
+
+	It("correctly orders serialized informer initial add events and subsequent update events", func() {
+		type opTest struct {
+			namespace *v1.Namespace
+			added     int
+			updated   int
+		}
+		testNamespaces := make(map[string]*opTest)
+
+		for i := 0; i < 598; i++ {
+			name := fmt.Sprintf("mynamespace-%d", i)
+			namespace := newNamespace(name)
+			testNamespaces[name] = &opTest{namespace: namespace}
+			// Add all namespaces to the initial list
+			namespaces = append(namespaces, namespace)
+		}
+
+		wf, err := NewWatchFactory(fakeClient, stop)
+		Expect(err).NotTo(HaveOccurred())
+
+		startWg := sync.WaitGroup{}
+		startWg.Add(1)
+		doneWg := sync.WaitGroup{}
+		doneWg.Add(1)
+		go func() {
+			startWg.Done()
+			// Send an update event for each namespace
+			for _, n := range namespaces {
+				n.Status.Phase = v1.NamespaceTerminating
+				namespaceWatch.Modify(n)
+			}
+			doneWg.Done()
+		}()
+		startWg.Wait()
+
+		h, c := addHandler(wf, namespaceType, cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				namespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[namespace.Name]
+				Expect(ok).To(BeTrue())
+				Expect(ot.added).To(Equal(0))
+				ot.added++
+			},
+			UpdateFunc: func(old, new interface{}) {
+				defer GinkgoRecover()
+				newNamespace := new.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Expect updates to be processed after Add
+				Expect(ot.added).To(Equal(1), "update for namespace %s processed before initial add!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(0))
+				ot.updated++
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
+			},
+			DeleteFunc: func(obj interface{}) {},
+		})
+		doneWg.Wait()
+
+		// Adds are done synchronously at handler addition time
+		for _, ot := range testNamespaces {
+			Expect(ot.added).To(Equal(1), "missing add for namespace %s", ot.namespace.Name)
+		}
+		Expect(c.getAdded()).To(Equal(len(testNamespaces)))
+
+		// Updates are async and may take a bit longer to finish
+		Eventually(c.getUpdated, 10).Should(Equal(len(testNamespaces)))
+		for _, ot := range testNamespaces {
+			Expect(ot.updated).To(Equal(1), "missing update for namespace %s", ot.namespace.Name)
+		}
+
+		wf.RemoveNamespaceHandler(h)
 	})
 
 	It("responds to policy add/update/delete events", func() {
@@ -569,7 +730,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		added := newPolicy("mypolicy", "default")
-		h := addHandler(wf, policyType, cache.ResourceEventHandlerFuncs{
+		h, c := addHandler(wf, policyType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				np := obj.(*knet.NetworkPolicy)
 				Expect(reflect.DeepEqual(np, added)).To(BeTrue())
@@ -587,16 +748,15 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		policies = append(policies, added)
 		policyWatch.Add(added)
-		Eventually(func() int { return numAdded }, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(1))
 		added.Spec.PolicyTypes = []knet.PolicyType{knet.PolicyTypeIngress}
 		policyWatch.Modify(added)
-		Eventually(func() int { return numUpdated }, 2).Should(Equal(1))
+		Eventually(c.getUpdated, 2).Should(Equal(1))
 		policies = policies[:0]
 		policyWatch.Delete(added)
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
+		Eventually(c.getDeleted, 2).Should(Equal(1))
 
-		wf.removeHandler(policyType, h)
-		close(stop)
+		wf.RemovePolicyHandler(h)
 	})
 
 	It("responds to endpoints add/update/delete events", func() {
@@ -604,7 +764,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		added := newEndpoints("myendpoints", "default")
-		h := addHandler(wf, endpointsType, cache.ResourceEventHandlerFuncs{
+		h, c := addHandler(wf, endpointsType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				eps := obj.(*v1.Endpoints)
 				Expect(reflect.DeepEqual(eps, added)).To(BeTrue())
@@ -622,7 +782,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		endpoints = append(endpoints, added)
 		endpointsWatch.Add(added)
-		Eventually(func() int { return numAdded }, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(1))
 		added.Subsets = append(added.Subsets, v1.EndpointSubset{
 			Ports: []v1.EndpointPort{
 				{
@@ -632,13 +792,12 @@ var _ = Describe("Watch Factory Operations", func() {
 			},
 		})
 		endpointsWatch.Modify(added)
-		Eventually(func() int { return numUpdated }, 2).Should(Equal(1))
+		Eventually(c.getUpdated, 2).Should(Equal(1))
 		endpoints = endpoints[:0]
 		endpointsWatch.Delete(added)
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
+		Eventually(c.getDeleted, 2).Should(Equal(1))
 
-		wf.removeHandler(endpointsType, h)
-		close(stop)
+		wf.RemoveEndpointsHandler(h)
 	})
 
 	It("responds to service add/update/delete events", func() {
@@ -646,7 +805,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		added := newService("myservice", "default")
-		h := addHandler(wf, serviceType, cache.ResourceEventHandlerFuncs{
+		h, c := addHandler(wf, serviceType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				service := obj.(*v1.Service)
 				Expect(reflect.DeepEqual(service, added)).To(BeTrue())
@@ -664,16 +823,15 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		services = append(services, added)
 		serviceWatch.Add(added)
-		Eventually(func() int { return numAdded }, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(1))
 		added.Spec.ClusterIP = "1.1.1.1"
 		serviceWatch.Modify(added)
-		Eventually(func() int { return numUpdated }, 2).Should(Equal(1))
+		Eventually(c.getUpdated, 2).Should(Equal(1))
 		services = services[:0]
 		serviceWatch.Delete(added)
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
+		Eventually(c.getDeleted, 2).Should(Equal(1))
 
-		wf.removeHandler(serviceType, h)
-		close(stop)
+		wf.RemoveServiceHandler(h)
 	})
 
 	It("stops processing events after the handler is removed", func() {
@@ -681,7 +839,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		added := newNamespace("default")
-		h := addHandler(wf, namespaceType, cache.ResourceEventHandlerFuncs{
+		h, c := addHandler(wf, namespaceType, cache.ResourceEventHandlerFuncs{
 			AddFunc:    func(obj interface{}) {},
 			UpdateFunc: func(old, new interface{}) {},
 			DeleteFunc: func(obj interface{}) {},
@@ -689,22 +847,20 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		namespaces = append(namespaces, added)
 		namespaceWatch.Add(added)
-		Eventually(func() int { return numAdded }, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(1))
 		wf.RemoveNamespaceHandler(h)
 
 		added2 := newNamespace("other")
 		namespaces = append(namespaces, added2)
 		namespaceWatch.Add(added2)
-		Consistently(func() int { return numAdded }, 2).Should(Equal(1))
+		Consistently(c.getAdded, 2).Should(Equal(1))
 
 		added2.Status.Phase = v1.NamespaceTerminating
 		namespaceWatch.Modify(added2)
-		Consistently(func() int { return numUpdated }, 2).Should(Equal(0))
+		Consistently(c.getUpdated, 2).Should(Equal(0))
 		namespaces = []*v1.Namespace{added}
 		namespaceWatch.Delete(added2)
-		Consistently(func() int { return numDeleted }, 2).Should(Equal(0))
-
-		close(stop)
+		Consistently(c.getDeleted, 2).Should(Equal(0))
 	})
 
 	It("filters correctly by label and namespace", func() {
@@ -718,7 +874,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		failsFilter2 := newPod("pod3", "otherns")
 		failsFilter2.ObjectMeta.Labels["blah"] = "foobar"
 
-		addFilteredHandler(wf,
+		_, c := addFilteredHandler(wf,
 			podType,
 			"default",
 			&metav1.LabelSelector{
@@ -741,36 +897,34 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		pods = append(pods, passesFilter)
 		podWatch.Add(passesFilter)
-		Eventually(func() int { return numAdded }, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(1))
 
 		// numAdded should remain 1
 		pods = append(pods, failsFilter)
 		podWatch.Add(failsFilter)
-		Consistently(func() int { return numAdded }, 2).Should(Equal(1))
+		Consistently(c.getAdded, 2).Should(Equal(1))
 
 		// numAdded should remain 1
 		pods = append(pods, failsFilter2)
 		podWatch.Add(failsFilter2)
-		Consistently(func() int { return numAdded }, 2).Should(Equal(1))
+		Consistently(c.getAdded, 2).Should(Equal(1))
 
 		passesFilter.Status.Phase = v1.PodFailed
 		podWatch.Modify(passesFilter)
-		Eventually(func() int { return numUpdated }, 2).Should(Equal(1))
+		Eventually(c.getUpdated, 2).Should(Equal(1))
 
 		// numAdded should remain 1
 		failsFilter.Status.Phase = v1.PodFailed
 		podWatch.Modify(failsFilter)
-		Consistently(func() int { return numUpdated }, 2).Should(Equal(1))
+		Consistently(c.getUpdated, 2).Should(Equal(1))
 
 		failsFilter2.Status.Phase = v1.PodFailed
 		podWatch.Modify(failsFilter2)
-		Consistently(func() int { return numUpdated }, 2).Should(Equal(1))
+		Consistently(c.getUpdated, 2).Should(Equal(1))
 
 		pods = []*v1.Pod{failsFilter, failsFilter2}
 		podWatch.Delete(passesFilter)
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
-
-		close(stop)
+		Eventually(c.getDeleted, 2).Should(Equal(1))
 	})
 
 	It("correctly handles object updates that cause filter changes", func() {
@@ -781,7 +935,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		pod.ObjectMeta.Labels["blah"] = "baz"
 
 		equalPod := pod
-		h := addFilteredHandler(wf,
+		h, c := addFilteredHandler(wf,
 			podType,
 			"default",
 			&metav1.LabelSelector{
@@ -803,7 +957,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		// Pod doesn't pass filter; shouldn't be added
 		podWatch.Add(pod)
-		Consistently(func() int { return numAdded }, 2).Should(Equal(0))
+		Consistently(c.getAdded, 2).Should(Equal(0))
 
 		// Update pod to pass filter; should be treated as add.  Need
 		// to deep-copy pod when modifying because it's a pointer all
@@ -813,16 +967,15 @@ var _ = Describe("Watch Factory Operations", func() {
 		pods = []*v1.Pod{podCopy}
 		equalPod = podCopy
 		podWatch.Modify(podCopy)
-		Eventually(func() int { return numAdded }, 2).Should(Equal(1))
+		Eventually(c.getAdded, 2).Should(Equal(1))
 
 		// Update pod to fail filter; should be treated as delete
 		pod.ObjectMeta.Labels["blah"] = "baz"
 		podWatch.Modify(pod)
-		Eventually(func() int { return numDeleted }, 2).Should(Equal(1))
-		Consistently(func() int { return numAdded }, 2).Should(Equal(1))
-		Consistently(func() int { return numUpdated }, 2).Should(Equal(0))
+		Eventually(c.getDeleted, 2).Should(Equal(1))
+		Consistently(c.getAdded, 2).Should(Equal(1))
+		Consistently(c.getUpdated, 2).Should(Equal(0))
 
 		wf.RemovePodHandler(h)
-		close(stop)
 	})
 })


### PR DESCRIPTION
Girish identified a race where the initial object Add events that are
sent when a handler is attached to an informer were not properly locked
against incoming events to that informer from the apiserver.

To fix this send the initial Add events while the informer's lock is held.

@girishmg @danwinship @ovn-org/ovn-kubernetes-committers @trozet @alexanderConstantinescu @juanluisvaladas @JacobTanenbaum @pecameron @mccv1r0 @rcarrillocruz