### PR TITLE
refactor Link{Addr|Route}Add API and add Link{Route|Neigh}Exists API

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -179,8 +179,10 @@ func initLocalnetGateway(nodeName string, subnet string, wf *factory.WatchFactor
 		return err
 	}
 
-	// Flush IPv4 address of localnetBridgeNextHop and set with an IP address.
-	err = util.LinkAddrAdd(link, localnetGatewayNextHopSubnet())
+	// Flush any addresses on localnetBridgeNextHopPort and add the new IP address.
+	if err = util.LinkAddrFlush(link); err == nil {
+		err = util.LinkAddrAdd(link, localnetGatewayNextHopSubnet())
+	}
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/vishvananda/netlink"
 )
@@ -23,8 +24,8 @@ func LinkSetUp(interfaceName string) (netlink.Link, error) {
 	return link, nil
 }
 
-// LinkAddrAdd removes existing addresses on the link and adds the new address
-func LinkAddrAdd(link netlink.Link, address string) error {
+// LinkAddrFlush flushes all the addresses on the given link
+func LinkAddrFlush(link netlink.Link) error {
 	addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
 	if err != nil {
 		return fmt.Errorf("failed to list addresses for the link %s: %v", link.Attrs().Name, err)
@@ -32,10 +33,15 @@ func LinkAddrAdd(link netlink.Link, address string) error {
 	for _, addr := range addrs {
 		err = netlink.AddrDel(link, &addr)
 		if err != nil {
-			return fmt.Errorf("failed to delete address on link %s: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to delete address %s on link %s: %v",
+				addr.IP.String(), link.Attrs().Name, err)
 		}
 	}
+	return nil
+}
 
+// LinkAddrAdd removes existing addresses on the link and adds the new address
+func LinkAddrAdd(link netlink.Link, address string) error {
 	ipnet, err := netlink.ParseIPNet(address)
 	if err != nil {
 		return fmt.Errorf("failed to parse ip %s :%v\n", address, err)
@@ -47,33 +53,38 @@ func LinkAddrAdd(link netlink.Link, address string) error {
 	return nil
 }
 
-// LinkRouteAdd flushes any existing routes for given subnet and adds a new route
-// for that subnet through the gwIPstr
-func LinkRouteAdd(link netlink.Link, gwIPstr string, subnets []string) error {
+// LinkRoutesDel deletes all the routes for the given subnets via the link
+func LinkRoutesDel(link netlink.Link, subnets []string) error {
+	routes, err := netlink.RouteList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		return fmt.Errorf("failed to get all the routes for link %s: %v",
+			link.Attrs().Name, err)
+	}
+	for _, subnet := range subnets {
+		for _, route := range routes {
+			if route.Dst.String() == subnet {
+				err = netlink.RouteDel(&route)
+				if err != nil {
+					return fmt.Errorf("failed to delete route '%s via %s' for link %s : %v\n",
+						route.Dst.String(), route.Gw.String(), link.Attrs().Name, err)
+				}
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// LinkRoutesAdd adds a new route for given subnets through the gwIPstr
+func LinkRoutesAdd(link netlink.Link, gwIPstr string, subnets []string) error {
 	gwIP := net.ParseIP(gwIPstr)
 	if gwIP == nil {
 		return fmt.Errorf("gateway IP %s is not a valid IPv4 or IPv6 address", gwIPstr)
-	}
-	family := netlink.FAMILY_V4
-	if gwIP.To4() == nil {
-		family = netlink.FAMILY_V6
 	}
 	for _, subnet := range subnets {
 		dstIPnet, err := netlink.ParseIPNet(subnet)
 		if err != nil {
 			return fmt.Errorf("failed to parse subnet %s :%v\n", subnet, err)
-		}
-		routeFilter := &netlink.Route{Dst: dstIPnet}
-		filterMask := netlink.RT_FILTER_DST
-		routes, err := netlink.RouteListFiltered(family, routeFilter, filterMask)
-		if err != nil {
-			return fmt.Errorf("failed to get the list of routes for subnet %s", subnet)
-		}
-		for _, route := range routes {
-			err = netlink.RouteDel(&route)
-			if err != nil {
-				return fmt.Errorf("failed to delete route for subnet %s : %v\n", subnet, err)
-			}
 		}
 		route := &netlink.Route{
 			Dst:       dstIPnet,
@@ -93,7 +104,36 @@ func LinkRouteAdd(link netlink.Link, gwIPstr string, subnets []string) error {
 	return nil
 }
 
-// LinkNeighAdd flushes any existing MAC/IP bindings and adds the new neighbour entries
+// LinkRouteExists checks for existence of routes for the given subnet through gwIPStr
+func LinkRouteExists(link netlink.Link, gwIPstr, subnet string) (bool, error) {
+	gwIP := net.ParseIP(gwIPstr)
+	if gwIP == nil {
+		return false, fmt.Errorf("gateway IP %s is not a valid IPv4 or IPv6 address", gwIPstr)
+	}
+	family := netlink.FAMILY_V4
+	if gwIP.To4() == nil {
+		family = netlink.FAMILY_V6
+	}
+
+	dstIPnet, err := netlink.ParseIPNet(subnet)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse subnet %s :%v\n", subnet, err)
+	}
+	routeFilter := &netlink.Route{Dst: dstIPnet}
+	filterMask := netlink.RT_FILTER_DST
+	routes, err := netlink.RouteListFiltered(family, routeFilter, filterMask)
+	if err != nil {
+		return false, fmt.Errorf("failed to get routes for subnet %s", subnet)
+	}
+	for _, route := range routes {
+		if route.Gw.String() == gwIPstr {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// LinkNeighAdd adds MAC/IP bindings for the given link
 func LinkNeighAdd(link netlink.Link, neighIPstr, neighMacstr string) error {
 	neighIP := net.ParseIP(neighIPstr)
 	if neighIP == nil {
@@ -120,4 +160,34 @@ func LinkNeighAdd(link netlink.Link, neighIPstr, neighMacstr string) error {
 		return fmt.Errorf("failed to add neighbour entry %+v: %v", neigh, err)
 	}
 	return nil
+}
+
+// LinkNeighExists checks to see if the given MAC/IP bindings exists
+func LinkNeighExists(link netlink.Link, neighIPstr, neighMacstr string) (bool, error) {
+	neighIP := net.ParseIP(neighIPstr)
+	if neighIP == nil {
+		return false, fmt.Errorf("neighbour IP %s is not a valid IPv4 or IPv6 address",
+			neighIPstr)
+	}
+
+	family := netlink.FAMILY_V4
+	if neighIP.To4() == nil {
+		family = netlink.FAMILY_V6
+	}
+
+	neighs, err := netlink.NeighList(link.Attrs().Index, family)
+	if err != nil {
+		return false, fmt.Errorf("failed to get the list of neighbour entries for link %s",
+			link.Attrs().Name)
+	}
+
+	for _, neigh := range neighs {
+		if neigh.IP.String() == neighIPstr {
+			if neigh.HardwareAddr.String() == strings.ToLower(neighMacstr) &&
+				(neigh.State&netlink.NUD_PERMANENT) == netlink.NUD_PERMANENT {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
Link{Addr|Route}Add API was deleting the existing entries and adding
the new entries. During the review it was suggested to split this into
two functions. This commit takes care of it.

It also adds two new APIs Link{Route|Neigh}Exists that will be used
by health check routines in future.

@dcbw PTAL