### PR TITLE
Several fixes to our yaml template files

### DIFF
--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -146,14 +146,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10256
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10256
-        #     scheme: HTTP
         lifecycle:
       # end of container
 
@@ -210,14 +202,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10255
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10255
-        #     scheme: HTTP
         lifecycle:
       # end of container
 

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -143,9 +143,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        ports:
-        - name: healthz
-          containerPort: 10256
       # end of container
 
       # sb-ovsdb - v3
@@ -198,9 +195,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        ports:
-        - name: healthz
-          containerPort: 10255
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -104,6 +104,7 @@ spec:
           capabilities:
             add: ["NET_ADMIN"]
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
         # (or in /etc/ovn if OVN from new repository is used)
@@ -156,6 +157,7 @@ spec:
           capabilities:
             add: ["NET_ADMIN"]
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
         # (or in /etc/ovn if OVN from new repository is used)

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -146,7 +146,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10256
-        lifecycle:
       # end of container
 
       # sb-ovsdb - v3
@@ -202,7 +201,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10255
-        lifecycle:
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -133,14 +133,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10256
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10256
-        #     scheme: HTTP
         lifecycle:
       # end of container
 

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -130,9 +130,6 @@ spec:
               fieldPath: metadata.namespace
         - name: OVN_DB_VIP
           value: "{{ ovn_db_vip }}"
-        ports:
-        - name: healthz
-          containerPort: 10256
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -91,6 +91,7 @@ spec:
           capabilities:
             add: ["NET_ADMIN"]
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
         # (or in /etc/ovn if OVN from new repository is used)

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -133,7 +133,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10256
-        lifecycle:
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -76,6 +76,7 @@ spec:
           capabilities:
             add: ["NET_ADMIN"]
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
         # (or in /etc/ovn if OVN from new repository is used)
@@ -131,6 +132,7 @@ spec:
           capabilities:
             add: ["NET_ADMIN"]
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # ovn db is stored in the pod in /etc/openvswitch
         # (or in /etc/ovn if OVN from new repository is used)

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -114,7 +114,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10256
-        lifecycle:
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
@@ -173,7 +172,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10255
-        lifecycle:
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -114,14 +114,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10256
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10256
-        #     scheme: HTTP
         lifecycle:
         readinessProbe:
           exec:
@@ -181,14 +173,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10255
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10255
-        #     scheme: HTTP
         lifecycle:
         readinessProbe:
           exec:

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -111,9 +111,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        ports:
-        - name: healthz
-          containerPort: 10256
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
@@ -169,9 +166,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        ports:
-        - name: healthz
-          containerPort: 10255
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -38,8 +38,32 @@ spec:
       serviceAccountName: ovn
       hostNetwork: true
 
-      containers:
+      # required to be scheduled on a linux node with node-role.kubernetes.io/master label and
+      # only one instance of ovnkube-master pod per node
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: In
+                    values:
+                      - ""
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                      - ovnkube-master
+              topologyKey: kubernetes.io/hostname
 
+      containers:
       # ovn-northd - v3
       - name: ovn-northd
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
@@ -194,9 +218,6 @@ spec:
               fieldPath: status.podIP
       # end of container
 
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-        kubernetes.io/os: "linux"
       volumes:
       # TODO: Need to check why we need this?
       - name: host-var-run-dbus

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -52,6 +52,7 @@ spec:
           capabilities:
             add: ["SYS_NICE"]
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # Run directories where we need to be able to access sockets
         - mountPath: /var/run/dbus/
@@ -101,6 +102,7 @@ spec:
         securityContext:
           runAsUser: 0
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/log/openvswitch/
           name: host-var-log-ovs
@@ -130,6 +132,7 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 30
           periodSeconds: 60
+        # end of container
 
       - name: ovnkube-master
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
@@ -140,6 +143,7 @@ spec:
         securityContext:
           runAsUser: 0
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # Run directories where we need to be able to access sockets
         - mountPath: /var/run/dbus/

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -87,7 +87,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10257
-        lifecycle:
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
@@ -131,7 +130,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10260
-        lifecycle:
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-nbctld"]
@@ -200,7 +198,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10254
-        lifecycle:
       # end of container
 
       nodeSelector:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -87,14 +87,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10257
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10257
-        #     scheme: HTTP
         lifecycle:
         readinessProbe:
           exec:
@@ -139,14 +131,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10260
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10258
-        #     scheme: HTTP
         lifecycle:
         readinessProbe:
           exec:
@@ -216,14 +200,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10254
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10254
-        #     scheme: HTTP
         lifecycle:
       # end of container
 

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -84,9 +84,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        ports:
-        - name: healthz
-          containerPort: 10257
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
@@ -127,9 +124,6 @@ spec:
               name: ovn-config
               key: k8s_apiserver
 
-        ports:
-        - name: healthz
-          containerPort: 10260
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-nbctld"]
@@ -194,10 +188,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-
-        ports:
-        - name: healthz
-          containerPort: 10254
       # end of container
 
       nodeSelector:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -140,7 +140,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10258
-        lifecycle:
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-controller"]

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -137,9 +137,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
 
-        ports:
-        - name: healthz
-          containerPort: 10258
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-controller"]
@@ -227,9 +224,6 @@ spec:
         - name: OVN_GATEWAY_OPTS
           value: "{{ ovn_gateway_opts }}"
 
-        ports:
-        - name: healthz
-          containerPort: 10259
         lifecycle:
           preStop:
             exec:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -140,14 +140,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10258
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10258
-        #     scheme: HTTP
         lifecycle:
         readinessProbe:
           exec:
@@ -239,14 +231,6 @@ spec:
         ports:
         - name: healthz
           containerPort: 10259
-        # TODO: Temporarily disabled until we determine how to wait for clean default
-        # config
-        # livenessProbe:
-        #   initialDelaySeconds: 10
-        #   httpGet:
-        #     path: /healthz
-        #     port: 10259
-        #     scheme: HTTP
         lifecycle:
           preStop:
             exec:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -95,12 +95,6 @@ spec:
           preStop:
             exec:
               command: ["/root/ovnkube.sh", "cleanup-ovs-server"]
-        readinessProbe:
-          exec:
-            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovs-daemons"]
-          initialDelaySeconds: 30
-          timeoutSeconds: 30
-          periodSeconds: 60
 
       - name: ovn-controller
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -63,6 +63,7 @@ spec:
           # Permission could be reduced by selecting an appropriate SELinux policy
           privileged: true
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /lib/modules
           name: host-modules
@@ -107,6 +108,7 @@ spec:
           capabilities:
             add: ["SYS_NICE"]
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/dbus/
           name: host-var-run-dbus
@@ -158,6 +160,7 @@ spec:
           privileged: true
           {% endif %}
 
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # for the iptables wrapper
         - mountPath: /host


### PR DESCRIPTION
-- added nodeAffinity and podAntiAffinity fields to onvkube-master.yaml to enable multi-master case
-- added terminationMessagePolicy to FallbackToLogsOnError for all the containers
-- removed duplicated readinessProbe for ovs-daemons container
-- removed commented out liveness probe spec in various containers
-- removed unused lifecycle field in various container spec
-- removed fake `healthz` named ports from various containers that was not being used

@dcbw PTAL