### PR TITLE
Fixed logging related parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ list to the above command. Set values are the default values.
 ```
     --master-loglevel="5" \\Log level for ovnkube (master)
     --node-logleve="5" \\ Log level for ovnkube (node)
-    --ovn-log-northd="-vconsole:info -vfile:info" \\ Log config for ovn northd
-    --ovn-log-nb="-vconsole:info -vfile:info" \\ Log config for northbound db
-    --ovn-log-sb="-vconsole:info -vfile:info" \\ Log config for southboudn db
-    --ovn-log-controller="-vconsole:info" \\ Log config for ovn-controller
-    --ovn-log-nbctld="-vconsole:info" \\ Log config for nbctl daemon
+    --ovn-loglevel-northd="-vconsole:info -vfile:info" \\ Log config for ovn northd
+    --ovn-loglevel-nb="-vconsole:info -vfile:info" \\ Log config for northbound db
+    --ovn-loglevel-sb="-vconsole:info -vfile:info" \\ Log config for southboudn db
+    --ovn-loglevel-controller="-vconsole:info" \\ Log config for ovn-controller
+    --ovn-loglevel-nbctld="-vconsole:info" \\ Log config for nbctl daemon
 ```
 
 Apply OVN daemonset and deployment yamls.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ cd $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/images
     --k8s-apiserver=https://$MASTER_IP:6443
 ```
 
+To set specific logging level for OVN components, pass the related parameter from the below mentioned 
+list to the above command. Set values are the default values.
+```
+    --master-loglevel="5" \\Log level for ovnkube (master)
+    --node-logleve="5" \\ Log level for ovnkube (node)
+    --ovn-log-northd="-vconsole:info -vfile:info" \\ Log config for ovn northd
+    --ovn-log-nb="-vconsole:info -vfile:info" \\ Log config for northbound db
+    --ovn-log-sb="-vconsole:info -vfile:info" \\ Log config for southboudn db
+    --ovn-log-controller="-vconsole:info" \\ Log config for ovn-controller
+    --ovn-log-nbctld="-vconsole:info" \\ Log config for nbctl daemon
+```
+
 Apply OVN daemonset and deployment yamls.
 
 ```

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -42,7 +42,17 @@ fedora-dev: bld
 	docker build -t ovn-kube-f-dev -f Dockerfile.fedora.dev .
 	# docker login -u ovnkube docker.io/ovnkube
 	# docker push docker.io/ovnkube/ovn-daemonset-f:latest
-	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest
+	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest \
+                    --net-cidr=10.244.0.0/16 \
+                    --svc-cidr=10.96.0.0/12 \
+                    --gateway-mode="local" \
+                    --master-loglevel="5" \
+                    --node-loglevel="5" \
+                    --ovn-log-northd="-vconsole:info -vfile:info" \
+                    --ovn-log-nb="-vconsole:info -vfile:info" \
+                    --ovn-log-sb="-vconsole:info -vfile:info" \
+                    --ovn-log-controller="-vconsole:info" \
+                    --ovn-log-nbctld="-vconsole:info"
 
 # This target expands the daemonset yaml templates into final form
 # It gets the image name from ../ansible/hosts

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -48,11 +48,11 @@ fedora-dev: bld
                     --gateway-mode="local" \
                     --master-loglevel="5" \
                     --node-loglevel="5" \
-                    --ovn-log-northd="-vconsole:info -vfile:info" \
-                    --ovn-log-nb="-vconsole:info -vfile:info" \
-                    --ovn-log-sb="-vconsole:info -vfile:info" \
-                    --ovn-log-controller="-vconsole:info" \
-                    --ovn-log-nbctld="-vconsole:info"
+                    --ovn-loglevel-northd="-vconsole:info -vfile:info" \
+                    --ovn-loglevel-nb="-vconsole:info -vfile:info" \
+                    --ovn-loglevel-sb="-vconsole:info -vfile:info" \
+                    --ovn-loglevel-controller="-vconsole:info" \
+                    --ovn-loglevel-nbctld="-vconsole:info"
 
 # This target expands the daemonset yaml templates into final form
 # It gets the image name from ../ansible/hosts

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -24,7 +24,14 @@ OVN_DB_VIP=""
 OVN_DB_REPLICAS=""
 OVN_MTU="1400"
 KIND=""
-MASTER_LOGLEVEL="4"
+MASTER_LOGLEVEL=""
+NODE_LOGLEVEL=""
+OVN_LOG_NORTHD=""
+OVN_LOG_NB=""
+OVN_LOG_SB=""
+OVN_LOG_CONTROLLER=""
+OVN_LOG_NBCTLD=""
+
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -69,6 +76,24 @@ while [ "$1" != "" ]; do
             ;;
         --master-loglevel)
             MASTER_LOGLEVEL=$VALUE
+            ;;
+        --node-loglevel)
+            NODE_LOGLEVEL=$VALUE
+            ;;
+        --ovn-log-northd)
+            OVN_LOG_NORTHD=$VALUE
+            ;;
+        --ovn-log-nb)
+            OVN_LOG_NB=$VALUE
+            ;;
+        --ovn-log-sb)
+            OVN_LOG_SB=$VALUE
+            ;;
+        --ovn-log-controller)
+            OVN_LOG_CONTROLLER=$VALUE
+            ;;
+        --ovn-log-nbctld)
+            OVN_LOG_NBCTLD=$VALUE
             ;;
         *)
             echo "WARNING: unknown parameter \"$PARAM\""
@@ -123,20 +148,55 @@ ovn_db_vip=${OVN_DB_VIP}
 echo "ovn_db_vip: ${ovn_db_vip}"
 ovn_db_minAvailable=$(((${ovn_db_replicas} + 1) / 2))
 echo "ovn_db_minAvailable: ${ovn_db_minAvailable}"
+master_loglevel=${MASTER_LOGLEVEL:-"4"}
+echo "master_loglevel: ${master-loglevel}"
+node_loglevel=${NODE_LOGLEVEL:-"4"}
+echo "node_loglevel: ${node-loglevel}"
+ovn_log_northd=${OVN_LOG_NORTHD:-"-vconsole:info -vfile:info"}
+echo "ovn_log_northd: ${ovn_log_northd}"
+ovn_log_nb=${OVN_LOG_NB:-"-vconsole:info -vfile:info"}
+echo "ovn_log_nb: ${ovn_log_nb}"
+ovn_log_sb=${OVN_LOG_SB:-"-vconsole:info -vfile:info"}
+echo "ovn_log_sb: ${ovn_log_sb}"
+ovn_log_controller=${OVN_LOG_CONTROLLER:-"-vconsole:info"}
+echo "ovn_log_controller: ${ovn_log_controller}"
+ovn_log_nbctld=${OVN_LOG_NBCTLD:-"-vconsole:info"}
+echo "ovn_log_nbctld: ${ovn_log_nbctld}"
 
-ovn_image=${image} ovn_image_pull_policy=${policy} kind=${KIND} ovn_gateway_mode=${ovn_gateway_mode} \
- ovn_gateway_opts=${ovn_gateway_opts} j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node.yaml
+ovn_image=${image} \
+ovn_image_pull_policy=${policy} \
+kind=${KIND} \
+ovn_gateway_mode=${ovn_gateway_mode} \
+ovn_gateway_opts=${ovn_gateway_opts} \
+ovn_kube_node_log_level=${node_loglevel} \
+ovn_log_controller=${ovn_log_controller} \
+j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node.yaml
 
-ovn_image=${image} ovn_image_pull_policy=${policy} ovn_kube_master_log_level=${MASTER_LOGLEVEL} j2 \
-../templates/ovnkube-master.yaml.j2 -o ../yaml/ovnkube-master.yaml
+ovn_image=${image} \
+ovn_image_pull_policy=${policy} \
+ovn_kube_master_log_level=${master_loglevel} \
+ovn_log_northd=${ovn_log_northd} \
+ovn_log_nbctld=${ovn_log_nbctld} \
+j2 ../templates/ovnkube-master.yaml.j2 -o ../yaml/ovnkube-master.yaml
 
-ovn_image=${image} ovn_image_pull_policy=${policy} j2 ../templates/ovnkube-db.yaml.j2 -o ../yaml/ovnkube-db.yaml
+ovn_image=${image} \
+ovn_image_pull_policy=${policy} \
+ovn_log_nb=${ovn_log_nb} \
+ovn_log_sb=${ovn_log_sb} \
+j2 ../templates/ovnkube-db.yaml.j2 -o ../yaml/ovnkube-db.yaml
 
-ovn_db_vip_image=${ovn_db_vip_image} ovn_image_pull_policy=${policy} ovn_db_replicas=${ovn_db_replicas} \
-ovn_db_vip=${ovn_db_vip} j2 ../templates/ovnkube-db-vip.yaml.j2 -o ../yaml/ovnkube-db-vip.yaml
+ovn_db_vip_image=${ovn_db_vip_image} \
+ovn_image_pull_policy=${policy} \
+ovn_db_replicas=${ovn_db_replicas} \
+ovn_db_vip=${ovn_db_vip} ovn_log_nb=${ovn_log_nb} \
+j2 ../templates/ovnkube-db-vip.yaml.j2 -o ../yaml/ovnkube-db-vip.yaml
 
-ovn_image=${image} ovn_image_pull_policy=${policy} ovn_db_replicas=${ovn_db_replicas} \
-ovn_db_minAvailable=${ovn_db_minAvailable} j2 ../templates/ovnkube-db-raft.yaml.j2 > ../yaml/ovnkube-db-raft.yaml
+ovn_image=${image} \
+ovn_image_pull_policy=${policy} \
+ovn_db_replicas=${ovn_db_replicas} \
+ovn_db_minAvailable=${ovn_db_minAvailable} \
+ovn_log_nb=${ovn_log_nb} ovn_log_sb=${ovn_log_sb} \
+j2 ../templates/ovnkube-db-raft.yaml.j2 > ../yaml/ovnkube-db-raft.yaml
 
 # ovn-setup.yaml
 # net_cidr=10.128.0.0/14/23

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -26,11 +26,11 @@ OVN_MTU="1400"
 KIND=""
 MASTER_LOGLEVEL=""
 NODE_LOGLEVEL=""
-OVN_LOG_NORTHD=""
-OVN_LOG_NB=""
-OVN_LOG_SB=""
-OVN_LOG_CONTROLLER=""
-OVN_LOG_NBCTLD=""
+OVN_LOGLEVEL_NORTHD=""
+OVN_LOGLEVEL_NB=""
+OVN_LOGLEVEL_SB=""
+OVN_LOGLEVEL_CONTROLLER=""
+OVN_LOGLEVEL_NBCTLD=""
 
 
 # Parse parameters given as arguments to this script.
@@ -80,20 +80,20 @@ while [ "$1" != "" ]; do
         --node-loglevel)
             NODE_LOGLEVEL=$VALUE
             ;;
-        --ovn-log-northd)
-            OVN_LOG_NORTHD=$VALUE
+        --ovn-loglevel-northd)
+            OVN_LOGLEVEL_NORTHD=$VALUE
             ;;
-        --ovn-log-nb)
-            OVN_LOG_NB=$VALUE
+        --ovn-loglevel-nb)
+            OVN_LOGLEVEL_NB=$VALUE
             ;;
-        --ovn-log-sb)
-            OVN_LOG_SB=$VALUE
+        --ovn-loglevel-sb)
+            OVN_LOGLEVEL_SB=$VALUE
             ;;
-        --ovn-log-controller)
-            OVN_LOG_CONTROLLER=$VALUE
+        --ovn-loglevel-controller)
+            OVN_LOGLEVEL_CONTROLLER=$VALUE
             ;;
-        --ovn-log-nbctld)
-            OVN_LOG_NBCTLD=$VALUE
+        --ovn-loglevel-nbctld)
+            OVN_LOGLEVEL_NBCTLD=$VALUE
             ;;
         *)
             echo "WARNING: unknown parameter \"$PARAM\""
@@ -149,53 +149,53 @@ echo "ovn_db_vip: ${ovn_db_vip}"
 ovn_db_minAvailable=$(((${ovn_db_replicas} + 1) / 2))
 echo "ovn_db_minAvailable: ${ovn_db_minAvailable}"
 master_loglevel=${MASTER_LOGLEVEL:-"4"}
-echo "master_loglevel: ${master-loglevel}"
+echo "master_loglevel: ${master_loglevel}"
 node_loglevel=${NODE_LOGLEVEL:-"4"}
-echo "node_loglevel: ${node-loglevel}"
-ovn_log_northd=${OVN_LOG_NORTHD:-"-vconsole:info -vfile:info"}
-echo "ovn_log_northd: ${ovn_log_northd}"
-ovn_log_nb=${OVN_LOG_NB:-"-vconsole:info -vfile:info"}
-echo "ovn_log_nb: ${ovn_log_nb}"
-ovn_log_sb=${OVN_LOG_SB:-"-vconsole:info -vfile:info"}
-echo "ovn_log_sb: ${ovn_log_sb}"
-ovn_log_controller=${OVN_LOG_CONTROLLER:-"-vconsole:info"}
-echo "ovn_log_controller: ${ovn_log_controller}"
-ovn_log_nbctld=${OVN_LOG_NBCTLD:-"-vconsole:info"}
-echo "ovn_log_nbctld: ${ovn_log_nbctld}"
+echo "node_loglevel: ${node_loglevel}"
+ovn_loglevel_northd=${OVN_LOGLEVEL_NORTHD:-"-vconsole:info -vfile:info"}
+echo "ovn_loglevel_northd: ${ovn_loglevel_northd}"
+ovn_loglevel_nb=${OVN_LOGLEVEL_NB:-"-vconsole:info -vfile:info"}
+echo "ovn_loglevel_nb: ${ovn_loglevel_nb}"
+ovn_loglevel_sb=${OVN_LOGLEVEL_SB:-"-vconsole:info -vfile:info"}
+echo "ovn_loglevel_sb: ${ovn_loglevel_sb}"
+ovn_loglevel_controller=${OVN_LOGLEVEL_CONTROLLER:-"-vconsole:info"}
+echo "ovn_loglevel_controller: ${ovn_loglevel_controller}"
+ovn_loglevel_nbctld=${OVN_LOGLEVEL_NBCTLD:-"-vconsole:info"}
+echo "ovn_loglevel_nbctld: ${ovn_loglevel_nbctld}"
 
 ovn_image=${image} \
 ovn_image_pull_policy=${policy} \
 kind=${KIND} \
 ovn_gateway_mode=${ovn_gateway_mode} \
 ovn_gateway_opts=${ovn_gateway_opts} \
-ovn_kube_node_log_level=${node_loglevel} \
-ovn_log_controller=${ovn_log_controller} \
+ovnkube_node_loglevel=${node_loglevel} \
+ovn_loglevel_controller=${ovn_loglevel_controller} \
 j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node.yaml
 
 ovn_image=${image} \
 ovn_image_pull_policy=${policy} \
-ovn_kube_master_log_level=${master_loglevel} \
-ovn_log_northd=${ovn_log_northd} \
-ovn_log_nbctld=${ovn_log_nbctld} \
+ovnkube_master_loglevel=${master_loglevel} \
+ovn_loglevel_northd=${ovn_loglevel_northd} \
+ovn_loglevel_nbctld=${ovn_loglevel_nbctld} \
 j2 ../templates/ovnkube-master.yaml.j2 -o ../yaml/ovnkube-master.yaml
 
 ovn_image=${image} \
 ovn_image_pull_policy=${policy} \
-ovn_log_nb=${ovn_log_nb} \
-ovn_log_sb=${ovn_log_sb} \
+ovn_loglevel_nb=${ovn_loglevel_nb} \
+ovn_loglevel_sb=${ovn_loglevel_sb} \
 j2 ../templates/ovnkube-db.yaml.j2 -o ../yaml/ovnkube-db.yaml
 
 ovn_db_vip_image=${ovn_db_vip_image} \
 ovn_image_pull_policy=${policy} \
 ovn_db_replicas=${ovn_db_replicas} \
-ovn_db_vip=${ovn_db_vip} ovn_log_nb=${ovn_log_nb} \
+ovn_db_vip=${ovn_db_vip} ovn_loglevel_nb=${ovn_loglevel_nb} \
 j2 ../templates/ovnkube-db-vip.yaml.j2 -o ../yaml/ovnkube-db-vip.yaml
 
 ovn_image=${image} \
 ovn_image_pull_policy=${policy} \
 ovn_db_replicas=${ovn_db_replicas} \
 ovn_db_minAvailable=${ovn_db_minAvailable} \
-ovn_log_nb=${ovn_log_nb} ovn_log_sb=${ovn_log_sb} \
+ovn_loglevel_nb=${ovn_loglevel_nb} ovn_loglevel_sb=${ovn_loglevel_sb} \
 j2 ../templates/ovnkube-db-raft.yaml.j2 > ../yaml/ovnkube-db-raft.yaml
 
 # ovn-setup.yaml

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -137,7 +137,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NB
-          value: "-vconsole:info -vfile:info"
+          value: "{{ ovn_log_nb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:
@@ -197,7 +197,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_SB
-          value: "-vconsole:info -vfile:info"
+          value: "{{ ovn_log_sb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -137,7 +137,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NB
-          value: "{{ ovn_log_nb }}"
+          value: "{{ ovn_loglevel_nb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:
@@ -197,7 +197,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_SB
-          value: "{{ ovn_log_sb }}"
+          value: "{{ ovn_loglevel_sb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -119,7 +119,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NB
-          value: "{{ ovn_log_nb }}"
+          value: "{{ ovn_loglevel_nb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -119,7 +119,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NB
-          value: "-vconsole:info -vfile:info"
+          value: "{{ ovn_log_nb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -102,7 +102,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NB
-          value: "{{ ovn_log_nb }}"
+          value: "{{ ovn_loglevel_nb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:
@@ -158,7 +158,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_SB
-          value: "{{ ovn_log_sb }}"
+          value: "{{ ovn_loglevel_sb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -102,7 +102,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NB
-          value: "-vconsole:info -vfile:info"
+          value: "{{ ovn_log_nb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:
@@ -158,7 +158,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_SB
-          value: "-vconsole:info -vfile:info"
+          value: "{{ ovn_log_sb }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -99,7 +99,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NORTHD
-          value: "{{ ovn_log_northd }}"
+          value: "{{ ovn_loglevel_northd }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:
@@ -145,7 +145,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NBCTLD
-          value: "{{ ovn_log_nbctld }}"
+          value: "{{ ovn_loglevel_nbctld }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:
@@ -190,7 +190,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVNKUBE_LOGLEVEL
-          value: "{{ ovn_kube_master_log_level }}"
+          value: "{{ ovnkube_master_loglevel }}"
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -99,7 +99,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_NORTHD
-          value: "-vconsole:info"
+          value: "{{ ovn_log_northd }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:
@@ -144,6 +144,8 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
+        - name: OVN_LOG_NBCTLD
+          value: "{{ ovn_log_nbctld }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -129,6 +129,8 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
+        - name: OVN_LOG_CONTROLLER
+          value: "{{ ovn_log_controller }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:
@@ -197,7 +199,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVNKUBE_LOGLEVEL
-          value: "5"
+          value: "{{ ovn_kube_node_log_level }}"
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -130,7 +130,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVN_LOG_CONTROLLER
-          value: "{{ ovn_log_controller }}"
+          value: "{{ ovn_loglevel_controller }}"
         - name: K8S_APISERVER
           valueFrom:
             configMapKeyRef:
@@ -199,7 +199,7 @@ spec:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
         - name: OVNKUBE_LOGLEVEL
-          value: "{{ ovn_kube_node_log_level }}"
+          value: "{{ ovnkube_node_loglevel }}"
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
This patch fixes the following
*.* Removes the hardcoded log levels for ovnkube and ovn.
*.* Exposes logging parametes for ovn (northd, nb db, sb db,
 ovn-controller, nbctl) for user to override before generating
deployment yamls.
*.* Updates yaml templates to inject the logging parameters
*.* Updates Dockerfile.fedora.dev file for user's reference
about how to consume these parameters
*.* Adds note in README as well.

Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>