### PR TITLE
ci: shorter GitHub action job names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,17 +109,17 @@ jobs:
         rm -rf .git
 
   e2e:
-    name: End-To-End Tests
+    name: e2e
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         target:
-          - e2e-kind-ovn-shard-n
-          - e2e-kind-ovn-shard-np
-          - e2e-kind-ovn-shard-s
-          - e2e-kind-ovn-shard-other
-          - e2e-control-plane
+          - shard-n
+          - shard-np
+          - shard-s
+          - shard-other
+          - control-plane
         ha:
          - enabled: "true"
            name: "HA"

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,10 +2,10 @@
 install-kind:
 	./scripts/install-kind.sh
 
-.PHONY: e2e-kind-ovn-shard-%
-e2e-kind-ovn-shard-%:
+.PHONY: shard-%
+shard-%:
 	./scripts/e2e-kind.sh $@
 
-.PHONY: e2e-control-plane
-e2e-control-plane:
+.PHONY: control-plane
+control-plane:
 	./scripts/e2e-cp.sh

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -14,18 +14,18 @@ SKIPPED_TESTS='Networking\sIPerf\sIPv[46]|\[Feature:PerformanceDNS\]|\[Feature:I
 GINKGO_ARGS="--num-nodes=3 --ginkgo.skip=${SKIPPED_TESTS} --disable-log-dump=false"
 
 case "$SHARD" in
-	e2e-kind-ovn-shard-n)
+	shard-n)
 		# all tests that don't have P as their sixth letter after the N
 		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$)'
 		;;
-	e2e-kind-ovn-shard-np)
+	shard-np)
 		# all tests that have P as the sixth letter after the N
 		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$'
 		;;
-	e2e-kind-ovn-shard-s)
+	shard-s)
 		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[Ss].*'
 		;;
-	e2e-kind-ovn-shard-other)
+	shard-other)
 		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[^NnSs].*'
 		;;
 	*)


### PR DESCRIPTION
Instead of "End-To-End Tests (e2e-k..." in the Github show more
of the relevant bits eg "e2e (shard-n,...". Since all the tests
use KIND, and all the tests use OVN, "kind-ovn-" seems less
relevant too.

@as-com @dave-tucker @trozet 