### PR TITLE
validate cluster/service CIDRs against reserved IPs

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -28,6 +28,12 @@ const DefaultEncapPort = 6081
 
 const DefaultAPIServer = "http://localhost:8443"
 
+// IP address range from which subnet is allocated for per-node join switch
+const (
+	V4JoinSubnet = "100.64.0.0/16"
+	V6JoinSubnet = "fd98::/64"
+)
+
 // The following are global config parameters that other modules may access directly
 var (
 	// ovn-kubernetes version, to be changed with every release
@@ -859,8 +865,16 @@ func buildKubernetesConfig(exec kexec.Interface, cli, file *config, saPath strin
 	}
 	if Kubernetes.ServiceCIDR == "" {
 		return fmt.Errorf("kubernetes service-cidr is required")
-	} else if _, _, err := net.ParseCIDR(Kubernetes.ServiceCIDR); err != nil {
+	}
+	_, serviceIPNet, err := net.ParseCIDR(Kubernetes.ServiceCIDR)
+	if err != nil {
 		return fmt.Errorf("kubernetes service network CIDR %q invalid: %v", Kubernetes.ServiceCIDR, err)
+	}
+
+	// To check if service-ip-range is in JoinSubnet(100.64.0.0/16 or fd98::/64) range
+	err = overlapsWithJoinSubnet([]*net.IPNet{serviceIPNet})
+	if err != nil {
+		return err
 	}
 
 	if Kubernetes.PodIP != "" {
@@ -975,6 +989,22 @@ func buildDefaultConfig(cli, file *config) error {
 	Default.ClusterSubnets, err = ParseClusterSubnetEntries(Default.RawClusterSubnets)
 	if err != nil {
 		return fmt.Errorf("cluster subnet invalid: %v", err)
+	}
+
+	// Determine if ovn-kubernetes is configured to run in IPv6 mode
+	IPv6Mode = false
+	if len(Default.ClusterSubnets) >= 1 && Default.ClusterSubnets[0].CIDR.IP.To4() == nil {
+		IPv6Mode = true
+	}
+
+	// To check if any of clustersubnets is in JoinSubnet(100.64.0.0/16) range
+	var clustersubnets []*net.IPNet
+	for _, subnet := range Default.ClusterSubnets {
+		clustersubnets = append(clustersubnets, subnet.CIDR)
+	}
+	err = overlapsWithJoinSubnet(clustersubnets)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -1124,12 +1154,6 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 		return "", err
 	}
 	OvnSouth = *tmpAuth
-
-	// Determine if ovn-kubernetes is configured to run in IPv6 mode
-	IPv6Mode = false
-	if len(Default.ClusterSubnets) >= 1 && Default.ClusterSubnets[0].CIDR.IP.To4() == nil {
-		IPv6Mode = true
-	}
 
 	klog.V(5).Infof("Default config: %+v", Default)
 	klog.V(5).Infof("Logging config: %+v", Logging)

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -94,3 +94,18 @@ func cidrsOverlap(cidr *net.IPNet, cidrList []CIDRNetworkEntry) bool {
 	}
 	return false
 }
+
+// joinSubnetOverlap returns an err if joinSubnet range contains the subnet
+func overlapsWithJoinSubnet(subnets []*net.IPNet) error {
+	_, v4JoinIPNet, _ := net.ParseCIDR(V4JoinSubnet)
+	_, v6JoinIPNet, _ := net.ParseCIDR(V6JoinSubnet)
+	for _, subnet := range subnets {
+		for _, ipnet := range []*net.IPNet{v4JoinIPNet, v6JoinIPNet} {
+			if ipnet.Contains(subnet.IP) || subnet.Contains(ipnet.IP) {
+				return fmt.Errorf("%s is a reserved subnet. %s overlaps with this subnet",
+					ipnet.String(), subnet)
+			}
+		}
+	}
+	return nil
+}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -65,11 +65,9 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	// We need a subnet allocator that allocates subnet for this per-node join switch. Use the 100.64.0.0/16
 	// or fd98::/64 network range with host bits set to 3. The allocator will start allocating subnet that has upto 6
 	// host IPs)
-	var joinSubnet string
+	joinSubnet := config.V4JoinSubnet
 	if config.IPv6Mode {
-		joinSubnet = "fd98::/64"
-	} else {
-		joinSubnet = "100.64.0.0/16"
+		joinSubnet = config.V6JoinSubnet
 	}
 	_ = oc.joinSubnetAllocator.AddNetworkRange(joinSubnet, 3)
 


### PR DESCRIPTION
ovn-kubernetes internally uses 100.64.0.0/16 (for IPv4) and fd98::/64
(for IPv6) for the join network. we need to ensure that the
cluster/service CIDRs don't overlap with these

Fixes #1132

@dcbw @danwinship PTAL