### PR TITLE
Remove f31 advisory repo

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -25,11 +25,6 @@ RUN INSTALL_PKGS=" \
 	dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
 	dnf clean all && rm -rf /var/cache/dnf/*
 
-# ensure we pick up ovn-2.12.1-1.fc31
-# this should have no effect in the future once the
-# advisory repo is gone and can be removed
-RUN dnf install ovn --best  --enablerepo=updates-testing --advisory=FEDORA-2020-34b65e864b1 || true
-
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /usr/libexec/cni/
 


### PR DESCRIPTION
2.12.1-1 is now in stable fedora.

Signed-off-by: Tim Rozet <trozet@redhat.com>