### PR TITLE
Free up disk space in CI environment setup

### DIFF
--- a/.github/workflow-templates/test.yml.erb
+++ b/.github/workflow-templates/test.yml.erb
@@ -11,6 +11,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+    - &step_cleanup
+      name: Free up disk space
+      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
+
     - &step_gosetup
       name: Set up Go 1.12
       uses: actions/setup-go@v1
@@ -63,6 +67,7 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
+    - *step_cleanup
     - *step_gosetup
     - *step_checkout
     - *step_environment
@@ -111,6 +116,7 @@ jobs:
     env:
       JOB_NAME: "e2e-shard-n"
     steps:
+    - *step_cleanup
     - *step_gosetup
     - *step_checkout
     - *step_environment
@@ -128,7 +134,7 @@ jobs:
         chmod +x $GOPATH/bin/kubetest
 
         pushd $GOPATH/src/k8s.io/kubernetes/
-        sudo cp ./_output/local/go/bin/kubectl /usr/local/bin/
+        sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
         popd
         
         GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
@@ -169,6 +175,7 @@ jobs:
     env:
       JOB_NAME: "e2e-shard-np"
     steps:
+    - *step_cleanup
     - *step_gosetup
     - *step_checkout
     - *step_environment
@@ -197,6 +204,7 @@ jobs:
     env:
       JOB_NAME: "e2e-shard-s"
     steps:
+    - *step_cleanup
     - *step_gosetup
     - *step_checkout
     - *step_environment
@@ -224,6 +232,7 @@ jobs:
     env:
       JOB_NAME: "e2e-shard-other"
     steps:
+    - *step_cleanup
     - *step_gosetup
     - *step_checkout
     - *step_environment
@@ -251,6 +260,7 @@ jobs:
     env:
       JOB_NAME: "e2e-control-plane"
     steps:
+    - *step_cleanup
     - *step_gosetup
     - *step_checkout
     - *step_environment

--- a/.github/workflows/test_generated.yml
+++ b/.github/workflows/test_generated.yml
@@ -14,6 +14,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+    - name: Free up disk space
+      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
+        mono-* msbuild php-* php7* ghc-* zulu-*
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:
@@ -58,6 +61,9 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
+    - name: Free up disk space
+      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
+        mono-* msbuild php-* php7* ghc-* zulu-*
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:
@@ -115,6 +121,9 @@ jobs:
     env:
       JOB_NAME: e2e-shard-n
     steps:
+    - name: Free up disk space
+      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
+        mono-* msbuild php-* php7* ghc-* zulu-*
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:
@@ -152,7 +161,7 @@ jobs:
         chmod +x $GOPATH/bin/kubetest
 
         pushd $GOPATH/src/k8s.io/kubernetes/
-        sudo cp ./_output/local/go/bin/kubectl /usr/local/bin/
+        sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
         popd
 
         GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
@@ -186,6 +195,9 @@ jobs:
     env:
       JOB_NAME: e2e-shard-np
     steps:
+    - name: Free up disk space
+      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
+        mono-* msbuild php-* php7* ghc-* zulu-*
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:
@@ -223,7 +235,7 @@ jobs:
         chmod +x $GOPATH/bin/kubetest
 
         pushd $GOPATH/src/k8s.io/kubernetes/
-        sudo cp ./_output/local/go/bin/kubectl /usr/local/bin/
+        sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
         popd
 
         GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
@@ -256,6 +268,9 @@ jobs:
     env:
       JOB_NAME: e2e-shard-s
     steps:
+    - name: Free up disk space
+      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
+        mono-* msbuild php-* php7* ghc-* zulu-*
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:
@@ -293,7 +308,7 @@ jobs:
         chmod +x $GOPATH/bin/kubetest
 
         pushd $GOPATH/src/k8s.io/kubernetes/
-        sudo cp ./_output/local/go/bin/kubectl /usr/local/bin/
+        sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
         popd
 
         GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
@@ -325,6 +340,9 @@ jobs:
     env:
       JOB_NAME: e2e-shard-other
     steps:
+    - name: Free up disk space
+      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
+        mono-* msbuild php-* php7* ghc-* zulu-*
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:
@@ -362,7 +380,7 @@ jobs:
         chmod +x $GOPATH/bin/kubetest
 
         pushd $GOPATH/src/k8s.io/kubernetes/
-        sudo cp ./_output/local/go/bin/kubectl /usr/local/bin/
+        sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
         popd
 
         GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
@@ -394,6 +412,9 @@ jobs:
     env:
       JOB_NAME: e2e-control-plane
     steps:
+    - name: Free up disk space
+      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
+        mono-* msbuild php-* php7* ghc-* zulu-*
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:
@@ -431,7 +452,7 @@ jobs:
         chmod +x $GOPATH/bin/kubetest
 
         pushd $GOPATH/src/k8s.io/kubernetes/
-        sudo cp ./_output/local/go/bin/kubectl /usr/local/bin/
+        sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
         popd
 
         GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0


### PR DESCRIPTION
This PR removes unnecessary packages (totaling about 10 GB) from the CI environment so we don't run out of disk space during testing and also removes an instance of an unnecessary file copy.