### PR TITLE
define the missing database variable

### DIFF
--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -94,6 +94,10 @@ ovsdb-raft () {
   ovn_db_pidfile=${OVN_RUNDIR}/ovn${db}_db.pid
   eval ovn_log_db=\$ovn_log_${db}
   ovn_db_file=${OVN_ETCDIR}/ovn${db}_db.db
+  database="OVN_Northbound"
+  if [[ ${db} == "sb" ]]; then
+    database="OVN_Southbound"
+  fi
 
   rm -f ${ovn_db_pidfile}
   verify-ovsdb-raft


### PR DESCRIPTION
while cherry picking the changes from my internal repo to upstream repo
I missed adding the database variable

Fixes: 5e98a62ab047 (use 'ovsdb-client wait' to check the running state
of OVN DB servers)