### PR TITLE
remove retrieving Index from the _Server database for now

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -503,7 +503,6 @@ func GetOvnRunDir() string {
 type OVNDBServerStatus struct {
 	Connected bool `json:"connected"`
 	Leader    bool `json:"leader"`
-	Index     int  `json:"index"`
 }
 
 type queryResult struct {
@@ -513,7 +512,7 @@ type queryResult struct {
 func GetOVNDBServerInfo(timeout int, direction, database string) (*OVNDBServerStatus, error) {
 	sockPath := fmt.Sprintf("unix:/var/run/openvswitch/ovn%s_db.sock", direction)
 	transact := fmt.Sprintf(`["_Server", {"op":"select", "table":"Database", "where":[["name", "==", "%s"]], `+
-		`"columns": ["connected", "leader", "index"]}]`, database)
+		`"columns": ["connected", "leader"]}]`, database)
 
 	stdout, stderr, err := RunOVSDBClient(fmt.Sprintf("--timeout=%d", timeout), "query", sockPath, transact)
 	if err != nil {


### PR DESCRIPTION
even though the column is defined as `integer` as you can see below

$ ovsdb-client list-columns unix:/var/run/openvswitch/ovnnb_db.sock \
  _Server Database |grep index
index     {"key":"integer","min":0}

there are instances where it is returned as [set []] and unmarshalling
fails. remove index for now since we don't need it.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>