### PR TITLE
sync: Delete the chassis records during deleteNode from sbdb

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -772,7 +772,7 @@ func (oc *Controller) deleteNode(nodeName string, nodeSubnet, joinSubnet *net.IP
 		return fmt.Errorf("Failed to clean up node %s gateway: (%v)", nodeName, err)
 	}
 
-	chassis_name, stderr, err := util.RunOVNSbctl("--data=bare", "--no-heading",
+	chassisName, stderr, err := util.RunOVNSbctl("--data=bare", "--no-heading",
 		"--columns=name", "find", "Chassis",
 		"hostname="+nodeName)
 	if err != nil {
@@ -781,12 +781,15 @@ func (oc *Controller) deleteNode(nodeName string, nodeSubnet, joinSubnet *net.IP
 		return err
 	}
 
-	_, stderr, err = util.RunOVNSbctl("--if-exist", "chassis-del", chassis_name)
-
-	if err != nil {
-		klog.Errorf("Failed to delete chassis with name %s for logical switch %s: stderr: %q, error: %v",
-			chassis_name, nodeName, stderr, err)
-		return err
+	if chassisName == "" {
+		klog.Warningf("Chassis name is empty for logical switch: %s", nodeName)
+	} else {
+		_, stderr, err = util.RunOVNSbctl("--if-exist", "chassis-del", chassisName)
+		if err != nil {
+			klog.Errorf("Failed to delete chassis with name %s for logical switch %s: stderr: %q, error: %v",
+				chassisName, nodeName, stderr, err)
+			return err
+		}
 	}
 
 	return nil
@@ -865,6 +868,28 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 	} else {
 		subnetAttr = "subnet"
 	}
+
+	//ChassisMap is a map of hostname (nodeName) to chassis name
+	chassisMap := make(map[string]string)
+
+	chassisData, stderr, err := util.RunOVNSbctl("--data=bare", "--no-heading",
+		"--columns=name,hostname", "list", "Chassis")
+	if err != nil {
+		klog.Errorf("Failed to get chassis list: stderr: %q, error: %v",
+			stderr, err)
+		return
+	}
+	for _, chassis := range strings.Split(chassisData, "\n\n") {
+		items := strings.Split(chassis, "\n")
+		if len(items) != 2 || len(items[1]) == 0 {
+			continue
+		}
+		if _, ok := foundNodes[items[1]]; !ok {
+			//node still exists, don't add it to the chassis map
+			chassisMap[items[1]] = items[0]
+		}
+	}
+
 	nodeSwitches, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=name,other-config", "find", "logical_switch",
 		"other-config:"+subnetAttr+"!=_")
@@ -924,6 +949,18 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 	for nodeName, nodeSubnets := range NodeSubnetsMap {
 		if err := oc.deleteNode(nodeName, nodeSubnets.hostSubnet, nodeSubnets.joinSubnet); err != nil {
 			klog.Error(err)
+		}
+		//remove the node from the chassis map so we don't delete it twice
+		delete(chassisMap, nodeName)
+	}
+
+	for nodeName, chassisName := range chassisMap {
+		if chassisName != "" {
+			_, stderr, err = util.RunOVNSbctl("--if-exist", "chassis-del", chassisName)
+			if err != nil {
+				klog.Errorf("Failed to delete chassis with name %s for logical switch %s: stderr: %q, error: %v",
+					chassisName, nodeName, stderr, err)
+			}
 		}
 	}
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -869,25 +869,23 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 		subnetAttr = "subnet"
 	}
 
-	//ChassisMap is a map of hostname (nodeName) to chassis name
-	chassisMap := make(map[string]string)
-
 	chassisData, stderr, err := util.RunOVNSbctl("--data=bare", "--no-heading",
-		"--columns=name,hostname", "list", "Chassis")
+		"--columns=name,hostname", "--format=json", "list", "Chassis")
 	if err != nil {
 		klog.Errorf("Failed to get chassis list: stderr: %q, error: %v",
 			stderr, err)
 		return
 	}
-	for _, chassis := range strings.Split(chassisData, "\n\n") {
-		items := strings.Split(chassis, "\n")
-		if len(items) != 2 || len(items[1]) == 0 {
-			continue
-		}
-		if _, ok := foundNodes[items[1]]; !ok {
-			//node still exists, don't add it to the chassis map
-			chassisMap[items[1]] = items[0]
-		}
+
+	chassisMap, err := oc.unmarshalChassisDataIntoMap([]byte(chassisData))
+	if err != nil {
+		klog.Errorf("Failed to unmarshal chassis data into chassis map, error: %v", err)
+		return
+	}
+
+	//delete existing nodes from the chassis map.
+	for nodeName, _ := range foundNodes {
+		delete(chassisMap, nodeName)
 	}
 
 	nodeSwitches, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
@@ -963,4 +961,52 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 			}
 		}
 	}
+}
+
+type chassisData struct {
+	nodeName    string
+	chassisName string
+}
+
+func (oc *Controller) unmarshalChassisDataIntoMap(chData []byte) (map[string]string, error) {
+	//map of node name to chassis name
+	chassisMap := make(map[string]string)
+
+	var mapUnmarshal map[string][]interface{}
+	json.Unmarshal(chData, &mapUnmarshal)
+
+	if data, ok := mapUnmarshal["data"]; !ok {
+		klog.Errorf("Got an error while unmarshaling, no data present")
+		return chassisMap, fmt.Errorf("Error while unmarshaling, no data present")
+	} else {
+		buf, _ := json.Marshal(data)
+		var chassisColl []interface{}
+		if err := json.Unmarshal(buf, &chassisColl); err != nil {
+			klog.Errorf("Got an error while unmarshaling: %s\n", err)
+			return chassisMap, err
+		} else {
+			for _, chassis := range chassisColl {
+				c, _ := json.Marshal(chassis)
+				var cd chassisData
+				if err = json.Unmarshal(c, &cd); err != nil {
+					klog.Errorf("Cannot unmarshal individual chassis: %s, incorrect format", err)
+					continue
+				}
+				chassisMap[cd.nodeName] = cd.chassisName
+			}
+		}
+	}
+	return chassisMap, nil
+}
+
+func (c *chassisData) UnmarshalJSON(buf []byte) error {
+	tmp := []interface{}{&c.chassisName, &c.nodeName}
+	wantLen := len(tmp)
+	if err := json.Unmarshal(buf, &tmp); err != nil {
+		return err
+	}
+	if g, e := len(tmp), wantLen; g != e {
+		return fmt.Errorf("wrong number of fields in Notification: %d != %d", g, e)
+	}
+	return nil
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -772,6 +772,23 @@ func (oc *Controller) deleteNode(nodeName string, nodeSubnet, joinSubnet *net.IP
 		return fmt.Errorf("Failed to clean up node %s gateway: (%v)", nodeName, err)
 	}
 
+	chassis_name, stderr, err := util.RunOVNSbctl("--data=bare", "--no-heading",
+		"--columns=name", "find", "Chassis",
+		"hostname="+nodeName)
+	if err != nil {
+		klog.Errorf("Failed to get chassis name for logical switch %s: stderr: %q, error: %v",
+			nodeName, stderr, err)
+		return err
+	}
+
+	_, stderr, err = util.RunOVNSbctl("--if-exist", "chassis-del", chassis_name)
+
+	if err != nil {
+		klog.Errorf("Failed to delete chassis with name %s for logical switch %s: stderr: %q, error: %v",
+			chassis_name, nodeName, stderr, err)
+		return err
+	}
+
 	return nil
 }
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -115,6 +115,7 @@ func defaultFakeExec(nodeSubnet, nodeName string) (*ovntest.FakeExec, string, st
 	nodeMgmtPortIP := util.NextIP(cidr.IP).String()
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname list Chassis",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -338,6 +339,9 @@ var _ = Describe("Master Operations", func() {
 			)
 
 			fexec := ovntest.NewFakeExec()
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname list Chassis",
+			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
 				// Return two nodes
@@ -385,6 +389,10 @@ subnet=%s
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_" + node1Name,
 				Output: "",
+			})
+
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + node1Name,
 			})
 
 			// Expect the code to re-add the master node (which still exists)
@@ -548,6 +556,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname list Chassis",
 				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
 			})
 
@@ -738,6 +747,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname list Chassis",
 				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
 			})
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -115,7 +115,7 @@ func defaultFakeExec(nodeSubnet, nodeName string) (*ovntest.FakeExec, string, st
 	nodeMgmtPortIP := util.NextIP(cidr.IP).String()
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname list Chassis",
+		"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -340,7 +340,7 @@ var _ = Describe("Master Operations", func() {
 
 			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname list Chassis",
+				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
@@ -556,7 +556,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname list Chassis",
+				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
 				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
 			})
 
@@ -747,7 +747,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname list Chassis",
+				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
 				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
 			})
 


### PR DESCRIPTION
This pull request is to delete the chassis record from the sbdb during sync when the nodes get deleted from the ovnkube-master's perspective.

Signed-off by: Aniket Bhat <anbhat@redhat.com>