### PR TITLE
Fix: adding klog specific flags when logging to file

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -1038,7 +1039,6 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 	if err := level.Set(strconv.Itoa(ctx.Int("loglevel"))); err != nil {
 		return "", fmt.Errorf("failed to set klog log level %v", err)
 	}
-	klog.SetOutput(os.Stderr)
 
 	if !configFileIsDefault {
 		// Only return explicitly specified config file
@@ -1082,6 +1082,14 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 	}
 
 	if Logging.File != "" {
+		klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+		klog.InitFlags(klogFlags)
+		if err := klogFlags.Set("logtostderr", "false"); err != nil {
+			klog.Errorf("Error setting klog logtostderr: %v", err)
+		}
+		if err := klogFlags.Set("alsologtostderr", "true"); err != nil {
+			klog.Errorf("Error setting klog alsologtostderr: %v", err)
+		}
 		klog.SetOutput(&lumberjack.Logger{
 			Filename:   Logging.File,
 			MaxSize:    100, // megabytes


### PR DESCRIPTION
The klog PR https://github.com/ovn-org/ovn-kubernetes/pull/1047 lacked proper klog flag definitions when writing to a log file. 

This PR adds those. 

I also removed the line `klog.SetOutput(os.Stderr)` because it's not actually needed. Klog writes to `os.Stderr` by default. 

Sorry for any trouble, @girishmg 

/cc @dcbw 