### PR TITLE
Abstract node annotation handling

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -122,21 +121,17 @@ func (n *OvnNode) initGateway(subnet string, nodeAnnotator kube.Annotator,
 		annotations, prFn, err = initSharedGateway(n.name, subnet, gatewayNextHop, gatewayIntf,
 			n.watchFactory)
 	case config.GatewayModeDisabled:
-		annotations = map[string]map[string]string{
-			ovn.OvnDefaultNetworkGateway: {
-				ovn.OvnNodeGatewayMode: string(config.GatewayModeDisabled),
-			},
-		}
+		annotations = util.CreateDisabledL3GatewayConfig()
 	}
 	if err != nil {
 		return err
 	}
 
-	if err := nodeAnnotator.Set(ovn.OvnNodeL3GatewayConfig, annotations); err != nil {
+	if err := nodeAnnotator.Set(util.OvnNodeL3GatewayConfig, annotations); err != nil {
 		return err
 	}
 	if systemID != "" {
-		if err := nodeAnnotator.Set(ovn.OvnNodeChassisID, systemID); err != nil {
+		if err := nodeAnnotator.Set(util.OvnNodeChassisID, systemID); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
@@ -159,21 +158,21 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		Expect(err).NotTo(HaveOccurred())
 
 		l3GatewayConfig := map[string]string{
-			ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
-			ovn.OvnNodeGatewayVlanID:     string(gatewayVLANID),
-			ovn.OvnNodeGatewayIfaceID:    gwRouter,
-			ovn.OvnNodeGatewayMacAddress: lrpMAC,
-			ovn.OvnNodeGatewayIP:         lrpIP,
-			//ovn.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+			util.OvnNodeGatewayMode:       string(config.Gateway.Mode),
+			util.OvnNodeGatewayVlanID:     string(gatewayVLANID),
+			util.OvnNodeGatewayIfaceID:    gwRouter,
+			util.OvnNodeGatewayMacAddress: lrpMAC,
+			util.OvnNodeGatewayIP:         lrpIP,
+			//util.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
 		}
-		byteArr, err := json.Marshal(map[string]map[string]string{ovn.OvnDefaultNetworkGateway: l3GatewayConfig})
+		byteArr, err := json.Marshal(map[string]map[string]string{util.OvnDefaultNetworkGateway: l3GatewayConfig})
 		Expect(err).NotTo(HaveOccurred())
 		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
 			Annotations: map[string]string{
-				ovn.OvnNodeSubnets:         nodeSubnet,
-				ovn.OvnNodeL3GatewayConfig: string(byteArr),
-				ovn.OvnNodeChassisID:       systemID,
+				util.OvnNodeSubnets:         nodeSubnet,
+				util.OvnNodeL3GatewayConfig: string(byteArr),
+				util.OvnNodeChassisID:       systemID,
 			},
 		}}
 		fakeClient := fake.NewSimpleClientset(&v1.NodeList{
@@ -331,21 +330,21 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			l3GatewayConfig := map[string]string{
-				ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
-				ovn.OvnNodeGatewayVlanID:     string(0),
-				ovn.OvnNodeGatewayIfaceID:    gwRouter,
-				ovn.OvnNodeGatewayMacAddress: lrpMAC,
-				ovn.OvnNodeGatewayIP:         lrpIP,
-				//ovn.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+				util.OvnNodeGatewayMode:       string(config.Gateway.Mode),
+				util.OvnNodeGatewayVlanID:     string(0),
+				util.OvnNodeGatewayIfaceID:    gwRouter,
+				util.OvnNodeGatewayMacAddress: lrpMAC,
+				util.OvnNodeGatewayIP:         lrpIP,
+				//util.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
 			}
-			byteArr, err := json.Marshal(map[string]map[string]string{ovn.OvnDefaultNetworkGateway: l3GatewayConfig})
+			byteArr, err := json.Marshal(map[string]map[string]string{util.OvnDefaultNetworkGateway: l3GatewayConfig})
 			Expect(err).NotTo(HaveOccurred())
 			existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
-					ovn.OvnNodeSubnets:         nodeSubnet,
-					ovn.OvnNodeL3GatewayConfig: string(byteArr),
-					ovn.OvnNodeChassisID:       systemID,
+					util.OvnNodeSubnets:         nodeSubnet,
+					util.OvnNodeL3GatewayConfig: string(byteArr),
+					util.OvnNodeChassisID:       systemID,
 				},
 			}}
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -12,7 +12,6 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/klog"
 
@@ -184,18 +183,7 @@ func initLocalnetGateway(nodeName string,
 		return nil, err
 	}
 
-	l3GatewayConfig := map[string]string{
-		ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
-		ovn.OvnNodeGatewayVlanID:     fmt.Sprintf("%d", config.Gateway.VLANID),
-		ovn.OvnNodeGatewayIfaceID:    ifaceID,
-		ovn.OvnNodeGatewayMacAddress: macAddress,
-		ovn.OvnNodeGatewayIP:         localnetGatewayIP(),
-		ovn.OvnNodeGatewayNextHop:    localnetGatewayNextHop(),
-		ovn.OvnNodePortEnable:        fmt.Sprintf("%t", config.Gateway.NodeportEnable),
-	}
-	annotations := map[string]map[string]string{
-		ovn.OvnDefaultNetworkGateway: l3GatewayConfig,
-	}
+	annotations := util.CreateL3GatewayConfig(ifaceID, macAddress, localnetGatewayIP(), localnetGatewayNextHop())
 
 	if config.IPv6Mode {
 		// TODO - IPv6 hack ... for some reason neighbor discovery isn't working here, so hard code a

--- a/go-controller/pkg/node/gateway_localnet_windows.go
+++ b/go-controller/pkg/node/gateway_localnet_windows.go
@@ -4,13 +4,15 @@ package node
 
 import (
 	"fmt"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 )
 
-func initLocalnetGateway(nodeName string,
-	subnet string, wf *factory.WatchFactory) (map[string]map[string]string, error) {
+func initLocalnetGateway(nodeName string, subnet string,
+	wf *factory.WatchFactory, nodeAnnotator kube.Annotator) error {
 	// TODO: Implement this
-	return nil, fmt.Errorf("Not implemented yet on Windows")
+	return fmt.Errorf("Not implemented yet on Windows")
 }
 
 func cleanupLocalnetGateway() error {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -253,7 +254,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string) error {
 }
 
 func initSharedGateway(nodeName string, subnet, gwNextHop, gwIntf string,
-	wf *factory.WatchFactory) (map[string]map[string]string, postWaitFunc, error) {
+	wf *factory.WatchFactory, nodeAnnotator kube.Annotator) (postWaitFunc, error) {
 	var bridgeName string
 	var uplinkName string
 	var brCreated bool
@@ -263,14 +264,14 @@ func initSharedGateway(nodeName string, subnet, gwNextHop, gwIntf string,
 		// This is an OVS bridge's internal port
 		uplinkName, err = util.GetNicName(bridgeName)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	} else if _, _, err := util.RunOVSVsctl("--", "br-exists", gwIntf); err != nil {
 		// This is not a OVS bridge. We need to create a OVS bridge
 		// and add cluster.GatewayIntf as a port of that bridge.
 		bridgeName, err = util.NicToBridge(gwIntf)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert %s to OVS bridge: %v",
+			return nil, fmt.Errorf("failed to convert %s to OVS bridge: %v",
 				gwIntf, err)
 		}
 		uplinkName = gwIntf
@@ -280,7 +281,7 @@ func initSharedGateway(nodeName string, subnet, gwNextHop, gwIntf string,
 		// gateway interface is an OVS bridge
 		uplinkName, err = getIntfName(gwIntf)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		bridgeName = gwIntf
 	}
@@ -289,21 +290,25 @@ func initSharedGateway(nodeName string, subnet, gwNextHop, gwIntf string,
 	// error out.
 	ipAddress, err := getIPv4Address(gwIntf)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to get interface details for %s (%v)",
+		return nil, fmt.Errorf("Failed to get interface details for %s (%v)",
 			gwIntf, err)
 	}
 	if ipAddress == "" {
-		return nil, nil, fmt.Errorf("%s does not have a ipv4 address", gwIntf)
+		return nil, fmt.Errorf("%s does not have a ipv4 address", gwIntf)
 	}
 
 	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, bridgeName, gwIntf, brCreated)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
+		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
 
-	annotations := util.CreateL3GatewayConfig(ifaceID, macAddress, ipAddress, gwNextHop)
+	err = util.SetSharedL3GatewayConfig(nodeAnnotator, ifaceID, macAddress, ipAddress, gwNextHop,
+		config.Gateway.NodeportEnable, config.Gateway.VLANID)
+	if err != nil {
+		return nil, err
+	}
 
-	return annotations, func() error {
+	return func() error {
 		// Program cluster.GatewayIntf to let non-pod traffic to go to host
 		// stack
 		if err := addDefaultConntrackRules(nodeName, bridgeName, uplinkName); err != nil {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -302,18 +301,7 @@ func initSharedGateway(nodeName string, subnet, gwNextHop, gwIntf string,
 		return nil, nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
 
-	l3GatewayConfig := map[string]string{
-		ovn.OvnNodeGatewayMode:       string(config.Gateway.Mode),
-		ovn.OvnNodeGatewayVlanID:     fmt.Sprintf("%d", config.Gateway.VLANID),
-		ovn.OvnNodeGatewayIfaceID:    ifaceID,
-		ovn.OvnNodeGatewayMacAddress: macAddress,
-		ovn.OvnNodeGatewayIP:         ipAddress,
-		ovn.OvnNodeGatewayNextHop:    gwNextHop,
-		ovn.OvnNodePortEnable:        fmt.Sprintf("%t", config.Gateway.NodeportEnable),
-	}
-	annotations := map[string]map[string]string{
-		ovn.OvnDefaultNetworkGateway: l3GatewayConfig,
-	}
+	annotations := util.CreateL3GatewayConfig(ifaceID, macAddress, ipAddress, gwNextHop)
 
 	return annotations, func() error {
 		// Program cluster.GatewayIntf to let non-pod traffic to go to host

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -63,7 +63,7 @@ func createManagementPort(nodeName string, localSubnet *net.IPNet, nodeAnnotator
 		return nil
 	}
 
-	if err := nodeAnnotator.Set(util.OvnNodeManagementPortMacAddress, macAddress); err != nil {
+	if err := util.SetNodeManagementPortMacAddr(nodeAnnotator, macAddress); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/klog"
 )
@@ -64,7 +63,7 @@ func createManagementPort(nodeName string, localSubnet *net.IPNet, nodeAnnotator
 		return nil
 	}
 
-	if err := nodeAnnotator.Set(ovn.OvnNodeManagementPortMacAddress, macAddress); err != nil {
+	if err := nodeAnnotator.Set(util.OvnNodeManagementPortMacAddress, macAddress); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
@@ -107,7 +106,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 		Name: nodeName,
 		Annotations: map[string]string{
-			ovn.OvnNodeSubnets: nodeSubnet,
+			util.OvnNodeSubnets: nodeSubnet,
 		},
 	}}
 	fakeClient := fake.NewSimpleClientset(&v1.NodeList{
@@ -203,7 +202,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 
 	updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(updatedNode.Annotations).To(HaveKeyWithValue(ovn.OvnNodeManagementPortMacAddress, mgtPortMAC))
+	Expect(updatedNode.Annotations).To(HaveKeyWithValue(util.OvnNodeManagementPortMacAddress, mgtPortMAC))
 
 	Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1,11 +1,9 @@
 package ovn
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"reflect"
-	"strconv"
 	"strings"
 
 	kapi "k8s.io/api/core/v1"
@@ -20,36 +18,9 @@ import (
 )
 
 const (
-	// OvnNodeSubnets is the constant string representing the node subnets annotation key
-	OvnNodeSubnets = "k8s.ovn.org/node-subnets"
-	// OvnNodeJoinSubnets is the constant string representing the node's join switch subnets annotation key
-	OvnNodeJoinSubnets = "k8s.ovn.org/node-join-subnets"
-	// OvnNodeManagementPortMacAddress is the constant string representing the annotation key
-	OvnNodeManagementPortMacAddress = "k8s.ovn.org/node-mgmt-port-mac-address"
-	// OvnNodeChassisID is the systemID of the node needed for creating L3 gateway
-	OvnNodeChassisID = "k8s.ovn.org/node-chassis-id"
 	// OvnServiceIdledAt is a constant string representing the Service annotation key
 	// whose value indicates the time stamp in RFC3339 format when a Service was idled
 	OvnServiceIdledAt = "k8s.ovn.org/idled-at"
-	// OvnNodeL3GatewayConfig is the constant string representing the l3 gateway annotation key
-	OvnNodeL3GatewayConfig = "k8s.ovn.org/l3-gateway-config"
-	// OvnNodeGatewayMode is the mode of the gateway in the l3 gateway annotation
-	OvnNodeGatewayMode = "mode"
-	// OvnNodeGatewayVlanID is the vlanid used by the gateway in the l3 gateway annotation
-	OvnNodeGatewayVlanID = "vlan-id"
-	// OvnNodeGatewayIfaceID is the interfaceID of the gateway in the l3 gateway annotation
-	OvnNodeGatewayIfaceID = "interface-id"
-	// OvnNodeGatewayMacAddress is the MacAddress of the Gateway interface in the l3 gateway annotation
-	OvnNodeGatewayMacAddress = "mac-address"
-	// OvnNodeGatewayIP is the IP address of the Gateway in the l3 gateway annotation
-	OvnNodeGatewayIP = "ip-address"
-	// OvnNodeGatewayNextHop is the Next Hop in the l3 gateway annotation
-	OvnNodeGatewayNextHop = "next-hop"
-	// OvnNodePortEnable in the l3 gateway annotation captures whether load balancer needs to
-	// be created or not
-	OvnNodePortEnable = "node-port-enable"
-	// OvnDefaultNetworkGateway captures L3 gateway config for default OVN network interface
-	OvnDefaultNetworkGateway = "default"
 )
 
 // StartClusterMaster runs a subnet IPAM and a controller that watches arrival/departure
@@ -83,14 +54,14 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		}
 	}
 	for _, node := range existingNodes.Items {
-		hostsubnet, _ := parseNodeHostSubnet(&node)
+		hostsubnet, _ := util.ParseNodeHostSubnetAnnotation(&node)
 		if hostsubnet != nil {
 			err := oc.masterSubnetAllocator.MarkAllocatedNetwork(hostsubnet)
 			if err != nil {
 				utilruntime.HandleError(err)
 			}
 		}
-		joinsubnet, _ := parseNodeJoinSubnet(&node)
+		joinsubnet, _ := util.ParseNodeJoinSubnetAnnotation(&node)
 		if joinsubnet != nil {
 			err := oc.joinSubnetAllocator.MarkAllocatedNetwork(joinsubnet)
 			if err != nil {
@@ -193,32 +164,22 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 	return nil
 }
 
-// annotate the node with the join subnet information assigned to node's join logical switch.
-// the format of the annotation is:
-//
-// k8s.ovn.org/node-join-subnets: {
-//	  "default": "100.64.0.0/29",
-// }
 func (oc *Controller) addNodeJoinSubnetAnnotations(node *kapi.Node, subnet string) error {
-	bytes, err := json.Marshal(map[string]string{
-		"default": subnet,
-	})
+	nodeAnnotations, err := util.CreateNodeJoinSubnetAnnotation(subnet)
 	if err != nil {
 		return fmt.Errorf("failed to marshal node %q annotation %q for subnet %s",
-			node.Name, OvnNodeJoinSubnets, subnet)
+			node.Name, util.OvnNodeJoinSubnets, subnet)
 	}
-	nodeAnnotations := make(map[string]interface{})
-	nodeAnnotations[OvnNodeJoinSubnets] = string(bytes)
 	err = oc.kube.SetAnnotationsOnNode(node, nodeAnnotations)
 	if err != nil {
 		return fmt.Errorf("failed to set node annotation %q on existing node %s to %q: %v",
-			OvnNodeJoinSubnets, node.Name, subnet, err)
+			util.OvnNodeJoinSubnets, node.Name, subnet, err)
 	}
 	return nil
 }
 
 func (oc *Controller) allocateJoinSubnet(node *kapi.Node) (*net.IPNet, error) {
-	joinSubnet, err := parseNodeJoinSubnet(node)
+	joinSubnet, err := util.ParseNodeJoinSubnetAnnotation(node)
 	if err == nil {
 		return joinSubnet, nil
 	}
@@ -259,24 +220,8 @@ func (oc *Controller) deleteNodeJoinSubnet(nodeName string, subnet *net.IPNet) e
 	return nil
 }
 
-func parseNodeManagementPortMacAddr(node *kapi.Node) (string, error) {
-	macAddress, ok := node.Annotations[OvnNodeManagementPortMacAddress]
-	if !ok {
-		klog.Errorf("macAddress annotation not found for node %q ", node.Name)
-		return "", nil
-	}
-
-	_, err := net.ParseMAC(macAddress)
-	if err != nil {
-		return "", fmt.Errorf("Error %v in parsing node %v macAddress %v", err, node.Name, macAddress)
-	}
-
-	return macAddress, nil
-}
-
 func (oc *Controller) syncNodeManagementPort(node *kapi.Node, subnet *net.IPNet) error {
-
-	macAddress, err := parseNodeManagementPortMacAddr(node)
+	macAddress, err := util.ParseNodeManagementPortMacAddr(node)
 	if err != nil {
 		return err
 	}
@@ -292,7 +237,7 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, subnet *net.IPNet)
 	}
 
 	if subnet == nil {
-		subnet, err = parseNodeHostSubnet(node)
+		subnet, err = util.ParseNodeHostSubnetAnnotation(node)
 		if err != nil {
 			return err
 		}
@@ -324,90 +269,6 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, subnet *net.IPNet)
 	return nil
 }
 
-// UnmarshalPodAnnotation returns a the unmarshalled pod annotation
-func UnmarshalNodeL3GatewayAnnotation(node *kapi.Node) (map[string]string, error) {
-	l3GatewayAnnotation, ok := node.Annotations[OvnNodeL3GatewayConfig]
-	if !ok {
-		return nil, fmt.Errorf("%s annotation not found for node %q", OvnNodeL3GatewayConfig, node.Name)
-	}
-
-	l3GatewayConfigMap := map[string]map[string]string{}
-	if err := json.Unmarshal([]byte(l3GatewayAnnotation), &l3GatewayConfigMap); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal l3 gateway config annotation %s for node %q", l3GatewayAnnotation, node.Name)
-	}
-
-	l3GatewayConfig, ok := l3GatewayConfigMap[OvnDefaultNetworkGateway]
-	if !ok {
-		return nil, fmt.Errorf("%s annotation for %s network not found", OvnNodeL3GatewayConfig, OvnDefaultNetworkGateway)
-	}
-	return l3GatewayConfig, nil
-}
-
-func parseGatewayIfaceID(l3GatewayConfig map[string]string) (string, error) {
-	ifaceID, ok := l3GatewayConfig[OvnNodeGatewayIfaceID]
-	if !ok || ifaceID == "" {
-		return "", fmt.Errorf("%s annotation not found or invalid", OvnNodeGatewayIfaceID)
-	}
-
-	return ifaceID, nil
-}
-
-func parseGatewayMacAddress(l3GatewayConfig map[string]string) (string, error) {
-	gatewayMacAddress, ok := l3GatewayConfig[OvnNodeGatewayMacAddress]
-	if !ok {
-		return "", fmt.Errorf("%s annotation not found", OvnNodeGatewayMacAddress)
-	}
-
-	_, err := net.ParseMAC(gatewayMacAddress)
-	if err != nil {
-		return "", fmt.Errorf("Error %v in parsing node gateway macAddress %v", err, gatewayMacAddress)
-	}
-
-	return gatewayMacAddress, nil
-}
-
-func parseGatewayLogicalNetwork(l3GatewayConfig map[string]string) (string, string, error) {
-	ipAddress, ok := l3GatewayConfig[OvnNodeGatewayIP]
-	if !ok {
-		return "", "", fmt.Errorf("%s annotation not found", OvnNodeGatewayIP)
-	}
-
-	gwNextHop, ok := l3GatewayConfig[OvnNodeGatewayNextHop]
-	if !ok {
-		return "", "", fmt.Errorf("%s annotation not found", OvnNodeGatewayNextHop)
-	}
-
-	return ipAddress, gwNextHop, nil
-}
-
-func parseGatewayVLANID(l3GatewayConfig map[string]string, ifaceID string) ([]string, error) {
-
-	var lspArgs []string
-	vID, ok := l3GatewayConfig[OvnNodeGatewayVlanID]
-	if !ok {
-		return nil, fmt.Errorf("%s annotation not found", OvnNodeGatewayVlanID)
-	}
-
-	vlanID, errVlan := strconv.Atoi(vID)
-	if errVlan != nil {
-		return nil, fmt.Errorf("%s annotation has an invalid format", OvnNodeGatewayVlanID)
-	}
-	if vlanID > 0 {
-		lspArgs = []string{"--", "set", "logical_switch_port",
-			ifaceID, fmt.Sprintf("tag_request=%d", vlanID)}
-	}
-
-	return lspArgs, nil
-}
-
-func parseNodeChassisID(node *kapi.Node) (string, error) {
-	systemID, ok := node.Annotations[OvnNodeChassisID]
-	if !ok {
-		return "", fmt.Errorf("%s annotation not found", OvnNodeChassisID)
-	}
-	return systemID, nil
-}
-
 func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig map[string]string, subnet string) error {
 	var err error
 	var clusterSubnets []string
@@ -415,27 +276,27 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 		clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR.String())
 	}
 
-	mode := l3GatewayConfig[OvnNodeGatewayMode]
+	mode := l3GatewayConfig[util.OvnNodeGatewayMode]
 	nodePortEnable := false
-	if l3GatewayConfig[OvnNodePortEnable] == "true" {
+	if l3GatewayConfig[util.OvnNodePortEnable] == "true" {
 		nodePortEnable = true
 	}
-	ifaceID, err := parseGatewayIfaceID(l3GatewayConfig)
+	ifaceID, err := util.ParseGatewayIfaceID(l3GatewayConfig)
 	if err != nil {
 		return err
 	}
 
-	gwMacAddress, err := parseGatewayMacAddress(l3GatewayConfig)
+	gwMacAddress, err := util.ParseGatewayMacAddress(l3GatewayConfig)
 	if err != nil {
 		return err
 	}
 
-	ipAddress, gwNextHop, err := parseGatewayLogicalNetwork(l3GatewayConfig)
+	ipAddress, gwNextHop, err := util.ParseGatewayLogicalNetwork(l3GatewayConfig)
 	if err != nil {
 		return err
 	}
 
-	systemID, err := parseNodeChassisID(node)
+	systemID, err := util.ParseNodeChassisID(node)
 	if err != nil {
 		return err
 	}
@@ -443,7 +304,7 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 	var lspArgs []string
 	var lspErr error
 	if mode == string(config.GatewayModeShared) {
-		lspArgs, lspErr = parseGatewayVLANID(l3GatewayConfig, ifaceID)
+		lspArgs, lspErr = util.ParseGatewayVLANID(l3GatewayConfig, ifaceID)
 		if lspErr != nil {
 			return lspErr
 		}
@@ -491,7 +352,7 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 
 func addStaticRouteToHost(node *kapi.Node, nicIP string) error {
 	k8sClusterRouter := util.GetK8sClusterRouter()
-	subnet, err := parseNodeHostSubnet(node)
+	subnet, err := util.ParseNodeHostSubnetAnnotation(node)
 	if err != nil {
 		return fmt.Errorf("failed to get interface IP address for %s (%v)",
 			util.GetK8sMgmtIntfName(node.Name), err)
@@ -506,48 +367,6 @@ func addStaticRouteToHost(node *kapi.Node, nicIP string) error {
 	}
 
 	return nil
-}
-
-func parseNodeHostSubnet(node *kapi.Node) (*net.IPNet, error) {
-	sub, ok := node.Annotations[OvnNodeSubnets]
-	if ok {
-		nodeSubnets := make(map[string]string)
-		if err := json.Unmarshal([]byte(sub), &nodeSubnets); err != nil {
-			return nil, fmt.Errorf("error parsing node-subnets annotation: %v", err)
-		}
-		sub, ok = nodeSubnets["default"]
-	}
-	if !ok {
-		return nil, fmt.Errorf("node %q has no subnet annotation", node.Name)
-	}
-
-	_, subnet, err := net.ParseCIDR(sub)
-	if err != nil {
-		return nil, fmt.Errorf("Error in parsing hostsubnet - %v", err)
-	}
-
-	return subnet, nil
-}
-
-func parseNodeJoinSubnet(node *kapi.Node) (*net.IPNet, error) {
-	sub, ok := node.Annotations[OvnNodeJoinSubnets]
-	if ok {
-		nodeSubnets := make(map[string]string)
-		if err := json.Unmarshal([]byte(sub), &nodeSubnets); err != nil {
-			return nil, fmt.Errorf("error parsing node-subnets annotation: %v", err)
-		}
-		sub, ok = nodeSubnets["default"]
-	}
-	if !ok {
-		return nil, fmt.Errorf("node %q has no join subnet annotation", node.Name)
-	}
-
-	_, subnet, err := net.ParseCIDR(sub)
-	if err != nil {
-		return nil, fmt.Errorf("Error in parsing hostsubnet - %v", err)
-	}
-
-	return subnet, nil
 }
 
 func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.IPNet) error {
@@ -672,26 +491,16 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 	return nil
 }
 
-// annotate the node with the subnet information assigned to node's logical switch. the
-// new format of the annotation is:
-//
-// k8s.ovn.org/node-subnets: {
-//	  "default": "192.168.2.1",
-// }
 func (oc *Controller) addNodeAnnotations(node *kapi.Node, subnet string) error {
-	bytes, err := json.Marshal(map[string]string{
-		"default": subnet,
-	})
+	nodeAnnotations, err := util.CreateNodeHostSubnetAnnotation(subnet)
 	if err != nil {
 		return fmt.Errorf("failed to marshal node %q annotation for subnet %s",
 			node.Name, subnet)
 	}
-	nodeAnnotations := make(map[string]interface{})
-	nodeAnnotations[OvnNodeSubnets] = string(bytes)
 	err = oc.kube.SetAnnotationsOnNode(node, nodeAnnotations)
 	if err != nil {
 		return fmt.Errorf("failed to set node annotation %q on existing node %s to %q: %v",
-			OvnNodeSubnets, node.Name, subnet, err)
+			util.OvnNodeSubnets, node.Name, subnet, err)
 	}
 	return nil
 }
@@ -699,7 +508,7 @@ func (oc *Controller) addNodeAnnotations(node *kapi.Node, subnet string) error {
 func (oc *Controller) addNode(node *kapi.Node) (hostsubnet *net.IPNet, err error) {
 	oc.clearInitialNodeNetworkUnavailableCondition(node, nil)
 
-	hostsubnet, _ = parseNodeHostSubnet(node)
+	hostsubnet, _ = util.ParseNodeHostSubnetAnnotation(node)
 	if hostsubnet != nil {
 		// Node already has subnet assigned; ensure its logical network is set up
 		return hostsubnet, oc.ensureNodeLogicalNetwork(node.Name, hostsubnet)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -200,12 +200,6 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 //	  "default": "100.64.0.0/29",
 // }
 func (oc *Controller) addNodeJoinSubnetAnnotations(node *kapi.Node, subnet string) error {
-	// nothing to do if the node already has the annotation key
-	_, ok := node.Annotations[OvnNodeJoinSubnets]
-	if ok {
-		return nil
-	}
-
 	bytes, err := json.Marshal(map[string]string{
 		"default": subnet,
 	})
@@ -685,12 +679,6 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 //	  "default": "192.168.2.1",
 // }
 func (oc *Controller) addNodeAnnotations(node *kapi.Node, subnet string) error {
-	// nothing to do if the node already has the annotation key
-	_, ok := node.Annotations[OvnNodeSubnets]
-	if ok {
-		return nil
-	}
-
 	bytes, err := json.Marshal(map[string]string{
 		"default": subnet,
 	})
@@ -713,12 +701,6 @@ func (oc *Controller) addNode(node *kapi.Node) (hostsubnet *net.IPNet, err error
 
 	hostsubnet, _ = parseNodeHostSubnet(node)
 	if hostsubnet != nil {
-		// Update the node's annotation to use the new annotation key and remove the
-		// old annotation key.
-		err = oc.addNodeAnnotations(node, hostsubnet.String())
-		if err != nil {
-			return nil, err
-		}
 		// Node already has subnet assigned; ensure its logical network is set up
 		return hostsubnet, oc.ensureNodeLogicalNetwork(node.Name, hostsubnet)
 	}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -153,8 +153,8 @@ func addNodeportLBs(fexec *ovntest.FakeExec, nodeName, tcpLBUUID, udpLBUUID stri
 
 func getDisabledGwModeAnnotation() string {
 	l3GatewayConfig := map[string]interface{}{
-		OvnDefaultNetworkGateway: map[string]string{
-			OvnNodeGatewayMode: string(config.GatewayModeDisabled),
+		util.OvnDefaultNetworkGateway: map[string]string{
+			util.OvnNodeGatewayMode: string(config.GatewayModeDisabled),
 		},
 	}
 	bytes, err := json.Marshal(l3GatewayConfig)
@@ -196,8 +196,8 @@ var _ = Describe("Master Operations", func() {
 			testNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
-					OvnNodeManagementPortMacAddress: mgmtMAC,
-					OvnNodeL3GatewayConfig:          getDisabledGwModeAnnotation(),
+					util.OvnNodeManagementPortMacAddress: mgmtMAC,
+					util.OvnNodeL3GatewayConfig:          getDisabledGwModeAnnotation(),
 				},
 			}}
 
@@ -230,8 +230,8 @@ var _ = Describe("Master Operations", func() {
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 			updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedNode.Annotations[OvnNodeSubnets]).To(MatchJSON(fmt.Sprintf(`{"default": "%s"}`, nodeSubnet)))
-			Expect(updatedNode.Annotations).To(HaveKeyWithValue(OvnNodeManagementPortMacAddress, mgmtMAC))
+			Expect(updatedNode.Annotations[util.OvnNodeSubnets]).To(MatchJSON(fmt.Sprintf(`{"default": "%s"}`, nodeSubnet)))
+			Expect(updatedNode.Annotations).To(HaveKeyWithValue(util.OvnNodeManagementPortMacAddress, mgmtMAC))
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
 		}
@@ -262,9 +262,9 @@ var _ = Describe("Master Operations", func() {
 			testNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
-					OvnNodeManagementPortMacAddress: mgmtMAC,
-					OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
-					OvnNodeL3GatewayConfig:          getDisabledGwModeAnnotation(),
+					util.OvnNodeManagementPortMacAddress: mgmtMAC,
+					util.OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
+					util.OvnNodeL3GatewayConfig:          getDisabledGwModeAnnotation(),
 				},
 			}}
 
@@ -304,8 +304,8 @@ var _ = Describe("Master Operations", func() {
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 			updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedNode.Annotations[OvnNodeSubnets]).To(MatchJSON(fmt.Sprintf(`{"default": "%s"}`, nodeSubnet)))
-			Expect(updatedNode.Annotations).To(HaveKeyWithValue(OvnNodeManagementPortMacAddress, mgmtMAC))
+			Expect(updatedNode.Annotations[util.OvnNodeSubnets]).To(MatchJSON(fmt.Sprintf(`{"default": "%s"}`, nodeSubnet)))
+			Expect(updatedNode.Annotations).To(HaveKeyWithValue(util.OvnNodeManagementPortMacAddress, mgmtMAC))
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
 		}
@@ -406,9 +406,9 @@ subnet=%s
 				ObjectMeta: metav1.ObjectMeta{
 					Name: masterName,
 					Annotations: map[string]string{
-						OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, masterSubnet),
-						OvnNodeManagementPortMacAddress: masterMgmtPortMAC,
-						OvnNodeL3GatewayConfig:          getDisabledGwModeAnnotation(),
+						util.OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, masterSubnet),
+						util.OvnNodeManagementPortMacAddress: masterMgmtPortMAC,
+						util.OvnNodeL3GatewayConfig:          getDisabledGwModeAnnotation(),
 					},
 				},
 				Spec: v1.NodeSpec{
@@ -514,13 +514,13 @@ var _ = Describe("Gateway Init Operations", func() {
 
 			ifaceID := localnetBridgeName + "_" + nodeName
 			l3GatewayConfig := map[string]string{
-				OvnNodeGatewayMode:       string(config.GatewayModeLocal),
-				OvnNodeGatewayVlanID:     string(config.Gateway.VLANID),
-				OvnNodeGatewayIfaceID:    ifaceID,
-				OvnNodeGatewayMacAddress: brLocalnetMAC,
-				OvnNodeGatewayIP:         localnetGatewayIP,
-				OvnNodeGatewayNextHop:    localnetGatewayNextHop,
-				OvnNodePortEnable:        "true",
+				util.OvnNodeGatewayMode:       string(config.GatewayModeLocal),
+				util.OvnNodeGatewayVlanID:     string(config.Gateway.VLANID),
+				util.OvnNodeGatewayIfaceID:    ifaceID,
+				util.OvnNodeGatewayMacAddress: brLocalnetMAC,
+				util.OvnNodeGatewayIP:         localnetGatewayIP,
+				util.OvnNodeGatewayNextHop:    localnetGatewayNextHop,
+				util.OvnNodePortEnable:        "true",
 			}
 			bytes, err := json.Marshal(map[string]map[string]string{"default": l3GatewayConfig})
 			Expect(err).NotTo(HaveOccurred())
@@ -528,11 +528,11 @@ var _ = Describe("Gateway Init Operations", func() {
 			testNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
-					OvnNodeManagementPortMacAddress: brLocalnetMAC,
-					OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
-					OvnNodeJoinSubnets:              fmt.Sprintf(`{"default": "%s"}`, joinSubnet),
-					OvnNodeL3GatewayConfig:          string(bytes),
-					OvnNodeChassisID:                systemID,
+					util.OvnNodeManagementPortMacAddress: brLocalnetMAC,
+					util.OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
+					util.OvnNodeJoinSubnets:              fmt.Sprintf(`{"default": "%s"}`, joinSubnet),
+					util.OvnNodeL3GatewayConfig:          string(bytes),
+					util.OvnNodeChassisID:                systemID,
 				},
 			}}
 
@@ -702,24 +702,24 @@ var _ = Describe("Gateway Init Operations", func() {
 
 			ifaceID := physicalBridgeName + "_" + nodeName
 			l3GatewayConfig := map[string]string{
-				OvnNodeGatewayMode:       string(config.GatewayModeShared),
-				OvnNodeGatewayVlanID:     "1024",
-				OvnNodeGatewayIfaceID:    ifaceID,
-				OvnNodeGatewayMacAddress: physicalBridgeMAC,
-				OvnNodeGatewayIP:         physicalGatewayIPMask,
-				OvnNodeGatewayNextHop:    physicalGatewayNextHop,
-				OvnNodePortEnable:        "true",
+				util.OvnNodeGatewayMode:       string(config.GatewayModeShared),
+				util.OvnNodeGatewayVlanID:     "1024",
+				util.OvnNodeGatewayIfaceID:    ifaceID,
+				util.OvnNodeGatewayMacAddress: physicalBridgeMAC,
+				util.OvnNodeGatewayIP:         physicalGatewayIPMask,
+				util.OvnNodeGatewayNextHop:    physicalGatewayNextHop,
+				util.OvnNodePortEnable:        "true",
 			}
 			bytes, err := json.Marshal(map[string]map[string]string{"default": l3GatewayConfig})
 			Expect(err).NotTo(HaveOccurred())
 			testNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 				Annotations: map[string]string{
-					OvnNodeManagementPortMacAddress: nodeMgmtPortMAC,
-					OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
-					OvnNodeJoinSubnets:              fmt.Sprintf(`{"default": "%s"}`, joinSubnet),
-					OvnNodeL3GatewayConfig:          string(bytes),
-					OvnNodeChassisID:                systemID,
+					util.OvnNodeManagementPortMacAddress: nodeMgmtPortMAC,
+					util.OvnNodeSubnets:                  fmt.Sprintf(`{"default": "%s"}`, nodeSubnet),
+					util.OvnNodeJoinSubnets:              fmt.Sprintf(`{"default": "%s"}`, joinSubnet),
+					util.OvnNodeL3GatewayConfig:          string(bytes),
+					util.OvnNodeChassisID:                systemID,
 				},
 			}}
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -504,14 +504,14 @@ func (oc *Controller) WatchNamespaces() error {
 }
 
 func (oc *Controller) syncNodeGateway(node *kapi.Node, subnet *net.IPNet) error {
-	l3GatewayConfig, err := UnmarshalNodeL3GatewayAnnotation(node)
+	l3GatewayConfig, err := util.UnmarshalNodeL3GatewayAnnotation(node)
 	if err != nil {
 		return err
 	}
 	if subnet == nil {
-		subnet, _ = parseNodeHostSubnet(node)
+		subnet, _ = util.ParseNodeHostSubnetAnnotation(node)
 	}
-	if l3GatewayConfig[OvnNodeGatewayMode] == string(config.GatewayModeDisabled) {
+	if l3GatewayConfig[util.OvnNodeGatewayMode] == string(config.GatewayModeDisabled) {
 		if err := util.GatewayCleanup(node.Name, subnet); err != nil {
 			return fmt.Errorf("error cleaning up gateway for node %s: %v", node.Name, err)
 		}
@@ -602,8 +602,8 @@ func (oc *Controller) WatchNodes() error {
 			klog.V(5).Infof("Delete event for Node %q. Removing the node from "+
 				"various caches", node.Name)
 
-			nodeSubnet, _ := parseNodeHostSubnet(node)
-			joinSubnet, _ := parseNodeJoinSubnet(node)
+			nodeSubnet, _ := util.ParseNodeHostSubnetAnnotation(node)
+			joinSubnet, _ := util.ParseNodeJoinSubnetAnnotation(node)
 			err := oc.deleteNode(node.Name, nodeSubnet, joinSubnet)
 			if err != nil {
 				klog.Error(err)
@@ -723,8 +723,8 @@ func (oc *Controller) removeServiceEndpoints(lb, vip string) {
 
 // gatewayChanged() compares old annotations to new and returns true if something has changed.
 func gatewayChanged(oldNode, newNode *kapi.Node) bool {
-	oldL3GatewayConfig, _ := UnmarshalNodeL3GatewayAnnotation(oldNode)
-	l3GatewayConfig, _ := UnmarshalNodeL3GatewayAnnotation(newNode)
+	oldL3GatewayConfig, _ := util.UnmarshalNodeL3GatewayAnnotation(oldNode)
+	l3GatewayConfig, _ := util.UnmarshalNodeL3GatewayAnnotation(newNode)
 
 	if oldL3GatewayConfig == nil && l3GatewayConfig == nil {
 		return false
@@ -735,8 +735,8 @@ func gatewayChanged(oldNode, newNode *kapi.Node) bool {
 
 // macAddressChanged() compares old annotations to new and returns true if something has changed.
 func macAddressChanged(oldNode, node *kapi.Node) bool {
-	oldMacAddress := oldNode.Annotations[OvnNodeManagementPortMacAddress]
-	macAddress := node.Annotations[OvnNodeManagementPortMacAddress]
+	oldMacAddress := oldNode.Annotations[util.OvnNodeManagementPortMacAddress]
+	macAddress := node.Annotations[util.OvnNodeManagementPortMacAddress]
 	return oldMacAddress != macAddress
 }
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -504,14 +504,14 @@ func (oc *Controller) WatchNamespaces() error {
 }
 
 func (oc *Controller) syncNodeGateway(node *kapi.Node, subnet *net.IPNet) error {
-	l3GatewayConfig, err := util.UnmarshalNodeL3GatewayAnnotation(node)
+	l3GatewayConfig, err := util.ParseNodeL3GatewayAnnotation(node)
 	if err != nil {
 		return err
 	}
 	if subnet == nil {
 		subnet, _ = util.ParseNodeHostSubnetAnnotation(node)
 	}
-	if l3GatewayConfig[util.OvnNodeGatewayMode] == string(config.GatewayModeDisabled) {
+	if l3GatewayConfig.Mode == config.GatewayModeDisabled {
 		if err := util.GatewayCleanup(node.Name, subnet); err != nil {
 			return fmt.Errorf("error cleaning up gateway for node %s: %v", node.Name, err)
 		}
@@ -723,8 +723,8 @@ func (oc *Controller) removeServiceEndpoints(lb, vip string) {
 
 // gatewayChanged() compares old annotations to new and returns true if something has changed.
 func gatewayChanged(oldNode, newNode *kapi.Node) bool {
-	oldL3GatewayConfig, _ := util.UnmarshalNodeL3GatewayAnnotation(oldNode)
-	l3GatewayConfig, _ := util.UnmarshalNodeL3GatewayAnnotation(newNode)
+	oldL3GatewayConfig, _ := util.ParseNodeL3GatewayAnnotation(oldNode)
+	l3GatewayConfig, _ := util.ParseNodeL3GatewayAnnotation(newNode)
 
 	if oldL3GatewayConfig == nil && l3GatewayConfig == nil {
 		return false
@@ -735,8 +735,8 @@ func gatewayChanged(oldNode, newNode *kapi.Node) bool {
 
 // macAddressChanged() compares old annotations to new and returns true if something has changed.
 func macAddressChanged(oldNode, node *kapi.Node) bool {
-	oldMacAddress := oldNode.Annotations[util.OvnNodeManagementPortMacAddress]
-	macAddress := node.Annotations[util.OvnNodeManagementPortMacAddress]
+	oldMacAddress, _ := util.ParseNodeManagementPortMacAddr(oldNode)
+	macAddress, _ := util.ParseNodeManagementPortMacAddr(node)
 	return oldMacAddress != macAddress
 }
 

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -102,26 +102,14 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, error) {
 }
 
 // GatewayInit creates a gateway router for the local chassis.
-func GatewayInit(clusterIPSubnet []string, joinSubnet *net.IPNet, systemID, nodeName, ifaceID, nicIP, nicMacAddress,
-	defaultGW string, rampoutIPSubnet string, nodePortEnable bool, lspArgs []string) error {
-
-	ip, physicalIPNet, err := net.ParseCIDR(nicIP)
-	if err != nil {
-		return fmt.Errorf("error parsing %s (%v)", nicIP, err)
-	}
-	n, _ := physicalIPNet.Mask.Size()
-	physicalIPMask := fmt.Sprintf("%s/%d", ip.String(), n)
-	physicalIP := ip.String()
-
-	defaultgwByte := net.ParseIP(defaultGW)
-	defaultGW = defaultgwByte.String()
-
+func GatewayInit(clusterIPSubnet []string, hostSubnet string, joinSubnet *net.IPNet, nodeName string, l3GatewayConfig *L3GatewayConfig) error {
 	k8sClusterRouter := GetK8sClusterRouter()
 	// Create a gateway router.
 	gatewayRouter := GWRouterPrefix + nodeName
 	stdout, stderr, err := RunOVNNbctl("--", "--may-exist", "lr-add",
 		gatewayRouter, "--", "set", "logical_router", gatewayRouter,
-		"options:chassis="+systemID, "external_ids:physical_ip="+physicalIP)
+		"options:chassis="+l3GatewayConfig.ChassisID,
+		"external_ids:physical_ip="+l3GatewayConfig.IPAddress.IP.String())
 	if err != nil {
 		return fmt.Errorf("Failed to create logical router %v, stdout: %q, "+
 			"stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
@@ -202,7 +190,7 @@ func GatewayInit(clusterIPSubnet []string, joinSubnet *net.IPNet, systemID, node
 		}
 	}
 
-	if nodePortEnable {
+	if l3GatewayConfig.NodePortEnable {
 		// Create 2 load-balancers for north-south traffic for each gateway
 		// router.  One handles UDP and another handles TCP.
 		var k8sNSLbTCP, k8sNSLbUDP string
@@ -261,11 +249,19 @@ func GatewayInit(clusterIPSubnet []string, joinSubnet *net.IPNet, systemID, node
 	// This is a learning switch port with "unknown" address. The external
 	// world is accessed via this port.
 	cmdArgs := []string{
-		"--", "--may-exist", "lsp-add", externalSwitch, ifaceID,
-		"--", "lsp-set-addresses", ifaceID, "unknown",
-		"--", "lsp-set-type", ifaceID, "localnet",
-		"--", "lsp-set-options", ifaceID, "network_name=" + PhysicalNetworkName}
-	cmdArgs = append(cmdArgs, lspArgs...)
+		"--", "--may-exist", "lsp-add", externalSwitch, l3GatewayConfig.InterfaceID,
+		"--", "lsp-set-addresses", l3GatewayConfig.InterfaceID, "unknown",
+		"--", "lsp-set-type", l3GatewayConfig.InterfaceID, "localnet",
+		"--", "lsp-set-options", l3GatewayConfig.InterfaceID, "network_name=" + PhysicalNetworkName}
+
+	if l3GatewayConfig.VLANID != nil {
+		lspArgs := []string{
+			"--", "set", "logical_switch_port", l3GatewayConfig.InterfaceID,
+			fmt.Sprintf("tag_request=%d", *l3GatewayConfig.VLANID),
+		}
+		cmdArgs = append(cmdArgs, lspArgs...)
+	}
+
 	stdout, stderr, err = RunOVNNbctl(cmdArgs...)
 	if err != nil {
 		return fmt.Errorf("Failed to add logical port to switch, stdout: %q, "+
@@ -279,7 +275,8 @@ func GatewayInit(clusterIPSubnet []string, joinSubnet *net.IPNet, systemID, node
 	// has changed. So, we need to delete that port, if it exists, and it back.
 	stdout, stderr, err = RunOVNNbctl(
 		"--", "--if-exists", "lrp-del", "rtoe-"+gatewayRouter,
-		"--", "lrp-add", gatewayRouter, "rtoe-"+gatewayRouter, nicMacAddress, physicalIPMask,
+		"--", "lrp-add", gatewayRouter, "rtoe-"+gatewayRouter,
+		l3GatewayConfig.MACAddress.String(), l3GatewayConfig.IPAddress.String(),
 		"--", "set", "logical_router_port", "rtoe-"+gatewayRouter,
 		"external-ids:gateway-physical-ip=yes")
 	if err != nil {
@@ -292,7 +289,7 @@ func GatewayInit(clusterIPSubnet []string, joinSubnet *net.IPNet, systemID, node
 		externalSwitch, "etor-"+gatewayRouter, "--", "set",
 		"logical_switch_port", "etor-"+gatewayRouter, "type=router",
 		"options:router-port=rtoe-"+gatewayRouter,
-		"addresses="+"\""+nicMacAddress+"\"")
+		"addresses="+"\""+l3GatewayConfig.MACAddress.String()+"\"")
 	if err != nil {
 		return fmt.Errorf("Failed to add logical port to router, stdout: %q, "+
 			"stderr: %q, error: %v", stdout, stderr, err)
@@ -306,7 +303,7 @@ func GatewayInit(clusterIPSubnet []string, joinSubnet *net.IPNet, systemID, node
 		allIPs = "0.0.0.0/0"
 	}
 	stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
-		gatewayRouter, allIPs, defaultGW,
+		gatewayRouter, allIPs, l3GatewayConfig.NextHop.String(),
 		fmt.Sprintf("rtoe-%s", gatewayRouter))
 	if err != nil {
 		return fmt.Errorf("Failed to add a static route in GR with physical "+
@@ -314,8 +311,8 @@ func GatewayInit(clusterIPSubnet []string, joinSubnet *net.IPNet, systemID, node
 			"stderr: %q, error: %v", stdout, stderr, err)
 	}
 
-	rampoutIPSubnets := strings.Split(rampoutIPSubnet, ",")
-	for _, rampoutIPSubnet = range rampoutIPSubnets {
+	rampoutIPSubnets := strings.Split(hostSubnet, ",")
+	for _, rampoutIPSubnet := range rampoutIPSubnets {
 		_, _, err = net.ParseCIDR(rampoutIPSubnet)
 		if err != nil {
 			continue
@@ -336,7 +333,7 @@ func GatewayInit(clusterIPSubnet []string, joinSubnet *net.IPNet, systemID, node
 	// Default SNAT rules.
 	for _, entry := range clusterIPSubnet {
 		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-nat-add",
-			gatewayRouter, "snat", physicalIP, entry)
+			gatewayRouter, "snat", l3GatewayConfig.IPAddress.IP.String(), entry)
 		if err != nil {
 			return fmt.Errorf("Failed to create default SNAT rules, stdout: %q, "+
 				"stderr: %q, error: %v", stdout, stderr, err)

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 )
 
 // This handles the annotations used by the node to pass information about its local
@@ -32,62 +33,106 @@ import (
 //     k8s.ovn.org/node-mgmt-port-mac-address: fa:f1:27:f5:54:69
 
 const (
-	// OvnNodeL3GatewayConfig is the constant string representing the l3 gateway annotation key
-	OvnNodeL3GatewayConfig = "k8s.ovn.org/l3-gateway-config"
+	// ovnNodeL3GatewayConfig is the constant string representing the l3 gateway annotation key
+	ovnNodeL3GatewayConfig = "k8s.ovn.org/l3-gateway-config"
 
 	// OvnDefaultNetworkGateway captures L3 gateway config for default OVN network interface
-	OvnDefaultNetworkGateway = "default"
+	ovnDefaultNetworkGateway = "default"
 
-	// OvnNodeGatewayMode is the mode of the gateway in the l3 gateway annotation
-	OvnNodeGatewayMode = "mode"
-	// OvnNodeGatewayVlanID is the vlanid used by the gateway in the l3 gateway annotation
-	OvnNodeGatewayVlanID = "vlan-id"
-	// OvnNodeGatewayIfaceID is the interfaceID of the gateway in the l3 gateway annotation
-	OvnNodeGatewayIfaceID = "interface-id"
-	// OvnNodeGatewayMacAddress is the MacAddress of the Gateway interface in the l3 gateway annotation
-	OvnNodeGatewayMacAddress = "mac-address"
-	// OvnNodeGatewayIP is the IP address of the Gateway in the l3 gateway annotation
-	OvnNodeGatewayIP = "ip-address"
-	// OvnNodeGatewayNextHop is the Next Hop in the l3 gateway annotation
-	OvnNodeGatewayNextHop = "next-hop"
-	// OvnNodePortEnable in the l3 gateway annotation captures whether load balancer needs to
+	// ovnNodeGatewayMode is the mode of the gateway in the l3 gateway annotation
+	ovnNodeGatewayMode = "mode"
+	// ovnNodeGatewayVlanID is the vlanid used by the gateway in the l3 gateway annotation
+	ovnNodeGatewayVlanID = "vlan-id"
+	// ovnNodeGatewayIfaceID is the interfaceID of the gateway in the l3 gateway annotation
+	ovnNodeGatewayIfaceID = "interface-id"
+	// ovnNodeGatewayMacAddress is the MacAddress of the Gateway interface in the l3 gateway annotation
+	ovnNodeGatewayMacAddress = "mac-address"
+	// ovnNodeGatewayIP is the IP address of the Gateway in the l3 gateway annotation
+	ovnNodeGatewayIP = "ip-address"
+	// ovnNodeGatewayNextHop is the Next Hop in the l3 gateway annotation
+	ovnNodeGatewayNextHop = "next-hop"
+	// ovnNodePortEnable in the l3 gateway annotation captures whether load balancer needs to
 	// be created or not
-	OvnNodePortEnable = "node-port-enable"
+	ovnNodePortEnable = "node-port-enable"
 
-	// OvnNodeManagementPortMacAddress is the constant string representing the annotation key
-	OvnNodeManagementPortMacAddress = "k8s.ovn.org/node-mgmt-port-mac-address"
+	// ovnNodeManagementPortMacAddress is the constant string representing the annotation key
+	ovnNodeManagementPortMacAddress = "k8s.ovn.org/node-mgmt-port-mac-address"
 
-	// OvnNodeChassisID is the systemID of the node needed for creating L3 gateway
-	OvnNodeChassisID = "k8s.ovn.org/node-chassis-id"
+	// ovnNodeChassisID is the systemID of the node needed for creating L3 gateway
+	ovnNodeChassisID = "k8s.ovn.org/node-chassis-id"
 )
 
-func CreateDisabledL3GatewayConfig() map[string]map[string]string {
-	return map[string]map[string]string{
-		OvnDefaultNetworkGateway: {
-			OvnNodeGatewayMode: string(config.GatewayModeDisabled),
-		},
-	}
+type L3GatewayConfig struct {
+	Mode           config.GatewayMode
+	ChassisID      string
+	InterfaceID    string
+	MACAddress     net.HardwareAddr
+	IPAddress      *net.IPNet
+	NextHop        net.IP
+	NodePortEnable bool
+	VLANID         *uint
 }
 
-func CreateL3GatewayConfig(ifaceID, macAddress, gatewayAddress, nextHop string) map[string]map[string]string {
-	return map[string]map[string]string{
-		OvnDefaultNetworkGateway: {
-			OvnNodeGatewayMode:       string(config.Gateway.Mode),
-			OvnNodeGatewayVlanID:     fmt.Sprintf("%d", config.Gateway.VLANID),
-			OvnNodeGatewayIfaceID:    ifaceID,
-			OvnNodeGatewayMacAddress: macAddress,
-			OvnNodeGatewayIP:         gatewayAddress,
-			OvnNodeGatewayNextHop:    nextHop,
-			OvnNodePortEnable:        fmt.Sprintf("%t", config.Gateway.NodeportEnable),
-		},
+func setAnnotations(nodeAnnotator kube.Annotator, l3GatewayConfig map[string]string) error {
+	gatewayAnnotation := map[string]map[string]string{ovnDefaultNetworkGateway: l3GatewayConfig}
+	if err := nodeAnnotator.Set(ovnNodeL3GatewayConfig, gatewayAnnotation); err != nil {
+		return err
 	}
+	if l3GatewayConfig[ovnNodeGatewayMode] != string(config.GatewayModeDisabled) {
+		systemID, err := GetNodeChassisID()
+		if err != nil {
+			return err
+		}
+		if err := nodeAnnotator.Set(ovnNodeChassisID, systemID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-// UnmarshalNodeL3GatewayAnnotation returns the unmarshalled l3-gateway-config annotation
-func UnmarshalNodeL3GatewayAnnotation(node *kapi.Node) (map[string]string, error) {
-	l3GatewayAnnotation, ok := node.Annotations[OvnNodeL3GatewayConfig]
+// SetDisabledL3GatewayConfig uses nodeAnnotator set an l3-gateway-config annotation
+// indicating the gateway is disabled.
+func SetDisabledL3GatewayConfig(nodeAnnotator kube.Annotator) error {
+	return setAnnotations(nodeAnnotator, map[string]string{
+		ovnNodeGatewayMode: string(config.GatewayModeDisabled),
+	})
+}
+
+// SetSharedL3GatewayConfig uses nodeAnnotator set an l3-gateway-config annotation
+// for the "shared interface" gateway mode.
+func SetSharedL3GatewayConfig(nodeAnnotator kube.Annotator,
+	ifaceID, macAddress, gatewayAddress, nextHop string, nodePortEnable bool,
+	vlanID uint) error {
+	return setAnnotations(nodeAnnotator, map[string]string{
+		ovnNodeGatewayMode:       string(config.GatewayModeShared),
+		ovnNodeGatewayVlanID:     fmt.Sprintf("%d", vlanID),
+		ovnNodeGatewayIfaceID:    ifaceID,
+		ovnNodeGatewayMacAddress: macAddress,
+		ovnNodeGatewayIP:         gatewayAddress,
+		ovnNodeGatewayNextHop:    nextHop,
+		ovnNodePortEnable:        fmt.Sprintf("%t", nodePortEnable),
+	})
+}
+
+// SetSharedL3GatewayConfig uses nodeAnnotator set an l3-gateway-config annotation
+// for the "localnet" gateway mode.
+func SetLocalL3GatewayConfig(nodeAnnotator kube.Annotator,
+	ifaceID, macAddress, gatewayAddress, nextHop string, nodePortEnable bool) error {
+	return setAnnotations(nodeAnnotator, map[string]string{
+		ovnNodeGatewayMode:       string(config.GatewayModeLocal),
+		ovnNodeGatewayIfaceID:    ifaceID,
+		ovnNodeGatewayMacAddress: macAddress,
+		ovnNodeGatewayIP:         gatewayAddress,
+		ovnNodeGatewayNextHop:    nextHop,
+		ovnNodePortEnable:        fmt.Sprintf("%t", nodePortEnable),
+	})
+}
+
+// ParseNodeL3GatewayAnnotation returns the parsed l3-gateway-config annotation
+func ParseNodeL3GatewayAnnotation(node *kapi.Node) (*L3GatewayConfig, error) {
+	l3GatewayAnnotation, ok := node.Annotations[ovnNodeL3GatewayConfig]
 	if !ok {
-		return nil, fmt.Errorf("%s annotation not found for node %q", OvnNodeL3GatewayConfig, node.Name)
+		return nil, fmt.Errorf("%s annotation not found for node %q", ovnNodeL3GatewayConfig, node.Name)
 	}
 
 	l3GatewayConfigMap := map[string]map[string]string{}
@@ -95,79 +140,69 @@ func UnmarshalNodeL3GatewayAnnotation(node *kapi.Node) (map[string]string, error
 		return nil, fmt.Errorf("failed to unmarshal l3 gateway config annotation %s for node %q", l3GatewayAnnotation, node.Name)
 	}
 
-	l3GatewayConfig, ok := l3GatewayConfigMap[OvnDefaultNetworkGateway]
+	configRaw, ok := l3GatewayConfigMap[ovnDefaultNetworkGateway]
 	if !ok {
-		return nil, fmt.Errorf("%s annotation for %s network not found", OvnNodeL3GatewayConfig, OvnDefaultNetworkGateway)
+		return nil, fmt.Errorf("%s annotation for %s network not found", ovnNodeL3GatewayConfig, ovnDefaultNetworkGateway)
 	}
+
+	l3GatewayConfig := &L3GatewayConfig{}
+	l3GatewayConfig.Mode = config.GatewayMode(configRaw[ovnNodeGatewayMode])
+	if l3GatewayConfig.Mode == config.GatewayModeDisabled {
+		return l3GatewayConfig, nil
+	} else if l3GatewayConfig.Mode != config.GatewayModeShared && l3GatewayConfig.Mode != config.GatewayModeLocal {
+		return nil, fmt.Errorf("bad %q value %q", ovnNodeGatewayMode, l3GatewayConfig.Mode)
+	}
+
+	l3GatewayConfig.ChassisID, ok = node.Annotations[ovnNodeChassisID]
+	if !ok {
+		return nil, fmt.Errorf("%s annotation not found", ovnNodeChassisID)
+	}
+
+	l3GatewayConfig.InterfaceID, ok = configRaw[ovnNodeGatewayIfaceID]
+	if !ok {
+		return nil, fmt.Errorf("%s property not found in %s annotation", ovnNodeGatewayIfaceID, ovnNodeL3GatewayConfig)
+	}
+
+	var err error
+	l3GatewayConfig.MACAddress, err = net.ParseMAC(configRaw[ovnNodeGatewayMacAddress])
+	if err != nil {
+		return nil, fmt.Errorf("bad %q value %q (%v)", ovnNodeGatewayMacAddress, configRaw[ovnNodeGatewayMacAddress], err)
+	}
+
+	ip, ipNet, err := net.ParseCIDR(configRaw[ovnNodeGatewayIP])
+	if err != nil {
+		return nil, fmt.Errorf("bad %q value %q (%v)", ovnNodeGatewayIP, configRaw[ovnNodeGatewayIP], err)
+	}
+	l3GatewayConfig.IPAddress = &net.IPNet{IP: ip, Mask: ipNet.Mask}
+
+	l3GatewayConfig.NextHop = net.ParseIP(configRaw[ovnNodeGatewayNextHop])
+	if l3GatewayConfig.NextHop == nil {
+		return nil, fmt.Errorf("bad %q value %q", ovnNodeGatewayNextHop, configRaw[ovnNodeGatewayNextHop])
+	}
+
+	l3GatewayConfig.NodePortEnable = (configRaw[ovnNodePortEnable] == "true")
+
+	if l3GatewayConfig.Mode == config.GatewayModeShared {
+		vlanIDStr, ok := configRaw[ovnNodeGatewayVlanID]
+		if ok {
+			vlanID64, err := strconv.ParseUint(vlanIDStr, 10, 0)
+			if err != nil {
+				return nil, fmt.Errorf("bad %q value %q (%v)", ovnNodeGatewayVlanID, vlanIDStr, err)
+			}
+			vlanID := uint(vlanID64)
+			l3GatewayConfig.VLANID = &vlanID
+		}
+	}
+
 	return l3GatewayConfig, nil
 }
 
-func ParseGatewayIfaceID(l3GatewayConfig map[string]string) (string, error) {
-	ifaceID, ok := l3GatewayConfig[OvnNodeGatewayIfaceID]
-	if !ok || ifaceID == "" {
-		return "", fmt.Errorf("%s annotation not found or invalid", OvnNodeGatewayIfaceID)
-	}
-
-	return ifaceID, nil
-}
-
-func ParseGatewayMacAddress(l3GatewayConfig map[string]string) (string, error) {
-	gatewayMacAddress, ok := l3GatewayConfig[OvnNodeGatewayMacAddress]
-	if !ok {
-		return "", fmt.Errorf("%s annotation not found", OvnNodeGatewayMacAddress)
-	}
-
-	_, err := net.ParseMAC(gatewayMacAddress)
-	if err != nil {
-		return "", fmt.Errorf("Error %v in parsing node gateway macAddress %v", err, gatewayMacAddress)
-	}
-
-	return gatewayMacAddress, nil
-}
-
-func ParseGatewayLogicalNetwork(l3GatewayConfig map[string]string) (string, string, error) {
-	ipAddress, ok := l3GatewayConfig[OvnNodeGatewayIP]
-	if !ok {
-		return "", "", fmt.Errorf("%s annotation not found", OvnNodeGatewayIP)
-	}
-
-	gwNextHop, ok := l3GatewayConfig[OvnNodeGatewayNextHop]
-	if !ok {
-		return "", "", fmt.Errorf("%s annotation not found", OvnNodeGatewayNextHop)
-	}
-
-	return ipAddress, gwNextHop, nil
-}
-
-func ParseGatewayVLANID(l3GatewayConfig map[string]string, ifaceID string) ([]string, error) {
-	var lspArgs []string
-	vID, ok := l3GatewayConfig[OvnNodeGatewayVlanID]
-	if !ok {
-		return nil, fmt.Errorf("%s annotation not found", OvnNodeGatewayVlanID)
-	}
-
-	vlanID, errVlan := strconv.Atoi(vID)
-	if errVlan != nil {
-		return nil, fmt.Errorf("%s annotation has an invalid format", OvnNodeGatewayVlanID)
-	}
-	if vlanID > 0 {
-		lspArgs = []string{"--", "set", "logical_switch_port",
-			ifaceID, fmt.Sprintf("tag_request=%d", vlanID)}
-	}
-
-	return lspArgs, nil
-}
-
-func ParseNodeChassisID(node *kapi.Node) (string, error) {
-	systemID, ok := node.Annotations[OvnNodeChassisID]
-	if !ok {
-		return "", fmt.Errorf("%s annotation not found", OvnNodeChassisID)
-	}
-	return systemID, nil
+func SetNodeManagementPortMacAddr(nodeAnnotator kube.Annotator, macAddress string) error {
+	return nodeAnnotator.Set(ovnNodeManagementPortMacAddress, macAddress)
 }
 
 func ParseNodeManagementPortMacAddr(node *kapi.Node) (string, error) {
-	macAddress, ok := node.Annotations[OvnNodeManagementPortMacAddress]
+	macAddress, ok := node.Annotations[ovnNodeManagementPortMacAddress]
 	if !ok {
 		klog.Errorf("macAddress annotation not found for node %q ", node.Name)
 		return "", nil

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -1,0 +1,182 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+)
+
+// This handles the annotations used by the node to pass information about its local
+// network configuration to the master:
+//
+//   annotations:
+//     k8s.ovn.org/l3-gateway-config: |
+//       {
+//         "default": {
+//           "mode": "local",
+//           "interface-id": "br-local_ip-10-0-129-64.us-east-2.compute.internal",
+//           "mac-address": "f2:20:a0:3c:26:4c",
+//           "ip-address": "169.254.33.2/24",
+//           "next-hop": "169.254.33.1",
+//           "node-port-enable": "true",
+//           "vlan-id": "0"
+//         }
+//       }
+//     k8s.ovn.org/node-chassis-id: b1f96182-2bdd-42b6-88f9-9a1fc1c85ece
+//     k8s.ovn.org/node-mgmt-port-mac-address: fa:f1:27:f5:54:69
+
+const (
+	// OvnNodeL3GatewayConfig is the constant string representing the l3 gateway annotation key
+	OvnNodeL3GatewayConfig = "k8s.ovn.org/l3-gateway-config"
+
+	// OvnDefaultNetworkGateway captures L3 gateway config for default OVN network interface
+	OvnDefaultNetworkGateway = "default"
+
+	// OvnNodeGatewayMode is the mode of the gateway in the l3 gateway annotation
+	OvnNodeGatewayMode = "mode"
+	// OvnNodeGatewayVlanID is the vlanid used by the gateway in the l3 gateway annotation
+	OvnNodeGatewayVlanID = "vlan-id"
+	// OvnNodeGatewayIfaceID is the interfaceID of the gateway in the l3 gateway annotation
+	OvnNodeGatewayIfaceID = "interface-id"
+	// OvnNodeGatewayMacAddress is the MacAddress of the Gateway interface in the l3 gateway annotation
+	OvnNodeGatewayMacAddress = "mac-address"
+	// OvnNodeGatewayIP is the IP address of the Gateway in the l3 gateway annotation
+	OvnNodeGatewayIP = "ip-address"
+	// OvnNodeGatewayNextHop is the Next Hop in the l3 gateway annotation
+	OvnNodeGatewayNextHop = "next-hop"
+	// OvnNodePortEnable in the l3 gateway annotation captures whether load balancer needs to
+	// be created or not
+	OvnNodePortEnable = "node-port-enable"
+
+	// OvnNodeManagementPortMacAddress is the constant string representing the annotation key
+	OvnNodeManagementPortMacAddress = "k8s.ovn.org/node-mgmt-port-mac-address"
+
+	// OvnNodeChassisID is the systemID of the node needed for creating L3 gateway
+	OvnNodeChassisID = "k8s.ovn.org/node-chassis-id"
+)
+
+func CreateDisabledL3GatewayConfig() map[string]map[string]string {
+	return map[string]map[string]string{
+		OvnDefaultNetworkGateway: {
+			OvnNodeGatewayMode: string(config.GatewayModeDisabled),
+		},
+	}
+}
+
+func CreateL3GatewayConfig(ifaceID, macAddress, gatewayAddress, nextHop string) map[string]map[string]string {
+	return map[string]map[string]string{
+		OvnDefaultNetworkGateway: {
+			OvnNodeGatewayMode:       string(config.Gateway.Mode),
+			OvnNodeGatewayVlanID:     fmt.Sprintf("%d", config.Gateway.VLANID),
+			OvnNodeGatewayIfaceID:    ifaceID,
+			OvnNodeGatewayMacAddress: macAddress,
+			OvnNodeGatewayIP:         gatewayAddress,
+			OvnNodeGatewayNextHop:    nextHop,
+			OvnNodePortEnable:        fmt.Sprintf("%t", config.Gateway.NodeportEnable),
+		},
+	}
+}
+
+// UnmarshalNodeL3GatewayAnnotation returns the unmarshalled l3-gateway-config annotation
+func UnmarshalNodeL3GatewayAnnotation(node *kapi.Node) (map[string]string, error) {
+	l3GatewayAnnotation, ok := node.Annotations[OvnNodeL3GatewayConfig]
+	if !ok {
+		return nil, fmt.Errorf("%s annotation not found for node %q", OvnNodeL3GatewayConfig, node.Name)
+	}
+
+	l3GatewayConfigMap := map[string]map[string]string{}
+	if err := json.Unmarshal([]byte(l3GatewayAnnotation), &l3GatewayConfigMap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal l3 gateway config annotation %s for node %q", l3GatewayAnnotation, node.Name)
+	}
+
+	l3GatewayConfig, ok := l3GatewayConfigMap[OvnDefaultNetworkGateway]
+	if !ok {
+		return nil, fmt.Errorf("%s annotation for %s network not found", OvnNodeL3GatewayConfig, OvnDefaultNetworkGateway)
+	}
+	return l3GatewayConfig, nil
+}
+
+func ParseGatewayIfaceID(l3GatewayConfig map[string]string) (string, error) {
+	ifaceID, ok := l3GatewayConfig[OvnNodeGatewayIfaceID]
+	if !ok || ifaceID == "" {
+		return "", fmt.Errorf("%s annotation not found or invalid", OvnNodeGatewayIfaceID)
+	}
+
+	return ifaceID, nil
+}
+
+func ParseGatewayMacAddress(l3GatewayConfig map[string]string) (string, error) {
+	gatewayMacAddress, ok := l3GatewayConfig[OvnNodeGatewayMacAddress]
+	if !ok {
+		return "", fmt.Errorf("%s annotation not found", OvnNodeGatewayMacAddress)
+	}
+
+	_, err := net.ParseMAC(gatewayMacAddress)
+	if err != nil {
+		return "", fmt.Errorf("Error %v in parsing node gateway macAddress %v", err, gatewayMacAddress)
+	}
+
+	return gatewayMacAddress, nil
+}
+
+func ParseGatewayLogicalNetwork(l3GatewayConfig map[string]string) (string, string, error) {
+	ipAddress, ok := l3GatewayConfig[OvnNodeGatewayIP]
+	if !ok {
+		return "", "", fmt.Errorf("%s annotation not found", OvnNodeGatewayIP)
+	}
+
+	gwNextHop, ok := l3GatewayConfig[OvnNodeGatewayNextHop]
+	if !ok {
+		return "", "", fmt.Errorf("%s annotation not found", OvnNodeGatewayNextHop)
+	}
+
+	return ipAddress, gwNextHop, nil
+}
+
+func ParseGatewayVLANID(l3GatewayConfig map[string]string, ifaceID string) ([]string, error) {
+	var lspArgs []string
+	vID, ok := l3GatewayConfig[OvnNodeGatewayVlanID]
+	if !ok {
+		return nil, fmt.Errorf("%s annotation not found", OvnNodeGatewayVlanID)
+	}
+
+	vlanID, errVlan := strconv.Atoi(vID)
+	if errVlan != nil {
+		return nil, fmt.Errorf("%s annotation has an invalid format", OvnNodeGatewayVlanID)
+	}
+	if vlanID > 0 {
+		lspArgs = []string{"--", "set", "logical_switch_port",
+			ifaceID, fmt.Sprintf("tag_request=%d", vlanID)}
+	}
+
+	return lspArgs, nil
+}
+
+func ParseNodeChassisID(node *kapi.Node) (string, error) {
+	systemID, ok := node.Annotations[OvnNodeChassisID]
+	if !ok {
+		return "", fmt.Errorf("%s annotation not found", OvnNodeChassisID)
+	}
+	return systemID, nil
+}
+
+func ParseNodeManagementPortMacAddr(node *kapi.Node) (string, error) {
+	macAddress, ok := node.Annotations[OvnNodeManagementPortMacAddress]
+	if !ok {
+		klog.Errorf("macAddress annotation not found for node %q ", node.Name)
+		return "", nil
+	}
+
+	_, err := net.ParseMAC(macAddress)
+	if err != nil {
+		return "", fmt.Errorf("Error %v in parsing node %v macAddress %v", err, node.Name, macAddress)
+	}
+
+	return macAddress, nil
+}

--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -1,0 +1,106 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	kapi "k8s.io/api/core/v1"
+)
+
+// This handles the annotations related to subnets assigned to a node. The annotations are
+// created by the master, and then read by the node, and look like:
+//
+//   annotations:
+//     k8s.ovn.org/node-subnets: |
+//       {
+//         "default": "10.130.0.0/23"
+//       }
+//     k8s.ovn.org/node-join-subnets: |
+//       {
+//         "default": "100.64.2.0/29"
+//       }
+//
+// (This allows for specifying multiple network attachments, but currently only "default"
+// is used.)
+
+const (
+	// OvnNodeSubnets is the constant string representing the node subnets annotation key
+	OvnNodeSubnets = "k8s.ovn.org/node-subnets"
+	// OvnNodeJoinSubnets is the constant string representing the node's join switch subnets annotation key
+	OvnNodeJoinSubnets = "k8s.ovn.org/node-join-subnets"
+)
+
+// CreateNodeHostSubnetAnnotation creates a "k8s.ovn.org/node-subnets" annotation,
+// with a single "default" network, suitable for passing to kube.SetAnnotationsOnNode
+func CreateNodeHostSubnetAnnotation(defaultSubnet string) (map[string]interface{}, error) {
+	bytes, err := json.Marshal(map[string]string{
+		"default": defaultSubnet,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		OvnNodeSubnets: string(bytes),
+	}, nil
+}
+
+// ParseNodeHostSubnetAnnotation parses the "k8s.ovn.org/node-subnets" annotation
+// on a node and returns the "default" host subnet.
+func ParseNodeHostSubnetAnnotation(node *kapi.Node) (*net.IPNet, error) {
+	sub, ok := node.Annotations[OvnNodeSubnets]
+	if ok {
+		nodeSubnets := make(map[string]string)
+		if err := json.Unmarshal([]byte(sub), &nodeSubnets); err != nil {
+			return nil, fmt.Errorf("error parsing node-subnets annotation: %v", err)
+		}
+		sub, ok = nodeSubnets["default"]
+	}
+	if !ok {
+		return nil, fmt.Errorf("node %q has no host subnet annotation", node.Name)
+	}
+
+	_, subnet, err := net.ParseCIDR(sub)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing host subnet: %v", err)
+	}
+
+	return subnet, nil
+}
+
+// CreateNodeJoinSubnetAnnotation creates a "k8s.ovn.org/node-join-subnets" annotation
+// with a single "default" network, suitable for passing to kube.SetAnnotationsOnNode
+func CreateNodeJoinSubnetAnnotation(defaultSubnet string) (map[string]interface{}, error) {
+	bytes, err := json.Marshal(map[string]string{
+		"default": defaultSubnet,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		OvnNodeJoinSubnets: string(bytes),
+	}, nil
+}
+
+// ParseNodeJoinSubnetAnnotation parses the "k8s.ovn.org/node-join-subnets" annotation on
+// a node and returns the "default" join subnet.
+func ParseNodeJoinSubnetAnnotation(node *kapi.Node) (*net.IPNet, error) {
+	sub, ok := node.Annotations[OvnNodeJoinSubnets]
+	if ok {
+		nodeSubnets := make(map[string]string)
+		if err := json.Unmarshal([]byte(sub), &nodeSubnets); err != nil {
+			return nil, fmt.Errorf("error parsing node-join-subnets annotation: %v", err)
+		}
+		sub, ok = nodeSubnets["default"]
+	}
+	if !ok {
+		return nil, fmt.Errorf("node %q has no join subnet annotation", node.Name)
+	}
+
+	_, subnet, err := net.ParseCIDR(sub)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing join subnet: %v", err)
+	}
+
+	return subnet, nil
+}

--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -6,6 +6,8 @@ import (
 	"net"
 
 	kapi "k8s.io/api/core/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 )
 
 // This handles the annotations related to subnets assigned to a node. The annotations are
@@ -25,10 +27,10 @@ import (
 // is used.)
 
 const (
-	// OvnNodeSubnets is the constant string representing the node subnets annotation key
-	OvnNodeSubnets = "k8s.ovn.org/node-subnets"
-	// OvnNodeJoinSubnets is the constant string representing the node's join switch subnets annotation key
-	OvnNodeJoinSubnets = "k8s.ovn.org/node-join-subnets"
+	// ovnNodeSubnets is the constant string representing the node subnets annotation key
+	ovnNodeSubnets = "k8s.ovn.org/node-subnets"
+	// ovnNodeJoinSubnets is the constant string representing the node's join switch subnets annotation key
+	ovnNodeJoinSubnets = "k8s.ovn.org/node-join-subnets"
 )
 
 // CreateNodeHostSubnetAnnotation creates a "k8s.ovn.org/node-subnets" annotation,
@@ -41,14 +43,24 @@ func CreateNodeHostSubnetAnnotation(defaultSubnet string) (map[string]interface{
 		return nil, err
 	}
 	return map[string]interface{}{
-		OvnNodeSubnets: string(bytes),
+		ovnNodeSubnets: string(bytes),
 	}, nil
+}
+
+// SetNodeHostSubnetAnnotation sets a "k8s.ovn.org/node-subnets" annotation
+// using a kube.Annotator
+func SetNodeHostSubnetAnnotation(nodeAnnotator kube.Annotator, defaultSubnet string) error {
+	annotation, err := CreateNodeHostSubnetAnnotation(defaultSubnet)
+	if err != nil {
+		return err
+	}
+	return nodeAnnotator.Set(ovnNodeSubnets, annotation[ovnNodeSubnets])
 }
 
 // ParseNodeHostSubnetAnnotation parses the "k8s.ovn.org/node-subnets" annotation
 // on a node and returns the "default" host subnet.
 func ParseNodeHostSubnetAnnotation(node *kapi.Node) (*net.IPNet, error) {
-	sub, ok := node.Annotations[OvnNodeSubnets]
+	sub, ok := node.Annotations[ovnNodeSubnets]
 	if ok {
 		nodeSubnets := make(map[string]string)
 		if err := json.Unmarshal([]byte(sub), &nodeSubnets); err != nil {
@@ -78,14 +90,24 @@ func CreateNodeJoinSubnetAnnotation(defaultSubnet string) (map[string]interface{
 		return nil, err
 	}
 	return map[string]interface{}{
-		OvnNodeJoinSubnets: string(bytes),
+		ovnNodeJoinSubnets: string(bytes),
 	}, nil
+}
+
+// SetNodeJoinSubnetAnnotation sets a "k8s.ovn.org/node-join-subnets" annotation
+// using a kube.Annotator
+func SetNodeJoinSubnetAnnotation(nodeAnnotator kube.Annotator, defaultSubnet string) error {
+	annotation, err := CreateNodeJoinSubnetAnnotation(defaultSubnet)
+	if err != nil {
+		return err
+	}
+	return nodeAnnotator.Set(ovnNodeJoinSubnets, annotation[ovnNodeJoinSubnets])
 }
 
 // ParseNodeJoinSubnetAnnotation parses the "k8s.ovn.org/node-join-subnets" annotation on
 // a node and returns the "default" join subnet.
 func ParseNodeJoinSubnetAnnotation(node *kapi.Node) (*net.IPNet, error) {
-	sub, ok := node.Annotations[OvnNodeJoinSubnets]
+	sub, ok := node.Annotations[ovnNodeJoinSubnets]
 	if ok {
 		nodeSubnets := make(map[string]string)
 		if err := json.Unmarshal([]byte(sub), &nodeSubnets); err != nil {


### PR DESCRIPTION
To support dual stack (#1142) we will need to modify the node-related annotations, as currently neither the `node-subnets`/`node-join-subnets` annotations nor the `l3-gateway-config` annotation supports listing dual-stack IPs/subnets.

As a prelude to that, this abstracts the handling of those annotations into helper utilities in `pkg/util/`. Then to add support for dual-stack we can just change the helper functions/types to use arrays of IPs/CIDRs rather than individual IPs/CIDRs, and the helper functions can then continue to create/parse backward-compatible annotations in single-stack clusters, but use an updated annotation format in dual-stack clusters, and the callers don't need to care.

(The updates to the unit tests got a bit ugly... maybe that should be done differently...)

@dcbw 