### PR TITLE
use utilnet.IsIPv6(), drop most uses of config.IPv6Mode

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -175,8 +176,10 @@ func (pr *PodRequest) getCNIResult(podInterfaceInfo *PodInterfaceInfo) (*current
 	}
 
 	// Build the result structure to pass back to the runtime
-	ipVersion := "6"
-	if podInterfaceInfo.IP.IP.To4() != nil {
+	var ipVersion string
+	if utilnet.IsIPv6(podInterfaceInfo.IP.IP) {
+		ipVersion = "6"
+	} else {
 		ipVersion = "4"
 	}
 	return &current.Result{

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/klog"
 
 	kexec "k8s.io/utils/exec"
+	utilnet "k8s.io/utils/net"
 )
 
 // DefaultEncapPort number used if not supplied
@@ -1078,10 +1079,7 @@ func buildDefaultConfig(cli, file *config) error {
 	}
 
 	// Determine if ovn-kubernetes is configured to run in IPv6 mode
-	IPv6Mode = false
-	if len(Default.ClusterSubnets) >= 1 && Default.ClusterSubnets[0].CIDR.IP.To4() == nil {
-		IPv6Mode = true
-	}
+	IPv6Mode = utilnet.IsIPv6(Default.ClusterSubnets[0].CIDR.IP)
 
 	// To check if any of clustersubnets is in JoinSubnet(100.64.0.0/16) range
 	var clustersubnets []*net.IPNet

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"strconv"
 	"strings"
+
+	utilnet "k8s.io/utils/net"
 )
 
 // CIDRNetworkEntry is the object that holds the definition for a single network CIDR range
@@ -41,7 +43,7 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 			return nil, err
 		}
 
-		if parsedClusterEntry.CIDR.IP.To4() == nil {
+		if utilnet.IsIPv6(parsedClusterEntry.CIDR.IP) {
 			ipv6 = true
 		}
 

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"k8s.io/klog"
+	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -63,7 +64,7 @@ loop:
 	for _, addr := range addrs {
 		switch ip := addr.(type) {
 		case *net.IPNet:
-			if ip.IP.To4() != nil {
+			if !utilnet.IsIPv6(ip.IP) {
 				ipAddress = ip.String()
 			}
 			// get the first ip address

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -385,7 +385,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				},
 				"nat": {
 					"POSTROUTING": []string{
-						"-s 169.254.33.2/24 -j MASQUERADE",
+						"-s 169.254.33.2 -j MASQUERADE",
 					},
 					"PREROUTING": []string{
 						"-j OVN-KUBE-NODEPORT",

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -4,7 +4,6 @@ package node
 
 import (
 	"fmt"
-	"k8s.io/client-go/tools/cache"
 	"net"
 	"reflect"
 	"strings"
@@ -17,15 +16,19 @@ import (
 	"k8s.io/klog"
 
 	kapi "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	utilnet "k8s.io/utils/net"
 )
 
 const (
-	v4localnetGatewayIP            = "169.254.33.2/24"
-	v4localnetGatewayNextHop       = "169.254.33.1"
-	v4localnetGatewayNextHopSubnet = "169.254.33.1/24"
-	v6localnetGatewayIP            = "fd99::2/64"
-	v6localnetGatewayNextHop       = "fd99::1"
-	v6localnetGatewayNextHopSubnet = "fd99::1/64"
+	v4localnetGatewayIP           = "169.254.33.2"
+	v4localnetGatewayNextHop      = "169.254.33.1"
+	v4localnetGatewaySubnetPrefix = "/24"
+
+	v6localnetGatewayIP           = "fd99::2"
+	v6localnetGatewayNextHop      = "fd99::1"
+	v6localnetGatewaySubnetPrefix = "/64"
+
 	// localnetGatewayNextHopPort is the name of the gateway port on the host to which all
 	// the packets leaving the OVN logical topology will be forwarded
 	localnetGatewayNextHopPort       = "ovn-k8s-gw0"
@@ -40,27 +43,6 @@ type iptRule struct {
 	table string
 	chain string
 	args  []string
-}
-
-func localnetGatewayIP() string {
-	if config.IPv6Mode {
-		return v6localnetGatewayIP
-	}
-	return v4localnetGatewayIP
-}
-
-func localnetGatewayNextHop() string {
-	if config.IPv6Mode {
-		return v6localnetGatewayNextHop
-	}
-	return v4localnetGatewayNextHop
-}
-
-func localnetGatewayNextHopSubnet() string {
-	if config.IPv6Mode {
-		return v6localnetGatewayNextHopSubnet
-	}
-	return v4localnetGatewayNextHopSubnet
 }
 
 func ensureChain(ipt util.IPTablesHelper, table, chain string) error {
@@ -140,11 +122,6 @@ func localnetGatewayNAT(ipt util.IPTablesHelper, ifname, ip string) error {
 }
 
 func initLocalnetGateway(nodeName string, subnet string, wf *factory.WatchFactory, nodeAnnotator kube.Annotator) error {
-	ipt, err := localnetIPTablesHelper()
-	if err != nil {
-		return err
-	}
-
 	// Create a localnet OVS bridge.
 	localnetBridgeName := "br-local"
 	_, stderr, err := util.RunOVSVsctl("--may-exist", "add-br",
@@ -179,45 +156,76 @@ func initLocalnetGateway(nodeName string, subnet string, wf *factory.WatchFactor
 		return err
 	}
 
+	var gatewayIP, gatewayNextHop, gatewaySubnetPrefix string
+	if utilnet.IsIPv6CIDRString(subnet) {
+		gatewayIP = v6localnetGatewayIP
+		gatewayNextHop = v6localnetGatewayNextHop
+		gatewaySubnetPrefix = v6localnetGatewaySubnetPrefix
+	} else {
+		gatewayIP = v4localnetGatewayIP
+		gatewayNextHop = v4localnetGatewayNextHop
+		gatewaySubnetPrefix = v4localnetGatewaySubnetPrefix
+	}
+
 	// Flush any addresses on localnetBridgeNextHopPort and add the new IP address.
 	if err = util.LinkAddrFlush(link); err == nil {
-		err = util.LinkAddrAdd(link, localnetGatewayNextHopSubnet())
+		err = util.LinkAddrAdd(link, gatewayNextHop+gatewaySubnetPrefix)
 	}
 	if err != nil {
 		return err
 	}
 
 	err = util.SetLocalL3GatewayConfig(nodeAnnotator, ifaceID, macAddress,
-		localnetGatewayIP(), localnetGatewayNextHop(),
+		gatewayIP+gatewaySubnetPrefix, gatewayNextHop,
 		config.Gateway.NodeportEnable)
 	if err != nil {
 		return err
 	}
 
-	if config.IPv6Mode {
+	if utilnet.IsIPv6CIDRString(subnet) {
 		// TODO - IPv6 hack ... for some reason neighbor discovery isn't working here, so hard code a
 		// MAC binding for the gateway IP address for now - need to debug this further
-		err = util.LinkNeighAdd(link, "fd99::2", macAddress)
+		err = util.LinkNeighAdd(link, gatewayIP, macAddress)
 		if err == nil {
-			klog.Infof("Added MAC binding for fd99::2 on %s", localnetGatewayNextHopPort)
+			klog.Infof("Added MAC binding for %s on %s", gatewayIP, localnetGatewayNextHopPort)
 		} else {
-			klog.Errorf("Error in adding MAC binding for fd99::2 on %s: %v", localnetGatewayNextHopPort, err)
+			klog.Errorf("Error in adding MAC binding for %s on %s: %v", gatewayIP, localnetGatewayNextHopPort, err)
 		}
 	}
 
-	err = localnetGatewayNAT(ipt, localnetGatewayNextHopPort, localnetGatewayIP())
+	ipt, err := localnetIPTablesHelper(subnet)
+	if err != nil {
+		return err
+	}
+
+	err = localnetGatewayNAT(ipt, localnetGatewayNextHopPort, gatewayIP)
 	if err != nil {
 		return fmt.Errorf("Failed to add NAT rules for localnet gateway (%v)", err)
 	}
 
 	if config.Gateway.NodeportEnable {
-		err = localnetNodePortWatcher(ipt, wf)
+		err = localnetNodePortWatcher(ipt, wf, gatewayIP)
 	}
 
 	return err
 }
 
-func localnetIptRules(svc *kapi.Service) []iptRule {
+// localnetIPTablesHelper gets an IPTablesHelper for IPv4 or IPv6 as appropriate
+func localnetIPTablesHelper(subnet string) (util.IPTablesHelper, error) {
+	var ipt util.IPTablesHelper
+	var err error
+	if utilnet.IsIPv6CIDRString(subnet) {
+		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv6)
+	} else {
+		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv4)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize iptables: %v", err)
+	}
+	return ipt, nil
+}
+
+func localnetIptRules(svc *kapi.Service, gatewayIP string) []iptRule {
 	rules := make([]iptRule, 0)
 	for _, svcPort := range svc.Spec.Ports {
 		protocol := svcPort.Protocol
@@ -229,62 +237,48 @@ func localnetIptRules(svc *kapi.Service) []iptRule {
 		rules = append(rules, iptRule{
 			table: "nat",
 			chain: iptableNodePortChain,
-			args: []string{"-p", string(protocol), "--dport", nodePort, "-j", "DNAT", "--to-destination",
-				net.JoinHostPort(strings.Split(localnetGatewayIP(), "/")[0], nodePort)},
+			args: []string{
+				"-p", string(protocol), "--dport", nodePort,
+				"-j", "DNAT", "--to-destination", net.JoinHostPort(gatewayIP, nodePort),
+			},
 		})
 		rules = append(rules, iptRule{
 			table: "filter",
 			chain: iptableNodePortChain,
-			args:  []string{"-p", string(protocol), "--dport", nodePort, "-j", "ACCEPT"},
+			args: []string{
+				"-p", string(protocol), "--dport", nodePort,
+				"-j", "ACCEPT",
+			},
 		})
 	}
 	return rules
 }
 
-// localnetIPTablesHelper gets an IPTablesHelper for IPv4 or IPv6 as appropriate
-func localnetIPTablesHelper() (util.IPTablesHelper, error) {
-	var ipt util.IPTablesHelper
-	var err error
-	if config.IPv6Mode {
-		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv6)
-	} else {
-		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv4)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize iptables: %v", err)
-	}
-	return ipt, nil
+type localnetNodePortWatcherData struct {
+	ipt       util.IPTablesHelper
+	gatewayIP string
 }
 
-// AddService adds service and creates corresponding resources in OVN
-func localnetAddService(svc *kapi.Service) error {
+func (npw *localnetNodePortWatcherData) addService(svc *kapi.Service) error {
 	if !util.ServiceTypeHasNodePort(svc) {
 		return nil
 	}
-	ipt, err := localnetIPTablesHelper()
-	if err != nil {
-		return err
-	}
-	rules := localnetIptRules(svc)
+	rules := localnetIptRules(svc, npw.gatewayIP)
 	klog.V(5).Infof("Add rules %v for service %v", rules, svc.Name)
-	return addIptRules(ipt, rules)
+	return addIptRules(npw.ipt, rules)
 }
 
-func localnetDeleteService(svc *kapi.Service) error {
+func (npw *localnetNodePortWatcherData) deleteService(svc *kapi.Service) error {
 	if !util.ServiceTypeHasNodePort(svc) {
 		return nil
 	}
-	ipt, err := localnetIPTablesHelper()
-	if err != nil {
-		return err
-	}
-	rules := localnetIptRules(svc)
+	rules := localnetIptRules(svc, npw.gatewayIP)
 	klog.V(5).Infof("Delete rules %v for service %v", rules, svc.Name)
-	delIptRules(ipt, rules)
+	delIptRules(npw.ipt, rules)
 	return nil
 }
 
-func localnetNodePortWatcher(ipt util.IPTablesHelper, wf *factory.WatchFactory) error {
+func localnetNodePortWatcher(ipt util.IPTablesHelper, wf *factory.WatchFactory, gatewayIP string) error {
 	// delete all the existing OVN-NODEPORT rules
 	// TODO: Add a localnetSyncService method to remove the stale entries only
 	_ = ipt.ClearChain("nat", iptableNodePortChain)
@@ -311,10 +305,11 @@ func localnetNodePortWatcher(ipt util.IPTablesHelper, wf *factory.WatchFactory) 
 		return err
 	}
 
+	npw := &localnetNodePortWatcherData{ipt: ipt, gatewayIP: gatewayIP}
 	_, err := wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			svc := obj.(*kapi.Service)
-			err := localnetAddService(svc)
+			err := npw.addService(svc)
 			if err != nil {
 				klog.Errorf("Error in adding service: %v", err)
 			}
@@ -325,18 +320,18 @@ func localnetNodePortWatcher(ipt util.IPTablesHelper, wf *factory.WatchFactory) 
 			if reflect.DeepEqual(svcNew.Spec, svcOld.Spec) {
 				return
 			}
-			err := localnetDeleteService(svcOld)
+			err := npw.deleteService(svcOld)
 			if err != nil {
 				klog.Errorf("Error in deleting service - %v", err)
 			}
-			err = localnetAddService(svcNew)
+			err = npw.addService(svcNew)
 			if err != nil {
 				klog.Errorf("Error in modifying service: %v", err)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			svc := obj.(*kapi.Service)
-			err := localnetDeleteService(svc)
+			err := npw.deleteService(svc)
 			if err != nil {
 				klog.Errorf("Error in deleting service - %v", err)
 			}

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -11,7 +11,9 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	"k8s.io/klog"
+	utilnet "k8s.io/utils/net"
 )
 
 const (
@@ -80,10 +82,10 @@ func addMgtPortIptRules(ifname, interfaceIP string) error {
 	}
 	var ipt util.IPTablesHelper
 	var err error
-	if ip.To4() != nil {
-		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv4)
-	} else {
+	if utilnet.IsIPv6(ip) {
 		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv6)
+	} else {
+		ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv4)
 	}
 	if err != nil {
 		return err

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -91,7 +92,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 
 	iptProto := iptables.ProtocolIPv4
 	family := netlink.FAMILY_V4
-	if nsIP.To4() == nil {
+	if utilnet.IsIPv6(nsIP) {
 		iptProto = iptables.ProtocolIPv6
 		family = netlink.FAMILY_V6
 	}

--- a/go-controller/pkg/ovn/allocator/allocator.go
+++ b/go-controller/pkg/ovn/allocator/allocator.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 	"sync"
+
+	utilnet "k8s.io/utils/net"
 )
 
 var ErrSubnetAllocatorFull = fmt.Errorf("no subnets available.")
@@ -32,10 +34,10 @@ func (sna *SubnetAllocator) AddNetworkRange(network string, hostBits uint32) err
 		return err
 	}
 
-	if snr.network.IP.To4() != nil {
-		sna.v4ranges = append(sna.v4ranges, snr)
-	} else {
+	if utilnet.IsIPv6(snr.network.IP) {
 		sna.v6ranges = append(sna.v6ranges, snr)
+	} else {
+		sna.v4ranges = append(sna.v4ranges, snr)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -10,6 +10,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog"
+	utilnet "k8s.io/utils/net"
 )
 
 func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string,
@@ -183,10 +184,10 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb string, serviceIP string, 
 	}
 	var aclMatch string
 	var l3Prefix string
-	if ip.To4() != nil {
-		l3Prefix = "ip4"
-	} else {
+	if utilnet.IsIPv6(ip) {
 		l3Prefix = "ip6"
+	} else {
+		l3Prefix = "ip4"
 	}
 	vip := util.JoinHostPortInt32(serviceIP, port)
 	aclName := fmt.Sprintf("%s-%s", lb, vip)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -11,11 +11,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
+	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-
-	"k8s.io/klog"
 )
 
 const (
@@ -372,7 +372,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 
 		// Configure querier only if we have an IPv4 address, otherwise
 		// disable querier.
-		if firstIP.IP.To4() != nil {
+		if !utilnet.IsIPv6(firstIP.IP) {
 			stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
 				nodeName, "other-config:mcast_querier=\"true\"",
 				"other-config:mcast_eth_src=\""+nodeLRPMac+"\"",

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 
 	"k8s.io/klog"
-
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	utilnet "k8s.io/utils/net"
 )
 
 const (
@@ -297,7 +296,7 @@ func GatewayInit(clusterIPSubnet []string, hostSubnet string, joinSubnet *net.IP
 
 	// Add a static route in GR with physical gateway as the default next hop.
 	var allIPs string
-	if config.IPv6Mode {
+	if utilnet.IsIPv6(l3GatewayConfig.NextHop) {
 		allIPs = "::/0"
 	} else {
 		allIPs = "0.0.0.0/0"

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/vishvananda/netlink"
+
+	utilnet "k8s.io/utils/net"
 )
 
 // LinkSetUp returns the netlink device with its state marked up
@@ -111,7 +113,7 @@ func LinkRouteExists(link netlink.Link, gwIPstr, subnet string) (bool, error) {
 		return false, fmt.Errorf("gateway IP %s is not a valid IPv4 or IPv6 address", gwIPstr)
 	}
 	family := netlink.FAMILY_V4
-	if gwIP.To4() == nil {
+	if utilnet.IsIPv6(gwIP) {
 		family = netlink.FAMILY_V6
 	}
 
@@ -145,7 +147,7 @@ func LinkNeighAdd(link netlink.Link, neighIPstr, neighMacstr string) error {
 	}
 
 	family := netlink.FAMILY_V4
-	if neighIP.To4() == nil {
+	if utilnet.IsIPv6(neighIP) {
 		family = netlink.FAMILY_V6
 	}
 	neigh := &netlink.Neigh{
@@ -171,7 +173,7 @@ func LinkNeighExists(link netlink.Link, neighIPstr, neighMacstr string) (bool, e
 	}
 
 	family := netlink.FAMILY_V4
-	if neighIP.To4() == nil {
+	if utilnet.IsIPv6(neighIP) {
 		family = netlink.FAMILY_V6
 	}
 

--- a/go-controller/vendor/k8s.io/utils/net/ipnet.go
+++ b/go-controller/vendor/k8s.io/utils/net/ipnet.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"net"
+	"strings"
+)
+
+// IPNetSet maps string to net.IPNet.
+type IPNetSet map[string]*net.IPNet
+
+// ParseIPNets parses string slice to IPNetSet.
+func ParseIPNets(specs ...string) (IPNetSet, error) {
+	ipnetset := make(IPNetSet)
+	for _, spec := range specs {
+		spec = strings.TrimSpace(spec)
+		_, ipnet, err := net.ParseCIDR(spec)
+		if err != nil {
+			return nil, err
+		}
+		k := ipnet.String() // In case of normalization
+		ipnetset[k] = ipnet
+	}
+	return ipnetset, nil
+}
+
+// Insert adds items to the set.
+func (s IPNetSet) Insert(items ...*net.IPNet) {
+	for _, item := range items {
+		s[item.String()] = item
+	}
+}
+
+// Delete removes all items from the set.
+func (s IPNetSet) Delete(items ...*net.IPNet) {
+	for _, item := range items {
+		delete(s, item.String())
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s IPNetSet) Has(item *net.IPNet) bool {
+	_, contained := s[item.String()]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s IPNetSet) HasAll(items ...*net.IPNet) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s IPNetSet) Difference(s2 IPNetSet) IPNetSet {
+	result := make(IPNetSet)
+	for k, i := range s {
+		_, found := s2[k]
+		if found {
+			continue
+		}
+		result[k] = i
+	}
+	return result
+}
+
+// StringSlice returns a []string with the String representation of each element in the set.
+// Order is undefined.
+func (s IPNetSet) StringSlice() []string {
+	a := make([]string, 0, len(s))
+	for k := range s {
+		a = append(a, k)
+	}
+	return a
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s IPNetSet) IsSuperset(s2 IPNetSet) bool {
+	for k := range s2 {
+		_, found := s[k]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s IPNetSet) Equal(s2 IPNetSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
+}
+
+// Len returns the size of the set.
+func (s IPNetSet) Len() int {
+	return len(s)
+}

--- a/go-controller/vendor/k8s.io/utils/net/net.go
+++ b/go-controller/vendor/k8s.io/utils/net/net.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"strconv"
+)
+
+// ParseCIDRs parses a list of cidrs and return error if any is invalid.
+// order is maintained
+func ParseCIDRs(cidrsString []string) ([]*net.IPNet, error) {
+	cidrs := make([]*net.IPNet, 0, len(cidrsString))
+	for _, cidrString := range cidrsString {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cidr value:%q with error:%v", cidrString, err)
+		}
+		cidrs = append(cidrs, cidr)
+	}
+	return cidrs, nil
+}
+
+// IsDualStackIPs returns if a slice of ips is:
+// - all are valid ips
+// - at least one ip from each family (v4 or v6)
+func IsDualStackIPs(ips []net.IP) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for _, ip := range ips {
+		if ip == nil {
+			return false, fmt.Errorf("ip %v is invalid", ip)
+		}
+
+		if v4Found && v6Found {
+			continue
+		}
+
+		if IsIPv6(ip) {
+			v6Found = true
+			continue
+		}
+
+		v4Found = true
+	}
+
+	return (v4Found && v6Found), nil
+}
+
+// IsDualStackIPStrings returns if
+// - all are valid ips
+// - at least one ip from each family (v4 or v6)
+func IsDualStackIPStrings(ips []string) (bool, error) {
+	parsedIPs := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		parsedIP := net.ParseIP(ip)
+		parsedIPs = append(parsedIPs, parsedIP)
+	}
+	return IsDualStackIPs(parsedIPs)
+}
+
+// IsDualStackCIDRs returns if
+// - all are valid cidrs
+// - at least one cidr from each family (v4 or v6)
+func IsDualStackCIDRs(cidrs []*net.IPNet) (bool, error) {
+	v4Found := false
+	v6Found := false
+	for _, cidr := range cidrs {
+		if cidr == nil {
+			return false, fmt.Errorf("cidr %v is invalid", cidr)
+		}
+
+		if v4Found && v6Found {
+			continue
+		}
+
+		if IsIPv6(cidr.IP) {
+			v6Found = true
+			continue
+		}
+		v4Found = true
+	}
+
+	return v4Found && v6Found, nil
+}
+
+// IsDualStackCIDRStrings returns if
+// - all are valid cidrs
+// - at least one cidr from each family (v4 or v6)
+func IsDualStackCIDRStrings(cidrs []string) (bool, error) {
+	parsedCIDRs, err := ParseCIDRs(cidrs)
+	if err != nil {
+		return false, err
+	}
+	return IsDualStackCIDRs(parsedCIDRs)
+}
+
+// IsIPv6 returns if netIP is IPv6.
+func IsIPv6(netIP net.IP) bool {
+	return netIP != nil && netIP.To4() == nil
+}
+
+// IsIPv6String returns if ip is IPv6.
+func IsIPv6String(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return IsIPv6(netIP)
+}
+
+// IsIPv6CIDRString returns if cidr is IPv6.
+// This assumes cidr is a valid CIDR.
+func IsIPv6CIDRString(cidr string) bool {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return IsIPv6(ip)
+}
+
+// IsIPv6CIDR returns if a cidr is ipv6
+func IsIPv6CIDR(cidr *net.IPNet) bool {
+	ip := cidr.IP
+	return IsIPv6(ip)
+}
+
+// ParsePort parses a string representing an IP port.  If the string is not a
+// valid port number, this returns an error.
+func ParsePort(port string, allowZero bool) (int, error) {
+	portInt, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return 0, err
+	}
+	if portInt == 0 && !allowZero {
+		return 0, errors.New("0 is not a valid port number")
+	}
+	return int(portInt), nil
+}
+
+// BigForIP creates a big.Int based on the provided net.IP
+func BigForIP(ip net.IP) *big.Int {
+	b := ip.To4()
+	if b == nil {
+		b = ip.To16()
+	}
+	return big.NewInt(0).SetBytes(b)
+}
+
+// AddIPOffset adds the provided integer offset to a base big.Int representing a
+// net.IP
+func AddIPOffset(base *big.Int, offset int) net.IP {
+	return net.IP(big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes())
+}
+
+// RangeSize returns the size of a range in valid addresses.
+// returns the size of the subnet (or math.MaxInt64 if the range size would overflow int64)
+func RangeSize(subnet *net.IPNet) int64 {
+	ones, bits := subnet.Mask.Size()
+	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
+		return 0
+	}
+	// this checks that we are not overflowing an int64
+	if bits-ones >= 63 {
+		return math.MaxInt64
+	}
+	return int64(1) << uint(bits-ones)
+}
+
+// GetIndexedIP returns a net.IP that is subnet.IP + index in the contiguous IP space.
+func GetIndexedIP(subnet *net.IPNet, index int) (net.IP, error) {
+	ip := AddIPOffset(BigForIP(subnet.IP), index)
+	if !subnet.Contains(ip) {
+		return nil, fmt.Errorf("can't generate IP with index %d from subnet. subnet too small. subnet: %q", index, subnet)
+	}
+	return ip, nil
+}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -521,10 +521,11 @@ k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/utils v0.0.0-20191030222137-2b95a09bc58d
+k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/exec/testing
-k8s.io/utils/buffer
-k8s.io/utils/trace
 k8s.io/utils/integer
+k8s.io/utils/net
+k8s.io/utils/trace
 # sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml


### PR DESCRIPTION
In a dual-stack world, code needs to decide whether to do IPv4-ish stuff or IPv6-ish stuff based on what sort of addresses it's actually working with, not based on a global switch. So this mostly moves us to that. (There are a few remaining uses of `config.IPv6Mode` which will be dealt with later.)

As part of this, I also switched some code to use `IsIPv6()/IsIPv6String()/IsIPv6CIDR()/IsIPv6CIDRString()` from `k8s.io/utils/net` rather than confusingly fiddling with `ip.To4() == nil` / `!= nil`, etc.

oh, also, the localnet code was previously adding an iptables rule

    -t nat -A POSTROUTING -s 169.254.33.2/24 -j MASQUERADE

which is technically invalid; the address should be either `169.254.33.2/32` or `169.254.33.0/24`. iptables interprets it as the latter, but I'm pretty sure we meant the former and this patch changes it to that. (The change is mostly cosmetic, other than that previously we would have been NATting both 169.254.33.2 and 169.254.33.1, but there shouldn't have been any traffic from the latter anyway.)