### PR TITLE
cluster.go: Disable Southbound DB conditional monitoring.

### DIFF
--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -57,6 +57,7 @@ func setupOVNNode(node *kapi.Node) error {
 		fmt.Sprintf("external_ids:ovn-openflow-probe-interval=%d",
 			config.Default.OpenFlowProbe),
 		fmt.Sprintf("external_ids:hostname=\"%s\"", nodeName),
+		"external_ids:ovn-monitor-all=true",
 	)
 	if err != nil {
 		return fmt.Errorf("error setting OVS external IDs: %v\n  %q", err, stderr)

--- a/go-controller/pkg/cluster/node_test.go
+++ b/go-controller/pkg/cluster/node_test.go
@@ -59,7 +59,8 @@ var _ = Describe("Node Operations", func() {
 					"external_ids:ovn-encap-ip=%s "+
 					"external_ids:ovn-remote-probe-interval=%d "+
 					"external_ids:ovn-openflow-probe-interval=%d "+
-					"external_ids:hostname=\"%s\"",
+					"external_ids:hostname=\"%s\" "+
+					"external_ids:ovn-monitor-all=true",
 					nodeIP, interval, ofintval, nodeName),
 			})
 
@@ -112,7 +113,8 @@ var _ = Describe("Node Operations", func() {
 					"external_ids:ovn-encap-ip=%s "+
 					"external_ids:ovn-remote-probe-interval=%d "+
 					"external_ids:ovn-openflow-probe-interval=%d "+
-					"external_ids:hostname=\"%s\"",
+					"external_ids:hostname=\"%s\" "+
+					"external_ids:ovn-monitor-all=true",
 					nodeIP, interval, ofintval, nodeName),
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{


### PR DESCRIPTION
ovn-controller enables conditional monitoring by default for tables in
the Southbound Database it is interested in (e.g., Logical_Flow). This
effectively performs row level filtering for the SB DB tables such that
an ovn-controller would receive only updates about records that refer to
logical datapaths that are local to the chassis.

However, in an ovn-kubernetes cluster, all node logical switches are
connected to the ovn-cluster-router which forces all ovn-controllers to
register for updates about all logical switches.

The conditional monitoring implementation in OVSDB turns out to not
scale so well in such scenarios.

OVN 20.03 supports a new configuration knob (ovn-monitor-all=true) which
instructs ovn-controllers to not use row level filtering of records.
This was introduced by:
https://github.com/ovn-org/ovn/commit/3c355e35298b72dd3bfb1fcee2594021ebb6d293

ovn-kubernetes per node gateway routers are bound to individual chassis
and should not generate openflow entries on other chassis. This is also
handled in OVN 20.03 by follow up commits:
https://github.com/ovn-org/ovn/commit/166a33c68204314c7eb614cb4109313401829c22
https://github.com/ovn-org/ovn/commit/eebef509ed6bcb8b785848fd85acf91c4e91acb3

Note regarding backwards compatibility:
When ovn-kubernetes is used with older OVN versions (i.e., <20.03)
setting "ovn-monitor-all=true" has no effect as the knob will just be
ignored by ovn-controller.

Reported-by: Girish Moodalbail <gmoodalbail@nvidia.com>
Reported-at: https://groups.google.com/d/msg/ovn-kubernetes/OalZ5-2ljnA/FOGlAyK5DQAJ
Signed-off-by: Dumitru Ceara <dceara@redhat.com>