### PR TITLE
Fix JOB_NAME to include ha/noha

### DIFF
--- a/.github/workflow-templates/test.yml.erb
+++ b/.github/workflow-templates/test.yml.erb
@@ -120,7 +120,7 @@ jobs:
           - {ha: "true", name: "HA"}
     env:
       KIND_HA: ${{matrix.config.ha}}
-      JOB_NAME: "e2e-shard-n"
+      JOB_NAME: e2e-shard-n-${{ matrix.config.name }}
     steps:
     - *step_cleanup
     - *step_gosetup
@@ -180,7 +180,7 @@ jobs:
     needs: k8s
     strategy: *e2e_strategy
     env:
-      JOB_NAME: "e2e-shard-np"
+      JOB_NAME: e2e-shard-np-${{ matrix.config.name }}
       KIND_HA: ${{matrix.config.ha}}
     steps:
     - *step_cleanup
@@ -211,7 +211,7 @@ jobs:
     needs: k8s
     strategy: *e2e_strategy
     env:
-      JOB_NAME: "e2e-shard-s"
+      JOB_NAME: e2e-shard-s-${{ matrix.config.name }}
       KIND_HA: ${{matrix.config.ha}}
     steps:
     - *step_cleanup
@@ -241,7 +241,7 @@ jobs:
     needs: k8s
     strategy: *e2e_strategy
     env:
-      JOB_NAME: "e2e-shard-other"
+      JOB_NAME: e2e-shard-other-${{ matrix.config.name }}
       KIND_HA: ${{matrix.config.ha}}
     steps:
     - *step_cleanup
@@ -271,7 +271,7 @@ jobs:
     needs: k8s
     strategy: *e2e_strategy
     env:
-      JOB_NAME: "e2e-control-plane"
+      JOB_NAME: e2e-control-plane-${{ matrix.config.name }}
       KIND_HA: ${{matrix.config.ha}}
     steps:
     - *step_cleanup

--- a/.github/workflows/test_generated.yml
+++ b/.github/workflows/test_generated.yml
@@ -127,7 +127,7 @@ jobs:
           name: HA
     env:
       KIND_HA: "${{matrix.config.ha}}"
-      JOB_NAME: e2e-shard-n
+      JOB_NAME: e2e-shard-n-${{ matrix.config.name }}
     steps:
     - name: Free up disk space
       run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-*
@@ -208,7 +208,7 @@ jobs:
         - ha: 'true'
           name: HA
     env:
-      JOB_NAME: e2e-shard-np
+      JOB_NAME: e2e-shard-np-${{ matrix.config.name }}
       KIND_HA: "${{matrix.config.ha}}"
     steps:
     - name: Free up disk space
@@ -289,7 +289,7 @@ jobs:
         - ha: 'true'
           name: HA
     env:
-      JOB_NAME: e2e-shard-s
+      JOB_NAME: e2e-shard-s-${{ matrix.config.name }}
       KIND_HA: "${{matrix.config.ha}}"
     steps:
     - name: Free up disk space
@@ -369,7 +369,7 @@ jobs:
         - ha: 'true'
           name: HA
     env:
-      JOB_NAME: e2e-shard-other
+      JOB_NAME: e2e-shard-other-${{ matrix.config.name }}
       KIND_HA: "${{matrix.config.ha}}"
     steps:
     - name: Free up disk space
@@ -449,7 +449,7 @@ jobs:
         - ha: 'true'
           name: HA
     env:
-      JOB_NAME: e2e-control-plane
+      JOB_NAME: e2e-control-plane-${{ matrix.config.name }}
       KIND_HA: "${{matrix.config.ha}}"
     steps:
     - name: Free up disk space


### PR DESCRIPTION
Logs are named after JOB_NAME so without this distinction logs for
noha/ha were overwriting each other.

Signed-off-by: Tim Rozet <trozet@redhat.com>