### PR TITLE
Minor test case fixups

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -8,10 +8,9 @@ setup_env
 
 cd "${OVN_KUBE_ROOT}"
 
-PKGS="${PKGS:-./cmd/... ./pkg/...}"
+PKGS=$(go list -mod vendor -f '{{if len .TestGoFiles}} {{.ImportPath}} {{end}}' ${PKGS:-./cmd/... ./pkg/...})
 
-
-for pkg in $(go list -mod vendor ${PKGS}); do
+for pkg in ${PKGS}; do
     # This package requires root
     if [[ "$USER" != root && "$pkg" == github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node ]]; then
         testfile=$(mktemp --tmpdir ovn-test.XXXXXXXX)

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -292,9 +292,9 @@ func init() {
 	Flags = append(Flags, MasterHAFlags...)
 }
 
-// RestoreDefaultConfig restores default config values. Used by testcases to
+// PrepareTestConfig restores default config values. Used by testcases to
 // provide a pristine environment between tests.
-func RestoreDefaultConfig() {
+func PrepareTestConfig() {
 	Default = savedDefault
 	Logging = savedLogging
 	CNI = savedCNI
@@ -303,6 +303,12 @@ func RestoreDefaultConfig() {
 	OvnSouth = savedOvnSouth
 	Gateway = savedGateway
 	MasterHA = savedMasterHA
+
+	// Don't pick up defaults from the environment
+	os.Unsetenv("KUBECONFIG")
+	os.Unsetenv("K8S_CACERT")
+	os.Unsetenv("K8S_APISERVER")
+	os.Unsetenv("K8S_TOKEN")
 }
 
 // copy members of struct 'src' into the corresponding field in struct 'dst'

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Config Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		RestoreDefaultConfig()
+		PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -226,12 +226,6 @@ var _ = Describe("Config Operations", func() {
 	})
 
 	It("uses expected defaults", func() {
-		// Don't pick up defaults from the environment
-		os.Unsetenv("KUBECONFIG")
-		os.Unsetenv("K8S_CACERT")
-		os.Unsetenv("K8S_APISERVER")
-		os.Unsetenv("K8S_TOKEN")
-
 		app.Action = func(ctx *cli.Context) error {
 			cfgPath, err := InitConfigSa(ctx, kexec.New(), tmpDir, nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Gateway Init Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Management Port Operations", func() {
 	BeforeEach(func() {
 		var err error
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/node/management-port_windows_test.go
+++ b/go-controller/pkg/node/management-port_windows_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Management Port Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Node Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/endpoints_test.go
+++ b/go-controller/pkg/ovn/endpoints_test.go
@@ -76,7 +76,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Master Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"
@@ -476,7 +476,7 @@ var _ = Describe("Gateway Init Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -108,7 +108,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -181,7 +181,7 @@ var _ = Describe("OVN Pod Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/policy_old_test.go
+++ b/go-controller/pkg/ovn/policy_old_test.go
@@ -286,7 +286,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -296,7 +296,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -114,7 +114,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/util/util_test.go
+++ b/go-controller/pkg/util/util_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Util tests", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		config.RestoreDefaultConfig()
+		config.PrepareTestConfig()
 
 		app = cli.NewApp()
 		app.Name = "test"


### PR DESCRIPTION
In #1071 I tried to fix it so that `make test` didn't depend on `KUBECONFIG` in the environment, but only actually fixed it for `pkg/config/`, not the rest of the tree. This fixes it everywhere.

Also, in #744 I fixed it to not run "go test" in directories with no tests but then in #925 Casey accidentally reverted that. This unreverts it.

@dcbw @girishmg 
