### PR TITLE
build: bump lint timeout to 10 mintues

### DIFF
--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -2,5 +2,5 @@
 
 GO111MODULE=on ${GOPATH}/bin/golangci-lint run \
     --tests=false --enable gofmt \
-    --timeout=8m0s \
+    --timeout=10m0s \
     && echo "lint OK!"


### PR DESCRIPTION
We've had this downstream in OpenShift ovn-kubernetes for a while.

@girishmg