### PR TITLE
ci: various cleanups and stop using kubetest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,5 +174,5 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v1
       with:
-        name: kind-logs-${{ github.run_id }}-${{ env.JOB_NAME }}
+        name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
       if: always()
       run: |
         mkdir -p /tmp/kind/logs 
-        kind export logs --name ${KIND_CLUSTER_NAME} /tmp/kind/logs
+        kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
 
     - name: Upload logs
       if: always()

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -2,6 +2,25 @@
 
 set -euxo pipefail
 
+run_kubectl() {
+  local retries=0
+  local attempts=10
+  while true; do
+    kubectl $@
+    if [[ $? == 0 ]]; then
+      break
+    fi
+
+    ((retries += 1))
+    if [[ "${retries}" -gt ${attempts} ]]; then
+      echo "error: 'kubectl $@' did not succeed, failing"
+      exit 1
+    fi
+    echo "info: waiting for 'kubectl $@' to succeed..."
+    sleep 1
+  done
+}
+
 K8S_VERSION=${K8S_VERSION:-v1.17.2}
 KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS:-false}
 KIND_HA=${KIND_HA:-false}
@@ -26,6 +45,7 @@ sed -i "s/apiServerAddress.*/apiServerAddress: ${API_IP}/" ${KIND_CONFIG}
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
 kind create cluster --name ${KIND_CLUSTER_NAME} --kubeconfig ${HOME}/admin.conf --image kindest/node:${K8S_VERSION} --config=${KIND_CONFIG}
 export KUBECONFIG=${HOME}/admin.conf
+cat ${KUBECONFIG}
 mkdir -p /tmp/kind
 sudo chmod 777 /tmp/kind
 count=0
@@ -52,26 +72,26 @@ docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
 popd
 kind load docker-image ovn-daemonset-f:dev --name ${KIND_CLUSTER_NAME}
 pushd ../dist/yaml
-kubectl create -f ovn-setup.yaml
+run_kubectl create -f ovn-setup.yaml
 CONTROL_NODES=$(docker ps -f name=ovn-control | grep -v NAMES | awk '{ print $NF }')
 for n in $CONTROL_NODES; do
-  kubectl label node $n k8s.ovn.org/ovnkube-db=true
+  run_kubectl label node $n k8s.ovn.org/ovnkube-db=true
   if [ "$KIND_REMOVE_TAINT" == true ]; then
-    kubectl taint node $n node-role.kubernetes.io/master:NoSchedule-
+    run_kubectl taint node $n node-role.kubernetes.io/master:NoSchedule-
   fi
 done
 if [ "$KIND_HA" == true ]; then
-  kubectl create -f ovnkube-db-raft.yaml
+  run_kubectl create -f ovnkube-db-raft.yaml
 else
-  kubectl create -f ovnkube-db.yaml
+  run_kubectl create -f ovnkube-db.yaml
 fi
-kubectl create -f ovnkube-master.yaml
-kubectl create -f ovnkube-node.yaml
+run_kubectl create -f ovnkube-master.yaml
+run_kubectl create -f ovnkube-node.yaml
 popd
-kubectl -n kube-system delete ds kube-proxy
+run_kubectl -n kube-system delete ds kube-proxy
 kind get clusters
 kind get nodes --name ${KIND_CLUSTER_NAME}
 kind export kubeconfig --name ovn
 if [ "$KIND_INSTALL_INGRESS" == true ]; then
-  kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
+  run_kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
 fi

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -23,8 +23,8 @@ fi
 sed -i "s/apiServerAddress.*/apiServerAddress: ${API_IP}/" ${KIND_CONFIG}
 
 # Create KIND cluster
-CLUSTER_NAME=${CLUSTER_NAME:-ovn}
-kind create cluster --name ${CLUSTER_NAME} --kubeconfig ${HOME}/admin.conf --image kindest/node:${K8S_VERSION} --config=${KIND_CONFIG}
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
+kind create cluster --name ${KIND_CLUSTER_NAME} --kubeconfig ${HOME}/admin.conf --image kindest/node:${K8S_VERSION} --config=${KIND_CONFIG}
 export KUBECONFIG=${HOME}/admin.conf
 mkdir -p /tmp/kind
 sudo chmod 777 /tmp/kind
@@ -50,7 +50,7 @@ echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse 
 docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
 ./daemonset.sh --image=docker.io/library/ovn-daemonset-f:dev --net-cidr=10.244.0.0/16 --svc-cidr=10.96.0.0/12 --gateway-mode="local" --k8s-apiserver=https://${API_IP}:11337 --kind --master-loglevel=5
 popd
-kind load docker-image ovn-daemonset-f:dev --name ${CLUSTER_NAME}
+kind load docker-image ovn-daemonset-f:dev --name ${KIND_CLUSTER_NAME}
 pushd ../dist/yaml
 kubectl create -f ovn-setup.yaml
 CONTROL_NODES=$(docker ps -f name=ovn-control | grep -v NAMES | awk '{ print $NF }')
@@ -70,7 +70,7 @@ kubectl create -f ovnkube-node.yaml
 popd
 kubectl -n kube-system delete ds kube-proxy
 kind get clusters
-kind get nodes --name ${CLUSTER_NAME}
+kind get nodes --name ${KIND_CLUSTER_NAME}
 kind export kubeconfig --name ovn
 if [ "$KIND_INSTALL_INGRESS" == true ]; then
   kubectl create -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -15,5 +15,5 @@ export KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS}
 sed -E -i 's/"\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}" "\$\{e2e_test\}"/pushd \$GITHUB_WORKSPACE\/test\/e2e\nGO111MODULE=on "\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}"/' ${GOPATH}/src/k8s.io/kubernetes/hack/ginkgo-e2e.sh
 
 pushd ${GOPATH}/src/k8s.io/kubernetes
-kubetest --provider=local --deployment=kind --kind-cluster-name=kind-ovn --test --test_args='--disable-log-dump=false'
+hack/ginkgo-e2e.sh --disable-log-dump=false
 popd

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -33,10 +33,6 @@ case "$SHARD" in
 		exit 1
 	;;
 esac
-kubetest \
-	--provider=local \
-	--deployment=kind \
-	--kind-cluster-name=${KIND_CLUSTER_NAME} \
-	--test \
-	--test_args="${GINKGO_ARGS}"
+
+e2e.test ${GINKGO_ARGS}
 

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -3,14 +3,13 @@
 set -ex
 
 export GO111MODULE="on"
-mkdir -p $GOPATH/bin
-curl -fs https://chunk.io/trozet/ba750701d0af4e2b94b249ab9de27b50 -o $GOPATH/bin/kubetest
-chmod +x $GOPATH/bin/kubetest
 
 pushd $GOPATH/src/k8s.io/kubernetes/
 sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
+sudo ln ./_output/local/go/bin/e2e.test /usr/local/bin/e2e.test
 popd
 
+mkdir -p $GOPATH/bin
 wget -O $GOPATH/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
 chmod +x $GOPATH/bin/kind
 pushd ../contrib


### PR DESCRIPTION
Put the test name earlier since the GitHub Actions UI only shows
the first 24 characters or so.

Don't use kubetest; don't think we need it since we just use kind.

Retry kubectl commands a couple times when things fail.

@as-com @trozet @dave-tucker 