### PR TITLE
Scalability: Delete logical ports for completed pods

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -90,9 +90,13 @@ func (n *NodeController) AddPod(pod *kapi.Pod) error {
 	if !util.PodWantsNetwork(pod) {
 		return nil
 	}
+	if util.PodCompleted(pod) {
+		klog.Infof("Cleaning up hybrid overlay pod %s/%s because it has completed", pod.Namespace, pod.Name)
+		return n.DeletePod(pod)
+	}
 	podIPs, podMAC, err := getPodDetails(pod)
 	if err != nil {
-		klog.V(5).Infof("Cleaning up hybrid overlay pod %s/%s because %v", pod.Namespace, pod.Name, err)
+		klog.Warningf("Cleaning up hybrid overlay pod %s/%s because it has no OVN annotation %v", pod.Namespace, pod.Name, err)
 		return n.DeletePod(pod)
 	}
 

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -277,6 +277,9 @@ func (oc *Controller) reconcileEgressIP(old, new *egressipv1.EgressIP) (err erro
 							return err
 						}
 					}
+					if util.PodCompleted(pod) {
+						continue
+					}
 					if newPodSelector.Matches(podLabels) && !oldPodSelector.Matches(podLabels) {
 						if err := oc.addPodEgressIPAssignments(name, newEIP.Status.Items, pod); err != nil {
 							return err
@@ -1308,6 +1311,10 @@ func (oc *Controller) generateCacheForEgressIP(eIPs []interface{}) (map[string]e
 				continue
 			}
 			for _, pod := range pods {
+				if util.PodCompleted(pod) {
+					continue
+				}
+				// FIXME(trozet): potential race where pod is not yet added in the cache by the pod handler
 				logicalPort, err := oc.logicalPortCache.get(util.GetLogicalPortName(pod.Namespace, pod.Name))
 				if err != nil {
 					klog.Errorf("Error getting logical port %s, err: %v", util.GetLogicalPortName(pod.Namespace, pod.Name), err)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -643,7 +643,7 @@ func (oc *Controller) WatchPods() {
 				oc.recordPodEvent(err, pod)
 				klog.Errorf("Failed to update pod %s, error: %v",
 					getPodNamespacedName(pod), err)
-
+				oc.initRetryAddPod(pod)
 				// unskip failed pod for next retry iteration
 				oc.unSkipRetryPod(pod)
 				return

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -537,8 +537,32 @@ func (oc *Controller) WatchPods() {
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
 			go oc.metricsRecorder.AddPod(pod.UID)
-			oc.initRetryAddPod(pod)
 			oc.checkAndSkipRetryPod(pod)
+			// in case ovnkube-master is restarted and gets all the add events with completed pods
+			if util.PodCompleted(pod) {
+				// pod is in completed state, remove it
+				klog.Infof("Detected completed pod: %s. Will remove.", getPodNamespacedName(pod))
+				oc.initRetryDelPod(pod)
+				oc.removeAddRetry(pod)
+				oc.logicalPortCache.remove(util.GetLogicalPortName(pod.Namespace, pod.Name))
+				retryEntry := oc.getPodRetryEntry(pod)
+				var portInfo *lpInfo
+				if retryEntry != nil {
+					// retryEntry shouldn't be nil since we usually add the pod to retryCache above
+					portInfo = retryEntry.needsDel
+				}
+				if err := oc.removePod(pod, portInfo); err != nil {
+					oc.recordPodEvent(err, pod)
+					klog.Errorf("Failed to delete completed pod %s, error: %v",
+						getPodNamespacedName(pod), err)
+					oc.unSkipRetryPod(pod)
+					return
+				}
+				oc.checkAndDeleteRetryPod(pod)
+				return
+			}
+			// need to add new pod
+			oc.initRetryAddPod(pod)
 			if retryEntry := oc.getPodRetryEntry(pod); retryEntry != nil && retryEntry.needsDel != nil {
 				klog.Infof("Detected leftover old pod during new pod add with the same name: %s. "+
 					"Attempting deletion of leftover old...", getPodNamespacedName(pod))
@@ -592,7 +616,7 @@ func (oc *Controller) WatchPods() {
 				}
 				// deletion was a success; remove delete retry entry
 				oc.removeDeleteRetry(pod)
-			} else if pod.Status.Phase == kapi.PodSucceeded {
+			} else if util.PodCompleted(pod) {
 				// pod is in completed state, remove it
 				klog.Infof("Detected completed pod: %s. Will remove.", getPodNamespacedName(pod))
 				oc.initRetryDelPod(pod)
@@ -619,6 +643,7 @@ func (oc *Controller) WatchPods() {
 				oc.recordPodEvent(err, pod)
 				klog.Errorf("Failed to update pod %s, error: %v",
 					getPodNamespacedName(pod), err)
+
 				// unskip failed pod for next retry iteration
 				oc.unSkipRetryPod(pod)
 				return
@@ -996,8 +1021,15 @@ func (oc *Controller) WatchEgressIPPods() {
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			oldPod := oldObj.(*kapi.Pod)
 			newPod := newObj.(*kapi.Pod)
-			if err := oc.reconcileEgressIPPod(oldPod, newPod); err != nil {
-				klog.Errorf("Unable to update egress IP matching pod: %s/%s, err: %v", newPod.Name, newPod.Namespace, err)
+			if util.PodCompleted(newPod) {
+				if err := oc.reconcileEgressIPPod(oldPod, nil); err != nil {
+					klog.Errorf("Unable to delete egress IP matching completed pod: %s/%s, err: %v",
+						oldPod.Name, oldPod.Namespace, err)
+				}
+			} else {
+				if err := oc.reconcileEgressIPPod(oldPod, newPod); err != nil {
+					klog.Errorf("Unable to update egress IP matching pod: %s/%s, err: %v", newPod.Name, newPod.Namespace, err)
+				}
 			}
 		},
 		DeleteFunc: func(obj interface{}) {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -173,6 +173,8 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 		return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
 	}
 
+	klog.Infof("Attempting to release IPs for pod: %s/%s, ips: %s", pod.Namespace, pod.Name,
+		util.JoinIPNetIPs(podIfAddrs, " "))
 	if err := oc.lsManager.ReleaseIPs(pod.Spec.NodeName, podIfAddrs); err != nil {
 		return fmt.Errorf("cannot release IPs for pod %s: %w", podDesc, err)
 	}

--- a/go-controller/pkg/ovn/pods_retry.go
+++ b/go-controller/pkg/ovn/pods_retry.go
@@ -159,6 +159,15 @@ func (oc *Controller) initRetryDelPod(pod *kapi.Pod) {
 	}
 }
 
+func (oc *Controller) removeAddRetry(pod *kapi.Pod) {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	key := getPodNamespacedName(pod)
+	if entry, ok := oc.retryPods[key]; ok {
+		entry.needsAdd = false
+	}
+}
+
 func (oc *Controller) removeDeleteRetry(pod *kapi.Pod) {
 	oc.retryPodsLock.Lock()
 	defer oc.retryPodsLock.Unlock()
@@ -202,6 +211,14 @@ func (oc *Controller) requestRetryPods() {
 	default:
 		klog.V(5).Infof("Iterate retry pods already requested")
 	}
+}
+
+// unit testing only
+func (oc *Controller) hasPodRetryEntry(pod *kapi.Pod) bool {
+	oc.retryPodsLock.Lock()
+	defer oc.retryPodsLock.Unlock()
+	_, ok := oc.retryPods[getPodNamespacedName(pod)]
+	return ok
 }
 
 // getPodNamespacedName returns <namespace>_<podname> for the provided pod

--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -37,7 +37,8 @@ func (c *portCache) get(logicalPort string) (*lpInfo, error) {
 	c.RLock()
 	defer c.RUnlock()
 	if info, ok := c.cache[logicalPort]; ok {
-		return info, nil
+		x := *info
+		return &x, nil
 	}
 	return nil, fmt.Errorf("logical port %s not found in cache", logicalPort)
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -216,6 +216,11 @@ func PodWantsNetwork(pod *kapi.Pod) bool {
 	return !pod.Spec.HostNetwork
 }
 
+// PodCompleted checks if the pod is marked as completed (in a terminal state)
+func PodCompleted(pod *kapi.Pod) bool {
+	return pod.Status.Phase == kapi.PodSucceeded || pod.Status.Phase == kapi.PodFailed
+}
+
 // PodScheduled returns if the given pod is scheduled
 func PodScheduled(pod *kapi.Pod) bool {
 	return pod.Spec.NodeName != ""


### PR DESCRIPTION
This pull request is to delete the logicial ports associated with a pod when a
pods runs to completion. The intent of this change is to reduce the size of OVN
databases by removing entries that are no longer needed.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>