### PR TITLE
add build_info metric for ovn, OVN DB schema, and ovn-k8s artifacts

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -230,8 +230,10 @@ func runOvnKube(ctx *cli.Context) error {
 		if config.Kubernetes.Token == "" {
 			return fmt.Errorf("cannot initialize node without service account 'token'. Please provide one with --k8s-token argument")
 		}
-		// register prometheus metrics exported by the node
+		// register ovnkube node specific prometheus metrics exported by the node
 		metrics.RegisterNodeMetrics()
+		// register ovn specific (ovn-controller and ovn-northd) metrics
+		metrics.RegisterOvnMetrics()
 		start := time.Now()
 		n := ovnnode.NewNode(clientset, factory, node)
 		if err := n.Start(); err != nil {

--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -14,12 +14,21 @@ build_binaries() {
 
     # Add a buildid to the executable - needed by rpmbuild
     BUILDID=${BUILDID:-0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')}
+    GIT_COMMIT=$(git rev-parse HEAD)
+    GIT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+    BUILD_USER=$(whoami)
+    BUILD_DATE=$(date +"%Y-%m-%d")
+
     set -x
     for bin in "$@"; do
         go build -v \
             -mod vendor \
             -gcflags "${GCFLAGS}" \
-            -ldflags "-B ${BUILDID}" \
+            -ldflags "-B ${BUILDID} \
+                -X ${OVN_KUBE_GO_PACKAGE}/pkg/metrics.Commit=${GIT_COMMIT} \
+                -X ${OVN_KUBE_GO_PACKAGE}/pkg/metrics.Branch=${GIT_BRANCH} \
+                -X ${OVN_KUBE_GO_PACKAGE}/pkg/metrics.BuildUser=${BUILD_USER} \
+                -X ${OVN_KUBE_GO_PACKAGE}/pkg/metrics.BuildDate=${BUILD_DATE}" \
             -o "${OVN_KUBE_OUTPUT_BINPATH}/${bin}"\
             "./cmd/${bin}"
     done

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -83,6 +84,24 @@ func RegisterMasterMetrics() {
 		prometheus.MustRegister(metricOvnCliLatency)
 		// this is to not to create circular import between metrics and util package
 		util.MetricOvnCliLatency = metricOvnCliLatency
+		prometheus.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: MetricOvnkubeNamespace,
+				Subsystem: MetricOvnkubeSubsystemMaster,
+				Name:      "build_info",
+				Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
+					"and go version from which ovnkube was built and when and who built it",
+				ConstLabels: prometheus.Labels{
+					"version":    "0.0",
+					"revision":   Commit,
+					"branch":     Branch,
+					"build_user": BuildUser,
+					"build_date": BuildDate,
+					"goversion":  runtime.Version(),
+				},
+			},
+			func() float64 { return 1 },
+		))
 	})
 }
 

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -20,6 +20,14 @@ const (
 	MetricOvnSubsystemDBRaft     = "db_raft"
 )
 
+// Build information. Populated at build-time.
+var (
+	Commit    string
+	Branch    string
+	BuildUser string
+	BuildDate string
+)
+
 // StartMetricsServer runs the prometheus listner so that metrics can be collected
 func StartMetricsServer(bindAddress string, enablePprof bool) {
 	mux := http.NewServeMux()

--- a/go-controller/pkg/metrics/node.go
+++ b/go-controller/pkg/metrics/node.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -56,5 +57,23 @@ func RegisterNodeMetrics() {
 				}
 				return 0
 			}))
+		prometheus.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: MetricOvnkubeNamespace,
+				Subsystem: MetricOvnkubeSubsystemNode,
+				Name:      "build_info",
+				Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
+					"and go version from which ovnkube was built and when and who built it",
+				ConstLabels: prometheus.Labels{
+					"version":    "0.0",
+					"revision":   Commit,
+					"branch":     Branch,
+					"build_user": BuildUser,
+					"build_date": BuildDate,
+					"goversion":  runtime.Version(),
+				},
+			},
+			func() float64 { return 1 },
+		))
 	})
 }

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -1,0 +1,53 @@
+package metrics
+
+import (
+	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	ovnVersion    string
+	ovsLibVersion string
+)
+
+func getOvnVersionInfo() {
+	stdout, _, err := util.RunOVNNbctl("--version")
+	if err != nil {
+		return
+	}
+
+	// post ovs/ovn split, the output is:
+	//	ovn-nbctl 20.03.90
+	//	Open vSwitch Library 2.13.1
+	//
+	// and before the split we have:
+	// ovn-nbctl (Open vSwitch) 2.12.0
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.HasPrefix("ovn-nbctl (Open vSwitch) ", line) {
+			ovnVersion = strings.Fields(line)[3]
+		} else if strings.HasPrefix("ovn-nbctl ", line) {
+			ovnVersion = strings.Fields(line)[1]
+		} else if strings.HasPrefix("Open  vSwitch Library ", line) {
+			ovsLibVersion = strings.Fields(line)[3]
+		}
+	}
+}
+
+func RegisterOvnMetrics() {
+	getOvnVersionInfo()
+	prometheus.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: MetricOvnNamespace,
+			Name:      "build_info",
+			Help: "A metric with a constant '1' value labeled by version and library " +
+				"from which ovn binaries were built",
+			ConstLabels: prometheus.Labels{
+				"version":         ovnVersion,
+				"ovs_lib_version": ovsLibVersion,
+			},
+		},
+		func() float64 { return 1 },
+	))
+}


### PR DESCRIPTION
1.  ovn_build_info metric captures OVN version and OVS Library version
    against which the OVN was build in the constant labels part of the
    metric. The metric itself returns a constant value of 1.
        
2.  ovn_db_raft_build_info metric captures OVN DB version, the Northbound DB
    schema and the Southbound DB schema version in the constant labels part
    of the metric. The metric itself returns a constant value of 1
    
3.  ovnkube_master_build_info and ovnkube_node_build_info metrics capture
    the commit, branch, build date, and build user information in the
    constant labels part of the metric. The metric itself returns a constant
    value of 1
@dcbw @danwinship PTAL