### PR TITLE
add more metrics for ovnkube-master and ovnkube-node daemons

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -51,6 +51,15 @@ func RegisterMasterMetrics() {
 				Name:      "sb_e2e_timestamp",
 				Help:      "The current e2e-timestamp value as observed in the southbound database",
 			}, scrapeOvnTimestamp))
+		prometheus.MustRegister(prometheus.NewCounterFunc(
+			prometheus.CounterOpts{
+				Namespace: MetricOvnkubeNamespace,
+				Subsystem: MetricOvnkubeSubsystemMaster,
+				Name:      "skipped_nbctl_daemon_total",
+				Help:      "The number of times we skipped using ovn-nbctl daemon and directly interacted with OVN NB DB",
+			}, func() float64 {
+				return float64(util.SkippedNbctlDaemonCounter)
+			}))
 	})
 }
 

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -32,6 +32,13 @@ var metricPodCreationLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15),
 })
 
+var MetricMasterReadyDuration = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "ready_duration_seconds",
+	Help:      "The duration for the master to get to ready state",
+})
+
 var registerMasterMetricsOnce sync.Once
 var startMasterUpdaterOnce sync.Once
 
@@ -60,6 +67,7 @@ func RegisterMasterMetrics() {
 			}, func() float64 {
 				return float64(util.SkippedNbctlDaemonCounter)
 			}))
+		prometheus.MustRegister(MetricMasterReadyDuration)
 	})
 }
 

--- a/go-controller/pkg/metrics/node.go
+++ b/go-controller/pkg/metrics/node.go
@@ -18,10 +18,18 @@ var MetricCNIRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOp
 	[]string{"command", "err"},
 )
 
+var MetricNodeReadyDuration = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemNode,
+	Name:      "ready_duration_seconds",
+	Help:      "The duration for the node to get to ready state",
+})
+
 var registerNodeMetricsOnce sync.Once
 
 func RegisterNodeMetrics() {
 	registerNodeMetricsOnce.Do(func() {
 		prometheus.MustRegister(MetricCNIRequestDuration)
+		prometheus.MustRegister(MetricNodeReadyDuration)
 	})
 }

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -292,6 +292,8 @@ func runOVNretry(cmdPath string, envVars []string, args ...string) (*bytes.Buffe
 	}
 }
 
+var SkippedNbctlDaemonCounter uint64
+
 func getNbctlArgsAndEnv(timeout int, args ...string) ([]string, []string) {
 	var cmdArgs, envVars []string
 
@@ -312,6 +314,7 @@ func getNbctlArgsAndEnv(timeout int, args ...string) ([]string, []string) {
 		}
 		klog.Warningf("failed to retrieve ovn-nbctl daemon's control socket " +
 			"so resorting to non-daemon mode")
+		atomic.AddUint64(&SkippedNbctlDaemonCounter, 1)
 	}
 
 	if config.OvnNorth.Scheme == config.OvnDBSchemeSSL {


### PR DESCRIPTION
- add metric to record the time taken for the onvkube daemons to come up

    added ovnkube_master_ready_duration_seconds and
    ovnkube_node_ready_duration_seconds. this is information type metric
    since its value doesn't change once the daemons are up and running. we
    have found this to be very helpful while bringing up large clusters
    to figure out how adding more nodes ot k8s cluster impacts ovn control
    plane

- add metric to count number of times we have skipped using nbctl daemon

@dcbw @danwinship PTAL
