### PR TITLE
explicitly delete conntrack entries for deleted pods

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -12,6 +12,8 @@ import (
 
 	"k8s.io/klog"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	"github.com/Mellanox/sriovnet"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/plugins/pkg/ip"
@@ -307,6 +309,29 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 	return []*current.Interface{hostIface, contIface}, nil
 }
 
+func (pr *PodRequest) deletePodConntrack() {
+	if pr.CNIConf.PrevResult == nil {
+		return
+	}
+	result, err := current.NewResultFromResult(pr.CNIConf.PrevResult)
+	if err != nil {
+		klog.Warningf("could not convert result to current version: %v", err)
+		return
+	}
+
+	for _, ip := range result.IPs {
+		// Skip known non-sandbox interfaces
+		if ip.Interface != nil {
+			intIdx := *ip.Interface
+			if intIdx >= 0 &&
+				intIdx < len(result.Interfaces) && result.Interfaces[intIdx].Sandbox == "" {
+				continue
+			}
+		}
+		util.DeleteConntrack(ip.Address.IP.String())
+	}
+}
+
 // PlatformSpecificCleanup deletes the OVS port
 func (pr *PodRequest) PlatformSpecificCleanup() error {
 	ifaceName := pr.SandboxID[:15]
@@ -320,6 +345,7 @@ func (pr *PodRequest) PlatformSpecificCleanup() error {
 	}
 
 	_ = clearPodBandwidth(pr.SandboxID)
+	pr.deletePodConntrack()
 
 	return nil
 }

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -54,3 +54,7 @@ func getIntfName(gatewayIntf string) (string, error) {
 	}
 	return intfName, nil
 }
+
+func deleteConntrack(ip string) {
+	util.DeleteConntrack(ip)
+}

--- a/go-controller/pkg/node/helper_windows.go
+++ b/go-controller/pkg/node/helper_windows.go
@@ -31,3 +31,7 @@ func getIntfName(gatewayIntf string) (string, error) {
 	}
 	return intfName, nil
 }
+
+func deleteConntrack(ip string) {
+	//conntrack deletion not supported in windows
+}

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"os"
 
+	"k8s.io/klog"
+
 	"github.com/vishvananda/netlink"
 
 	utilnet "k8s.io/utils/net"
@@ -166,4 +168,26 @@ func LinkNeighExists(link netlink.Link, neighIP net.IP, neighMAC net.HardwareAdd
 		}
 	}
 	return false, nil
+}
+
+func DeleteConntrack(ip string) {
+	ipAddress := net.ParseIP(ip)
+	if ipAddress == nil {
+		klog.Errorf("Value \"%s\" passed to DeleteConntrack is not an IP address", ipAddress)
+	}
+
+	filter := &netlink.ConntrackFilter{}
+	err := filter.AddIP(netlink.ConntrackReplyAnyIP, ipAddress)
+	if err != nil {
+		klog.Warningf("could not add IP: %s to conntrack filter: %v", ipAddress, err)
+		return
+	}
+	if ipAddress.To4() != nil {
+		_, err = netlink.ConntrackDeleteFilter(netlink.ConntrackTable, netlink.FAMILY_V4, filter)
+	} else {
+		_, err = netlink.ConntrackDeleteFilter(netlink.ConntrackTable, netlink.FAMILY_V6, filter)
+	}
+	if err != nil {
+		klog.Errorf("failed to delete Conntrack entry: %v", err)
+	}
 }


### PR DESCRIPTION
when a pod is deleted make sure to delete any conntrack entries assocaited with
those pods.

https://bugzilla.redhat.com/show_bug.cgi?id=1787434

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>