### PR TITLE
remove legacy br-nexthop internal port, if it exists, before proceeding

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -321,7 +321,8 @@ var _ = Describe("Gateway Init Operations", func() {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovs-vsctl --timeout=15 set bridge br-local other-config:hwaddr=" + brLocalnetMAC,
 				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + util.PhysicalNetworkName + ":br-local",
-				"ovs-vsctl --timeout=15 --may-exist add-port br-local " + localnetGatewayNextHopPort + " -- set interface " + localnetGatewayNextHopPort + " type=internal mtu_request=" + mtu + " mac=00\\:00\\:a9\\:fe\\:21\\:01",
+				"ovs-vsctl --timeout=15 --if-exists del-port br-local " + legacyLocalnetGatewayNextHopPort +
+					" -- --may-exist add-port br-local " + localnetGatewayNextHopPort + " -- set interface " + localnetGatewayNextHopPort + " type=internal mtu_request=" + mtu + " mac=00\\:00\\:a9\\:fe\\:21\\:01",
 			})
 
 			err := util.SetExec(fexec)

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -28,7 +28,8 @@ const (
 	v6localnetGatewayNextHopSubnet = "fd99::1/64"
 	// localnetGatewayNextHopPort is the name of the gateway port on the host to which all
 	// the packets leaving the OVN logical topology will be forwarded
-	localnetGatewayNextHopPort = "ovn-k8s-gw0"
+	localnetGatewayNextHopPort       = "ovn-k8s-gw0"
+	legacyLocalnetGatewayNextHopPort = "br-nexthop"
 	// fixed MAC address for the br-nexthop interface. the last 4 hex bytes
 	// translates to the br-nexthop's IP address
 	localnetGatewayNextHopMac = "00:00:a9:fe:21:01"
@@ -165,7 +166,8 @@ func initLocalnetGateway(nodeName string,
 
 	// Create a localnet bridge gateway port
 	_, stderr, err = util.RunOVSVsctl(
-		"--may-exist", "add-port", localnetBridgeName, localnetGatewayNextHopPort,
+		"--if-exists", "del-port", localnetBridgeName, legacyLocalnetGatewayNextHopPort,
+		"--", "--may-exist", "add-port", localnetBridgeName, localnetGatewayNextHopPort,
 		"--", "set", "interface", localnetGatewayNextHopPort, "type=internal",
 		"mtu_request="+fmt.Sprintf("%d", config.Default.MTU),
 		fmt.Sprintf("mac=%s", strings.ReplaceAll(localnetGatewayNextHopMac, ":", "\\:")))


### PR DESCRIPTION
in the upgrade path, with the rename br-nexthop to ovn-k8s-gw0 changes,
the br-local OVS bridge will have two internal ports -- the old and the
new. both of these ports claim the same logical_port through iface-id
on the chassis and it causes confusion and connectivity issues

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>