### PR TITLE
export ovs-appctl cluster/status output as ovn_db_raft_cluster metrics

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/ovn-db-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovn-db-exporter.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"k8s.io/klog"
 	"net/http"
 	"strconv"
@@ -54,6 +55,203 @@ var metricOVNDBMonitor = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Help:      "Number of OVSDB Monitors on the server"},
 	[]string{
 		"db_name",
+	},
+)
+
+// ClusterStatus metrics
+var metricDBClusterCID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_id",
+	Help:      "A metric with a constant '1' value labeled by database name and cluster uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+	},
+)
+
+var metricDBClusterSID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_server_id",
+	Help: "A metric with a constant '1' value labeled by database name, cluster uuid " +
+		"and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterServerStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_server_status",
+	Help: "A metric with a constant '1' value labeled by database name, cluster uuid, server uuid " +
+		"server status"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+		"server_status",
+	},
+)
+
+var metricDBClusterServerRole = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_server_role",
+	Help: "A metric with a constant '1' value labeled by database name, cluster uuid, server uuid " +
+		"and server role"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+		"server_role",
+	},
+)
+
+var metricDBClusterTerm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_term",
+	Help: "A metric that returns the current election term value labeled by database name, cluster uuid, and " +
+		"server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterServerVote = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_server_vote",
+	Help: "A metric with a constant '1' value labeled by database name, cluster uuid, server uuid " +
+		"and server vote"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+		"server_vote",
+	},
+)
+
+var metricDBClusterElectionTimer = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_election_timer",
+	Help: "A metric that returns the current election timer value labeled by database name, cluster uuid, " +
+		"and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterLogIndexStart = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_log_index_start",
+	Help: "A metric that returns the log entry index start value labeled by database name, cluster uuid, " +
+		"and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterLogIndexNext = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_log_index_next",
+	Help: "A metric that returns the log entry index next value labeled by database name, cluster uuid, " +
+		"and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterLogNotCommitted = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_log_not_committed",
+	Help: "A metric that returns the number of log entries not committed labeled by database name, cluster uuid, " +
+		"and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterLogNotApplied = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_log_not_applied",
+	Help: "A metric that returns the number of log entries not applied labeled by database name, cluster uuid, " +
+		"and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterConnIn = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_inbound_connections_total",
+	Help: "A metric that returns the total number of inbound  connections to the server labeled by " +
+		"database name, cluster uuid, and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterConnOut = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_outbound_connections_total",
+	Help: "A metric that returns the total number of outbound connections from the server labeled by " +
+		"database name, cluster uuid, and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterConnInErr = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_inbound_connections_error_total",
+	Help: "A metric that returns the total number of failed inbound connections to the server labeled by " +
+		" database name, cluster uuid, and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
+	},
+)
+
+var metricDBClusterConnOutErr = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.MetricOvnNamespace,
+	Subsystem: metrics.MetricOvnSubsystemDBRaft,
+	Name:      "cluster_outbound_connections_error_total",
+	Help: "A metric that returns the total number of failed  outbound connections from the server labeled by " +
+		"database name, cluster uuid, and server uuid"},
+	[]string{
+		"db_name",
+		"cluster_id",
+		"server_id",
 	},
 )
 
@@ -175,6 +373,21 @@ var OvnDBExporterCommand = cli.Command{
 			},
 			func() float64 { return 1 },
 		))
+		prometheus.MustRegister(metricDBClusterCID)
+		prometheus.MustRegister(metricDBClusterSID)
+		prometheus.MustRegister(metricDBClusterServerStatus)
+		prometheus.MustRegister(metricDBClusterTerm)
+		prometheus.MustRegister(metricDBClusterServerRole)
+		prometheus.MustRegister(metricDBClusterServerVote)
+		prometheus.MustRegister(metricDBClusterElectionTimer)
+		prometheus.MustRegister(metricDBClusterLogIndexStart)
+		prometheus.MustRegister(metricDBClusterLogIndexNext)
+		prometheus.MustRegister(metricDBClusterLogNotCommitted)
+		prometheus.MustRegister(metricDBClusterLogNotApplied)
+		prometheus.MustRegister(metricDBClusterConnIn)
+		prometheus.MustRegister(metricDBClusterConnOut)
+		prometheus.MustRegister(metricDBClusterConnInErr)
+		prometheus.MustRegister(metricDBClusterConnOutErr)
 
 		// functions responsible for collecting the values and updating the prometheus metrics
 		go func() {
@@ -193,10 +406,162 @@ var OvnDBExporterCommand = cli.Command{
 			}
 		}()
 
+		go func() {
+			for {
+				ovnDBClusterStatusMetricsUpdater("nb", "OVN_Northbound")
+				ovnDBClusterStatusMetricsUpdater("sb", "OVN_Southbound")
+				time.Sleep(30 * time.Second)
+			}
+		}()
+
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {
 			klog.Exitf("starting metrics server failed: %v", err)
 		}
 		return nil
 	},
+}
+
+type OVNDBClusterStatus struct {
+	cid             string
+	sid             string
+	status          string
+	role            string
+	vote            string
+	term            float64
+	electionTimer   float64
+	logIndexStart   float64
+	logIndexNext    float64
+	logNotCommitted float64
+	logNotApplied   float64
+	connIn          float64
+	connOut         float64
+	connInErr       float64
+	connOutErr      float64
+}
+
+func getOVNDBClusterStatusInfo(timeout int, direction, database string) (clusterStatus *OVNDBClusterStatus,
+	err error) {
+	var stdout, stderr string
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovering from a panic while parsing the cluster/status output "+
+				"for database %q: %v", database, r)
+		}
+	}()
+
+	if direction == "sb" {
+		stdout, stderr, err = util.RunOVNSBAppCtl(fmt.Sprintf("--timeout=%d", timeout),
+			"cluster/status", database)
+	} else {
+		stdout, stderr, err = util.RunOVNSBAppCtl(fmt.Sprintf("--timeout=%d", timeout),
+			"cluster/status", database)
+	}
+	if err != nil {
+		klog.Errorf("failed to retrieve cluster/status info for database %q, stderr: %s, err: (%v)",
+			database, stderr, err)
+		return nil, err
+	}
+
+	clusterStatus = &OVNDBClusterStatus{}
+	for _, line := range strings.Split(stdout, "\n") {
+		idx := strings.Index(line, ":")
+		if idx == -1 {
+			continue
+		}
+		switch line[:idx] {
+		case "Cluster ID":
+			// the value is of the format `45ef (45ef51b9-9401-46e7-810d-6db0fc344ea2)`
+			clusterStatus.cid = strings.Trim(strings.Fields(line[idx+2:])[1], "()")
+		case "Server ID":
+			clusterStatus.sid = strings.Trim(strings.Fields(line[idx+2:])[1], "()")
+		case "Status":
+			clusterStatus.status = line[idx+2:]
+		case "Role":
+			clusterStatus.role = line[idx+2:]
+		case "Term":
+			if value, err := strconv.ParseFloat(line[idx+2:], 64); err == nil {
+				clusterStatus.term = value
+			}
+		case "Vote":
+			clusterStatus.vote = line[idx+2:]
+		case "Election timer":
+			if value, err := strconv.ParseFloat(line[idx+2:], 64); err == nil {
+				clusterStatus.electionTimer = value
+			}
+		case "Log":
+			// the value is of the format [2, 1108]
+			values := strings.Split(strings.Trim(line[idx+2:], "[]"), ", ")
+			if value, err := strconv.ParseFloat(values[0], 64); err == nil {
+				clusterStatus.logIndexStart = value
+			}
+			if value, err := strconv.ParseFloat(values[1], 64); err == nil {
+				clusterStatus.logIndexNext = value
+			}
+		case "Entries not yet committed":
+			if value, err := strconv.ParseFloat(line[idx+2:], 64); err == nil {
+				clusterStatus.logNotCommitted = value
+			}
+		case "Entries not yet applied":
+			if value, err := strconv.ParseFloat(line[idx+2:], 64); err == nil {
+				clusterStatus.logNotApplied = value
+			}
+		case "Connections":
+			// the value is of the format `->0000 (->56d7) <-46ac <-56d7`
+			var connIn, connOut, connInErr, connOutErr float64
+			for _, conn := range strings.Fields(line[idx+2:]) {
+				if strings.HasPrefix(conn, "->") {
+					connOut++
+				} else if strings.HasPrefix(conn, "<-") {
+					connIn++
+				} else if strings.HasPrefix(conn, "(->") {
+					connOutErr++
+				} else if strings.HasPrefix(conn, "(<-") {
+					connInErr++
+				}
+			}
+			clusterStatus.connIn = connIn
+			clusterStatus.connOut = connOut
+			clusterStatus.connInErr = connInErr
+			clusterStatus.connOutErr = connOutErr
+		}
+	}
+
+	return clusterStatus, nil
+}
+
+func ovnDBClusterStatusMetricsUpdater(direction, database string) {
+	clusterStatus, err := getOVNDBClusterStatusInfo(5, direction, database)
+	if err != nil {
+		klog.Errorf(err.Error())
+		return
+	}
+	metricDBClusterCID.WithLabelValues(database, clusterStatus.cid).Set(1)
+	metricDBClusterSID.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(1)
+	metricDBClusterServerStatus.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
+		clusterStatus.status).Set(1)
+	metricDBClusterTerm.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid).Set(clusterStatus.term)
+	metricDBClusterServerRole.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
+		clusterStatus.role).Set(1)
+	metricDBClusterServerVote.WithLabelValues(database, clusterStatus.cid, clusterStatus.sid,
+		clusterStatus.vote).Set(1)
+	metricDBClusterElectionTimer.WithLabelValues(database, clusterStatus.cid,
+		clusterStatus.sid).Set(clusterStatus.electionTimer)
+	metricDBClusterLogIndexStart.WithLabelValues(database, clusterStatus.cid,
+		clusterStatus.sid).Set(clusterStatus.logIndexStart)
+	metricDBClusterLogIndexNext.WithLabelValues(database, clusterStatus.cid,
+		clusterStatus.sid).Set(clusterStatus.logIndexNext)
+	metricDBClusterLogNotCommitted.WithLabelValues(database, clusterStatus.cid,
+		clusterStatus.sid).Set(clusterStatus.logNotCommitted)
+	metricDBClusterLogNotApplied.WithLabelValues(database, clusterStatus.cid,
+		clusterStatus.sid).Set(clusterStatus.logNotApplied)
+	metricDBClusterConnIn.WithLabelValues(database, clusterStatus.cid,
+		clusterStatus.sid).Set(clusterStatus.connIn)
+	metricDBClusterConnOut.WithLabelValues(database, clusterStatus.cid,
+		clusterStatus.sid).Set(clusterStatus.connOut)
+	metricDBClusterConnInErr.WithLabelValues(database, clusterStatus.cid,
+		clusterStatus.sid).Set(clusterStatus.connInErr)
+	metricDBClusterConnOutErr.WithLabelValues(database, clusterStatus.cid,
+		clusterStatus.sid).Set(clusterStatus.connOutErr)
 }


### PR DESCRIPTION
added following metrics:

ovn_db_raft_cluster_id
ovn_db_raft_cluster_server_id
ovn_db_raft_cluster_server_role
ovn_db_raft_cluster_server_status
ovn_db_raft_cluster_server_vote
ovn_db_raft_cluster_election_timer
ovn_db_raft_cluster_term
ovn_db_raft_cluster_log_index_next
ovn_db_raft_cluster_log_index_start
ovn_db_raft_cluster_log_not_applied
ovn_db_raft_cluster_log_not_committed
ovn_db_raft_cluster_inbound_connections_total
ovn_db_raft_cluster_inbound_connections_error
ovn_db_raft_cluster_outbound_connection_total
ovn_db_raft_cluster_outbound_connection_error

@dcbw @danwinship PTAL