### PR TITLE
remove redundant log message that fills up the onvkube-master log file

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -371,7 +371,6 @@ func getNbctlArgsAndEnv(timeout int, args ...string) ([]string, []string) {
 		envVar, err := getNbctlSocketPath()
 		if err == nil {
 			envVars := []string{envVar}
-			klog.V(5).Infof("using ovn-nbctl daemon mode at %s", envVars)
 			cmdArgs = append(cmdArgs, fmt.Sprintf("--timeout=%d", timeout))
 			cmdArgs = append(cmdArgs, args...)
 			return cmdArgs, envVars


### PR DESCRIPTION
if we fail to use the ovn-nbctl daemon mode for whatever reason, then
we throw a warning message. if this warning message is missing, then
the command was executed using the ovn-nbctl in daemon mode. so, no need
to log the info that we are using ovn-nbctl daemon mode. this can be
inferred from missing warning message

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>