### PR TITLE
SSL for OVN daemonsets

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -17,11 +17,11 @@ OVN_SVC_DIDR=""
 OVN_K8S_APISERVER=""
 OVN_GATEWAY_MODE=""
 OVN_GATEWAY_OPTS=""
-# In the future we will have RAFT based HA support.
 OVN_DB_VIP_IMAGE=""
 OVN_DB_VIP=""
 OVN_DB_REPLICAS=""
 OVN_MTU=""
+OVN_SSL_ENABLE=""
 KIND=""
 MASTER_LOGLEVEL=""
 NODE_LOGLEVEL=""
@@ -93,6 +93,9 @@ while [ "$1" != "" ]; do
   --ovn-loglevel-nbctld)
     OVN_LOGLEVEL_NBCTLD=$VALUE
     ;;
+  --ssl)
+    OVN_SSL_ENABLE="yes"
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -142,6 +145,8 @@ ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE}
 echo "ovn_hybrid_overlay_enable: ${ovn_hybrid_overlay_enable}"
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR}
 echo "ovn_hybrid_overlay_net_cidr: ${ovn_hybrid_overlay_net_cidr}"
+ovn_ssl_en=${OVN_SSL_ENABLE:-"no"}
+echo "ovn_ssl_enable: ${ovn_ssl_en}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -152,6 +157,7 @@ ovn_image=${image} \
   ovn_loglevel_controller=${ovn_loglevel_controller} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
+  ovn_ssl_en=${ovn_ssl_en} \
   j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node.yaml
 
 ovn_image=${image} \
@@ -161,12 +167,14 @@ ovn_image=${image} \
   ovn_loglevel_nbctld=${ovn_loglevel_nbctld} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
+  ovn_ssl_en=${ovn_ssl_en} \
   j2 ../templates/ovnkube-master.yaml.j2 -o ../yaml/ovnkube-master.yaml
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
   ovn_loglevel_nb=${ovn_loglevel_nb} \
   ovn_loglevel_sb=${ovn_loglevel_sb} \
+  ovn_ssl_en=${ovn_ssl_en} \
   j2 ../templates/ovnkube-db.yaml.j2 -o ../yaml/ovnkube-db.yaml
 
 ovn_db_vip_image=${ovn_db_vip_image} \
@@ -180,6 +188,7 @@ ovn_image=${image} \
   ovn_db_replicas=${ovn_db_replicas} \
   ovn_db_minAvailable=${ovn_db_minAvailable} \
   ovn_loglevel_nb=${ovn_loglevel_nb} ovn_loglevel_sb=${ovn_loglevel_sb} \
+  ovn_ssl_en=${ovn_ssl_en} \
   j2 ../templates/ovnkube-db-raft.yaml.j2 -o ../yaml/ovnkube-db-raft.yaml
 
 # ovn-setup.yaml

--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -4,6 +4,11 @@
 verify-ovsdb-raft() {
   check_ovn_daemonset_version "3"
 
+  if [[ ${ovn_db_host} == "" ]]; then
+    echo "failed to retrieve the IP address of the host $(hostname). Exiting..."
+    exit 1
+  fi
+
   replicas=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
     get statefulset -n ${ovn_kubernetes_namespace} ovnkube-db -o=jsonpath='{.spec.replicas}')
   if [[ ${replicas} -lt 3 || $((${replicas} % 2)) -eq 0 ]]; then
@@ -16,16 +21,17 @@ verify-ovsdb-raft() {
 # This waits for ovnkube-db-0 POD to come up
 ready_to_join_cluster() {
   # See if ep is available ...
-  db=${1}
-  port=${2}
+  local db=${1}
+  local port=${2}
 
   init_ip="$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
     get pod -n ${ovn_kubernetes_namespace} ovnkube-db-0 -o=jsonpath='{.status.podIP}')"
   if [[ $? != 0 ]]; then
     return 1
   fi
-  target=$(ovn-${db}ctl --db=tcp:${init_ip}:${port} --data=bare --no-headings --columns=target list connection 2>/dev/null)
-  if [[ "${target}" != "ptcp:${port}" ]]; then
+  target=$(ovn-${db}ctl --db=${transport}:${init_ip}:${port} ${ovndb_ctl_ssl_opts} --data=bare --no-headings \
+    --columns=target list connection 2>/dev/null)
+  if [[ "${target}" != "p${transport}:${port}" ]]; then
     return 1
   fi
   return 0
@@ -37,7 +43,7 @@ check_ovnkube_db_ep() {
 
   # TODO: Right now only checks for NB ovsdb instances
   echo "======= checking ${dbaddr}:${dbport} OVSDB instance ==============="
-  ovsdb-client list-dbs tcp:${dbaddr}:${dbport} >/dev/null 2>&1
+  ovsdb-client ${ovndb_ctl_ssl_opts} list-dbs ${transport}:${dbaddr}:${dbport} >/dev/null 2>&1
   if [[ $? != 0 ]]; then
     return 1
   fi
@@ -85,7 +91,8 @@ check_and_apply_ovnkube_db_ep() {
 
 # election timer can only be at most doubled each time, and it can only be set on the leader
 set_election_timer() {
-  local election_timer=${1}
+  local db=${1}
+  local election_timer=${2}
   local current_election_timer
 
   echo "setting election timer for ${database} to ${election_timer} ms"
@@ -127,7 +134,8 @@ set_election_timer() {
 # the pod is a part of mutli-pods cluster and may not be a leader and the connection information should
 # have already been set, so we don't care.
 set_connection() {
-  local port=${1}
+  local db=${1}
+  local port=${2}
   local target
   local output
 
@@ -137,8 +145,8 @@ set_connection() {
     # this instance is a leader, check if we need to make any changes
     echo "found the current value of target and inactivity probe to be ${output}"
     target=$(echo "${output}" | awk 'ORS=","')
-    if [[ "${target}" != "ptcp:${port},0," ]]; then
-      ovn-${db}ctl --inactivity-probe=0 set-connection ptcp:${port}
+    if [[ "${target}" != "p${transport}:${port},0," ]]; then
+      ovn-${db}ctl --inactivity-probe=0 set-connection p${transport}:${port}
       if [[ $? != 0 ]]; then
         echo "Failed to set connection and disable inactivity probe. Exiting...."
         exit 12
@@ -186,30 +194,43 @@ ovsdb-raft() {
   ovn_db_pidfile=${OVN_RUNDIR}/ovn${db}_db.pid
   eval ovn_log_db=\$ovn_log_${db}
   ovn_db_file=${OVN_ETCDIR}/ovn${db}_db.db
-  database="OVN_Northbound"
-  if [[ ${db} == "sb" ]]; then
-    database="OVN_Southbound"
-  fi
 
   rm -f ${ovn_db_pidfile}
 
   verify-ovsdb-raft
-  if [[ ${ovn_db_host} == "" ]] ; then
-    echo "failed to retrieve the IP address of the host $(hostname). Exiting..."
-    exit 1
-  fi
-  iptables-rules ${raft_port}
-
   echo "=============== run ${db}-ovsdb-raft pod ${POD_NAME} =========="
 
   if [[ ! -e ${ovn_db_file} ]] || ovsdb-tool db-is-standalone ${ovn_db_file}; then
     initialize="true"
+  fi
+
+  local db_ssl_opts=""
+  if [[ ${db} == "nb" ]]; then
+    database="OVN_Northbound"
+    [[ "yes" == ${OVN_SSL_ENABLE} ]] && {
+      db_ssl_opts="
+            --ovn-nb-db-ssl-key=${ovn_nb_pk}
+            --ovn-nb-db-ssl-cert=${ovn_nb_cert}
+            --ovn-nb-db-ssl-ca-cert=${ovn_ca_cert}
+      "
+    }
+  else
+    database="OVN_Southbound"
+    [[ "yes" == ${OVN_SSL_ENABLE} ]] && {
+      db_ssl_opts="
+            --ovn-sb-db-ssl-key=${ovn_sb_pk}
+            --ovn-sb-db-ssl-cert=${ovn_sb_cert}
+            --ovn-sb-db-ssl-ca-cert=${ovn_ca_cert}
+      "
+    }
   fi
   if [[ "${POD_NAME}" == "ovnkube-db-0" ]]; then
     run_as_ovs_user_if_needed \
       ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
       --db-${db}-cluster-local-addr=${ovn_db_host} \
       --db-${db}-cluster-local-port=${raft_port} \
+      --db-${db}-cluster-local-proto=${transport} \
+      ${db_ssl_opts} \
       --ovn-${db}-log="${ovn_log_db}" &
   else
     # join the remote cluster node if the DB is not created
@@ -220,6 +241,8 @@ ovsdb-raft() {
       ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
       --db-${db}-cluster-local-addr=${ovn_db_host} --db-${db}-cluster-remote-addr=${init_ip} \
       --db-${db}-cluster-local-port=${raft_port} --db-${db}-cluster-remote-port=${raft_port} \
+      --db-${db}-cluster-local-proto=${transport} --db-${db}-cluster-remote-proto=${transport} \
+      ${db_ssl_opts} \
       --ovn-${db}-log="${ovn_log_db}" &
   fi
 
@@ -238,12 +261,12 @@ ovsdb-raft() {
     # set the election timer value before other servers join the cluster and it can
     # only be set on the leader so we must do this in ovnkube-db-0 when it is still
     # a single-node cluster
-    set_election_timer ${election_timer}
+    set_election_timer ${db} ${election_timer}
     if [[ ${db} == "nb" ]]; then
       set_northd_probe_interval
     fi
     # set the connection and disable inactivity probe, this deletes the old connection if any
-    set_connection ${port}
+    set_connection ${db} ${port}
   fi
 
   last_node_index=$(expr ${replicas} - 1)

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -128,6 +128,9 @@ spec:
           name: host-var-run-ovs
         - mountPath: /var/run/ovn/
           name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
 
         resources:
           requests:
@@ -155,6 +158,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
       # end of container
 
       # sb-ovsdb - v3
@@ -192,6 +197,9 @@ spec:
           name: host-var-run-ovs
         - mountPath: /var/run/ovn/
           name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
 
         resources:
           requests:
@@ -219,6 +227,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
       # end of container
 
       # db-metrics-exporter - v3
@@ -245,6 +255,9 @@ spec:
             name: host-var-run-ovs
           - mountPath: /var/run/ovn/
             name: host-var-run-ovs
+          - mountPath: /ovn-cert
+            name: host-ovn-cert
+            readOnly: true
 
         resources:
           requests:
@@ -262,6 +275,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: OVN_SSL_ENABLE
+            value: "{{ ovn_ssl_en }}"
       # end of container
 
       volumes:
@@ -274,5 +289,9 @@ spec:
       - name: host-var-run-ovs
         hostPath:
           path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
       tolerations:
       - operator: "Exists"

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -93,6 +93,9 @@ spec:
         - mountPath: /host
           name: host-slash
           readOnly: true
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
 
         resources:
           requests:
@@ -116,6 +119,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
@@ -153,6 +158,9 @@ spec:
         - mountPath: /host
           name: host-slash
           readOnly: true
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
 
         resources:
           requests:
@@ -176,6 +184,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]
@@ -198,5 +208,9 @@ spec:
       - name: host-slash
         hostPath:
           path: /
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
       tolerations:
       - operator: "Exists"

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -90,6 +90,9 @@ spec:
           name: host-var-run-ovs
         - mountPath: /var/run/ovn/
           name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
 
         resources:
           requests:
@@ -109,6 +112,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
@@ -136,7 +141,9 @@ spec:
           name: host-var-run-ovs
         - mountPath: /var/run/ovn/
           name: host-var-run-ovs
-
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
         resources:
           requests:
             cpu: 100m
@@ -151,6 +158,8 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: k8s_apiserver
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
 
         readinessProbe:
           exec:
@@ -181,6 +190,9 @@ spec:
           name: host-var-run-ovs
         - mountPath: /var/run/ovn/
           name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
 
         resources:
           requests:
@@ -218,6 +230,8 @@ spec:
           value: "{{ ovn_hybrid_overlay_enable }}"
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
       # end of container
 
       volumes:
@@ -234,5 +248,9 @@ spec:
       - name: host-var-run-ovs
         hostPath:
           path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
       tolerations:
       - operator: "Exists"

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -121,6 +121,9 @@ spec:
           name: host-var-run-ovs
         - mountPath: /var/run/ovn/
           name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
 
         resources:
           requests:
@@ -140,6 +143,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
 
         readinessProbe:
           exec:
@@ -185,6 +190,9 @@ spec:
           name: host-opt-cni-bin
         - mountPath: /etc/cni/net.d
           name: host-etc-cni-netd
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
         {% if kind is defined and kind -%}
         - mountPath: /var/run/netns
           name: host-netns
@@ -232,6 +240,8 @@ spec:
           value: "{{ ovn_hybrid_overlay_enable }}"
         - name: OVN_HYBRID_OVERLAY_NET_CIDR
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
 
         lifecycle:
           preStop:
@@ -278,6 +288,10 @@ spec:
       - name: host-etc-cni-netd
         hostPath:
           path: /etc/cni/net.d
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
       - name: host-slash
         hostPath:
           path: /


### PR DESCRIPTION
-- assumes that all the required private keys and corresponding signed
certificates are mounted into the container at /ovn-cert path

-- the private keys and certificates for various OVN components are
named as below
   ovncontroller-cert.pem
   ovncontroller-privkey.pem
   ovnnb-cert.pem
   ovnnb-privkey.pem
   ovnnorthd-cert.pem
   ovnnorthd-privkey.pem
   ovnsb-cert.pem
   ovnsb-privkey.pem

-- the name of the CA certificate that signed the CSRs is ca-cert.pem

-- disabled by default since there are lot of pre-requisites to get this
thing to work. to enable it, one needs to set the OVN_SSL_ENABLE
environment variable in each of the container

@dcbw @danwinship @trozet @squeed PTAL