### PR TITLE
identify default flows with 0xdeffl05 cookie and add healthcheck for it

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -109,8 +109,7 @@ func (n *OvnNode) initGateway(subnet string, nodeAnnotator kube.Annotator,
 				gatewayIntf = defaultGatewayIntf
 			}
 		}
-		prFn, err = initSharedGateway(n.name, subnet, gatewayNextHop, gatewayIntf,
-			n.watchFactory, nodeAnnotator)
+		prFn, err = n.initSharedGateway(subnet, gatewayNextHop, gatewayIntf, nodeAnnotator)
 	case config.GatewayModeDisabled:
 		err = util.SetDisabledL3GatewayConfig(nodeAnnotator)
 	}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -119,11 +119,14 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: "7",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-ofctl add-flow breth0 priority=100, in_port=5, ip, actions=ct(commit, zone=64000), output:7",
-			"ovs-ofctl add-flow breth0 priority=50, in_port=7, ip, actions=ct(zone=64000, table=1)",
-			"ovs-ofctl add-flow breth0 priority=100, table=1, ct_state=+trk+est, actions=output:5",
-			"ovs-ofctl add-flow breth0 priority=100, table=1, ct_state=+trk+rel, actions=output:5",
-			"ovs-ofctl add-flow breth0 priority=0, table=1, actions=output:NORMAL",
+			"ovs-ofctl -O OpenFlow13 replace-flows breth0 -",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, in_port=5, ip, actions=ct(commit, zone=64000), output:7",
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=50, in_port=7, ip, actions=ct(zone=64000, table=1)",
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, table=1, ct_state=+trk+est, actions=output:5",
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, table=1, ct_state=+trk+rel, actions=output:5",
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=1, actions=output:NORMAL",
 		})
 		// nodePortWatcher()
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{


### PR DESCRIPTION
in the shared gateway mode, we share the host's k8s node ip for SNATing.
we add default set of 'five' flows to steer the nodeport traffic into
the OVN logical topology and to also connection track the l3 gateway
north-south traffic

these flows are very critical and if they are missing for whatever
reason, then that node is not functional. so, we need to add check for
it and take corrective action (for now just kill the ovnkube daemon
so that it restarts with right flows).

@dcbw PTAL
(Note: this commit is based of PR  #1184)