### PR TITLE
dual-stack support for l3-gateway-config annotation

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -105,7 +105,9 @@ func (n *OvnNode) initGateway(subnet *net.IPNet, nodeAnnotator kube.Annotator,
 		}
 		prFn, err = n.initSharedGateway(subnet, gatewayNextHop, gatewayIntf, nodeAnnotator)
 	case config.GatewayModeDisabled:
-		err = util.SetDisabledL3GatewayConfig(nodeAnnotator)
+		err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
+			Mode: config.GatewayModeDisabled,
+		})
 	}
 	if err != nil {
 		return err

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -188,8 +188,8 @@ func initLocalnetGateway(nodeName string, subnet *net.IPNet, wf *factory.WatchFa
 		ChassisID:      chassisID,
 		InterfaceID:    ifaceID,
 		MACAddress:     macAddress,
-		IPAddress:      gatewayIPCIDR,
-		NextHop:        gatewayNextHop,
+		IPAddresses:    []*net.IPNet{gatewayIPCIDR},
+		NextHops:       []net.IP{gatewayNextHop},
 		NodePortEnable: config.Gateway.NodeportEnable,
 	})
 	if err != nil {

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -178,8 +178,20 @@ func initLocalnetGateway(nodeName string, subnet *net.IPNet, wf *factory.WatchFa
 		return err
 	}
 
-	err = util.SetLocalL3GatewayConfig(nodeAnnotator, ifaceID, macAddress,
-		gatewayIPCIDR, gatewayNextHop, config.Gateway.NodeportEnable)
+	chassisID, err := util.GetNodeChassisID()
+	if err != nil {
+		return err
+	}
+
+	err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
+		Mode:           config.GatewayModeLocal,
+		ChassisID:      chassisID,
+		InterfaceID:    ifaceID,
+		MACAddress:     macAddress,
+		IPAddress:      gatewayIPCIDR,
+		NextHop:        gatewayNextHop,
+		NodePortEnable: config.Gateway.NodeportEnable,
+	})
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -344,8 +344,8 @@ func (n *OvnNode) initSharedGateway(subnet *net.IPNet, gwNextHop net.IP, gwIntf 
 		ChassisID:      chassisID,
 		InterfaceID:    ifaceID,
 		MACAddress:     macAddress,
-		IPAddress:      ipAddress,
-		NextHop:        gwNextHop,
+		IPAddresses:    []*net.IPNet{ipAddress},
+		NextHops:       []net.IP{gwNextHop},
 		NodePortEnable: config.Gateway.NodeportEnable,
 		VLANID:         &config.Gateway.VLANID,
 	})

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -334,8 +334,21 @@ func (n *OvnNode) initSharedGateway(subnet *net.IPNet, gwNextHop net.IP, gwIntf 
 		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
 
-	err = util.SetSharedL3GatewayConfig(nodeAnnotator, ifaceID, macAddress, ipAddress, gwNextHop,
-		config.Gateway.NodeportEnable, config.Gateway.VLANID)
+	chassisID, err := util.GetNodeChassisID()
+	if err != nil {
+		return nil, err
+	}
+
+	err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
+		Mode:           config.GatewayModeShared,
+		ChassisID:      chassisID,
+		InterfaceID:    ifaceID,
+		MACAddress:     macAddress,
+		IPAddress:      ipAddress,
+		NextHop:        gwNextHop,
+		NodePortEnable: config.Gateway.NodeportEnable,
+		VLANID:         &config.Gateway.VLANID,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -19,6 +19,12 @@ func (ovn *Controller) getOvnGateways() ([]string, string, error) {
 }
 
 func (ovn *Controller) getGatewayPhysicalIPs(physicalGateway string) ([]string, error) {
+	physicalIPs, _, err := util.RunOVNNbctl("get", "logical_router",
+		physicalGateway, "external_ids:physical_ips")
+	if err == nil {
+		return strings.Split(physicalIPs, ","), nil
+	}
+
 	physicalIP, _, err := util.RunOVNNbctl("get", "logical_router",
 		physicalGateway, "external_ids:physical_ip")
 	if err != nil {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/urfave/cli"
 	v1 "k8s.io/api/core/v1"
@@ -705,8 +706,8 @@ var _ = Describe("Gateway Init Operations", func() {
 				ChassisID:      systemID,
 				InterfaceID:    ifaceID,
 				MACAddress:     ovntest.MustParseMAC(brLocalnetMAC),
-				IPAddress:      ovntest.MustParseIPNet(localnetGatewayIP),
-				NextHop:        ovntest.MustParseIP(localnetGatewayNextHop),
+				IPAddresses:    []*net.IPNet{ovntest.MustParseIPNet(localnetGatewayIP)},
+				NextHops:       []net.IP{ovntest.MustParseIP(localnetGatewayNextHop)},
 				NodePortEnable: true,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -746,7 +747,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			joinSwitch := util.JoinSwitchPrefix + nodeName
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
-				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2",
+				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2",
 				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
 				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
@@ -770,11 +771,11 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_router " + util.GWRouterPrefix + nodeName + " external_ids:physical_ip",
+				Cmd:    "ovn-nbctl --timeout=15 get logical_router " + util.GWRouterPrefix + nodeName + " external_ids:physical_ips",
 				Output: "169.254.33.2",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2",
+				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2",
 				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
 				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
@@ -798,7 +799,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 --may-exist lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_router " + util.GWRouterPrefix + nodeName + " external_ids:physical_ip",
+				Cmd:    "ovn-nbctl --timeout=15 get logical_router " + util.GWRouterPrefix + nodeName + " external_ids:physical_ips",
 				Output: "169.254.33.2",
 			})
 
@@ -891,8 +892,8 @@ var _ = Describe("Gateway Init Operations", func() {
 				ChassisID:      systemID,
 				InterfaceID:    ifaceID,
 				MACAddress:     ovntest.MustParseMAC(physicalBridgeMAC),
-				IPAddress:      ovntest.MustParseIPNet(physicalGatewayIPMask),
-				NextHop:        ovntest.MustParseIP(physicalGatewayNextHop),
+				IPAddresses:    []*net.IPNet{ovntest.MustParseIPNet(physicalGatewayIPMask)},
+				NextHops:       []net.IP{ovntest.MustParseIP(physicalGatewayNextHop)},
 				NodePortEnable: true,
 				VLANID:         &vlanID,
 			})
@@ -932,7 +933,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			joinSwitch := util.JoinSwitchPrefix + nodeName
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
-				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + physicalGatewayIP,
+				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + physicalGatewayIP + " external_ids:physical_ips=" + physicalGatewayIP,
 				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
 				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
@@ -960,11 +961,11 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + nodeIPMask + " " + nodeMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_router " + util.GWRouterPrefix + nodeName + " external_ids:physical_ip",
+				Cmd:    "ovn-nbctl --timeout=15 get logical_router " + util.GWRouterPrefix + nodeName + " external_ids:physical_ips",
 				Output: "169.254.33.2",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + physicalGatewayIP,
+				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + physicalGatewayIP + " external_ids:physical_ips=" + physicalGatewayIP,
 				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
 				"ovn-nbctl --timeout=15 -- --may-exist lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
@@ -993,7 +994,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + clusterRouter + " " + nodeIPMask + " " + nodeMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 get logical_router " + util.GWRouterPrefix + nodeName + " external_ids:physical_ip",
+				Cmd:    "ovn-nbctl --timeout=15 get logical_router " + util.GWRouterPrefix + nodeName + " external_ids:physical_ips",
 				Output: "169.254.33.2",
 			})
 

--- a/go-controller/pkg/util/node_annotations_test.go
+++ b/go-controller/pkg/util/node_annotations_test.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Node annotation tests", func() {
+	It("marshals the l3-gateway-config annotation", func() {
+		type testcase struct {
+			name   string
+			setter func(kube.Annotator) error
+			out    string
+
+			setChassisID bool
+		}
+
+		testcases := []testcase{
+			{
+				name: "Disabled",
+				setter: func(nodeAnnotator kube.Annotator) error {
+					return SetDisabledL3GatewayConfig(nodeAnnotator)
+				},
+				out: `{"default":{"mode":""}}`,
+			},
+			{
+				name: "Local",
+				setter: func(nodeAnnotator kube.Annotator) error {
+					return SetLocalL3GatewayConfig(nodeAnnotator,
+						"INTERFACE-ID",
+						ovntest.MustParseMAC("11:22:33:44:55:66"),
+						ovntest.MustParseIPNet("192.168.1.10/24"),
+						ovntest.MustParseIP("192.168.1.1"),
+						true)
+				},
+				out: `{"default":{"mode":"local","interface-id":"INTERFACE-ID","mac-address":"11:22:33:44:55:66","ip-address":"192.168.1.10/24","next-hop":"192.168.1.1","node-port-enable":"true"}}`,
+
+				setChassisID: true,
+			},
+			{
+				name: "Shared",
+				setter: func(nodeAnnotator kube.Annotator) error {
+					return SetSharedL3GatewayConfig(nodeAnnotator,
+						"INTERFACE-ID",
+						ovntest.MustParseMAC("11:22:33:44:55:66"),
+						ovntest.MustParseIPNet("192.168.1.10/24"),
+						ovntest.MustParseIP("192.168.1.1"),
+						false,
+						1024)
+				},
+				out: `{"default":{"mode":"shared","interface-id":"INTERFACE-ID","mac-address":"11:22:33:44:55:66","ip-address":"192.168.1.10/24","next-hop":"192.168.1.1","node-port-enable":"false","vlan-id":"1024"}}`,
+
+				setChassisID: true,
+			},
+		}
+
+		for _, tc := range testcases {
+			testNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name: "test-node",
+			}}
+
+			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
+				Items: []v1.Node{testNode},
+			})
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &testNode)
+
+			fexec := ovntest.NewFakeExec()
+			err := SetExec(fexec)
+			Expect(err).NotTo(HaveOccurred())
+
+			if tc.setChassisID {
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
+					Output: "SYSTEM-ID",
+				})
+			}
+
+			err = tc.setter(nodeAnnotator)
+			Expect(err).NotTo(HaveOccurred())
+			err = nodeAnnotator.Run()
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedNode, err := fakeClient.CoreV1().Nodes().Get(testNode.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(updatedNode.Annotations[ovnNodeL3GatewayConfig]).To(MatchJSON(tc.out))
+			if tc.setChassisID {
+				Expect(updatedNode.Annotations[ovnNodeChassisID]).To(Equal("SYSTEM-ID"))
+			}
+		}
+	})
+})

--- a/go-controller/pkg/util/node_annotations_test.go
+++ b/go-controller/pkg/util/node_annotations_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 
@@ -15,49 +16,47 @@ import (
 var _ = Describe("Node annotation tests", func() {
 	It("marshals the l3-gateway-config annotation", func() {
 		type testcase struct {
-			name   string
-			setter func(kube.Annotator) error
-			out    string
-
-			setChassisID bool
+			name string
+			in   *L3GatewayConfig
+			out  string
 		}
+
+		vlanid := uint(1024)
 
 		testcases := []testcase{
 			{
 				name: "Disabled",
-				setter: func(nodeAnnotator kube.Annotator) error {
-					return SetDisabledL3GatewayConfig(nodeAnnotator)
+				in: &L3GatewayConfig{
+					Mode: config.GatewayModeDisabled,
 				},
 				out: `{"default":{"mode":""}}`,
 			},
 			{
 				name: "Local",
-				setter: func(nodeAnnotator kube.Annotator) error {
-					return SetLocalL3GatewayConfig(nodeAnnotator,
-						"INTERFACE-ID",
-						ovntest.MustParseMAC("11:22:33:44:55:66"),
-						ovntest.MustParseIPNet("192.168.1.10/24"),
-						ovntest.MustParseIP("192.168.1.1"),
-						true)
+				in: &L3GatewayConfig{
+					Mode:           config.GatewayModeLocal,
+					ChassisID:      "SYSTEM-ID",
+					InterfaceID:    "INTERFACE-ID",
+					MACAddress:     ovntest.MustParseMAC("11:22:33:44:55:66"),
+					IPAddress:      ovntest.MustParseIPNet("192.168.1.10/24"),
+					NextHop:        ovntest.MustParseIP("192.168.1.1"),
+					NodePortEnable: true,
 				},
 				out: `{"default":{"mode":"local","interface-id":"INTERFACE-ID","mac-address":"11:22:33:44:55:66","ip-address":"192.168.1.10/24","next-hop":"192.168.1.1","node-port-enable":"true"}}`,
-
-				setChassisID: true,
 			},
 			{
 				name: "Shared",
-				setter: func(nodeAnnotator kube.Annotator) error {
-					return SetSharedL3GatewayConfig(nodeAnnotator,
-						"INTERFACE-ID",
-						ovntest.MustParseMAC("11:22:33:44:55:66"),
-						ovntest.MustParseIPNet("192.168.1.10/24"),
-						ovntest.MustParseIP("192.168.1.1"),
-						false,
-						1024)
+				in: &L3GatewayConfig{
+					Mode:           config.GatewayModeShared,
+					ChassisID:      "SYSTEM-ID",
+					InterfaceID:    "INTERFACE-ID",
+					MACAddress:     ovntest.MustParseMAC("11:22:33:44:55:66"),
+					IPAddress:      ovntest.MustParseIPNet("192.168.1.10/24"),
+					NextHop:        ovntest.MustParseIP("192.168.1.1"),
+					NodePortEnable: false,
+					VLANID:         &vlanid,
 				},
 				out: `{"default":{"mode":"shared","interface-id":"INTERFACE-ID","mac-address":"11:22:33:44:55:66","ip-address":"192.168.1.10/24","next-hop":"192.168.1.1","node-port-enable":"false","vlan-id":"1024"}}`,
-
-				setChassisID: true,
 			},
 		}
 
@@ -71,18 +70,7 @@ var _ = Describe("Node annotation tests", func() {
 			})
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &testNode)
 
-			fexec := ovntest.NewFakeExec()
-			err := SetExec(fexec)
-			Expect(err).NotTo(HaveOccurred())
-
-			if tc.setChassisID {
-				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
-					Output: "SYSTEM-ID",
-				})
-			}
-
-			err = tc.setter(nodeAnnotator)
+			err := SetL3GatewayConfig(nodeAnnotator, tc.in)
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
@@ -91,9 +79,13 @@ var _ = Describe("Node annotation tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(updatedNode.Annotations[ovnNodeL3GatewayConfig]).To(MatchJSON(tc.out))
-			if tc.setChassisID {
+			if tc.in.Mode != config.GatewayModeDisabled {
 				Expect(updatedNode.Annotations[ovnNodeChassisID]).To(Equal("SYSTEM-ID"))
 			}
+
+			l3gc, err := ParseNodeL3GatewayAnnotation(updatedNode)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(l3gc).To(Equal(tc.in))
 		}
 	})
 })

--- a/go-controller/pkg/util/pod_annotation_test.go
+++ b/go-controller/pkg/util/pod_annotation_test.go
@@ -3,6 +3,8 @@ package util
 import (
 	"net"
 
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -19,8 +21,8 @@ var _ = Describe("Pod annotation tests", func() {
 			{
 				name: "Single-stack IPv4",
 				in: &PodAnnotation{
-					IPs:      []*net.IPNet{mustParseCIDRAddress("192.168.0.5/24")},
-					MAC:      mustParseMAC("0A:58:FD:98:00:01"),
+					IPs:      []*net.IPNet{ovntest.MustParseIPNet("192.168.0.5/24")},
+					MAC:      ovntest.MustParseMAC("0A:58:FD:98:00:01"),
 					Gateways: []net.IP{net.ParseIP("192.168.0.1")},
 				},
 				out: map[string]string{
@@ -30,8 +32,8 @@ var _ = Describe("Pod annotation tests", func() {
 			{
 				name: "No GW",
 				in: &PodAnnotation{
-					IPs: []*net.IPNet{mustParseCIDRAddress("192.168.0.5/24")},
-					MAC: mustParseMAC("0A:58:FD:98:00:01"),
+					IPs: []*net.IPNet{ovntest.MustParseIPNet("192.168.0.5/24")},
+					MAC: ovntest.MustParseMAC("0A:58:FD:98:00:01"),
 				},
 				out: map[string]string{
 					"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","ip_address":"192.168.0.5/24"}}`,
@@ -40,12 +42,12 @@ var _ = Describe("Pod annotation tests", func() {
 			{
 				name: "Routes",
 				in: &PodAnnotation{
-					IPs:      []*net.IPNet{mustParseCIDRAddress("192.168.0.5/24")},
-					MAC:      mustParseMAC("0A:58:FD:98:00:01"),
+					IPs:      []*net.IPNet{ovntest.MustParseIPNet("192.168.0.5/24")},
+					MAC:      ovntest.MustParseMAC("0A:58:FD:98:00:01"),
 					Gateways: []net.IP{net.ParseIP("192.168.0.1")},
 					Routes: []PodRoute{
 						{
-							Dest:    mustParseCIDR("192.168.1.0/24"),
+							Dest:    ovntest.MustParseIPNet("192.168.1.0/24"),
 							NextHop: net.ParseIP("192.168.1.1"),
 						},
 					},
@@ -57,8 +59,8 @@ var _ = Describe("Pod annotation tests", func() {
 			{
 				name: "Single-stack IPv6",
 				in: &PodAnnotation{
-					IPs:      []*net.IPNet{mustParseCIDRAddress("fd01::1234/64")},
-					MAC:      mustParseMAC("0A:58:FD:98:00:01"),
+					IPs:      []*net.IPNet{ovntest.MustParseIPNet("fd01::1234/64")},
+					MAC:      ovntest.MustParseMAC("0A:58:FD:98:00:01"),
 					Gateways: []net.IP{net.ParseIP("fd01::1")},
 				},
 				out: map[string]string{
@@ -69,10 +71,10 @@ var _ = Describe("Pod annotation tests", func() {
 				name: "Dual-stack",
 				in: &PodAnnotation{
 					IPs: []*net.IPNet{
-						mustParseCIDRAddress("192.168.0.5/24"),
-						mustParseCIDRAddress("fd01::1234/64"),
+						ovntest.MustParseIPNet("192.168.0.5/24"),
+						ovntest.MustParseIPNet("fd01::1234/64"),
 					},
-					MAC: mustParseMAC("0A:58:FD:98:00:01"),
+					MAC: ovntest.MustParseMAC("0A:58:FD:98:00:01"),
 					Gateways: []net.IP{
 						net.ParseIP("192.168.1.0"),
 						net.ParseIP("fd01::1"),
@@ -94,22 +96,3 @@ var _ = Describe("Pod annotation tests", func() {
 		}
 	})
 })
-
-func mustParseCIDRAddress(addr string) *net.IPNet {
-	ip, subnet, err := net.ParseCIDR(addr)
-	Expect(err).NotTo(HaveOccurred())
-	subnet.IP = ip
-	return subnet
-}
-
-func mustParseCIDR(cidr string) *net.IPNet {
-	_, subnet, err := net.ParseCIDR(cidr)
-	Expect(err).NotTo(HaveOccurred())
-	return subnet
-}
-
-func mustParseMAC(mac string) net.HardwareAddr {
-	parsed, err := net.ParseMAC(mac)
-	Expect(err).NotTo(HaveOccurred())
-	return parsed
-}


### PR DESCRIPTION
This adds dual-stack support to the setting and parsing of the l3-gateway-config annotation (but not rippling much beyond that).

Similarly to the pod annotation, I've added new array-valued `ip-addresses` and `next-hops` to replace `ip-address` and `next-hop`, and we set both fields in single-stack clusters but only the new fields in dual-stack clusters; eventually we can migrate to only setting the new fields everywhere.

`node_annotations.go` gets mostly rewritten but the new unit test shows that it's a no-op except where expected.

This also updates one of our external-ids in ovn similarly.

@dcbw 