### PR TITLE
add the ability for ovn-kubernetes to ignore a node by label

### DIFF
--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -143,6 +143,7 @@ apiserver=https://1.2.3.4:6443
 token=TG9yZW0gaXBzdW0gZ
 cacert=/path/to/kubeca.crt
 service-cidr=172.18.0.0/24
+no-hostsubnet-nodes=label=another-test-label
 
 [logging]
 loglevel=5
@@ -241,6 +242,7 @@ var _ = Describe("Config Operations", func() {
 			Expect(Kubernetes.Token).To(Equal(""))
 			Expect(Kubernetes.APIServer).To(Equal("http://localhost:8080"))
 			Expect(Kubernetes.ServiceCIDR).To(Equal("172.16.1.0/24"))
+			Expect(Kubernetes.RawNoHostSubnetNodes).To(Equal(""))
 			Expect(Default.ClusterSubnets).To(Equal([]CIDRNetworkEntry{
 				{mustParseCIDR("10.128.0.0/14"), 23},
 			}))
@@ -530,6 +532,7 @@ var _ = Describe("Config Operations", func() {
 			Expect(Kubernetes.Token).To(Equal("asdfasdfasdfasfd"))
 			Expect(Kubernetes.APIServer).To(Equal("https://4.4.3.2:8080"))
 			Expect(Kubernetes.ServiceCIDR).To(Equal("172.15.0.0/24"))
+			Expect(Kubernetes.RawNoHostSubnetNodes).To(Equal("test=pass"))
 			Expect(Default.ClusterSubnets).To(Equal([]CIDRNetworkEntry{
 				{mustParseCIDR("10.130.0.0/15"), 24},
 			}))
@@ -566,6 +569,7 @@ var _ = Describe("Config Operations", func() {
 			"-k8s-token=asdfasdfasdfasfd",
 			"-k8s-service-cidr=172.15.0.0/24",
 			"-nb-address=ssl://6.5.4.3:6651",
+			"-no-hostsubnet-nodes=test=pass",
 			"-nb-client-privkey=/client/privkey",
 			"-nb-client-cert=/client/cert",
 			"-nb-client-cacert=/client/cacert",
@@ -746,6 +750,7 @@ mode=shared
 			Expect(Kubernetes.CACert).To(Equal(kubeCAFile))
 			Expect(Kubernetes.Token).To(Equal("asdfasdfasdfasfd"))
 			Expect(Kubernetes.APIServer).To(Equal("https://4.4.3.2:8080"))
+			Expect(Kubernetes.RawNoHostSubnetNodes).To(Equal("label=another-test-label"))
 			Expect(Kubernetes.ServiceCIDR).To(Equal("172.15.0.0/24"))
 
 			Expect(OvnNorth.Scheme).To(Equal(OvnDBSchemeSSL))

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -17,6 +17,8 @@ import (
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	kapisnetworking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -504,6 +506,15 @@ func (oc *Controller) WatchNodes() error {
 	_, err := oc.watchFactory.AddNodeHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			node := obj.(*kapi.Node)
+
+			if noHostSubnet := noHostSubnet(node); noHostSubnet {
+				oc.lsMutex.Lock()
+				defer oc.lsMutex.Unlock()
+				//setting the value to nil in the cache means it was not assigned a hostSubnet by ovn-kube
+				oc.logicalSwitchCache[node.Name] = nil
+				return
+			}
+
 			logrus.Debugf("Added event for Node %q", node.Name)
 			hostSubnet, err := oc.addNode(node)
 			if err != nil {
@@ -525,6 +536,16 @@ func (oc *Controller) WatchNodes() error {
 		UpdateFunc: func(old, new interface{}) {
 			oldNode := old.(*kapi.Node)
 			node := new.(*kapi.Node)
+
+			shouldUpdate, err := shouldUpdate(node, oldNode)
+			if err != nil {
+				logrus.Errorf(err.Error())
+			}
+			if !shouldUpdate {
+				// the hostsubnet is not assigned by ovn-kubernetes
+				return
+			}
+
 			logrus.Debugf("Updated event for Node %q", node.Name)
 
 			_, failed := mgmtPortFailed.Load(node.Name)
@@ -610,4 +631,33 @@ func macAddressChanged(oldNode, node *kapi.Node) bool {
 	oldMacAddress := oldNode.Annotations[OvnNodeManagementPortMacAddress]
 	macAddress := node.Annotations[OvnNodeManagementPortMacAddress]
 	return oldMacAddress != macAddress
+}
+
+// noHostSubnet() compares the no-hostsubenet-nodes flag with node labels to see if the node is manageing its
+// own network.
+func noHostSubnet(node *kapi.Node) bool {
+	if config.Kubernetes.NoHostSubnetNodes == nil {
+		return false
+	}
+
+	nodeSelector, _ := metav1.LabelSelectorAsSelector(config.Kubernetes.NoHostSubnetNodes)
+	return nodeSelector.Matches(labels.Set(node.Labels))
+}
+
+// shouldUpdate() determines if the ovn-kubernetes plugin should update the state of the node.
+// ovn-kube should not perform an update if it does not assign a hostsubnet, or if you want to change
+// whether or not ovn-kubernetes assigns a hostsubnet
+func shouldUpdate(node, oldNode *kapi.Node) (bool, error) {
+	newNoHostSubnet := noHostSubnet(node)
+	oldNoHostSubnet := noHostSubnet(oldNode)
+
+	if oldNoHostSubnet && newNoHostSubnet {
+		return false, nil
+	} else if oldNoHostSubnet && !newNoHostSubnet {
+		return false, fmt.Errorf("error updating node %s, cannot remove assigned hostsubnet, please delete node and recreate.", node.Name)
+	} else if !oldNoHostSubnet && newNoHostSubnet {
+		return false, fmt.Errorf("error updating node %s, cannot assign a hostsubnet to already created node, please delete node and recreate.", node.Name)
+	}
+
+	return true, nil
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -231,6 +231,11 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 	var out, stderr string
 	var err error
 
+	// If a node does node have an assigned hostsubnet don't wait for the logical switch to appear
+	if val, ok := oc.logicalSwitchCache[pod.Spec.NodeName]; ok && val == nil {
+		return nil
+	}
+
 	// Keep track of how long syncs take.
 	start := time.Now()
 	defer func() {


### PR DESCRIPTION
add an -ignore-node-labeled flag to the command line to specify a
node label for ovn-kubernetes to ignore. When ignored the node must
have some way to manage the network on its own.

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>