### PR TITLE
nodePortWatcher for the shared-gateway mode doesn't handle service update

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -164,6 +165,13 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, wf *factory.WatchFactory
 			addService(service, ofportPhys, ofportPatch, gwBridge)
 		},
 		UpdateFunc: func(old, new interface{}) {
+			svcNew := new.(*kapi.Service)
+			svcOld := old.(*kapi.Service)
+			if reflect.DeepEqual(svcNew.Spec, svcOld.Spec) {
+				return
+			}
+			deleteService(svcOld, ofportPhys, gwBridge)
+			addService(svcNew, ofportPhys, ofportPatch, gwBridge)
 		},
 		DeleteFunc: func(obj interface{}) {
 			service := obj.(*kapi.Service)


### PR DESCRIPTION
Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@dcbw @danwinship PTAL
