### PR TITLE
exit early from script upon failure to determine ip address of the host

### DIFF
--- a/dist/images/ovndb-raft-functions
+++ b/dist/images/ovndb-raft-functions
@@ -98,6 +98,10 @@ ovsdb-raft () {
   rm -f ${ovn_db_pidfile}
   verify-ovsdb-raft
   local_ip=$(getent ahostsv4 $(hostname) | grep -v "^127\." | head -1 | awk '{ print $1 }')
+  if [[ ${local_ip} == "" ]] ; then
+      echo "failed to retrieve the IP address of the host $(hostname). Exiting..."
+      exit 1
+  fi
   echo "=============== run ${db}-ovsdb-raft pod ${POD_NAME} =========="
 
   if [[ ! -e ${ovn_db_file} ]] || ovsdb-tool db-is-standalone ${ovn_db_file} ; then

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -589,6 +589,10 @@ nb-ovsdb () {
   check_ovn_daemonset_version "3"
   rm -f ${OVN_RUNDIR}/ovnnb_db.pid
 
+  if [[ ${ovn_db_host} == "" ]] ; then
+      echo "The IP address of the host $(hostname) could not be determined. Exiting..."
+      exit 1
+  fi
   iptables-rules ${ovn_nb_port}
 
   echo "=============== run nb_ovsdb ========== MASTER ONLY"
@@ -615,6 +619,10 @@ sb-ovsdb () {
   check_ovn_daemonset_version "3"
   rm -f ${OVN_RUNDIR}/ovnsb_db.pid
 
+  if [[ ${ovn_db_host} == "" ]] ; then
+      echo "The IP address of the host $(hostname) could not be determined. Exiting..."
+      exit 1
+  fi
   iptables-rules ${ovn_sb_port}
 
   echo "=============== run sb_ovsdb ========== MASTER ONLY"


### PR DESCRIPTION
Wasted good two hours debugging this. With this check we exit early instead of continuing and ovsdb-server interpreting the empty host ip address incorrectly and screwing up the cluster.

@dcbw PTAL