### PR TITLE
Node: add iptables rules and openflow flows for certain cloud load balancers

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -140,6 +140,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, table=1, ct_state=+trk+est, actions=output:5",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, table=1, ct_state=+trk+rel, actions=output:5",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=1, actions=output:NORMAL",
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=2, actions=output:7",
 		})
 		// nodePortWatcher()
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{


### PR DESCRIPTION
Originally discussed in #831. We've been carrying a patch in OpenShift that only fixes it for local gateway mode.

Based on discussion in #831 it seems like if we fully masquerade the incoming packets that would do the right thing in shared gateway mode, but how do we do that? iptables doesn't get a chance to run in that case, right?

Fixes #831 
