### PR TITLE
remove LinkSetVfTxRate from setupSriovInterface

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -186,33 +186,7 @@ func setupSriovInterface(netns ns.NetNS, containerID, ifName string, ifInfo *Pod
 		return nil, nil, fmt.Errorf("failed to set MTU on %s: %v", hostIface.Name, err)
 	}
 
-	physlink, err := netlink.LinkByName(uplink)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed getting link for %s: %v", uplink, err)
-	}
-
-	// 7. Clean up any left over bandwidth configuration, before proceeding.
-	// Probably put this in a function that cleans up/resets other configs too.
-	err = netlink.LinkSetVfTxRate(physlink, vfIndex, 0)
-	if err != nil {
-		klog.Infof("failed to clean up bandwidth on %s (%s/%d): %v", pciAddrs, physlink, vfIndex, err)
-	}
-
-	// 8. set rate, if any.
-	if ifInfo.Egress > 0 {
-		// Rate in Mbps, LinkSetVfTxRate takes an int, and a value of 0 means no rate limit.
-		if ifInfo.Egress < 1000000 {
-			return nil, nil, fmt.Errorf("rate of %d bps not supported on device %s/%d", ifInfo.Egress, uplink, vfIndex)
-		}
-		// in Mbps
-		egressMbps := int(ifInfo.Egress / 1000000)
-		err = netlink.LinkSetVfTxRate(physlink, vfIndex, egressMbps)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed setting link bandwidth of %d Mbps on device %s/%d: %v", egressMbps, uplink, vfIndex, err)
-		}
-	}
-
-	// 9. Move VF to Container namespace
+	// 7. Move VF to Container namespace
 	err = moveIfToNetns(vfNetdevice, netns)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
ovs 2.12 [1] with hardware offload support ingress ratelimiting therefore
LinkSetVfTxRate is not needed. The patch remove the duplicate configuration
for SR-IOV VF. This kernel patch [2] add the support the mellanox driver.

Closes: #1066

[1] - https://github.com/openvswitch/ovs/commit/e7f6ba220e10c0b560da097185514b6e33e2dc71
[2] - https://www.spinics.net/lists/netdev/msg589937.html