### PR TITLE
fix chroot's cannot change root directory to '/host' error

### DIFF
--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -88,6 +88,10 @@ spec:
           name: host-var-log-ovs
         - mountPath: /var/log/ovn/
           name: host-var-log-ovs
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
 
         resources:
           requests:
@@ -145,6 +149,10 @@ spec:
           name: host-var-log-ovs
         - mountPath: /var/log/ovn/
           name: host-var-log-ovs
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
 
         resources:
           requests:
@@ -188,5 +196,8 @@ spec:
       - name: host-var-log-ovs
         hostPath:
           path: /var/log/openvswitch
+      - name: host-slash
+        hostPath:
+          path: /
       tolerations:
       - operator: "Exists"


### PR DESCRIPTION
both the NB/SB container runs the iptable rules to open their
respective ports on which it listens for client connections. post
commit 42848736b202 (fix for iptables issue in CentOS 8), we are seeing
errors in the nb/sb db log files that chroot cannot change the directory
to '/host' since we forgot to add volumes and volume mounts in
ovnkube-db.yaml.j2

@dcbw @danwinship PTAL