### PR TITLE
fix ovsFind one last time

### DIFF
--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -30,14 +30,7 @@ func ovsExec(args ...string) (string, error) {
 		return "", fmt.Errorf("failed to run 'ovs-vsctl %s': %v\n  %q", strings.Join(args, " "), err, string(output))
 	}
 
-	outStr := string(output)
-	trimmed := strings.TrimSpace(outStr)
-	// If output is a single line, strip the trailing newline
-	if strings.Count(trimmed, "\n") == 0 {
-		outStr = trimmed
-	}
-
-	return outStr, nil
+	return strings.TrimSuffix(string(output), "\n"), nil
 }
 
 func ovsCreate(table string, values ...string) (string, error) {
@@ -62,7 +55,10 @@ func ovsFind(table, column, condition string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return strings.Split(strings.TrimSpace(output), "\n"), nil
+	if output == "" {
+		return nil, nil
+	}
+	return strings.Split(output, "\n"), nil
 }
 
 func ovsClear(table, record string, columns ...string) error {


### PR DESCRIPTION
I am still seeing following error messages in /var/log/messages

Apr 19 16:08:27 sdn-test2 ovs-vsctl[30199]: ovs|00001|vsctl|INFO|Called
as /usr/bin/ovs-vsctl --timeout=30 remove Interface  external-ids
iface-id
Apr 19 16:08:27 sdn-test2 kubelet[35640]: W0419 16:08:27.912489
30181 helper_linux.go:252] failed to clear stale OVS port "" iface-id
"default_web-c22xr": failed to run 'ovs-vsctl --timeout=30 remove
Interface  external-ids iface-id': exit status 1

@dcbw @danwinship PTAL