### PR TITLE
[WIP] Reduce complexity of networkPolicy processing

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -399,6 +399,7 @@ type ObjectCacheInterface interface {
 	GetService(namespace, name string) (*kapi.Service, error)
 	GetEndpoints(namespace string) ([]*kapi.Endpoints, error)
 	GetEndpoint(namespace, name string) (*kapi.Endpoints, error)
+	GetNamespace(name string) (*kapi.Namespace, error)
 	GetNamespaces() ([]*kapi.Namespace, error)
 }
 
@@ -682,6 +683,12 @@ func (wf *WatchFactory) GetEndpoints(namespace string) ([]*kapi.Endpoints, error
 func (wf *WatchFactory) GetEndpoint(namespace, name string) (*kapi.Endpoints, error) {
 	endpointsLister := wf.informers[endpointsType].lister.(listers.EndpointsLister)
 	return endpointsLister.Endpoints(namespace).Get(name)
+}
+
+//GetNamespace returns the namespace spec of a given namespace
+func (wf *WatchFactory) GetNamespace(name string) (*kapi.Namespace, error) {
+	namespaceLister := wf.informers[namespaceType].lister.(listers.NamespaceLister)
+	return namespaceLister.Get(name)
 }
 
 //GetNamespaces returns a list of namespaces in the cluster


### PR DESCRIPTION
flatten out the watchers for network policy currently each network policy gets
many watchers depending on how many from/to rules there are. This commit changes that
so that each namespace policy gets 4 watchers a pod and namespace watcher for ingress and egress

also this fixes a bug that when using namespace and podwatcher the networkpolicy correctly changes behavior when the namespace labels change

https://bugzilla.redhat.com/show_bug.cgi?id=1752220