### PR TITLE
readiness-probe for OVN NB and SB Raft ovsdb-server

### DIFF
--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -99,6 +99,13 @@ spec:
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
         command: ["/root/ovnkube.sh", "nb-ovsdb-raft"]
 
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db-raft"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
         securityContext:
           runAsUser: 0
           capabilities:
@@ -151,6 +158,13 @@ spec:
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
         command: ["/root/ovnkube.sh", "sb-ovsdb-raft"]
+
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db-raft"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
 
         securityContext:
           runAsUser: 0

--- a/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
+++ b/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
@@ -62,8 +62,7 @@ func ovnNBDBReadiness(target string) error {
 
 	// 1. Check if the OVN NB process is running.
 	// 2. Check if OVN NB process is listening on the port that it is supposed to
-	_, _, err = util.RunOVNAppctlWithTimeout(5, "-t", fmt.Sprintf("%s/ovnnb_db.ctl", util.GetOvnRunDir()),
-		"ovsdb-server/list-dbs")
+	_, _, err = util.RunOVNNBAppCtl("--timeout=5", "ovsdb-server/list-dbs")
 	if err != nil {
 		return fmt.Errorf("failed connecting to %q: (%v)", target, err)
 	}
@@ -85,8 +84,7 @@ func ovnSBDBReadiness(target string) error {
 
 	// 1. Check if the OVN SB process is running.
 	// 2. Check if OVN SB process is listening on the port that it is supposed to
-	_, _, err = util.RunOVNAppctlWithTimeout(5, "-t", fmt.Sprintf("%s/ovnsb_db.ctl", util.GetOvnRunDir()),
-		"ovsdb-server/list-dbs")
+	_, _, err = util.RunOVNSBAppCtl("--timeout=5", "ovsdb-server/list-dbs")
 	if err != nil {
 		return fmt.Errorf("failed connecting to %q: (%v)", target, err)
 	}

--- a/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
+++ b/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
@@ -21,6 +21,8 @@ var callbacks = map[string]readinessFunc{
 	"ovn-nbctld":     ovnNbCtldReadiness,
 	"ovs-daemons":    ovsDaemonsReadiness,
 	"ovnkube-node":   ovnNodeReadiness,
+	"ovnnb-db-raft":  ovnNBDBRaftReadiness,
+	"ovnsb-db-raft":  ovnSBDBRaftReadiness,
 }
 
 func ovnControllerReadiness(target string) error {
@@ -135,6 +137,28 @@ func ovnNodeReadiness(target string) error {
 	_, err := os.Stat(confFile)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("OVN Kubernetes config file %q doesn't exist", confFile)
+	}
+	return nil
+}
+
+func ovnNBDBRaftReadiness(target string) error {
+	status, err := util.GetOVNDBServerInfo(15, "nb", "OVN_Northbound")
+	if err != nil {
+		return err
+	}
+	if !status.Connected {
+		return fmt.Errorf("this instance of ovsdb-server is not in contact with a majority of its cluster")
+	}
+	return nil
+}
+
+func ovnSBDBRaftReadiness(target string) error {
+	status, err := util.GetOVNDBServerInfo(15, "sb", "OVN_Southbound")
+	if err != nil {
+		return err
+	}
+	if !status.Connected {
+		return fmt.Errorf("this instance of ovsdb-server is not in contact with a majority of its cluster")
 	}
 	return nil
 }


### PR DESCRIPTION
ovsdb-server 2.9 or later introduced a database called _Server. this
database exists in every instance of ovsdb-server process. this database
has a table called Database and the rows in that table captures the
status and configuration of every database ovsdb-server handles
(including _Server database)

for example, in the case of NB ovsdb-server there will be two databases
OVN_Northbound and _Server. the _Server`Database table will have two
rows. one of the columns in the row is called Connected and it is of
boolean type and for cluster database it reprsents whether the server
is in contact with a majority of its cluster.

checking on `connected` to be true is a good readiness probe for both
NB and SB container.

@dcbw @numansiddique @alexanderConstantinescu PTAL
