### PR TITLE
Trivial fix for kind setup wait

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,7 @@ jobs:
       if: steps.cache-k8s.outputs.cache-hit != 'true'
       run: |
         set -x
+        rm -rf $GOPATH/src/k8s.io/kubernetes
         git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
         pushd $GOPATH/src/k8s.io/kubernetes/
         make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -103,7 +103,7 @@ until [ -z "$(kubectl get pod -A -o custom-columns=NAME:metadata.name,STATUS:.st
     exit 1
   fi
   echo "All pods not available yet on attempt $count:"
-  kubectl get pod -A
+  kubectl get pod -A || true
   count=$((count+1))
   sleep 10
 done


### PR DESCRIPTION
When waiting for install to stabilize, the command will sometimes fail:
```
++ grep -v Running
++ kubectl get pod -A -o custom-columns=NAME:metadata.name,STATUS:.status.phase
+ '[' -z 'coredns-6955765f44-fw7lq                     Pending
All pods not available yet on attempt 1:
coredns-6955765f44-mg5pz                     Pending
local-path-provisioner-85445b74d4-vb48p      Pending' ']'
+ '[' 1 -gt 15 ']'
+ echo 'All pods not available yet on attempt 1:'
+ kubectl get pod -A
Error from server: etcdserver: leader changed
make: *** [install-kind] Error 1
make: Leaving directory '/home/runner/work/ovn-kubernetes/ovn-kubernetes/test'
```
Signed-off-by: Tim Rozet <trozet@redhat.com>