### PR TITLE
initial dual-stack loadbalancer support

### DIFF
--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -90,8 +90,9 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 								svcPort.Protocol, err)
 							continue
 						}
-						err = ovn.createLoadBalancerVIP(loadBalancer,
-							svc.Spec.ClusterIP, svcPort.Port, ips, targetPort)
+						err = ovn.createLoadBalancerVIPs(loadBalancer,
+							[]string{svc.Spec.ClusterIP},
+							svcPort.Port, ips, targetPort)
 						if err != nil {
 							klog.Errorf("Error in creating Cluster IP for svc %s, target port: %d - %v\n", svc.Name, targetPort, err)
 							continue
@@ -109,8 +110,8 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 
 func (ovn *Controller) handleNodePortLB(node *kapi.Node) error {
 	physicalGateway := util.GWRouterPrefix + node.Name
-	var physicalIP string
-	if physicalIP, _ = ovn.getGatewayPhysicalIP(physicalGateway); physicalIP == "" {
+	var physicalIPs []string
+	if physicalIPs, _ = ovn.getGatewayPhysicalIPs(physicalGateway); physicalIPs == nil {
 		return fmt.Errorf("gateway physical IP for node %q does not yet exist", node.Name)
 	}
 	namespaces, err := ovn.watchFactory.GetNamespaces()
@@ -143,7 +144,7 @@ func (ovn *Controller) handleNodePortLB(node *kapi.Node) error {
 								return fmt.Errorf("%s load balancer for node %q does not yet exist",
 									proto, node.Name)
 							}
-							err = ovn.createLoadBalancerVIP(k8sNSLb, physicalIP, svcPort.NodePort, ips, targetPort)
+							err = ovn.createLoadBalancerVIPs(k8sNSLb, physicalIPs, svcPort.NodePort, ips, targetPort)
 							if err != nil {
 								klog.Errorf("failed to create VIP in load balancer %s - %v", k8sNSLb, err)
 								continue
@@ -210,21 +211,22 @@ func (ovn *Controller) handleExternalIPs(svc *kapi.Service, svcPort kapi.Service
 	if len(svc.Spec.ExternalIPs) == 0 {
 		return
 	}
-	for _, extIP := range svc.Spec.ExternalIPs {
-		lb := ovn.getDefaultGatewayLoadBalancer(svcPort.Protocol)
-		if lb == "" {
-			klog.Warningf("No default gateway found for protocol %s\n\tNote: 'nodeport' flag needs to be enabled for default gateway", svcPort.Protocol)
-			continue
-		}
-		if removeLoadBalancerVIP {
+	lb := ovn.getDefaultGatewayLoadBalancer(svcPort.Protocol)
+	if lb == "" {
+		klog.Warningf("No default gateway found for protocol %s\n\tNote: 'nodeport' flag needs to be enabled for default gateway", svcPort.Protocol)
+		return
+	}
+
+	if removeLoadBalancerVIP {
+		for _, extIP := range svc.Spec.ExternalIPs {
 			vip := util.JoinHostPortInt32(extIP, svcPort.Port)
 			klog.V(5).Infof("Removing external VIP: %s from load balancer: %s", vip, lb)
 			ovn.deleteLoadBalancerVIP(lb, vip)
-		} else {
-			err := ovn.createLoadBalancerVIP(lb, extIP, svcPort.Port, ips, targetPort)
-			if err != nil {
-				klog.Errorf("Error in creating external IP for service: %s, externalIP: %s", svc.Name, extIP)
-			}
+		}
+	} else {
+		err := ovn.createLoadBalancerVIPs(lb, svc.Spec.ExternalIPs, svcPort.Port, ips, targetPort)
+		if err != nil {
+			klog.Errorf("Error in creating external IPs for service: %s", svc.Name)
 		}
 	}
 }

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -76,7 +76,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 					}
 					if util.ServiceTypeHasNodePort(svc) {
 						klog.V(5).Infof("Creating Gateways IP for NodePort: %d, %v", svcPort.NodePort, ips)
-						err = ovn.createGatewaysVIP(svcPort.Protocol, svcPort.NodePort, targetPort, ips)
+						err = ovn.createGatewayVIPs(svcPort.Protocol, svcPort.NodePort, ips, targetPort)
 						if err != nil {
 							klog.Errorf("Error in creating Node Port for svc %s, node port: %d - %v\n", svc.Name, svcPort.NodePort, err)
 							continue

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -13,8 +13,7 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string,
-	error) {
+func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string, error) {
 	if outStr, ok := ovn.loadbalancerClusterCache[protocol]; ok {
 		return outStr, nil
 	}
@@ -44,6 +43,8 @@ func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string,
 	return out, nil
 }
 
+// getDefaultGatewayLoadBalancer returns the load balancer for the node with the lowest gateway IP.
+// This is used in the implementation of ExternalIPs
 func (ovn *Controller) getDefaultGatewayLoadBalancer(protocol kapi.Protocol) string {
 	if outStr, ok := ovn.loadbalancerGWCache[protocol]; ok {
 		return outStr
@@ -66,8 +67,8 @@ func (ovn *Controller) getDefaultGatewayLoadBalancer(protocol kapi.Protocol) str
 	return lb
 }
 
-func (ovn *Controller) getLoadBalancerVIPS(
-	loadBalancer string) (map[string]interface{}, error) {
+// getLoadBalancerVIPs returns a map whose keys are VIPs (IP:port) on loadBalancer
+func (ovn *Controller) getLoadBalancerVIPs(loadBalancer string) (map[string]interface{}, error) {
 	outStr, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"get", "load_balancer", loadBalancer, "vips")
 	if err != nil {
@@ -105,37 +106,40 @@ func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) {
 	ovn.removeServiceLB(loadBalancer, vip)
 }
 
-func (ovn *Controller) configureLoadBalancer(lb, serviceIP string, port int32, endpoints []string) error {
+// configureLoadBalancer updates the VIP for sourceIP:sourcePort to point to targets (an
+// array of IP:port strings)
+func (ovn *Controller) configureLoadBalancer(lb, sourceIP string, sourcePort int32, targets []string) error {
 	ovn.serviceLBLock.Lock()
 	defer ovn.serviceLBLock.Unlock()
-	commaSeparatedEps := strings.Join(endpoints, ",")
-	target := fmt.Sprintf(`vips:"%s"="%s"`, util.JoinHostPortInt32(serviceIP, port), commaSeparatedEps)
 
-	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, target)
+	vip := util.JoinHostPortInt32(sourceIP, sourcePort)
+	lbTarget := fmt.Sprintf(`vips:"%s"="%s"`, vip, strings.Join(targets, ","))
+
+	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, lbTarget)
 	if err != nil {
 		return fmt.Errorf("error in configuring load balancer: %s "+
 			"stdout: %q, stderr: %q, error: %v", lb, out, stderr, err)
 	}
-	ovn.setServiceEndpointsToLB(lb, util.JoinHostPortInt32(serviceIP, port), endpoints)
-	klog.V(5).Infof("lb entry set for %s, %s, %v", lb, target,
-		ovn.serviceLBMap[lb][util.JoinHostPortInt32(serviceIP, port)])
+	ovn.setServiceEndpointsToLB(lb, vip, targets)
+	klog.V(5).Infof("lb entry set for %s, %s, %v", lb, lbTarget,
+		ovn.serviceLBMap[lb][vip])
 	return nil
 }
 
-// createLoadBalancerVIP either creates or updates a load balancer VIP
-// Calls to this method assume that if ips are passed that those endpoints actually exist
-// and thus the reject ACL is removed
-func (ovn *Controller) createLoadBalancerVIP(lb, serviceIP string, port int32, ips []string, targetPort int32) error {
-	klog.V(5).Infof("Creating lb with %s, %s, %d, [%v], %d", lb, serviceIP, port, ips, targetPort)
+// createLoadBalancerVIP either creates or updates a load balancer VIP mapping from
+// sourceIP:sourcePort to targetIP:targetPort for each IP in targetIPs. If targetIPs
+// is non-empty then the reject ACL for the service is removed.
+func (ovn *Controller) createLoadBalancerVIP(lb, sourceIP string, sourcePort int32, targetIPs []string, targetPort int32) error {
+	klog.V(5).Infof("Creating lb with %s, %s, %d, [%v], %d", lb, sourceIP, sourcePort, targetIPs, targetPort)
 
-	var endpoints []string
-	for _, ip := range ips {
-		endpoints = append(endpoints, util.JoinHostPortInt32(ip, targetPort))
+	var targets []string
+	for _, targetIP := range targetIPs {
+		targets = append(targets, util.JoinHostPortInt32(targetIP, targetPort))
 	}
-	err := ovn.configureLoadBalancer(lb, serviceIP, port, endpoints)
-	if len(ips) > 0 {
+	err := ovn.configureLoadBalancer(lb, sourceIP, sourcePort, targets)
+	if len(targets) > 0 {
 		// ensure the ACL is removed if it exists
-		ovn.deleteLoadBalancerRejectACL(lb, util.JoinHostPortInt32(serviceIP, port))
+		ovn.deleteLoadBalancerRejectACL(lb, util.JoinHostPortInt32(sourceIP, sourcePort))
 	}
 	return err
 }
@@ -169,7 +173,7 @@ func (ovn *Controller) getLogicalSwitchesForLoadBalancer(lb string) ([]string, e
 	return nil, fmt.Errorf("router detected with load balancer that is not a GR")
 }
 
-func (ovn *Controller) createLoadBalancerRejectACL(lb string, serviceIP string, port int32, proto kapi.Protocol) (string, error) {
+func (ovn *Controller) createLoadBalancerRejectACL(lb string, sourceIP string, sourcePort int32, proto kapi.Protocol) (string, error) {
 	ovn.serviceLBLock.Lock()
 	defer ovn.serviceLBLock.Unlock()
 	switches, err := ovn.getLogicalSwitchesForLoadBalancer(lb)
@@ -182,9 +186,9 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb string, serviceIP string, 
 		return "", nil
 	}
 
-	ip := net.ParseIP(serviceIP)
+	ip := net.ParseIP(sourceIP)
 	if ip == nil {
-		return "", fmt.Errorf("cannot create reject ACL, invalid cluster IP: %s", serviceIP)
+		return "", fmt.Errorf("cannot create reject ACL, invalid source IP: %s", sourceIP)
 	}
 	var aclMatch string
 	var l3Prefix string
@@ -193,7 +197,7 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb string, serviceIP string, 
 	} else {
 		l3Prefix = "ip4"
 	}
-	vip := util.JoinHostPortInt32(serviceIP, port)
+	vip := util.JoinHostPortInt32(sourceIP, sourcePort)
 	aclName := fmt.Sprintf("%s-%s", lb, vip)
 	// If ovn-k8s was restarted, we lost the cache, and an ACL may already exist in OVN. In that case we need to check
 	// using ACL name
@@ -210,12 +214,12 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb string, serviceIP string, 
 				klog.Warningf("Unable to add reject ACL: %s for switch: %s", aclUUID, ls)
 			}
 		}
-		ovn.setServiceACLToLB(lb, util.JoinHostPortInt32(serviceIP, port), aclUUID)
+		ovn.setServiceACLToLB(lb, vip, aclUUID)
 		return aclUUID, nil
 	}
 
-	aclMatch = fmt.Sprintf("match=\"%s.dst==%s && %s && %s.dst==%d\"", l3Prefix, serviceIP,
-		strings.ToLower(string(proto)), strings.ToLower(string(proto)), port)
+	aclMatch = fmt.Sprintf("match=\"%s.dst==%s && %s && %s.dst==%d\"", l3Prefix, sourceIP,
+		strings.ToLower(string(proto)), strings.ToLower(string(proto)), sourcePort)
 
 	cmd := []string{"--id=@acl", "create", "acl", "direction=from-lport", "priority=1000", aclMatch, "action=reject",
 		fmt.Sprintf("name=%s", strings.ReplaceAll(aclName, ":", "\\:"))}
@@ -230,7 +234,7 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb string, serviceIP string, 
 	} else {
 		// Associate ACL UUID with load balancer and ip+port so we can remove this ACL if
 		// backends are re-added.
-		ovn.setServiceACLToLB(lb, util.JoinHostPortInt32(serviceIP, port), aclUUID)
+		ovn.setServiceACLToLB(lb, vip, aclUUID)
 	}
 	return aclUUID, nil
 }

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -88,17 +88,17 @@ func (ovn *Controller) syncServices(services []interface{}) {
 			continue
 		}
 
-		loadBalancerVIPS, err := ovn.getLoadBalancerVIPS(loadBalancer)
+		loadBalancerVIPs, err := ovn.getLoadBalancerVIPs(loadBalancer)
 		if err != nil {
 			klog.Errorf("failed to get load-balancer vips for %s (%v)",
 				loadBalancer, err)
 			continue
 		}
-		if loadBalancerVIPS == nil {
+		if loadBalancerVIPs == nil {
 			continue
 		}
 
-		for vip := range loadBalancerVIPS {
+		for vip := range loadBalancerVIPs {
 			if !stringSliceMembership(clusterServices[protocol], vip) {
 				klog.V(5).Infof("Deleting stale cluster vip %s in "+
 					"loadbalancer %s", vip, loadBalancer)
@@ -128,17 +128,17 @@ func (ovn *Controller) syncServices(services []interface{}) {
 				continue
 			}
 
-			loadBalancerVIPS, err := ovn.getLoadBalancerVIPS(loadBalancer)
+			loadBalancerVIPs, err := ovn.getLoadBalancerVIPs(loadBalancer)
 			if err != nil {
 				klog.Errorf("failed to get load-balancer vips for %s (%v)",
 					loadBalancer, err)
 				continue
 			}
-			if loadBalancerVIPS == nil {
+			if loadBalancerVIPs == nil {
 				continue
 			}
 
-			for vip := range loadBalancerVIPS {
+			for vip := range loadBalancerVIPs {
 				_, port, err := net.SplitHostPort(vip)
 				if err != nil {
 					// In a OVN load-balancer, we should always have vip:port.
@@ -319,7 +319,7 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 		var targetPort int32
 		if util.ServiceTypeHasNodePort(service) {
 			// Delete the 'NodePort' service from a load-balancer instantiated in gateways.
-			ovn.deleteGatewaysVIP(protocol, port)
+			ovn.deleteGatewayVIPs(protocol, port)
 		}
 		if util.ServiceTypeHasClusterIP(service) {
 			loadBalancer, err := ovn.getLoadBalancer(protocol)


### PR DESCRIPTION
This is mostly a no-op at this point, but this updates the loadbalancer support to allow passing multiple source IPs, and then it maps all the IPv4 source IPs to all the IPv4 target IPs, and all the IPv6 source IPs to all the IPv6 target IPs.

This PR renames `ovn.getGatewayPhysicalIP` to `ovn.getGatewayPhysicalIPs` and makes it return an array, but at the moment it still only ever returns a single IP. But when it does start returning multiple IPs, the NodePort code will now do the right thing with it (using either or both of the IPv4 and IPv6 node IPs, depending on what endpoint IPs it has available).

(The first commit also does some renaming to IMHO make things clearer. YMMV?)

@dcbw @girishmg 
@trozet since you were just in this code...