### PR TITLE
trivial: use correct sock for retrieving OVN_Northbound cluster/status

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/ovn-db-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovn-db-exporter.go
@@ -455,7 +455,7 @@ func getOVNDBClusterStatusInfo(timeout int, direction, database string) (cluster
 		stdout, stderr, err = util.RunOVNSBAppCtl(fmt.Sprintf("--timeout=%d", timeout),
 			"cluster/status", database)
 	} else {
-		stdout, stderr, err = util.RunOVNSBAppCtl(fmt.Sprintf("--timeout=%d", timeout),
+		stdout, stderr, err = util.RunOVNNBAppCtl(fmt.Sprintf("--timeout=%d", timeout),
 			"cluster/status", database)
 	}
 	if err != nil {


### PR DESCRIPTION
Sigh, had used incorrect command to to retrieve OVN_Northbound status.