### PR TITLE
dual stack management port creation

### DIFF
--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -11,12 +11,8 @@ import (
 	"k8s.io/klog"
 )
 
-func (n *OvnNode) createManagementPort(localSubnet *net.IPNet, nodeAnnotator kube.Annotator,
+func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator kube.Annotator,
 	waiter *startupWaiter) error {
-	// Retrieve the routerIP and mangementPortIP for a given localSubnet
-	routerIP, portIP := util.GetNodeWellKnownAddresses(localSubnet)
-	routerMAC := util.IPAddrToHWAddr(routerIP.IP)
-
 	// Kubernetes emits events when pods are created. The event will contain
 	// only lowercase letters of the hostname even though the kubelet is
 	// started with a hostname that contains lowercase and uppercase letters.
@@ -60,7 +56,7 @@ func (n *OvnNode) createManagementPort(localSubnet *net.IPNet, nodeAnnotator kub
 		return err
 	}
 
-	err = createPlatformManagementPort(util.K8sMgmtIntfName, portIP, routerIP.IP, routerMAC, n.stopChan)
+	err = createPlatformManagementPort(util.K8sMgmtIntfName, hostSubnets, n.stopChan)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -20,7 +20,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -46,8 +45,20 @@ func createTempFile(name string) (string, error) {
 	return fname, nil
 }
 
+type managementPortTestConfig struct {
+	family   int
+	protocol iptables.Protocol
+
+	clusterCIDR string
+	serviceCIDR string
+	nodeSubnet  string
+
+	expectedManagementPortIP string
+	expectedGatewayIP        string
+}
+
 func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.NetNS,
-	clusterCIDR, nodeSubnet, mgtPortIP, gwIP, serviceCIDR, lrpMAC string) {
+	configs []managementPortTestConfig, expectedLRPMAC string) {
 	const (
 		nodeName      string = "node1"
 		mgtPortMAC    string = "00:00:00:55:66:77"
@@ -81,29 +92,26 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	err := util.SetExec(fexec)
 	Expect(err).NotTo(HaveOccurred())
 
-	nodeSubnetCIDR := ovntest.MustParseIPNet(nodeSubnet)
-	Expect(err).NotTo(HaveOccurred())
+	nodeSubnetCIDRs := make([]*net.IPNet, len(configs))
+	mgtPortAddrs := make([]*netlink.Addr, len(configs))
+	fakeipt := make([]*util.FakeIPTables, len(configs))
+	for i, cfg := range configs {
+		nodeSubnetCIDRs[i] = ovntest.MustParseIPNet(cfg.nodeSubnet)
+		mpCIDR := &net.IPNet{
+			IP:   ovntest.MustParseIP(cfg.expectedManagementPortIP),
+			Mask: nodeSubnetCIDRs[i].Mask,
+		}
+		mgtPortAddrs[i], err = netlink.ParseAddr(mpCIDR.String())
+		Expect(err).NotTo(HaveOccurred())
 
-	mpCIDR := &net.IPNet{
-		IP:   ovntest.MustParseIP(mgtPortIP),
-		Mask: nodeSubnetCIDR.Mask,
+		fakeipt[i], err = util.NewFakeWithProtocol(cfg.protocol)
+		Expect(err).NotTo(HaveOccurred())
+		util.SetIPTablesHelper(cfg.protocol, fakeipt[i])
+		err = fakeipt[i].NewChain("nat", "POSTROUTING")
+		Expect(err).NotTo(HaveOccurred())
+		err = fakeipt[i].NewChain("nat", "OVN-KUBE-SNAT-MGMTPORT")
+		Expect(err).NotTo(HaveOccurred())
 	}
-	mgtPortCIDR := mpCIDR.String()
-
-	iptProto := iptables.ProtocolIPv4
-	family := netlink.FAMILY_V4
-	if utilnet.IsIPv6CIDR(nodeSubnetCIDR) {
-		iptProto = iptables.ProtocolIPv6
-		family = netlink.FAMILY_V6
-	}
-
-	fakeipt, err := util.NewFakeWithProtocol(iptProto)
-	Expect(err).NotTo(HaveOccurred())
-	util.SetIPTablesHelper(iptProto, fakeipt)
-	err = fakeipt.NewChain("nat", "POSTROUTING")
-	Expect(err).NotTo(HaveOccurred())
-	err = fakeipt.NewChain("nat", "OVN-KUBE-SNAT-MGMTPORT")
-	Expect(err).NotTo(HaveOccurred())
 
 	existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
 		Name: nodeName,
@@ -116,70 +124,65 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	Expect(err).NotTo(HaveOccurred())
 
 	nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient}, &existingNode)
-	err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNet(nodeSubnet))
-	Expect(err).NotTo(HaveOccurred())
-	err = nodeAnnotator.Run()
-	Expect(err).NotTo(HaveOccurred())
-
 	waiter := newStartupWaiter()
 
 	err = testNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
 		n := OvnNode{name: nodeName, stopChan: make(chan struct{})}
-		err = n.createManagementPort(nodeSubnetCIDR, nodeAnnotator, waiter)
+		err = n.createManagementPort(nodeSubnetCIDRs[0], nodeAnnotator, waiter)
 		Expect(err).NotTo(HaveOccurred())
 		l, err := netlink.LinkByName(mgtPort)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Check whether IP has been added
-		addrs, err := netlink.AddrList(l, family)
-		Expect(err).NotTo(HaveOccurred())
-		var foundAddr bool
-		expectedAddr, err := netlink.ParseAddr(mgtPortCIDR)
-		Expect(err).NotTo(HaveOccurred())
-		for _, a := range addrs {
-			if a.IP.Equal(expectedAddr.IP) && bytes.Equal(a.Mask, expectedAddr.Mask) {
-				foundAddr = true
-				break
-			}
-		}
-		Expect(foundAddr).To(BeTrue())
-
-		// Check whether the route has been added
-		j := 0
-		gatewayIP := ovntest.MustParseIP(gwIP)
-		subnets := []string{clusterCIDR, serviceCIDR}
-		for _, subnet := range subnets {
-			foundRoute := false
-			dstIPnet := ovntest.MustParseIPNet(subnet)
-			route := &netlink.Route{Dst: dstIPnet}
-			filterMask := netlink.RT_FILTER_DST
-			routes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, route, filterMask)
+		for i, cfg := range configs {
+			// Check whether IP has been added
+			addrs, err := netlink.AddrList(l, cfg.family)
 			Expect(err).NotTo(HaveOccurred())
-			for _, r := range routes {
-				if r.Gw.Equal(gatewayIP) && r.LinkIndex == l.Attrs().Index {
-					foundRoute = true
+			var foundAddr bool
+			for _, a := range addrs {
+				if a.IP.Equal(mgtPortAddrs[i].IP) && bytes.Equal(a.Mask, mgtPortAddrs[i].Mask) {
+					foundAddr = true
 					break
 				}
 			}
-			Expect(foundRoute).To(BeTrue())
-			foundRoute = false
-			j++
-		}
-		Expect(j).To(Equal(2))
+			Expect(foundAddr).To(BeTrue(), "did not find expected management port IP %s", mgtPortAddrs[i].String())
 
-		// Check whether router IP has been added in the arp entry for mgmt port
-		neighbours, err := netlink.NeighList(l.Attrs().Index, netlink.FAMILY_ALL)
-		Expect(err).NotTo(HaveOccurred())
-		var foundNeighbour bool
-		for _, neighbour := range neighbours {
-			if neighbour.IP.Equal(gatewayIP) && (neighbour.HardwareAddr.String() == lrpMAC) {
-				foundNeighbour = true
-				break
+			// Check whether the routes have been added
+			j := 0
+			gatewayIP := ovntest.MustParseIP(cfg.expectedGatewayIP)
+			subnets := []string{cfg.clusterCIDR, cfg.serviceCIDR}
+			for _, subnet := range subnets {
+				foundRoute := false
+				dstIPnet := ovntest.MustParseIPNet(subnet)
+				route := &netlink.Route{Dst: dstIPnet}
+				filterMask := netlink.RT_FILTER_DST
+				routes, err := netlink.RouteListFiltered(cfg.family, route, filterMask)
+				Expect(err).NotTo(HaveOccurred())
+				for _, r := range routes {
+					if r.Gw.Equal(gatewayIP) && r.LinkIndex == l.Attrs().Index {
+						foundRoute = true
+						break
+					}
+				}
+				Expect(foundRoute).To(BeTrue(), "did not find expected route to %s", subnet)
+				foundRoute = false
+				j++
 			}
+			Expect(j).To(Equal(2))
+
+			// Check whether router IP has been added in the arp entry for mgmt port
+			neighbours, err := netlink.NeighList(l.Attrs().Index, cfg.family)
+			Expect(err).NotTo(HaveOccurred())
+			var foundNeighbour bool
+			for _, neighbour := range neighbours {
+				if neighbour.IP.Equal(gatewayIP) && (neighbour.HardwareAddr.String() == expectedLRPMAC) {
+					foundNeighbour = true
+					break
+				}
+			}
+			Expect(foundNeighbour).To(BeTrue())
 		}
-		Expect(foundNeighbour).To(BeTrue())
 
 		return nil
 	})
@@ -190,19 +193,21 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	err = waiter.Wait()
 	Expect(err).NotTo(HaveOccurred())
 
-	expectedTables := map[string]util.FakeTable{
-		"filter": {},
-		"nat": {
-			"POSTROUTING": []string{
-				"-o " + mgtPort + " -j OVN-KUBE-SNAT-MGMTPORT",
+	for i, cfg := range configs {
+		expectedTables := map[string]util.FakeTable{
+			"filter": {},
+			"nat": {
+				"POSTROUTING": []string{
+					"-o " + mgtPort + " -j OVN-KUBE-SNAT-MGMTPORT",
+				},
+				"OVN-KUBE-SNAT-MGMTPORT": []string{
+					"-o " + mgtPort + " -j SNAT --to-source " + cfg.expectedManagementPortIP + " -m comment --comment OVN SNAT to Management Port",
+				},
 			},
-			"OVN-KUBE-SNAT-MGMTPORT": []string{
-				"-o " + mgtPort + " -j SNAT --to-source " + mgtPortIP + " -m comment --comment OVN SNAT to Management Port",
-			},
-		},
+		}
+		err = fakeipt[i].MatchState(expectedTables)
+		Expect(err).NotTo(HaveOccurred())
 	}
-	err = fakeipt.MatchState(expectedTables)
-	Expect(err).NotTo(HaveOccurred())
 
 	updatedNode, err := fakeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
@@ -257,46 +262,70 @@ var _ = Describe("Management Port Operations", func() {
 		Expect(testNS.Close()).To(Succeed())
 	})
 
-	It("sets up the management port for IPv4 clusters", func() {
-		const (
-			clusterCIDR string = "10.1.0.0/16"
-			nodeSubnet  string = "10.1.1.0/24"
-			gwIP        string = "10.1.1.1"
-			mgtPortIP   string = "10.1.1.2"
-			serviceCIDR string = "172.16.1.0/24"
-			lrpMAC      string = "0a:58:0a:01:01:01"
-		)
+	const (
+		v4clusterCIDR string = "10.1.0.0/16"
+		v4nodeSubnet  string = "10.1.1.0/24"
+		v4gwIP        string = "10.1.1.1"
+		v4mgtPortIP   string = "10.1.1.2"
+		v4serviceCIDR string = "172.16.1.0/24"
+		v4lrpMAC      string = "0a:58:0a:01:01:01"
 
+		v6clusterCIDR string = "fda6::/48"
+		v6nodeSubnet  string = "fda6:0:0:1::/64"
+		v6gwIP        string = "fda6:0:0:1::1"
+		v6mgtPortIP   string = "fda6:0:0:1::2"
+		v6serviceCIDR string = "fc95::/64"
+		v6lrpMAC      string = "0a:58:fd:a6:00:01" // generated from gatewayIP
+	)
+
+	It("sets up the management port for IPv4 clusters", func() {
 		app.Action = func(ctx *cli.Context) error {
-			testManagementPort(ctx, fexec, testNS, clusterCIDR, nodeSubnet, mgtPortIP, gwIP, serviceCIDR, lrpMAC)
+			testManagementPort(ctx, fexec, testNS,
+				[]managementPortTestConfig{
+					{
+						family:   netlink.FAMILY_V4,
+						protocol: iptables.ProtocolIPv4,
+
+						clusterCIDR: v4clusterCIDR,
+						serviceCIDR: v4serviceCIDR,
+						nodeSubnet:  v4nodeSubnet,
+
+						expectedManagementPortIP: v4mgtPortIP,
+						expectedGatewayIP:        v4gwIP,
+					},
+				}, v4lrpMAC)
 			return nil
 		}
 		err := app.Run([]string{
 			app.Name,
-			"--cluster-subnets=" + clusterCIDR,
-			"--k8s-service-cidr=" + serviceCIDR,
+			"--cluster-subnets=" + v4clusterCIDR,
+			"--k8s-service-cidr=" + v4serviceCIDR,
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("sets up the management port for IPv6 clusters", func() {
-		const (
-			clusterCIDR string = "fda6::/48"
-			nodeSubnet  string = "fda6:0:0:1::/64"
-			gwIP        string = "fda6:0:0:1::1"
-			mgtPortIP   string = "fda6:0:0:1::2"
-			serviceCIDR string = "fc95::/64"
-			lrpMAC      string = "0a:58:fd:a6:00:01" // generated from gatewayIP
-		)
-
 		app.Action = func(ctx *cli.Context) error {
-			testManagementPort(ctx, fexec, testNS, clusterCIDR, nodeSubnet, mgtPortIP, gwIP, serviceCIDR, lrpMAC)
+			testManagementPort(ctx, fexec, testNS,
+				[]managementPortTestConfig{
+					{
+						family:   netlink.FAMILY_V6,
+						protocol: iptables.ProtocolIPv6,
+
+						clusterCIDR: v6clusterCIDR,
+						serviceCIDR: v6serviceCIDR,
+						nodeSubnet:  v6nodeSubnet,
+
+						expectedManagementPortIP: v6mgtPortIP,
+						expectedGatewayIP:        v6gwIP,
+					},
+				}, v6lrpMAC)
 			return nil
 		}
 		err := app.Run([]string{
 			app.Name,
-			"--cluster-subnets=" + clusterCIDR,
-			"--k8s-service-cidr=" + serviceCIDR,
+			"--cluster-subnets=" + v6clusterCIDR,
+			"--k8s-service-cidr=" + v6serviceCIDR,
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -206,7 +206,7 @@ func (n *OvnNode) Start() error {
 	}
 
 	// Initialize management port resources on the node
-	if err := n.createManagementPort(subnet, nodeAnnotator, waiter); err != nil {
+	if err := n.createManagementPort([]*net.IPNet{subnet}, nodeAnnotator, waiter); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If we have multiple hostsubnets, create a dual-stack management port. We don't actually have multiple hostsubnets yet but this at least extends the unit test to exercise the new code.

@dcbw @girishmg 