### PR TITLE
add cluster db related metrics using ovn-kube-util as an exporter

### DIFF
--- a/dist/images/ovndb-raft-functions
+++ b/dist/images/ovndb-raft-functions
@@ -140,3 +140,21 @@ ovsdb-raft () {
   process_healthy ovn${db}_db ${ovn_tail_pid}
   echo "=============== run ${db}_ovsdb-raft ========== terminated"
 }
+
+# v3 - Runs ovn-kube-util in daemon mode to export prometheus metrics related to OVN clustered db
+db-raft-metrics() {
+  check_ovn_daemonset_version "3"
+
+  echo "=============== db-raft-metrics - (wait for ready_to_start_node)"
+  wait_for_event ready_to_start_node
+
+  ovndb_exporter_bind_address=${OVNDB_EXPORTER_BIND_ADDRESS:-"0.0.0.0:9476"}
+
+  /usr/bin/ovn-kube-util \
+    --loglevel=${ovnkube_loglevel} \
+    ovn-db-exporter \
+    --metrics-bind-address ${ovndb_exporter_bind_address}
+
+  echo "=============== db-raft-metrics with pid ${?} terminated ========== "
+  exit 1
+}

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -946,9 +946,14 @@ case ${cmd} in
   "sb-ovsdb-raft")
     ovsdb-raft sb ${ovn_sb_port}
     ;;
+  "db-raft-metrics")
+    db-raft-metrics
+    ;;
   *)
     echo "invalid command ${cmd}"
-    echo "valid v3 commands: ovs-server nb-ovsdb sb-ovsdb run-ovn-northd ovn-master ovn-controller ovn-node display_env display ovn_debug cleanup-ovs-server cleanup-ovn-node nb-ovsdb-raft sb-ovsdb-raft"
+    echo "valid v3 commands: ovs-server nb-ovsdb sb-ovsdb run-ovn-northd ovn-master "\
+      "ovn-controller ovn-node display_env display ovn_debug cleanup-ovs-server "\
+      "cleanup-ovn-node nb-ovsdb-raft sb-ovsdb-raft db-raft-metrics"
 	  exit 0
 esac
 

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -213,6 +213,49 @@ spec:
               fieldPath: metadata.name
       # end of container
 
+      # db-metrics-exporter - v3
+      - name: db-metrics-exporter
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+        command: ["/root/ovnkube.sh", "db-raft-metrics"]
+
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          # ovn db is stored in the pod in /etc/openvswitch
+          # (or in /etc/ovn if OVN from new repository is used)
+          # and on the host in /var/lib/openvswitch/
+          - mountPath: /etc/openvswitch/
+            name: host-var-lib-ovs
+          - mountPath: /etc/ovn/
+            name: host-var-lib-ovs
+          - mountPath: /var/run/openvswitch/
+            name: host-var-run-ovs
+          - mountPath: /var/run/ovn/
+            name: host-var-run-ovs
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+          - name: OVN_DAEMONSET_VERSION
+            value: "3"
+          - name: K8S_APISERVER
+            valueFrom:
+              configMapKeyRef:
+                name: ovn-config
+                key: k8s_apiserver
+          - name: OVN_KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      # end of container
+
       volumes:
       - name: host-var-log-ovs
         hostPath:

--- a/go-controller/cmd/ovn-kube-util/app/ovn-db-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovn-db-exporter.go
@@ -1,0 +1,162 @@
+package app
+
+import (
+	"k8s.io/klog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/urfave/cli"
+	kexec "k8s.io/utils/exec"
+)
+
+var metricOVNDBRaftIndex = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "log_entry_index",
+	Help: "The index of log entry currently exposed to clients. " +
+		"This value on all the instances of db should be close to " +
+		"each other otherwise they are said to lagging with eaxch other."},
+	[]string{
+		"db_name",
+	},
+)
+
+var metricOVNDBLeader = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_leader",
+	Help:      "Identifies whether this pod is a leader for given database"},
+	[]string{
+		"db_name",
+	},
+)
+
+var metricOVNDBSessions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "jsonrpc_server_sessions",
+	Help:      "Active number of JSON RPC Server sessions to the DB"},
+	[]string{
+		"db_name",
+	},
+)
+
+var metricOVNDBMonitor = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "ovsdb_monitors",
+	Help:      "Number of OVSDB Monitors on the server"},
+	[]string{
+		"db_name",
+	},
+)
+
+func ovnDBStatusMetricsUpdater(direction, database string) {
+	status, err := util.GetOVNDBServerInfo(5, direction, database)
+	if err != nil {
+		klog.Errorf(err.Error())
+		return
+	}
+	metricOVNDBRaftIndex.WithLabelValues(database).Set(float64(status.Index))
+	if status.Leader {
+		metricOVNDBLeader.WithLabelValues(database).Set(1)
+	} else {
+		metricOVNDBLeader.WithLabelValues(database).Set(0)
+	}
+}
+
+func ovnDBMemoryMetricsUpdater(direction, database string) {
+	var stdout, stderr string
+	var err error
+
+	if direction == "sb" {
+		stdout, stderr, err = util.RunOVNSBAppCtl("--timeout=5", "memory/show")
+	} else {
+		stdout, stderr, err = util.RunOVNNBAppCtl("--timeout=5", "memory/show")
+	}
+	if err != nil {
+		klog.Errorf("failed retrieving memory/show output for %q, stderr: %s, err: (%v)",
+			strings.ToUpper(database), stderr, err)
+		return
+	}
+	for _, kvPair := range strings.Fields(stdout) {
+		if strings.HasPrefix(kvPair, "monitors:") {
+			// kvPair will be of the form monitors:2
+			fields := strings.Split(kvPair, ":")
+			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
+				metricOVNDBMonitor.WithLabelValues(database).Set(value)
+			} else {
+				klog.Errorf("failed to parse the monitor's value %s to float64: err(%v)",
+					fields[1], err)
+			}
+		} else if strings.HasPrefix(kvPair, "sessions:") {
+			// kvPair will be of the form sessions:2
+			fields := strings.Split(kvPair, ":")
+			if value, err := strconv.ParseFloat(fields[1], 64); err == nil {
+				metricOVNDBSessions.WithLabelValues(database).Set(value)
+			} else {
+				klog.Errorf("failed to parse the sessions' value %s to float64: err(%v)",
+					fields[1], err)
+			}
+		}
+	}
+}
+
+// ReadinessProbeCommand runs readiness probes against various targets
+var OvnDBExporterCommand = cli.Command{
+	Name:  "ovn-db-exporter",
+	Usage: "",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "metrics-bind-address",
+			Usage: `The IP address and port for the metrics server to serve on (default ":9476")`,
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		bindAddress := ctx.String("metrics-bind-address")
+		if bindAddress == "" {
+			bindAddress = "0.0.0.0:9476"
+		}
+
+		if err := util.SetExec(kexec.New()); err != nil {
+			return err
+		}
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+
+		// register metrics that will be served off of /metrics path
+		prometheus.MustRegister(metricOVNDBRaftIndex)
+		prometheus.MustRegister(metricOVNDBLeader)
+		prometheus.MustRegister(metricOVNDBMonitor)
+		prometheus.MustRegister(metricOVNDBSessions)
+
+		// functions responsible for collecting the values and updating the prometheus metrics
+		go func() {
+			for {
+				ovnDBStatusMetricsUpdater("nb", "OVN_Northbound")
+				ovnDBStatusMetricsUpdater("sb", "OVN_Southbound")
+				time.Sleep(30 * time.Second)
+			}
+		}()
+
+		go func() {
+			for {
+				ovnDBMemoryMetricsUpdater("nb", "OVN_Northbound")
+				ovnDBMemoryMetricsUpdater("sb", "OVN_Southbound")
+				time.Sleep(30 * time.Second)
+			}
+		}()
+
+		err := http.ListenAndServe(bindAddress, mux)
+		if err != nil {
+			klog.Exitf("starting metrics server failed: %v", err)
+		}
+		return nil
+	},
+}

--- a/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
+++ b/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/cmd/ovn-kube-util/app"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -14,11 +16,28 @@ func main() {
 	c.Name = "ovn-kube-util"
 	c.Usage = "Utils for kubernetes ovn"
 	c.Version = config.Version
-
+	c.Flags = []cli.Flag{
+		cli.IntFlag{
+			Name: "loglevel",
+			Usage: "klog verbosity level (default: 4). Info, warn, fatal, error are always printed. " +
+				"For debug messages, use 5. ",
+			Value: 0,
+		},
+	}
 	c.Commands = []cli.Command{
 		app.NicsToBridgeCommand,
 		app.BridgesToNicCommand,
 		app.ReadinessProbeCommand,
+	}
+
+	c.Before = func(ctx *cli.Context) error {
+		var level klog.Level
+
+		klog.SetOutput(os.Stderr)
+		if err := level.Set(strconv.Itoa(ctx.Int("loglevel"))); err != nil {
+			return fmt.Errorf("failed to set klog log level %v", err)
+		}
+		return nil
 	}
 
 	if err := c.Run(os.Args); err != nil {

--- a/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
+++ b/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
@@ -28,6 +28,7 @@ func main() {
 		app.NicsToBridgeCommand,
 		app.BridgesToNicCommand,
 		app.ReadinessProbeCommand,
+		app.OvnDBExporterCommand,
 	}
 
 	c.Before = func(ctx *cli.Context) error {


### PR DESCRIPTION
add new subcommand to ovn-kube-util called ovn-db-exporter that exports
metrics as relates to OVN DB (clustered db in this commit). since we
cannot instrument the ovsdb-server daemon directly, we are going to
use ovn-kube-util running as a daemon handling http requests on port
'9476' for '/metrics' path.

the ovn-db-exporter is currently running as a 3rd container in the
ovnkube-db pod and exports the following metrics with labels
(OVN_Northbound and OVN_Southbound)

ovn_db_raft_cluster_leader
 - a gauge vector metric type that captures whether the current instance
   is a leader or not.

ovn_db_raft_jsonrpc_server_sessions
 - a gauge vector metric type that captures the number of jsonrpc server
   sessions that are currently active on the server.

ovn_db_raft_ovsdb_monitors
 - a gauge vector metric type that captures the number of ovsdb monitors
   that are currently active on the server.

ovn_db_raft_log_entry_index
 - a counter vector metric type that captures the log entry that is
   currently exposed to the client.

@dcbw @danwinship @numansiddique PTAL