### PR TITLE
add back -O OpenFlow option to replace-flows

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -510,7 +510,7 @@ func RawExec(cmdPath string, args ...string) (string, string, error) {
 
 // AddNormalActionOFFlow replaces flows in the bridge with a NORMAL action flow
 func AddNormalActionOFFlow(bridgeName string) (string, string, error) {
-	args := []string{"replace-flows", bridgeName, "-"}
+	args := []string{"-O", "OpenFlow13", "replace-flows", bridgeName, "-"}
 
 	stdin := &bytes.Buffer{}
 	stdin.Write([]byte("table=0,priority=0,actions=NORMAL\n"))


### PR DESCRIPTION
from OVS FAQ, we have:

All current versions of ovs-ofctl enable only OpenFlow 1.0 by default.
Use the -O option to enable support for later versions of OpenFlow in
ovs-ofctl.

without the -O option the replace-flows command doesn't work

@dcbw any reason why you removed this in your `hybrid-overlay series`?