### PR TITLE
group all prometheus metrics and functions under metric package

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -26,7 +26,6 @@ import (
 // DefaultEncapPort number used if not supplied
 const DefaultEncapPort = 6081
 
-const MetricNamespace = "ovnkube"
 const DefaultAPIServer = "http://localhost:8443"
 
 // The following are global config parameters that other modules may access directly

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -1,4 +1,4 @@
-package util
+package metrics
 
 import (
 	"fmt"
@@ -10,6 +10,14 @@ import (
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	MetricOvnkubeNamespace       = "ovnkube"
+	MetricOvnkubeSubsystemMaster = "master"
+	MetricOvnkubeSubsystemNode   = "node"
+	MetricOvnNamespace           = "ovn"
+	MetricOvnSubsystemDBRaft     = "db_raft"
 )
 
 // StartMetricsServer runs the prometheus listner so that metrics can be collected

--- a/go-controller/pkg/metrics/node.go
+++ b/go-controller/pkg/metrics/node.go
@@ -1,0 +1,27 @@
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MetricCNIRequestDuration is a prometheus metric that tracks the duration
+// of CNI requests
+var MetricCNIRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemNode,
+	Name:      "cni_request_duration_seconds",
+	Help:      "The duration of CNI server requests",
+	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
+	//labels
+	[]string{"command", "err"},
+)
+
+var registerNodeMetricsOnce sync.Once
+
+func RegisterNodeMetrics() {
+	registerNodeMetricsOnce.Do(func() {
+		prometheus.MustRegister(MetricCNIRequestDuration)
+	})
+}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -151,8 +151,6 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
 
 // Run starts the actual watching.
 func (oc *Controller) Run(stopChan chan struct{}) error {
-	startOvnUpdater()
-
 	// WatchNodes must be started first so that its initial Add will
 	// create all node logical switches, which other watches may depend on.
 	// https://github.com/ovn-org/ovn-kubernetes/pull/859

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -377,7 +378,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) error {
 		}
 
 		// observe the pod creation latency metric.
-		recordPodCreated(pod)
+		metrics.RecordPodCreated(pod)
 	}
 
 	return nil


### PR DESCRIPTION
in preparation for bringing in various prometheus metrics under
following namespaces

 - ovnkube_master_
 - ovnkube_node_
 - ovn_db_
 - ovn_db_raft_
 - ovn_northd_
 - ovn_contorller_

 move all the existing metrics and the function behind them under
 `metric` package. right now, they are all in various files across
 various packages.

@dcbw @danwinship @squeed @trozet PTAL