### PR TITLE
Node: Optimize CNI to reuse clientset created by ovnkube-node

### DIFF
--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"k8s.io/client-go/kubernetes"
 )
 
 // serverRunDir is the default directory for CNIServer runtime files
@@ -69,7 +70,7 @@ type PodRequest struct {
 	CNIConf *types.NetConf
 }
 
-type cniRequestFunc func(request *PodRequest) ([]byte, error)
+type cniRequestFunc func(request *PodRequest, kclient kubernetes.Interface) ([]byte, error)
 
 // Server object that listens for JSON-marshaled Request objects
 // on a private root-only Unix domain socket.
@@ -77,4 +78,5 @@ type Server struct {
 	http.Server
 	requestFunc cniRequestFunc
 	rundir      string
+	kclient     kubernetes.Interface
 }

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -270,8 +270,13 @@ func (n *OvnNode) Start() error {
 		}
 	}
 
+	kclient, ok := n.Kube.(*kube.Kube)
+	if !ok {
+		return fmt.Errorf("Cannot get kubeclient for starting CNI server")
+	}
+
 	// start the cni server
-	cniServer := cni.NewCNIServer("")
+	cniServer := cni.NewCNIServer("", kclient.KClient)
 	err = cniServer.Start(cni.HandleCNIRequest)
 
 	return err


### PR DESCRIPTION
When profiling the ovnkube-node, the clientset creation showed up as a
bottleneck for cni commands. This PR changes the cmdAdd implementation
to use the clientset passed in from the node process via the server to
the pod request.

Signed-off By: Aniket Bhat <anbhat@redhat.com>