### PR TITLE
Pull new OVN rpm for Fedora

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -22,11 +22,13 @@ RUN INSTALL_PKGS=" \
         ovn ovn-central ovn-host \
 	iptables iproute strace socat \
         " && \
-	dnf install --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+	dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
 	dnf clean all && rm -rf /var/cache/dnf/*
 
-# REMOVE ME when ovn is fixed
-RUN dnf -y downgrade ovn
+# ensure we pick up ovn-2.12.1-1.fc31
+# this should have no effect in the future once the
+# advisory repo is gone and can be removed
+RUN dnf install ovn --best  --enablerepo=updates-testing --advisory=FEDORA-2020-34b65e864b1 || true
 
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /usr/libexec/cni/


### PR DESCRIPTION
Includes fixes to regressions that were causing CI to fail before
downgrade.

Signed-off-by: Tim Rozet <trozet@redhat.com>