### PR TITLE
Enable more CI tests for k8s e2e

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -10,7 +10,8 @@ export KUBECONFIG=${HOME}/admin.conf
 export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
 export NODE_NAMES=${MASTER_NAME}
 
-SKIPPED_TESTS='Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|NetworkPolicy\sbetween\sserver\sand\sclient.+(ingress\saccess|multiple\segress\spolicies|allow\segress\saccess)|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|(Namespace|Pod)Selector\s\[Feature:NetworkPolicy\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout|EndpointSlices'
+#REMOVE skip for "ingress access from updated pod" when k8s is updated to 1.18
+SKIPPED_TESTS='Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:IPv6DualStackAlphaFeature\]|\[Feature:NoSNAT\]|Services.+(ESIPP|cleanup\sfinalizer|session\saffinity)|\[Feature:Networking-IPv6\]|\[Feature:Federation\]|configMap\snameserver|ClusterDns\s\[Feature:Example\]|kube-proxy|should\sset\sTCP\sCLOSE_WAIT\stimeout|EndpointSlices|named\sport.+\[Feature:NetworkPolicy\]|should\sallow\singress\saccess\sfrom\supdated\spod.+\[Feature:NetworkPolicy\]'
 GINKGO_ARGS="--num-nodes=3 --ginkgo.skip=${SKIPPED_TESTS} --disable-log-dump=false"
 
 case "$SHARD" in


### PR DESCRIPTION
A bunch of network policy tests were being skipped which should pass now.

Closes #1190

Signed-off-by: Tim Rozet <trozet@redhat.com>