### PR TITLE
added more metrics and moved the metric collection for ovnkube-master

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -217,32 +217,28 @@ func runOvnKube(ctx *cli.Context) error {
 		if runtime.GOOS == "windows" {
 			return fmt.Errorf("Windows is not supported as master node")
 		}
+		// register prometheus metrics exported by the master
+		metrics.RegisterMasterMetrics()
 		// run the HA master controller to init the master
-		start := time.Now()
 		ovnHAController := ovn.NewHAMasterController(clientset, factory, master, stopChan)
 		if err := ovnHAController.StartHAMasterController(); err != nil {
 			return err
 		}
-		end := time.Since(start)
-		// register prometheus metrics exported by the master
-		metrics.RegisterMasterMetrics()
-		metrics.MetricMasterReadyDuration.Set(float64(end))
 	}
 
 	if node != "" {
 		if config.Kubernetes.Token == "" {
 			return fmt.Errorf("cannot initialize node without service account 'token'. Please provide one with --k8s-token argument")
 		}
-
+		// register prometheus metrics exported by the node
+		metrics.RegisterNodeMetrics()
 		start := time.Now()
 		n := ovnnode.NewNode(clientset, factory, node)
 		if err := n.Start(); err != nil {
 			return err
 		}
 		end := time.Since(start)
-		// register prometheus metrics exported by the node
-		metrics.RegisterNodeMetrics()
-		metrics.MetricNodeReadyDuration.Set(float64(end))
+		metrics.MetricNodeReadyDuration.Set(end.Seconds())
 	}
 
 	// now that ovnkube master/node are running, lets expose the metrics HTTP endpoint if configured

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -32,6 +32,18 @@ var metricPodCreationLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15),
 })
 
+// metricPodCreationLatency is the time between a pod being scheduled and the
+// ovn controller setting the network annotations.
+var metricOvnCliLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "ovn_cli_latency_seconds",
+	Help:      "The latency of various OVN commands. Currently, ovn-nbctl and ovn-sbctl",
+	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
+	// labels
+	[]string{"command"},
+)
+
 var MetricMasterReadyDuration = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
@@ -68,6 +80,9 @@ func RegisterMasterMetrics() {
 				return float64(util.SkippedNbctlDaemonCounter)
 			}))
 		prometheus.MustRegister(MetricMasterReadyDuration)
+		prometheus.MustRegister(metricOvnCliLatency)
+		// this is to not to create circular import between metrics and util package
+		util.MetricOvnCliLatency = metricOvnCliLatency
 	})
 }
 

--- a/go-controller/pkg/ovn/ha_master.go
+++ b/go-controller/pkg/ovn/ha_master.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -197,12 +199,15 @@ func (hacontroller *HAMasterController) ConfigureAsActive(masterNodeName string)
 	}
 
 	// run the cluster controller to init the master
+	start := time.Now()
 	err := hacontroller.ovnController.StartClusterMaster(hacontroller.nodeName)
 	if err != nil {
 		return err
 	}
-
-	return hacontroller.ovnController.Run(hacontroller.stopChan)
+	err = hacontroller.ovnController.Run(hacontroller.stopChan)
+	end := time.Since(start)
+	metrics.MetricMasterReadyDuration.Set(end.Seconds())
+	return err
 }
 
 //updateOvnDbEndpoints Updates the ovnkube-db endpoints. Should be called


### PR DESCRIPTION
1. added ovnkube_node_integration_bridge_openflow_total metric that exports the number of
     OpenFlow flows in the integration bridge

2. added ovnkube_master_ovn_cli_latency_seconds metric that exporst the latency of various OVN commands that runs on the master. Right now, only exports ovn-nbctl and ovn-sbctl calls

3.  miscellaneous fixes to ovnkube-master daemon's duration to ready state metric
    
    - export duration metric in seconds instead of nanoseconds
    - measure the duration to ready state in the ha_master.go where we
      setup various logical topology on the master and then start watchers.
    
@danwinship @dcbw @squeed PTAL