### PR TITLE
ci: always export logs

### DIFF
--- a/.github/workflow-templates/test.yml
+++ b/.github/workflow-templates/test.yml
@@ -83,15 +83,13 @@ jobs:
         kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\].*Conformance --disable-log-dump=false --ginkgo.skip=\[Serial\]'
         kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\].*NetworkPolicy --disable-log-dump=false --ginkgo.skip=ingress\saccess|multiple\segress\spolicies|allow\segress\saccess|\[Serial\]'
     
-    - name: Export logs on failure
+    - name: Export logs
       run: |
         mkdir -p /tmp/kind/logs 
         kind export logs --name ${KIND_CLUSTER_NAME} /tmp/kind/logs
       working-directory: ${{ env.WORKDIR }}
-      if: failure()
     - name: Upload logs
       uses: actions/upload-artifact@v1
-      if: failure()
       with:
         name: kind-logs
         path: /tmp/kind/logs

--- a/.github/workflows/test_generated.yml
+++ b/.github/workflows/test_generated.yml
@@ -90,14 +90,12 @@ jobs:
         export NODE_NAMES=${MASTER_NAME}
         kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\].*Conformance --disable-log-dump=false --ginkgo.skip=\[Serial\]'
         kubetest --ginkgo-parallel=2 --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\].*NetworkPolicy --disable-log-dump=false --ginkgo.skip=ingress\saccess|multiple\segress\spolicies|allow\segress\saccess|\[Serial\]'
-    - name: Export logs on failure
+    - name: Export logs
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}
         /tmp/kind/logs\n"
       working-directory: "${{ env.WORKDIR }}"
-      if: failure()
     - name: Upload logs
       uses: actions/upload-artifact@v1
-      if: failure()
       with:
         name: kind-logs
         path: "/tmp/kind/logs"


### PR DESCRIPTION
It's useful to see successful logs too.

Signed-off-by: Dan Williams <dcbw@redhat.com>