### PR TITLE
fix CNIRequestMetrics that tracks CNI requests (ADD, DEL) duration

### DIFF
--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -45,6 +45,13 @@ type Request struct {
 	Config []byte `json:"config,omitempty"`
 }
 
+// CNIRequestMetrics info to report from CNI shim to CNI server
+type CNIRequestMetrics struct {
+	Command     command `json:"command"`
+	ElapsedTime float64 `json:"elapsedTime"`
+	HasErr      bool    `json:"hasErr"`
+}
+
 // Response sent to the OVN CNI plugin by the Server
 type Response struct {
 	Result    *current.Result


### PR DESCRIPTION
this is the flow of handling CNIAdd/CNIDel requests from either kubelet
or multus

```
+--------+      CNIShim                                  CNIServer
|Kubelet/|   +-----------+  /var/run/ovn-kubernetes/  +--------------+
| Multus |   | ovn-k8s-  |   cni/ovn-cni-server.sock  | ovnkube-node |
| exec's |-->|cni-overlay|--------------------------->|  httpServer  |
+--------+   +-----------+          AF_UNIX           +--------------+
   (a)            (b)               Socket                    (c)
```

If OVS daemons are running inside the container, then all the namespace
creattion, VETH creation, plugging the interface into the POD, and
creating and adding OVS internal port occurs in the container. This
requires the container to be `privileged`. Everything happens in (c)

In the other mode, aka unprivileged mode, everything happens in (b). We
just get pod interface informaction from (c) but all the plumbing
happens in (b).

The current metric computation was happening in (c) and was showing
incorrect metrics for the unprivileged case.

This commit computes the `elapsedTime` for a given command in (b) and
finally posts the value to http://dummy/metrics endpoint for (c) to
publish the prometheus metric.

This captures the true end-to-end delay in setting up the interface or
bringing down the interface.

@squeed @dcbw PTAL