### PR TITLE
rename k8s-<hostname> management OVS internal port to ovn-k8s-mp0

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -140,14 +140,14 @@ func CleanupClusterNode(name string) error {
 
 	// Delete iptable rules for management port on Linux.
 	if runtime.GOOS != "windows" {
-		DelMgtPortIptRules(name)
+		DelMgtPortIptRules()
 	}
 
 	return nil
 }
 
 // GatewayReady will check to see if we have successfully added SNAT OpenFlow rules in the L3Gateway Routers
-func gatewayReady(string) (bool, error) {
+func gatewayReady() (bool, error) {
 	// OpenFlow table 41 performs SNATing of packets that are heading to physical network from
 	// logical network.
 	for _, clusterSubnet := range config.Default.ClusterSubnets {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -184,7 +184,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			waiter := newStartupWaiter(nodeName)
+			waiter := newStartupWaiter()
 			err = n.initGateway(nodeSubnet, nodeAnnotator, waiter)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -35,31 +35,32 @@ func createManagementPort(nodeName string, localSubnet *net.IPNet, nodeAnnotator
 	}
 
 	// Create a OVS internal interface.
-	interfaceName := util.GetK8sMgmtIntfName(nodeName)
-
-	stdout, stderr, err = util.RunOVSVsctl("--", "--may-exist", "add-port",
-		"br-int", interfaceName, "--", "set", "interface", interfaceName,
+	legacyMgmtIntfName := util.GetLegacyK8sMgmtIntfName(nodeName)
+	stdout, stderr, err = util.RunOVSVsctl(
+		"--", "--if-exists", "del-port", "br-int", legacyMgmtIntfName,
+		"--", "--may-exist", "add-port", "br-int", util.K8sMgmtIntfName,
+		"--", "set", "interface", util.K8sMgmtIntfName,
 		"type=internal", "mtu_request="+fmt.Sprintf("%d", config.Default.MTU),
 		"external-ids:iface-id=k8s-"+nodeName)
 	if err != nil {
 		klog.Errorf("Failed to add port to br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err
 	}
-	macAddress, err := util.GetOVSPortMACAddress(interfaceName)
+	macAddress, err := util.GetOVSPortMACAddress(util.K8sMgmtIntfName)
 	if err != nil {
 		klog.Errorf("Failed to get management port MAC address: %v", err)
 		return err
 	}
 	// persist the MAC address so that upon node reboot we get back the same mac address.
-	_, stderr, err = util.RunOVSVsctl("set", "interface", interfaceName,
+	_, stderr, err = util.RunOVSVsctl("set", "interface", util.K8sMgmtIntfName,
 		fmt.Sprintf("mac=%s", strings.ReplaceAll(macAddress, ":", "\\:")))
 	if err != nil {
 		klog.Errorf("failed to persist MAC address %q for %q: stderr:%s (%v)", macAddress,
-			interfaceName, stderr, err)
+			util.K8sMgmtIntfName, stderr, err)
 		return err
 	}
 
-	if err := createPlatformManagementPort(interfaceName, portIP.String(), routerIP.IP.String(), routerMac); err != nil {
+	if err := createPlatformManagementPort(util.K8sMgmtIntfName, portIP.String(), routerIP.IP.String(), routerMac); err != nil {
 		return nil
 	}
 
@@ -72,10 +73,9 @@ func createManagementPort(nodeName string, localSubnet *net.IPNet, nodeAnnotator
 }
 
 // managementPortReady will check to see if OpenFlow rules for management port has been created
-func managementPortReady(nodeName string) (bool, error) {
+func managementPortReady() (bool, error) {
 	// Get the OVS interface name for the Management Port
-	interfaceName := util.GetK8sMgmtIntfName(nodeName)
-	ofport, _, err := util.RunOVSVsctl("--if-exists", "get", "interface", interfaceName, "ofport")
+	ofport, _, err := util.RunOVSVsctl("--if-exists", "get", "interface", util.K8sMgmtIntfName, "ofport")
 	if err != nil {
 		return false, nil
 	}

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -110,7 +110,7 @@ func addMgtPortIptRules(ifname, interfaceIP string) error {
 }
 
 //DelMgtPortIptRules delete all the iptable rules for the management port.
-func DelMgtPortIptRules(nodeName string) {
+func DelMgtPortIptRules() {
 	// Clean up all iptables and ip6tables remnants that may be left around
 	ipt, err := util.GetIPTablesHelper(iptables.ProtocolIPv4)
 	if err != nil {
@@ -120,8 +120,7 @@ func DelMgtPortIptRules(nodeName string) {
 	if err != nil {
 		return
 	}
-	ifname := util.GetK8sMgmtIntfName(nodeName)
-	rule := []string{"-o", ifname, "-j", iptableMgmPortChain}
+	rule := []string{"-o", util.K8sMgmtIntfName, "-j", iptableMgmPortChain}
 	_ = ipt.Delete("nat", "POSTROUTING", rule...)
 	_ = ipt6.Delete("nat", "POSTROUTING", rule...)
 	_ = ipt.ClearChain("nat", iptableMgmPortChain)

--- a/go-controller/pkg/node/management-port_windows.go
+++ b/go-controller/pkg/node/management-port_windows.go
@@ -121,5 +121,5 @@ func createPlatformManagementPort(interfaceName, interfaceIP, routerIP, routerMA
 	return nil
 }
 
-func DelMgtPortIptRules(nodeName string) {
+func DelMgtPortIptRules() {
 }

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -210,7 +210,7 @@ func (n *OvnNode) Start() error {
 	}
 
 	nodeAnnotator := kube.NewNodeAnnotator(n.Kube, node)
-	waiter := newStartupWaiter(n.name)
+	waiter := newStartupWaiter()
 
 	// Initialize gateway resources on the node
 	if err := n.initGateway(subnet.String(), nodeAnnotator, waiter); err != nil {

--- a/go-controller/pkg/node/startup-waiter.go
+++ b/go-controller/pkg/node/startup-waiter.go
@@ -9,12 +9,11 @@ import (
 )
 
 type startupWaiter struct {
-	nodeName string
-	tasks    []*waitTask
-	wg       *sync.WaitGroup
+	tasks []*waitTask
+	wg    *sync.WaitGroup
 }
 
-type waitFunc func(string) (bool, error)
+type waitFunc func() (bool, error)
 type postWaitFunc func() error
 
 type waitTask struct {
@@ -22,11 +21,10 @@ type waitTask struct {
 	postFn postWaitFunc
 }
 
-func newStartupWaiter(nodeName string) *startupWaiter {
+func newStartupWaiter() *startupWaiter {
 	return &startupWaiter{
-		nodeName: nodeName,
-		tasks:    make([]*waitTask, 0, 2),
-		wg:       &sync.WaitGroup{},
+		tasks: make([]*waitTask, 0, 2),
+		wg:    &sync.WaitGroup{},
 	}
 }
 
@@ -44,7 +42,7 @@ func (w *startupWaiter) Wait() error {
 		go func(task *waitTask) {
 			defer w.wg.Done()
 			err := wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
-				return task.waitFn(w.nodeName)
+				return task.waitFn()
 			})
 			if err == nil && task.postFn != nil {
 				err = task.postFn()

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -314,7 +314,7 @@ func addStaticRouteToHost(node *kapi.Node, nicIP string) error {
 	subnet, err := util.ParseNodeHostSubnetAnnotation(node)
 	if err != nil {
 		return fmt.Errorf("failed to get interface IP address for %s (%v)",
-			util.GetK8sMgmtIntfName(node.Name), err)
+			util.K8sMgmtIntfName, err)
 	}
 	_, secondIP := util.GetNodeWellKnownAddresses(subnet)
 	prefix := strings.Split(nicIP, "/")[0] + "/32"

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -9,6 +9,11 @@ import (
 	"k8s.io/klog"
 )
 
+// K8sMgmtIntfName name to be used as an OVS internal port on the node
+const (
+	K8sMgmtIntfName = "ovn-k8s-mp0"
+)
+
 // StringArg gets the named command-line argument or returns an error if it is empty
 func StringArg(context *cli.Context, name string) (string, error) {
 	val := context.String(name)
@@ -18,9 +23,8 @@ func StringArg(context *cli.Context, name string) (string, error) {
 	return val, nil
 }
 
-// GetK8sMgmtIntfName returns the correct length interface name to be used
-// as an OVS internal port on the node
-func GetK8sMgmtIntfName(nodeName string) string {
+// GetLegacyK8sMgmtIntfName returns legacy management ovs-port name
+func GetLegacyK8sMgmtIntfName(nodeName string) string {
 	if len(nodeName) > 11 {
 		return "k8s-" + (nodeName[:11])
 	}


### PR DESCRIPTION
Note: the logical port name is still going to be k8s-<hostname>, just
that the physical port on every k8s node is going to be ovn-k8s-mp0

see: https://groups.google.com/forum/#!topic/ovn-kubernetes/Q9E5FMXC2GM

@danwinship @dcbw PTAL