### PR TITLE
fix up config for dual-stack, add dual-stack service CIDRs

### DIFF
--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -99,16 +100,28 @@ type configSubnet struct {
 // configSubnets represets a set of configured subnets (and their names)
 type configSubnets struct {
 	subnets []configSubnet
+	v4      map[configSubnetType]bool
+	v6      map[configSubnetType]bool
 }
 
 // newConfigSubnets returns a new configSubnets
 func newConfigSubnets() *configSubnets {
-	return &configSubnets{}
+	return &configSubnets{
+		v4: make(map[configSubnetType]bool),
+		v6: make(map[configSubnetType]bool),
+	}
 }
 
 // append adds a single subnet to cs
 func (cs *configSubnets) append(subnetType configSubnetType, subnet *net.IPNet) {
 	cs.subnets = append(cs.subnets, configSubnet{subnetType: subnetType, subnet: subnet})
+	if subnetType != configSubnetJoin {
+		if utilnet.IsIPv6CIDR(subnet) {
+			cs.v6[subnetType] = true
+		} else {
+			cs.v4[subnetType] = true
+		}
+	}
 }
 
 // appendConst adds a single subnet to cs; it will panic if subnetStr is not a valid CIDR
@@ -134,4 +147,45 @@ func (cs *configSubnets) checkForOverlaps() error {
 		}
 	}
 	return nil
+}
+
+func (cs *configSubnets) describeSubnetType(subnetType configSubnetType) string {
+	ipv4 := cs.v4[subnetType]
+	ipv6 := cs.v6[subnetType]
+	var familyType string
+	switch {
+	case ipv4 && !ipv6:
+		familyType = "IPv4"
+	case !ipv4 && ipv6:
+		familyType = "IPv6"
+	case ipv4 && ipv6:
+		familyType = "dual-stack"
+	default:
+		familyType = "unknown type"
+	}
+	return familyType + " " + string(subnetType)
+}
+
+// checkIPFamilies determines if cs contains a valid single-stack IPv4 configuration, a
+// valid single-stack IPv6 configuration, a valid dual-stack configuration, or none of the
+// above.
+func (cs *configSubnets) checkIPFamilies() (usingIPv4, usingIPv6 bool, err error) {
+	if len(cs.v6) == 0 {
+		// Single-stack IPv4
+		return true, false, nil
+	} else if len(cs.v4) == 0 {
+		// Single-stack IPv6
+		return false, true, nil
+	} else if reflect.DeepEqual(cs.v4, cs.v6) {
+		// Dual-stack
+		return true, true, nil
+	}
+
+	netConfig := cs.describeSubnetType(configSubnetCluster)
+	netConfig += ", " + cs.describeSubnetType(configSubnetService)
+	if cs.v4[configSubnetHybrid] || cs.v6[configSubnetHybrid] {
+		netConfig += ", " + cs.describeSubnetType(configSubnetHybrid)
+	}
+
+	return false, false, fmt.Errorf("illegal network configuration: %s", netConfig)
 }

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -49,7 +49,9 @@ func newManagementPortConfig(interfaceName, interfaceIP, routerIP, routerMAC str
 	for _, subnet := range config.Default.ClusterSubnets {
 		cfg.allSubnets = append(cfg.allSubnets, subnet.CIDR.String())
 	}
-	cfg.allSubnets = append(cfg.allSubnets, config.Kubernetes.ServiceCIDR)
+	for _, subnet := range config.Kubernetes.ServiceCIDRs {
+		cfg.allSubnets = append(cfg.allSubnets, subnet.String())
+	}
 
 	cfg.ifIP = strings.Split(cfg.ifIPMask, "/")[0]
 	if utilnet.IsIPv6(net.ParseIP(cfg.ifIP)) {
@@ -107,7 +109,7 @@ func setupManagementPortConfig(cfg *managementPortConfig) ([]string, error) {
 			if err != nil {
 				if os.IsExist(err) {
 					klog.V(5).Infof("Ignoring error %s from 'route add %s via %s' - already added via IPv6 RA?",
-						err.Error(), config.Kubernetes.ServiceCIDR, cfg.routerIP)
+						err.Error(), subnet, cfg.routerIP)
 					continue
 				}
 			}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -177,6 +177,12 @@ func getRoutesGatewayIP(pod *kapi.Pod, gatewayIPnet *net.IPNet) ([]util.PodRoute
 			route.NextHop = gatewayIPnet.IP
 			routes = append(routes, route)
 		}
+		for _, serviceSubnet := range config.Kubernetes.ServiceCIDRs {
+			var route util.PodRoute
+			route.Dest = serviceSubnet
+			route.NextHop = gatewayIPnet.IP
+			routes = append(routes, route)
+		}
 	} else {
 		gatewayIP = gatewayIPnet.IP
 	}


### PR DESCRIPTION
This builds on #1185; the last two commits ("`config: abstract CIDR-overlap-checking`" and "`config: allow multiple service CIDRs`") are new. You can review the PRs separately or review it all here...

The effects of the new commits are:
- `--k8s-service-cidr` and the `service-cidr` config file option are now deprecated in favor of `--k8s-service-cidrs` / `service-cidrs`, which allow a comma-separated list of CIDRs. This is similar to what kube-apiserver does now, and like kube-apiserver we currently require that the "list" is either a single element, or else an IPv4/IPv6 pair (while holding open the possibility that we might allow arbitrary multiple service CIDRs in the future).
- We validate that cluster-subnets and service-cidrs are valid together (ie, both single-stack ipv4, both single-stack ipv6, or both dual-stack), which we weren't previously checking.
- `config.IPv6Mode` now means "we are using IPv6 at all", not "we are using IPv6 exclusively", and is paired with `config.IPv4Mode`.
- If you configure dual-stack (or in fact, just "multiple") service CIDRs, we add routes for all of them on the management port.
- If you have a network attachment that declares a default route, we now add an explicit route to the service subnet(s) to each pod, in addition to the existing code adding routes to the cluster subnet(s). (I'm assuming the fact that we weren't doing this before is an oversight.)

This does not add any further support for actually implementing the dual-stack configurations that it now explicitly allows, but due to the lack of sanity-checking before that's not really a regression...

@dcbw @girishmg 