### PR TITLE
deadlock in ovnkube node while waiting on ready functions to complete

### DIFF
--- a/go-controller/pkg/node/startup-waiter.go
+++ b/go-controller/pkg/node/startup-waiter.go
@@ -47,7 +47,7 @@ func (w *startupWaiter) Wait() error {
 			err := wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
 				return task.waitFn(w.nodeName)
 			})
-			if task.postFn != nil {
+			if err == nil && task.postFn != nil {
 				err = task.postFn()
 			}
 			if err != nil {

--- a/go-controller/pkg/node/startup-waiter.go
+++ b/go-controller/pkg/node/startup-waiter.go
@@ -12,7 +12,6 @@ type startupWaiter struct {
 	nodeName string
 	tasks    []*waitTask
 	wg       *sync.WaitGroup
-	errors   chan error
 }
 
 type waitFunc func(string) (bool, error)
@@ -28,7 +27,6 @@ func newStartupWaiter(nodeName string) *startupWaiter {
 		nodeName: nodeName,
 		tasks:    make([]*waitTask, 0, 2),
 		wg:       &sync.WaitGroup{},
-		errors:   make(chan error),
 	}
 }
 
@@ -40,6 +38,7 @@ func (w *startupWaiter) AddWait(waitFn waitFunc, postFn postWaitFunc) {
 }
 
 func (w *startupWaiter) Wait() error {
+	errors := make(chan error, len(w.tasks))
 	for _, t := range w.tasks {
 		w.wg.Add(1)
 		go func(task *waitTask) {
@@ -51,13 +50,13 @@ func (w *startupWaiter) Wait() error {
 				err = task.postFn()
 			}
 			if err != nil {
-				w.errors <- err
+				errors <- err
 			}
 		}(t)
 	}
 	w.wg.Wait()
-	close(w.errors)
-	for err := range w.errors {
+	close(errors)
+	for err := range errors {
 		return fmt.Errorf("error waiting for node readiness: %v", err)
 	}
 	return nil


### PR DESCRIPTION
 we have two ready functions that check for management port and gateway
 readiness. if both of them timeout, then they try to write to an
 unbuffered `errors` channel. one of the function will succeed while
 the other function gets blocked in
 
   w.errors <- err
 
 the main goroutine gets blocked waiting for both the ready functions to
 complete, however one of them cannot complete as it is blocked.

@dcbw PTAL