### PR TITLE
iptables: remove all the iptables logic to open up ports that we care

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,6 @@
 # OVN Kubernetes CNI FAQ
 
-Q: How do I configure a non-default location for CNI configuration and bin directory?
+## 1. How do I configure a non-default location for CNI configuration and bin directory?
 
 By default the CNI configuration directory is set to /etc/cni/net.d and the
 CNI bin directory is set to /opt/cni/bin. One can change these default locations by
@@ -14,3 +14,36 @@ need to be made aware of it by following the instructions below.
    spec with mountPath set to '/etc/cni/net.d'.
 3. Define volumeMounts for CNI bin directory in the ovnkube-node container spec with
    mountPath set to '/opt/cni/bin'
+
+
+## 2. What TCP and UDP ports to open on the host for a functional OVN CNI?
+
+OVN CNI requires several TCP and UDP ports to be opened on each of the node
+that is part of the K8s cluster.
+
+ 1. The node on which ovnkube-master runs, open following ports:
+    ```text
+    TCP:
+      port 9409 (prometheus port to export ovnkube-master metrics)
+    ```
+
+ 2. The node on which ovnkube-node runs, open following ports:
+    ```text
+    TCP:
+      port 9410 (prometheus port to export ovn and ovnkube-node metrics)
+    
+    UDP:
+      port 6081 (for GENEVE traffic)
+      port 4789 (when using Hybrid overlay mode)
+    ```
+
+ 3. The node on which ovnkube-db runs, open following ports:
+    ```text
+    TCP:
+      port 6641 (for OVN Northbound OVSDB Server)
+      port 6642 (for OVN Southbound OVSDB Server)
+      port 6643 (when using RAFT and is required for NB RAFT control plane)
+      port 6644 (when using RAFT and is required for SB RAFT control plane)
+      port 9476 (prometheus port to export ovn DB metrics)
+    ```
+ 

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -89,10 +89,6 @@ spec:
           name: host-var-log-ovs
         - mountPath: /var/log/ovn/
           name: host-var-log-ovs
-        # for the iptables wrapper
-        - mountPath: /host
-          name: host-slash
-          readOnly: true
         - mountPath: /ovn-cert
           name: host-ovn-cert
           readOnly: true
@@ -154,10 +150,6 @@ spec:
           name: host-var-log-ovs
         - mountPath: /var/log/ovn/
           name: host-var-log-ovs
-        # for the iptables wrapper
-        - mountPath: /host
-          name: host-slash
-          readOnly: true
         - mountPath: /ovn-cert
           name: host-ovn-cert
           readOnly: true
@@ -205,9 +197,6 @@ spec:
       - name: host-var-log-ovs
         hostPath:
           path: /var/log/openvswitch
-      - name: host-slash
-        hostPath:
-          path: /
       - name: host-ovn-cert
         hostPath:
           path: /etc/ovn


### PR DESCRIPTION
instead of opening up the ports that are required for a functional ovn
k8s deployment from within the container's entrypoint script, make it
a requirement to an operator or deployer to open these ports

we have found instances that the current code doesn't work when the host
uses either firewalld (in the case of centos) or ufw (in the case of
ubuntu) or some other host-firewall mechanism.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>