### PR TITLE
Also run CI on non-master branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: ovn-ci
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
This PR allows the CI test suite to run on branches that aren't master.

Signed-off-by: Andrew Sun <asun@redhat.com>