### PR TITLE
remove OVN specific podsecuritypolicy resource

### DIFF
--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -32,37 +32,7 @@ metadata:
   namespace: ovn-kubernetes
 
 ---
-# for now throw in all the privileges to run a pod. we can fine grain it further later.
 
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: ovn-kubernetes
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-  - '*'
-  fsGroup:
-    rule: RunAsAny
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - '*'
-  hostPID: true
-  hostIPC: true
-  hostNetwork: true
-  hostPorts:
-  - min: 0
-    max: 65536
-
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -99,14 +69,6 @@ rules:
   - nodes
   - pods
   verbs: ["patch", "update"]
-- apiGroups:
-  - extensions
-  - policy
-  resources:
-  - podsecuritypolicies
-  resourceNames:
-  - ovn-kubernetes
-  verbs: ["use"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1241,6 +1241,7 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 	klog.V(5).Infof("Logging config: %+v", Logging)
 	klog.V(5).Infof("CNI config: %+v", CNI)
 	klog.V(5).Infof("Kubernetes config: %+v", Kubernetes)
+	klog.V(5).Infof("Gateway config: %+v", Gateway)
 	klog.V(5).Infof("OVN North config: %+v", OvnNorth)
 	klog.V(5).Infof("OVN South config: %+v", OvnSouth)
 	klog.V(5).Infof("Hybrid Overlay config: %+v", HybridOverlay)


### PR DESCRIPTION
the podsecuritypolicy is a cluster-level resource and we were defining
it in ovn-setup.yaml. when PodSecurityPolicy admission controller was
enabled, all the non-ovn-k8s pods were getting tagged with this policy
and that definitely was not the intent when it was initially added

the workflow would be that the cluster-admin would define a policy for
the whole cluster and add 'use' verb for the polices definied for the
'ovn' service account. in short, it should come from the cluster
deployer and not from us

@dcbw @danwinship PTAL