### PR TITLE
update pod annotation and CNI shim communication for dual-stack

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -55,17 +55,19 @@ func podToCookie(pod *kapi.Pod) string {
 }
 
 func (n *NodeController) addOrUpdatePod(pod *kapi.Pod) error {
-	podIP, podMAC, err := getPodDetails(pod, n.nodeName)
+	podIPs, podMAC, err := getPodDetails(pod, n.nodeName)
 	if err != nil {
 		klog.V(5).Infof("cleaning up hybrid overlay pod %s/%s because %v", pod.Namespace, pod.Name, err)
 		return n.deletePod(pod)
 	}
 
 	cookie := podToCookie(pod)
-	_, _, err = util.RunOVSOfctl("add-flow", extBridgeName,
-		fmt.Sprintf("table=10,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=set_field:%s->eth_src,set_field:%s->eth_dst,output:ext", cookie, podIP.IP, n.drMAC, podMAC))
-	if err != nil {
-		return fmt.Errorf("failed to add flows for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+	for _, podIP := range podIPs {
+		_, _, err = util.RunOVSOfctl("add-flow", extBridgeName,
+			fmt.Sprintf("table=10,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=set_field:%s->eth_src,set_field:%s->eth_dst,output:ext", cookie, podIP.IP, n.drMAC, podMAC))
+		if err != nil {
+			return fmt.Errorf("failed to add flows for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		}
 	}
 	return nil
 }
@@ -79,7 +81,7 @@ func (n *NodeController) deletePod(pod *kapi.Pod) error {
 	return nil
 }
 
-func getPodDetails(pod *kapi.Pod, nodeName string) (*net.IPNet, net.HardwareAddr, error) {
+func getPodDetails(pod *kapi.Pod, nodeName string) ([]*net.IPNet, net.HardwareAddr, error) {
 	if pod.Spec.NodeName != nodeName {
 		return nil, nil, fmt.Errorf("not scheduled")
 	}
@@ -88,14 +90,23 @@ func getPodDetails(pod *kapi.Pod, nodeName string) (*net.IPNet, net.HardwareAddr
 	if err != nil {
 		return nil, nil, err
 	}
-	return podInfo.IP, podInfo.MAC, nil
+	return podInfo.IPs, podInfo.MAC, nil
 }
 
 // podChanged returns true if any relevant pod attributes changed
 func podChanged(pod1 *kapi.Pod, pod2 *kapi.Pod, nodeName string) bool {
-	podIP1, mac1, _ := getPodDetails(pod1, nodeName)
-	podIP2, mac2, _ := getPodDetails(pod2, nodeName)
-	return !reflect.DeepEqual(podIP1, podIP2) || !reflect.DeepEqual(mac1, mac2)
+	podIPs1, mac1, _ := getPodDetails(pod1, nodeName)
+	podIPs2, mac2, _ := getPodDetails(pod2, nodeName)
+
+	if len(podIPs1) != len(podIPs2) || !reflect.DeepEqual(mac1, mac2) {
+		return false
+	}
+	for i := range podIPs1 {
+		if podIPs1[i].String() != podIPs2[i].String() {
+			return false
+		}
+	}
+	return true
 }
 
 func (n *NodeController) syncPods(pods []interface{}) {

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -60,17 +60,17 @@ func setupNetwork(link netlink.Link, ifInfo *PodInterfaceInfo) error {
 	if err := netlink.LinkSetHardwareAddr(link, ifInfo.MAC); err != nil {
 		return fmt.Errorf("failed to add mac address %s to %s: %v", ifInfo.MAC, link.Attrs().Name, err)
 	}
-	addr := &netlink.Addr{IPNet: ifInfo.IP}
-	if err := netlink.AddrAdd(link, addr); err != nil {
-		return fmt.Errorf("failed to add IP addr %s to %s: %v", ifInfo.IP, link.Attrs().Name, err)
+	for _, ip := range ifInfo.IPs {
+		addr := &netlink.Addr{IPNet: ip}
+		if err := netlink.AddrAdd(link, addr); err != nil {
+			return fmt.Errorf("failed to add IP addr %s to %s: %v", ip, link.Attrs().Name, err)
+		}
 	}
-
-	if ifInfo.GW != nil {
-		if err := ip.AddRoute(nil, ifInfo.GW, link); err != nil {
+	for _, gw := range ifInfo.Gateways {
+		if err := ip.AddRoute(nil, gw, link); err != nil {
 			return fmt.Errorf("failed to add gateway route: %v", err)
 		}
 	}
-
 	for _, route := range ifInfo.Routes {
 		if err := ip.AddRoute(route.Dest, route.NextHop, link); err != nil {
 			return fmt.Errorf("failed to add pod route %v via %v: %v", route.Dest, route.NextHop, err)
@@ -253,13 +253,18 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 		}
 	}
 
+	ipStrs := make([]string, len(ifInfo.IPs))
+	for i, ip := range ifInfo.IPs {
+		ipStrs[i] = ip.String()
+	}
+
 	// Add the new sandbox's OVS port
 	ovsArgs := []string{
 		"add-port", "br-int", hostIface.Name, "--", "set",
 		"interface", hostIface.Name,
 		fmt.Sprintf("external_ids:attached_mac=%s", ifInfo.MAC),
 		fmt.Sprintf("external_ids:iface-id=%s", ifaceID),
-		fmt.Sprintf("external_ids:ip_address=%s", ifInfo.IP),
+		fmt.Sprintf("external_ids:ip_addresses=%s", strings.Join(ipStrs, ",")),
 		fmt.Sprintf("external_ids:sandbox=%s", pr.SandboxID),
 	}
 

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -244,7 +244,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				podAnnotation, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 
 				return nil
 			}
@@ -291,7 +291,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				podAnnotation, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 
 				return nil
 			}
@@ -335,7 +335,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				podAnnotation, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
 				// Delete it
@@ -399,7 +399,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				podAnnotation, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 
 				return nil
 			}
@@ -456,7 +456,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				podAnnotation, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 
 				return nil
 			}
@@ -533,7 +533,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				podAnnotation, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 
 				return nil
 			}
@@ -580,7 +580,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				podAnnotation, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 
 				// Simulate an OVN restart with a new IP assignment and verify that the pod annotation is updated.
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -606,7 +606,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				// Check that pod annotations have been re-written to correct values
 				podAnnotation, ok = pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 
 				return nil
 			}
@@ -650,7 +650,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 				podAnnotation, ok := pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 
 				// Simulate an OVN restart with a new IP assignment and verify that the pod annotation is updated.
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -676,7 +676,7 @@ var _ = Describe("OVN Pod Operations", func() {
 				// Check that pod annotations have been re-written to correct values
 				podAnnotation, ok = pod.Annotations[util.OvnPodAnnotationName]
 				Expect(ok).To(BeTrue())
-				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_address":"` + t.podIP + `/24", "mac_address":"` + t.podMAC + `", "gateway_ip": "` + t.nodeGWIP + `"}}`))
+				Expect(podAnnotation).To(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 
 				return nil
 			}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1145,7 +1145,8 @@ func (oc *Controller) handlePeerPodSelectorAddUpdate(np *namespacePolicy,
 	if err != nil {
 		return
 	}
-	ipAddress := podAnnotation.IP.IP.String()
+	// DUAL-STACK FIXME: handle multiple IPs
+	ipAddress := podAnnotation.IPs[0].IP.String()
 	if addressMap[ipAddress] {
 		return
 	}
@@ -1181,7 +1182,8 @@ func (oc *Controller) handlePeerPodSelectorDelete(np *namespacePolicy,
 	if err != nil {
 		return
 	}
-	ipAddress := podAnnotation.IP.IP.String()
+	// DUAL-STACK FIXME: handle multiple IPs
+	ipAddress := podAnnotation.IPs[0].IP.String()
 
 	np.Lock()
 	defer np.Unlock()

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -62,6 +62,9 @@ func MarshalPodAnnotation(podInfo *PodAnnotation) (map[string]string, error) {
 		GW:  gw,
 	}
 	for _, r := range podInfo.Routes {
+		if r.Dest.IP.IsUnspecified() {
+			return nil, fmt.Errorf("bad podNetwork data: default route %v should be specified as gateway", r)
+		}
 		var nh string
 		if r.NextHop != nil {
 			nh = r.NextHop.String()
@@ -126,6 +129,9 @@ func UnmarshalPodAnnotation(annotations map[string]string) (*PodAnnotation, erro
 		_, route.Dest, err = net.ParseCIDR(r.Dest)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse pod route dest %q: %v", r.Dest, err)
+		}
+		if route.Dest.IP.IsUnspecified() {
+			return nil, fmt.Errorf("bad podNetwork data: default route %v should be specified as gateway", route)
 		}
 		if r.NextHop != "" {
 			route.NextHop = net.ParseIP(r.NextHop)

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -1,0 +1,140 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"k8s.io/klog"
+)
+
+const (
+	// OvnPodAnnotationName is the constant string representing the POD annotation key
+	OvnPodAnnotationName = "k8s.ovn.org/pod-networks"
+	// OvnPodDefaultNetwork is the constant string representing the first OVN interface to the Pod
+	OvnPodDefaultNetwork = "default"
+)
+
+// PodAnnotation describes the pod's assigned network details
+type PodAnnotation struct {
+	// IP is the pod's assigned IP address and prefix
+	IP *net.IPNet
+	// MAC is the pod's assigned MAC address
+	MAC net.HardwareAddr
+	// GW is the pod's gateway IP address
+	GW net.IP
+	// Routes are routes to add to the pod's network namespace
+	Routes []PodRoute
+}
+
+// PodRoute describes any routes to be added to the pod's network namespace
+type PodRoute struct {
+	// Dest is the route destination
+	Dest *net.IPNet
+	// NextHop is the IP address of the next hop for traffic destined for Dest
+	NextHop net.IP
+}
+
+// Internal struct used to correctly marshal IPs to JSON
+type podAnnotation struct {
+	IP     string     `json:"ip_address"`
+	MAC    string     `json:"mac_address"`
+	GW     string     `json:"gateway_ip"`
+	Routes []podRoute `json:"routes,omitempty"`
+}
+
+// Internal struct used to correctly marshal IPs to JSON
+type podRoute struct {
+	Dest    string `json:"dest"`
+	NextHop string `json:"nextHop"`
+}
+
+// MarshalPodAnnotation returns a JSON-formatted annotation describing the pod's
+// network details
+func MarshalPodAnnotation(podInfo *PodAnnotation) (map[string]string, error) {
+	var gw string
+	if podInfo.GW != nil {
+		gw = podInfo.GW.String()
+	}
+	pa := podAnnotation{
+		IP:  podInfo.IP.String(),
+		MAC: podInfo.MAC.String(),
+		GW:  gw,
+	}
+	for _, r := range podInfo.Routes {
+		var nh string
+		if r.NextHop != nil {
+			nh = r.NextHop.String()
+		}
+		pa.Routes = append(pa.Routes, podRoute{
+			Dest:    r.Dest.String(),
+			NextHop: nh,
+		})
+	}
+
+	podNetworks := map[string]podAnnotation{
+		OvnPodDefaultNetwork: pa,
+	}
+	bytes, err := json.Marshal(podNetworks)
+	if err != nil {
+		klog.Errorf("failed marshaling podNetworks map %v", podNetworks)
+		return nil, err
+	}
+	return map[string]string{
+		OvnPodAnnotationName: string(bytes),
+	}, nil
+}
+
+// UnmarshalPodAnnotation returns a the unmarshalled pod annotation
+func UnmarshalPodAnnotation(annotations map[string]string) (*PodAnnotation, error) {
+	ovnAnnotation, ok := annotations[OvnPodAnnotationName]
+	if !ok {
+		return nil, fmt.Errorf("could not find OVN pod annotation in %v", annotations)
+	}
+
+	podNetworks := make(map[string]podAnnotation)
+	if err := json.Unmarshal([]byte(ovnAnnotation), &podNetworks); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ovn pod annotation %q: %v",
+			ovnAnnotation, err)
+	}
+	tempA := podNetworks[OvnPodDefaultNetwork]
+	a := &tempA
+
+	podAnnotation := &PodAnnotation{}
+	// Minimal validation
+	ip, ipnet, err := net.ParseCIDR(a.IP)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pod IP %q: %v", a.IP, err)
+	}
+	ipnet.IP = ip
+	podAnnotation.IP = ipnet
+
+	podAnnotation.MAC, err = net.ParseMAC(a.MAC)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pod MAC %q: %v", a.MAC, err)
+	}
+
+	if a.GW != "" {
+		podAnnotation.GW = net.ParseIP(a.GW)
+		if podAnnotation.GW == nil {
+			return nil, fmt.Errorf("failed to parse pod gateway %q", a.GW)
+		}
+	}
+
+	for _, r := range a.Routes {
+		route := PodRoute{}
+		_, route.Dest, err = net.ParseCIDR(r.Dest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse pod route dest %q: %v", r.Dest, err)
+		}
+		if r.NextHop != "" {
+			route.NextHop = net.ParseIP(r.NextHop)
+			if route.NextHop == nil {
+				return nil, fmt.Errorf("failed to parse pod route next hop %q", r.NextHop)
+			}
+		}
+		podAnnotation.Routes = append(podAnnotation.Routes, route)
+	}
+
+	return podAnnotation, nil
+}

--- a/go-controller/pkg/util/pod_annotation_test.go
+++ b/go-controller/pkg/util/pod_annotation_test.go
@@ -19,30 +19,30 @@ var _ = Describe("Pod annotation tests", func() {
 			{
 				name: "Single-stack IPv4",
 				in: &PodAnnotation{
-					IP:  mustParseCIDRAddress("192.168.0.5/24"),
-					MAC: mustParseMAC("0A:58:FD:98:00:01"),
-					GW:  net.ParseIP("192.168.0.1"),
+					IPs:      []*net.IPNet{mustParseCIDRAddress("192.168.0.5/24")},
+					MAC:      mustParseMAC("0A:58:FD:98:00:01"),
+					Gateways: []net.IP{net.ParseIP("192.168.0.1")},
 				},
 				out: map[string]string{
-					"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"192.168.0.5/24","mac_address":"0a:58:fd:98:00:01","gateway_ip":"192.168.0.1"}}`,
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.0.1"],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`,
 				},
 			},
 			{
 				name: "No GW",
 				in: &PodAnnotation{
-					IP:  mustParseCIDRAddress("192.168.0.5/24"),
+					IPs: []*net.IPNet{mustParseCIDRAddress("192.168.0.5/24")},
 					MAC: mustParseMAC("0A:58:FD:98:00:01"),
 				},
 				out: map[string]string{
-					"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"192.168.0.5/24","mac_address":"0a:58:fd:98:00:01","gateway_ip":""}}`,
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","ip_address":"192.168.0.5/24"}}`,
 				},
 			},
 			{
 				name: "Routes",
 				in: &PodAnnotation{
-					IP:  mustParseCIDRAddress("192.168.0.5/24"),
-					MAC: mustParseMAC("0A:58:FD:98:00:01"),
-					GW:  net.ParseIP("192.168.0.1"),
+					IPs:      []*net.IPNet{mustParseCIDRAddress("192.168.0.5/24")},
+					MAC:      mustParseMAC("0A:58:FD:98:00:01"),
+					Gateways: []net.IP{net.ParseIP("192.168.0.1")},
 					Routes: []PodRoute{
 						{
 							Dest:    mustParseCIDR("192.168.1.0/24"),
@@ -51,18 +51,35 @@ var _ = Describe("Pod annotation tests", func() {
 					},
 				},
 				out: map[string]string{
-					"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"192.168.0.5/24","mac_address":"0a:58:fd:98:00:01","gateway_ip":"192.168.0.1","routes":[{"dest":"192.168.1.0/24","nextHop":"192.168.1.1"}]}}`,
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.0.1"],"routes":[{"dest":"192.168.1.0/24","nextHop":"192.168.1.1"}],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`,
 				},
 			},
 			{
 				name: "Single-stack IPv6",
 				in: &PodAnnotation{
-					IP:  mustParseCIDRAddress("fd01::1234/64"),
-					MAC: mustParseMAC("0A:58:FD:98:00:01"),
-					GW:  net.ParseIP("fd01::1"),
+					IPs:      []*net.IPNet{mustParseCIDRAddress("fd01::1234/64")},
+					MAC:      mustParseMAC("0A:58:FD:98:00:01"),
+					Gateways: []net.IP{net.ParseIP("fd01::1")},
 				},
 				out: map[string]string{
-					"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"fd01::1234/64","mac_address":"0a:58:fd:98:00:01","gateway_ip":"fd01::1"}}`,
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["fd01::1234/64"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["fd01::1"],"ip_address":"fd01::1234/64","gateway_ip":"fd01::1"}}`,
+				},
+			},
+			{
+				name: "Dual-stack",
+				in: &PodAnnotation{
+					IPs: []*net.IPNet{
+						mustParseCIDRAddress("192.168.0.5/24"),
+						mustParseCIDRAddress("fd01::1234/64"),
+					},
+					MAC: mustParseMAC("0A:58:FD:98:00:01"),
+					Gateways: []net.IP{
+						net.ParseIP("192.168.1.0"),
+						net.ParseIP("fd01::1"),
+					},
+				},
+				out: map[string]string{
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24","fd01::1234/64"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.1.0","fd01::1"]}}`,
 				},
 			},
 		}

--- a/go-controller/pkg/util/pod_annotation_test.go
+++ b/go-controller/pkg/util/pod_annotation_test.go
@@ -1,0 +1,98 @@
+package util
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Pod annotation tests", func() {
+	It("marshals network info to pod annotations", func() {
+		type testcase struct {
+			name string
+			in   *PodAnnotation
+			out  map[string]string
+		}
+
+		testcases := []testcase{
+			{
+				name: "Single-stack IPv4",
+				in: &PodAnnotation{
+					IP:  mustParseCIDRAddress("192.168.0.5/24"),
+					MAC: mustParseMAC("0A:58:FD:98:00:01"),
+					GW:  net.ParseIP("192.168.0.1"),
+				},
+				out: map[string]string{
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"192.168.0.5/24","mac_address":"0a:58:fd:98:00:01","gateway_ip":"192.168.0.1"}}`,
+				},
+			},
+			{
+				name: "No GW",
+				in: &PodAnnotation{
+					IP:  mustParseCIDRAddress("192.168.0.5/24"),
+					MAC: mustParseMAC("0A:58:FD:98:00:01"),
+				},
+				out: map[string]string{
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"192.168.0.5/24","mac_address":"0a:58:fd:98:00:01","gateway_ip":""}}`,
+				},
+			},
+			{
+				name: "Routes",
+				in: &PodAnnotation{
+					IP:  mustParseCIDRAddress("192.168.0.5/24"),
+					MAC: mustParseMAC("0A:58:FD:98:00:01"),
+					GW:  net.ParseIP("192.168.0.1"),
+					Routes: []PodRoute{
+						{
+							Dest:    mustParseCIDR("192.168.1.0/24"),
+							NextHop: net.ParseIP("192.168.1.1"),
+						},
+					},
+				},
+				out: map[string]string{
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"192.168.0.5/24","mac_address":"0a:58:fd:98:00:01","gateway_ip":"192.168.0.1","routes":[{"dest":"192.168.1.0/24","nextHop":"192.168.1.1"}]}}`,
+				},
+			},
+			{
+				name: "Single-stack IPv6",
+				in: &PodAnnotation{
+					IP:  mustParseCIDRAddress("fd01::1234/64"),
+					MAC: mustParseMAC("0A:58:FD:98:00:01"),
+					GW:  net.ParseIP("fd01::1"),
+				},
+				out: map[string]string{
+					"k8s.ovn.org/pod-networks": `{"default":{"ip_address":"fd01::1234/64","mac_address":"0a:58:fd:98:00:01","gateway_ip":"fd01::1"}}`,
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			marshalled, err := MarshalPodAnnotation(tc.in)
+			Expect(err).NotTo(HaveOccurred(), "test case %q got unexpected marshalling error", tc.name)
+			Expect(marshalled).To(Equal(tc.out), "test case %q marshalled to wrong value", tc.name)
+			unmarshalled, err := UnmarshalPodAnnotation(marshalled)
+			Expect(err).NotTo(HaveOccurred(), "test case %q got unexpected unmarshalling error", tc.name)
+			Expect(unmarshalled).To(Equal(tc.in), "test case %q unmarshalled to wrong value", tc.name)
+		}
+	})
+})
+
+func mustParseCIDRAddress(addr string) *net.IPNet {
+	ip, subnet, err := net.ParseCIDR(addr)
+	Expect(err).NotTo(HaveOccurred())
+	subnet.IP = ip
+	return subnet
+}
+
+func mustParseCIDR(cidr string) *net.IPNet {
+	_, subnet, err := net.ParseCIDR(cidr)
+	Expect(err).NotTo(HaveOccurred())
+	return subnet
+}
+
+func mustParseMAC(mac string) net.HardwareAddr {
+	parsed, err := net.ParseMAC(mac)
+	Expect(err).NotTo(HaveOccurred())
+	return parsed
+}

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 
 	"github.com/urfave/cli"
+
 	"k8s.io/klog"
 )
 
@@ -116,135 +116,4 @@ func UpdateNodeSwitchExcludeIPs(nodeName string, subnet *net.IPNet) error {
 			"stderr: %q, error: %v", nodeName, stderr, err)
 	}
 	return nil
-}
-
-const (
-	// OvnPodAnnotationName is the constant string representing the POD annotation key
-	OvnPodAnnotationName = "k8s.ovn.org/pod-networks"
-	// OvnPodDefaultNetwork is the constant string representing the first OVN interface to the Pod
-	OvnPodDefaultNetwork = "default"
-)
-
-// PodAnnotation describes the pod's assigned network details
-type PodAnnotation struct {
-	// IP is the pod's assigned IP address and prefix
-	IP *net.IPNet
-	// MAC is the pod's assigned MAC address
-	MAC net.HardwareAddr
-	// GW is the pod's gateway IP address
-	GW net.IP
-	// Routes are routes to add to the pod's network namespace
-	Routes []PodRoute
-}
-
-// PodRoute describes any routes to be added to the pod's network namespace
-type PodRoute struct {
-	// Dest is the route destination
-	Dest *net.IPNet
-	// NextHop is the IP address of the next hop for traffic destined for Dest
-	NextHop net.IP
-}
-
-// Internal struct used to correctly marshal IPs to JSON
-type podAnnotation struct {
-	IP     string     `json:"ip_address"`
-	MAC    string     `json:"mac_address"`
-	GW     string     `json:"gateway_ip"`
-	Routes []podRoute `json:"routes,omitempty"`
-}
-
-// Internal struct used to correctly marshal IPs to JSON
-type podRoute struct {
-	Dest    string `json:"dest"`
-	NextHop string `json:"nextHop"`
-}
-
-// MarshalPodAnnotation returns a JSON-formatted annotation describing the pod's
-// network details
-func MarshalPodAnnotation(podInfo *PodAnnotation) (map[string]string, error) {
-	var gw string
-	if podInfo.GW != nil {
-		gw = podInfo.GW.String()
-	}
-	pa := podAnnotation{
-		IP:  podInfo.IP.String(),
-		MAC: podInfo.MAC.String(),
-		GW:  gw,
-	}
-	for _, r := range podInfo.Routes {
-		var nh string
-		if r.NextHop != nil {
-			nh = r.NextHop.String()
-		}
-		pa.Routes = append(pa.Routes, podRoute{
-			Dest:    r.Dest.String(),
-			NextHop: nh,
-		})
-	}
-
-	podNetworks := map[string]podAnnotation{
-		OvnPodDefaultNetwork: pa,
-	}
-	bytes, err := json.Marshal(podNetworks)
-	if err != nil {
-		klog.Errorf("failed marshaling podNetworks map %v", podNetworks)
-		return nil, err
-	}
-	return map[string]string{
-		OvnPodAnnotationName: string(bytes),
-	}, nil
-}
-
-// UnmarshalPodAnnotation returns a the unmarshalled pod annotation
-func UnmarshalPodAnnotation(annotations map[string]string) (*PodAnnotation, error) {
-	ovnAnnotation, ok := annotations[OvnPodAnnotationName]
-	if !ok {
-		return nil, fmt.Errorf("could not find OVN pod annotation in %v", annotations)
-	}
-
-	podNetworks := make(map[string]podAnnotation)
-	if err := json.Unmarshal([]byte(ovnAnnotation), &podNetworks); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal ovn pod annotation %q: %v",
-			ovnAnnotation, err)
-	}
-	tempA := podNetworks[OvnPodDefaultNetwork]
-	a := &tempA
-
-	podAnnotation := &PodAnnotation{}
-	// Minimal validation
-	ip, ipnet, err := net.ParseCIDR(a.IP)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse pod IP %q: %v", a.IP, err)
-	}
-	ipnet.IP = ip
-	podAnnotation.IP = ipnet
-
-	podAnnotation.MAC, err = net.ParseMAC(a.MAC)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse pod MAC %q: %v", a.MAC, err)
-	}
-
-	if a.GW != "" {
-		podAnnotation.GW = net.ParseIP(a.GW)
-		if podAnnotation.GW == nil {
-			return nil, fmt.Errorf("failed to parse pod gateway %q", a.GW)
-		}
-	}
-
-	for _, r := range a.Routes {
-		route := PodRoute{}
-		_, route.Dest, err = net.ParseCIDR(r.Dest)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse pod route dest %q: %v", r.Dest, err)
-		}
-		if r.NextHop != "" {
-			route.NextHop = net.ParseIP(r.NextHop)
-			if route.NextHop == nil {
-				return nil, fmt.Errorf("failed to parse pod route next hop %q", a.GW)
-			}
-		}
-		podAnnotation.Routes = append(podAnnotation.Routes, route)
-	}
-
-	return podAnnotation, nil
 }


### PR DESCRIPTION
OK, starting to think about dual-stack

The first thing in the source tree alphabetically that needs to be updated is the cniserver/cnishim communication, which currently inlines the pod annotation data.

The pod annotation currently only allows for a single IP per network:

    k8s.ovn.org/pod-networks: |
      {
        "default": {
          "ip_address": "192.168.0.5/24",
          "mac_address": "0a:58:fd:98:00:01",
          "gateway_ip": "192.168.0.1"
        }
      }

----
EDIT: current version of the patch continues using the above format for single-stack clusters, and replaces `ip_address` and `gateway_ip` with `ip_addresses` and `gateway_ips` arrays only in dual-stack clusters.

original proposal continues below...

----

So options for extending that to dual-stack include:
1. deprecate the existing annotation, add a new one
2. deprecate the `ip_address` and `gateway_ip` fields, add new `ip_addresses` and `gateway_ips` fields. (`routes` is already dual-stack friendly)
3. add new `ip6_address` and `gateway_ip6` fields (and maybe `routes6`) in addition to the existing fields
4. treat the IPv6 address as a second network

The current version of this patch does the 4th option:

    k8s.ovn.org/pod-networks: |
      {
        "default": {
          "ip_address": "192.168.0.5/24",
          "mac_address": "0a:58:fd:98:00:01",
          "gateway_ip": "192.168.0.1"
        },
        "defaultv6": {
          "ip_address": "fd01::1234/64",
          "mac_address": "0a:58:fd:98:00:01",
          "gateway_ip": "fd01::1"
        }
      }

This is simple but maybe not ideal... what do you do with other networks besides `"default"`? Do we just say that `"X"` and `"Xv6"` always go together? (Note that you can correlate "matching" IPv4 and IPv6 addresses by their `mac_address` anyway.) Maybe it would have been better to do one of the other options...

Meanwhile, the cniserver→cnishim data changes from:

    {
      "ip_address": "192.168.0.5/24",
      "mac_address": "0a:58:fd:98:00:01",
      "gateway_ip": "192.168.0.1",
      "mtu": 1400,
      "ingress": 0,
      "egress": 0,
    }

to:

    {
      ipConfig: [
        {
          "ip_address": "192.168.0.5/24",
          "mac_address": "0a:58:fd:98:00:01",
          "gateway_ip": "192.168.0.1"
        },
        {
          "ip_address": "fd01::1234/64",
          "mac_address": "0a:58:fd:98:00:01",
          "gateway_ip": "fd01::1"
        }
      ],
      "mtu": 1400,
      "ingress": 0,
      "egress": 0,
    }

which seems fine other than the redundant MAC address

Thoughts?

@girishmg @dcbw @russellb 