### PR TITLE
Drop IPv6 cluster subnet limitation

### DIFF
--- a/README_MANUAL.md
+++ b/README_MANUAL.md
@@ -115,8 +115,6 @@ Now start the ovnkube utility on the master node.
 The below command expects the user to provide
 * A cluster wide private address range of $CLUSTER_IP_SUBNET
 (e.g: 192.168.0.0/16).  The pods are provided IP address from this range.
-Note that with IPv6, there’s a limitation that the CIDR prefix must only have
-the first two bytes set.  For example: fd01::/48.
 
 * $NODE_NAME should be the same as the one used by kubelet.  kubelet by default
 uses the hostname.  kubelet allows this name to be overridden with

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -43,16 +43,6 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 
 		if parsedClusterEntry.CIDR.IP.To4() == nil {
 			ipv6 = true
-
-			// We require a simple CIDR with only the first 2 bytes set.  This is
-			// because of how we generate MAC addresses in IPAddrToHWAddr() in pkg/util/net.go.
-			var bits byte
-			for i := 2; i < 16; i++ {
-				bits |= parsedClusterEntry.CIDR.IP[i]
-			}
-			if bits != 0 {
-				return nil, fmt.Errorf("IPv6 cluster subnet must only have first 2 bytes set.")
-			}
 		}
 
 		entryMaskLength, _ := parsedClusterEntry.CIDR.Mask.Size()

--- a/go-controller/pkg/config/utils_test.go
+++ b/go-controller/pkg/config/utils_test.go
@@ -110,12 +110,6 @@ func TestParseClusterSubnetEntries(t *testing.T) {
 			clusterNetworks: nil,
 			expectedErr:     true,
 		},
-		{
-			name:            "IPv6 cluster subnet must only set first 2 bytes",
-			cmdLineArg:      "fda6:1234::/48",
-			clusterNetworks: nil,
-			expectedErr:     true,
-		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This is a follow up after some discussion on PR #1091.  Even with this
limitation in place, we will still end up with some duplicate MACs in
a system.  The duplicates won't be on the same logical switch though,
so it's not harmful.  The cluster subnet doesn't change this
situation.