### PR TITLE
cluster: Make GatewayReady() IPv6/dual-stack safe

### DIFF
--- a/go-controller/pkg/cluster/gateway_init.go
+++ b/go-controller/pkg/cluster/gateway_init.go
@@ -176,12 +176,19 @@ func GatewayReady(nodeName string, portName string) (bool, error) {
 	// OpenFlow table 41 performs SNATing of packets that are heading to physical network from
 	// logical network.
 	for _, clusterSubnet := range config.Default.ClusterSubnets {
+		var cidr, match string
+		cidr = clusterSubnet.CIDR.String()
+		if strings.Contains(cidr, ":") {
+			match = "ipv6,ipv6_src=" + cidr
+		} else {
+			match = "ip,nw_src=" + cidr
+		}
 		stdout, _, err := util.RunOVSOfctl("--no-stats", "--no-names", "dump-flows", "br-int",
-			"table=41,ip,nw_src="+clusterSubnet.CIDR.String())
+			"table=41,"+match)
 		if err != nil {
 			return false, nil
 		}
-		if !strings.Contains(stdout, "nw_src="+clusterSubnet.CIDR.String()) {
+		if !strings.Contains(stdout, cidr) {
 			return false, nil
 		}
 	}

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -211,13 +211,13 @@ func (cluster *OvnClusterController) StartClusterNode(name string) error {
 		wg.Wait()
 		close(messages)
 	}()
-	logrus.Infof("Gateway and ManagementPort are Ready")
 
 	for i := range messages {
 		if i != nil {
 			return fmt.Errorf("Timeout error while obtaining addresses for %s (%v)", portName, i)
 		}
 	}
+	logrus.Infof("Gateway and ManagementPort are Ready")
 
 	if postReady != nil {
 		err = postReady()


### PR DESCRIPTION
7358508a changed GatewayReady() from using ovn-nbctl to using ovs-ofctl, but checked for an IPv4-specific rule. Fix it to use IPv6 syntax when checking for IPv6 CIDRs.

(I checked the actual CIDR rather than using `config.IPv6Mode` because it was easy, and it means we won't have to revisit this for dual-stack.)

@dcbw @girishmg 