### PR TITLE
build: increase lint timeout

### DIFF
--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -2,5 +2,5 @@
 
 GO111MODULE=on ${GOPATH}/bin/golangci-lint run \
     --tests=false --enable gofmt \
-    --timeout=5m0s \
+    --timeout=8m0s \
     && echo "lint OK!"


### PR DESCRIPTION
We're seeing more CI flakes due to golangci-lint timeouts so bump that for now. For example:

https://pipelines.actions.githubusercontent.com/rx2q6cyVnb1KdY24EzqfkXItIKb3SzT55t8LHdEU6zlqA0chrw/_apis/pipelines/1/runs/410/signedlogcontent/5?urlExpires=2020-03-18T15%3A26%3A18.9706764Z&urlSigningMethod=HMACV1&urlSignature=dVoodq7JRIPc7Y%2BtCoUj%2F44lyyUYkACo0inyIEN89E0%3D

```
+ make install.tools
curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /home/runner/go/bin
golangci/golangci-lint info checking GitHub for latest tag
golangci/golangci-lint info found version: 1.24.0 for v1.24.0/linux/amd64
golangci/golangci-lint info installed /home/runner/go/bin/golangci-lint
+ make lint
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
make: *** [lint] Error 4
##[error]Makefile:45: recipe for target 'lint' failed
##[error]Process completed with exit code 2.
```