### PR TITLE
Adds HA deployment option to KIND

### DIFF
--- a/.github/workflow-templates/test.yml.erb
+++ b/.github/workflow-templates/test.yml.erb
@@ -110,10 +110,16 @@ jobs:
 
       
   e2e-shard-n:
-    name: e2e-kind-ovn-shard-n
+    name: e2e-kind-ovn-shard-n-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy: &e2e_strategy
+      matrix:
+        config:
+          - {ha: "false", name: "noHA"}
+          - {ha: "true", name: "HA"}
     env:
+      KIND_HA: ${{matrix.config.ha}}
       JOB_NAME: "e2e-shard-n"
     steps:
     - *step_cleanup
@@ -151,7 +157,7 @@ jobs:
         export NODE_NAMES=${MASTER_NAME}
         
         # all tests that don't have P as their sixth letter after the N
-        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$) --disable-log-dump=false <%= ginkgo_skip %>'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--num-nodes=3 --ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$) --disable-log-dump=false <%= ginkgo_skip %>'
 
     - &step_export_logs
       name: Export logs
@@ -169,11 +175,13 @@ jobs:
         path: /tmp/kind/logs
 
   e2e-shard-np:
-    name: e2e-kind-ovn-shard-np
+    name: e2e-kind-ovn-shard-np-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy: *e2e_strategy
     env:
       JOB_NAME: "e2e-shard-np"
+      KIND_HA: ${{matrix.config.ha}}
     steps:
     - *step_cleanup
     - *step_gosetup
@@ -192,17 +200,19 @@ jobs:
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
         # all tests that have P as the sixth letter after the N
-        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$ --disable-log-dump=false <%= ginkgo_skip %>'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--num-nodes=3 --ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$ --disable-log-dump=false <%= ginkgo_skip %>'
 
     - *step_export_logs
     - *step_upload_logs
   
   e2e-shard-s:
-    name: e2e-kind-ovn-shard-s
+    name: e2e-kind-ovn-shard-s-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy: *e2e_strategy
     env:
       JOB_NAME: "e2e-shard-s"
+      KIND_HA: ${{matrix.config.ha}}
     steps:
     - *step_cleanup
     - *step_gosetup
@@ -220,17 +230,19 @@ jobs:
         export KUBECONFIG=${HOME}/admin.conf
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
-        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\]\s[Ss].* --disable-log-dump=false <%= ginkgo_skip %>'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--num-nodes=3 --ginkgo.focus=\[sig-network\]\s[Ss].* --disable-log-dump=false <%= ginkgo_skip %>'
 
     - *step_export_logs
     - *step_upload_logs
 
   e2e-shard-other:
-    name: e2e-kind-ovn-shard-other
+    name: e2e-kind-ovn-shard-other-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy: *e2e_strategy
     env:
       JOB_NAME: "e2e-shard-other"
+      KIND_HA: ${{matrix.config.ha}}
     steps:
     - *step_cleanup
     - *step_gosetup
@@ -248,17 +260,19 @@ jobs:
         export KUBECONFIG=${HOME}/admin.conf
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
-        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\]\s[^NnSs].* --disable-log-dump=false <%= ginkgo_skip %>'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--num-nodes=3 --ginkgo.focus=\[sig-network\]\s[^NnSs].* --disable-log-dump=false <%= ginkgo_skip %>'
 
     - *step_export_logs
     - *step_upload_logs
   
   e2e-control-plane:
-    name: e2e-control-plane
+    name: e2e-control-plane-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy: *e2e_strategy
     env:
       JOB_NAME: "e2e-control-plane"
+      KIND_HA: ${{matrix.config.ha}}
     steps:
     - *step_cleanup
     - *step_gosetup
@@ -283,7 +297,7 @@ jobs:
 
         sed -E -i 's/"\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}" "\$\{e2e_test\}"/pushd \$GITHUB_WORKSPACE\/test\/e2e\nGO111MODULE=on "\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}"/' hack/ginkgo-e2e.sh
 
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--disable-log-dump=false'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--num-nodes=3 --disable-log-dump=false'
 
     - *step_export_logs
     - *step_upload_logs

--- a/.github/workflows/test_generated.yml
+++ b/.github/workflows/test_generated.yml
@@ -115,10 +115,18 @@ jobs:
         make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
         rm -rf .git
   e2e-shard-n:
-    name: e2e-kind-ovn-shard-n
+    name: e2e-kind-ovn-shard-n-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy:
+      matrix:
+        config:
+        - ha: 'false'
+          name: noHA
+        - ha: 'true'
+          name: HA
     env:
+      KIND_HA: "${{matrix.config.ha}}"
       JOB_NAME: e2e-shard-n
     steps:
     - name: Free up disk space
@@ -177,7 +185,7 @@ jobs:
         export NODE_NAMES=${MASTER_NAME}
 
         # all tests that don't have P as their sixth letter after the N
-        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$) --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--num-nodes=3 --ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$) --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout'
     - name: Export logs
       if: always()
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}
@@ -189,11 +197,19 @@ jobs:
         name: kind-logs-${{ github.run_id }}-${{ env.JOB_NAME }}
         path: "/tmp/kind/logs"
   e2e-shard-np:
-    name: e2e-kind-ovn-shard-np
+    name: e2e-kind-ovn-shard-np-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy:
+      matrix:
+        config:
+        - ha: 'false'
+          name: noHA
+        - ha: 'true'
+          name: HA
     env:
       JOB_NAME: e2e-shard-np
+      KIND_HA: "${{matrix.config.ha}}"
     steps:
     - name: Free up disk space
       run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
@@ -250,7 +266,7 @@ jobs:
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
         # all tests that have P as the sixth letter after the N
-        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$ --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--num-nodes=3 --ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$ --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout'
     - name: Export logs
       if: always()
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}
@@ -262,11 +278,19 @@ jobs:
         name: kind-logs-${{ github.run_id }}-${{ env.JOB_NAME }}
         path: "/tmp/kind/logs"
   e2e-shard-s:
-    name: e2e-kind-ovn-shard-s
+    name: e2e-kind-ovn-shard-s-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy:
+      matrix:
+        config:
+        - ha: 'false'
+          name: noHA
+        - ha: 'true'
+          name: HA
     env:
       JOB_NAME: e2e-shard-s
+      KIND_HA: "${{matrix.config.ha}}"
     steps:
     - name: Free up disk space
       run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
@@ -322,7 +346,7 @@ jobs:
         export KUBECONFIG=${HOME}/admin.conf
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
-        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\]\s[Ss].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--num-nodes=3 --ginkgo.focus=\[sig-network\]\s[Ss].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout'
     - name: Export logs
       if: always()
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}
@@ -334,11 +358,19 @@ jobs:
         name: kind-logs-${{ github.run_id }}-${{ env.JOB_NAME }}
         path: "/tmp/kind/logs"
   e2e-shard-other:
-    name: e2e-kind-ovn-shard-other
+    name: e2e-kind-ovn-shard-other-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy:
+      matrix:
+        config:
+        - ha: 'false'
+          name: noHA
+        - ha: 'true'
+          name: HA
     env:
       JOB_NAME: e2e-shard-other
+      KIND_HA: "${{matrix.config.ha}}"
     steps:
     - name: Free up disk space
       run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
@@ -394,7 +426,7 @@ jobs:
         export KUBECONFIG=${HOME}/admin.conf
         export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
         export NODE_NAMES=${MASTER_NAME}
-        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--ginkgo.focus=\[sig-network\]\s[^NnSs].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=${KIND_CLUSTER_NAME} --test --test_args='--num-nodes=3 --ginkgo.focus=\[sig-network\]\s[^NnSs].* --disable-log-dump=false --ginkgo.skip=Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout'
     - name: Export logs
       if: always()
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}
@@ -406,11 +438,19 @@ jobs:
         name: kind-logs-${{ github.run_id }}-${{ env.JOB_NAME }}
         path: "/tmp/kind/logs"
   e2e-control-plane:
-    name: e2e-control-plane
+    name: e2e-control-plane-${{ matrix.config.name }}
     runs-on: ubuntu-latest
     needs: k8s
+    strategy:
+      matrix:
+        config:
+        - ha: 'false'
+          name: noHA
+        - ha: 'true'
+          name: HA
     env:
       JOB_NAME: e2e-control-plane
+      KIND_HA: "${{matrix.config.ha}}"
     steps:
     - name: Free up disk space
       run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
@@ -473,7 +513,7 @@ jobs:
 
         sed -E -i 's/"\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}" "\$\{e2e_test\}"/pushd \$GITHUB_WORKSPACE\/test\/e2e\nGO111MODULE=on "\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}"/' hack/ginkgo-e2e.sh
 
-        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--disable-log-dump=false'
+        kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--num-nodes=3 --disable-log-dump=false'
     - name: Export logs
       if: always()
       run: "mkdir -p /tmp/kind/logs \nkind export logs --name ${KIND_CLUSTER_NAME}

--- a/contrib/kind-ha.yaml
+++ b/contrib/kind-ha.yaml
@@ -1,0 +1,37 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # the default CNI will not be installed
+  disableDefaultCNI: true
+  apiServerAddress: 11.12.13.1
+  apiServerPort: 11337
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      "feature-gates": "SCTPSupport=true"
+nodes:
+ - role: control-plane
+   extraMounts:
+     - hostPath: /tmp/kind
+       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
+ - role: control-plane
+   extraMounts:
+     - hostPath: /tmp/kind
+       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
+ - role: control-plane
+   extraMounts:
+     - hostPath: /tmp/kind
+       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
+# - role: worker
+#   extraMounts:
+#     - hostPath: /tmp/kind
+#       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
+# - role: worker
+#   extraMounts:
+#     - hostPath: /tmp/kind
+#       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
+


### PR DESCRIPTION
This patch adds secondary jobs to execute E2E tests against an HA
cluster using RAFT. 3 nodes are provisioned (to keep resource usage
down) that will act as masters and workers.

Signed-off-by: Tim Rozet <trozet@redhat.com>