### PR TITLE
Wait for pod to start running before deleting things in e2e tests

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo"
@@ -103,6 +104,8 @@ var _ = Describe("e2e control plane", func() {
 		testPod := <-podChan
 		framework.Logf("Test pod running on %q", testPod.Spec.NodeName)
 
+		time.Sleep(5 * time.Second)
+
 		podClient := f.ClientSet.CoreV1().Pods("ovn-kubernetes")
 
 		podList, _ := podClient.List(metav1.ListOptions{})
@@ -129,6 +132,8 @@ var _ = Describe("e2e control plane", func() {
 
 		testPod := <-podChan
 		framework.Logf("Test pod running on %q", testPod.Spec.NodeName)
+
+		time.Sleep(5 * time.Second)
 
 		podClient := f.ClientSet.CoreV1().Pods("ovn-kubernetes")
 


### PR DESCRIPTION
I'm noticing some unexpected behavior in the e2e tests that are probably caused by an earlier removal of the delay between creating the pod and doing the rest of the test. Turns out "not pending" might not necessarily mean "running" or "ready."

Signed-off-by: Andrew Sun <asun@redhat.com>