### PR TITLE
handle correct parsing of _Server`Database's index column

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
+++ b/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
@@ -178,7 +178,9 @@ var ReadinessProbeCommand = cli.Command{
 		if err := util.SetExec(kexec.New()); err != nil {
 			return err
 		}
-
-		return callbacks[target](target)
+		if cbfunc, ok := callbacks[target]; ok {
+			return cbfunc(target)
+		}
+		return fmt.Errorf("incorrect target specified")
 	},
 }


### PR DESCRIPTION
the `index` column holds ["set": []] when it is not populated yet and
holds `integer` when it is populated, so we need to use `interface{}`
data type for the structure field that holds its value.

@dcbw @danwinship @trozet PTAL