### PR TITLE
Adding gatewayRouter name in error messages.

### DIFF
--- a/go-controller/pkg/util/gateway-cleanup.go
+++ b/go-controller/pkg/util/gateway-cleanup.go
@@ -20,8 +20,8 @@ func GatewayCleanup(nodeName string, nodeSubnet *net.IPNet) error {
 	routerIPNetwork, stderr, err := RunOVNNbctl("--if-exist", "get",
 		"logical_router_port", "rtoj-"+gatewayRouter, "networks")
 	if err != nil {
-		return fmt.Errorf("Failed to get logical router port, stderr: %q, "+
-			"error: %v", stderr, err)
+		return fmt.Errorf("failed to get logical router port for gateway router %s, "+
+			"stderr: %q, error: %v", gatewayRouter, stderr, err)
 	}
 
 	routerIPNetwork = strings.Trim(routerIPNetwork, "[]\"")
@@ -45,7 +45,7 @@ func GatewayCleanup(nodeName string, nodeSubnet *net.IPNet) error {
 	// Remove the join switch that connects ovn_cluster_router to gateway router
 	_, stderr, err = RunOVNNbctl("--if-exist", "ls-del", JoinSwitchPrefix+nodeName)
 	if err != nil {
-		return fmt.Errorf("Failed to delete the join logical switch %s, "+
+		return fmt.Errorf("failed to delete the join logical switch %s, "+
 			"stderr: %q, error: %v", JoinSwitchPrefix+nodeName, stderr, err)
 	}
 
@@ -53,7 +53,7 @@ func GatewayCleanup(nodeName string, nodeSubnet *net.IPNet) error {
 	_, stderr, err = RunOVNNbctl("--if-exist", "lr-del",
 		gatewayRouter)
 	if err != nil {
-		return fmt.Errorf("Failed to delete gateway router %s, stderr: %q, "+
+		return fmt.Errorf("failed to delete gateway router %s, stderr: %q, "+
 			"error: %v", gatewayRouter, stderr, err)
 	}
 
@@ -62,14 +62,14 @@ func GatewayCleanup(nodeName string, nodeSubnet *net.IPNet) error {
 	_, stderr, err = RunOVNNbctl("--if-exist", "ls-del",
 		externalSwitch)
 	if err != nil {
-		return fmt.Errorf("Failed to delete external switch %s, stderr: %q, "+
+		return fmt.Errorf("failed to delete external switch %s, stderr: %q, "+
 			"error: %v", externalSwitch, stderr, err)
 	}
 
 	// Remove the patch port on the distributed router that connects to join switch
 	_, stderr, err = RunOVNNbctl("--if-exist", "lrp-del", "dtoj-"+nodeName)
 	if err != nil {
-		return fmt.Errorf("Failed to delete the patch port dtoj-%s on distributed router "+
+		return fmt.Errorf("failed to delete the patch port dtoj-%s on distributed router "+
 			"stderr: %q, error: %v", nodeName, stderr, err)
 	}
 
@@ -81,22 +81,22 @@ func GatewayCleanup(nodeName string, nodeSubnet *net.IPNet) error {
 	if k8sNSLbTCP != "" {
 		_, stderr, err = RunOVNNbctl("lb-del", k8sNSLbTCP)
 		if err != nil {
-			return fmt.Errorf("failed to delete Gateway router TCP load balancer %s, stderr: %q, "+
-				"error: %v", k8sNSLbTCP, stderr, err)
+			return fmt.Errorf("failed to delete Gateway router %s's TCP load balancer %s, stderr: %q, "+
+				"error: %v", gatewayRouter, k8sNSLbTCP, stderr, err)
 		}
 	}
 	if k8sNSLbUDP != "" {
 		_, stderr, err = RunOVNNbctl("lb-del", k8sNSLbUDP)
 		if err != nil {
-			return fmt.Errorf("failed to delete Gateway router UDP load balancer %s, stderr: %q, "+
-				"error: %v", k8sNSLbUDP, stderr, err)
+			return fmt.Errorf("failed to delete Gateway router %s's UDP load balancer %s, stderr: %q, "+
+				"error: %v", gatewayRouter, k8sNSLbUDP, stderr, err)
 		}
 	}
 	if k8sNSLbSCTP != "" {
 		_, stderr, err = RunOVNNbctl("lb-del", k8sNSLbSCTP)
 		if err != nil {
-			return fmt.Errorf("failed to delete Gateway router SCTP load balancer %s, stderr: %q, "+
-				"error: %v", k8sNSLbSCTP, stderr, err)
+			return fmt.Errorf("failed to delete Gateway router %s's SCTP load balancer %s, stderr: %q, "+
+				"error: %v", gatewayRouter, k8sNSLbSCTP, stderr, err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -118,7 +118,7 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		"options:chassis="+l3GatewayConfig.ChassisID,
 		"external_ids:physical_ip="+l3GatewayConfig.IPAddress.IP.String())
 	if err != nil {
-		return fmt.Errorf("Failed to create logical router %v, stdout: %q, "+
+		return fmt.Errorf("failed to create logical router %v, stdout: %q, "+
 			"stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 	}
 
@@ -132,7 +132,7 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 	// create the per-node join switch
 	stdout, stderr, err = RunOVNNbctl("--", "--may-exist", "ls-add", joinSwitch)
 	if err != nil {
-		return fmt.Errorf("Failed to create logical switch %q, stdout: %q, stderr: %q, error: %v",
+		return fmt.Errorf("failed to create logical switch %q, stdout: %q, stderr: %q, error: %v",
 			joinSwitch, stdout, stderr, err)
 	}
 
@@ -151,7 +151,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		"--", "--may-exist", "lrp-add", gatewayRouter, gwRouterPort, gwLRPMAC.String(),
 		fmt.Sprintf("%s/%d", gwLRPIp.String(), prefixLen))
 	if err != nil {
-		return fmt.Errorf("Failed to add logical router port %q, stderr: %q, error: %v", gwRouterPort, stderr, err)
+		return fmt.Errorf("failed to add logical router port %q for gateway router %s, "+
+			"stderr: %q, error: %v", gwRouterPort, gatewayRouter, stderr, err)
 	}
 
 	// jtod/dtoj - patch ports that connect the per-node join switch to distributed router
@@ -172,7 +173,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		"--", "--may-exist", "lrp-add", k8sClusterRouter, drRouterPort, drLRPMAC.String(),
 		fmt.Sprintf("%s/%d", drLRPIp.String(), prefixLen))
 	if err != nil {
-		return fmt.Errorf("Failed to add logical router port %q, stderr: %q, error: %v", drRouterPort, stderr, err)
+		return fmt.Errorf("failed to add logical router port %q to %s, "+
+			"stderr: %q, error: %v", drRouterPort, k8sClusterRouter, stderr, err)
 	}
 
 	// When there are multiple gateway routers (which would be the likely
@@ -182,8 +184,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 	stdout, stderr, err = RunOVNNbctl("set", "logical_router",
 		gatewayRouter, "options:lb_force_snat_ip="+gwLRPIp.String())
 	if err != nil {
-		return fmt.Errorf("Failed to set logical router, stdout: %q, "+
-			"stderr: %q, error: %v", stdout, stderr, err)
+		return fmt.Errorf("failed to set logical router %s's lb_force_snat_ip option, "+
+			"stdout: %q, stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 	}
 
 	for _, entry := range clusterIPSubnet {
@@ -191,9 +193,9 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-route-add",
 			gatewayRouter, entry.String(), drLRPIp.String())
 		if err != nil {
-			return fmt.Errorf("Failed to add a static route in GR with distributed "+
+			return fmt.Errorf("failed to add a static route in GR %s with distributed "+
 				"router as the nexthop, stdout: %q, stderr: %q, error: %v",
-				stdout, stderr, err)
+				gatewayRouter, stdout, stderr, err)
 		}
 	}
 
@@ -221,8 +223,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 					fmt.Sprintf("external_ids:%s_lb_gateway_router=%s", proto, gatewayRouter),
 					fmt.Sprintf("protocol=%s", strings.ToLower(string(proto))))
 				if err != nil {
-					return fmt.Errorf("failed to create load balancer for protocol %s: "+
-						"stderr: %q, error: %v", proto, stderr, err)
+					return fmt.Errorf("failed to create load balancer for gateway router %s for protocol %s: "+
+						"stderr: %q, error: %v", gatewayRouter, proto, stderr, err)
 				}
 			}
 		}
@@ -234,8 +236,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		stdout, stderr, err = RunOVNNbctl("set", "logical_router", gatewayRouter, "load_balancer="+lbString)
 		if err != nil {
 			return fmt.Errorf("failed to set north-south load-balancers to the "+
-				"gateway router, stdout: %q, stderr: %q, error: %v",
-				stdout, stderr, err)
+				"gateway router %s, stdout: %q, stderr: %q, error: %v",
+				gatewayRouter, stdout, stderr, err)
 		}
 	}
 
@@ -244,8 +246,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 	stdout, stderr, err = RunOVNNbctl("--may-exist", "ls-add",
 		externalSwitch)
 	if err != nil {
-		return fmt.Errorf("failed to create logical switch, stdout: %q, "+
-			"stderr: %q, error: %v", stdout, stderr, err)
+		return fmt.Errorf("failed to create logical switch %s, stdout: %q, "+
+			"stderr: %q, error: %v", externalSwitch, stdout, stderr, err)
 	}
 
 	// Add external interface as a logical port to external_switch.
@@ -267,8 +269,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 
 	stdout, stderr, err = RunOVNNbctl(cmdArgs...)
 	if err != nil {
-		return fmt.Errorf("Failed to add logical port to switch, stdout: %q, "+
-			"stderr: %q, error: %v", stdout, stderr, err)
+		return fmt.Errorf("failed to add logical port to switch %s, stdout: %q, "+
+			"stderr: %q, error: %v", externalSwitch, stdout, stderr, err)
 	}
 
 	// Connect GR to external_switch with mac address of external interface
@@ -283,8 +285,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		"--", "set", "logical_router_port", "rtoe-"+gatewayRouter,
 		"external-ids:gateway-physical-ip=yes")
 	if err != nil {
-		return fmt.Errorf("Failed to add logical port to router, stdout: %q, "+
-			"stderr: %q, error: %v", stdout, stderr, err)
+		return fmt.Errorf("failed to add logical port to router %s, stdout: %q, "+
+			"stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 	}
 
 	// Connect the external_switch to the router.
@@ -294,8 +296,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		"options:router-port=rtoe-"+gatewayRouter,
 		"addresses="+"\""+l3GatewayConfig.MACAddress.String()+"\"")
 	if err != nil {
-		return fmt.Errorf("Failed to add logical port to router, stdout: %q, "+
-			"stderr: %q, error: %v", stdout, stderr, err)
+		return fmt.Errorf("failed to add logical port to router %s, stdout: %q, "+
+			"stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 	}
 
 	// Add a static route in GR with physical gateway as the default next hop.
@@ -309,9 +311,9 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		gatewayRouter, allIPs, l3GatewayConfig.NextHop.String(),
 		fmt.Sprintf("rtoe-%s", gatewayRouter))
 	if err != nil {
-		return fmt.Errorf("Failed to add a static route in GR with physical "+
+		return fmt.Errorf("failed to add a static route in GR %s with physical "+
 			"gateway as the default next hop, stdout: %q, "+
-			"stderr: %q, error: %v", stdout, stderr, err)
+			"stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 	}
 
 	// Add source IP address based routes in distributed router
@@ -320,9 +322,9 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		"--policy=src-ip", "lr-route-add", k8sClusterRouter,
 		hostSubnet.String(), gwLRPIp.String())
 	if err != nil {
-		return fmt.Errorf("Failed to add source IP address based "+
-			"routes in distributed router, stdout: %q, "+
-			"stderr: %q, error: %v", stdout, stderr, err)
+		return fmt.Errorf("failed to add source IP address based "+
+			"routes in distributed router %s, stdout: %q, "+
+			"stderr: %q, error: %v", k8sClusterRouter, stdout, stderr, err)
 	}
 
 	// Default SNAT rules.
@@ -330,8 +332,8 @@ func GatewayInit(clusterIPSubnet []*net.IPNet, hostSubnet *net.IPNet, joinSubnet
 		stdout, stderr, err = RunOVNNbctl("--may-exist", "lr-nat-add",
 			gatewayRouter, "snat", l3GatewayConfig.IPAddress.IP.String(), entry.String())
 		if err != nil {
-			return fmt.Errorf("Failed to create default SNAT rules, stdout: %q, "+
-				"stderr: %q, error: %v", stdout, stderr, err)
+			return fmt.Errorf("failed to create default SNAT rules for gateway router %s, "+
+				"stdout: %q, stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 		}
 	}
 


### PR DESCRIPTION
error messages in GatewayInit() and GatewayCleanup() functions doesn't
have the gatewayRouter name that makes it diffuclt to know
for which k8s node the functionality has failed.

Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>