### PR TITLE
Switch from logrus to klog

### DIFF
--- a/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
+++ b/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/cmd/ovn-kube-util/app"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"k8s.io/klog"
 )
 
 func main() {
@@ -21,6 +21,6 @@ func main() {
 	}
 
 	if err := c.Run(os.Args); err != nil {
-		logrus.Fatal(err)
+		klog.Exit(err)
 	}
 }

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -13,7 +13,8 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
+
 	"github.com/urfave/cli"
 	"gopkg.in/fsnotify/fsnotify.v1"
 
@@ -103,7 +104,7 @@ func main() {
 	}
 
 	if err := c.Run(os.Args); err != nil {
-		logrus.Fatal(err)
+		klog.Exit(err)
 	}
 }
 
@@ -111,7 +112,7 @@ func delPidfile(pidfile string) {
 	if pidfile != "" {
 		if _, err := os.Stat(pidfile); err == nil {
 			if err := os.Remove(pidfile); err != nil {
-				logrus.Errorf("%s delete failed: %v", pidfile, err)
+				klog.Errorf("%s delete failed: %v", pidfile, err)
 			}
 		}
 	}
@@ -132,7 +133,7 @@ func setupPIDFile(pidfile string) error {
 	// Create if it doesn't exist, else exit with error
 	if os.IsNotExist(err) {
 		if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
-			logrus.Errorf("failed to write pidfile %s (%v). Ignoring..", pidfile, err)
+			klog.Errorf("failed to write pidfile %s (%v). Ignoring..", pidfile, err)
 		}
 	} else {
 		// get the pid and see if it exists
@@ -144,7 +145,7 @@ func setupPIDFile(pidfile string) error {
 		if os.IsNotExist(err1) {
 			// Left over pid from dead process
 			if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
-				logrus.Errorf("failed to write pidfile %s (%v). Ignoring..", pidfile, err)
+				klog.Errorf("failed to write pidfile %s (%v). Ignoring..", pidfile, err)
 			}
 		} else {
 			return fmt.Errorf("pidfile %s exists and ovnkube is running", pidfile)
@@ -268,7 +269,7 @@ func watchForChanges(configPath string) error {
 					return
 				}
 				if event.Op&fsnotify.Write == fsnotify.Write {
-					logrus.Infof("Configuration file %s changed, exiting...", event.Name)
+					klog.Infof("Configuration file %s changed, exiting...", event.Name)
 					os.Exit(0)
 					return
 				}
@@ -276,7 +277,7 @@ func watchForChanges(configPath string) error {
 				if !ok {
 					return
 				}
-				logrus.Errorf("fsnotify error %v", err)
+				klog.Errorf("fsnotify error %v", err)
 			}
 		}
 	}()
@@ -288,7 +289,7 @@ func watchForChanges(configPath string) error {
 		if err := watcher.Add(p); err != nil {
 			return err
 		}
-		logrus.Infof("Watching config file %s for changes", p)
+		klog.Infof("Watching config file %s for changes", p)
 
 		stat, err := os.Lstat(p)
 		if err != nil {

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/onsi/gomega v1.8.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/satori/go.uuid v0.0.0-20181028125025-b2ce2384e17b // indirect
-	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/urfave/cli v1.22.1
 	github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -164,7 +164,6 @@ github.com/satori/go.uuid v0.0.0-20181028125025-b2ce2384e17b h1:8O/3dJ2dGfuLVN0b
 github.com/satori/go.uuid v0.0.0-20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sirupsen/logrus v1.0.6 h1:hcP1GmhGigz/O7h1WVUM5KklBp1JoNS9FggWKdj/j3s=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -244,7 +243,8 @@ gopkg.in/fsnotify/fsnotify.v1 v1.4.7 h1:XNNYLJHt73EyYiCZi6+xjupS9CpvmiDgjPTAjrBl
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
-gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 h1:OAj3g0cR6Dx/R07QgQe8wkA9RNjB2u4i700xBkIT4e0=
+gopkg.in/gemnasium/klog-airbrake-hook.v2 v2.1.2 h1:OAj3g0cR6Dx/R07QgQe8wkA9RNjB2u4i700xBkIT4e0=
+gopkg.in/gemnasium/klog-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -8,7 +8,7 @@ import (
 
 	"net"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
@@ -152,7 +152,7 @@ func (cluster *OvnClusterController) initGateway(
 func CleanupClusterNode(name string) error {
 	var err error
 
-	logrus.Debugf("Cleaning up gateway resources on node: %q", name)
+	klog.V(5).Infof("Cleaning up gateway resources on node: %q", name)
 	switch config.Gateway.Mode {
 	case config.GatewayModeLocal:
 		err = cleanupLocalnetGateway()
@@ -160,7 +160,7 @@ func CleanupClusterNode(name string) error {
 		err = cleanupSharedGateway()
 	}
 	if err != nil {
-		logrus.Errorf("Failed to cleanup Gateway, error: %v", err)
+		klog.Errorf("Failed to cleanup Gateway, error: %v", err)
 	}
 
 	// Delete iptable rules for management port on Linux.

--- a/go-controller/pkg/cluster/gateway_shared_intf.go
+++ b/go-controller/pkg/cluster/gateway_shared_intf.go
@@ -10,9 +10,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 )
 
 func addService(service *kapi.Service, inport, outport, gwBridge string) {
@@ -31,7 +31,7 @@ func addService(service *kapi.Service, inport, outport, gwBridge string) {
 			fmt.Sprintf("priority=100, in_port=%s, %s, tp_dst=%d, actions=%s",
 				inport, protocol, svcPort.NodePort, outport))
 		if err != nil {
-			logrus.Errorf("Failed to add openflow flow on %s for nodePort "+
+			klog.Errorf("Failed to add openflow flow on %s for nodePort "+
 				"%d, stderr: %q, error: %v", gwBridge,
 				svcPort.NodePort, stderr, err)
 		}
@@ -55,7 +55,7 @@ func deleteService(service *kapi.Service, inport, gwBridge string) {
 			fmt.Sprintf("in_port=%s, %s, tp_dst=%d",
 				inport, protocol, svcPort.NodePort))
 		if err != nil {
-			logrus.Errorf("Failed to delete openflow flow on %s for nodePort "+
+			klog.Errorf("Failed to delete openflow flow on %s for nodePort "+
 				"%d, stderr: %q, error: %v", gwBridge,
 				svcPort.NodePort, stderr, err)
 		}
@@ -67,7 +67,7 @@ func syncServices(services []interface{}, inport, gwBridge string) {
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*kapi.Service)
 		if !ok {
-			logrus.Errorf("Spurious object in syncServices: %v",
+			klog.Errorf("Spurious object in syncServices: %v",
 				serviceInterface)
 			continue
 		}
@@ -96,14 +96,14 @@ func syncServices(services []interface{}, inport, gwBridge string) {
 	stdout, stderr, err := util.RunOVSOfctl("dump-flows",
 		gwBridge)
 	if err != nil {
-		logrus.Errorf("dump-flows failed: %q (%v)", stderr, err)
+		klog.Errorf("dump-flows failed: %q (%v)", stderr, err)
 		return
 	}
 	flows := strings.Split(stdout, "\n")
 
 	re, err := regexp.Compile(`tp_dst=(.*?)[, ]`)
 	if err != nil {
-		logrus.Errorf("regexp compile failed: %v", err)
+		klog.Errorf("regexp compile failed: %v", err)
 		return
 	}
 
@@ -131,7 +131,7 @@ func syncServices(services []interface{}, inport, gwBridge string) {
 				fmt.Sprintf("in_port=%s, %s, tp_dst=%s",
 					inport, protocol, port))
 			if err != nil {
-				logrus.Errorf("del-flows of %s failed: %q",
+				klog.Errorf("del-flows of %s failed: %q",
 					gwBridge, stdout)
 			}
 		}

--- a/go-controller/pkg/cluster/management-port.go
+++ b/go-controller/pkg/cluster/management-port.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 )
 
 func createManagementPortGeneric(nodeName string, localSubnet *net.IPNet) (string, string, string, string, string, error) {
@@ -29,7 +29,7 @@ func createManagementPortGeneric(nodeName string, localSubnet *net.IPNet) (strin
 	// Make sure br-int is created.
 	stdout, stderr, err := util.RunOVSVsctl("--", "--may-exist", "add-br", "br-int")
 	if err != nil {
-		logrus.Errorf("Failed to create br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+		klog.Errorf("Failed to create br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return "", "", "", "", "", err
 	}
 
@@ -41,19 +41,19 @@ func createManagementPortGeneric(nodeName string, localSubnet *net.IPNet) (strin
 		"type=internal", "mtu_request="+fmt.Sprintf("%d", config.Default.MTU),
 		"external-ids:iface-id=k8s-"+nodeName)
 	if err != nil {
-		logrus.Errorf("Failed to add port to br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+		klog.Errorf("Failed to add port to br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return "", "", "", "", "", err
 	}
 	macAddress, err := util.GetOVSPortMACAddress(interfaceName)
 	if err != nil {
-		logrus.Errorf("Failed to get management port MAC address: %v", err)
+		klog.Errorf("Failed to get management port MAC address: %v", err)
 		return "", "", "", "", "", err
 	}
 	// persist the MAC address so that upon node reboot we get back the same mac address.
 	_, stderr, err = util.RunOVSVsctl("set", "interface", interfaceName,
 		fmt.Sprintf("mac=%s", strings.ReplaceAll(macAddress, ":", "\\:")))
 	if err != nil {
-		logrus.Errorf("failed to persist MAC address %q for %q: stderr:%s (%v)", macAddress,
+		klog.Errorf("failed to persist MAC address %q for %q: stderr:%s (%v)", macAddress,
 			interfaceName, stderr, err)
 		return "", "", "", "", "", err
 	}

--- a/go-controller/pkg/cluster/management-port_linux.go
+++ b/go-controller/pkg/cluster/management-port_linux.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 )
 
 const (
@@ -61,7 +61,7 @@ func CreateManagementPort(nodeName string, localSubnet *net.IPNet, clusterSubnet
 		_, stderr, err := util.RunIP("route", "add", subnet, "via", routerIP)
 		if err != nil {
 			if strings.HasPrefix(stderr, "RTNETLINK answers: File exists") {
-				logrus.Debugf("Ignoring error %s from 'route add %s via %s' - already added via IPv6 RA?",
+				klog.V(5).Infof("Ignoring error %s from 'route add %s via %s' - already added via IPv6 RA?",
 					strings.TrimSpace(stderr), subnet, routerIP)
 			} else {
 				return nil, fmt.Errorf("Failed to add route for %s via %s: %s", subnet, routerIP, err)
@@ -79,7 +79,7 @@ func CreateManagementPort(nodeName string, localSubnet *net.IPNet, clusterSubnet
 	_, stderr, err := util.RunIP("route", "add", config.Kubernetes.ServiceCIDR, "via", routerIP)
 	if err != nil {
 		if strings.HasPrefix(stderr, "RTNETLINK answers: File exists") {
-			logrus.Debugf("Ignoring error %s from 'route add %s via %s' - already added via IPv6 RA?",
+			klog.V(5).Infof("Ignoring error %s from 'route add %s via %s' - already added via IPv6 RA?",
 				strings.TrimSpace(stderr), config.Kubernetes.ServiceCIDR, routerIP)
 		} else {
 			return nil, fmt.Errorf("Failed to add route for %s via %s: %s", config.Kubernetes.ServiceCIDR, routerIP, err)

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -39,7 +39,7 @@ func isOVNControllerReady(name string) (bool, error) {
 		ctlFile := runDir + fmt.Sprintf("ovn-controller.%s.ctl", strings.TrimSuffix(string(pid), "\n"))
 		ret, _, err := util.RunOVSAppctl("-t", ctlFile, "connection-status")
 		if err == nil {
-			logrus.Infof("node %s connection status = %s", name, ret)
+			klog.Infof("node %s connection status = %s", name, ret)
 			return ret == "connected", nil
 		}
 		return false, err
@@ -100,8 +100,12 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 
 	// Setting debug log level during node bring up to expose bring up process.
 	// Log level is returned to configured value when bring up is complete.
-	var LogLevel = logrus.GetLevel()
-	logrus.SetLevel(5)
+	var level klog.Level
+	lastLevel := fmt.Sprintf("%v", level.Get())
+
+	if err := level.Set("5"); err != nil {
+		klog.Errorf("setting klog \"loglevel\" to 5 failed, err: %v", err)
+	}
 
 	if config.MasterHA.ManageDBServers {
 		var readyChan = make(chan bool, 1)
@@ -138,12 +142,12 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	// First wait for the node logical switch to be created by the Master, timeout is 300s.
 	err = wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
 		if node, err = cluster.Kube.GetNode(name); err != nil {
-			logrus.Errorf("error retrieving node %s: %v", name, err)
+			klog.Errorf("error retrieving node %s: %v", name, err)
 			return false, nil
 		}
 		cidr, err = getNodeHostSubnetAnnotation(node)
 		if err != nil {
-			logrus.Errorf("Error starting node %s, no annotation found on node for subnet - %v", name, err)
+			klog.Errorf("Error starting node %s, no annotation found on node for subnet - %v", name, err)
 			return false, nil
 		}
 		return true, nil
@@ -157,7 +161,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		return fmt.Errorf("invalid hostsubnet found for node %s: %v", node.Name, err)
 	}
 
-	logrus.Infof("Node %s ready for ovn initialization with subnet %s", node.Name, subnet.String())
+	klog.Infof("Node %s ready for ovn initialization with subnet %s", node.Name, subnet.String())
 
 	if _, err = isOVNControllerReady(name); err != nil {
 		return err
@@ -199,7 +203,7 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 
 	portName := "k8s-" + node.Name
 
-	logrus.Infof("Waiting for GatewayReady and ManagementPortReady on node %s", node.Name)
+	klog.Infof("Waiting for GatewayReady and ManagementPortReady on node %s", node.Name)
 	// Wait for the portMac to be created
 	for _, f := range readyFuncs {
 		go func(rf readyFunc) {
@@ -220,7 +224,8 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 			return fmt.Errorf("Timeout error while obtaining addresses for %s (%v)", portName, i)
 		}
 	}
-	logrus.Infof("Gateway and ManagementPort are Ready")
+
+	klog.Infof("Gateway and ManagementPort are Ready")
 
 	if postReady != nil {
 		err = postReady()
@@ -229,7 +234,9 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		}
 	}
 
-	logrus.SetLevel(LogLevel)
+	if err := level.Set(lastLevel); err != nil {
+		klog.Errorf("reset of initial klog \"loglevel\" failed, err: %v", err)
+	}
 
 	confFile := filepath.Join(config.CNI.ConfDir, config.CNIConfFileName)
 	_, err = os.Stat(confFile)
@@ -261,7 +268,7 @@ func updateOVNConfig(ep *kapi.Endpoints, readyChan chan bool) error {
 		}
 	}
 
-	logrus.Infof("OVN databases reconfigured, masterIPs %v, northbound-db %v, southbound-db %v", masterIPList, northboundDBPort, southboundDBPort)
+	klog.Infof("OVN databases reconfigured, masterIPs %v, northbound-db %v, southbound-db %v", masterIPList, northboundDBPort, southboundDBPort)
 
 	readyChan <- true
 	return nil
@@ -275,7 +282,7 @@ func (cluster *OvnClusterController) watchConfigEndpoints(readyChan chan bool) e
 				ep := obj.(*kapi.Endpoints)
 				if ep.Name == "ovnkube-db" {
 					if err := updateOVNConfig(ep, readyChan); err != nil {
-						logrus.Errorf(err.Error())
+						klog.Errorf(err.Error())
 					}
 				}
 			},
@@ -284,7 +291,7 @@ func (cluster *OvnClusterController) watchConfigEndpoints(readyChan chan bool) e
 				epOld := old.(*kapi.Endpoints)
 				if !reflect.DeepEqual(epNew.Subsets, epOld.Subsets) && epNew.Name == "ovnkube-db" {
 					if err := updateOVNConfig(epNew, readyChan); err != nil {
-						logrus.Errorf(err.Error())
+						klog.Errorf(err.Error())
 					}
 				}
 			},

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -142,12 +142,12 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 	// First wait for the node logical switch to be created by the Master, timeout is 300s.
 	err = wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
 		if node, err = cluster.Kube.GetNode(name); err != nil {
-			klog.Errorf("error retrieving node %s: %v", name, err)
+			klog.Infof("waiting to retrieve node %s: %v", name, err)
 			return false, nil
 		}
 		cidr, err = getNodeHostSubnetAnnotation(node)
 		if err != nil {
-			klog.Errorf("Error starting node %s, no annotation found on node for subnet - %v", name, err)
+			klog.Infof("waiting for node %s to start, no annotation found on node for subnet - %v", name, err)
 			return false, nil
 		}
 		return true, nil

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 
 	"github.com/containernetworking/cni/pkg/types/current"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -92,7 +92,7 @@ func (pr *PodRequest) cmdAdd() ([]byte, error) {
 				// Pod not found; don't bother waiting longer
 				return false, err
 			}
-			logrus.Warningf("error getting pod annotations: %v", err)
+			klog.Warningf("error getting pod annotations: %v", err)
 			return false, nil
 		}
 		if _, ok := annotations[util.OvnPodAnnotationName]; ok {
@@ -149,7 +149,7 @@ func (pr *PodRequest) cmdDel() ([]byte, error) {
 // Return value is the actual bytes to be sent back without further processing.
 func HandleCNIRequest(request *PodRequest) ([]byte, error) {
 	pd := podDescription(request)
-	logrus.Infof("%s dispatching pod network request %v", pd, request)
+	klog.Infof("%s dispatching pod network request %v", pd, request)
 	var result []byte
 	var err error
 	switch request.Command {
@@ -159,7 +159,7 @@ func HandleCNIRequest(request *PodRequest) ([]byte, error) {
 		result, err = request.cmdDel()
 	default:
 	}
-	logrus.Infof("%s CNI request %v, result %q, err %v", pd, request, string(result), err)
+	klog.Infof("%s CNI request %v, result %q, err %v", pd, request, string(result), err)
 	if err != nil {
 		// Prefix errors with pod info for easier failure debugging
 		return nil, fmt.Errorf("%s %v", pd, err)

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 )
@@ -162,7 +162,7 @@ func (s *Server) handleCNIRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logrus.Infof("Waiting for %s result for pod %s/%s", req.Command, req.PodNamespace, req.PodName)
+	klog.Infof("Waiting for %s result for pod %s/%s", req.Command, req.PodNamespace, req.PodName)
 	result, err := s.requestFunc(req)
 	hasErr := "false"
 	if err != nil {
@@ -172,7 +172,7 @@ func (s *Server) handleCNIRequest(w http.ResponseWriter, r *http.Request) {
 		// Empty response JSON means success with no body
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write(result); err != nil {
-			logrus.Warningf("Error writing %s HTTP response: %v", req.Command, err)
+			klog.Warningf("Error writing %s HTTP response: %v", req.Command, err)
 		}
 	}
 

--- a/go-controller/pkg/cni/cniserver_windows.go
+++ b/go-controller/pkg/cni/cniserver_windows.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
@@ -40,6 +40,6 @@ func (s *Server) Start(requestFunc cniRequestFunc) error {
 			utilruntime.HandleError(fmt.Errorf("CNI server Serve() failed: %v", err))
 		}
 	}, 0)
-	logrus.Infof("CNI server started")
+	klog.Infof("CNI server started")
 	return nil
 }

--- a/go-controller/pkg/cni/helper_windows.go
+++ b/go-controller/pkg/cni/helper_windows.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -25,7 +25,7 @@ import (
 // return an error asking to give the HNS Network Id in config.
 func getHNSIdFromConfigOrByGatewayIP(gatewayIP net.IP) (string, error) {
 	if config.CNI.WinHNSNetworkID != "" {
-		logrus.Infof("Using HNS Network Id from config: %v", config.CNI.WinHNSNetworkID)
+		klog.Infof("Using HNS Network Id from config: %v", config.CNI.WinHNSNetworkID)
 		return config.CNI.WinHNSNetworkID, nil
 	}
 	if gatewayIP == nil {
@@ -49,7 +49,7 @@ func getHNSIdFromConfigOrByGatewayIP(gatewayIP net.IP) (string, error) {
 		}
 	}
 	if len(hnsNetworkId) != 0 {
-		logrus.Infof("HNS Network Id found: %v", hnsNetworkId)
+		klog.Infof("HNS Network Id found: %v", hnsNetworkId)
 		return hnsNetworkId, nil
 	}
 	return "", fmt.Errorf("Could not find any suitable network to attach the container")
@@ -58,52 +58,52 @@ func getHNSIdFromConfigOrByGatewayIP(gatewayIP net.IP) (string, error) {
 // createHNSEndpoint creates the HNS endpoint with the given configuration.
 // On success it returns the created HNS endpoint.
 func createHNSEndpoint(hnsConfiguration *hcsshim.HNSEndpoint) (*hcsshim.HNSEndpoint, error) {
-	logrus.Infof("Creating HNS endpoint")
+	klog.Infof("Creating HNS endpoint")
 	hnsConfigBytes, err := json.Marshal(hnsConfiguration)
 	if err != nil {
 		return nil, err
 	}
-	logrus.Infof("hnsConfigBytes: %v", string(hnsConfigBytes))
+	klog.Infof("hnsConfigBytes: %v", string(hnsConfigBytes))
 
 	createdHNSEndpoint, err := hcsshim.HNSEndpointRequest("POST", "", string(hnsConfigBytes))
 	if err != nil {
-		logrus.Errorf("Could not create the HNSEndpoint, error: %v", err)
+		klog.Errorf("Could not create the HNSEndpoint, error: %v", err)
 		return nil, err
 	}
-	logrus.Infof("Created HNS endpoint with ID: %v", createdHNSEndpoint.Id)
+	klog.Infof("Created HNS endpoint with ID: %v", createdHNSEndpoint.Id)
 	return createdHNSEndpoint, nil
 }
 
 // containerHotAttachEndpoint attaches the given endpoint to a running container
 func containerHotAttachEndpoint(existingHNSEndpoint *hcsshim.HNSEndpoint, containerID string) error {
-	logrus.Infof("Attaching endpoint %v to container %v", existingHNSEndpoint.Id, containerID)
+	klog.Infof("Attaching endpoint %v to container %v", existingHNSEndpoint.Id, containerID)
 	if err := hcsshim.HotAttachEndpoint(containerID, existingHNSEndpoint.Id); err != nil {
-		logrus.Infof("Error attaching the endpoint to the container, error: %v", err)
+		klog.Infof("Error attaching the endpoint to the container, error: %v", err)
 		return err
 	}
-	logrus.Infof("Endpoint attached successfully to the container")
+	klog.Infof("Endpoint attached successfully to the container")
 	return nil
 }
 
 // deleteHNSEndpoint deletes the given endpoint if it exists
 func deleteHNSEndpoint(endpointName string) error {
-	logrus.Infof("Deleting HNS endpoint: %v", endpointName)
+	klog.Infof("Deleting HNS endpoint: %v", endpointName)
 	// The HNS endpoint must be manually deleted
 	hnsEndpoint, err := hcsshim.GetHNSEndpointByName(endpointName)
 	if err == nil {
-		logrus.Infof("Fetched endpoint: %v", endpointName)
+		klog.Infof("Fetched endpoint: %v", endpointName)
 		// Endpoint exists, try to delete it
 		_, err = hnsEndpoint.Delete()
 		if err != nil {
-			logrus.Warningf("Failed to delete HNS endpoint: %q", err)
+			klog.Warningf("Failed to delete HNS endpoint: %q", err)
 		} else {
-			logrus.Infof("HNS endpoint successfully deleted: %q", endpointName)
+			klog.Infof("HNS endpoint successfully deleted: %q", endpointName)
 		}
 		// Return the error in case delete failed, we don't want to leak any HNS Endpoints
 		return err
 	}
 	// If endpoint was not found just log a message and return no error
-	logrus.Infof("No endpoint with name %v was found, error %v", endpointName, err)
+	klog.Infof("No endpoint with name %v was found, error %v", endpointName, err)
 	return nil
 }
 
@@ -131,7 +131,7 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 		if err != nil {
 			errHNSDelete := deleteHNSEndpoint(endpointName)
 			if errHNSDelete != nil {
-				logrus.Warningf("Failed to delete the HNS Endpoint, reason: %q", errHNSDelete)
+				klog.Warningf("Failed to delete the HNS Endpoint, reason: %q", errHNSDelete)
 			}
 		}
 	}()
@@ -139,7 +139,7 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 	var hnsNetworkId string
 	hnsNetworkId, err = getHNSIdFromConfigOrByGatewayIP(ifInfo.GW)
 	if err != nil {
-		logrus.Infof("Error when detecting the HNS Network Id: %q", err)
+		klog.Infof("Error when detecting the HNS Network Id: %q", err)
 		return nil, err
 	}
 
@@ -148,7 +148,7 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 	var createdEndpoint *hcsshim.HNSEndpoint
 	createdEndpoint, err = hcsshim.GetHNSEndpointByName(endpointName)
 	if err != nil {
-		logrus.Infof("HNS endpoint %q does not exist", endpointName)
+		klog.Infof("HNS endpoint %q does not exist", endpointName)
 
 		// HNSEndpoint requires the xx-xx-xx-xx-xx-xx format for the MacAddress field
 		macAddressIpFormat := strings.Replace(ifInfo.MAC.String(), ":", "-", -1)
@@ -167,12 +167,12 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 			return nil, err
 		}
 	} else {
-		logrus.Infof("HNS endpoint already exists with name: %q", endpointName)
+		klog.Infof("HNS endpoint already exists with name: %q", endpointName)
 	}
 
 	err = containerHotAttachEndpoint(createdEndpoint, pr.SandboxID)
 	if err != nil {
-		logrus.Warningf("Failed to hot attach HNS Endpoint %q to container %q, reason: %q", endpointName, pr.SandboxID, err)
+		klog.Warningf("Failed to hot attach HNS Endpoint %q to container %q, reason: %q", endpointName, pr.SandboxID, err)
 		return nil, err
 	}
 
@@ -184,7 +184,7 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 	// within a pod. Issue: https://github.com/kubernetes/kubernetes/issues/64188
 	ifaceName, errFind := ovsFind("interface", "name", "external-ids:iface-id="+ifaceID)
 	if errFind == nil && len(ifaceName) > 0 && ifaceName[0] != "" {
-		logrus.Infof("HNS endpoint %q already set up for container %q", endpointName, pr.SandboxID)
+		klog.Infof("HNS endpoint %q already set up for container %q", endpointName, pr.SandboxID)
 		return []*current.Interface{}, nil
 	}
 
@@ -213,7 +213,7 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 
 	out, err = exec.Command("powershell", mtuArgs...).CombinedOutput()
 	if err != nil {
-		logrus.Warningf("Failed to set MTU on endpoint %q, with: %q", endpointName, string(out))
+		klog.Warningf("Failed to set MTU on endpoint %q, with: %q", endpointName, string(out))
 		return nil, fmt.Errorf("failed to set MTU on endpoint, reason: %q", err)
 	}
 
@@ -234,7 +234,7 @@ func (pr *PodRequest) PlatformSpecificCleanup() error {
 	namespace := pr.PodNamespace
 	podName := pr.PodName
 	if namespace == "" || podName == "" {
-		logrus.Warningf("cleanup failed, required CNI variable missing from args: %v", pr)
+		klog.Warningf("cleanup failed, required CNI variable missing from args: %v", pr)
 		return nil
 	}
 
@@ -245,10 +245,10 @@ func (pr *PodRequest) PlatformSpecificCleanup() error {
 	out, err := exec.Command("ovs-vsctl", ovsArgs...).CombinedOutput()
 	if err != nil && !strings.Contains(string(out), "no port named") {
 		// DEL should be idempotent; don't return an error just log it
-		logrus.Warningf("failed to delete OVS port %s: %v  %q", endpointName, err, string(out))
+		klog.Warningf("failed to delete OVS port %s: %v  %q", endpointName, err, string(out))
 	}
 	if err = deleteHNSEndpoint(endpointName); err != nil {
-		logrus.Warningf("failed to delete HNSEndpoint %v: %v", endpointName, err)
+		klog.Warningf("failed to delete HNSEndpoint %v: %v", endpointName, err)
 	}
 	// TODO: uncomment when OVS QoS is supported on Windows
 	// _ = clearPodBandwidth(args.ContainerID)

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -2,7 +2,7 @@ package kube
 
 import (
 	"encoding/json"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,16 +44,16 @@ func (k *Kube) SetAnnotationsOnPod(pod *kapi.Pod, annotations map[string]string)
 	}
 
 	podDesc := pod.Namespace + "/" + pod.Name
-	logrus.Infof("Setting annotations %v on pod %s", annotations, podDesc)
+	klog.Infof("Setting annotations %v on pod %s", annotations, podDesc)
 	patchData, err = json.Marshal(&patch)
 	if err != nil {
-		logrus.Errorf("Error in setting annotations on pod %s: %v", podDesc, err)
+		klog.Errorf("Error in setting annotations on pod %s: %v", podDesc, err)
 		return err
 	}
 
 	_, err = k.KClient.CoreV1().Pods(pod.Namespace).Patch(pod.Name, types.MergePatchType, patchData)
 	if err != nil {
-		logrus.Errorf("Error in setting annotation on pod %s: %v", podDesc, err)
+		klog.Errorf("Error in setting annotation on pod %s: %v", podDesc, err)
 	}
 	return err
 }
@@ -70,26 +70,26 @@ func (k *Kube) SetAnnotationsOnNode(node *kapi.Node, annotations map[string]inte
 		},
 	}
 
-	logrus.Infof("Setting annotations %v on node %s", annotations, node.Name)
+	klog.Infof("Setting annotations %v on node %s", annotations, node.Name)
 	patchData, err = json.Marshal(&patch)
 	if err != nil {
-		logrus.Errorf("Error in setting annotations on node %s: %v", node.Name, err)
+		klog.Errorf("Error in setting annotations on node %s: %v", node.Name, err)
 		return err
 	}
 
 	_, err = k.KClient.CoreV1().Nodes().Patch(node.Name, types.MergePatchType, patchData)
 	if err != nil {
-		logrus.Errorf("Error in setting annotation on node %s: %v", node.Name, err)
+		klog.Errorf("Error in setting annotation on node %s: %v", node.Name, err)
 	}
 	return err
 }
 
 // UpdateNodeStatus takes the node object and sets the provided update status
 func (k *Kube) UpdateNodeStatus(node *kapi.Node) error {
-	logrus.Infof("Updating status on node %s", node.Name)
+	klog.Infof("Updating status on node %s", node.Name)
 	_, err := k.KClient.CoreV1().Nodes().UpdateStatus(node)
 	if err != nil {
-		logrus.Errorf("Error in updating status on node %s: %v", node.Name, err)
+		klog.Errorf("Error in updating status on node %s: %v", node.Name, err)
 	}
 	return err
 }

--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 )
 
 // hash the provided input to make it a valid addressSet or portGroup name.
@@ -15,7 +15,7 @@ func hashForOVN(s string) string {
 	h := fnv.New64a()
 	_, err := h.Write([]byte(s))
 	if err != nil {
-		logrus.Errorf("failed to hash %s", s)
+		klog.Errorf("failed to hash %s", s)
 	}
 	hashString := strconv.FormatUint(h.Sum64(), 10)
 	return fmt.Sprintf("a%s", hashString)
@@ -40,7 +40,7 @@ func (oc *Controller) forEachAddressSetUnhashedName(iteratorFn func(
 	output, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=external_ids", "find", "address_set")
 	if err != nil {
-		logrus.Errorf("Error in obtaining list of address sets from OVN: "+
+		klog.Errorf("Error in obtaining list of address sets from OVN: "+
 			"stdout: %q, stderr: %q err: %v", output, stderr, err)
 		return err
 	}
@@ -61,35 +61,35 @@ func (oc *Controller) forEachAddressSetUnhashedName(iteratorFn func(
 }
 
 func addToAddressSet(hashName string, address string) {
-	logrus.Debugf("addToAddressSet for %s with %s", hashName, address)
+	klog.V(5).Infof("addToAddressSet for %s with %s", hashName, address)
 
 	_, stderr, err := util.RunOVNNbctl("add", "address_set",
 		hashName, "addresses", address)
 	if err != nil {
-		logrus.Errorf("failed to add an address %q to address_set %q, stderr: %q (%v)",
+		klog.Errorf("failed to add an address %q to address_set %q, stderr: %q (%v)",
 			address, hashName, stderr, err)
 	}
 }
 
 func removeFromAddressSet(hashName string, address string) {
-	logrus.Debugf("removeFromAddressSet for %s with %s", hashName, address)
+	klog.V(5).Infof("removeFromAddressSet for %s with %s", hashName, address)
 
 	_, stderr, err := util.RunOVNNbctl("remove", "address_set",
 		hashName, "addresses", address)
 	if err != nil {
-		logrus.Errorf("failed to remove an address %q from address_set %q, stderr: %q (%v)",
+		klog.Errorf("failed to remove an address %q from address_set %q, stderr: %q (%v)",
 			address, hashName, stderr, err)
 	}
 }
 
 func createAddressSet(name string, hashName string,
 	addresses []string) {
-	logrus.Debugf("createAddressSet with %s and %s", name, addresses)
+	klog.V(5).Infof("createAddressSet with %s and %s", name, addresses)
 	addressSet, stderr, err := util.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "address_set",
 		fmt.Sprintf("name=%s", hashName))
 	if err != nil {
-		logrus.Errorf("find failed to get address set, stderr: %q (%v)",
+		klog.Errorf("find failed to get address set, stderr: %q (%v)",
 			stderr, err)
 		return
 	}
@@ -99,7 +99,7 @@ func createAddressSet(name string, hashName string,
 		_, stderr, err = util.RunOVNNbctl("clear", "address_set",
 			hashName, "addresses")
 		if err != nil {
-			logrus.Errorf("failed to clear address_set, stderr: %q (%v)",
+			klog.Errorf("failed to clear address_set, stderr: %q (%v)",
 				stderr, err)
 		}
 		return
@@ -113,7 +113,7 @@ func createAddressSet(name string, hashName string,
 		_, stderr, err = util.RunOVNNbctl("set", "address_set",
 			hashName, fmt.Sprintf("addresses=%s", ips))
 		if err != nil {
-			logrus.Errorf("failed to set address_set, stderr: %q (%v)",
+			klog.Errorf("failed to set address_set, stderr: %q (%v)",
 				stderr, err)
 		}
 		return
@@ -131,25 +131,25 @@ func createAddressSet(name string, hashName string,
 			fmt.Sprintf("addresses=%s", ips))
 	}
 	if err != nil {
-		logrus.Errorf("failed to create address_set %s, stderr: %q (%v)",
+		klog.Errorf("failed to create address_set %s, stderr: %q (%v)",
 			name, stderr, err)
 	}
 }
 
 func deleteAddressSet(hashName string) {
-	logrus.Debugf("deleteAddressSet %s", hashName)
+	klog.V(5).Infof("deleteAddressSet %s", hashName)
 
 	_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy",
 		"address_set", hashName)
 	if err != nil {
-		logrus.Errorf("failed to destroy address set %s, stderr: %q, (%v)",
+		klog.Errorf("failed to destroy address set %s, stderr: %q, (%v)",
 			hashName, stderr, err)
 		return
 	}
 }
 
 func createPortGroup(name string, hashName string) (string, error) {
-	logrus.Debugf("createPortGroup with %s", name)
+	klog.V(5).Infof("createPortGroup with %s", name)
 	portGroup, stderr, err := util.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "port_group",
 		fmt.Sprintf("name=%s", hashName))
@@ -174,13 +174,13 @@ func createPortGroup(name string, hashName string) (string, error) {
 }
 
 func deletePortGroup(hashName string) {
-	logrus.Debugf("deletePortGroup %s", hashName)
+	klog.V(5).Infof("deletePortGroup %s", hashName)
 
 	portGroup, stderr, err := util.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "port_group",
 		fmt.Sprintf("name=%s", hashName))
 	if err != nil {
-		logrus.Errorf("find failed to get port_group, stderr: %q (%v)",
+		klog.Errorf("find failed to get port_group, stderr: %q (%v)",
 			stderr, err)
 		return
 	}
@@ -192,7 +192,7 @@ func deletePortGroup(hashName string) {
 	_, stderr, err = util.RunOVNNbctl("--if-exists", "destroy",
 		"port_group", portGroup)
 	if err != nil {
-		logrus.Errorf("failed to destroy port_group %s, stderr: %q, (%v)",
+		klog.Errorf("failed to destroy port_group %s, stderr: %q, (%v)",
 			hashName, stderr, err)
 		return
 	}

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 )
 
 func (ovn *Controller) getOvnGateways() ([]string, string, error) {
@@ -42,7 +42,7 @@ func (ovn *Controller) getGatewayLoadBalancer(physicalGateway,
 
 func (ovn *Controller) createGatewaysVIP(protocol string, port, targetPort int32, ips []string) error {
 
-	logrus.Debugf("Creating Gateway VIP - %s, %d, %d, %v", protocol, port, targetPort, ips)
+	klog.V(5).Infof("Creating Gateway VIP - %s, %d, %d, %v", protocol, port, targetPort, ips)
 
 	// Each gateway has a separate load-balancer for N/S traffic
 
@@ -55,7 +55,7 @@ func (ovn *Controller) createGatewaysVIP(protocol string, port, targetPort int32
 		loadBalancer, err := ovn.getGatewayLoadBalancer(physicalGateway,
 			protocol)
 		if err != nil {
-			logrus.Errorf("physical gateway %s does not have load_balancer "+
+			klog.Errorf("physical gateway %s does not have load_balancer "+
 				"(%v)", physicalGateway, err)
 			continue
 		}
@@ -64,7 +64,7 @@ func (ovn *Controller) createGatewaysVIP(protocol string, port, targetPort int32
 		}
 		physicalIP, err := ovn.getGatewayPhysicalIP(physicalGateway)
 		if err != nil {
-			logrus.Errorf("physical gateway %s does not have physical ip (%v)",
+			klog.Errorf("physical gateway %s does not have physical ip (%v)",
 				physicalGateway, err)
 			continue
 		}
@@ -73,7 +73,7 @@ func (ovn *Controller) createGatewaysVIP(protocol string, port, targetPort int32
 		err = ovn.createLoadBalancerVIP(loadBalancer,
 			physicalIP, port, ips, targetPort)
 		if err != nil {
-			logrus.Errorf("Failed to create VIP in load balancer %s - %v", loadBalancer, err)
+			klog.Errorf("Failed to create VIP in load balancer %s - %v", loadBalancer, err)
 			continue
 		}
 	}

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog"
 )
 
 func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string,
@@ -44,7 +44,7 @@ func (ovn *Controller) getDefaultGatewayLoadBalancer(protocol kapi.Protocol) str
 
 	gw, _, err := util.GetDefaultGatewayRouterIP()
 	if err != nil {
-		logrus.Errorf(err.Error())
+		klog.Errorf(err.Error())
 		return ""
 	}
 
@@ -87,14 +87,14 @@ func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) {
 	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
 		"load_balancer", loadBalancer, "vips", vipQuotes)
 	if err != nil {
-		logrus.Errorf("Error in deleting load balancer vip %s for %s"+
+		klog.Errorf("Error in deleting load balancer vip %s for %s"+
 			"stdout: %q, stderr: %q, error: %v",
 			vip, loadBalancer, stdout, stderr, err)
 	}
 }
 
 func (ovn *Controller) createLoadBalancerVIP(lb string, serviceIP string, port int32, ips []string, targetPort int32) error {
-	logrus.Debugf("Creating lb with %s, %s, %d, [%v], %d", lb, serviceIP, port, ips, targetPort)
+	klog.V(5).Infof("Creating lb with %s, %s, %d, [%v], %d", lb, serviceIP, port, ips, targetPort)
 
 	// With service_ip:port as a VIP, create an entry in 'load_balancer'
 	// key is of the form "IP:port" (with quotes around)
@@ -119,7 +119,7 @@ func (ovn *Controller) createLoadBalancerVIP(lb string, serviceIP string, port i
 	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb,
 		target)
 	if err != nil {
-		logrus.Errorf("Error in creating load balancer: %s "+
+		klog.Errorf("Error in creating load balancer: %s "+
 			"stdout: %q, stderr: %q, error: %v", lb, out, stderr, err)
 	}
 	return err

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 )
 
 const (
@@ -75,7 +75,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 
 	existingNodes, err := oc.kube.GetNodes()
 	if err != nil {
-		logrus.Errorf("Error in initializing/fetching subnets: %v", err)
+		klog.Errorf("Error in initializing/fetching subnets: %v", err)
 		return err
 	}
 	for _, clusterEntry := range config.Default.ClusterSubnets {
@@ -109,23 +109,23 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		// Multicast support requires portGroupSupport
 		if oc.portGroupSupport {
 			if _, _, err := util.RunOVNSbctl("--columns=_uuid", "list", "IGMP_Group"); err != nil {
-				logrus.Warningf("Multicast support enabled, however version of OVN in use does not support IGMP Group. " +
+				klog.Warningf("Multicast support enabled, however version of OVN in use does not support IGMP Group. " +
 					"Disabling Multicast Support")
 				oc.multicastSupport = false
 			}
 		} else {
-			logrus.Warningf("Multicast support enabled, however version of OVN in use does not support Port Group. " +
+			klog.Warningf("Multicast support enabled, however version of OVN in use does not support Port Group. " +
 				"Disabling Multicast Support")
 			oc.multicastSupport = false
 		}
 		if config.IPv6Mode {
-			logrus.Warningf("Multicast support enabled, but can not be used along with IPv6. Disabling Multicast Support")
+			klog.Warningf("Multicast support enabled, but can not be used along with IPv6. Disabling Multicast Support")
 			oc.multicastSupport = false
 		}
 	}
 
 	if err := oc.SetupMaster(masterNodeName); err != nil {
-		logrus.Errorf("Failed to setup master (%v)", err)
+		klog.Errorf("Failed to setup master (%v)", err)
 		return err
 	}
 
@@ -139,7 +139,7 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 	stdout, stderr, err := util.RunOVNNbctl("--", "--may-exist", "lr-add", clusterRouter,
 		"--", "set", "logical_router", clusterRouter, "external_ids:k8s-cluster-router=yes")
 	if err != nil {
-		logrus.Errorf("Failed to create a single common distributed router for the cluster, "+
+		klog.Errorf("Failed to create a single common distributed router for the cluster, "+
 			"stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
 	}
@@ -150,7 +150,7 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 		stdout, stderr, err = util.RunOVNNbctl("--", "set", "logical_router",
 			clusterRouter, "options:mcast_relay=\"true\"")
 		if err != nil {
-			logrus.Errorf("Failed to enable IGMP relay on the cluster router, "+
+			klog.Errorf("Failed to enable IGMP relay on the cluster router, "+
 				"stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 			return err
 		}
@@ -159,7 +159,7 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 		// enabled in a namespace.
 		err = createDefaultDenyMulticastPolicy()
 		if err != nil {
-			logrus.Errorf("Failed to create default deny multicast policy, error: %v",
+			klog.Errorf("Failed to create default deny multicast policy, error: %v",
 				err)
 			return err
 		}
@@ -168,27 +168,27 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 	// Create 2 load-balancers for east-west traffic.  One handles UDP and another handles TCP.
 	oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes")
 	if err != nil {
-		logrus.Errorf("Failed to get tcp load-balancer, stderr: %q, error: %v", stderr, err)
+		klog.Errorf("Failed to get tcp load-balancer, stderr: %q, error: %v", stderr, err)
 		return err
 	}
 
 	if oc.TCPLoadBalancerUUID == "" {
 		oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes", "protocol=tcp")
 		if err != nil {
-			logrus.Errorf("Failed to create tcp load-balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+			klog.Errorf("Failed to create tcp load-balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 			return err
 		}
 	}
 
 	oc.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes")
 	if err != nil {
-		logrus.Errorf("Failed to get udp load-balancer, stderr: %q, error: %v", stderr, err)
+		klog.Errorf("Failed to get udp load-balancer, stderr: %q, error: %v", stderr, err)
 		return err
 	}
 	if oc.UDPLoadBalancerUUID == "" {
 		oc.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes", "protocol=udp")
 		if err != nil {
-			logrus.Errorf("Failed to create udp load-balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+			klog.Errorf("Failed to create udp load-balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 			return err
 		}
 	}
@@ -249,7 +249,7 @@ func (oc *Controller) allocateJoinSubnet(node *kapi.Node) (string, error) {
 		return "", err
 	}
 
-	logrus.Infof("Allocated join subnet %q for node %q", node.Name, joinSubnetStr)
+	klog.Infof("Allocated join subnet %q for node %q", node.Name, joinSubnetStr)
 	return joinSubnetStr, nil
 }
 
@@ -258,14 +258,14 @@ func (oc *Controller) deleteNodeJoinSubnet(nodeName string, subnet *net.IPNet) e
 	if err != nil {
 		return fmt.Errorf("Error deleting join subnet %v for node %q: %s", subnet, nodeName, err)
 	}
-	logrus.Infof("Deleted JoinSubnet %v for node %s", subnet, nodeName)
+	klog.Infof("Deleted JoinSubnet %v for node %s", subnet, nodeName)
 	return nil
 }
 
 func parseNodeManagementPortMacAddr(node *kapi.Node) (string, error) {
 	macAddress, ok := node.Annotations[OvnNodeManagementPortMacAddress]
 	if !ok {
-		logrus.Errorf("macAddress annotation not found for node %q ", node.Name)
+		klog.Errorf("macAddress annotation not found for node %q ", node.Name)
 		return "", nil
 	}
 
@@ -288,7 +288,7 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, subnet *net.IPNet)
 		// When macAddress was removed, delete the switch port
 		stdout, stderr, err := util.RunOVNNbctl("--", "--if-exists", "lsp-del", "k8s-"+node.Name)
 		if err != nil {
-			logrus.Errorf("Failed to delete logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+			klog.Errorf("Failed to delete logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		}
 
 		return nil
@@ -316,7 +316,7 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, subnet *net.IPNet)
 			"--", "--if-exists", "remove", "logical_switch", node.Name, "other-config", "exclude_ips")
 	}
 	if err != nil {
-		logrus.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+		klog.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
 	}
 
@@ -553,7 +553,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 	_, stderr, err := util.RunOVNNbctl("--may-exist", "lrp-add", clusterRouter, "rtos-"+nodeName,
 		nodeLRPMac, firstIP.String())
 	if err != nil {
-		logrus.Errorf("Failed to add logical port to router, stderr: %q, error: %v", stderr, err)
+		klog.Errorf("Failed to add logical port to router, stderr: %q, error: %v", stderr, err)
 		return err
 	}
 
@@ -568,7 +568,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 			"other-config:exclude_ips="+secondIP.IP.String())
 	}
 	if err != nil {
-		logrus.Errorf("Failed to create a logical switch %v, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
+		klog.Errorf("Failed to create a logical switch %v, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 		return err
 	}
 
@@ -577,7 +577,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 		stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
 			nodeName, "other-config:mcast_snoop=\"true\"")
 		if err != nil {
-			logrus.Errorf("Failed to enable IGMP on logical switch %v, stdout: %q, stderr: %q, error: %v",
+			klog.Errorf("Failed to enable IGMP on logical switch %v, stdout: %q, stderr: %q, error: %v",
 				nodeName, stdout, stderr, err)
 			return err
 		}
@@ -590,7 +590,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 				"other-config:mcast_eth_src=\""+nodeLRPMac+"\"",
 				"other-config:mcast_ip4_src=\""+firstIP.IP.String()+"\"")
 			if err != nil {
-				logrus.Errorf("Failed to enable IGMP Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
+				klog.Errorf("Failed to enable IGMP Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
 					nodeName, stdout, stderr, err)
 				return err
 			}
@@ -598,11 +598,11 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 			stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
 				nodeName, "other-config:mcast_querier=\"false\"")
 			if err != nil {
-				logrus.Errorf("Failed to disable IGMP Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
+				klog.Errorf("Failed to disable IGMP Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
 					nodeName, stdout, stderr, err)
 				return err
 			}
-			logrus.Infof("Disabled IGMP Querier on logical switch %v (No IPv4 Source IP available)",
+			klog.Infof("Disabled IGMP Querier on logical switch %v (No IPv4 Source IP available)",
 				nodeName)
 		}
 	}
@@ -611,7 +611,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", nodeName, "stor-"+nodeName,
 		"--", "set", "logical_switch_port", "stor-"+nodeName, "type=router", "options:router-port=rtos-"+nodeName, "addresses="+"\""+nodeLRPMac+"\"")
 	if err != nil {
-		logrus.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+		klog.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
 	}
 
@@ -621,7 +621,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 	}
 	stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch", nodeName, "load_balancer="+oc.TCPLoadBalancerUUID)
 	if err != nil {
-		logrus.Errorf("Failed to set logical switch %v's loadbalancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
+		klog.Errorf("Failed to set logical switch %v's loadbalancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 		return err
 	}
 
@@ -630,7 +630,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 	}
 	stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", oc.UDPLoadBalancerUUID)
 	if err != nil {
-		logrus.Errorf("Failed to add logical switch %v's loadbalancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
+		klog.Errorf("Failed to add logical switch %v's loadbalancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 		return err
 	}
 
@@ -638,7 +638,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 	oc.lsMutex.Lock()
 	defer oc.lsMutex.Unlock()
 	if existing, ok := oc.logicalSwitchCache[nodeName]; ok && !reflect.DeepEqual(existing, hostsubnet) {
-		logrus.Warningf("Node %q logical switch already in cache with subnet %v; replacing with %v", nodeName, existing, hostsubnet)
+		klog.Warningf("Node %q logical switch already in cache with subnet %v; replacing with %v", nodeName, existing, hostsubnet)
 	}
 	oc.logicalSwitchCache[nodeName] = hostsubnet
 
@@ -695,7 +695,7 @@ func (oc *Controller) addNode(node *kapi.Node) (hostsubnet *net.IPNet, err error
 	if err != nil {
 		return nil, fmt.Errorf("Error allocating network for node %s: %v", node.Name, err)
 	}
-	logrus.Infof("Allocated node %s HostSubnet %s", node.Name, hostsubnetStr)
+	klog.Infof("Allocated node %s HostSubnet %s", node.Name, hostsubnetStr)
 
 	_, hostsubnet, err = net.ParseCIDR(hostsubnetStr)
 	if err != nil {
@@ -731,7 +731,7 @@ func (oc *Controller) deleteNodeHostSubnet(nodeName string, subnet *net.IPNet) e
 	if err != nil {
 		return fmt.Errorf("Error deleting subnet %v for node %q: %s", subnet, nodeName, err)
 	}
-	logrus.Infof("Deleted HostSubnet %v for node %s", subnet, nodeName)
+	klog.Infof("Deleted HostSubnet %v for node %s", subnet, nodeName)
 	return nil
 }
 
@@ -755,17 +755,17 @@ func (oc *Controller) deleteNode(nodeName string, nodeSubnet, joinSubnet *net.IP
 	// Clean up as much as we can but don't hard error
 	if nodeSubnet != nil {
 		if err := oc.deleteNodeHostSubnet(nodeName, nodeSubnet); err != nil {
-			logrus.Errorf("Error deleting node %s HostSubnet %v: %v", nodeName, nodeSubnet, err)
+			klog.Errorf("Error deleting node %s HostSubnet %v: %v", nodeName, nodeSubnet, err)
 		}
 	}
 	if joinSubnet != nil {
 		if err := oc.deleteNodeJoinSubnet(nodeName, joinSubnet); err != nil {
-			logrus.Errorf("Error deleting node %s JoinSubnet %v: %v", nodeName, joinSubnet, err)
+			klog.Errorf("Error deleting node %s JoinSubnet %v: %v", nodeName, joinSubnet, err)
 		}
 	}
 
 	if err := oc.deleteNodeLogicalNetwork(nodeName); err != nil {
-		logrus.Errorf("Error deleting node %s logical network: %v", nodeName, err)
+		klog.Errorf("Error deleting node %s logical network: %v", nodeName, err)
 	}
 
 	if err := util.GatewayCleanup(nodeName, nodeSubnet); err != nil {
@@ -821,9 +821,9 @@ func (oc *Controller) clearInitialNodeNetworkUnavailableCondition(origNode, newN
 		return err
 	})
 	if resultErr != nil {
-		logrus.Errorf("status update failed for local node %s: %v", origNode.Name, resultErr)
+		klog.Errorf("status update failed for local node %s: %v", origNode.Name, resultErr)
 	} else if cleared {
-		logrus.Infof("Cleared node NetworkUnavailable/NoRouteCreated condition for %s", origNode.Name)
+		klog.Infof("Cleared node NetworkUnavailable/NoRouteCreated condition for %s", origNode.Name)
 	}
 }
 
@@ -832,7 +832,7 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 	for _, tmp := range nodes {
 		node, ok := tmp.(*kapi.Node)
 		if !ok {
-			logrus.Errorf("Spurious object in syncNodes: %v", tmp)
+			klog.Errorf("Spurious object in syncNodes: %v", tmp)
 			continue
 		}
 		foundNodes[node.Name] = node
@@ -852,7 +852,7 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 		"--columns=name,other-config", "find", "logical_switch",
 		"other-config:"+subnetAttr+"!=_")
 	if err != nil {
-		logrus.Errorf("Failed to get node logical switches: stderr: %q, error: %v",
+		klog.Errorf("Failed to get node logical switches: stderr: %q, error: %v",
 			stderr, err)
 		return
 	}
@@ -906,7 +906,7 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 
 	for nodeName, nodeSubnets := range NodeSubnetsMap {
 		if err := oc.deleteNode(nodeName, nodeSubnets.hostSubnet, nodeSubnets.joinSubnet); err != nil {
-			logrus.Error(err)
+			klog.Error(err)
 		}
 	}
 }

--- a/go-controller/pkg/ovn/metrics.go
+++ b/go-controller/pkg/ovn/metrics.go
@@ -11,7 +11,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 )
 
 const MetricSubsystem = "master"
@@ -59,13 +59,13 @@ func scrapeOvnTimestamp() float64 {
 	output, stderr, err := util.RunOVNSbctl("--if-exists",
 		"get", "SB_Global", ".", "options:e2e_timestamp")
 	if err != nil {
-		logrus.Errorf("failed to scrape timestamp: %s (%v)", stderr, err)
+		klog.Errorf("failed to scrape timestamp: %s (%v)", stderr, err)
 		return 0
 	}
 
 	out, err := strconv.ParseFloat(output, 64)
 	if err != nil {
-		logrus.Errorf("failed to parse timestamp %s: %v", output, err)
+		klog.Errorf("failed to parse timestamp %s: %v", output, err)
 		return 0
 	}
 	return out
@@ -81,7 +81,7 @@ func startOvnUpdater() {
 				_, stderr, err := util.RunOVNNbctl("set", "NB_Global", ".",
 					fmt.Sprintf(`options:e2e_timestamp="%d"`, t))
 				if err != nil {
-					logrus.Errorf("failed to bump timestamp: %s (%v)", stderr, err)
+					klog.Errorf("failed to bump timestamp: %s (%v)", stderr, err)
 				} else {
 					metricE2ETimestamp.Set(float64(t))
 				}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 )
 
 func (oc *Controller) syncNetworkPoliciesPortGroup(
@@ -17,7 +17,7 @@ func (oc *Controller) syncNetworkPoliciesPortGroup(
 	for _, npInterface := range networkPolicies {
 		policy, ok := npInterface.(*knet.NetworkPolicy)
 		if !ok {
-			logrus.Errorf("Spurious object in syncNetworkPolicies: %v",
+			klog.Errorf("Spurious object in syncNetworkPolicies: %v",
 				npInterface)
 			continue
 		}
@@ -45,7 +45,7 @@ func (oc *Controller) syncNetworkPoliciesPortGroup(
 		}
 	})
 	if err != nil {
-		logrus.Errorf("Error in syncing network policies: %v", err)
+		klog.Errorf("Error in syncing network policies: %v", err)
 	}
 }
 
@@ -67,7 +67,7 @@ func addACLAllow(np *namespacePolicy, match, l4Match string, ipBlockCidr bool, g
 		fmt.Sprintf("external-ids:%s_num=%d", policyType, gressNum),
 		fmt.Sprintf("external-ids:policy_type=%s", policyType))
 	if err != nil {
-		logrus.Errorf("find failed to get the allow rule for "+
+		klog.Errorf("find failed to get the allow rule for "+
 			"namespace=%s, policy=%s, stderr: %q (%v)",
 			np.namespace, np.name, stderr, err)
 		return
@@ -89,7 +89,7 @@ func addACLAllow(np *namespacePolicy, match, l4Match string, ipBlockCidr bool, g
 		fmt.Sprintf("external-ids:policy_type=%s", policyType),
 		"--", "add", "port_group", np.portGroupUUID, "acls", "@acl")
 	if err != nil {
-		logrus.Errorf("failed to create the acl allow rule for "+
+		klog.Errorf("failed to create the acl allow rule for "+
 			"namespace=%s, policy=%s, stderr: %q (%v)", np.namespace,
 			np.name, stderr, err)
 		return
@@ -104,7 +104,7 @@ func modifyACLAllow(namespace, policy, oldMatch string, newMatch string, gressNu
 		fmt.Sprintf("external-ids:%s_num=%d", policyType, gressNum),
 		fmt.Sprintf("external-ids:policy_type=%s", policyType))
 	if err != nil {
-		logrus.Errorf("find failed to get the allow rule for "+
+		klog.Errorf("find failed to get the allow rule for "+
 			"namespace=%s, policy=%s, stderr: %q (%v)",
 			namespace, policy, stderr, err)
 		return
@@ -115,7 +115,7 @@ func modifyACLAllow(namespace, policy, oldMatch string, newMatch string, gressNu
 		_, stderr, err = util.RunOVNNbctl("set", "acl", uuid,
 			newMatch)
 		if err != nil {
-			logrus.Errorf("failed to modify the allow-from rule for "+
+			klog.Errorf("failed to modify the allow-from rule for "+
 				"namespace=%s, policy=%s, stderr: %q (%v)",
 				namespace, policy, stderr, err)
 		}
@@ -143,7 +143,7 @@ func addIPBlockACLDeny(np *namespacePolicy, except, priority string, gressNum in
 		fmt.Sprintf("external-ids:%s_num=%d", policyType, gressNum),
 		fmt.Sprintf("external-ids:policy=%s", np.name))
 	if err != nil {
-		logrus.Errorf("find failed to get the ipblock default deny rule for "+
+		klog.Errorf("find failed to get the ipblock default deny rule for "+
 			"namespace=%s, policy=%s stderr: %q, (%v)",
 			np.namespace, np.name, stderr, err)
 		return
@@ -163,7 +163,7 @@ func addIPBlockACLDeny(np *namespacePolicy, except, priority string, gressNum in
 		"--", "add", "port_group", np.portGroupUUID,
 		"acls", "@acl")
 	if err != nil {
-		logrus.Errorf("error executing create ACL command, stderr: %q, %+v",
+		klog.Errorf("error executing create ACL command, stderr: %q, %+v",
 			stderr, err)
 	}
 }
@@ -401,7 +401,7 @@ func (oc *Controller) createMulticastAllowPolicy(ns string) error {
 	// Add all ports from this namespace to the multicast allow group.
 	for _, portName := range oc.namespaceAddressSet[ns] {
 		if err := oc.podAddAllowMulticastPolicy(ns, portName); err != nil {
-			logrus.Warningf("failed to add port %s to port group ACL: %v", portName, err)
+			klog.Warningf("failed to add port %s to port group ACL: %v", portName, err)
 		}
 	}
 
@@ -497,12 +497,12 @@ func (oc *Controller) localPodAddDefaultDeny(
 
 	err := oc.createDefaultDenyPortGroup(knet.PolicyTypeIngress)
 	if err != nil {
-		logrus.Errorf(err.Error())
+		klog.Errorf(err.Error())
 		return
 	}
 	err = oc.createDefaultDenyPortGroup(knet.PolicyTypeEgress)
 	if err != nil {
-		logrus.Errorf(err.Error())
+		klog.Errorf(err.Error())
 		return
 	}
 
@@ -521,7 +521,7 @@ func (oc *Controller) localPodAddDefaultDeny(
 	if !(len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) {
 		if oc.lspIngressDenyCache[logicalPort] == 0 {
 			if err := oc.addToPortGroup(oc.portGroupIngressDeny, logicalPort); err != nil {
-				logrus.Warningf("failed to add port %s to ingress deny ACL: %v", logicalPort, err)
+				klog.Warningf("failed to add port %s to ingress deny ACL: %v", logicalPort, err)
 			}
 		}
 		oc.lspIngressDenyCache[logicalPort]++
@@ -532,7 +532,7 @@ func (oc *Controller) localPodAddDefaultDeny(
 		len(policy.Spec.Egress) > 0 || len(policy.Spec.PolicyTypes) == 2 {
 		if oc.lspEgressDenyCache[logicalPort] == 0 {
 			if err := oc.addToPortGroup(oc.portGroupEgressDeny, logicalPort); err != nil {
-				logrus.Warningf("failed to add port %s to egress deny ACL: %v", logicalPort, err)
+				klog.Warningf("failed to add port %s to egress deny ACL: %v", logicalPort, err)
 			}
 		}
 		oc.lspEgressDenyCache[logicalPort]++
@@ -549,7 +549,7 @@ func (oc *Controller) localPodDelDefaultDeny(
 			oc.lspIngressDenyCache[logicalPort]--
 			if oc.lspIngressDenyCache[logicalPort] == 0 {
 				if err := oc.deleteFromPortGroup(oc.portGroupIngressDeny, logicalPort); err != nil {
-					logrus.Warningf("failed to remove port %s from ingress deny ACL: %v", logicalPort, err)
+					klog.Warningf("failed to remove port %s from ingress deny ACL: %v", logicalPort, err)
 				}
 			}
 		}
@@ -561,7 +561,7 @@ func (oc *Controller) localPodDelDefaultDeny(
 			oc.lspEgressDenyCache[logicalPort]--
 			if oc.lspEgressDenyCache[logicalPort] == 0 {
 				if err := oc.deleteFromPortGroup(oc.portGroupEgressDeny, logicalPort); err != nil {
-					logrus.Warningf("failed to remove port %s from egress deny ACL: %v", logicalPort, err)
+					klog.Warningf("failed to remove port %s from egress deny ACL: %v", logicalPort, err)
 				}
 			}
 		}
@@ -585,7 +585,7 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(
 	logicalPort := podLogicalPortName(pod)
 	logicalPortUUID, err := oc.getLogicalPortUUID(logicalPort)
 	if err != nil {
-		logrus.Errorf(err.Error())
+		klog.Errorf(err.Error())
 		return
 	}
 
@@ -610,7 +610,7 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(
 		"port_group", np.portGroupUUID, "ports", logicalPortUUID, "--",
 		"add", "port_group", np.portGroupUUID, "ports", logicalPortUUID)
 	if err != nil {
-		logrus.Errorf("Failed to add logicalPort %s to portGroup %s "+
+		klog.Errorf("Failed to add logicalPort %s to portGroup %s "+
 			"stderr: %q (%v)", logicalPort, np.portGroupUUID, stderr, err)
 	}
 
@@ -649,7 +649,7 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 
 	logicalPortUUID, err := oc.getLogicalPortUUID(logicalPort)
 	if err != nil {
-		logrus.Errorf(err.Error())
+		klog.Errorf(err.Error())
 		return
 	}
 	if np.portGroupUUID == "" {
@@ -659,7 +659,7 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 	_, stderr, err := util.RunOVNNbctl("--if-exists", "remove",
 		"port_group", np.portGroupUUID, "ports", logicalPortUUID)
 	if err != nil {
-		logrus.Errorf("Failed to delete logicalPort %s from portGroup %s "+
+		klog.Errorf("Failed to delete logicalPort %s from portGroup %s "+
 			"stderr: %q (%v)", logicalPort, np.portGroupUUID, stderr, err)
 	}
 }
@@ -681,7 +681,7 @@ func (oc *Controller) handleLocalPodSelector(
 			},
 		}, nil)
 	if err != nil {
-		logrus.Errorf("error watching local pods for policy %s in namespace %s: %v",
+		klog.Errorf("error watching local pods for policy %s in namespace %s: %v",
 			policy.Name, policy.Namespace, err)
 		return
 	}
@@ -731,7 +731,7 @@ func hasAnyLabelSelector(peers []knet.NetworkPolicyPeer) bool {
 // addNetworkPolicyPortGroup creates and applies OVN ACLs to pod logical switch
 // ports from Kubernetes NetworkPolicy objects using OVN Port Groups
 func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
-	logrus.Infof("Adding network policy %s in namespace %s", policy.Name,
+	klog.Infof("Adding network policy %s in namespace %s", policy.Name,
 		policy.Namespace)
 
 	if oc.namespacePolicies[policy.Namespace] != nil &&
@@ -741,7 +741,7 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 
 	err := oc.waitForNamespaceEvent(policy.Namespace)
 	if err != nil {
-		logrus.Errorf("failed to wait for namespace %s event (%v)",
+		klog.Errorf("failed to wait for namespace %s event (%v)",
 			policy.Namespace, err)
 		return
 	}
@@ -755,7 +755,7 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 
 	np.portGroupUUID, err = createPortGroup(readableGroupName, np.portGroupName)
 	if err != nil {
-		logrus.Errorf("Failed to create port_group for network policy %s in "+
+		klog.Errorf("Failed to create port_group for network policy %s in "+
 			"namespace %s", policy.Name, policy.Namespace)
 		return
 	}
@@ -763,7 +763,7 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 	// Go through each ingress rule.  For each ingress rule, create an
 	// addressSet for the peer pods.
 	for i, ingressJSON := range policy.Spec.Ingress {
-		logrus.Debugf("Network policy ingress is %+v", ingressJSON)
+		klog.V(5).Infof("Network policy ingress is %+v", ingressJSON)
 
 		ingress := newGressPolicy(knet.PolicyTypeIngress, i)
 
@@ -824,7 +824,7 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 	// Go through each egress rule.  For each egress rule, create an
 	// addressSet for the peer pods.
 	for i, egressJSON := range policy.Spec.Egress {
-		logrus.Debugf("Network policy egress is %+v", egressJSON)
+		klog.V(5).Infof("Network policy egress is %+v", egressJSON)
 
 		egress := newGressPolicy(knet.PolicyTypeEgress, i)
 
@@ -891,12 +891,12 @@ func (oc *Controller) addNetworkPolicyPortGroup(policy *knet.NetworkPolicy) {
 
 func (oc *Controller) deleteNetworkPolicyPortGroup(
 	policy *knet.NetworkPolicy) {
-	logrus.Infof("Deleting network policy %s in namespace %s",
+	klog.Infof("Deleting network policy %s in namespace %s",
 		policy.Name, policy.Namespace)
 
 	if oc.namespacePolicies[policy.Namespace] == nil ||
 		oc.namespacePolicies[policy.Namespace][policy.Name] == nil {
-		logrus.Errorf("Delete network policy %s in namespace %s "+
+		klog.Errorf("Delete network policy %s in namespace %s "+
 			"received without getting a create event",
 			policy.Name, policy.Namespace)
 		return

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -10,11 +10,11 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 )
 
 type namespacePolicy struct {
@@ -279,7 +279,7 @@ func (oc *Controller) handlePeerPodSelector(
 			},
 		}, nil)
 	if err != nil {
-		logrus.Errorf("error watching peer pods for policy %s in namespace %s: %v",
+		klog.Errorf("error watching peer pods for policy %s in namespace %s: %v",
 			policy.Name, policy.Namespace, err)
 		return
 	}
@@ -317,7 +317,7 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(policy *knet.NetworkPoli
 						},
 					}, nil)
 				if err != nil {
-					logrus.Errorf("error watching pods in namespace %s for policy %s: %v", namespace.Name, policy.Name, err)
+					klog.Errorf("error watching pods in namespace %s for policy %s: %v", namespace.Name, policy.Name, err)
 					return
 				}
 				np.Lock()
@@ -334,7 +334,7 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(policy *knet.NetworkPoli
 			},
 		}, nil)
 	if err != nil {
-		logrus.Errorf("error watching namespaces for policy %s: %v",
+		klog.Errorf("error watching namespaces for policy %s: %v",
 			policy.Name, err)
 		return
 	}
@@ -382,7 +382,7 @@ func (oc *Controller) handlePeerNamespaceSelector(
 			},
 		}, nil)
 	if err != nil {
-		logrus.Errorf("error watching namespaces for policy %s: %v",
+		klog.Errorf("error watching namespaces for policy %s: %v",
 			policy.Name, err)
 		return
 	}

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 )
 
 func (oc *Controller) syncNetworkPoliciesOld(networkPolicies []interface{}) {
@@ -16,7 +16,7 @@ func (oc *Controller) syncNetworkPoliciesOld(networkPolicies []interface{}) {
 	for _, npInterface := range networkPolicies {
 		policy, ok := npInterface.(*knet.NetworkPolicy)
 		if !ok {
-			logrus.Errorf("Spurious object in syncNetworkPolicies: %v",
+			klog.Errorf("Spurious object in syncNetworkPolicies: %v",
 				npInterface)
 			continue
 		}
@@ -35,7 +35,7 @@ func (oc *Controller) syncNetworkPoliciesOld(networkPolicies []interface{}) {
 		}
 	})
 	if err != nil {
-		logrus.Errorf("Error in syncing network policies: %v", err)
+		klog.Errorf("Error in syncing network policies: %v", err)
 	}
 }
 
@@ -60,7 +60,7 @@ func addACLAllowOld(namespace, policy, logicalSwitch, logicalPort, match, l4Matc
 		fmt.Sprintf("external-ids:logical_switch=%s", logicalSwitch),
 		fmt.Sprintf("external-ids:logical_port=%s", logicalPort))
 	if err != nil {
-		logrus.Errorf("find failed to get the allow rule for "+
+		klog.Errorf("find failed to get the allow rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q (%v)",
 			namespace, logicalPort, stderr, err)
 		return
@@ -84,7 +84,7 @@ func addACLAllowOld(namespace, policy, logicalSwitch, logicalPort, match, l4Matc
 		fmt.Sprintf("external-ids:logical_port=%s", logicalPort),
 		"--", "add", "logical_switch", logicalSwitch, "acls", "@acl")
 	if err != nil {
-		logrus.Errorf("failed to create the allow-from rule for "+
+		klog.Errorf("failed to create the allow-from rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q (%v)", namespace,
 			logicalPort, stderr, err)
 		return
@@ -101,7 +101,7 @@ func modifyACLAllowOld(namespace, policy, logicalPort, oldMatch string, newMatch
 		fmt.Sprintf("external-ids:policy_type=%s", policyType),
 		fmt.Sprintf("external-ids:logical_port=%s", logicalPort))
 	if err != nil {
-		logrus.Errorf("find failed to get the allow rule for "+
+		klog.Errorf("find failed to get the allow rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q (%v)",
 			namespace, logicalPort, stderr, err)
 		return
@@ -112,7 +112,7 @@ func modifyACLAllowOld(namespace, policy, logicalPort, oldMatch string, newMatch
 		_, stderr, err = util.RunOVNNbctl("set", "acl", uuid,
 			newMatch)
 		if err != nil {
-			logrus.Errorf("failed to modify the allow-from rule for "+
+			klog.Errorf("failed to modify the allow-from rule for "+
 				"namespace=%s, logical_port=%s, stderr: %q (%v)",
 				namespace, logicalPort, stderr, err)
 		}
@@ -133,21 +133,21 @@ func deleteACLAllowOld(namespace, policy, logicalSwitch, logicalPort, match, l4M
 		fmt.Sprintf("external-ids:logical_switch=%s", logicalSwitch),
 		fmt.Sprintf("external-ids:logical_port=%s", logicalPort))
 	if err != nil {
-		logrus.Errorf("find failed to get the allow rule for "+
+		klog.Errorf("find failed to get the allow rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q, (%v)",
 			namespace, logicalPort, stderr, err)
 		return
 	}
 
 	if uuid == "" {
-		logrus.Infof("deleteACLAllow: returning because find returned empty")
+		klog.Infof("deleteACLAllow: returning because find returned empty")
 		return
 	}
 
 	_, stderr, err = util.RunOVNNbctl("remove", "logical_switch",
 		logicalSwitch, "acls", uuid)
 	if err != nil {
-		logrus.Errorf("remove failed to delete the allow-from rule for "+
+		klog.Errorf("remove failed to delete the allow-from rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q (%v)", namespace,
 			logicalPort, stderr, err)
 		return
@@ -176,7 +176,7 @@ func addIPBlockACLDenyOld(namespace, policy, logicalSwitch, logicalPort, except,
 		fmt.Sprintf("external-ids:logical_switch=%s", logicalSwitch),
 		fmt.Sprintf("external-ids:logical_port=%s", logicalPort))
 	if err != nil {
-		logrus.Errorf("find failed to get the default deny rule for "+
+		klog.Errorf("find failed to get the default deny rule for "+
 			"namespace=%s, logical_port=%s stderr: %q, (%v)",
 			namespace, logicalPort, stderr, err)
 		return
@@ -197,7 +197,7 @@ func addIPBlockACLDenyOld(namespace, policy, logicalSwitch, logicalPort, except,
 		"--", "add", "logical_switch", logicalSwitch,
 		"acls", "@acl")
 	if err != nil {
-		logrus.Errorf("error executing create ACL command, stderr: %q, %+v",
+		klog.Errorf("error executing create ACL command, stderr: %q, %+v",
 			stderr, err)
 	}
 }
@@ -223,7 +223,7 @@ func deleteIPBlockACLDenyOld(namespace, policy, logicalSwitch, logicalPort, exce
 		fmt.Sprintf("external-ids:logical_switch=%s", logicalSwitch),
 		fmt.Sprintf("external-ids:logical_port=%s", logicalPort))
 	if err != nil {
-		logrus.Errorf("find failed to get the default deny rule for "+
+		klog.Errorf("find failed to get the default deny rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q. (%v)",
 			namespace, logicalPort, stderr, err)
 		return
@@ -236,7 +236,7 @@ func deleteIPBlockACLDenyOld(namespace, policy, logicalSwitch, logicalPort, exce
 	_, stderr, err = util.RunOVNNbctl("remove", "logical_switch",
 		logicalSwitch, "acls", uuid)
 	if err != nil {
-		logrus.Errorf("remove failed to delete the deny rule for "+
+		klog.Errorf("remove failed to delete the deny rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q (%v)",
 			namespace, logicalPort, stderr, err)
 		return
@@ -259,7 +259,7 @@ func addACLDenyOld(namespace, logicalSwitch, logicalPort, priority string, polic
 		fmt.Sprintf("external-ids:logical_switch=%s", logicalSwitch),
 		fmt.Sprintf("external-ids:logical_port=%s", logicalPort))
 	if err != nil {
-		logrus.Errorf("find failed to get the default deny rule for "+
+		klog.Errorf("find failed to get the default deny rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q (%v)", namespace,
 			logicalPort, stderr, err)
 		return
@@ -279,7 +279,7 @@ func addACLDenyOld(namespace, logicalSwitch, logicalPort, priority string, polic
 		"--", "add", "logical_switch", logicalSwitch,
 		"acls", "@acl")
 	if err != nil {
-		logrus.Errorf("error executing create ACL command, stderr: %q, %+v",
+		klog.Errorf("error executing create ACL command, stderr: %q, %+v",
 			stderr, err)
 	}
 }
@@ -299,7 +299,7 @@ func deleteACLDenyOld(namespace, logicalSwitch, logicalPort string, policyType k
 		fmt.Sprintf("external-ids:logical_switch=%s", logicalSwitch),
 		fmt.Sprintf("external-ids:logical_port=%s", logicalPort))
 	if err != nil {
-		logrus.Errorf("find failed to get the default deny rule for "+
+		klog.Errorf("find failed to get the default deny rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q, (%v)",
 			namespace, logicalPort, stderr, err)
 		return
@@ -312,7 +312,7 @@ func deleteACLDenyOld(namespace, logicalSwitch, logicalPort string, policyType k
 	_, stderr, err = util.RunOVNNbctl("remove", "logical_switch",
 		logicalSwitch, "acls", uuid)
 	if err != nil {
-		logrus.Errorf("remove failed to delete the deny rule for "+
+		klog.Errorf("remove failed to delete the deny rule for "+
 			"namespace=%s, logical_port=%s, stderr: %q (%v)",
 			namespace, logicalPort, stderr, err)
 		return
@@ -325,14 +325,14 @@ func deleteAclsPolicyOld(namespace, policy string) {
 		fmt.Sprintf("external-ids:namespace=%s", namespace),
 		fmt.Sprintf("external-ids:policy=%s", policy))
 	if err != nil {
-		logrus.Errorf("find failed to get the allow rule for "+
+		klog.Errorf("find failed to get the allow rule for "+
 			"namespace=%s, policy=%s, stderr: %q (%v)",
 			namespace, policy, stderr, err)
 		return
 	}
 
 	if uuids == "" {
-		logrus.Debugf("deleteAclsPolicy: returning because find " +
+		klog.V(5).Infof("deleteAclsPolicy: returning because find " +
 			"returned no ACLs")
 		return
 	}
@@ -344,7 +344,7 @@ func deleteAclsPolicyOld(namespace, policy string) {
 			"--no-heading", "--columns=_uuid", "find", "logical_switch",
 			fmt.Sprintf("acls{>=}%s", uuid))
 		if err != nil {
-			logrus.Errorf("find failed to get the logical_switch of acl"+
+			klog.Errorf("find failed to get the logical_switch of acl"+
 				"uuid=%s, stderr: %q (%v)", uuid, stderr, err)
 			continue
 		}
@@ -356,7 +356,7 @@ func deleteAclsPolicyOld(namespace, policy string) {
 		_, stderr, err = util.RunOVNNbctl("remove", "logical_switch",
 			logicalSwitch, "acls", uuid)
 		if err != nil {
-			logrus.Errorf("remove failed to delete the allow-from rule %s for"+
+			klog.Errorf("remove failed to delete the allow-from rule %s for"+
 				" namespace=%s, policy=%s, logical_switch=%s, stderr: %q (%v)",
 				uuid, namespace, policy, logicalSwitch, stderr, err)
 			continue
@@ -615,7 +615,7 @@ func (oc *Controller) handleLocalPodSelectorOld(
 			},
 		}, nil)
 	if err != nil {
-		logrus.Errorf("error watching local pods for policy %s in namespace %s: %v",
+		klog.Errorf("error watching local pods for policy %s in namespace %s: %v",
 			policy.Name, policy.Namespace, err)
 		return
 	}
@@ -660,7 +660,7 @@ func (oc *Controller) handlePeerNamespaceSelectorModifyOld(
 // addNetworkPolicyOld creates and applies OVN ACLs to pod logical switch
 // ports from Kubernetes NetworkPolicy objects without using OVN Port Groups
 func (oc *Controller) addNetworkPolicyOld(policy *knet.NetworkPolicy) {
-	logrus.Infof("Adding network policy %s in namespace %s", policy.Name,
+	klog.Infof("Adding network policy %s in namespace %s", policy.Name,
 		policy.Namespace)
 
 	if oc.namespacePolicies[policy.Namespace] != nil &&
@@ -670,7 +670,7 @@ func (oc *Controller) addNetworkPolicyOld(policy *knet.NetworkPolicy) {
 
 	err := oc.waitForNamespaceEvent(policy.Namespace)
 	if err != nil {
-		logrus.Errorf("failed to wait for namespace %s event (%v)",
+		klog.Errorf("failed to wait for namespace %s event (%v)",
 			policy.Namespace, err)
 		return
 	}
@@ -680,7 +680,7 @@ func (oc *Controller) addNetworkPolicyOld(policy *knet.NetworkPolicy) {
 	// Go through each ingress rule.  For each ingress rule, create an
 	// addressSet for the peer pods.
 	for i, ingressJSON := range policy.Spec.Ingress {
-		logrus.Debugf("Network policy ingress is %+v", ingressJSON)
+		klog.V(5).Infof("Network policy ingress is %+v", ingressJSON)
 
 		ingress := newGressPolicy(knet.PolicyTypeIngress, i)
 
@@ -737,7 +737,7 @@ func (oc *Controller) addNetworkPolicyOld(policy *knet.NetworkPolicy) {
 	// Go through each egress rule.  For each egress rule, create an
 	// addressSet for the peer pods.
 	for i, egressJSON := range policy.Spec.Egress {
-		logrus.Debugf("Network policy egress is %+v", egressJSON)
+		klog.V(5).Infof("Network policy egress is %+v", egressJSON)
 
 		egress := newGressPolicy(knet.PolicyTypeEgress, i)
 
@@ -806,12 +806,12 @@ func (oc *Controller) getLogicalSwitchForLogicalPort(
 	logicalSwitch, stderr, err := util.RunOVNNbctl("get",
 		"logical_switch_port", logicalPort, "external-ids:logical_switch")
 	if err != nil {
-		logrus.Errorf("Error obtaining logical switch for %s, stderr: %q (%v)",
+		klog.Errorf("Error obtaining logical switch for %s, stderr: %q (%v)",
 			logicalPort, stderr, err)
 		return ""
 	}
 	if logicalSwitch == "" {
-		logrus.Errorf("Error obtaining logical switch for %s",
+		klog.Errorf("Error obtaining logical switch for %s",
 			logicalPort)
 		return ""
 	}
@@ -820,12 +820,12 @@ func (oc *Controller) getLogicalSwitchForLogicalPort(
 
 func (oc *Controller) deleteNetworkPolicyOld(
 	policy *knet.NetworkPolicy) {
-	logrus.Infof("Deleting network policy %s in namespace %s",
+	klog.Infof("Deleting network policy %s in namespace %s",
 		policy.Name, policy.Namespace)
 
 	if oc.namespacePolicies[policy.Namespace] == nil ||
 		oc.namespacePolicies[policy.Namespace][policy.Name] == nil {
-		logrus.Errorf("Delete network policy %s in namespace %s "+
+		klog.Errorf("Delete network policy %s in namespace %s "+
 			"received without getting a create event",
 			policy.Name, policy.Namespace)
 		return

--- a/go-controller/pkg/util/gateway-cleanup.go
+++ b/go-controller/pkg/util/gateway-cleanup.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 )
 
 // GatewayCleanup removes all the NB DB objects created for a node's gateway
@@ -103,7 +103,7 @@ func staticRouteCleanup(clusterRouter string, nextHops []string) {
 			"--columns=_uuid", "find", "logical_router_static_route",
 			"nexthop=\""+nextHop+"\"")
 		if err != nil {
-			logrus.Errorf("Failed to fetch all routes with "+
+			klog.Errorf("Failed to fetch all routes with "+
 				"IP %s as nexthop, stderr: %q, "+
 				"error: %v", nextHop, stderr, err)
 			continue
@@ -115,7 +115,7 @@ func staticRouteCleanup(clusterRouter string, nextHops []string) {
 			_, stderr, err = RunOVNNbctl("--if-exists", "remove",
 				"logical_router", clusterRouter, "static_routes", route)
 			if err != nil {
-				logrus.Errorf("Failed to delete static route %s"+
+				klog.Errorf("Failed to delete static route %s"+
 					", stderr: %q, err = %v", route, stderr, err)
 				continue
 			}

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 )
@@ -61,7 +61,7 @@ func GetDefaultGatewayRouterIP() (string, net.IP, error) {
 				if ip := net.ParseIP(ipStr); ip != nil {
 					routers = append(routers, gwRouter{parts[0], ip})
 				} else {
-					logrus.Warnf("failed to parse gateway router %q IP %q", parts[0], ipStr)
+					klog.Warningf("failed to parse gateway router %q IP %q", parts[0], ipStr)
 				}
 			}
 		}

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"k8s.io/klog"
 )
 
 const (
@@ -45,17 +45,17 @@ func saveIPAddress(oldLink, newLink netlink.Link, addrs []netlink.Addr) error {
 
 		// Remove from oldLink
 		if err := netlink.AddrDel(oldLink, &addr); err != nil {
-			logrus.Errorf("Remove addr from %q failed: %v", oldLink.Attrs().Name, err)
+			klog.Errorf("Remove addr from %q failed: %v", oldLink.Attrs().Name, err)
 			return err
 		}
 
 		// Add to newLink
 		addr.Label = newLink.Attrs().Name
 		if err := netlink.AddrAdd(newLink, &addr); err != nil {
-			logrus.Errorf("Add addr to newLink %q failed: %v", newLink.Attrs().Name, err)
+			klog.Errorf("Add addr to newLink %q failed: %v", newLink.Attrs().Name, err)
 			return err
 		}
-		logrus.Infof("Successfully saved addr %q to newLink %q", addr.String(), newLink.Attrs().Name)
+		klog.Infof("Successfully saved addr %q to newLink %q", addr.String(), newLink.Attrs().Name)
 	}
 
 	return netlink.LinkSetUp(newLink)
@@ -65,18 +65,18 @@ func saveIPAddress(oldLink, newLink netlink.Link, addrs []netlink.Addr) error {
 func delAddRoute(oldLink, newLink netlink.Link, route netlink.Route) error {
 	// Remove route from old interface
 	if err := netlink.RouteDel(&route); err != nil && !strings.Contains(err.Error(), "no such process") {
-		logrus.Errorf("Remove route from %q failed: %v", oldLink.Attrs().Name, err)
+		klog.Errorf("Remove route from %q failed: %v", oldLink.Attrs().Name, err)
 		return err
 	}
 
 	// Add route to newLink
 	route.LinkIndex = newLink.Attrs().Index
 	if err := netlink.RouteAdd(&route); err != nil && !os.IsExist(err) {
-		logrus.Errorf("Add route to newLink %q failed: %v", newLink.Attrs().Name, err)
+		klog.Errorf("Add route to newLink %q failed: %v", newLink.Attrs().Name, err)
 		return err
 	}
 
-	logrus.Infof("Successfully saved route %q", route.String())
+	klog.Infof("Successfully saved route %q", route.String())
 	return nil
 }
 
@@ -115,7 +115,7 @@ func saveRoute(oldLink, newLink netlink.Link, routes []netlink.Route) error {
 func setupDefaultFile() {
 	platform, err := runningPlatform()
 	if err != nil {
-		logrus.Errorf("Failed to set OVS package default file (%v)", err)
+		klog.Errorf("Failed to set OVS package default file (%v)", err)
 		return
 	}
 
@@ -132,7 +132,7 @@ func setupDefaultFile() {
 
 	fileContents, err := ioutil.ReadFile(defaultFile)
 	if err != nil {
-		logrus.Warningf("failed to parse file %s (%v)",
+		klog.Warningf("failed to parse file %s (%v)",
 			defaultFile, err)
 		return
 	}
@@ -149,13 +149,13 @@ func setupDefaultFile() {
 	// We should set it.
 	f, err := os.OpenFile(defaultFile, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
-		logrus.Errorf("failed to open %s to write (%v)", defaultFile, err)
+		klog.Errorf("failed to open %s to write (%v)", defaultFile, err)
 		return
 	}
 	defer f.Close()
 
 	if _, err = f.WriteString(text); err != nil {
-		logrus.Errorf("failed to write to %s (%v)",
+		klog.Errorf("failed to write to %s (%v)",
 			defaultFile, err)
 		return
 	}
@@ -179,10 +179,10 @@ func NicToBridge(iface string) (string, error) {
 		"--", "--may-exist", "add-port", bridge, iface,
 		"--", "set", "port", iface, "other-config:transient=true")
 	if err != nil {
-		logrus.Errorf("Failed to create OVS bridge, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+		klog.Errorf("Failed to create OVS bridge, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return "", err
 	}
-	logrus.Infof("Successfully created OVS bridge %q", bridge)
+	klog.Infof("Successfully created OVS bridge %q", bridge)
 
 	setupDefaultFile()
 
@@ -256,7 +256,7 @@ func BridgeToNic(bridge string) error {
 	// interface and delete that interface from the integration bridge
 	stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)
 	if err != nil {
-		logrus.Errorf("Failed to get interfaces for OVS bridge: %q, "+
+		klog.Errorf("Failed to get interfaces for OVS bridge: %q, "+
 			"stderr: %q, error: %v", bridge, stderr, err)
 		return err
 	}
@@ -264,7 +264,7 @@ func BridgeToNic(bridge string) error {
 	for _, iface := range ifacesList {
 		stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "type")
 		if err != nil {
-			logrus.Warnf("Failed to determine the type of interface: %q, "+
+			klog.Warningf("Failed to determine the type of interface: %q, "+
 				"stderr: %q, error: %v", iface, stderr, err)
 			continue
 		} else if stdout != "patch" {
@@ -272,7 +272,7 @@ func BridgeToNic(bridge string) error {
 		}
 		stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")
 		if err != nil {
-			logrus.Warnf("Failed to get the peer port for patch interface: %q, "+
+			klog.Warningf("Failed to get the peer port for patch interface: %q, "+
 				"stderr: %q, error: %v", iface, stderr, err)
 			continue
 		}
@@ -280,7 +280,7 @@ func BridgeToNic(bridge string) error {
 		peer := strings.TrimSpace(stdout)
 		_, stderr, err = RunOVSVsctl("--if-exists", "del-port", "br-int", peer)
 		if err != nil {
-			logrus.Warnf("Failed to delete patch port %q on br-int, "+
+			klog.Warningf("Failed to delete patch port %q on br-int, "+
 				"stderr: %q, error: %v", peer, stderr, err)
 		}
 	}
@@ -288,9 +288,9 @@ func BridgeToNic(bridge string) error {
 	// Now delete the bridge
 	stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)
 	if err != nil {
-		logrus.Errorf("Failed to delete OVS bridge, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+		klog.Errorf("Failed to delete OVS bridge, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
 	}
-	logrus.Infof("Successfully deleted OVS bridge %q", bridge)
+	klog.Infof("Successfully deleted OVS bridge %q", bridge)
 	return nil
 }

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -4,15 +4,14 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/klog"
+	kexec "k8s.io/utils/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync/atomic"
 	"time"
 	"unicode"
-
-	"github.com/sirupsen/logrus"
-	kexec "k8s.io/utils/exec"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 )
@@ -203,13 +202,13 @@ func runCmd(cmd kexec.Cmd, cmdPath string, args ...string) (*bytes.Buffer, *byte
 
 	counter := atomic.AddUint64(&runCounter, 1)
 	logCmd := fmt.Sprintf("%s %s", cmdPath, strings.Join(args, " "))
-	logrus.Debugf("exec(%d): %s", counter, logCmd)
+	klog.V(5).Infof("exec(%d): %s", counter, logCmd)
 
 	err := cmd.Run()
-	logrus.Debugf("exec(%d): stdout: %q", counter, stdout)
-	logrus.Debugf("exec(%d): stderr: %q", counter, stderr)
+	klog.V(5).Infof("exec(%d): stdout: %q", counter, stdout)
+	klog.V(5).Infof("exec(%d): stderr: %q", counter, stderr)
 	if err != nil {
-		logrus.Debugf("exec(%d): err: %v", counter, err)
+		klog.V(5).Infof("exec(%d): err: %v", counter, err)
 	}
 	return stdout, stderr, err
 }
@@ -286,12 +285,12 @@ func getNbctlArgsAndEnv(timeout int, args ...string) ([]string, []string) {
 			envVars = append(envVars,
 				fmt.Sprintf("OVN_NB_DAEMON=%sovn-nbctl.%s.ctl", runner.ovnRunDir,
 					strings.Trim(string(pid), " \n")))
-			logrus.Debugf("using ovn-nbctl daemon mode at %s", envVars)
+			klog.V(5).Infof("using ovn-nbctl daemon mode at %s", envVars)
 			cmdArgs = append(cmdArgs, fmt.Sprintf("--timeout=%d", timeout))
 			cmdArgs = append(cmdArgs, args...)
 			return cmdArgs, envVars
 		}
-		logrus.Warningf("failed to retrieve ovn-nbctl daemon's control socket " +
+		klog.Warningf("failed to retrieve ovn-nbctl daemon's control socket " +
 			"so resorting to non-daemon mode")
 	}
 

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"k8s.io/klog"
 )
 
 // StringArg gets the named command-line argument or returns an error if it is empty
@@ -32,7 +32,7 @@ func GetNodeChassisID() (string, error) {
 	chassisID, stderr, err := RunOVSVsctl("--if-exists", "get",
 		"Open_vSwitch", ".", "external_ids:system-id")
 	if err != nil {
-		logrus.Errorf("No system-id configured in the local host, "+
+		klog.Errorf("No system-id configured in the local host, "+
 			"stderr: %q, error: %v", stderr, err)
 		return "", err
 	}
@@ -112,7 +112,7 @@ func MarshalPodAnnotation(podInfo *PodAnnotation) (map[string]string, error) {
 	}
 	bytes, err := json.Marshal(podNetworks)
 	if err != nil {
-		logrus.Errorf("failed marshaling podNetworks map %v", podNetworks)
+		klog.Errorf("failed marshaling podNetworks map %v", podNetworks)
 		return nil, err
 	}
 	return map[string]string{


### PR DESCRIPTION
This PR deals with https://github.com/ovn-org/ovn-kubernetes/issues/1006 

It keeps the previously defined ovnkube flag: `loglevel` and sets `klog`s verbosity level through that. This is in contradiction to `klog`s standard verbosity setting - which is done by parsing the user defined flag `-v`. This cannot be done however as the package `github.com/urfave/cli` is directly incompatible with `klog` as it implements the default arg `-v = version`.  

This PR keeps the previous functionality of attaching debug logs to level 5. `klog` can dump a much more verbose output (client - server requests for example) if the log level is bigger than that

@danwinship @girishmg @dcbw 
