### PR TITLE
node: fix management port IPv6 neighbor addition

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/vishvananda/netlink"
 	"k8s.io/klog"
 
 	kapi "k8s.io/api/core/v1"
@@ -199,7 +198,7 @@ func initLocalnetGateway(nodeName string,
 	if config.IPv6Mode {
 		// TODO - IPv6 hack ... for some reason neighbor discovery isn't working here, so hard code a
 		// MAC binding for the gateway IP address for now - need to debug this further
-		err = util.LinkNeighAdd(link, "fd99::2", macAddress, netlink.FAMILY_V6)
+		err = util.LinkNeighAdd(link, "fd99::2", macAddress)
 		if err == nil {
 			klog.Infof("Added MAC binding for fd99::2 on br-nexthop")
 		} else {

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -11,7 +11,6 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/vishvananda/netlink"
 	"k8s.io/klog"
 )
 
@@ -59,7 +58,7 @@ func createPlatformManagementPort(interfaceName, interfaceIP, routerIP, routerMA
 	// arrives on OVN Logical Router pipeline with ARP source protocol address set to
 	// K8s Node IP. OVN Logical Router pipeline drops such packets since it expects
 	// source protocol address to be in the Logical Switch's subnet.
-	err = util.LinkNeighAdd(link, routerIP, routerMAC, netlink.FAMILY_V4)
+	err = util.LinkNeighAdd(link, routerIP, routerMAC)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
@@ -47,10 +46,173 @@ func createTempFile(name string) (string, error) {
 	return fname, nil
 }
 
+func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.NetNS,
+	clusterCIDR, nodeSubnet, mgtPortIP, gwIP, serviceCIDR, lrpMAC string) {
+	const (
+		nodeName   string = "node1"
+		mgtPortMAC string = "00:00:00:55:66:77"
+		mgtPort    string = "k8s-" + nodeName
+		mtu        string = "1400"
+	)
+
+	// generic setup
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovs-vsctl --timeout=15 -- --may-exist add-br br-int",
+		"ovs-vsctl --timeout=15 -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mgtPort,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface " + mgtPort + " mac_in_use",
+		Output: mgtPortMAC,
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovs-vsctl --timeout=15 set interface " + mgtPort + " " + fmt.Sprintf("mac=%s", strings.ReplaceAll(mgtPortMAC, ":", "\\:")),
+	})
+
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface " + mgtPort + " ofport",
+		Output: "1",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovs-ofctl --no-stats --no-names dump-flows br-int table=65,out_port=1",
+		Output: " table=65, priority=100,reg15=0x2,metadata=0x2 actions=output:1",
+	})
+
+	err := util.SetExec(fexec)
+	Expect(err).NotTo(HaveOccurred())
+
+	nsIP, nodeSubnetCIDR, err := net.ParseCIDR(nodeSubnet)
+	Expect(err).NotTo(HaveOccurred())
+
+	mpCIDR := &net.IPNet{
+		IP:   net.ParseIP(mgtPortIP),
+		Mask: nodeSubnetCIDR.Mask,
+	}
+	mgtPortCIDR := mpCIDR.String()
+
+	iptProto := iptables.ProtocolIPv4
+	family := netlink.FAMILY_V4
+	if nsIP.To4() == nil {
+		iptProto = iptables.ProtocolIPv6
+		family = netlink.FAMILY_V6
+	}
+
+	fakeipt, err := util.NewFakeWithProtocol(iptProto)
+	Expect(err).NotTo(HaveOccurred())
+	util.SetIPTablesHelper(iptProto, fakeipt)
+	err = fakeipt.NewChain("nat", "POSTROUTING")
+	Expect(err).NotTo(HaveOccurred())
+	err = fakeipt.NewChain("nat", "OVN-KUBE-SNAT-MGMTPORT")
+	Expect(err).NotTo(HaveOccurred())
+
+	existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: nodeName,
+		Annotations: map[string]string{
+			ovn.OvnNodeSubnets: nodeSubnet,
+		},
+	}}
+	fakeClient := fake.NewSimpleClientset(&v1.NodeList{
+		Items: []v1.Node{existingNode},
+	})
+
+	_, err = config.InitConfig(ctx, fexec, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &existingNode)
+	waiter := newStartupWaiter(nodeName)
+
+	err = testNS.Do(func(ns.NetNS) error {
+		defer GinkgoRecover()
+
+		err = createManagementPort(nodeName, nodeSubnetCIDR, nodeAnnotator, waiter)
+		Expect(err).NotTo(HaveOccurred())
+		l, err := netlink.LinkByName(mgtPort)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check whether IP has been added
+		addrs, err := netlink.AddrList(l, family)
+		Expect(err).NotTo(HaveOccurred())
+		var foundAddr bool
+		expectedAddr, err := netlink.ParseAddr(mgtPortCIDR)
+		Expect(err).NotTo(HaveOccurred())
+		for _, a := range addrs {
+			if a.IP.Equal(expectedAddr.IP) && bytes.Equal(a.Mask, expectedAddr.Mask) {
+				foundAddr = true
+				break
+			}
+		}
+		Expect(foundAddr).To(BeTrue())
+
+		// Check whether the route has been added
+		j := 0
+		gatewayIP := net.ParseIP(gwIP)
+		subnets := []string{clusterCIDR, serviceCIDR}
+		for _, subnet := range subnets {
+			foundRoute := false
+			dstIPnet, err := netlink.ParseIPNet(subnet)
+			Expect(err).NotTo(HaveOccurred())
+			route := &netlink.Route{Dst: dstIPnet}
+			filterMask := netlink.RT_FILTER_DST
+			routes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, route, filterMask)
+			Expect(err).NotTo(HaveOccurred())
+			for _, r := range routes {
+				if r.Gw.Equal(gatewayIP) && r.LinkIndex == l.Attrs().Index {
+					foundRoute = true
+					break
+				}
+			}
+			Expect(foundRoute).To(BeTrue())
+			foundRoute = false
+			j++
+		}
+		Expect(j).To(Equal(2))
+
+		// Check whether router IP has been added in the arp entry for mgmt port
+		neighbours, err := netlink.NeighList(l.Attrs().Index, netlink.FAMILY_ALL)
+		Expect(err).NotTo(HaveOccurred())
+		var foundNeighbour bool
+		for _, neighbour := range neighbours {
+			if neighbour.IP.Equal(gatewayIP) && (neighbour.HardwareAddr.String() == lrpMAC) {
+				foundNeighbour = true
+				break
+			}
+		}
+		Expect(foundNeighbour).To(BeTrue())
+
+		return nil
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = nodeAnnotator.Run()
+	Expect(err).NotTo(HaveOccurred())
+	err = waiter.Wait()
+	Expect(err).NotTo(HaveOccurred())
+
+	expectedTables := map[string]util.FakeTable{
+		"filter": {},
+		"nat": {
+			"POSTROUTING": []string{
+				"-o " + mgtPort + " -j OVN-KUBE-SNAT-MGMTPORT",
+			},
+			"OVN-KUBE-SNAT-MGMTPORT": []string{
+				"-o " + mgtPort + " -j SNAT --to-source " + mgtPortIP + " -m comment --comment OVN SNAT to Management Port",
+			},
+		},
+	}
+	err = fakeipt.MatchState(expectedTables)
+	Expect(err).NotTo(HaveOccurred())
+
+	updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(updatedNode.Annotations).To(HaveKeyWithValue(ovn.OvnNodeManagementPortMacAddress, mgtPortMAC))
+
+	Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+}
+
 var _ = Describe("Management Port Operations", func() {
 	var tmpErr error
 	var app *cli.App
 	var testNS ns.NetNS
+	var fexec *ovntest.FakeExec
 
 	tmpDir, tmpErr = ioutil.TempDir("", "clusternodetest_certdir")
 	if tmpErr != nil {
@@ -81,175 +243,54 @@ var _ = Describe("Management Port Operations", func() {
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
+
+		fexec = ovntest.NewFakeExec()
 	})
 
 	AfterEach(func() {
 		Expect(testNS.Close()).To(Succeed())
 	})
 
-	It("sets up the management port", func() {
-		const clusterCIDR string = "10.1.0.0/16"
+	It("sets up the management port for IPv4 clusters", func() {
+		const (
+			clusterCIDR string = "10.1.0.0/16"
+			nodeSubnet  string = "10.1.1.0/24"
+			gwIP        string = "10.1.1.1"
+			mgtPortIP   string = "10.1.1.2"
+			serviceCIDR string = "172.16.1.0/24"
+			lrpMAC      string = "0a:58:0a:01:01:01"
+		)
 
 		app.Action = func(ctx *cli.Context) error {
-			const (
-				nodeName      string = "node1"
-				nodeSubnet    string = "10.1.1.0/24"
-				mgtPortMAC    string = "00:00:00:55:66:77"
-				mgtPort       string = "k8s-" + nodeName
-				mgtPortIP     string = "10.1.1.2"
-				mgtPortPrefix string = "24"
-				mgtPortCIDR   string = mgtPortIP + "/" + mgtPortPrefix
-				serviceIPNet  string = "172.16.1.0"
-				serviceCIDR   string = serviceIPNet + "/24"
-				mtu           string = "1400"
-				gwIP          string = "10.1.1.1"
-				lrpMAC        string = "0a:58:0a:01:01:01"
-			)
-
-			fexec := ovntest.NewFakeExec()
-
-			// generic setup
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 -- --may-exist add-br br-int",
-				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mgtPort,
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface " + mgtPort + " mac_in_use",
-				Output: mgtPortMAC,
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set interface k8s-node1 " + fmt.Sprintf("mac=%s", strings.ReplaceAll(mgtPortMAC, ":", "\\:")),
-			})
-
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface k8s-node1 ofport",
-				Output: "1",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovs-ofctl --no-stats --no-names dump-flows br-int table=65,out_port=1",
-				Output: " table=65, priority=100,reg15=0x2,metadata=0x2 actions=output:1",
-			})
-
-			err := util.SetExec(fexec)
-			Expect(err).NotTo(HaveOccurred())
-
-			fakeipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
-			Expect(err).NotTo(HaveOccurred())
-			util.SetIPTablesHelper(iptables.ProtocolIPv4, fakeipt)
-			err = fakeipt.NewChain("nat", "POSTROUTING")
-			Expect(err).NotTo(HaveOccurred())
-			err = fakeipt.NewChain("nat", "OVN-KUBE-SNAT-MGMTPORT")
-			Expect(err).NotTo(HaveOccurred())
-
-			existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
-				Name: nodeName,
-				Annotations: map[string]string{
-					ovn.OvnNodeSubnets: nodeSubnet,
-				},
-			}}
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{existingNode},
-			})
-
-			_, err = config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &existingNode)
-			waiter := newStartupWaiter(nodeName)
-
-			err = testNS.Do(func(ns.NetNS) error {
-				defer GinkgoRecover()
-
-				_, nodeSubnetCIDR, _ := net.ParseCIDR(nodeSubnet)
-				err = createManagementPort(nodeName, nodeSubnetCIDR, nodeAnnotator, waiter)
-				Expect(err).NotTo(HaveOccurred())
-				l, err := netlink.LinkByName(mgtPort)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Check whether IP has been added
-				addrs, err := netlink.AddrList(l, syscall.AF_INET)
-				Expect(err).NotTo(HaveOccurred())
-				var foundAddr bool
-				expectedAddr, err := netlink.ParseAddr(mgtPortCIDR)
-				Expect(err).NotTo(HaveOccurred())
-				for _, a := range addrs {
-					if a.IP.Equal(expectedAddr.IP) && bytes.Equal(a.Mask, expectedAddr.Mask) {
-						foundAddr = true
-						break
-					}
-				}
-				Expect(foundAddr).To(BeTrue())
-
-				// Check whether the route has been added
-				j := 0
-				gatewayIP := net.ParseIP(gwIP)
-				subnets := []string{clusterCIDR, serviceCIDR}
-				for _, subnet := range subnets {
-					foundRoute := false
-					dstIPnet, err := netlink.ParseIPNet(subnet)
-					Expect(err).NotTo(HaveOccurred())
-					route := &netlink.Route{Dst: dstIPnet}
-					filterMask := netlink.RT_FILTER_DST
-					routes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, route, filterMask)
-					Expect(err).NotTo(HaveOccurred())
-					for _, r := range routes {
-						if r.Gw.Equal(gatewayIP) && r.LinkIndex == l.Attrs().Index {
-							foundRoute = true
-							break
-						}
-					}
-					Expect(foundRoute).To(BeTrue())
-					foundRoute = false
-					j++
-				}
-				Expect(j).To(Equal(2))
-
-				// Check whether router IP has been added in the arp entry for mgmt port
-				neighbours, err := netlink.NeighList(l.Attrs().Index, netlink.FAMILY_ALL)
-				Expect(err).NotTo(HaveOccurred())
-				var foundNeighbour bool
-				for _, neighbour := range neighbours {
-					if neighbour.IP.Equal(gatewayIP) && (neighbour.HardwareAddr.String() == lrpMAC) {
-						foundNeighbour = true
-						break
-					}
-				}
-				Expect(foundNeighbour).To(BeTrue())
-
-				return nil
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = nodeAnnotator.Run()
-			Expect(err).NotTo(HaveOccurred())
-			err = waiter.Wait()
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedTables := map[string]util.FakeTable{
-				"filter": {},
-				"nat": {
-					"POSTROUTING": []string{
-						"-o " + mgtPort + " -j OVN-KUBE-SNAT-MGMTPORT",
-					},
-					"OVN-KUBE-SNAT-MGMTPORT": []string{
-						"-o " + mgtPort + " -j SNAT --to-source " + mgtPortIP + " -m comment --comment OVN SNAT to Management Port",
-					},
-				},
-			}
-			err = fakeipt.MatchState(expectedTables)
-			Expect(err).NotTo(HaveOccurred())
-
-			updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedNode.Annotations).To(HaveKeyWithValue(ovn.OvnNodeManagementPortMacAddress, mgtPortMAC))
-
-			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+			testManagementPort(ctx, fexec, testNS, clusterCIDR, nodeSubnet, mgtPortIP, gwIP, serviceCIDR, lrpMAC)
 			return nil
 		}
-
 		err := app.Run([]string{
 			app.Name,
 			"--cluster-subnets=" + clusterCIDR,
+			"--k8s-service-cidr=" + serviceCIDR,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("sets up the management port for IPv6 clusters", func() {
+		const (
+			clusterCIDR string = "fda6::/48"
+			nodeSubnet  string = "fda6:0:0:1::/64"
+			gwIP        string = "fda6:0:0:1::1"
+			mgtPortIP   string = "fda6:0:0:1::2"
+			serviceCIDR string = "fc95::/64"
+			lrpMAC      string = "0a:58:fd:a6:00:01" // generated from gatewayIP
+		)
+
+		app.Action = func(ctx *cli.Context) error {
+			testManagementPort(ctx, fexec, testNS, clusterCIDR, nodeSubnet, mgtPortIP, gwIP, serviceCIDR, lrpMAC)
+			return nil
+		}
+		err := app.Run([]string{
+			app.Name,
+			"--cluster-subnets=" + clusterCIDR,
+			"--k8s-service-cidr=" + serviceCIDR,
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -94,7 +94,7 @@ func LinkRouteAdd(link netlink.Link, gwIPstr string, subnets []string) error {
 }
 
 // LinkNeighAdd flushes any existing MAC/IP bindings and adds the new neighbour entries
-func LinkNeighAdd(link netlink.Link, neighIPstr, neighMacstr string, family int) error {
+func LinkNeighAdd(link netlink.Link, neighIPstr, neighMacstr string) error {
 	neighIP := net.ParseIP(neighIPstr)
 	if neighIP == nil {
 		return fmt.Errorf("neighbour IP %s is not a valid IPv4 or IPv6 address", neighIPstr)
@@ -104,6 +104,10 @@ func LinkNeighAdd(link netlink.Link, neighIPstr, neighMacstr string, family int)
 		return fmt.Errorf("neighbour MAC address %s is not valid: %v", neighMacstr, err)
 	}
 
+	family := netlink.FAMILY_V4
+	if neighIP.To4() == nil {
+		family = netlink.FAMILY_V6
+	}
 	neigh := &netlink.Neigh{
 		LinkIndex:    link.Attrs().Index,
 		Family:       family,


### PR DESCRIPTION
Instead of passing the address family to LinkNeighAdd() just have
it autodetect the family from the neighor's IP address.

Fixes: 2bfa79bf61d116dee276a0544690c448c2230769

@girishmg @danwinship 