### PR TITLE
cni: bump supported version to 0.4.0 for PrevResult on delete

### DIFF
--- a/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
+++ b/go-controller/cmd/ovn-k8s-cni-overlay/ovn-k8s-cni-overlay.go
@@ -23,7 +23,7 @@ func main() {
 			p.CmdAdd,
 			p.CmdCheck,
 			p.CmdDel,
-			version.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1"),
+			version.All,
 			bv.BuildString("ovn-k8s-cni-overlay"))
 		return nil
 	}

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
 
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 )
@@ -15,7 +16,7 @@ import (
 // WriteCNIConfig writes a CNI JSON config file to directory given by global config
 func WriteCNIConfig(ConfDir string, fileName string) error {
 	bytes, err := json.Marshal(&types.NetConf{
-		CNIVersion: "0.3.1",
+		CNIVersion: "0.4.0",
 		Name:       "ovn-kubernetes",
 		Type:       CNI.Plugin,
 	})
@@ -56,6 +57,11 @@ func ReadCNIConfig(bytes []byte) (*ovntypes.NetConf, error) {
 	conf := &ovntypes.NetConf{}
 	if err := json.Unmarshal(bytes, conf); err != nil {
 		return nil, err
+	}
+	if conf.RawPrevResult != nil {
+		if err := version.ParsePrevResult(&conf.NetConf); err != nil {
+			return nil, err
+		}
 	}
 	return conf, nil
 }


### PR DESCRIPTION
Allow reading the PrevResult on DEL so that we can extract the pod's IP address (if available) at deletion time.

@JacobTanenbaum 