### PR TITLE
network policy's logicalport cache gets out-of-sync on pod deletion

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -610,11 +610,6 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 
 	// Get the logical port name.
 	logicalPort := podLogicalPortName(pod)
-	logicalPortUUID, err := oc.getLogicalPortUUID(logicalPort)
-	if err != nil {
-		logrus.Errorf(err.Error())
-		return
-	}
 
 	np.Lock()
 	defer np.Unlock()
@@ -634,7 +629,12 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 	delete(oc.lspEgressDenyCache, logicalPort)
 	oc.lspMutex.Unlock()
 
-	if logicalPortUUID == "" || np.portGroupUUID == "" {
+	logicalPortUUID, err := oc.getLogicalPortUUID(logicalPort)
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return
+	}
+	if np.portGroupUUID == "" {
 		return
 	}
 


### PR DESCRIPTION
when a pod is deleted, its logical_switch_port is deleted and so is the
corresponding entry from logicalPortUUIDCache. In the
handleLocalPodSelectorAddFunc, we fail to get the UUID for the just
deleted pod's logical switch port and we return early from the function
without cleaning up various caches.

Now, say the same pod is added back. All these caches will have stale
data and we fail to add the newly added logical_switch_port to the
port_group.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>