### PR TITLE
Obtaining Node IP's from status.Host IP instead of using DNS

### DIFF
--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -194,8 +194,7 @@ ovsdb-raft() {
   rm -f ${ovn_db_pidfile}
 
   verify-ovsdb-raft
-  local_ip=$(getent ahostsv4 $(hostname) | grep -v "^127\." | head -1 | awk '{ print $1 }')
-  if [[ ${local_ip} == "" ]]; then
+  if [[ ${ovn_db_host} == "" ]] ; then
     echo "failed to retrieve the IP address of the host $(hostname). Exiting..."
     exit 1
   fi
@@ -207,7 +206,7 @@ ovsdb-raft() {
   if [[ "${POD_NAME}" == "ovnkube-db-0" ]]; then
     run_as_ovs_user_if_needed \
       ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
-      --db-${db}-cluster-local-addr=${local_ip} \
+      --db-${db}-cluster-local-addr=${ovn_db_host} \
       --db-${db}-cluster-local-port=${raft_port} \
       --ovn-${db}-log="${ovn_log_db}" &
   else
@@ -217,7 +216,7 @@ ovsdb-raft() {
     fi
     run_as_ovs_user_if_needed \
       ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
-      --db-${db}-cluster-local-addr=${local_ip} --db-${db}-cluster-remote-addr=${init_ip} \
+      --db-${db}-cluster-local-addr=${ovn_db_host} --db-${db}-cluster-remote-addr=${init_ip} \
       --db-${db}-cluster-local-port=${raft_port} --db-${db}-cluster-remote-port=${raft_port} \
       --ovn-${db}-log="${ovn_log_db}" &
   fi

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -123,8 +123,8 @@ mtu=${OVN_MTU:-1400}
 ovn_kubernetes_namespace=${OVN_KUBERNETES_NAMESPACE:-ovn-kubernetes}
 
 # host on which ovnkube-db POD is running and this POD contains both
-# OVN NB and SB DB running in their own container. Ignore IPs in loopback range (127.0.0.0/8)
-ovn_db_host=$(getent ahostsv4 $(hostname) | grep -v "^127\." | head -1 | awk '{ print $1 }')
+# OVN NB and SB DB running in their own container.
+ovn_db_host=${K8S_NODE_IP:-""}
 
 # OVN_NB_PORT - ovn north db port (default 6641)
 ovn_nb_port=${OVN_NB_PORT:-6641}

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -151,6 +151,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
       # end of container
 
       # sb-ovsdb - v3
@@ -211,6 +215,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
       # end of container
 
       # db-metrics-exporter - v3

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -129,6 +129,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+	- name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: OVN_DB_VIP
           value: "{{ ovn_db_vip }}"
       # end of container

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -112,6 +112,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
@@ -168,6 +172,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]


### PR DESCRIPTION
In Ovnkube.sh, currently Node IP's are obtained using DNS.
Instead, Pod spec (status.HOST IP) is used to obtain the Node IP's.

Signed-off-by: Pardhakeswar <ppacha@nvidia.com>