### PR TITLE
ipv6: Make IPAddrToHWAddr() aware of IPv6

### DIFF
--- a/README_MANUAL.md
+++ b/README_MANUAL.md
@@ -115,6 +115,8 @@ Now start the ovnkube utility on the master node.
 The below command expects the user to provide
 * A cluster wide private address range of $CLUSTER_IP_SUBNET
 (e.g: 192.168.0.0/16).  The pods are provided IP address from this range.
+Note that with IPv6, there’s a limitation that the CIDR prefix must only have
+the first two bytes set.  For example: fd01::/48.
 
 * $NODE_NAME should be the same as the one used by kubelet.  kubelet by default
 uses the hostname.  kubelet allows this name to be overridden with

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -43,6 +43,16 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 
 		if parsedClusterEntry.CIDR.IP.To4() == nil {
 			ipv6 = true
+
+			// We require a simple CIDR with only the first 2 bytes set.  This is
+			// because of how we generate MAC addresses in IPAddrToHWAddr() in pkg/util/net.go.
+			var bits byte
+			for i := 2; i < 16; i++ {
+				bits |= parsedClusterEntry.CIDR.IP[i]
+			}
+			if bits != 0 {
+				return nil, fmt.Errorf("IPv6 cluster subnet must only have first 2 bytes set.")
+			}
 		}
 
 		entryMaskLength, _ := parsedClusterEntry.CIDR.Mask.Size()

--- a/go-controller/pkg/config/utils_test.go
+++ b/go-controller/pkg/config/utils_test.go
@@ -110,6 +110,12 @@ func TestParseClusterSubnetEntries(t *testing.T) {
 			clusterNetworks: nil,
 			expectedErr:     true,
 		},
+		{
+			name:            "IPv6 cluster subnet must only set first 2 bytes",
+			cmdLineArg:      "fda6:1234::/48",
+			clusterNetworks: nil,
+			expectedErr:     true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -112,8 +112,16 @@ func JoinHostPortInt32(host string, port int32) string {
 }
 
 // IPAddrToHWAddr takes the four octets of IPv4 address (aa.bb.cc.dd, for example) and uses them in creating
-// a MAC address (0A:58:AA:BB:CC:DD)
+// a MAC address (0A:58:AA:BB:CC:DD).  For IPv6, we'll use the first two bytes and last two bytes and hope
+// that results in a unique MAC for the scope of where it's used.
 func IPAddrToHWAddr(ip net.IP) string {
-	// safe to use private MAC prefix: 0A:58
-	return fmt.Sprintf("0A:58:%02X:%02X:%02X:%02X", ip[0], ip[1], ip[2], ip[3])
+	// Ensure that for IPv4, we are always working with the IP in 4-byte form.
+	ip4 := ip.To4()
+	if ip4 != nil {
+		// safe to use private MAC prefix: 0A:58
+		return fmt.Sprintf("0A:58:%02X:%02X:%02X:%02X", ip4[0], ip4[1], ip4[2], ip4[3])
+	}
+
+	// IPv6 - use the first two and last two bytes.
+	return fmt.Sprintf("0A:58:%02X:%02X:%02X:%02X", ip[0], ip[1], ip[14], ip[15])
 }

--- a/go-controller/pkg/util/util_test.go
+++ b/go-controller/pkg/util/util_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"net"
+
 	"github.com/urfave/cli"
 	kapi "k8s.io/api/core/v1"
 
@@ -20,6 +22,34 @@ var _ = Describe("Util tests", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+	})
+
+	It("test IPAddrToHWAddr()", func() {
+
+		type testcase struct {
+			name        string
+			IP          string
+			expectedMAC string
+		}
+
+		testcases := []testcase{
+			{
+				name:        "IPv4 to MAC",
+				IP:          "10.1.2.3",
+				expectedMAC: "0A:58:0A:01:02:03",
+			},
+			{
+				name:        "IPv6 to MAC",
+				IP:          "fd98::1",
+				expectedMAC: "0A:58:FD:98:00:01",
+			},
+		}
+
+		for _, tc := range testcases {
+			ip := net.ParseIP(tc.IP)
+			mac := IPAddrToHWAddr(ip)
+			Expect(mac).To(Equal(tc.expectedMAC), " test case \"%s\" returned %s instead of %s from IP %s", tc.name, mac, tc.expectedMAC, ip.String())
+		}
 	})
 
 	It("test validateOVNConfigEndpoint()", func() {


### PR DESCRIPTION
I had a problem in an IPv6 cluster where certain traffic was getting
dropped.  A closer look revealed that duplicate MACs had been
configured in the OVN virtual network topology.  In particular, the
join bridge between the gateway router and distributed cluster router
had the same MAC on both of its ports.

The root cause was this function.  It assumed IPv4.

While working on a fix for this and writing test cases, I discovered
that the function would sometimes also break for IPv4.  It assumed
that the IPv4 address was always in 4-byte form.  Sometimes the IP
type actually has 16 bytes, even when holding an IPv4 address.  The
first fix is to ensure that we're always using the 4-byte
representation when working with the IPv4 address.

The second fix is to make this function aware of IPv6.  We have more
bytes in the address than we have bytes in a MAC, so it's not
technically possible to always guarantee this results in a unique mac.
However, the subnets we have hard coded internally in OVN are of a
pretty simple format like fd98::N, so using the first two and last two
bytes seems good enough.

Really it's better to just generate a random unique MAC, but this
patch attempts a compromise by covering some cases without
re-introducing the performance concern that was addressed when this
code was first introduced by commit
b453f7398653b9e663866cd337c0d01dbfd80758.

Signed-off-by: Russell Bryant <russell@ovn.org>