### PR TITLE
Clustered database (aka RAFT) support for OVN DBs

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -62,6 +62,7 @@ COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
 COPY ovn-debug.sh /root/
+COPY ovndb-raft-functions /root/
 # override the rpm's ovn_k8s.conf with this local copy
 COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -38,7 +38,7 @@ COPY git_info /root
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
 COPY ovn-debug.sh /root/
-
+COPY ovndb-raft-functions /root/
 
 LABEL io.k8s.display-name="ovn-kubernetes" \
       io.k8s.description="This is a Kubernetes network plugin that provides an overlay network using OVN." \

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -39,6 +39,7 @@ COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
 COPY ovn-debug.sh /root/
+COPY ovndb-raft-functions /root/
 # override the pkg's ovn_k8s.conf with this local copy
 COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -121,6 +121,8 @@ ovn_db_replicas=${OVN_DB_REPLICAS:-3}
 echo "ovn_db_replicas: ${ovn_db_replicas}"
 ovn_db_vip=${OVN_DB_VIP}
 echo "ovn_db_vip: ${ovn_db_vip}"
+ovn_db_minAvailable=$(((${ovn_db_replicas} + 1) / 2))
+echo "ovn_db_minAvailable: ${ovn_db_minAvailable}"
 
 ovn_image=${image} ovn_image_pull_policy=${policy} kind=${KIND} ovn_gateway_mode=${ovn_gateway_mode} \
  ovn_gateway_opts=${ovn_gateway_opts} j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node.yaml
@@ -132,6 +134,9 @@ ovn_image=${image} ovn_image_pull_policy=${policy} j2 ../templates/ovnkube-db.ya
 
 ovn_db_vip_image=${ovn_db_vip_image} ovn_image_pull_policy=${policy} ovn_db_replicas=${ovn_db_replicas} \
 ovn_db_vip=${ovn_db_vip} j2 ../templates/ovnkube-db-vip.yaml.j2 -o ../yaml/ovnkube-db-vip.yaml
+
+ovn_image=${image} ovn_image_pull_policy=${policy} ovn_db_replicas=${ovn_db_replicas} \
+ovn_db_minAvailable=${ovn_db_minAvailable} j2 ../templates/ovnkube-db-raft.yaml.j2 > ../yaml/ovnkube-db-raft.yaml
 
 # ovn-setup.yaml
 # net_cidr=10.128.0.0/14/23

--- a/dist/images/ovndb-raft-functions
+++ b/dist/images/ovndb-raft-functions
@@ -1,0 +1,135 @@
+#!/bin/bash
+#set -euo pipefail
+
+verify-ovsdb-raft () {
+  check_ovn_daemonset_version "3"
+
+  replicas=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+    get statefulset -n ovn-kubernetes ovnkube-db -o=jsonpath='{.spec.replicas}')
+  if [[ ${replicas} -lt 3 || $((${replicas} % 2)) -eq 0 ]]; then
+    echo "at least 3 nodes need to be configured, and it must be odd number of nodes"
+    exit 1
+  fi
+}
+
+# OVN DB must be up in the first DB node
+# This waits for ovnkube-db-0 POD to come up
+ready_to_join_cluster () {
+  # See if ep is available ...
+  db=${1}
+  port=${2}
+
+  init_ip="$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+    get pod -n ovn-kubernetes ovnkube-db-0 -o=jsonpath='{.status.podIP}')"
+  if [[ $? != 0 ]]; then
+    return 1
+  fi
+  ovsdb-client list-dbs tcp:${init_ip}:${port} > /dev/null 2>&1
+  if [[ $? != 0 ]] ; then
+      return 1
+  fi
+  return 0
+}
+
+check_ovnkube_db_ep () {
+  local dbaddr=${1}
+  local dbport=${2}
+
+  # TODO: Right now only checks for NB ovsdb instances
+  echo "======= checking ${dbaddr}:${dbport} OVSDB instance ==============="
+  ovsdb-client list-dbs tcp:${dbaddr}:${dbport} > /dev/null 2>&1
+  if [[ $? != 0 ]] ; then
+      return 1
+  fi
+  return 0
+}
+
+check_and_apply_ovnkube_db_ep () {
+  local port=${1}
+
+  # Get IPs of all ovnkube-db PODs
+  ips=()
+  for (( i=0; i<${replicas}; i++ )); do
+    ip=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+      get pod -n ovn-kubernetes ovnkube-db-${i} -o=jsonpath='{.status.podIP}' 2>/dev/null)
+    if [[ ${ip} == "" ]]; then
+      break
+    fi
+    ips+=(${ip})
+  done
+
+  if [[ ${i} -eq ${replicas} ]]; then
+    # Number of POD IPs is same as number of statefulset replicas. Now, if the number of ovnkube-db endpoints
+    # is 0, then we are applying the endpoint for the first time. So, we need to make sure that each of the
+    # pod IP responds to the `ovsdb-client list-dbs` call before we set the endpoint. If they don't, retry several
+    # times and then give up.
+
+    # Get the current set of ovnkube-db endpoints, if any
+    IFS=" " read -a old_ips <<< "$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+      get ep -n ovn-kubernetes ovnkube-db -o=jsonpath='{range .subsets[0].addresses[*]}{.ip}{" "}' 2>/dev/null)"
+    if [[ ${#old_ips[@]} -ne 0 ]]; then
+      return
+    fi
+
+    for ip in ${ips[@]} ; do
+      wait_for_event attempts=10 check_ovnkube_db_ep ${ip} ${port}
+    done
+    set_ovnkube_db_ep ${ips[@]}
+  else
+    # ideally shouldn't happen
+    echo "Not all the pods in the statefulset are up. Expecting ${replicas} pods, but found ${i} pods."
+    echo "Exiting...."
+    exit 10
+  fi
+}
+
+# v3 - create nb_ovsdb/sb_ovsdb cluster in a separate container
+ovsdb-raft () {
+  trap 'kill $(jobs -p); exit 0' TERM
+
+  local db=${1}
+  local port=${2}
+
+  ovn_db_pidfile=${OVN_RUNDIR}/ovn${db}_db.pid
+  eval ovn_log_db=\$ovn_log_${db}
+  ovn_db_file=${OVN_ETCDIR}/ovn${db}.db
+
+  rm -f ${ovn_db_pidfile}
+  verify-ovsdb-raft
+  local_ip=$(getent ahostsv4 $(hostname) | grep -v "^127\." | head -1 | awk '{ print $1 }')
+  echo "=============== run ${db}-ovsdb-raft pod ${POD_NAME} =========="
+
+  if [[ "${POD_NAME}" == "ovnkube-db-0" ]]; then
+    run_as_ovs_user_if_needed \
+      /usr/share/openvswitch/scripts/ovn-ctl run_${db}_ovsdb --no-monitor \
+      --db-${db}-create-insecure-remote=yes --db-${db}-cluster-local-addr=${local_ip} \
+      --ovn-${db}-log="${ovn_log_db}" &
+  else
+    # join the remote cluster node if the DB is not created
+    if [[ ! -e ${ovn_db_file} ]] || ovsdb-tool db-is-standalone ${ovn_db_file} ; then
+      wait_for_event ready_to_join_cluster ${db} ${port}
+    fi
+    run_as_ovs_user_if_needed \
+      /usr/share/openvswitch/scripts/ovn-ctl run_${db}_ovsdb --no-monitor \
+      --db-${db}-create-insecure-remote=yes --db-${db}-cluster-local-addr=${local_ip} \
+      --db-${db}-cluster-remote-addr=${init_ip} \
+      --ovn-${db}-log="${ovn_log_db}" &
+  fi
+
+  wait_for_event process_ready ovn${db}_db
+  echo "=============== ${db}-ovsdb-raft ========== RUNNING"
+  sleep 3
+
+  last_node_index=$(expr ${replicas} - 1)
+  # Create endpoints only if all ovnkube-db pods have started and are running. We do this
+  # from the last pod of the statefulset.
+  if [[ ${db} == "nb" && "${POD_NAME}" == "ovnkube-db-"${last_node_index} ]]; then
+    check_and_apply_ovnkube_db_ep ${port}
+  fi
+
+  tail --follow=name /var/log/openvswitch/ovsdb-server-${db}.log &
+  ovn_tail_pid=$!
+
+  process_healthy ovn${db}_db ${ovn_tail_pid}
+  echo "=============== run ${db}_ovsdb-raft ========== terminated"
+}

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -6,6 +6,9 @@ if [[ "${OVNKUBE_SH_VERBOSE:-}" == "true" ]]; then
   set -x
 fi
 
+# source the functions in ovndb-raft-functions
+. /root/ovndb-raft-functions
+
 # This script is the entrypoint to the image.
 # Supports version 3 daemonsets
 #    $1 is the daemon to start.
@@ -187,19 +190,19 @@ wait_for_event () {
     shift
   fi
   while true; do
-    $1 $2
+    $@
     if [[ $? != 0 ]] ; then
       (( retries += 1 ))
       if [[ "${retries}" -gt ${attempts} ]]; then
-        echo "error: $1 $2 did not come up, exiting"
+        echo "error: $@ did not come up, exiting"
         exit 1
       fi
-      echo "info: Waiting for $1 $2 to come up, waiting ${sleeper}s ..."
+      echo "info: Waiting for $@ to come up, waiting ${sleeper}s ..."
       sleep ${sleeper}
       sleeper=5
     else
       if [[ "${retries}" != 0 ]]; then
-        echo "$1 $2 came up in ${retries} ${sleeper} sec tries"
+        echo "$@ came up in ${retries} ${sleeper} sec tries"
       fi
       break
     fi
@@ -212,13 +215,16 @@ wait_for_event () {
 ready_to_start_node () {
 
   # See if ep is available ...
-  ovn_db_host=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
-    get ep -n ${ovn_kubernetes_namespace} ovnkube-db 2>/dev/null | grep ${ovn_sb_port} | sed 's/:/ /' | awk '/ovnkube-db/{ print $2 }')
-  if [[ ${ovn_db_host} == "" ]] ; then
+  IFS=" " read -a ovn_db_hosts <<< "$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+    get ep -n ovn-kubernetes ovnkube-db -o=jsonpath='{range .subsets[0].addresses[*]}{.ip}{" "}')"
+  if [[ ${#ovn_db_hosts[@]} == 0 ]] ; then
       return 1
   fi
   get_ovn_db_vars
-  ovsdb-client list-dbs ${ovn_nbdb_test} > /dev/null 2>&1
+  # cannot use ovsdb-client in the case of raft, since it will succeed even if one of the
+  # instance of DB is up and running. HOwever, ovn-nbctl always connects to the leader in the clustered
+  # database, so use it.
+  ovn-nbctl --db=${ovn_nbdb_test} list NB_Global > /dev/null 2>&1
   if [[ $? != 0 ]] ; then
       return 1
   fi
@@ -240,9 +246,24 @@ check_ovn_daemonset_version () {
 }
 
 get_ovn_db_vars () {
-  ovn_nbdb=tcp://${ovn_db_host}:${ovn_nb_port}
-  ovn_sbdb=tcp://${ovn_db_host}:${ovn_sb_port}
-  ovn_nbdb_test=$(echo ${ovn_nbdb} | sed 's;//;;')
+  # OVN_NORTH and OVN_SOUTH override derived host
+  # Currently limited to tcp (ssl is not supported yet)
+  ovn_nbdb_str=""
+  ovn_sbdb_str=""
+  for i in ${!ovn_db_hosts[@]}; do
+    if [[ ${i} -ne 0 ]]; then
+      ovn_nbdb_str=${ovn_nbdb_str}","
+      ovn_sbdb_str=${ovn_sbdb_str}","
+    fi
+    ovn_nbdb_str=${ovn_nbdb_str}tcp://${ovn_db_hosts[${i}]}:${ovn_nb_port}
+    ovn_sbdb_str=${ovn_sbdb_str}tcp://${ovn_db_hosts[${i}]}:${ovn_sb_port}
+  done
+  ovn_nbdb=${OVN_NORTH:-$ovn_nbdb_str}
+  ovn_sbdb=${OVN_SOUTH:-$ovn_sbdb_str}
+
+  echo ovn_nbdb=$ovn_nbdb
+  echo ovn_sbdb=$ovn_sbdb
+  ovn_nbdb_test=$(echo ${ovn_nbdb} | sed 's;//;;g')
 }
 
 # OVS must be up before OVN comes up.
@@ -410,7 +431,6 @@ echo ovnkube.sh version ${ovnkube_version}
 }
 
 ovn_debug () {
-  # get ovn_db_host
   ready_to_start_node
   echo "ovn_nbdb ${ovn_nbdb}   ovn_sbdb ${ovn_sbdb}"
   echo "ovn_nbdb_test ${ovn_nbdb_test}"
@@ -440,7 +460,7 @@ ovn_debug () {
   ovs-ofctl dump-flows br-int
   echo " "
   echo "=========== ovn-sbctl show ============="
-  ovn_sbdb_test=$(echo ${ovn_sbdb} | sed 's;//;;')
+  ovn_sbdb_test=$(echo ${ovn_sbdb} | sed 's;//;;g')
   echo "=========== ovn-sbctl --db=${ovn_sbdb_test} show ============="
   ovn-sbctl --db=${ovn_sbdb_test} show
   echo " "
@@ -538,8 +558,10 @@ cleanup-ovs-server () {
 
 # set the ovnkube_db endpoint for other pods to query the OVN DB IP
 set_ovnkube_db_ep () {
+  ips=("$@")
+
+  echo "=============== setting ovnkube-db endpoints to ${ips[@]}"
   # create a new endpoint for the headless onvkube-db service without selectors
-  # using the current host has the endpoint IP. Ignore IPs in loopback range (127.0.0.0/8)
   kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} apply -f - << EOF
 apiVersion: v1
 kind: Endpoints
@@ -548,7 +570,7 @@ metadata:
   namespace: ${ovn_kubernetes_namespace}
 subsets:
   - addresses:
-      - ip: ${ovn_db_host}
+`for ip in ${ips[@]}; do printf "    - ip: ${ip}\n"; done`
     ports:
     - name: north
       port: ${ovn_nb_port}
@@ -558,7 +580,7 @@ subsets:
       protocol: TCP
 EOF
     if [[ $? != 0 ]] ; then
-        echo "Failed to create endpoint with host ${ovn_db_host} for ovnkube-db service"
+        echo "Failed to create endpoint with host(s) ${ips[@]} for ovnkube-db service"
         exit 1
     fi
 }
@@ -609,7 +631,7 @@ sb-ovsdb () {
   ovn-sbctl set-connection ptcp:${ovn_sb_port}:${ovn_db_host} -- set connection . inactivity_probe=0
 
   # create the ovnkube_db endpoint for other pods to query the OVN DB IP
-  set_ovnkube_db_ep
+  set_ovnkube_db_ep ${ovn_db_host}
 
   tail --follow=name ${OVN_LOGDIR}/ovsdb-server-sb.log &
   ovn_tail_pid=$!
@@ -631,15 +653,14 @@ run-ovn-northd () {
   sleep 1
 
   echo "=============== run_ovn_northd ========== MASTER ONLY"
-  echo "ovn_db_host ${ovn_db_host}"
   echo "ovn_nbdb ${ovn_nbdb}   ovn_sbdb ${ovn_sbdb}"
   echo "ovn_northd_opts=${ovn_northd_opts}"
   echo "ovn_log_northd=${ovn_log_northd}"
 
   # no monitor (and no detach), start northd which connects to the
   # ovnkube-db service
-  ovn_nbdb_i=$(echo ${ovn_nbdb} | sed 's;//;;')
-  ovn_sbdb_i=$(echo ${ovn_sbdb} | sed 's;//;;')
+  ovn_nbdb_i=$(echo ${ovn_nbdb} | sed 's;//;;g')
+  ovn_sbdb_i=$(echo ${ovn_sbdb} | sed 's;//;;g')
   run_as_ovs_user_if_needed \
       ${OVNCTL_PATH} start_northd \
       --no-monitor --ovn-manage-ovsdb=no \
@@ -725,6 +746,10 @@ ovn-controller () {
 
   echo "ovn_nbdb ${ovn_nbdb}   ovn_sbdb ${ovn_sbdb}"
   echo "ovn_nbdb_test ${ovn_nbdb_test}"
+
+  # cleanup any stale ovn-nb and ovn-remote keys in Open_vSwitch table
+  ovs-vsctl remove Open_vSwitch . external_ids ovn-remote
+  ovs-vsctl remove Open_vSwitch . external_ids ovn-nb
 
   echo "=============== ovn-controller  start_controller"
   rm -f /var/run/ovn-kubernetes/cni/*
@@ -914,9 +939,15 @@ case ${cmd} in
   "cleanup-ovn-node")
 	  cleanup-ovn-node
     ;;
+  "nb-ovsdb-raft")
+    ovsdb-raft nb ${ovn_nb_port}
+    ;;
+  "sb-ovsdb-raft")
+    ovsdb-raft sb ${ovn_sb_port}
+    ;;
   *)
-	  echo "invalid command ${cmd}"
-	  echo "valid v3 commands: ovs-server nb-ovsdb sb-ovsdb run-ovn-northd ovn-master ovn-controller ovn-node display_env display ovn_debug cleanup-ovs-server cleanup-ovn-node"
+    echo "invalid command ${cmd}"
+    echo "valid v3 commands: ovs-server nb-ovsdb sb-ovsdb run-ovn-northd ovn-master ovn-controller ovn-node display_env display ovn_debug cleanup-ovs-server cleanup-ovn-node nb-ovsdb-raft sb-ovsdb-raft"
 	  exit 0
 esac
 

--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -81,8 +81,10 @@ rules:
 - apiGroups:
   - extensions
   - networking.k8s.io
+  - apps
   resources:
   - networkpolicies
+  - statefulsets
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - ""
@@ -119,27 +121,6 @@ subjects:
 - kind: ServiceAccount
   name: ovn
   namespace: ovn-kubernetes
-
----
-# service to expose the ovnkube-db pod
-apiVersion: v1
-kind: Service
-metadata:
-  name: ovnkube-db
-  namespace: ovn-kubernetes
-spec:
-  ports:
-  - name: north
-    port: 6641
-    protocol: TCP
-    targetPort: 6641
-  - name: south
-    port: 6642
-    protocol: TCP
-    targetPort: 6642
-  sessionAffinity: None
-  clusterIP: None
-  type: ClusterIP
 
 ---
 # The network cidr and service cidr are set in the ovn-config configmap

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -20,31 +20,41 @@ spec:
 
 ---
 
-# ovnkube-db
+# ovndb-raft PodDisruptBudget to prevent majority of ovnkube raft cluster
+# nodes from disruption
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: ovndb-raft-pdb
+  namespace: ovn-kubernetes
+spec:
+  minAvailable: {{ ovn_db_minAvailable | default(2) }}
+  selector:
+    matchLabels:
+      name: ovnkube-db
+
+---
+
+# ovnkube-db raft statefulset
 # daemonset version 3
 # starts ovn NB/SB ovsdb daemons, each in a separate container
-# it is running on master node for now, but does not need to be the case
-kind: Deployment
+#
+kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: ovnkube-db
-  # namespace set up by install
   namespace: ovn-kubernetes
   annotations:
     kubernetes.io/description: |
-      This daemonset launches the OVN NB/SB ovsdb service components.
+      This statefulset launches the OVN NB/SB ovsdb components.
 spec:
-  progressDeadlineSeconds: 600
-  replicas: 1
+  serviceName: ovnkube-db
+  podManagementPolicy: "Parallel"
+  replicas: {{ ovn_db_replicas | default(3) }}
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       name: ovnkube-db
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -55,21 +65,39 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      # Requires fairly broad permissions - ability to read all services and network functions as well
-      # as all pods.
+      terminationGracePeriodSeconds: 30
+      imagePullSecrets:
+        - name: registry-credentials
       serviceAccountName: ovn
       hostNetwork: true
-      containers:
-      # firewall rules for ovn - assumed to be setup
-      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
-      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
 
+      # required to be scheduled on node with ovn.org/ovnkube-db=true label but can
+      # only have one instance per node
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: ovn.org/ovnkube-db
+                operator: In
+                values:
+                - "true"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - ovnkube-db
+            topologyKey: kubernetes.io/hostname
+
+      containers:
       # nb-ovsdb - v3
       - name: nb-ovsdb
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
-
-        command: ["/root/ovnkube.sh", "nb-ovsdb"]
+        command: ["/root/ovnkube.sh", "nb-ovsdb-raft"]
 
         securityContext:
           runAsUser: 0
@@ -88,6 +116,10 @@ spec:
           name: host-var-log-ovs
         - mountPath: /var/log/ovn/
           name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
 
         resources:
           requests:
@@ -107,6 +139,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         ports:
         - name: healthz
           containerPort: 10256
@@ -125,8 +161,7 @@ spec:
       - name: sb-ovsdb
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
-
-        command: ["/root/ovnkube.sh", "sb-ovsdb"]
+        command: ["/root/ovnkube.sh", "sb-ovsdb-raft"]
 
         securityContext:
           runAsUser: 0
@@ -145,6 +180,10 @@ spec:
           name: host-var-log-ovs
         - mountPath: /var/log/ovn/
           name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
 
         resources:
           requests:
@@ -164,6 +203,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         ports:
         - name: healthz
           containerPort: 10255
@@ -178,15 +221,15 @@ spec:
         lifecycle:
       # end of container
 
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-        kubernetes.io/os: "linux"
       volumes:
-      - name: host-var-lib-ovs
-        hostPath:
-          path: /var/lib/openvswitch
       - name: host-var-log-ovs
         hostPath:
           path: /var/log/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
       tolerations:
       - operator: "Exists"

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -1,3 +1,25 @@
+# service to expose the ovnkube-db pod
+apiVersion: v1
+kind: Service
+metadata:
+  name: ovnkube-db
+  namespace: ovn-kubernetes
+spec:
+  ports:
+  - name: north
+    port: 6641
+    protocol: TCP
+    targetPort: 6641
+  - name: south
+    port: 6642
+    protocol: TCP
+    targetPort: 6642
+  sessionAffinity: None
+  clusterIP: None
+  type: ClusterIP
+
+---
+
 # ovnkube-db HA using Corosync/Pacemaker
 # daemonset version 3
 # starts ovn NB/SB ovsdb daemons in a single container

--- a/dist/yaml/.gitignore
+++ b/dist/yaml/.gitignore
@@ -5,4 +5,4 @@ ovnkube-db-vip.yaml
 ovnkube-db.yaml
 ovnkube-node.yaml
 ovnkube-monitor.yaml
-
+ovnkube-db-raft.yaml


### PR DESCRIPTION
This commit implements the clustered database as a statefulsets with
replicas set to 3. The PodManagementPolicy of OrderReady is too
restrictive for how RAFT works, so instead Parallel policy is used.
The existing ovnkube-db service acts as the headless Service for the
statefulset. The pods are scheduled on the nodes with labels
`ovn.org/ovnkube-db=true`.

Implementation notes:

1. ovnkube-db-0, the first pod in the statefulset creates the initial
cluster DB. If an existing standalone DB is present, then it converts it
into the clustered DB.

2. ovnkube-db-1 ... ovnkube-db-{n-1} pods wait until the ovnkube-db-0
has successfully started and then only join the cluster.

3. ovnkube-db-{n-1}, the last pod in the statefulset will ensure that
all of the pods in the statefulet are up and running and then only
publish the ovnkube-db endpoints to the ovnkube-db service.

4. Like before, all of the ovnkube-nodes and ovnkube-master are waiting
on the endpoints to be published. Once the endpoints are published, they
proceed further.

@dcbw @danwinship PTAL thanks