### PR TITLE
Fix nbctld log-file

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -54,7 +54,7 @@ fi
 # OVN_LOG_NB - log level (ovn-ctl default: -vconsole:off -vfile:info) - v3
 # OVN_LOG_SB - log level (ovn-ctl default: -vconsole:off -vfile:info) - v3
 # OVN_LOG_CONTROLLER - log level (ovn-ctl default: -vconsole:off -vfile:info) - v3
-# OVN_LOG_NBCTLD - log file (ovn-nbctl daemon mode default: /var/log/openvswitch/ovn-nbctl.log)
+# OVN_LOG_NBCTLD - log level (ovn-ctl default: -vconsole:off -vfile:info)
 # OVN_NB_PORT - ovn north db port (default 6641)
 # OVN_SB_PORT - ovn south db port (default 6642)
 
@@ -68,6 +68,7 @@ ovn_log_northd=${OVN_LOG_NORTHD:-"-vconsole:info"}
 ovn_log_nb=${OVN_LOG_NB:-"-vconsole:info"}
 ovn_log_sb=${OVN_LOG_SB:-"-vconsole:info"}
 ovn_log_controller=${OVN_LOG_CONTROLLER:-"-vconsole:info"}
+ovn_log_nbctld=${OVN_LOG_NBCTLD:-"-vfile:info"}
 
 ovnkubelogdir=/var/log/ovn-kubernetes
 
@@ -146,8 +147,6 @@ fi
 
 OVS_RUNDIR=/var/run/openvswitch
 OVS_LOGDIR=/var/log/openvswitch
-
-ovn_log_nbctld=${OVN_LOG_NBCTLD:-"${OVN_LOGDIR}/ovn-nbctl.log"}
 
 # =========================================
 
@@ -854,7 +853,7 @@ run-nbctld () {
   echo "ovn_log_nbctld=${ovn_log_nbctld}"
 
   # use unix socket
-  /usr/bin/ovn-nbctl --pidfile --detach --db=${ovn_nbdb_test} --log-file=${ovn_log_nbctld}
+  /usr/bin/ovn-nbctl ${ovn_log_nbctld} --pidfile --db=${ovn_nbdb_test} --log-file=${OVN_LOGDIR}/ovn-nbctl.log --detach
 
   wait_for_event attempts=3 process_ready ovn-nbctl
   echo "=============== run_ovn_nbctl ========== RUNNING"


### PR DESCRIPTION
OVN_LOG_NBCTLD env var was not used in ovnkube-master deployment,
so interally in ovnkube.sh it was not mapping to anything, and hence
it was setting to right log file name. Once we injected this env var
through patch (35f27054) it was mapped to log-file and not log-level
and configured --log-file incorrectly.

Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>