### PR TITLE
ovnkube-node daemon is not logging messages at level=5

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1034,11 +1034,6 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 
 	configFile, configFileIsDefault = getConfigFilePath(ctx)
 
-	var level klog.Level
-	if err := level.Set(strconv.Itoa(ctx.Int("loglevel"))); err != nil {
-		return "", fmt.Errorf("failed to set klog log level %v", err)
-	}
-
 	if !configFileIsDefault {
 		// Only return explicitly specified config file
 		retConfigFile = configFile
@@ -1080,6 +1075,10 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 		return "", err
 	}
 
+	var level klog.Level
+	if err := level.Set(strconv.Itoa(Logging.Level)); err != nil {
+		return "", fmt.Errorf("failed to set klog log level %v", err)
+	}
 	if Logging.File != "" {
 		klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 		klog.InitFlags(klogFlags)

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -174,8 +174,6 @@ func (n *OvnNode) Start() error {
 	// Setting debug log level during node bring up to expose bring up process.
 	// Log level is returned to configured value when bring up is complete.
 	var level klog.Level
-	lastLevel := fmt.Sprintf("%v", level.Get())
-
 	if err := level.Set("5"); err != nil {
 		klog.Errorf("setting klog \"loglevel\" to 5 failed, err: %v", err)
 	}
@@ -259,7 +257,7 @@ func (n *OvnNode) Start() error {
 	}
 	klog.Infof("Gateway and management port readiness took %v", time.Since(start))
 
-	if err := level.Set(lastLevel); err != nil {
+	if err := level.Set(strconv.Itoa(config.Logging.Level)); err != nil {
 		klog.Errorf("reset of initial klog \"loglevel\" failed, err: %v", err)
 	}
 


### PR DESCRIPTION
we are not restoring the correct log level after we initially setup
the ovnkube-node daemon to print debug messages at startup time

@dcbw @danwinship   @alexanderConstantinescu PTAL