### PR TITLE
use 'ovsdb-client wait' to check running state of OVN DB servers

### DIFF
--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -61,7 +61,7 @@ COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
-COPY ovndb-raft-functions /root/
+COPY ovndb-raft-functions.sh /root/
 # override the rpm's ovn_k8s.conf with this local copy
 COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -37,7 +37,7 @@ COPY git_info /root
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
-COPY ovndb-raft-functions /root/
+COPY ovndb-raft-functions.sh /root/
 
 LABEL io.k8s.display-name="ovn-kubernetes" \
       io.k8s.description="This is a Kubernetes network plugin that provides an overlay network using OVN." \

--- a/dist/images/Dockerfile.fedora.dev
+++ b/dist/images/Dockerfile.fedora.dev
@@ -86,7 +86,7 @@ RUN cat /root/git_info
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
-COPY ovndb-raft-functions /root/
+COPY ovndb-raft-functions.sh /root/
 
 LABEL io.k8s.display-name="ovn-kubernetes-master" \
       io.k8s.description="OVN based Kubernetes CNI Plugin stack. Image contains latest code of all the components in the stack (OVN-kubernetes, OVN, OVS)." \

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -38,7 +38,7 @@ COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
-COPY ovndb-raft-functions /root/
+COPY ovndb-raft-functions.sh /root/
 # override the pkg's ovn_k8s.conf with this local copy
 COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
 

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -6,8 +6,8 @@ if [[ "${OVNKUBE_SH_VERBOSE:-}" == "true" ]]; then
   set -x
 fi
 
-# source the functions in ovndb-raft-functions
-. /root/ovndb-raft-functions
+# source the functions in ovndb-raft-functions.sh
+. /root/ovndb-raft-functions.sh
 
 # This script is the entrypoint to the image.
 # Supports version 3 daemonsets


### PR DESCRIPTION
From the manpage of `ovsdb-client wait`, we have:

  wait [server] database state
     Waits for database on server to enter a desired state, which may
     be one of:

     connected
       Waits until a database with the given name has been added
       to server.  Then, if database is clustered,  additionally
       waits until it has joined and connected to its cluster.

So, instead of checking `pid` associated with the process is present.
The above command looks more appropriate.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>