### PR TITLE
fix the label prefix for ovnkube-db-raft - s/ovn.org/k8s.ovn.org/

### DIFF
--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -71,14 +71,14 @@ spec:
       serviceAccountName: ovn
       hostNetwork: true
 
-      # required to be scheduled on node with ovn.org/ovnkube-db=true label but can
+      # required to be scheduled on node with k8s.ovn.org/ovnkube-db=true label but can
       # only have one instance per node
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: ovn.org/ovnkube-db
+              - key: k8s.ovn.org/ovnkube-db
                 operator: In
                 values:
                 - "true"


### PR DESCRIPTION
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>