### PR TITLE
util: remove an unused and erroneous function

### DIFF
--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -3,21 +3,11 @@ package util
 import (
 	"fmt"
 	"math/big"
-	"math/rand"
 	"net"
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 )
-
-// GenerateMac generates mac address.
-func GenerateMac() string {
-	prefix := "00:00:00"
-	newRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	mac := fmt.Sprintf("%s:%02X:%02X:%02X", prefix, newRand.Intn(255), newRand.Intn(255), newRand.Intn(255))
-	return mac
-}
 
 // NextIP returns IP incremented by 1
 func NextIP(ip net.IP) net.IP {


### PR DESCRIPTION
`util.GenerateMac` generates pseudo-random MAC addresses but without setting the bit indicating that they are locally-generated rather than being from a formally-assigned block. Fortunately, no one was using it anyway.

@dcbw