### PR TITLE
ci: use checkout@v2 to work around v1 issues on job reruns

### DIFF
--- a/.github/workflow-templates/test.yml
+++ b/.github/workflow-templates/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     - &step_checkout
       name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       
     - &step_environment
       name: Set up environment

--- a/.github/workflows/test_generated.yml
+++ b/.github/workflows/test_generated.yml
@@ -19,7 +19,7 @@ jobs:
         go-version: 1.12
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Set up environment
       run: |
         export GOPATH=$HOME/go
@@ -93,7 +93,7 @@ jobs:
         go-version: 1.12
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Set up environment
       run: |
         export GOPATH=$HOME/go
@@ -172,7 +172,7 @@ jobs:
         go-version: 1.12
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Set up environment
       run: |
         export GOPATH=$HOME/go
@@ -250,7 +250,7 @@ jobs:
         go-version: 1.12
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Set up environment
       run: |
         export GOPATH=$HOME/go
@@ -327,7 +327,7 @@ jobs:
         go-version: 1.12
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Set up environment
       run: |
         export GOPATH=$HOME/go


### PR DESCRIPTION
See https://github.com/actions/checkout/issues/23

We'll often get errors in CI build job reruns like:

```
Resolving deltas: 100% (14917/14917), done.
From https://github.com/ovn-org/ovn-kubernetes
 * [new branch]      35d4a96e508311d5f0adda -> origin/35d4a96e508311d5f0adda
 * [new branch]      bindings               -> origin/bindings
 * [new branch]      branch-0.5             -> origin/branch-0.5
 * [new branch]      dcbw-patch-1           -> origin/dcbw-patch-1
 * [new branch]      master                 -> origin/master
 * [new branch]      rajatchopra-patch-1    -> origin/rajatchopra-patch-1
 * [new branch]      revert-440-master-build-ubuntu-docker-image -> origin/revert-440-master-build-ubuntu-docker-image
 * [new branch]      revert-890-fix-lint    -> origin/revert-890-fix-lint
 * [new tag]         v0.1-alpha             -> v0.1-alpha
 * [new tag]         v0.1.0                 -> v0.1.0
 * [new tag]         v0.2.0                 -> v0.2.0
 * [new tag]         v0.3.0                 -> v0.3.0
 * [new tag]         v0.3.11                -> v0.3.11
git checkout --progress --force b327b1a7119b2a62a8ba05de7e8078f59bfcdea4
##[error]fatal: reference is not a tree: b327b1a7119b2a62a8ba05de7e8078f59bfcdea4
Removed matchers: 'checkout-git'
##[error]Git checkout failed with exit code: 128
```

Which is the right git SHA, but apparently the completely wrong
branch.

@trozet @as-com 