### PR TITLE
Raft orchestration configuration settings

### DIFF
--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -89,6 +89,7 @@ ovsdb-raft () {
 
   local db=${1}
   local port=${2}
+  local raft_port=${3}
   local initialize="false"
 
   ovn_db_pidfile=${OVN_RUNDIR}/ovn${db}_db.pid
@@ -114,7 +115,9 @@ ovsdb-raft () {
   if [[ "${POD_NAME}" == "ovnkube-db-0" ]]; then
     run_as_ovs_user_if_needed \
       ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
-      --db-${db}-cluster-local-addr=${local_ip} --ovn-${db}-log="${ovn_log_db}" &
+      --db-${db}-cluster-local-addr=${local_ip} \
+      --db-${db}-cluster-local-port=${raft_port} \
+      --ovn-${db}-log="${ovn_log_db}" &
   else
     # join the remote cluster node if the DB is not created
     if [[ "${initialize}" == "true" ]]; then
@@ -123,6 +126,7 @@ ovsdb-raft () {
     run_as_ovs_user_if_needed \
       ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
       --db-${db}-cluster-local-addr=${local_ip} --db-${db}-cluster-remote-addr=${init_ip} \
+      --db-${db}-cluster-local-port=${raft_port} --db-${db}-cluster-remote-port=${raft_port} \
       --ovn-${db}-log="${ovn_log_db}" &
   fi
 

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -608,6 +608,8 @@ nb-ovsdb () {
   wait_for_event attempts=3 process_ready ovnnb_db
   echo "=============== nb-ovsdb ========== RUNNING"
 
+  # setting northd probe interval
+  set_northd_probe_interval
   ovn-nbctl set-connection ptcp:${ovn_nb_port}:${ovn_db_host} -- set connection . inactivity_probe=0
 
   tail --follow=name ${OVN_LOGDIR}/ovsdb-server-nb.log &

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -127,6 +127,10 @@ ovn_db_host=$(getent ahostsv4 $(hostname) | grep -v "^127\." | head -1 | awk '{ 
 ovn_nb_port=${OVN_NB_PORT:-6641}
 # OVN_SB_PORT - ovn south db port (default 6642)
 ovn_sb_port=${OVN_SB_PORT:-6642}
+# OVN_NB_RAFT_PORT - ovn north db port used for raft communication (default 6643)
+ovn_nb_raft_port=${OVN_NB_RAFT_PORT:-6643}
+# OVN_SB_RAFT_PORT - ovn south db port used for raft communication (default 6644)
+ovn_sb_raft_port=${OVN_SB_RAFT_PORT:-6644}
 # OVN_ENCAP_PORT - GENEVE UDP port (default 6081)
 ovn_encap_port=${OVN_ENCAP_PORT:-6081}
 
@@ -931,10 +935,10 @@ case ${cmd} in
 	  cleanup-ovn-node
     ;;
   "nb-ovsdb-raft")
-    ovsdb-raft nb ${ovn_nb_port}
+    ovsdb-raft nb ${ovn_nb_port} ${ovn_nb_raft_port}
     ;;
   "sb-ovsdb-raft")
-    ovsdb-raft sb ${ovn_sb_port}
+    ovsdb-raft sb ${ovn_sb_port} ${ovn_sb_raft_port}
     ;;
   "db-raft-metrics")
     db-raft-metrics

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -57,6 +57,10 @@ fi
 # OVN_LOG_NBCTLD - log level (ovn-ctl default: -vconsole:off -vfile:info)
 # OVN_NB_PORT - ovn north db port (default 6641)
 # OVN_SB_PORT - ovn south db port (default 6642)
+# OVN_NB_RAFT_PORT - ovn north db raft port (default 6643)
+# OVN_SB_RAFT_PORT - ovn south db raft port (default 6644)
+# OVN_NB_RAFT_ELECTION_TIMER - ovn north db election timer in ms (default 1000)
+# OVN_SB_RAFT_ELECTION_TIMER - ovn south db election timer in ms (default 1000)
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -133,6 +137,10 @@ ovn_nb_raft_port=${OVN_NB_RAFT_PORT:-6643}
 ovn_sb_raft_port=${OVN_SB_RAFT_PORT:-6644}
 # OVN_ENCAP_PORT - GENEVE UDP port (default 6081)
 ovn_encap_port=${OVN_ENCAP_PORT:-6081}
+# OVN_NB_RAFT_ELECTION_TIMER - ovn north db election timer in ms (default 1000)
+ovn_nb_raft_election_timer=${OVN_NB_RAFT_ELECTION_TIMER:-1000}
+# OVN_SB_RAFT_ELECTION_TIMER - ovn south db election timer in ms (default 1000)
+ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
 
 # Determine the ovn rundir.
 if [[ -f /usr/bin/ovn-appctl ]] ; then
@@ -937,10 +945,10 @@ case ${cmd} in
 	  cleanup-ovn-node
     ;;
   "nb-ovsdb-raft")
-    ovsdb-raft nb ${ovn_nb_port} ${ovn_nb_raft_port}
+    ovsdb-raft nb ${ovn_nb_port} ${ovn_nb_raft_port} ${ovn_nb_raft_election_timer}
     ;;
   "sb-ovsdb-raft")
-    ovsdb-raft sb ${ovn_sb_port} ${ovn_sb_raft_port}
+    ovsdb-raft sb ${ovn_sb_port} ${ovn_sb_raft_port} ${ovn_sb_raft_election_timer}
     ;;
   "db-raft-metrics")
     db-raft-metrics


### PR DESCRIPTION
Added following changes:

- add support to configure election timer for the clustered DB

   we have found that the default value of 1s is not sufficient at scale
    and therefore we need a way to modify this value at deploy time

- configure probe interval for {NB|SB} db connections from ovn-northd
- set passive connection and disable inactivity probe for raft reliably
    
    today, if we failed to set passive connection, then we don't re-try
    again on the pod restart since it is wrapped under `initialize=true`.
    so, we need to re-try on restart if it not set to begin with.

- add support to modify the default TCP ports for RAFT control traffic

@dcbw @danwinship PTAL