### PR TITLE
fix errors in ovn-appctl and ovs-appctl usage

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -383,7 +383,7 @@ func RunOVNNBAppCtl(args ...string) (string, string, error) {
 		runner.ovnRunDir + nbdbCtlSock,
 	}
 	cmdArgs = append(cmdArgs, args...)
-	stdout, stderr, err := runOVNretry(runner.appctlPath, nil, cmdArgs...)
+	stdout, stderr, err := runOVNretry(runner.ovnappctlPath, nil, cmdArgs...)
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
@@ -395,7 +395,7 @@ func RunOVNSBAppCtl(args ...string) (string, string, error) {
 		runner.ovnRunDir + sbdbCtlSock,
 	}
 	cmdArgs = append(cmdArgs, args...)
-	stdout, stderr, err := runOVNretry(runner.appctlPath, nil, cmdArgs...)
+	stdout, stderr, err := runOVNretry(runner.ovnappctlPath, nil, cmdArgs...)
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
@@ -407,7 +407,7 @@ func RunOVNNorthAppCtl(args ...string) (string, string, error) {
 		runner.ovnRunDir + northdCtlSock,
 	}
 	cmdArgs = append(cmdArgs, args...)
-	stdout, stderr, err := runOVNretry(runner.appctlPath, nil, cmdArgs...)
+	stdout, stderr, err := runOVNretry(runner.ovnappctlPath, nil, cmdArgs...)
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -40,9 +40,8 @@ const (
 )
 
 const (
-	nbdbCtlSock   = "ovnnb_db.ctl"
-	sbdbCtlSock   = "ovnsb_db.ctl"
-	northdCtlSock = "ovn-northd.ctl"
+	nbdbCtlSock = "ovnnb_db.ctl"
+	sbdbCtlSock = "ovnsb_db.ctl"
 )
 
 func runningPlatform() (string, error) {
@@ -402,9 +401,15 @@ func RunOVNSBAppCtl(args ...string) (string, string, error) {
 // RunOVNNorthAppCtl runs an 'ovs-appctl -t ovn-northd command'.
 func RunOVNNorthAppCtl(args ...string) (string, string, error) {
 	var cmdArgs []string
+
+	pid, err := ioutil.ReadFile(runner.ovnRunDir + "ovn-northd.pid")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to run the command since failed to get ovn-northd's pid: %v", err)
+	}
+
 	cmdArgs = []string{
 		"-t",
-		runner.ovnRunDir + northdCtlSock,
+		runner.ovnRunDir + fmt.Sprintf("ovn-northd.%s.ctl", strings.TrimSpace(string(pid))),
 	}
 	cmdArgs = append(cmdArgs, args...)
 	stdout, stderr, err := runOVNretry(runner.ovnappctlPath, nil, cmdArgs...)


### PR DESCRIPTION
1.  RunOVNNorthAppCtl() API uses incorrect ctl file
    
    this api uses the incorrect path of ${OVN_RUN_DIR}/ovn-northd.ctl.
    however, the control file path for ovn-northd is of the format
    ${OVN_RUN_DIR}/ovn-northd.<pid>.ctl.
    
2.  use ovn-appctl when available otherwise use ovs-appctl
    
    this commit fixes small issue introduced by acbe1c59d00f (Support latest
    OVN). the current code always uses ovs-appctl even though ovn-appctl
    might be available.

@numansiddique @dcbw PTAL