### PR TITLE
Fix golang linter timeouts

### DIFF
--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-
 GO111MODULE=on ${GOPATH}/bin/golangci-lint run \
     --tests=false --enable gofmt \
-    --timeout=10m0s \
+    --timeout=15m0s --verbose --print-resources-usage --modules-download-mode=vendor \
     && echo "lint OK!"


### PR DESCRIPTION
Changes-Include:
 - Use verbose print resource usage
 - Use vendor folder to avoid having to download deps

Closes #1222

Signed-off-by: Tim Rozet <trozet@redhat.com>