### PR TITLE
Remove kube-proxy in KIND deployment

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -48,6 +48,7 @@ kubectl create -f ovnkube-db.yaml
 kubectl create -f ovnkube-master.yaml
 kubectl create -f ovnkube-node.yaml
 popd
+kubectl -n kube-system delete ds kube-proxy
 kind get clusters
 kind get nodes --name ${CLUSTER_NAME}
 


### PR DESCRIPTION
kube-proxy is not necessary for OVN.

Signed-off-by: Tim Rozet <trozet@redhat.com>