### PR TITLE
Address set objects

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -231,7 +231,7 @@ func runOvnKube(ctx *cli.Context) error {
 		}
 		// register prometheus metrics exported by the master
 		metrics.RegisterMasterMetrics()
-		ovnController := ovn.NewOvnController(clientset, factory, stopChan)
+		ovnController := ovn.NewOvnController(clientset, factory, stopChan, nil)
 		if err := ovnController.Start(clientset, master); err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/address_set.go
+++ b/go-controller/pkg/ovn/address_set.go
@@ -1,0 +1,250 @@
+package ovn
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	"k8s.io/klog"
+)
+
+type AddressSetIterFunc func(hashedName, namespace, suffix string)
+type AddressSetDoFunc func(as AddressSet) error
+
+// AddressSetFactory is an interface for managing address set objects
+type AddressSetFactory interface {
+	// NewAddressSet returns a new object that implements NewAddressSet
+	// and contains the given IPs, or an error
+	NewAddressSet(name string, ips []net.IP) (AddressSet, error)
+	// ForEachAddressSet calls the given function for each address set
+	// known to the factory
+	ForEachAddressSet(iteratorFn AddressSetIterFunc) error
+}
+
+type ovnAddressSetFactory struct{}
+
+// NewOvnAddressSetFactory creates a new AddressSetFactory backed by
+// address set objects that execute OVN commands
+func NewOvnAddressSetFactory() AddressSetFactory {
+	return &ovnAddressSetFactory{}
+}
+
+// ovnAddressSetFactory implements the AddressSetFactory interface
+var _ AddressSetFactory = &ovnAddressSetFactory{}
+
+// NewAddressSet returns a new address set object
+func (asf *ovnAddressSetFactory) NewAddressSet(name string, ips []net.IP) (AddressSet, error) {
+	return newOvnAddressSet(name, ips)
+}
+
+// ForEachAddressSet will pass the hashedName, namespaceName and
+// the first suffix in the name to the 'iteratorFn' for every address_set in
+// OVN. (Each unhashed name for an ovnAddressSet can be of the form
+// namespaceName.suffix1.suffix2. .suffixN)
+func (asf *ovnAddressSetFactory) ForEachAddressSet(iteratorFn AddressSetIterFunc) error {
+	output, stderr, err := util.RunOVNNbctl("--format=csv", "--data=bare", "--no-heading",
+		"--columns=name,external_ids", "find", "address_set")
+	if err != nil {
+		return fmt.Errorf("error reading address sets: "+
+			"stdout: %q, stderr: %q err: %v", output, stderr, err)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		fmt.Printf("#### %q\n", line)
+		parts := strings.Split(line, ",")
+		if len(parts) != 2 {
+			continue
+		}
+		hashedName := parts[0]
+		for _, externalID := range strings.Fields(parts[1]) {
+			if !strings.HasPrefix(externalID, "name=") {
+				continue
+			}
+			addrSetName := externalID[5:]
+			names := strings.Split(addrSetName, ".")
+			addrSetNamespace := names[0]
+			nameSuffix := ""
+			if len(names) >= 2 {
+				nameSuffix = names[1]
+			}
+			iteratorFn(hashedName, addrSetNamespace, nameSuffix)
+			break
+		}
+	}
+	return nil
+}
+
+// AddressSet is an interface for address set objects
+type AddressSet interface {
+	// GetHashName returns the hashed name of the address set
+	GetHashName() string
+	// GetName returns the descriptive name of the address set
+	GetName() string
+	AddIP(ip net.IP) error
+	DeleteIP(ip net.IP) error
+	Destroy()
+}
+
+type removeFunc func(string)
+
+type ovnAddressSet struct {
+	sync.RWMutex
+	name     string
+	hashName string
+	uuid     string
+	ips      map[string]net.IP
+}
+
+// ovnAddressSet implements the AddressSet interface
+var _ AddressSet = &ovnAddressSet{}
+
+// hash the provided input to make it a valid ovnAddressSet name.
+func hashedAddressSet(s string) string {
+	return hashForOVN(s)
+}
+
+func asDetail(as *ovnAddressSet) string {
+	return fmt.Sprintf("%s/%s/%s", as.uuid, as.name, as.hashName)
+}
+
+func newOvnAddressSet(name string, ips []net.IP) (*ovnAddressSet, error) {
+	as := &ovnAddressSet{
+		name:     name,
+		hashName: hashedAddressSet(name),
+		ips:      make(map[string]net.IP),
+	}
+	for _, ip := range ips {
+		as.ips[ip.String()] = ip
+	}
+
+	uuid, stderr, err := util.RunOVNNbctl("--data=bare",
+		"--no-heading", "--columns=_uuid", "find", "address_set",
+		"name="+as.hashName)
+	if err != nil {
+		return nil, fmt.Errorf("find failed to get address set %q, stderr: %q (%v)",
+			as.name, stderr, err)
+	}
+	as.uuid = uuid
+
+	if uuid != "" {
+		klog.V(5).Infof("New(%s) already exists; updating IPs", asDetail(as))
+		// ovnAddressSet already exists in the database; just update IPs
+		if err := as.setOrClear(); err != nil {
+			return nil, err
+		}
+	} else {
+		// ovnAddressSet has not been created yet. Create it.
+		args := []string{
+			"create",
+			"address_set",
+			"name=" + as.hashName,
+			"external-ids:name=" + as.name,
+		}
+		joinedIPs := as.joinIPs()
+		if len(joinedIPs) > 0 {
+			args = append(args, "addresses="+joinedIPs)
+		}
+		as.uuid, stderr, err = util.RunOVNNbctl(args...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create address set %q, stderr: %q (%v)",
+				asDetail(as), stderr, err)
+		}
+	}
+
+	klog.V(5).Infof("New(%s) with %v", asDetail(as), ips)
+
+	return as, nil
+}
+
+func (as *ovnAddressSet) GetHashName() string {
+	return as.hashName
+}
+
+func (as *ovnAddressSet) GetName() string {
+	return as.name
+}
+
+func (as *ovnAddressSet) joinIPs() string {
+	list := make([]string, 0, len(as.ips))
+	for ipStr := range as.ips {
+		list = append(list, `"`+ipStr+`"`)
+	}
+	sort.Strings(list)
+	return strings.Join(list, " ")
+}
+
+// setOrClear updates the OVN database with the address set's addresses or
+// clears the address set if there are no addresses in the address set
+func (as *ovnAddressSet) setOrClear() error {
+	joinedIPs := as.joinIPs()
+	if len(joinedIPs) > 0 {
+		_, stderr, err := util.RunOVNNbctl("set", "address_set", as.uuid, "addresses="+joinedIPs)
+		if err != nil {
+			return fmt.Errorf("failed to set address set %q, stderr: %q (%v)",
+				asDetail(as), stderr, err)
+		}
+	} else {
+		_, stderr, err := util.RunOVNNbctl("clear", "address_set", as.uuid, "addresses")
+		if err != nil {
+			return fmt.Errorf("failed to clear address set %q, stderr: %q (%v)",
+				asDetail(as), stderr, err)
+		}
+	}
+	return nil
+}
+
+func (as *ovnAddressSet) AddIP(ip net.IP) error {
+	as.Lock()
+	defer as.Unlock()
+
+	ipStr := ip.String()
+	if _, ok := as.ips[ipStr]; ok {
+		return nil
+	}
+
+	klog.V(5).Infof("(%s) adding IP %s to address set", asDetail(as), ipStr)
+
+	_, stderr, err := util.RunOVNNbctl("add", "address_set", as.uuid, "addresses", `"`+ipStr+`"`)
+	if err != nil {
+		return fmt.Errorf("failed to add IP %q to address set %q, stderr: %q (%v)",
+			ip, asDetail(as), stderr, err)
+	}
+
+	as.ips[ip.String()] = ip
+	return nil
+}
+
+func (as *ovnAddressSet) DeleteIP(ip net.IP) error {
+	as.Lock()
+	defer as.Unlock()
+
+	ipStr := ip.String()
+	if _, ok := as.ips[ipStr]; !ok {
+		return nil
+	}
+
+	klog.V(5).Infof("(%s) deleting IP %s from address set", asDetail(as), ipStr)
+
+	_, stderr, err := util.RunOVNNbctl("remove", "address_set", as.uuid, "addresses", `"`+ipStr+`"`)
+	if err != nil {
+		return fmt.Errorf("failed to remove IP %q from address set %q, stderr: %q (%v)",
+			ip, asDetail(as), stderr, err)
+	}
+
+	delete(as.ips, ipStr)
+	return nil
+}
+
+func (as *ovnAddressSet) Destroy() {
+	as.Lock()
+	defer as.Unlock()
+	klog.V(5).Infof("Destroy(%s)", asDetail(as))
+	_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy", "address_set", as.uuid)
+	if err != nil {
+		klog.Errorf("failed to destroy address set %q, stderr: %q, (%v)",
+			asDetail(as), stderr, err)
+	}
+}

--- a/go-controller/pkg/ovn/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set_test.go
@@ -53,9 +53,19 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				namespaces := []testAddressSetName{
-					{"ns1", "foo", "bar"},
-					{"ns2", "test", "test2"},
-					{namespace: "ns3"},
+					{
+						namespace: "ns1",
+						suffix1:   "foo",
+						suffix2:   "bar",
+					},
+					{
+						namespace: "ns2",
+						suffix1:   "test",
+						suffix2:   "test2",
+					},
+					{
+						namespace: "ns3",
+					},
 				}
 
 				var namespacesRes string
@@ -114,7 +124,9 @@ var _ = Describe("OVN Address Set operations", func() {
 					`ovn-nbctl --timeout=15 set address_set ` + fakeUUID + ` addresses="` + addr1 + `" "` + addr2 + `"`,
 				})
 
-				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				ip1 := net.ParseIP(addr1)
+				ip2 := net.ParseIP(addr2)
+				_, err = asFactory.NewAddressSet("foobar", []*net.IP{&ip1, &ip2})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 				return nil
@@ -165,7 +177,9 @@ var _ = Describe("OVN Address Set operations", func() {
 					Output: fakeUUID,
 				})
 
-				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				ip1 := net.ParseIP(addr1)
+				ip2 := net.ParseIP(addr2)
+				_, err = asFactory.NewAddressSet("foobar", []*net.IP{&ip1, &ip2})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 				return nil
@@ -193,7 +207,8 @@ var _ = Describe("OVN Address Set operations", func() {
 			as, err := asFactory.NewAddressSet("foobar", nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			as.Destroy()
+			err = as.Destroy()
+			Expect(err).NotTo(HaveOccurred())
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 			return nil
 		}
@@ -257,7 +272,8 @@ var _ = Describe("OVN Address Set operations", func() {
 					`ovn-nbctl --timeout=15 remove address_set ` + fakeUUID + ` addresses "` + addr1 + `"`,
 				})
 
-				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1)})
+				ip1 := net.ParseIP(addr1)
+				as, err := asFactory.NewAddressSet("foobar", []*net.IP{&ip1})
 				Expect(err).NotTo(HaveOccurred())
 
 				err = as.DeleteIP(net.ParseIP(addr1))

--- a/go-controller/pkg/ovn/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set_test.go
@@ -74,16 +74,15 @@ var _ = Describe("OVN Address Set operations", func() {
 					namespacesRes += fmt.Sprintf("%s,name=%s\n", hashedAddressSet(name), name)
 				}
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=name,external_ids find address_set",
+					Cmd:    "ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=external_ids find address_set",
 					Output: namespacesRes,
 				})
 
-				err = asFactory.ForEachAddressSet(func(hashedAddrSetName, namespaceName, nameSuffix string) {
+				err = asFactory.ForEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) {
 					found := false
-					fmt.Printf("%q %q %q\n", hashedAddrSetName, namespaceName, nameSuffix)
 					for _, n := range namespaces {
 						name := n.makeName()
-						if hashedAddrSetName == hashedAddressSet(name) {
+						if addrSetName == name {
 							found = true
 							Expect(namespaceName).To(Equal(n.namespace))
 							if n.suffix1 != "" {
@@ -124,9 +123,7 @@ var _ = Describe("OVN Address Set operations", func() {
 					`ovn-nbctl --timeout=15 set address_set ` + fakeUUID + ` addresses="` + addr1 + `" "` + addr2 + `"`,
 				})
 
-				ip1 := net.ParseIP(addr1)
-				ip2 := net.ParseIP(addr2)
-				_, err = asFactory.NewAddressSet("foobar", []*net.IP{&ip1, &ip2})
+				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 				return nil
@@ -177,9 +174,7 @@ var _ = Describe("OVN Address Set operations", func() {
 					Output: fakeUUID,
 				})
 
-				ip1 := net.ParseIP(addr1)
-				ip2 := net.ParseIP(addr2)
-				_, err = asFactory.NewAddressSet("foobar", []*net.IP{&ip1, &ip2})
+				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 				return nil
@@ -272,8 +267,7 @@ var _ = Describe("OVN Address Set operations", func() {
 					`ovn-nbctl --timeout=15 remove address_set ` + fakeUUID + ` addresses "` + addr1 + `"`,
 				})
 
-				ip1 := net.ParseIP(addr1)
-				as, err := asFactory.NewAddressSet("foobar", []*net.IP{&ip1})
+				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1)})
 				Expect(err).NotTo(HaveOccurred())
 
 				err = as.DeleteIP(net.ParseIP(addr1))

--- a/go-controller/pkg/ovn/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set_test.go
@@ -1,0 +1,278 @@
+package ovn
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type testAddressSetName struct {
+	namespace string
+	suffix1   string
+	suffix2   string
+}
+
+func (asn *testAddressSetName) makeName() string {
+	return fmt.Sprintf("%s.%s.%s", asn.namespace, asn.suffix1, asn.suffix2)
+}
+
+var _ = Describe("OVN Address Set operations", func() {
+	var (
+		app       *cli.App
+		fexec     *ovntest.FakeExec
+		asFactory AddressSetFactory
+	)
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.PrepareTestConfig()
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		fexec = ovntest.NewFakeExec()
+		err := util.SetExec(fexec)
+		Expect(err).NotTo(HaveOccurred())
+
+		asFactory = NewOvnAddressSetFactory()
+	})
+
+	Context("when iterating address sets", func() {
+		It("calls the iterator function for each address set with the given prefix", func() {
+			app.Action = func(ctx *cli.Context) error {
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				namespaces := []testAddressSetName{
+					{"ns1", "foo", "bar"},
+					{"ns2", "test", "test2"},
+					{namespace: "ns3"},
+				}
+
+				var namespacesRes string
+				for _, n := range namespaces {
+					name := n.makeName()
+					namespacesRes += fmt.Sprintf("%s,name=%s\n", hashedAddressSet(name), name)
+				}
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=name,external_ids find address_set",
+					Output: namespacesRes,
+				})
+
+				err = asFactory.ForEachAddressSet(func(hashedAddrSetName, namespaceName, nameSuffix string) {
+					found := false
+					fmt.Printf("%q %q %q\n", hashedAddrSetName, namespaceName, nameSuffix)
+					for _, n := range namespaces {
+						name := n.makeName()
+						if hashedAddrSetName == hashedAddressSet(name) {
+							found = true
+							Expect(namespaceName).To(Equal(n.namespace))
+							if n.suffix1 != "" {
+								Expect(nameSuffix).To(Equal(n.suffix1))
+							} else {
+								Expect(nameSuffix).To(Equal(""))
+							}
+						}
+					}
+					Expect(found).To(BeTrue())
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when creating an address set object", func() {
+		It("re-uses an existing address set and replaces IPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					addr1 string = "1.2.3.4"
+					addr2 string = "5.6.7.8"
+				)
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 set address_set ` + fakeUUID + ` addresses="` + addr1 + `" "` + addr2 + `"`,
+				})
+
+				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("clears an existing address set of IPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 clear address_set " + fakeUUID + " addresses",
+				})
+
+				_, err = asFactory.NewAddressSet("foobar", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates a new address set and sets IPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					addr1 string = "1.2.3.4"
+					addr2 string = "5.6.7.8"
+				)
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a9625390261332436968 external-ids:name=foobar addresses="` + addr1 + `" "` + addr2 + `"`,
+					Output: fakeUUID,
+				})
+
+				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	It("destroys an address set", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+				Output: fakeUUID,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 clear address_set " + fakeUUID + " addresses",
+				"ovn-nbctl --timeout=15 --if-exists destroy address_set " + fakeUUID,
+			})
+
+			as, err := asFactory.NewAddressSet("foobar", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			as.Destroy()
+			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+			return nil
+		}
+
+		err := app.Run([]string{app.Name})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when manipulating IPs in an address set object", func() {
+		It("adds an IP to an empty address set", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const addr1 string = "1.2.3.4"
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 create address_set name=a9625390261332436968 external-ids:name=foobar",
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 add address_set ` + fakeUUID + ` addresses "` + addr1 + `"`,
+				})
+
+				as, err := asFactory.NewAddressSet("foobar", nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = as.AddIP(net.ParseIP(addr1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// Re-adding is a no-op
+				err = as.AddIP(net.ParseIP(addr1))
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("deletes an IP from an address set", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const addr1 string = "1.2.3.4"
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a9625390261332436968 external-ids:name=foobar addresses="` + addr1 + `"`,
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 remove address_set ` + fakeUUID + ` addresses "` + addr1 + `"`,
+				})
+
+				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1)})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = as.DeleteIP(net.ParseIP(addr1))
+				Expect(err).NotTo(HaveOccurred())
+
+				// Deleting a non-existent address is a no-op
+				err = as.DeleteIP(net.ParseIP(addr1))
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strconv"
-	"strings"
 
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/klog"
@@ -21,133 +20,9 @@ func hashForOVN(s string) string {
 	return fmt.Sprintf("a%s", hashString)
 }
 
-// hash the provided input to make it a valid addressSet name.
-func hashedAddressSet(s string) string {
-	return hashForOVN(s)
-}
-
 // hash the provided input to make it a valid portGroup name.
 func hashedPortGroup(s string) string {
 	return hashForOVN(s)
-}
-
-// forEachAddressSetUnhashedName will pass the unhashedName, namespaceName and
-// the first suffix in the name to the 'iteratorFn' for every address_set in
-// OVN. (Each unhashed name for an addressSet can be of the form
-// namespaceName.suffix1.suffix2. .suffixN)
-func (oc *Controller) forEachAddressSetUnhashedName(iteratorFn func(
-	string, string, string)) error {
-	output, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=external_ids", "find", "address_set")
-	if err != nil {
-		klog.Errorf("Error in obtaining list of address sets from OVN: "+
-			"stdout: %q, stderr: %q err: %v", output, stderr, err)
-		return err
-	}
-	for _, addrSet := range strings.Fields(output) {
-		if !strings.HasPrefix(addrSet, "name=") {
-			continue
-		}
-		addrSetName := addrSet[5:]
-		names := strings.Split(addrSetName, ".")
-		addrSetNamespace := names[0]
-		nameSuffix := ""
-		if len(names) >= 2 {
-			nameSuffix = names[1]
-		}
-		iteratorFn(addrSetName, addrSetNamespace, nameSuffix)
-	}
-	return nil
-}
-
-func addToAddressSet(hashName string, address string) {
-	klog.V(5).Infof("addToAddressSet for %s with %s", hashName, address)
-
-	// IPv6 addresses need to be quoted, IPv4 work either way.
-	_, stderr, err := util.RunOVNNbctl("add", "address_set",
-		hashName, "addresses", `"`+address+`"`)
-	if err != nil {
-		klog.Errorf("failed to add an address %q to address_set %q, stderr: %q (%v)",
-			address, hashName, stderr, err)
-	}
-}
-
-func removeFromAddressSet(hashName string, address string) {
-	klog.V(5).Infof("removeFromAddressSet for %s with %s", hashName, address)
-
-	// IPv6 addresses need to be quoted, IPv4 work either way.
-	_, stderr, err := util.RunOVNNbctl("remove", "address_set",
-		hashName, "addresses", `"`+address+`"`)
-	if err != nil {
-		klog.Errorf("failed to remove an address %q from address_set %q, stderr: %q (%v)",
-			address, hashName, stderr, err)
-	}
-}
-
-func createAddressSet(name string, hashName string,
-	addresses []string) {
-	klog.V(5).Infof("createAddressSet with %s and %s", name, addresses)
-	addressSet, stderr, err := util.RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=_uuid", "find", "address_set",
-		fmt.Sprintf("name=%s", hashName))
-	if err != nil {
-		klog.Errorf("find failed to get address set, stderr: %q (%v)",
-			stderr, err)
-		return
-	}
-
-	// addressSet has already been created in the database and nothing to set.
-	if addressSet != "" && len(addresses) == 0 {
-		_, stderr, err = util.RunOVNNbctl("clear", "address_set",
-			hashName, "addresses")
-		if err != nil {
-			klog.Errorf("failed to clear address_set, stderr: %q (%v)",
-				stderr, err)
-		}
-		return
-	}
-
-	ips := `"` + strings.Join(addresses, `" "`) + `"`
-
-	// An addressSet has already been created. Just set addresses.
-	if addressSet != "" {
-		// Set the addresses
-		_, stderr, err = util.RunOVNNbctl("set", "address_set",
-			hashName, fmt.Sprintf("addresses=%s", ips))
-		if err != nil {
-			klog.Errorf("failed to set address_set, stderr: %q (%v)",
-				stderr, err)
-		}
-		return
-	}
-
-	// addressSet has not been created yet. Create it.
-	if len(addresses) == 0 {
-		_, stderr, err = util.RunOVNNbctl("create", "address_set",
-			fmt.Sprintf("name=%s", hashName),
-			fmt.Sprintf("external-ids:name=%s", name))
-	} else {
-		_, stderr, err = util.RunOVNNbctl("create", "address_set",
-			fmt.Sprintf("name=%s", hashName),
-			fmt.Sprintf("external-ids:name=%s", name),
-			fmt.Sprintf("addresses=%s", ips))
-	}
-	if err != nil {
-		klog.Errorf("failed to create address_set %s, stderr: %q (%v)",
-			name, stderr, err)
-	}
-}
-
-func deleteAddressSet(hashName string) {
-	klog.V(5).Infof("deleteAddressSet %s", hashName)
-
-	_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy",
-		"address_set", hashName)
-	if err != nil {
-		klog.Errorf("failed to destroy address set %s, stderr: %q, (%v)",
-			hashName, stderr, err)
-		return
-	}
 }
 
 func createPortGroup(name string, hashName string) (string, error) {

--- a/go-controller/pkg/ovn/fake_address_set.go
+++ b/go-controller/pkg/ovn/fake_address_set.go
@@ -1,0 +1,181 @@
+package ovn
+
+import (
+	"fmt"
+	"hash/fnv"
+	"net"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/gomega"
+)
+
+func newFakeAddressSetFactory() *fakeAddressSetFactory {
+	return &fakeAddressSetFactory{
+		sets: make(map[string]*fakeAddressSet),
+	}
+}
+
+type fakeAddressSetFactory struct {
+	sync.RWMutex
+	// maps address set name to object
+	sets map[string]*fakeAddressSet
+}
+
+// fakeFactory implements the AddressSetFactory interface
+var _ AddressSetFactory = &fakeAddressSetFactory{}
+
+// NewAddressSet returns a new address set object
+func (f *fakeAddressSetFactory) NewAddressSet(name string, ips []net.IP) (AddressSet, error) {
+	f.Lock()
+	defer f.Unlock()
+	_, ok := f.sets[name]
+	Expect(ok).To(BeFalse())
+	set := newFakeAddressSet(name, ips, f.removeAddressSet)
+	f.sets[name] = set
+	return set, nil
+}
+
+func (f *fakeAddressSetFactory) ForEachAddressSet(iteratorFn AddressSetIterFunc) error {
+	for name, set := range f.sets {
+		parts := strings.Split(set.GetName(), ".")
+		addrSetNamespace := parts[0]
+		nameSuffix := ""
+		if len(parts) >= 2 {
+			nameSuffix = parts[1]
+		}
+		iteratorFn(name, addrSetNamespace, nameSuffix)
+	}
+	return nil
+}
+
+func (f *fakeAddressSetFactory) getAddressSet(name string) *fakeAddressSet {
+	f.RLock()
+	defer f.RUnlock()
+	if as, ok := f.sets[name]; ok {
+		as.Lock()
+		return as
+	}
+	return nil
+}
+
+// removeAddressSet removes the address set from the factory
+func (f *fakeAddressSetFactory) removeAddressSet(name string) {
+	f.Lock()
+	defer f.Unlock()
+	delete(f.sets, name)
+}
+
+// ExpectAddressSetWithIPs ensures the named address set exists with the given set of IPs
+func (f *fakeAddressSetFactory) ExpectAddressSetWithIPs(name string, ips []string) {
+	as := f.getAddressSet(name)
+	Expect(as).NotTo(BeNil())
+	defer as.Unlock()
+	for _, expectedIP := range ips {
+		Expect(as.ips).To(HaveKey(expectedIP))
+	}
+	Expect(as.ips).To(HaveLen(len(ips)))
+}
+
+// ExpectEmptyAddressSet ensures the named address set exists with no IPs
+func (f *fakeAddressSetFactory) ExpectEmptyAddressSet(name string) {
+	f.ExpectAddressSetWithIPs(name, nil)
+}
+
+// EventuallyExpectEmptyAddressSet ensures the named address set eventually exists with no IPs
+func (f *fakeAddressSetFactory) EventuallyExpectEmptyAddressSet(name string) {
+	Eventually(func() bool {
+		as := f.getAddressSet(name)
+		Expect(as).NotTo(BeNil())
+		defer as.Unlock()
+		return len(as.ips) == 0
+	}).Should(BeTrue())
+}
+
+// EventuallyExpectNoAddressSet ensures the named address set eventually does not exist
+func (f *fakeAddressSetFactory) EventuallyExpectNoAddressSet(name string) {
+	Eventually(func() bool {
+		f.RLock()
+		defer f.RUnlock()
+		_, ok := f.sets[name]
+		return ok
+	}).Should(BeFalse())
+}
+
+type fakeAddressSet struct {
+	sync.Mutex
+	name      string
+	hashName  string
+	uuid      string
+	ips       map[string]net.IP
+	destroyed bool
+	removeFn  removeFunc
+}
+
+// fakeAddressSet implements the AddressSet interface
+var _ AddressSet = &fakeAddressSet{}
+
+func newUUID(name string) string {
+	h := fnv.New128a()
+	_, err := h.Write([]byte(name))
+	Expect(err).NotTo(HaveOccurred())
+	b := make([]byte, 0, 32)
+	h.Sum(b)
+	return fmt.Sprintf("%08s-%04s-%04s-%04s-%12s", b[0:8], b[8:12], b[12:16], b[16:20], b[20:32])
+}
+
+func newFakeAddressSet(name string, ips []net.IP, removeFn removeFunc) *fakeAddressSet {
+	as := &fakeAddressSet{
+		name:     name,
+		uuid:     newUUID(name),
+		hashName: hashedAddressSet(name),
+		ips:      make(map[string]net.IP),
+		removeFn: removeFn,
+	}
+	for _, ip := range ips {
+		as.ips[ip.String()] = ip
+	}
+	return as
+}
+
+func (as *fakeAddressSet) GetHashName() string {
+	Expect(as.destroyed).To(BeFalse())
+	return as.hashName
+}
+
+func (as *fakeAddressSet) GetName() string {
+	Expect(as.destroyed).To(BeFalse())
+	return as.name
+}
+
+func (as *fakeAddressSet) AddIP(ip net.IP) error {
+	Expect(as.destroyed).To(BeFalse())
+	as.Lock()
+	defer as.Unlock()
+	ipStr := ip.String()
+	if _, ok := as.ips[ipStr]; !ok {
+		as.ips[ip.String()] = ip
+	}
+	return nil
+}
+
+func (as *fakeAddressSet) DeleteIP(ip net.IP) error {
+	Expect(as.destroyed).To(BeFalse())
+	as.Lock()
+	defer as.Unlock()
+	delete(as.ips, ip.String())
+	return nil
+}
+
+func (as *fakeAddressSet) destroyInternal() {
+	Expect(as.destroyed).To(BeFalse())
+	as.destroyed = true
+	as.removeFn(as.name)
+}
+
+func (as *fakeAddressSet) Destroy() {
+	Expect(as.destroyed).To(BeFalse())
+	as.Lock()
+	defer as.Unlock()
+	as.destroyInternal()
+}

--- a/go-controller/pkg/ovn/fake_address_set_test.go
+++ b/go-controller/pkg/ovn/fake_address_set_test.go
@@ -24,7 +24,7 @@ type fakeAddressSetFactory struct {
 var _ AddressSetFactory = &fakeAddressSetFactory{}
 
 // NewAddressSet returns a new address set object
-func (f *fakeAddressSetFactory) NewAddressSet(name string, ips []*net.IP) (AddressSet, error) {
+func (f *fakeAddressSetFactory) NewAddressSet(name string, ips []net.IP) (AddressSet, error) {
 	f.Lock()
 	defer f.Unlock()
 	_, ok := f.sets[name]
@@ -111,7 +111,7 @@ type fakeAddressSet struct {
 	sync.Mutex
 	name      string
 	hashName  string
-	ips       map[string]*net.IP
+	ips       map[string]net.IP
 	destroyed bool
 	removeFn  removeFunc
 }
@@ -119,11 +119,11 @@ type fakeAddressSet struct {
 // fakeAddressSet implements the AddressSet interface
 var _ AddressSet = &fakeAddressSet{}
 
-func newFakeAddressSet(name string, ips []*net.IP, removeFn removeFunc) *fakeAddressSet {
+func newFakeAddressSet(name string, ips []net.IP, removeFn removeFunc) *fakeAddressSet {
 	as := &fakeAddressSet{
 		name:     name,
 		hashName: hashedAddressSet(name),
-		ips:      make(map[string]*net.IP),
+		ips:      make(map[string]net.IP),
 		removeFn: removeFn,
 	}
 	for _, ip := range ips {
@@ -148,7 +148,7 @@ func (as *fakeAddressSet) AddIP(ip net.IP) error {
 	defer as.Unlock()
 	ipStr := ip.String()
 	if _, ok := as.ips[ipStr]; !ok {
-		as.ips[ip.String()] = &ip
+		as.ips[ip.String()] = ip
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 )
 
@@ -17,11 +19,12 @@ type gressPolicy struct {
 	policyType      knet.PolicyType
 	idx             int
 
-	// peerAddressSets points to all the addressSets that hold
-	// the peer pod's IP addresses. We will have one addressSet for
-	// local pods and multiple addressSets that each represent a
-	// peer namespace
-	peerAddressSets map[string]bool
+	// peerAddressSet points to the addressSet that holds all peer pod
+	// IP addresess.
+	peerAddressSet AddressSet
+
+	// nsAddressSets holds the names of all namespace address sets
+	nsAddressSets sets.String
 
 	// sortedPeerAddressSets has the sorted peerAddressSets
 	sortedPeerAddressSets []string
@@ -58,12 +61,46 @@ func newGressPolicy(policyType knet.PolicyType, idx int, namespace, name string)
 		policyName:            name,
 		policyType:            policyType,
 		idx:                   idx,
-		peerAddressSets:       make(map[string]bool),
+		nsAddressSets:         sets.String{},
 		sortedPeerAddressSets: make([]string, 0),
 		portPolicies:          make([]*portPolicy, 0),
 		ipBlockCidr:           make([]string, 0),
 		ipBlockExcept:         make([]string, 0),
 	}
+}
+
+func (gp *gressPolicy) ensurePeerAddressSet(factory AddressSetFactory) error {
+	if gp.peerAddressSet != nil {
+		return nil
+	}
+
+	direction := strings.ToLower(string(gp.policyType))
+	asName := fmt.Sprintf("%s.%s.%s.%d", gp.policyNamespace, gp.policyName, direction, gp.idx)
+	as, err := factory.NewAddressSet(asName, nil)
+	if err != nil {
+		return err
+	}
+
+	gp.peerAddressSet = as
+	gp.sortedPeerAddressSets = append(gp.sortedPeerAddressSets, as.GetHashName())
+	sort.Strings(gp.sortedPeerAddressSets)
+	return nil
+}
+
+func (gp *gressPolicy) addPeerPod(pod *v1.Pod) error {
+	ips, err := util.GetAllPodIPs(pod)
+	if err != nil {
+		return err
+	}
+	return gp.peerAddressSet.AddIP(ips[0])
+}
+
+func (gp *gressPolicy) deletePeerPod(pod *v1.Pod) error {
+	ips, err := util.GetAllPodIPs(pod)
+	if err != nil {
+		return err
+	}
+	return gp.peerAddressSet.DeleteIP(ips[0])
 }
 
 func (gp *gressPolicy) addPortPolicy(portJSON *knet.NetworkPolicyPort) {
@@ -86,17 +123,16 @@ func ipMatch() string {
 }
 
 func (gp *gressPolicy) getL3MatchFromAddressSet() string {
-	var l3Match, addresses string
-	for _, addressSet := range gp.sortedPeerAddressSets {
-		if addresses == "" {
-			addresses = fmt.Sprintf("$%s", addressSet)
-			continue
-		}
-		addresses = fmt.Sprintf("%s, $%s", addresses, addressSet)
+	addressSets := make([]string, 0, len(gp.sortedPeerAddressSets))
+	for _, hashName := range gp.sortedPeerAddressSets {
+		addressSets = append(addressSets, fmt.Sprintf("$%s", hashName))
 	}
-	if addresses == "" {
+
+	var l3Match string
+	if len(addressSets) == 0 {
 		l3Match = ipMatch()
 	} else {
+		addresses := strings.Join(addressSets, ", ")
 		if gp.policyType == knet.PolicyTypeIngress {
 			l3Match = fmt.Sprintf("%s.src == {%s}", ipMatch(), addresses)
 		} else {
@@ -129,40 +165,38 @@ func (gp *gressPolicy) getMatchFromIPBlock(lportMatch, l4Match string) string {
 	return match
 }
 
-// addAddressSet adds a new peer or namespace address set to the gress policy
-func (gp *gressPolicy) addAddressSet(hashedAddressSet string) (string, string, bool) {
-	if gp.peerAddressSets[hashedAddressSet] {
-		return "", "", false
+// addNamespaceAddressSet adds a new namespace address set to the gress policy
+func (gp *gressPolicy) addNamespaceAddressSet(name, portGroupName string) {
+	hashName := hashedAddressSet(name)
+	if gp.nsAddressSets.Has(hashName) {
+		return
 	}
 
 	oldL3Match := gp.getL3MatchFromAddressSet()
-
-	gp.sortedPeerAddressSets = append(gp.sortedPeerAddressSets, hashedAddressSet)
+	gp.nsAddressSets.Insert(hashName)
+	gp.sortedPeerAddressSets = append(gp.sortedPeerAddressSets, hashName)
 	sort.Strings(gp.sortedPeerAddressSets)
-	gp.peerAddressSets[hashedAddressSet] = true
-
-	return oldL3Match, gp.getL3MatchFromAddressSet(), true
+	gp.localPodUpdateACL(oldL3Match, gp.getL3MatchFromAddressSet(), portGroupName)
 }
 
-// delAddressSet removes a peer or namespace address set from the gress policy
-func (gp *gressPolicy) delAddressSet(hashedAddressSet string) (string, string, bool) {
-	if !gp.peerAddressSets[hashedAddressSet] {
-		return "", "", false
+// delNamespaceAddressSet removes a namespace address set from the gress policy
+func (gp *gressPolicy) delNamespaceAddressSet(name, portGroupName string) {
+	hashName := hashedAddressSet(name)
+	if !gp.nsAddressSets.Has(hashName) {
+		return
 	}
 
 	oldL3Match := gp.getL3MatchFromAddressSet()
-
 	for i, addressSet := range gp.sortedPeerAddressSets {
-		if addressSet == hashedAddressSet {
+		if addressSet == hashName {
 			gp.sortedPeerAddressSets = append(
 				gp.sortedPeerAddressSets[:i],
 				gp.sortedPeerAddressSets[i+1:]...)
 			break
 		}
 	}
-	delete(gp.peerAddressSets, hashedAddressSet)
-
-	return oldL3Match, gp.getL3MatchFromAddressSet(), true
+	gp.nsAddressSets.Delete(hashName)
+	gp.localPodUpdateACL(oldL3Match, gp.getL3MatchFromAddressSet(), portGroupName)
 }
 
 // localPodAddACL adds an ACL that implements the gress policy's rules to the
@@ -375,4 +409,9 @@ func (gp *gressPolicy) localPodUpdateACL(oldl3Match, newl3Match, portGroupName s
 			klog.Warningf(err.Error())
 		}
 	}
+}
+
+func (gp *gressPolicy) destroy() {
+	gp.peerAddressSet.Destroy()
+	gp.peerAddressSet = nil
 }

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -92,6 +92,7 @@ func (gp *gressPolicy) addPeerPod(pod *v1.Pod) error {
 	if err != nil {
 		return err
 	}
+	// FIXME dual-stack
 	return gp.peerAddressSet.AddIP(ips[0])
 }
 
@@ -100,6 +101,7 @@ func (gp *gressPolicy) deletePeerPod(pod *v1.Pod) error {
 	if err != nil {
 		return err
 	}
+	// FIXME dual-stack
 	return gp.peerAddressSet.DeleteIP(ips[0])
 }
 
@@ -411,7 +413,12 @@ func (gp *gressPolicy) localPodUpdateACL(oldl3Match, newl3Match, portGroupName s
 	}
 }
 
-func (gp *gressPolicy) destroy() {
-	gp.peerAddressSet.Destroy()
-	gp.peerAddressSet = nil
+func (gp *gressPolicy) destroy() error {
+	if gp.peerAddressSet != nil {
+		if err := gp.peerAddressSet.Destroy(); err != nil {
+			return err
+		}
+		gp.peerAddressSet = nil
+	}
+	return nil
 }

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
-			clusterController := NewOvnController(fakeClient, f, stopChan)
+			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -348,7 +348,7 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
-			clusterController := NewOvnController(fakeClient, f, stopChan)
+			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -434,7 +434,7 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
-			clusterController := NewOvnController(fakeClient, f, stopChan)
+			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -617,7 +617,7 @@ subnet=%s
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
-			clusterController := NewOvnController(fakeClient, f, stopChan)
+			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -814,7 +814,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stop)
 
-			clusterController := NewOvnController(fakeClient, wf, stop)
+			clusterController := NewOvnController(fakeClient, wf, stop, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -1008,7 +1008,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stop)
 
-			clusterController := NewOvnController(fakeClient, wf, stop)
+			clusterController := NewOvnController(fakeClient, wf, stop, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -28,9 +28,9 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 		expectedNs[ns.Name] = true
 	}
 
-	err := oc.addressSetFactory.ForEachAddressSet(func(hashedAddrSetName, namespaceName, nameSuffix string) {
+	err := oc.addressSetFactory.ForEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) {
 		if nameSuffix == "" && !expectedNs[namespaceName] {
-			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(hashedAddrSetName); err != nil {
+			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
 				klog.Errorf(err.Error())
 			}
 		}
@@ -153,12 +153,12 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 
 	// Get all the pods in the namespace and append their IP to the
 	// address_set
-	var ips []*net.IP
+	var ips []net.IP
 	existingPods, err := oc.watchFactory.GetPods(ns.Name)
 	if err != nil {
 		klog.Errorf("Failed to get all the pods (%v)", err)
 	} else {
-		ips = make([]*net.IP, 0, len(existingPods))
+		ips = make([]net.IP, 0, len(existingPods))
 		for _, pod := range existingPods {
 			if pod.Status.PodIP != "" && !pod.Spec.HostNetwork {
 				podIPs, err := util.GetAllPodIPs(pod)
@@ -166,9 +166,7 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 					klog.Warningf(err.Error())
 					continue
 				}
-				for _, ip := range podIPs {
-					ips = append(ips, &ip)
-				}
+				ips = append(ips, podIPs...)
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -51,6 +51,10 @@ type loadBalancerConf struct {
 type namespaceInfo struct {
 	sync.Mutex
 
+	// addressSet is an address set object that holds the IP addresses
+	// of all pods in the namespace.
+	addressSet AddressSet
+
 	// map from NetworkPolicy name to namespacePolicy. You must hold the
 	// namespaceInfo's mutex to add/delete/lookup policies, but must hold the
 	// namespacePolicy's mutex (and not necessarily the namespaceInfo's) to work with
@@ -64,10 +68,6 @@ type namespaceInfo struct {
 	portGroupUUID string
 
 	multicastEnabled bool
-
-	// addressSet is the name of an address set that holds the IP addresses
-	// of all pods in the namespace.
-	addressSet AddressSet
 }
 
 // Controller structure is the object which holds the controls for starting

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -24,6 +24,7 @@ type FakeOVN struct {
 	controller *Controller
 	stopChan   chan struct{}
 	fakeExec   *ovntest.FakeExec
+	asf        *fakeAddressSetFactory
 }
 
 func NewFakeOVN(fexec *ovntest.FakeExec) *FakeOVN {
@@ -32,6 +33,7 @@ func NewFakeOVN(fexec *ovntest.FakeExec) *FakeOVN {
 
 	return &FakeOVN{
 		fakeExec: fexec,
+		asf:      newFakeAddressSetFactory(),
 	}
 }
 
@@ -59,6 +61,6 @@ func (o *FakeOVN) init() {
 	o.watcher, err = factory.NewWatchFactory(o.fakeClient, o.stopChan)
 	Expect(err).NotTo(HaveOccurred())
 
-	o.controller = NewOvnController(o.fakeClient, o.watcher, o.stopChan)
+	o.controller = NewOvnController(o.fakeClient, o.watcher, o.stopChan, o.asf)
 	o.controller.multicastSupport = true
 }

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -111,6 +111,9 @@ func (p pod) addCmds(fexec *ovntest.FakeExec, fail bool) {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 lsp-set-port-security " + p.portName + " " + p.podMAC + " " + p.podIP,
 		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID + " -- add port_group mcastPortGroupDeny ports " + fakeUUID,
+		})
 	}
 }
 
@@ -134,6 +137,9 @@ func (p pod) addCmdsForExistingPod(fexec *ovntest.FakeExec, addPort bool) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 lsp-set-port-security " + p.portName + " " + p.podMAC + " " + p.podIP,
 	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID + " -- add port_group mcastPortGroupDeny ports " + fakeUUID,
+	})
 }
 
 func (p pod) addCmdsForNonExistingFailedPod(fexec *ovntest.FakeExec) {
@@ -141,32 +147,11 @@ func (p pod) addCmdsForNonExistingFailedPod(fexec *ovntest.FakeExec) {
 }
 
 func (p pod) delCmds(fexec *ovntest.FakeExec) {
-	// pod's logical switch port is removed
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists lsp-del " + p.portName,
-	})
-}
-
-func (p pod) delFromNamespaceCmds(fexec *ovntest.FakeExec, pod pod, isMulticastEnabled bool) {
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf(`ovn-nbctl --timeout=15 remove address_set %s addresses "%s"`, hashedAddressSet(pod.namespace), pod.podIP),
-	})
-	if isMulticastEnabled {
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID,
-		})
-	}
-}
-
-func (p pod) addPodDenyMcast(fexec *ovntest.FakeExec) {
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID + " -- add port_group mcastPortGroupDeny ports " + fakeUUID,
-	})
-}
-
-func (p pod) delPodDenyMcast(fexec *ovntest.FakeExec) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID,
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --if-exists lsp-del " + p.portName,
 	})
 }
 
@@ -234,7 +219,6 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.portName = t.namespace + "_" + t.podName
 				t.populateLogicalSwitchCache(fakeOvn)
 				t.addCmdsForNonExistingPod(fExec)
-				t.addPodDenyMcast(fExec)
 
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(t.namespace).Update(newPod(t.namespace, t.podName, t.nodeName, t.podIP))
 				Expect(err).NotTo(HaveOccurred())
@@ -281,7 +265,6 @@ var _ = Describe("OVN Pod Operations", func() {
 				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 				t.addCmdsForNonExistingPod(fExec)
-				t.addPodDenyMcast(fExec)
 
 				_, err := fakeOvn.fakeClient.CoreV1().Pods(t.namespace).Create(newPod(t.namespace, t.podName, t.nodeName, t.podIP))
 				Expect(err).NotTo(HaveOccurred())
@@ -321,7 +304,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: "\n",
 				})
 				t.addCmdsForNonExistingPod(fExec)
-				t.addPodDenyMcast(fExec)
 
 				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
@@ -340,7 +322,6 @@ var _ = Describe("OVN Pod Operations", func() {
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
 				// Delete it
-				t.delPodDenyMcast(fExec)
 				t.delCmds(fExec)
 
 				err = fakeOvn.fakeClient.CoreV1().Pods(t.namespace).Delete(t.podName, metav1.NewDeleteOptions(0))
@@ -390,7 +371,6 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				// Pod creation should be retried on Update event
 				t.addCmdsForNonExistingPod(fExec)
-				t.addPodDenyMcast(fExec)
 				_, err := fakeOvn.fakeClient.CoreV1().Pods(t.namespace).Update(newPod(t.namespace, t.podName, t.nodeName, t.podIP))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
@@ -434,7 +414,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					"ovn-nbctl --timeout=15 --if-exists lsp-del " + t.portName,
 				})
 				t.addCmdsForNonExistingPod(fExec)
-				t.addPodDenyMcast(fExec)
 
 				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
@@ -484,14 +463,13 @@ var _ = Describe("OVN Pod Operations", func() {
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true",
 					Output: t.portName + "\n",
 				})
-
-				t.delCmds(fExec)
+				fExec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --if-exists lsp-del " + t.portName,
+				})
 
 				fakeOvn.start(ctx)
 				fakeOvn.controller.WatchPods()
-
 				Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
-
 				return nil
 			}
 
@@ -518,7 +496,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: "\n",
 				})
 				t.addCmdsForNonExistingPod(fExec)
-				t.addPodDenyMcast(fExec)
 
 				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
@@ -565,7 +542,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: "\n",
 				})
 				t.addCmdsForNonExistingPod(fExec)
-				t.addPodDenyMcast(fExec)
 
 				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
@@ -594,7 +570,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: "\n",
 				})
 				t.addCmdsForExistingPod(fExec, true)
-				t.addPodDenyMcast(fExec)
 
 				fakeOvn.restart()
 				t.populateLogicalSwitchCache(fakeOvn)
@@ -635,7 +610,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: "\n",
 				})
 				t.addCmdsForNonExistingPod(fExec)
-				t.addPodDenyMcast(fExec)
 
 				fakeOvn.start(ctx, &v1.PodList{
 					Items: []v1.Pod{
@@ -664,7 +638,6 @@ var _ = Describe("OVN Pod Operations", func() {
 					Output: fakeUUID + "\n",
 				})
 				t.addCmdsForExistingPod(fExec, false)
-				t.addPodDenyMcast(fExec)
 
 				fakeOvn.restart()
 				t.populateLogicalSwitchCache(fakeOvn)

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -44,6 +44,9 @@ func newPod(namespace, name, node, podIP string) *v1.Pod {
 		Status: v1.PodStatus{
 			Phase: v1.PodRunning,
 			PodIP: podIP,
+			PodIPs: []v1.PodIP{
+				{IP: podIP},
+			},
 		},
 	}
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -76,7 +76,7 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 		}
 	}
 
-	err := oc.addressSetFactory.ForEachAddressSet(func(hashedAddrSetName, namespaceName, policyName string) {
+	err := oc.addressSetFactory.ForEachAddressSet(func(addrSetName, namespaceName, policyName string) {
 		if policyName != "" && !expectedPolicies[namespaceName][policyName] {
 			// policy doesn't exist on k8s. Delete the port group
 			portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
@@ -84,7 +84,7 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 			deletePortGroup(hashedLocalPortGroup)
 
 			// delete the address sets for this old policy from OVN
-			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(hashedAddrSetName); err != nil {
+			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
 				klog.Errorf(err.Error())
 			}
 		}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -76,17 +76,19 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 		}
 	}
 
-	err := oc.forEachAddressSetUnhashedName(func(addrSetName, namespaceName,
-		policyName string) {
-		if policyName != "" &&
-			!expectedPolicies[namespaceName][policyName] {
+	err := oc.addressSetFactory.ForEachAddressSet(func(hashedAddrSetName, namespaceName, policyName string) {
+		if policyName != "" && !expectedPolicies[namespaceName][policyName] {
 			// policy doesn't exist on k8s. Delete the port group
 			portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
 			hashedLocalPortGroup := hashedPortGroup(portGroupName)
 			deletePortGroup(hashedLocalPortGroup)
 
 			// delete the address sets for this policy from OVN
-			deleteAddressSet(hashedAddressSet(addrSetName))
+			_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy", "address_set", hashedAddrSetName)
+			if err != nil {
+				klog.Errorf("failed to destroy address set %q, stderr: %q, (%v)",
+					hashedAddrSetName, stderr, err)
+			}
 		}
 	})
 	if err != nil {
@@ -268,7 +270,12 @@ func (oc *Controller) createMulticastAllowPolicy(ns string, nsInfo *namespaceInf
 	}
 
 	// Add all ports from this namespace to the multicast allow group.
-	for _, portName := range nsInfo.addressSet {
+	pods, err := oc.watchFactory.GetPods(ns)
+	if err != nil {
+		klog.Warningf("failed to get pods for namespace %q: %v", ns, err)
+	}
+	for _, pod := range pods {
+		portName := podLogicalPortName(pod)
 		if portInfo, err := oc.logicalPortCache.get(portName); err != nil {
 			klog.Errorf(err.Error())
 		} else if err := podAddAllowMulticastPolicy(ns, portInfo); err != nil {
@@ -612,8 +619,6 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
 		gress             *gressPolicy
 		namespaceSelector *metav1.LabelSelector
 		podSelector       *metav1.LabelSelector
-		addrSet           string
-		peerMap           map[string]bool
 	}
 	var policyHandlers []policyHandler
 	// Go through each ingress rule.  For each ingress rule, create an
@@ -628,19 +633,11 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
 			ingress.addPortPolicy(&portJSON)
 		}
 
-		hashedLocalAddressSet := ""
-		// peerPodAddressMap represents the IP addresses of all the peer pods
-		// for this ingress.
-		peerPodAddressMap := make(map[string]bool)
 		if hasAnyLabelSelector(ingressJSON.From) {
-			// localPeerPods represents all the peer pods in the same
-			// namespace from which we need to allow traffic.
-			localPeerPods := fmt.Sprintf("%s.%s.%s.%d", policy.Namespace,
-				policy.Name, "ingress", i)
-
-			hashedLocalAddressSet = hashedAddressSet(localPeerPods)
-			createAddressSet(localPeerPods, hashedLocalAddressSet, nil)
-			ingress.addAddressSet(hashedLocalAddressSet)
+			if err := ingress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
+				klog.Errorf(err.Error())
+				continue
+			}
 		}
 
 		for _, fromJSON := range ingressJSON.From {
@@ -648,20 +645,14 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
 			if fromJSON.IPBlock != nil {
 				ingress.addIPBlock(fromJSON.IPBlock)
 			}
-		}
 
-		ingress.localPodAddACL(np.portGroupName, np.portGroupUUID)
-
-		for _, fromJSON := range ingressJSON.From {
-			ingressPolicyHandler := policyHandler{
+			policyHandlers = append(policyHandlers, policyHandler{
 				gress:             ingress,
 				namespaceSelector: fromJSON.NamespaceSelector,
 				podSelector:       fromJSON.PodSelector,
-				addrSet:           hashedLocalAddressSet,
-				peerMap:           peerPodAddressMap,
-			}
-			policyHandlers = append(policyHandlers, ingressPolicyHandler)
+			})
 		}
+		ingress.localPodAddACL(np.portGroupName, np.portGroupUUID)
 		np.ingressPolicies = append(np.ingressPolicies, ingress)
 	}
 
@@ -677,19 +668,11 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
 			egress.addPortPolicy(&portJSON)
 		}
 
-		hashedLocalAddressSet := ""
-		// peerPodAddressMap represents the IP addresses of all the peer pods
-		// for this egress.
-		peerPodAddressMap := make(map[string]bool)
 		if hasAnyLabelSelector(egressJSON.To) {
-			// localPeerPods represents all the peer pods in the same
-			// namespace to which we need to allow traffic.
-			localPeerPods := fmt.Sprintf("%s.%s.%s.%d", policy.Namespace,
-				policy.Name, "egress", i)
-
-			hashedLocalAddressSet = hashedAddressSet(localPeerPods)
-			createAddressSet(localPeerPods, hashedLocalAddressSet, nil)
-			egress.addAddressSet(hashedLocalAddressSet)
+			if err := egress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
+				klog.Errorf(err.Error())
+				continue
+			}
 		}
 
 		for _, toJSON := range egressJSON.To {
@@ -697,23 +680,18 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
 			if toJSON.IPBlock != nil {
 				egress.addIPBlock(toJSON.IPBlock)
 			}
-		}
 
-		egress.localPodAddACL(np.portGroupName, np.portGroupUUID)
-
-		for _, toJSON := range egressJSON.To {
-			egressPolicyHandler := policyHandler{
+			policyHandlers = append(policyHandlers, policyHandler{
 				gress:             egress,
 				namespaceSelector: toJSON.NamespaceSelector,
 				podSelector:       toJSON.PodSelector,
-				addrSet:           hashedLocalAddressSet,
-				peerMap:           peerPodAddressMap,
-			}
-			policyHandlers = append(policyHandlers, egressPolicyHandler)
+			})
 		}
+		egress.localPodAddACL(np.portGroupName, np.portGroupUUID)
 		np.egressPolicies = append(np.egressPolicies, egress)
 	}
 	np.Unlock()
+
 	// For all the pods in the local namespace that this policy
 	// effects, add them to the port group.
 	oc.handleLocalPodSelector(policy, np)
@@ -723,9 +701,9 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
 			// For each rule that contains both peer namespace selector and
 			// peer pod selector, we create a watcher for each matching namespace
 			// that populates the addressSet
-			oc.handlePeerNamespaceAndPodSelector(policy, handler.gress,
+			oc.handlePeerNamespaceAndPodSelector(policy,
 				handler.namespaceSelector, handler.podSelector,
-				handler.addrSet, handler.peerMap, np)
+				handler.gress, np)
 		} else if handler.namespaceSelector != nil {
 			// For each peer namespace selector, we create a watcher that
 			// populates ingress.peerAddressSets
@@ -735,7 +713,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
 			// For each peer pod selector, we create a watcher that
 			// populates the addressSet
 			oc.handlePeerPodSelector(policy, handler.podSelector,
-				handler.addrSet, handler.peerMap, np)
+				handler.gress, np)
 		}
 	}
 }
@@ -779,104 +757,50 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy) {
 	// Delete the port group
 	deletePortGroup(np.portGroupName)
 
-	// Go through each ingress rule.  For each ingress rule, delete the
-	// addressSet for the local peer pods.
-	for i := range np.ingressPolicies {
-		localPeerPods := fmt.Sprintf("%s.%s.%s.%d", policy.Namespace,
-			policy.Name, "ingress", i)
-		hashedAddressSet := hashedAddressSet(localPeerPods)
-		deleteAddressSet(hashedAddressSet)
+	// Delete ingress/egress address sets
+	for _, policy := range np.ingressPolicies {
+		policy.destroy()
 	}
-	// Go through each egress rule.  For each egress rule, delete the
-	// addressSet for the local peer pods.
-	for i := range np.egressPolicies {
-		localPeerPods := fmt.Sprintf("%s.%s.%s.%d", policy.Namespace,
-			policy.Name, "egress", i)
-		hashedAddressSet := hashedAddressSet(localPeerPods)
-		deleteAddressSet(hashedAddressSet)
+	for _, policy := range np.egressPolicies {
+		policy.destroy()
 	}
 }
 
 // handlePeerPodSelectorAddUpdate adds the IP address of a pod that has been
 // selected as a peer by a NetworkPolicy's ingress/egress section to that
 // ingress/egress address set
-func (oc *Controller) handlePeerPodSelectorAddUpdate(np *namespacePolicy,
-	addressMap map[string]bool, addressSet string, obj interface{}) {
-
+func (oc *Controller) handlePeerPodSelectorAddUpdate(gp *gressPolicy, obj interface{}) {
 	pod := obj.(*kapi.Pod)
-	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
-	if err != nil {
-		return
+	if err := gp.addPeerPod(pod); err != nil {
+		klog.Errorf(err.Error())
 	}
-	// DUAL-STACK FIXME: handle multiple IPs
-	ipAddress := podAnnotation.IPs[0].IP.String()
-	if addressMap[ipAddress] {
-		return
-	}
-
-	np.Lock()
-	defer np.Unlock()
-	if np.deleted {
-		return
-	}
-
-	addressMap[ipAddress] = true
-	addToAddressSet(addressSet, ipAddress)
-}
-
-func (oc *Controller) handlePeerPodSelectorDeleteACLRules(obj interface{}, gress *gressPolicy) {
-	pod := obj.(*kapi.Pod)
-	logicalPort := podLogicalPortName(pod)
-
-	oc.lspMutex.Lock()
-	delete(oc.lspIngressDenyCache, logicalPort)
-	delete(oc.lspEgressDenyCache, logicalPort)
-	oc.lspMutex.Unlock()
 }
 
 // handlePeerPodSelectorDelete removes the IP address of a pod that no longer
 // matches a NetworkPolicy ingress/egress section's selectors from that
 // ingress/egress address set
-func (oc *Controller) handlePeerPodSelectorDelete(np *namespacePolicy,
-	addressMap map[string]bool, addressSet string, obj interface{}) {
-
+func (oc *Controller) handlePeerPodSelectorDelete(gp *gressPolicy, obj interface{}) {
 	pod := obj.(*kapi.Pod)
-	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
-	if err != nil {
-		return
+	if err := gp.deletePeerPod(pod); err != nil {
+		klog.Errorf(err.Error())
 	}
-	// DUAL-STACK FIXME: handle multiple IPs
-	ipAddress := podAnnotation.IPs[0].IP.String()
-
-	np.Lock()
-	defer np.Unlock()
-	if np.deleted {
-		return
-	}
-
-	if !addressMap[ipAddress] {
-		return
-	}
-
-	delete(addressMap, ipAddress)
-	removeFromAddressSet(addressSet, ipAddress)
 }
 
 func (oc *Controller) handlePeerPodSelector(
 	policy *knet.NetworkPolicy, podSelector *metav1.LabelSelector,
-	addressSet string, addressMap map[string]bool, np *namespacePolicy) {
+	gp *gressPolicy, np *namespacePolicy) {
 
 	h, err := oc.watchFactory.AddFilteredPodHandler(policy.Namespace,
 		podSelector,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				oc.handlePeerPodSelectorAddUpdate(np, addressMap, addressSet, obj)
+				oc.handlePeerPodSelectorAddUpdate(gp, obj)
 			},
 			DeleteFunc: func(obj interface{}) {
-				oc.handlePeerPodSelectorDelete(np, addressMap, addressSet, obj)
+				oc.handlePeerPodSelectorDelete(gp, obj)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				oc.handlePeerPodSelectorAddUpdate(np, addressMap, addressSet, newObj)
+				oc.handlePeerPodSelectorAddUpdate(gp, newObj)
 			},
 		}, nil)
 	if err != nil {
@@ -888,7 +812,12 @@ func (oc *Controller) handlePeerPodSelector(
 	np.podHandlerList = append(np.podHandlerList, h)
 }
 
-func (oc *Controller) handlePeerNamespaceAndPodSelector(policy *knet.NetworkPolicy, gress *gressPolicy, namespaceSelector *metav1.LabelSelector, podSelector *metav1.LabelSelector, addressSet string, addressMap map[string]bool, np *namespacePolicy) {
+func (oc *Controller) handlePeerNamespaceAndPodSelector(
+	policy *knet.NetworkPolicy,
+	namespaceSelector *metav1.LabelSelector,
+	podSelector *metav1.LabelSelector,
+	gp *gressPolicy,
+	np *namespacePolicy) {
 	namespaceHandler, err := oc.watchFactory.AddFilteredNamespaceHandler("",
 		namespaceSelector,
 		cache.ResourceEventHandlerFuncs{
@@ -907,14 +836,13 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(policy *knet.NetworkPoli
 					podSelector,
 					cache.ResourceEventHandlerFuncs{
 						AddFunc: func(obj interface{}) {
-							oc.handlePeerPodSelectorAddUpdate(np, addressMap, addressSet, obj)
+							oc.handlePeerPodSelectorAddUpdate(gp, obj)
 						},
 						DeleteFunc: func(obj interface{}) {
-							oc.handlePeerPodSelectorDelete(np, addressMap, addressSet, obj)
-							oc.handlePeerPodSelectorDeleteACLRules(obj, gress)
+							oc.handlePeerPodSelectorDelete(gp, obj)
 						},
 						UpdateFunc: func(oldObj, newObj interface{}) {
-							oc.handlePeerPodSelectorAddUpdate(np, addressMap, addressSet, newObj)
+							oc.handlePeerPodSelectorAddUpdate(gp, newObj)
 						},
 					}, nil)
 				if err != nil {
@@ -954,26 +882,16 @@ func (oc *Controller) handlePeerNamespaceSelector(
 				namespace := obj.(*kapi.Namespace)
 				np.Lock()
 				defer np.Unlock()
-				if np.deleted {
-					return
-				}
-				hashedAddressSet := hashedAddressSet(namespace.Name)
-				oldL3Match, newL3Match, added := gress.addAddressSet(hashedAddressSet)
-				if added {
-					gress.localPodUpdateACL(oldL3Match, newL3Match, np.portGroupName)
+				if !np.deleted {
+					gress.addNamespaceAddressSet(namespace.Name, np.portGroupName)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				namespace := obj.(*kapi.Namespace)
 				np.Lock()
 				defer np.Unlock()
-				if np.deleted {
-					return
-				}
-				hashedAddressSet := hashedAddressSet(namespace.Name)
-				oldL3Match, newL3Match, removed := gress.delAddressSet(hashedAddressSet)
-				if removed {
-					gress.localPodUpdateACL(oldL3Match, newL3Match, np.portGroupName)
+				if !np.deleted {
+					gress.delNamespaceAddressSet(namespace.Name, np.portGroupName)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -213,23 +213,31 @@ func UnmarshalPodAnnotation(annotations map[string]string) (*PodAnnotation, erro
 }
 
 // GetAllPodIPs returns the pod's IP addresses, first from the OVN annotation
-// and then falling back to the Pod Status IP. This function is intended to
+// and then falling back to the Pod Status IPs. This function is intended to
 // also return IPs for HostNetwork and other non-OVN-IPAM-ed pods.
 func GetAllPodIPs(pod *v1.Pod) ([]net.IP, error) {
 	annotation, err := UnmarshalPodAnnotation(pod.Annotations)
 	if annotation != nil {
+		// Use the OVN annotation if valid
 		ips := make([]net.IP, 0, len(annotation.IPs))
 		for _, ip := range annotation.IPs {
 			ips = append(ips, ip.IP)
 		}
 		return ips, nil
 	}
-	if pod.Status.PodIP != "" {
-		ip := net.ParseIP(pod.Status.PodIP)
-		if ip == nil {
-			return nil, fmt.Errorf("failed to parse pod IP %s", pod.Status.PodIP)
-		}
-		return []net.IP{ip}, nil
+
+	if len(pod.Status.PodIPs) == 0 {
+		return nil, err
 	}
-	return nil, err
+
+	// Otherwise if the annotation is not valid try to use Kube API pod IPs
+	ips := make([]net.IP, 0, len(pod.Status.PodIPs))
+	for _, podIP := range pod.Status.PodIPs {
+		ip := net.ParseIP(podIP.IP)
+		if ip == nil {
+			klog.Warningf("failed to parse pod IP %q", podIP)
+		}
+		ips = append(ips, ip)
+	}
+	return ips, nil
 }


### PR DESCRIPTION
Put address sets into an object for better encapsulation and cleaner unit tests.

Note that this is based off the port cache code in https://github.com/ovn-org/ovn-kubernetes/pull/1000 so once that merges I'll rebase.