### PR TITLE
Fix references to "minions" and "master nodes"

### DIFF
--- a/README_MANUAL.md
+++ b/README_MANUAL.md
@@ -73,18 +73,18 @@ that node over IP address.
   internal interface).
 
 3. All containers should be able to communicate with the k8s daemons running
-in the master node.
+on the master.
 
-  This can be achieved by running OVN gateways in the minion nodes. With
+  This can be achieved by running OVN gateways on the nodes. With
   at least one OVN gateway, the pods can reach the k8s central daemons with
   NAT.
 
-### Master node initialization
+### Master initialization
 
-* Start the central components on a k8s master node.
+* Start the central components on a k8s master.
 
 OVN architecture has a central component which stores your networking intent
-in a database.  Start this central component on one of the nodes where you
+in a database.  Start this central component on one of the hosts where you
 have started your k8s central daemons and which has an IP address of
 $CENTRAL_IP.  (For HA of the central component, please read [HA.md])
 
@@ -110,7 +110,7 @@ Also start ovn-controller on this node.
 /usr/share/openvswitch/scripts/ovn-ctl start_controller
 ```
 
-Now start the ovnkube utility on the master node.
+Now start the ovnkube utility on the master
 
 The below command expects the user to provide
 * A cluster wide private address range of $CLUSTER_IP_SUBNET
@@ -140,20 +140,19 @@ uses the hostname.  kubelet allows this name to be overridden with
 
 Note: Make sure to read /var/log/ovn-kubernetes/ovnkube.log to see that there were
 no obvious errors with argument passing.  Also, you should only pass
-"-init-node" argument if there is a kubelet running on the master node too.
+"-init-node" argument if there is a kubelet running on the master too.
 
 If you want to use SSL instead of TCP for OVN databases, please read
 [INSTALL.SSL.md].
 
-### Minion node initialization.
+### Node initialization.
 
 On each host, you will need to run the following command once.
 
 The below command expects the user to provide
 * A cluster wide private address range of $CLUSTER_IP_SUBNET
 (e.g: 192.168.0.0/16).  The pods are provided IP address from this range.
-This value should be the same as the one provided to ovnkube in the master
-node.
+This value should be the same as the one provided to ovnkube in the master.
 
 * $NODE_NAME should be the same as the one used by kubelet.  kubelet by default
 uses the hostname.  kubelet allows this name to be overridden with
@@ -187,10 +186,10 @@ Notes on gateway nodes:
 * Gateway nodes are needed for North-South connectivity in OVN.
 OVN has support for multiple gateway nodes. In the above command,
 since '-init-gateways' has been provided as an option, a OVN
-gateway will be created on each minion.
+gateway will be created on each node.
 
 * Just providing '-init-gateways', will make OVN choose the
-interface in your minion via which the minion's default gateway
+interface in your node via which the node default gateway
 is reached.
 
 * If you want to chose the interface for your gateway, you should

--- a/dist/READMEcontainer.md
+++ b/dist/READMEcontainer.md
@@ -24,7 +24,7 @@ to start openvswitch. it must be running for the ovn-daemonsets to
 run.
 
 There are two daemonsets that support ovn. ovnkube-master runs
-on the cluster master node, ovnkube runs on the remaining nodes.
+on the cluster masters, ovnkube runs on all nodes.
 The daemonsets run with hostNetwork: true.
 
 The both daemonsets run the node daemons, ovn-controller and ovn-node.
@@ -32,8 +32,8 @@ In addition the daemonset runs ovn-northd and ovn-master.
 
 The startup sequence requires this startup order:
 - ovs
-- ovnkube-master on the master node
-- ovnkube on the rest of the nodes.
+- ovnkube-master on the masters
+- ovnkube on all nodes.
 
 ===============================
 

--- a/dist/images/ovndb-vip.sh
+++ b/dist/images/ovndb-vip.sh
@@ -31,7 +31,7 @@ ovnkube_version="3"
 ovn_daemonset_version=${OVN_DAEMONSET_VERSION:-"3"}
 
 # hostname is the host's hostname when using host networking,
-# This is useful on the master node
+# This is useful on the master
 # otherwise it is the container ID (useful for debugging).
 ovn_pod_host=$(hostname)
 

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -84,7 +84,7 @@ ovnkube_version="3"
 ovn_daemonset_version=${OVN_DAEMONSET_VERSION:-"3"}
 
 # hostname is the host's hostname when using host networking,
-# This is useful on the master node
+# This is useful on the master
 # otherwise it is the container ID (useful for debugging).
 ovn_pod_host=${K8S_NODE:-$(hostname)}
 
@@ -905,7 +905,7 @@ display_version
 # run-ovn-northd Runs ovn-northd as a process does not run nb_ovsdb or sb_ovsdb (v3)
 # nb-ovsdb       Runs nb_ovsdb as a process (no detach or monitor) (v3)
 # sb-ovsdb       Runs sb_ovsdb as a process (no detach or monitor) (v3)
-# ovn-master     - master node only (v3)
+# ovn-master     - master only (v3)
 # ovn-controller - all nodes (v3)
 # ovn-node       - all nodes (v3)
 # cleanup-ovn-node - all nodes (v3)

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -23,7 +23,7 @@ spec:
 # ovnkube-db
 # daemonset version 3
 # starts ovn NB/SB ovsdb daemons, each in a separate container
-# it is running on master node for now, but does not need to be the case
+# it is running on master for now, but does not need to be the case
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -1,7 +1,7 @@
 # ovnkube-master
 # daemonset version 3
 # starts master daemons, each in a separate container
-# it is run on the master node(s)
+# it is run on the master(s)
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -10,7 +10,7 @@ metadata:
   namespace: ovn-kubernetes
   annotations:
     kubernetes.io/description: |
-      This Deployment launches the ovn-kubernetes master node networking components.
+      This Deployment launches the ovn-kubernetes master networking components.
 spec:
   progressDeadlineSeconds: 600
   replicas: 1

--- a/docs/INSTALL.SSL.md
+++ b/docs/INSTALL.SSL.md
@@ -20,22 +20,22 @@ ovs-pki init --force
 
 The above command creates 2 certificate authorities.  But we are concerned only
 with one of them, i.e the "switch" certificate authority.  We will use this
-certificate authority to sign individual certificates of all the minions.  We
-will then use the same certificate authority's certificate to verify minion's
+certificate authority to sign individual certificates of all the nodes.  We
+will then use the same certificate authority's certificate to verify a node's
 connections to the master.
 
-Copy this certificate to the master node and each of the minion nodes. $CENTRAL_IP
-is the IP address of the master node.
+Copy this certificate to the master and each of the nodes. $CENTRAL_IP
+is the IP address of the master.
 
 ```
 scp /var/lib/openvswitch/pki/switchca/cacert.pem \
     root@$CENTRAL_IP:/etc/openvswitch/.
 ```
 
-### Generate signed certificates for OVN components running on the master node.
+### Generate signed certificates for OVN components running on the master.
 
 #### Generate signed certificates for OVN NB Database
-On the master node, run the following commands.
+On the master, run the following commands.
 
 ```
 cd /etc/openvswitch
@@ -52,7 +52,7 @@ ovs-pki -b sign ovnnb
 ```
 
 The above command will generate ovnnb-cert.pem. Copy over this file back
-to the master node's /etc/openvswitch. The ovnnb-privkey.pem and ovnnb-cert.pem
+to the master's /etc/openvswitch. The ovnnb-privkey.pem and ovnnb-cert.pem
 will be used by the ovsdb-server that fronts the OVN NB database.
 
 Now run the following commands to ask ovsdb-server to use these
@@ -82,7 +82,7 @@ ovs-pki -b sign ovnsb
 ```
 
 The above command will generate ovnsb-cert.pem. Copy over this file back
-to the master node's /etc/openvswitch. The ovnsb-privkey.pem and ovnsb-cert.pem
+to the master's /etc/openvswitch. The ovnsb-privkey.pem and ovnsb-cert.pem
 will be used by the ovsdb-server that fronts the OVN SB database.
 
 Now run the following commands to ask ovsdb-server to use these
@@ -98,24 +98,24 @@ ovn-sbctl set-connection pssl:6642
 
 #### Generate signed certificates for OVN Northd
 
-If you are running ovn-northd on the same node as OVN NB and SB database servers, then
+If you are running ovn-northd on the same host as the OVN NB and SB database servers, then
 there is no need to secure the communication between ovn-northd and OVN NB/SB daemons.
 ovn-northd will communicate using UNIX path.
 
-In case, you still want to secure the commnication or the daemons are running on
-separate nodes, then follow the instructions on this page [OVN-NORTHD.SSL.md]
+In case you still want to secure the communication, or the daemons are running on
+separate hosts, then follow the instructions on this page [OVN-NORTHD.SSL.md]
 
 
-### Generate certificates for the minion.
+### Generate certificates for the nodes
 
-On each minion, create a certificate request.
+On each node, create a certificate request.
 
 ```
 cd /etc/openvswitch
 ovs-pki req ovncontroller
 ```
 
-The above command will create a new private key for the minion called
+The above command will create a new private key for the node called
 ovncontroller-privkey.pem and a certificate request file called
 ovncontroller-req.pem.  Copy this certificate request file to the secure
 machine where you created the certificate authority and from the directory
@@ -125,9 +125,9 @@ where the copied file exists, run:
 ovs-pki -b sign ovncontroller switch
 ```
 
-The above will create the certificate for the minion called
+The above will create the certificate for the node called
 "ovncontroller-cert.pem". You should copy this certificate back to the
-minion's /etc/openvswitch directory.
+node's /etc/openvswitch directory.
 
 ## One time setup.
 
@@ -185,7 +185,7 @@ certificates to it. For e.g:
 ```
 sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -k8s-apiserver="http://$CENTRAL_IP:8080" \
-    -init-node="$MINION_NAME"  \
+    -init-node="$NODE_NAME"  \
     -nodeport \
     -nb-address="ssl:$CENTRAL_IP:6641" \
     -sb-address="ssl:$CENTRAL_IP:6642" -k8s-token=$TOKEN \

--- a/docs/INSTALL.UBUNTU.md
+++ b/docs/INSTALL.UBUNTU.md
@@ -23,7 +23,7 @@ sudo apt-get install openvswitch-datapath-dkms -y
 sudo apt-get install openvswitch-switch openvswitch-common -y
 ```
 
-On the master node, where you intend to start OVN's central components,
+On the master, where you intend to start OVN's central components,
 run:
 
 ```

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -17,7 +17,7 @@ same system-id for all your VMs - which is a problem.
 
 ### All nodes should register with OVN SB database.
 
-On the master node, run:
+On the master, run:
 
 ```
 ovn-sbctl list chassis
@@ -83,14 +83,14 @@ You can use the following command to achieve it via iptables.
 
 ### Check ovn-northd's log file.
 
-On the master node, look at /var/log/openvswitch/ovn-northd.log to see
+On the master, look at /var/log/openvswitch/ovn-northd.log to see
 for any errors with the setup of the OVN central node.
 
 ## Runtime issues
 
 ### Check the watcher's log file.
 
-On the master node, check whether ovnkube is running by:
+On the master, check whether ovnkube is running by:
 
 ```
 ps -ef | grep ovnkube
@@ -106,7 +106,7 @@ When you create a pod and it gets scheduled on a particular host, the
 OVN CNI plugin on that host, tries to access the pod's information from
 the K8s api server.  Specifically, it tries to get the IP address and
 mac address for that pod.  This information is logged in the OVN CNI log
-file on each minion if you have specified a log file via 
+file on each node if you have specified a log file via
 "/etc/openvswitch/ovn_k8s.conf". You can read how to provide a logfile
 by reading 'man ovn_k8s.conf.5'.
 

--- a/docs/ha.md
+++ b/docs/ha.md
@@ -3,14 +3,14 @@
 OVN architecture has two central databases that can be clustered.
 The databases are OVN_Northbound and OVN_Southbound.  This document
 explains how to cluster them and start various daemons for the
-ovn-kubernetes integration.  You will ideally need atleast 3 master
-nodes for a HA cluster. (You will need a miniumum of OVS/OVN 2.9.2
+ovn-kubernetes integration.  You will ideally need at least 3 masters
+for a HA cluster. (You will need a miniumum of OVS/OVN 2.9.2
 for clustering.)
 
-## Master1 node initialization
+## Master1 initialization
 
-To bootstrap your cluster, you need to start on one master node.
-For a lack of better name, lets call it MASTER1 with an IP
+To bootstrap your cluster, you need to start on one master.
+For a lack of better name, let's call it MASTER1 with an IP
 address of $MASTER1
 
 On MASTER1, delete any stale OVN databases and stop any
@@ -23,7 +23,7 @@ sudo rm /etc/openvswitch/ovn*.db
 sudo /usr/share/openvswitch/scripts/ovn-ctl stop_northd
 ```
 
-Start the two databases on that node with:
+Start the two databases on that host with:
 
 ```
 LOCAL_IP=$MASTER1
@@ -35,7 +35,7 @@ sudo /usr/share/openvswitch/scripts/ovn-ctl \
 ```
 
 
-## Master2, Master3... node initialization
+## Master2, Master3... initialization
 
 Delete any stale databases and stop any running ovn-northd
 daemons. e.g:
@@ -47,8 +47,8 @@ sudo rm /etc/openvswitch/ovn*.db
 sudo /usr/share/openvswitch/scripts/ovn-ctl stop_northd
 ```
 
-On master node, with a IP of $LOCAL_IP, start
-the databases and ask it to join $MASTER1
+On master with a IP of $LOCAL_IP, start the databases and ask it to
+join $MASTER1
 
 ```
 LOCAL_IP=$LOCAL_IP
@@ -76,7 +76,7 @@ sudo ovs-appctl -t /var/run/openvswitch/ovnsb_db.ctl \
 
 ## Start 'ovn-kube -init-master'
 
-On any one of the master nodes, we need to start 'ovnkube -init-master'.
+On any one of the masters, we need to start 'ovnkube -init-master'.
 (This should ideally be a daemonset with replica count of 1.)
 
 IP1="$MASTER1"
@@ -100,8 +100,8 @@ nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml \
 
 ## start ovn-northd
 
-On any one of the nodes (ideally via a daemonset with replica count as 1),
-start ovn-northd. Let the 3 master node IPs be $IP1, $IP2 and $IP3.
+On any one of the masters (ideally via a daemonset with replica count as 1),
+start ovn-northd. Let the 3 master IPs be $IP1, $IP2 and $IP3.
 
 ```
 IP1="$MASTER1"
@@ -119,7 +119,7 @@ sudo ovn-northd -vconsole:emer -vsyslog:err -vfile:info \
 
 ## Start 'ovn-kube -init-node'
 
-In all other minions (and if needed on other masters), start ovnkube with
+On all nodes (and if needed on other masters), start ovnkube with
 '-init-node'. For e.g:
 
 ```
@@ -133,7 +133,7 @@ ovn_sb="tcp:$IP1:6642,tcp:$IP2:6642,tcp:$IP3:6642"
 nohup sudo ovnkube -k8s-kubeconfig $HOME/kubeconfig.yaml -loglevel=4 \
     -logfile="/var/log/openvswitch/ovnkube.log" \
     -k8s-apiserver="http://$K8S_APISERVER_IP:8080" \
-    -init-node="$MINION_NAME"  \
+    -init-node="$NODE_NAME"  \
     -nb-address="${ovn_nb}" \
     -sb-address="${ovn_sb}" \
     -k8s-token="$TOKEN" \

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -211,7 +211,7 @@ func runOvnKube(ctx *cli.Context) error {
 
 	if master != "" {
 		if runtime.GOOS == "windows" {
-			return fmt.Errorf("Windows is not supported as master node")
+			return fmt.Errorf("Windows is not supported as a master")
 		}
 		// register prometheus metrics exported by the master
 		metrics.RegisterMasterMetrics()

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -673,7 +673,7 @@ var OVNGatewayFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name: "gateway-interface",
-		Usage: "The interface in minions that will be the gateway interface. " +
+		Usage: "The interface on nodes that will be the gateway interface. " +
 			"If none specified, then the node's interface on which the " +
 			"default gateway is configured will be used as the gateway " +
 			"interface. Only useful with \"init-gateways\"",

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -24,8 +24,7 @@ func (n *OvnNode) createManagementPort(localSubnet *net.IPNet, nodeAnnotator kub
 	// uppercase letters, this causes a mismatch between what the watcher
 	// will try to fetch and what kubernetes provides, thus failing to
 	// create the port on the logical switch.
-	// Until the above is changed, switch to a lowercase hostname for
-	// initMinion.
+	// Until the above is changed, switch to a lowercase hostname
 	nodeName := strings.ToLower(n.name)
 
 	// Make sure br-int is created.

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -542,7 +542,7 @@ subnet=%s
 				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + node1Name,
 			})
 
-			// Expect the code to re-add the master node (which still exists)
+			// Expect the code to re-add the master (which still exists)
 			// when the factory watch begins and enumerates all existing
 			// Kubernetes API nodes
 			fexec.AddFakeCmdsNoOutputNoError([]string{


### PR DESCRIPTION
I started this a long time ago when I first started looking at ovn-kubernetes, but wasn't sure what to do about the variable names referencing minions in the vagrant and ansible stuff because I didn't want to break anything but I didn't want to bother testing them either. But now all of those are gone, so all that's left to fix is docs and comments.

@dcbw @girishmg 
