### PR TITLE
use add and remove OVSDB table operations instead of set

### DIFF
--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -60,24 +60,25 @@ func (oc *Controller) forEachAddressSetUnhashedName(iteratorFn func(
 	return nil
 }
 
-func setAddressSet(hashName string, addresses []string) {
-	logrus.Debugf("setAddressSet for %s with %s", hashName, addresses)
-	if len(addresses) == 0 {
-		_, stderr, err := util.RunOVNNbctl("clear", "address_set",
-			hashName, "addresses")
-		if err != nil {
-			logrus.Errorf("failed to clear address_set, stderr: %q (%v)",
-				stderr, err)
-		}
-		return
-	}
+func addToAddressSet(hashName string, address string) {
+	logrus.Debugf("addToAddressSet for %s with %s", hashName, address)
 
-	ips := `"` + strings.Join(addresses, `" "`) + `"`
-	_, stderr, err := util.RunOVNNbctl("set", "address_set",
-		hashName, fmt.Sprintf("addresses=%s", ips))
+	_, stderr, err := util.RunOVNNbctl("add", "address_set",
+		hashName, "addresses", address)
 	if err != nil {
-		logrus.Errorf("failed to set address_set, stderr: %q (%v)",
-			stderr, err)
+		logrus.Errorf("failed to add an address %q to address_set %q, stderr: %q (%v)",
+			address, hashName, stderr, err)
+	}
+}
+
+func removeFromAddressSet(hashName string, address string) {
+	logrus.Debugf("removeFromAddressSet for %s with %s", hashName, address)
+
+	_, stderr, err := util.RunOVNNbctl("remove", "address_set",
+		hashName, "addresses", address)
+	if err != nil {
+		logrus.Errorf("failed to remove an address %q from address_set %q, stderr: %q (%v)",
+			address, hashName, stderr, err)
 	}
 }
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -72,12 +72,7 @@ func (oc *Controller) addPodToNamespace(ns string, ip net.IP, logicalPort string
 	}
 
 	oc.namespaceAddressSet[ns][address] = logicalPort
-	addresses := make([]string, 0)
-	for address := range oc.namespaceAddressSet[ns] {
-		addresses = append(addresses, address)
-	}
-
-	setAddressSet(hashedAddressSet(ns), addresses)
+	addToAddressSet(hashedAddressSet(ns), address)
 
 	// If multicast is allowed and enabled for the namespace, add the port
 	// to the allow policy.
@@ -107,12 +102,7 @@ func (oc *Controller) deletePodFromNamespace(ns string, ip net.IP, logicalPort s
 	}
 
 	delete(oc.namespaceAddressSet[ns], address)
-	addresses := make([]string, 0)
-	for address := range oc.namespaceAddressSet[ns] {
-		addresses = append(addresses, address)
-	}
-
-	setAddressSet(hashedAddressSet(ns), addresses)
+	removeFromAddressSet(hashedAddressSet(ns), address)
 
 	// Remove the port from the multicast allow policy.
 	if oc.multicastSupport && oc.multicastEnabled[ns] {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -144,7 +144,7 @@ func (p pod) delCmds(fexec *ovntest.FakeExec) {
 }
 func (p pod) delFromNamespaceCmds(fexec *ovntest.FakeExec, pod pod, isMulticastEnabled bool) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedAddressSet(pod.namespace)),
+		fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedAddressSet(pod.namespace), pod.podIP),
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists get logical_switch_port %s _uuid", pod.portName),

--- a/go-controller/pkg/ovn/policy_common.go
+++ b/go-controller/pkg/ovn/policy_common.go
@@ -213,11 +213,7 @@ func (oc *Controller) handlePeerPodSelectorAddUpdate(np *namespacePolicy,
 	}
 
 	addressMap[ipAddress] = true
-	addresses := make([]string, 0, len(addressMap))
-	for k := range addressMap {
-		addresses = append(addresses, k)
-	}
-	setAddressSet(addressSet, addresses)
+	addToAddressSet(addressSet, ipAddress)
 }
 
 func (oc *Controller) handlePeerPodSelectorDeleteACLRules(obj interface{}, gress *gressPolicy) {
@@ -262,12 +258,7 @@ func (oc *Controller) handlePeerPodSelectorDelete(np *namespacePolicy,
 	}
 
 	delete(addressMap, ipAddress)
-
-	addresses := make([]string, 0, len(addressMap))
-	for k := range addressMap {
-		addresses = append(addresses, k)
-	}
-	setAddressSet(addressSet, addresses)
+	removeFromAddressSet(addressSet, ipAddress)
 }
 
 func (oc *Controller) handlePeerPodSelector(

--- a/go-controller/pkg/ovn/policy_old_test.go
+++ b/go-controller/pkg/ovn/policy_old_test.go
@@ -150,14 +150,14 @@ func (n networkPolicyOld) addLocalPodSelectorCmds(fexec *ovntest.FakeExec, pod p
 		n.addNamespaceSelectorCmdsForGress(fexec, networkPolicy, "ingress", i)
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "ingress", i))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 set address_set %s addresses=\"%s\"", hashedOVNName, pod.podIP),
+			fmt.Sprintf("ovn-nbctl --timeout=15 add address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 	for i := range networkPolicy.Spec.Egress {
 		n.addNamespaceSelectorCmdsForGress(fexec, networkPolicy, "egress", i)
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "egress", i))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 set address_set %s addresses=\"%s\"", hashedOVNName, pod.podIP),
+			fmt.Sprintf("ovn-nbctl --timeout=15 add address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 	for i := range networkPolicy.Spec.Ingress {
@@ -187,14 +187,14 @@ func (n networkPolicyOld) addPodAndNamespaceSelectorCmds(fexec *ovntest.FakeExec
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "ingress", i))
 		n.addNamespaceSelectorCmdsForGress(fexec, networkPolicy, "ingress", i)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 set address_set %s addresses=\"%s\"", hashedOVNName, pod.podIP),
+			fmt.Sprintf("ovn-nbctl --timeout=15 add address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 	for i := range networkPolicy.Spec.Egress {
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "egress", i))
 		n.addNamespaceSelectorCmdsForGress(fexec, networkPolicy, "egress", i)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 set address_set %s addresses=\"%s\"", hashedOVNName, pod.podIP),
+			fmt.Sprintf("ovn-nbctl --timeout=15 add address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 }
@@ -235,18 +235,18 @@ func (n networkPolicyOld) delPodCmds(fexec *ovntest.FakeExec, pod pod, networkPo
 	for i := range networkPolicy.Spec.Ingress {
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "ingress", i))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedOVNName),
+			fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 	for i := range networkPolicy.Spec.Egress {
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "egress", i))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedOVNName),
+			fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 	hashedNamespace := hashedAddressSet(pod.namespace)
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedNamespace),
+		fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedNamespace, pod.podIP),
 	})
 }
 
@@ -261,19 +261,19 @@ func (n networkPolicyOld) delLocalPodCmds(fexec *ovntest.FakeExec, pod pod, netw
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "ingress", i))
 		n.baseLocalCmdsForGress(fexec, pod, networkPolicy, i, "Ingress", hashedOVNName)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedOVNName),
+			fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 	for i := range networkPolicy.Spec.Egress {
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "egress", i))
 		n.baseLocalCmdsForGress(fexec, pod, networkPolicy, i, "Egress", hashedOVNName)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedOVNName),
+			fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 	hashedNamespace := hashedAddressSet(pod.namespace)
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedNamespace),
+		fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedNamespace, pod.podIP),
 	})
 }
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -96,13 +96,13 @@ func (n networkPolicy) addPodSelectorCmds(fexec *ovntest.FakeExec, pod pod, netw
 	for i := range networkPolicy.Spec.Ingress {
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "ingress", i))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 set address_set %s addresses=\"%s\"", hashedOVNName, pod.podIP),
+			fmt.Sprintf("ovn-nbctl --timeout=15 add address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 	for i := range networkPolicy.Spec.Egress {
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "egress", i))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 set address_set %s addresses=\"%s\"", hashedOVNName, pod.podIP),
+			fmt.Sprintf("ovn-nbctl --timeout=15 add address_set %s addresses %s", hashedOVNName, pod.podIP),
 		})
 	}
 	if hasLocalPods {
@@ -168,19 +168,19 @@ func (n networkPolicy) delCmds(fexec *ovntest.FakeExec, pod pod, networkPolicy k
 	})
 }
 
-func (n networkPolicy) delPodCmds(fexec *ovntest.FakeExec, networkPolicy knet.NetworkPolicy, withLocal bool) {
+func (n networkPolicy) delPodCmds(fexec *ovntest.FakeExec, networkPolicy knet.NetworkPolicy, withLocal bool, podIP string) {
 	for i := range networkPolicy.Spec.Ingress {
 		localPeerPods := fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "ingress", i)
 		hashedLocalAddressSet := hashedAddressSet(localPeerPods)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedLocalAddressSet),
+			fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedLocalAddressSet, podIP),
 		})
 	}
 	for i := range networkPolicy.Spec.Egress {
 		localPeerPods := fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "egress", i)
 		hashedLocalAddressSet := hashedAddressSet(localPeerPods)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 clear address_set %s addresses", hashedLocalAddressSet),
+			fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedLocalAddressSet, podIP),
 		})
 	}
 	if withLocal {
@@ -847,7 +847,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				nPodTest.delCmds(fExec)
 				nPodTest.delFromNamespaceCmds(fExec, nPodTest, true)
-				npTest.delPodCmds(fExec, networkPolicy, true)
+				npTest.delPodCmds(fExec, networkPolicy, true, nPodTest.podIP)
 
 				err = fakeOvn.fakeClient.CoreV1().Pods(nPodTest.namespace).Delete(nPodTest.podName, metav1.NewDeleteOptions(0))
 				Expect(err).NotTo(HaveOccurred())
@@ -956,7 +956,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				nPodTest.delCmds(fExec)
 				nPodTest.delFromNamespaceCmds(fExec, nPodTest, true)
-				npTest.delPodCmds(fExec, networkPolicy, false)
+				npTest.delPodCmds(fExec, networkPolicy, false, nPodTest.podIP)
 
 				err = fakeOvn.fakeClient.CoreV1().Pods(nPodTest.namespace).Delete(nPodTest.podName, metav1.NewDeleteOptions(0))
 				Expect(err).NotTo(HaveOccurred())
@@ -1212,7 +1212,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				nPodTest.addCmdsForNonExistingPod(fExec)
 				nPodTest.addPodDenyMcast(fExec, false)
-				nTest.addPodCmds(fExec, nPodTest, namespace1)
+				nTest.addPodCmds(fExec, nPodTest, namespace1, false)
 
 				// The pod should be added to the multicast allow group.
 				mcastPolicy.addPodCmds(fExec, namespace1.Name, "fake_uuid")
@@ -1227,7 +1227,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				// The pod should be removed from the multicasts default deny
 				// group and from the multicast allow group.
 				nPodTest.delPodDenyMcast(fExec, false)
-				nTest.delPodCmds(fExec, nPodTest, namespace1)
+				nTest.delPodCmds(fExec, nPodTest, namespace1, false)
 				nPodTest.delCmds(fExec)
 
 				err = fakeOvn.fakeClient.CoreV1().Pods(nPodTest.namespace).Delete(


### PR DESCRIPTION
in the current code, we expand all of the addresses in a namespace and
then perform a set operation against the address_set OVN NB table. this
is very expensive.

consider a namespace with 100 pods and that a new pod is added to that
namespace. Now we walk through all the 101 addresses for the namespace
and set the 101 addresses against address_set OVN NB table instead of
just adding the new address. on pod deletion, we do the same thing as
well.

@dcbw @danwinship PTAL