### PR TITLE
pass MACs, IPs, CIDRs around in parsed form rather than as strings

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -125,7 +125,7 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 			portIP = util.NextIP(second)
 		}
 		if portMAC == nil {
-			portMAC, _ = net.ParseMAC(util.IPAddrToHWAddr(portIP))
+			portMAC = util.IPAddrToHWAddr(portIP)
 		}
 
 		klog.Infof("creating node %s hybrid overlay port", node.Name)

--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -33,7 +33,7 @@ func NewMaster(clientset kubernetes.Interface) (*MasterController, error) {
 
 	// Add our hybrid overlay CIDRs to the allocator
 	for _, clusterEntry := range config.HybridOverlay.ClusterSubnets {
-		err := m.allocator.AddNetworkRange(clusterEntry.CIDR.String(), 32-clusterEntry.HostSubnetLength)
+		err := m.allocator.AddNetworkRange(clusterEntry.CIDR, 32-clusterEntry.HostSubnetLength)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -36,7 +36,7 @@ func addGetPortAddressesCmds(fexec *ovntest.FakeExec, nodeName, hybMAC, hybIP st
 func newTestNode(name, os, ovnHostSubnet, hybridHostSubnet, drMAC string) v1.Node {
 	annotations := make(map[string]string)
 	if ovnHostSubnet != "" {
-		subnetAnnotations, err := util.CreateNodeHostSubnetAnnotation(ovnHostSubnet)
+		subnetAnnotations, err := util.CreateNodeHostSubnetAnnotation(ovntest.MustParseIPNet(ovnHostSubnet))
 		Expect(err).NotTo(HaveOccurred())
 		for k, v := range subnetAnnotations {
 			annotations[k] = fmt.Sprintf("%s", v)

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -406,7 +406,7 @@ func (n *NodeController) ensureHybridOverlayBridge() error {
 	if err != nil {
 		return err
 	}
-	stdout, stderr, err := util.RunOVSVsctl("set", "bridge", extBridgeName, "other-config:hwaddr="+macAddress)
+	stdout, stderr, err := util.RunOVSVsctl("set", "bridge", extBridgeName, "other-config:hwaddr="+macAddress.String())
 	if err != nil {
 		return fmt.Errorf("Failed to set bridge, stdout: %q, stderr: %q, "+
 			"error: %v", stdout, stderr, err)

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				node1IP     string = "10.0.0.2"
 			)
 
-			subnetAnnotations, err := util.CreateNodeHostSubnetAnnotation(node1Subnet)
+			subnetAnnotations, err := util.CreateNodeHostSubnetAnnotation(ovntest.MustParseIPNet(node1Subnet))
 			Expect(err).NotTo(HaveOccurred())
 			annotations := make(map[string]string)
 			for k, v := range subnetAnnotations {

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -17,20 +17,20 @@ import (
 // bridgedGatewayNodeSetup makes the bridge's MAC address permanent (if needed), sets up
 // the physical network name mappings for the bridge, and returns an ifaceID
 // created from the bridge name and the node name
-func bridgedGatewayNodeSetup(nodeName, bridgeName, bridgeInterface string, syncBridgeMac bool) (string, string, error) {
+func bridgedGatewayNodeSetup(nodeName, bridgeName, bridgeInterface string, syncBridgeMAC bool) (string, net.HardwareAddr, error) {
 	// A OVS bridge's mac address can change when ports are added to it.
 	// We cannot let that happen, so make the bridge mac address permanent.
 	macAddress, err := util.GetOVSPortMACAddress(bridgeInterface)
 	if err != nil {
-		return "", "", err
+		return "", nil, err
 	}
-	if syncBridgeMac {
+	if syncBridgeMAC {
 		var err error
 
 		stdout, stderr, err := util.RunOVSVsctl("set", "bridge",
-			bridgeName, "other-config:hwaddr="+macAddress)
+			bridgeName, "other-config:hwaddr="+macAddress.String())
 		if err != nil {
-			return "", "", fmt.Errorf("Failed to set bridge, stdout: %q, stderr: %q, "+
+			return "", nil, fmt.Errorf("Failed to set bridge, stdout: %q, stderr: %q, "+
 				"error: %v", stdout, stderr, err)
 		}
 	}
@@ -40,7 +40,7 @@ func bridgedGatewayNodeSetup(nodeName, bridgeName, bridgeInterface string, syncB
 	_, stderr, err := util.RunOVSVsctl("set", "Open_vSwitch", ".",
 		fmt.Sprintf("external_ids:ovn-bridge-mappings=%s:%s", util.PhysicalNetworkName, bridgeName))
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to set ovn-bridge-mappings for ovs bridge %s"+
+		return "", nil, fmt.Errorf("Failed to set ovn-bridge-mappings for ovs bridge %s"+
 			", stderr:%s (%v)", bridgeName, stderr, err)
 	}
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -182,7 +182,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 
 		nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &existingNode)
 
-		err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, nodeSubnet)
+		err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(nodeSubnet))
 		Expect(err).NotTo(HaveOccurred())
 		err = nodeAnnotator.Run()
 		Expect(err).NotTo(HaveOccurred())
@@ -191,7 +191,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 			defer GinkgoRecover()
 
 			waiter := newStartupWaiter()
-			err = n.initGateway(nodeSubnet, nodeAnnotator, waiter)
+			err = n.initGateway(ovntest.MustParseIPNet(nodeSubnet), nodeAnnotator, waiter)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = nodeAnnotator.Run()
@@ -347,7 +347,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			util.SetIPTablesHelper(iptables.ProtocolIPv4, ipt)
 
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &existingNode)
-			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, nodeSubnet)
+			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(nodeSubnet))
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -355,7 +355,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			err = testNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				err = initLocalnetGateway(nodeName, nodeSubnet, wf, nodeAnnotator)
+				err = initLocalnetGateway(nodeName, ovntest.MustParseIPNet(nodeSubnet), wf, nodeAnnotator)
 				Expect(err).NotTo(HaveOccurred())
 				// Check if IP has been assigned to LocalnetGatewayNextHopPort
 				link, err := netlink.LinkByName(localnetGatewayNextHopPort)

--- a/go-controller/pkg/node/gateway_localnet_windows.go
+++ b/go-controller/pkg/node/gateway_localnet_windows.go
@@ -4,12 +4,13 @@ package node
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 )
 
-func initLocalnetGateway(nodeName string, subnet string,
+func initLocalnetGateway(nodeName string, subnet *net.IPNet,
 	wf *factory.WatchFactory, nodeAnnotator kube.Annotator) error {
 	// TODO: Implement this
 	return fmt.Errorf("Not implemented yet on Windows")

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"regexp"
 	"strings"
@@ -284,7 +285,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 	return nil
 }
 
-func (n *OvnNode) initSharedGateway(subnet, gwNextHop, gwIntf string,
+func (n *OvnNode) initSharedGateway(subnet *net.IPNet, gwNextHop net.IP, gwIntf string,
 	nodeAnnotator kube.Annotator) (postWaitFunc, error) {
 	var bridgeName string
 	var uplinkName string
@@ -324,7 +325,7 @@ func (n *OvnNode) initSharedGateway(subnet, gwNextHop, gwIntf string,
 		return nil, fmt.Errorf("Failed to get interface details for %s (%v)",
 			gwIntf, err)
 	}
-	if ipAddress == "" {
+	if ipAddress == nil {
 		return nil, fmt.Errorf("%s does not have a ipv4 address", gwIntf)
 	}
 

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -4,6 +4,7 @@ package node
 
 import (
 	"fmt"
+	"net"
 	"syscall"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -14,10 +15,10 @@ import (
 // getDefaultGatewayInterfaceDetails returns the interface name on
 // which the default gateway (for route to 0.0.0.0) is configured.
 // It also returns the default gateway itself.
-func getDefaultGatewayInterfaceDetails() (string, string, error) {
+func getDefaultGatewayInterfaceDetails() (string, net.IP, error) {
 	routes, err := netlink.RouteList(nil, syscall.AF_INET)
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to get routing table in node")
+		return "", nil, fmt.Errorf("Failed to get routing table in node")
 	}
 
 	for i := range routes {
@@ -29,11 +30,11 @@ func getDefaultGatewayInterfaceDetails() (string, string, error) {
 			}
 			intfName := intfLink.Attrs().Name
 			if intfName != "" {
-				return intfName, route.Gw.String(), nil
+				return intfName, route.Gw, nil
 			}
 		}
 	}
-	return "", "", fmt.Errorf("Failed to get default gateway interface")
+	return "", nil, fmt.Errorf("Failed to get default gateway interface")
 }
 
 func getIntfName(gatewayIntf string) (string, error) {

--- a/go-controller/pkg/node/helper_windows.go
+++ b/go-controller/pkg/node/helper_windows.go
@@ -4,6 +4,7 @@ package node
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -11,9 +12,9 @@ import (
 // getDefaultGatewayInterfaceDetails returns the interface name on
 // which the default gateway (for route to 0.0.0.0) is configured.
 // It also returns the default gateway itself.
-func getDefaultGatewayInterfaceDetails() (string, string, error) {
+func getDefaultGatewayInterfaceDetails() (string, net.IP, error) {
 	// TODO: Implement this
-	return "", "", fmt.Errorf("Not implemented yet on Windows")
+	return "", nil, fmt.Errorf("Not implemented yet on Windows")
 }
 
 func getIntfName(gatewayIntf string) (string, error) {

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -15,7 +15,7 @@ func (n *OvnNode) createManagementPort(localSubnet *net.IPNet, nodeAnnotator kub
 	waiter *startupWaiter) error {
 	// Retrieve the routerIP and mangementPortIP for a given localSubnet
 	routerIP, portIP := util.GetNodeWellKnownAddresses(localSubnet)
-	routerMac := util.IPAddrToHWAddr(routerIP.IP)
+	routerMAC := util.IPAddrToHWAddr(routerIP.IP)
 
 	// Kubernetes emits events when pods are created. The event will contain
 	// only lowercase letters of the hostname even though the kubelet is
@@ -54,20 +54,20 @@ func (n *OvnNode) createManagementPort(localSubnet *net.IPNet, nodeAnnotator kub
 	}
 	// persist the MAC address so that upon node reboot we get back the same mac address.
 	_, stderr, err = util.RunOVSVsctl("set", "interface", util.K8sMgmtIntfName,
-		fmt.Sprintf("mac=%s", strings.ReplaceAll(macAddress, ":", "\\:")))
+		fmt.Sprintf("mac=%s", strings.ReplaceAll(macAddress.String(), ":", "\\:")))
 	if err != nil {
-		klog.Errorf("failed to persist MAC address %q for %q: stderr:%s (%v)", macAddress,
+		klog.Errorf("failed to persist MAC address %q for %q: stderr:%s (%v)", macAddress.String(),
 			util.K8sMgmtIntfName, stderr, err)
 		return err
 	}
 
 	err = createPlatformManagementPort(util.K8sMgmtIntfName, portIP.String(), routerIP.IP.String(),
-		routerMac, n.stopChan)
+		routerMAC, n.stopChan)
 	if err != nil {
 		return err
 	}
 
-	if err := util.SetNodeManagementPortMacAddr(nodeAnnotator, macAddress); err != nil {
+	if err := util.SetNodeManagementPortMACAddress(nodeAnnotator, macAddress); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -61,8 +61,7 @@ func (n *OvnNode) createManagementPort(localSubnet *net.IPNet, nodeAnnotator kub
 		return err
 	}
 
-	err = createPlatformManagementPort(util.K8sMgmtIntfName, portIP.String(), routerIP.IP.String(),
-		routerMAC, n.stopChan)
+	err = createPlatformManagementPort(util.K8sMgmtIntfName, portIP, routerIP.IP, routerMAC, n.stopChan)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -30,10 +30,10 @@ type managementPortConfig struct {
 	ifIPMask   string
 	ifIP       string
 	routerIP   string
-	routerMAC  string
+	routerMAC  net.HardwareAddr
 }
 
-func newManagementPortConfig(interfaceName, interfaceIP, routerIP, routerMAC string) (*managementPortConfig, error) {
+func newManagementPortConfig(interfaceName, interfaceIP, routerIP string, routerMAC net.HardwareAddr) (*managementPortConfig, error) {
 	var err error
 
 	cfg := &managementPortConfig{}
@@ -126,7 +126,7 @@ func setupManagementPortConfig(cfg *managementPortConfig) ([]string, error) {
 	// source protocol address to be in the Logical Switch's subnet.
 	if exists, err = util.LinkNeighExists(cfg.link, cfg.routerIP, cfg.routerMAC); err == nil && !exists {
 		warnings = append(warnings, fmt.Sprintf("missing arp entry for MAC/IP binding (%s/%s) on link %s",
-			cfg.routerMAC, cfg.routerIP, util.K8sMgmtIntfName))
+			cfg.routerMAC.String(), cfg.routerIP, util.K8sMgmtIntfName))
 		err = util.LinkNeighAdd(cfg.link, cfg.routerIP, cfg.routerMAC)
 	}
 	if err != nil {
@@ -159,7 +159,7 @@ func setupManagementPortConfig(cfg *managementPortConfig) ([]string, error) {
 // createPlatformManagementPort creates a management port attached to the node switch
 // that lets the node access its pods via their private IP address. This is used
 // for health checking and other management tasks.
-func createPlatformManagementPort(interfaceName, interfaceIP, routerIP, routerMAC string,
+func createPlatformManagementPort(interfaceName, interfaceIP, routerIP string, routerMAC net.HardwareAddr,
 	stopChan chan struct{}) error {
 	var cfg *managementPortConfig
 	var err error

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -25,15 +24,14 @@ const (
 type managementPortConfig struct {
 	link       netlink.Link
 	ipt        util.IPTablesHelper
-	allSubnets []string
+	allSubnets []*net.IPNet
 	ifName     string
-	ifIPMask   string
-	ifIP       string
-	routerIP   string
+	ifIPMask   *net.IPNet
+	routerIP   net.IP
 	routerMAC  net.HardwareAddr
 }
 
-func newManagementPortConfig(interfaceName, interfaceIP, routerIP string, routerMAC net.HardwareAddr) (*managementPortConfig, error) {
+func newManagementPortConfig(interfaceName string, interfaceIP *net.IPNet, routerIP net.IP, routerMAC net.HardwareAddr) (*managementPortConfig, error) {
 	var err error
 
 	cfg := &managementPortConfig{}
@@ -47,14 +45,11 @@ func newManagementPortConfig(interfaceName, interfaceIP, routerIP string, router
 
 	// capture all the subnets for which we need to add routes through management port
 	for _, subnet := range config.Default.ClusterSubnets {
-		cfg.allSubnets = append(cfg.allSubnets, subnet.CIDR.String())
+		cfg.allSubnets = append(cfg.allSubnets, subnet.CIDR)
 	}
-	for _, subnet := range config.Kubernetes.ServiceCIDRs {
-		cfg.allSubnets = append(cfg.allSubnets, subnet.String())
-	}
+	cfg.allSubnets = append(cfg.allSubnets, config.Kubernetes.ServiceCIDRs...)
 
-	cfg.ifIP = strings.Split(cfg.ifIPMask, "/")[0]
-	if utilnet.IsIPv6(net.ParseIP(cfg.ifIP)) {
+	if utilnet.IsIPv6CIDR(cfg.ifIPMask) {
 		cfg.ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv6)
 	} else {
 		cfg.ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv4)
@@ -105,7 +100,7 @@ func setupManagementPortConfig(cfg *managementPortConfig) ([]string, error) {
 			// we need to warn so that it can be debugged as to why routes are disappearing
 			warnings = append(warnings, fmt.Sprintf("missing route entry for subnet %s via gateway %s on link %v",
 				subnet, cfg.routerIP, cfg.ifName))
-			err = util.LinkRoutesAdd(cfg.link, cfg.routerIP, []string{subnet})
+			err = util.LinkRoutesAdd(cfg.link, cfg.routerIP, []*net.IPNet{subnet})
 			if err != nil {
 				if os.IsExist(err) {
 					klog.V(5).Infof("Ignoring error %s from 'route add %s via %s' - already added via IPv6 RA?",
@@ -142,7 +137,7 @@ func setupManagementPortConfig(cfg *managementPortConfig) ([]string, error) {
 	if err != nil {
 		return warnings, fmt.Errorf("could not set up iptables chain rules for management port: %v", err)
 	}
-	rule = []string{"-o", cfg.ifName, "-j", "SNAT", "--to-source", cfg.ifIP,
+	rule = []string{"-o", cfg.ifName, "-j", "SNAT", "--to-source", cfg.ifIPMask.IP.String(),
 		"-m", "comment", "--comment", "OVN SNAT to Management Port"}
 	if exists, err = cfg.ipt.Exists("nat", iptableMgmPortChain, rule...); err == nil && !exists {
 		warnings = append(warnings, fmt.Sprintf("missing management port nat rule in chain %s, adding it",
@@ -159,7 +154,7 @@ func setupManagementPortConfig(cfg *managementPortConfig) ([]string, error) {
 // createPlatformManagementPort creates a management port attached to the node switch
 // that lets the node access its pods via their private IP address. This is used
 // for health checking and other management tasks.
-func createPlatformManagementPort(interfaceName, interfaceIP, routerIP string, routerMAC net.HardwareAddr,
+func createPlatformManagementPort(interfaceName string, interfaceIP *net.IPNet, routerIP net.IP, routerMAC net.HardwareAddr,
 	stopChan chan struct{}) error {
 	var cfg *managementPortConfig
 	var err error

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -116,7 +116,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	Expect(err).NotTo(HaveOccurred())
 
 	nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &existingNode)
-	err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, nodeSubnet)
+	err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(nodeSubnet))
 	Expect(err).NotTo(HaveOccurred())
 	err = nodeAnnotator.Run()
 	Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -207,9 +207,9 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	macFromAnnotation, err := util.ParseNodeManagementPortMacAddr(updatedNode)
+	macFromAnnotation, err := util.ParseNodeManagementPortMACAddress(updatedNode)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(macFromAnnotation).To(Equal(mgtPortMAC))
+	Expect(macFromAnnotation.String()).To(Equal(mgtPortMAC))
 
 	Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 }

--- a/go-controller/pkg/node/management-port_windows.go
+++ b/go-controller/pkg/node/management-port_windows.go
@@ -18,8 +18,8 @@ import (
 // createPlatformManagementPort creates a management port attached to the node switch
 // that lets the node access its pods via their private IP address. This is used
 // for health checking and other management tasks.
-func createPlatformManagementPort(interfaceName, interfaceIP, routerIP, routerMAC string,
-	stopChan chan struct{}) error {
+func createPlatformManagementPort(interfaceName, interfaceIP, routerIP string,
+	routerMAC net.HardwareAddr, stopChan chan struct{}) error {
 	// Up the interface.
 	_, _, err := util.RunPowershell("Enable-NetAdapter", "-IncludeHidden", interfaceName)
 	if err != nil {

--- a/go-controller/pkg/node/management-port_windows.go
+++ b/go-controller/pkg/node/management-port_windows.go
@@ -18,7 +18,7 @@ import (
 // createPlatformManagementPort creates a management port attached to the node switch
 // that lets the node access its pods via their private IP address. This is used
 // for health checking and other management tasks.
-func createPlatformManagementPort(interfaceName, interfaceIP, routerIP string,
+func createPlatformManagementPort(interfaceName string, interfaceIP *net.IPNet, routerIP net.IP,
 	routerMAC net.HardwareAddr, stopChan chan struct{}) error {
 	// Up the interface.
 	_, _, err := util.RunPowershell("Enable-NetAdapter", "-IncludeHidden", interfaceName)
@@ -39,13 +39,9 @@ func createPlatformManagementPort(interfaceName, interfaceIP, routerIP string,
 	}
 
 	// Assign IP address to the internal interface.
-	portIP, interfaceIPNet, err := net.ParseCIDR(interfaceIP)
-	if err != nil {
-		return fmt.Errorf("Failed to parse interfaceIP %v : %v", interfaceIP, err)
-	}
-	portPrefix, _ := interfaceIPNet.Mask.Size()
+	portPrefix, _ := interfaceIP.Mask.Size()
 	_, _, err = util.RunPowershell("New-NetIPAddress",
-		fmt.Sprintf("-IPAddress %s", portIP),
+		fmt.Sprintf("-IPAddress %s", interfaceIP.IP),
 		fmt.Sprintf("-PrefixLength %d", portPrefix),
 		ifAlias)
 	if err != nil {
@@ -89,7 +85,7 @@ func createPlatformManagementPort(interfaceName, interfaceIP, routerIP string,
 	return nil
 }
 
-func addRoute(subnet *net.IPNet, routerIP, interfaceIndex string) error {
+func addRoute(subnet *net.IPNet, routerIP net.IP, interfaceIndex string) error {
 	var familyFlag string
 	if utilnet.IsIPv6CIDR(subnet) {
 		familyFlag = "-6"
@@ -112,7 +108,7 @@ func addRoute(subnet *net.IPNet, routerIP, interfaceIndex string) error {
 	// Create a route for the entire subnet.
 	_, stderr, err = util.RunRoute("-p", "add",
 		subnet.IP.String(), "mask", subnetMask,
-		routerIP, "METRIC", "2", "IF", interfaceIndex)
+		routerIP.String(), "METRIC", "2", "IF", interfaceIndex)
 	if err != nil {
 		return fmt.Errorf("failed to run route add, stderr: %q, error: %v", stderr, err)
 	}

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -201,7 +201,7 @@ func (n *OvnNode) Start() error {
 	waiter := newStartupWaiter()
 
 	// Initialize gateway resources on the node
-	if err := n.initGateway(subnet.String(), nodeAnnotator, waiter); err != nil {
+	if err := n.initGateway(subnet, nodeAnnotator, waiter); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/ovn/allocator/allocator.go
+++ b/go-controller/pkg/ovn/allocator/allocator.go
@@ -21,15 +21,11 @@ func NewSubnetAllocator() *SubnetAllocator {
 	return &SubnetAllocator{}
 }
 
-func (sna *SubnetAllocator) AddNetworkRange(network string, hostBits uint32) error {
+func (sna *SubnetAllocator) AddNetworkRange(network *net.IPNet, hostBits uint32) error {
 	sna.Lock()
 	defer sna.Unlock()
 
-	_, ipnet, err := net.ParseCIDR(network)
-	if err != nil {
-		return err
-	}
-	snr, err := newSubnetAllocatorRange(ipnet, hostBits)
+	snr, err := newSubnetAllocatorRange(network, hostBits)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/allocator/allocator_test.go
+++ b/go-controller/pkg/ovn/allocator/allocator_test.go
@@ -10,7 +10,7 @@ import (
 
 func newSubnetAllocator(clusterCIDR string, hostBits uint32) (*SubnetAllocator, error) {
 	sna := NewSubnetAllocator()
-	err := sna.AddNetworkRange(clusterCIDR, hostBits)
+	err := sna.AddNetworkRange(ovntest.MustParseIPNet(clusterCIDR), hostBits)
 	return sna, err
 }
 
@@ -279,22 +279,12 @@ func TestAllocateSubnetInvalidHostBitsOrCIDR(t *testing.T) {
 		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
 	}
 
-	_, err = newSubnetAllocator("10.1.0.0/33", 16)
-	if err == nil {
-		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
-	}
-
 	_, err = newSubnetAllocator("fd01::/64", 66)
 	if err == nil {
 		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
 	}
 
 	_, err = newSubnetAllocator("fd01::/64", 0)
-	if err == nil {
-		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
-	}
-
-	_, err = newSubnetAllocator("fd01::/129", 64)
 	if err == nil {
 		t.Fatal("Unexpectedly succeeded in initializing subnet allocator")
 	}
@@ -384,7 +374,7 @@ func TestMultipleSubnets(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to initialize IP allocator: ", err)
 	}
-	err = sna.AddNetworkRange("10.2.0.0/16", 14)
+	err = sna.AddNetworkRange(ovntest.MustParseIPNet("10.2.0.0/16"), 14)
 	if err != nil {
 		t.Fatal("Failed to add network range: ", err)
 	}
@@ -431,11 +421,11 @@ func TestDualStack(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to initialize IP allocator: ", err)
 	}
-	err = sna.AddNetworkRange("10.2.0.0/16", 14)
+	err = sna.AddNetworkRange(ovntest.MustParseIPNet("10.2.0.0/16"), 14)
 	if err != nil {
 		t.Fatal("Failed to add network range: ", err)
 	}
-	err = sna.AddNetworkRange("fd01::/48", 64)
+	err = sna.AddNetworkRange(ovntest.MustParseIPNet("fd01::/48"), 64)
 	if err != nil {
 		t.Fatal("Failed to add network range: ", err)
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -111,7 +111,8 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	if config.IPv6Mode {
 		joinSubnet = config.V6JoinSubnet
 	}
-	_ = oc.joinSubnetAllocator.AddNetworkRange(joinSubnet, 3)
+	_, joinSubnetCIDR, _ := net.ParseCIDR(joinSubnet)
+	_ = oc.joinSubnetAllocator.AddNetworkRange(joinSubnetCIDR, 3)
 
 	existingNodes, err := oc.kube.GetNodes()
 	if err != nil {
@@ -119,7 +120,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		return err
 	}
 	for _, clusterEntry := range config.Default.ClusterSubnets {
-		err := oc.masterSubnetAllocator.AddNetworkRange(clusterEntry.CIDR.String(), clusterEntry.HostBits())
+		err := oc.masterSubnetAllocator.AddNetworkRange(clusterEntry.CIDR, clusterEntry.HostBits())
 		if err != nil {
 			return err
 		}
@@ -252,11 +253,11 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 	return nil
 }
 
-func (oc *Controller) addNodeJoinSubnetAnnotations(node *kapi.Node, subnet string) error {
+func (oc *Controller) addNodeJoinSubnetAnnotations(node *kapi.Node, subnet *net.IPNet) error {
 	nodeAnnotations, err := util.CreateNodeJoinSubnetAnnotation(subnet)
 	if err != nil {
 		return fmt.Errorf("failed to marshal node %q join subnets annotation for subnet %s",
-			node.Name, subnet)
+			node.Name, subnet.String())
 	}
 	err = oc.kube.SetAnnotationsOnNode(node, nodeAnnotations)
 	if err != nil {
@@ -290,7 +291,7 @@ func (oc *Controller) allocateJoinSubnet(node *kapi.Node) (*net.IPNet, error) {
 	}()
 
 	// Set annotation on the node
-	err = oc.addNodeJoinSubnetAnnotations(node, joinSubnet.String())
+	err = oc.addNodeJoinSubnetAnnotations(node, joinSubnet)
 	if err != nil {
 		return nil, err
 	}
@@ -353,11 +354,11 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, subnet *net.IPNet)
 	return nil
 }
 
-func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig *util.L3GatewayConfig, subnet string) error {
+func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig *util.L3GatewayConfig, subnet *net.IPNet) error {
 	var err error
-	var clusterSubnets []string
+	var clusterSubnets []*net.IPNet
 	for _, clusterSubnet := range config.Default.ClusterSubnets {
-		clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR.String())
+		clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR)
 	}
 
 	// get a subnet for the per-node join switch
@@ -374,7 +375,7 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 	if l3GatewayConfig.Mode == config.GatewayModeShared {
 		// Add static routes to OVN Cluster Router to enable pods on this Node to
 		// reach the host IP
-		err = addStaticRouteToHost(node, l3GatewayConfig.IPAddress.String())
+		err = addStaticRouteToHost(node, l3GatewayConfig.IPAddress)
 		if err != nil {
 			return err
 		}
@@ -399,7 +400,7 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 	return err
 }
 
-func addStaticRouteToHost(node *kapi.Node, nicIP string) error {
+func addStaticRouteToHost(node *kapi.Node, nicIP *net.IPNet) error {
 	k8sClusterRouter := util.GetK8sClusterRouter()
 	subnet, err := util.ParseNodeHostSubnetAnnotation(node)
 	if err != nil {
@@ -407,8 +408,8 @@ func addStaticRouteToHost(node *kapi.Node, nicIP string) error {
 			util.K8sMgmtIntfName, err)
 	}
 	_, secondIP := util.GetNodeWellKnownAddresses(subnet)
-	prefix := strings.Split(nicIP, "/")[0] + "/32"
-	nexthop := strings.Split(secondIP.String(), "/")[0]
+	prefix := nicIP.IP.String() + "/32"
+	nexthop := secondIP.IP.String()
 	_, stderr, err := util.RunOVNNbctl("--may-exist", "lr-route-add", k8sClusterRouter, prefix, nexthop)
 	if err != nil {
 		return fmt.Errorf("failed to add static route '%s via %s' for host %q on %s "+
@@ -568,11 +569,11 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostsubnet *net.
 	return nil
 }
 
-func (oc *Controller) addNodeAnnotations(node *kapi.Node, subnet string) error {
+func (oc *Controller) addNodeAnnotations(node *kapi.Node, subnet *net.IPNet) error {
 	nodeAnnotations, err := util.CreateNodeHostSubnetAnnotation(subnet)
 	if err != nil {
 		return fmt.Errorf("failed to marshal node %q annotation for subnet %s",
-			node.Name, subnet)
+			node.Name, subnet.String())
 	}
 	err = oc.kube.SetAnnotationsOnNode(node, nodeAnnotations)
 	if err != nil {
@@ -618,7 +619,7 @@ func (oc *Controller) addNode(node *kapi.Node) (hostsubnet *net.IPNet, err error
 	// Set the HostSubnet annotation on the node object to signal
 	// to nodes that their logical infrastructure is set up and they can
 	// proceed with their initialization
-	err = oc.addNodeAnnotations(node, hostsubnet.String())
+	err = oc.addNodeAnnotations(node, hostsubnet)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -409,7 +409,7 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(mgmtMAC))
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, nodeSubnet)
+			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(nodeSubnet))
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -599,7 +599,7 @@ subnet=%s
 			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(masterMgmtPortMAC))
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, masterSubnet)
+			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(masterSubnet))
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -615,7 +615,7 @@ subnet=%s
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
 			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
-			_ = clusterController.joinSubnetAllocator.AddNetworkRange("100.64.0.0/16", 3)
+			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 3)
 
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()
@@ -706,14 +706,16 @@ var _ = Describe("Gateway Init Operations", func() {
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &testNode)
 			ifaceID := localnetBridgeName + "_" + nodeName
 			err = util.SetLocalL3GatewayConfig(nodeAnnotator, ifaceID,
-				ovntest.MustParseMAC(brLocalnetMAC), localnetGatewayIP, localnetGatewayNextHop,
+				ovntest.MustParseMAC(brLocalnetMAC),
+				ovntest.MustParseIPNet(localnetGatewayIP),
+				ovntest.MustParseIP(localnetGatewayNextHop),
 				true)
 			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(brLocalnetMAC))
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, nodeSubnet)
+			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(nodeSubnet))
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeJoinSubnetAnnotation(nodeAnnotator, joinSubnet)
+			err = util.SetNodeJoinSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(joinSubnet))
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -812,14 +814,14 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
 			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
-			_ = clusterController.joinSubnetAllocator.AddNetworkRange("100.64.0.0/16", 3)
+			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 3)
 
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
 
 			subnet := ovntest.MustParseIPNet(nodeSubnet)
-			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, subnet.String())
+			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, subnet)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
@@ -891,13 +893,14 @@ var _ = Describe("Gateway Init Operations", func() {
 			ifaceID := physicalBridgeName + "_" + nodeName
 			err = util.SetSharedL3GatewayConfig(nodeAnnotator, ifaceID,
 				ovntest.MustParseMAC(physicalBridgeMAC),
-				physicalGatewayIPMask, physicalGatewayNextHop,
+				ovntest.MustParseIPNet(physicalGatewayIPMask),
+				ovntest.MustParseIP(physicalGatewayNextHop),
 				true, 1024)
 			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(nodeMgmtPortMAC))
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, nodeSubnet)
+			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(nodeSubnet))
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeJoinSubnetAnnotation(nodeAnnotator, joinSubnet)
+			err = util.SetNodeJoinSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(joinSubnet))
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -1005,14 +1008,14 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
 			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
-			_ = clusterController.joinSubnetAllocator.AddNetworkRange("100.64.0.0/16", 3)
+			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 3)
 
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
 
 			subnet := ovntest.MustParseIPNet(nodeSubnet)
-			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, subnet.String())
+			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, subnet)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -134,7 +134,7 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	// Node-related logical network stuff
 	cidr := ovntest.MustParseIPNet(nodeSubnet)
 	cidr.IP = util.NextIP(cidr.IP)
-	lrpMAC := util.IPAddrToHWAddr(cidr.IP)
+	lrpMAC := util.IPAddrToHWAddr(cidr.IP).String()
 	gwCIDR := cidr.String()
 	gwIP := cidr.IP.String()
 	nodeMgmtPortIP := util.NextIP(cidr.IP)
@@ -244,7 +244,7 @@ var _ = Describe("Master Operations", func() {
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &testNode)
 			err = util.SetDisabledL3GatewayConfig(nodeAnnotator)
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeManagementPortMacAddr(nodeAnnotator, mgmtMAC)
+			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(mgmtMAC))
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -274,9 +274,9 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(subnetFromAnnotation.String()).To(Equal(nodeSubnet))
 
-			macFromAnnotation, err := util.ParseNodeManagementPortMacAddr(updatedNode)
+			macFromAnnotation, err := util.ParseNodeManagementPortMACAddress(updatedNode)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(macFromAnnotation).To(Equal(mgmtMAC))
+			Expect(macFromAnnotation.String()).To(Equal(mgmtMAC))
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
@@ -326,7 +326,7 @@ var _ = Describe("Master Operations", func() {
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &testNode)
 			err = util.SetDisabledL3GatewayConfig(nodeAnnotator)
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeManagementPortMacAddr(nodeAnnotator, mgmtMAC)
+			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(mgmtMAC))
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -356,9 +356,9 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(subnetFromAnnotation.String()).To(Equal(nodeSubnet))
 
-			macFromAnnotation, err := util.ParseNodeManagementPortMacAddr(updatedNode)
+			macFromAnnotation, err := util.ParseNodeManagementPortMACAddress(updatedNode)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(macFromAnnotation).To(Equal(mgmtMAC))
+			Expect(macFromAnnotation.String()).To(Equal(mgmtMAC))
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
@@ -407,7 +407,7 @@ var _ = Describe("Master Operations", func() {
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &testNode)
 			err = util.SetDisabledL3GatewayConfig(nodeAnnotator)
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeManagementPortMacAddr(nodeAnnotator, mgmtMAC)
+			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(mgmtMAC))
 			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, nodeSubnet)
 			Expect(err).NotTo(HaveOccurred())
@@ -445,9 +445,9 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(subnetFromAnnotation.String()).To(Equal(nodeSubnet))
 
-			macFromAnnotation, err := util.ParseNodeManagementPortMacAddr(updatedNode)
+			macFromAnnotation, err := util.ParseNodeManagementPortMACAddress(updatedNode)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(macFromAnnotation).To(Equal(mgmtMAC))
+			Expect(macFromAnnotation.String()).To(Equal(mgmtMAC))
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
@@ -477,7 +477,7 @@ var _ = Describe("Master Operations", func() {
 				masterSubnet      string = "10.128.2.0/24"
 				masterGWCIDR      string = "10.128.2.1/24"
 				masterMgmtPortIP  string = "10.128.2.2"
-				lrpMAC            string = "0A:58:0A:80:02:01"
+				lrpMAC            string = "0a:58:0a:80:02:01"
 				masterMgmtPortMAC string = "00:00:00:55:66:77"
 			)
 
@@ -597,7 +597,7 @@ subnet=%s
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &masterNode)
 			err = util.SetDisabledL3GatewayConfig(nodeAnnotator)
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeManagementPortMacAddr(nodeAnnotator, masterMgmtPortMAC)
+			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(masterMgmtPortMAC))
 			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, masterSubnet)
 			Expect(err).NotTo(HaveOccurred())
@@ -657,11 +657,11 @@ var _ = Describe("Gateway Init Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				nodeName               string = "node1"
-				nodeLRPMAC             string = "0A:58:0A:01:01:01"
+				nodeLRPMAC             string = "0a:58:0a:01:01:01"
 				joinSubnet             string = "100.64.0.0/29"
-				lrpMAC                 string = "0A:58:64:40:00:01"
+				lrpMAC                 string = "0a:58:64:40:00:01"
 				lrpIP                  string = "100.64.0.1"
-				drLrpMAC               string = "0A:58:64:40:00:02"
+				drLrpMAC               string = "0a:58:64:40:00:02"
 				drLrpIP                string = "100.64.0.2"
 				brLocalnetMAC          string = "11:22:33:44:55:66"
 				clusterRouter          string = util.OvnClusterRouter
@@ -706,9 +706,10 @@ var _ = Describe("Gateway Init Operations", func() {
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &testNode)
 			ifaceID := localnetBridgeName + "_" + nodeName
 			err = util.SetLocalL3GatewayConfig(nodeAnnotator, ifaceID,
-				brLocalnetMAC, localnetGatewayIP, localnetGatewayNextHop, true)
+				ovntest.MustParseMAC(brLocalnetMAC), localnetGatewayIP, localnetGatewayNextHop,
+				true)
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeManagementPortMacAddr(nodeAnnotator, brLocalnetMAC)
+			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(brLocalnetMAC))
 			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, nodeSubnet)
 			Expect(err).NotTo(HaveOccurred())
@@ -839,11 +840,11 @@ var _ = Describe("Gateway Init Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				nodeName               string = "node1"
-				nodeLRPMAC             string = "0A:58:0A:01:01:01"
+				nodeLRPMAC             string = "0a:58:0a:01:01:01"
 				joinSubnet             string = "100.64.0.0/29"
-				lrpMAC                 string = "0A:58:64:40:00:01"
+				lrpMAC                 string = "0a:58:64:40:00:01"
 				lrpIP                  string = "100.64.0.1"
-				drLrpMAC               string = "0A:58:64:40:00:02"
+				drLrpMAC               string = "0a:58:64:40:00:02"
 				drLrpIP                string = "100.64.0.2"
 				physicalBridgeMAC      string = "11:22:33:44:55:66"
 				lrpCIDR                string = lrpIP + "/16"
@@ -863,7 +864,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				physicalBridgeName     string = "br-eth0"
 				nodeGWIP               string = "10.1.1.1/24"
 				nodeMgmtPortIP         string = "10.1.1.2"
-				nodeMgmtPortMAC        string = "0A:58:0A:01:01:02"
+				nodeMgmtPortMAC        string = "0a:58:0a:01:01:02"
 			)
 
 			testNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
@@ -889,9 +890,10 @@ var _ = Describe("Gateway Init Operations", func() {
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &testNode)
 			ifaceID := physicalBridgeName + "_" + nodeName
 			err = util.SetSharedL3GatewayConfig(nodeAnnotator, ifaceID,
-				physicalBridgeMAC, physicalGatewayIPMask, physicalGatewayNextHop,
+				ovntest.MustParseMAC(physicalBridgeMAC),
+				physicalGatewayIPMask, physicalGatewayNextHop,
 				true, 1024)
-			err = util.SetNodeManagementPortMacAddr(nodeAnnotator, nodeMgmtPortMAC)
+			err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(nodeMgmtPortMAC))
 			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, nodeSubnet)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -539,7 +539,7 @@ func (oc *Controller) syncNodeGateway(node *kapi.Node, subnet *net.IPNet) error 
 			return fmt.Errorf("error cleaning up gateway for node %s: %v", node.Name, err)
 		}
 	} else if subnet != nil {
-		if err := oc.syncGatewayLogicalNetwork(node, l3GatewayConfig, subnet.String()); err != nil {
+		if err := oc.syncGatewayLogicalNetwork(node, l3GatewayConfig, subnet); err != nil {
 			return fmt.Errorf("error creating gateway for node %s: %v", node.Name, err)
 		}
 	}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -1,6 +1,7 @@
 package ovn
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -757,9 +758,9 @@ func gatewayChanged(oldNode, newNode *kapi.Node) bool {
 
 // macAddressChanged() compares old annotations to new and returns true if something has changed.
 func macAddressChanged(oldNode, node *kapi.Node) bool {
-	oldMacAddress, _ := util.ParseNodeManagementPortMacAddr(oldNode)
-	macAddress, _ := util.ParseNodeManagementPortMacAddr(node)
-	return oldMacAddress != macAddress
+	oldMacAddress, _ := util.ParseNodeManagementPortMACAddress(oldNode)
+	macAddress, _ := util.ParseNodeManagementPortMACAddress(node)
+	return !bytes.Equal(oldMacAddress, macAddress)
 }
 
 // noHostSubnet() compares the no-hostsubenet-nodes flag with node labels to see if the node is manageing its

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -125,8 +125,8 @@ func GatewayInit(clusterIPSubnet []string, hostSubnet string, joinSubnet *net.IP
 	prefixLen, _ := joinSubnet.Mask.Size()
 	gwLRPIp := NextIP(joinSubnet.IP)
 	drLRPIp := NextIP(gwLRPIp)
-	gwLRPMac := IPAddrToHWAddr(gwLRPIp)
-	drLRPMac := IPAddrToHWAddr(drLRPIp)
+	gwLRPMAC := IPAddrToHWAddr(gwLRPIp)
+	drLRPMAC := IPAddrToHWAddr(drLRPIp)
 
 	joinSwitch := JoinSwitchPrefix + nodeName
 	// create the per-node join switch
@@ -148,7 +148,7 @@ func GatewayInit(clusterIPSubnet []string, hostSubnet string, joinSubnet *net.IP
 	}
 
 	_, stderr, err = RunOVNNbctl(
-		"--", "--may-exist", "lrp-add", gatewayRouter, gwRouterPort, gwLRPMac,
+		"--", "--may-exist", "lrp-add", gatewayRouter, gwRouterPort, gwLRPMAC.String(),
 		fmt.Sprintf("%s/%d", gwLRPIp.String(), prefixLen))
 	if err != nil {
 		return fmt.Errorf("Failed to add logical router port %q, stderr: %q, error: %v", gwRouterPort, stderr, err)
@@ -169,7 +169,7 @@ func GatewayInit(clusterIPSubnet []string, hostSubnet string, joinSubnet *net.IP
 	}
 
 	_, stderr, err = RunOVNNbctl(
-		"--", "--may-exist", "lrp-add", k8sClusterRouter, drRouterPort, drLRPMac,
+		"--", "--may-exist", "lrp-add", k8sClusterRouter, drRouterPort, drLRPMAC.String(),
 		fmt.Sprintf("%s/%d", drLRPIp.String(), prefixLen))
 	if err != nil {
 		return fmt.Errorf("Failed to add logical router port %q, stderr: %q, error: %v", drRouterPort, stderr, err)

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -13,6 +13,14 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
+func getFamily(ip net.IP) int {
+	if utilnet.IsIPv6(ip) {
+		return netlink.FAMILY_V6
+	} else {
+		return netlink.FAMILY_V4
+	}
+}
+
 // LinkSetUp returns the netlink device with its state marked up
 func LinkSetUp(interfaceName string) (netlink.Link, error) {
 	link, err := netlink.LinkByName(interfaceName)
@@ -43,22 +51,14 @@ func LinkAddrFlush(link netlink.Link) error {
 }
 
 // LinkAddrExist returns true if the given address is present on the link
-func LinkAddrExist(link netlink.Link, address string) (bool, error) {
-	ipnet, err := netlink.ParseIPNet(address)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse ip %s :%v\n", address, err)
-	}
-	family := netlink.FAMILY_V4
-	if ipnet.IP.To4() == nil {
-		family = netlink.FAMILY_V6
-	}
-	addrs, err := netlink.AddrList(link, family)
+func LinkAddrExist(link netlink.Link, address *net.IPNet) (bool, error) {
+	addrs, err := netlink.AddrList(link, getFamily(address.IP))
 	if err != nil {
 		return false, fmt.Errorf("failed to list addresses for the link %s: %v",
 			link.Attrs().Name, err)
 	}
 	for _, addr := range addrs {
-		if addr.IPNet.String() == address {
+		if addr.IPNet.String() == address.String() {
 			return true, nil
 		}
 	}
@@ -66,12 +66,8 @@ func LinkAddrExist(link netlink.Link, address string) (bool, error) {
 }
 
 // LinkAddrAdd removes existing addresses on the link and adds the new address
-func LinkAddrAdd(link netlink.Link, address string) error {
-	ipnet, err := netlink.ParseIPNet(address)
-	if err != nil {
-		return fmt.Errorf("failed to parse ip %s :%v\n", address, err)
-	}
-	err = netlink.AddrAdd(link, &netlink.Addr{IPNet: ipnet})
+func LinkAddrAdd(link netlink.Link, address *net.IPNet) error {
+	err := netlink.AddrAdd(link, &netlink.Addr{IPNet: address})
 	if err != nil {
 		return fmt.Errorf("failed to add address %s on link %s: %v", address, link.Attrs().Name, err)
 	}
@@ -79,7 +75,7 @@ func LinkAddrAdd(link netlink.Link, address string) error {
 }
 
 // LinkRoutesDel deletes all the routes for the given subnets via the link
-func LinkRoutesDel(link netlink.Link, subnets []string) error {
+func LinkRoutesDel(link netlink.Link, subnets []*net.IPNet) error {
 	routes, err := netlink.RouteList(link, netlink.FAMILY_ALL)
 	if err != nil {
 		return fmt.Errorf("failed to get all the routes for link %s: %v",
@@ -87,7 +83,7 @@ func LinkRoutesDel(link netlink.Link, subnets []string) error {
 	}
 	for _, subnet := range subnets {
 		for _, route := range routes {
-			if route.Dst.String() == subnet {
+			if route.Dst.String() == subnet.String() {
 				err = netlink.RouteDel(&route)
 				if err != nil {
 					return fmt.Errorf("failed to delete route '%s via %s' for link %s : %v\n",
@@ -101,57 +97,36 @@ func LinkRoutesDel(link netlink.Link, subnets []string) error {
 }
 
 // LinkRoutesAdd adds a new route for given subnets through the gwIPstr
-func LinkRoutesAdd(link netlink.Link, gwIPstr string, subnets []string) error {
-	gwIP := net.ParseIP(gwIPstr)
-	if gwIP == nil {
-		return fmt.Errorf("gateway IP %s is not a valid IPv4 or IPv6 address", gwIPstr)
-	}
+func LinkRoutesAdd(link netlink.Link, gwIP net.IP, subnets []*net.IPNet) error {
 	for _, subnet := range subnets {
-		dstIPnet, err := netlink.ParseIPNet(subnet)
-		if err != nil {
-			return fmt.Errorf("failed to parse subnet %s :%v\n", subnet, err)
-		}
 		route := &netlink.Route{
-			Dst:       dstIPnet,
+			Dst:       subnet,
 			LinkIndex: link.Attrs().Index,
 			Scope:     netlink.SCOPE_UNIVERSE,
 			Gw:        gwIP,
 		}
-		err = netlink.RouteAdd(route)
+		err := netlink.RouteAdd(route)
 		if err != nil {
 			if os.IsExist(err) {
 				return err
 			}
 			return fmt.Errorf("failed to add route for subnet %s via gateway %s: %v",
-				subnet, gwIPstr, err)
+				subnet.String(), gwIP.String(), err)
 		}
 	}
 	return nil
 }
 
 // LinkRouteExists checks for existence of routes for the given subnet through gwIPStr
-func LinkRouteExists(link netlink.Link, gwIPstr, subnet string) (bool, error) {
-	gwIP := net.ParseIP(gwIPstr)
-	if gwIP == nil {
-		return false, fmt.Errorf("gateway IP %s is not a valid IPv4 or IPv6 address", gwIPstr)
-	}
-	family := netlink.FAMILY_V4
-	if utilnet.IsIPv6(gwIP) {
-		family = netlink.FAMILY_V6
-	}
-
-	dstIPnet, err := netlink.ParseIPNet(subnet)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse subnet %s :%v\n", subnet, err)
-	}
-	routeFilter := &netlink.Route{Dst: dstIPnet}
+func LinkRouteExists(link netlink.Link, gwIP net.IP, subnet *net.IPNet) (bool, error) {
+	routeFilter := &netlink.Route{Dst: subnet}
 	filterMask := netlink.RT_FILTER_DST
-	routes, err := netlink.RouteListFiltered(family, routeFilter, filterMask)
+	routes, err := netlink.RouteListFiltered(getFamily(gwIP), routeFilter, filterMask)
 	if err != nil {
-		return false, fmt.Errorf("failed to get routes for subnet %s", subnet)
+		return false, fmt.Errorf("failed to get routes for subnet %s", subnet.String())
 	}
 	for _, route := range routes {
-		if route.Gw.String() == gwIPstr {
+		if route.Gw.Equal(gwIP) {
 			return true, nil
 		}
 	}
@@ -159,19 +134,10 @@ func LinkRouteExists(link netlink.Link, gwIPstr, subnet string) (bool, error) {
 }
 
 // LinkNeighAdd adds MAC/IP bindings for the given link
-func LinkNeighAdd(link netlink.Link, neighIPstr string, neighMAC net.HardwareAddr) error {
-	neighIP := net.ParseIP(neighIPstr)
-	if neighIP == nil {
-		return fmt.Errorf("neighbour IP %s is not a valid IPv4 or IPv6 address", neighIPstr)
-	}
-
-	family := netlink.FAMILY_V4
-	if utilnet.IsIPv6(neighIP) {
-		family = netlink.FAMILY_V6
-	}
+func LinkNeighAdd(link netlink.Link, neighIP net.IP, neighMAC net.HardwareAddr) error {
 	neigh := &netlink.Neigh{
 		LinkIndex:    link.Attrs().Index,
-		Family:       family,
+		Family:       getFamily(neighIP),
 		State:        netlink.NUD_PERMANENT,
 		IP:           neighIP,
 		HardwareAddr: neighMAC,
@@ -184,26 +150,15 @@ func LinkNeighAdd(link netlink.Link, neighIPstr string, neighMAC net.HardwareAdd
 }
 
 // LinkNeighExists checks to see if the given MAC/IP bindings exists
-func LinkNeighExists(link netlink.Link, neighIPstr string, neighMAC net.HardwareAddr) (bool, error) {
-	neighIP := net.ParseIP(neighIPstr)
-	if neighIP == nil {
-		return false, fmt.Errorf("neighbour IP %s is not a valid IPv4 or IPv6 address",
-			neighIPstr)
-	}
-
-	family := netlink.FAMILY_V4
-	if utilnet.IsIPv6(neighIP) {
-		family = netlink.FAMILY_V6
-	}
-
-	neighs, err := netlink.NeighList(link.Attrs().Index, family)
+func LinkNeighExists(link netlink.Link, neighIP net.IP, neighMAC net.HardwareAddr) (bool, error) {
+	neighs, err := netlink.NeighList(link.Attrs().Index, getFamily(neighIP))
 	if err != nil {
 		return false, fmt.Errorf("failed to get the list of neighbour entries for link %s",
 			link.Attrs().Name)
 	}
 
 	for _, neigh := range neighs {
-		if neigh.IP.String() == neighIPstr {
+		if neigh.IP.Equal(neighIP) {
 			if bytes.Equal(neigh.HardwareAddr, neighMAC) &&
 				(neigh.State&netlink.NUD_PERMANENT) == netlink.NUD_PERMANENT {
 				return true, nil

--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -35,9 +35,9 @@ const (
 
 // CreateNodeHostSubnetAnnotation creates a "k8s.ovn.org/node-subnets" annotation,
 // with a single "default" network, suitable for passing to kube.SetAnnotationsOnNode
-func CreateNodeHostSubnetAnnotation(defaultSubnet string) (map[string]interface{}, error) {
+func CreateNodeHostSubnetAnnotation(defaultSubnet *net.IPNet) (map[string]interface{}, error) {
 	bytes, err := json.Marshal(map[string]string{
-		"default": defaultSubnet,
+		"default": defaultSubnet.String(),
 	})
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func CreateNodeHostSubnetAnnotation(defaultSubnet string) (map[string]interface{
 
 // SetNodeHostSubnetAnnotation sets a "k8s.ovn.org/node-subnets" annotation
 // using a kube.Annotator
-func SetNodeHostSubnetAnnotation(nodeAnnotator kube.Annotator, defaultSubnet string) error {
+func SetNodeHostSubnetAnnotation(nodeAnnotator kube.Annotator, defaultSubnet *net.IPNet) error {
 	annotation, err := CreateNodeHostSubnetAnnotation(defaultSubnet)
 	if err != nil {
 		return err
@@ -88,9 +88,9 @@ func ParseNodeHostSubnetAnnotation(node *kapi.Node) (*net.IPNet, error) {
 
 // CreateNodeJoinSubnetAnnotation creates a "k8s.ovn.org/node-join-subnets" annotation
 // with a single "default" network, suitable for passing to kube.SetAnnotationsOnNode
-func CreateNodeJoinSubnetAnnotation(defaultSubnet string) (map[string]interface{}, error) {
+func CreateNodeJoinSubnetAnnotation(defaultSubnet *net.IPNet) (map[string]interface{}, error) {
 	bytes, err := json.Marshal(map[string]string{
-		"default": defaultSubnet,
+		"default": defaultSubnet.String(),
 	})
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func CreateNodeJoinSubnetAnnotation(defaultSubnet string) (map[string]interface{
 
 // SetNodeJoinSubnetAnnotation sets a "k8s.ovn.org/node-join-subnets" annotation
 // using a kube.Annotator
-func SetNodeJoinSubnetAnnotation(nodeAnnotator kube.Annotator, defaultSubnet string) error {
+func SetNodeJoinSubnetAnnotation(nodeAnnotator kube.Annotator, defaultSubnet *net.IPNet) error {
 	annotation, err := CreateNodeJoinSubnetAnnotation(defaultSubnet)
 	if err != nil {
 		return err

--- a/go-controller/pkg/util/util_test.go
+++ b/go-controller/pkg/util/util_test.go
@@ -34,19 +34,19 @@ var _ = Describe("Util tests", func() {
 			{
 				name:        "IPv4 to MAC",
 				IP:          "10.1.2.3",
-				expectedMAC: "0A:58:0A:01:02:03",
+				expectedMAC: "0a:58:0a:01:02:03",
 			},
 			{
 				name:        "IPv6 to MAC",
 				IP:          "fd98::1",
-				expectedMAC: "0A:58:FD:98:00:01",
+				expectedMAC: "0a:58:fd:98:00:01",
 			},
 		}
 
 		for _, tc := range testcases {
 			ip := ovntest.MustParseIP(tc.IP)
 			mac := IPAddrToHWAddr(ip)
-			Expect(mac).To(Equal(tc.expectedMAC), " test case \"%s\" returned %s instead of %s from IP %s", tc.name, mac, tc.expectedMAC, ip.String())
+			Expect(mac.String()).To(Equal(tc.expectedMAC), " test case \"%s\" returned %s instead of %s from IP %s", tc.name, mac.String(), tc.expectedMAC, ip.String())
 		}
 	})
 })


### PR DESCRIPTION
In the course of updating a lot of functions that take or return an IP/CIDR to make them able to take/return two IPs/CIDRs for dual stack, I noticed that there are lots of places where we have a `net.IP` or `*net.IPNet`, then convert it to a string to pass to another function, and then that other function immediately reparses it back to struct form (with an error check since it doesn't actually know for sure that the string is valid). Or, we read a value, parse it to make sure it's valid, throw away the parsed form and return the string form to the caller, and then the caller parses it again.

The parsed forms seem to me to be superior to the unparsed ones, since given a `net.IP` or `*net.IPNet`, you are guaranteed to be able to convert it to a valid string without problems, but given a string, you are not guaranteed to be able to parse it without problems. Thus, it seems like we should parse IPs/CIDRs once when reading them in from config/annotations/command output, and then keep them in the parsed form internally until we need to write them to annotations/command input again.

This patch is probably not complete but it covers a lot of it.