### PR TITLE
Renaming loglevel capture variable names in ovnkube.sh & yaml files

### DIFF
--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -136,7 +136,7 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_LOG_NB
+        - name: OVN_LOGLEVEL_NB
           value: "{{ ovn_loglevel_nb }}"
         - name: K8S_APISERVER
           valueFrom:
@@ -200,7 +200,7 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_LOG_SB
+        - name: OVN_LOGLEVEL_SB
           value: "{{ ovn_loglevel_sb }}"
         - name: K8S_APISERVER
           valueFrom:

--- a/dist/templates/ovnkube-db-vip.yaml.j2
+++ b/dist/templates/ovnkube-db-vip.yaml.j2
@@ -118,7 +118,7 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_LOG_NB
+        - name: OVN_LOGLEVEL_NB
           value: "{{ ovn_loglevel_nb }}"
         - name: K8S_APISERVER
           valueFrom:

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -101,7 +101,7 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_LOG_NB
+        - name: OVN_LOGLEVEL_NB
           value: "{{ ovn_loglevel_nb }}"
         - name: K8S_APISERVER
           valueFrom:
@@ -161,7 +161,7 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_LOG_SB
+        - name: OVN_LOGLEVEL_SB
           value: "{{ ovn_loglevel_sb }}"
         - name: K8S_APISERVER
           valueFrom:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -98,7 +98,7 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_LOG_NORTHD
+        - name: OVN_LOGLEVEL_NORTHD
           value: "{{ ovn_loglevel_northd }}"
         - name: K8S_APISERVER
           valueFrom:
@@ -144,7 +144,7 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_LOG_NBCTLD
+        - name: OVN_LOGLEVEL_NBCTLD
           value: "{{ ovn_loglevel_nbctld }}"
         - name: K8S_APISERVER
           valueFrom:


### PR DESCRIPTION
Currently, ovn_log_northd variable is capturing the loglevel which should capture
the log location. Renaming ovn_log_northd -> ovn_loglevel_northd and similar renaming
is used for other variable names (ovn_log_nb, ovn_log_sb, ovn_log_controller).

Similarly in the YAML files, OVN_LOG_NB and other log level variables(OVN_LOG_SB, OVN_LOG_NBCTLD)
is used for for capturing the loglevel. Renaming them to OVN_LOGLEVEL_NB and others to similar nomenclature.

Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>