### PR TITLE
Force ovn-controller to recompute flows on failed readiness

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -114,7 +114,7 @@ func (n *OvnNode) initGateway(subnet *net.IPNet, nodeAnnotator kube.Annotator,
 	}
 
 	// Wait for gateway resources to be created by the master
-	waiter.AddWait(gatewayReady, prFn)
+	waiter.AddWait(gatewayReady, prFn, util.ForceOVNRecompute)
 	return nil
 }
 

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -58,7 +58,7 @@ func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator k
 		return err
 	}
 
-	waiter.AddWait(managementPortReady, nil)
+	waiter.AddWait(managementPortReady, nil, util.ForceOVNRecompute)
 	return nil
 }
 


### PR DESCRIPTION
We notice at scale that sometimes flows are missing from some nodes, and
restarting or forcing a recompute on ovn-controller will end up
programming those flows. This patch adds a force recompute when the node
readiness checks fail, and retries the wait condition, instead of just
exiting and restarting like we do today.

Signed-off-by: Tim Rozet <trozet@redhat.com>