### PR TITLE
the ovn db file is ovn{nb|sb}_db.db and not ovn{nb|sb}.db

### DIFF
--- a/dist/images/ovndb-raft-functions
+++ b/dist/images/ovndb-raft-functions
@@ -93,7 +93,7 @@ ovsdb-raft () {
 
   ovn_db_pidfile=${OVN_RUNDIR}/ovn${db}_db.pid
   eval ovn_log_db=\$ovn_log_${db}
-  ovn_db_file=${OVN_ETCDIR}/ovn${db}.db
+  ovn_db_file=${OVN_ETCDIR}/ovn${db}_db.db
 
   rm -f ${ovn_db_pidfile}
   verify-ovsdb-raft


### PR DESCRIPTION
because of this silly mistake when the ovnkube-db statefulset is restarted
it was trying to write to the DB  (ovn-nbctl set-connection) without
any quorum and the commands were getting hung.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>