### PR TITLE
Expose election-timer for NB/SB raft cluster

### DIFF
--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -55,7 +55,9 @@ fedora-dev: bld
                     --ovn-loglevel-nb="-vconsole:info -vfile:info" \
                     --ovn-loglevel-sb="-vconsole:info -vfile:info" \
                     --ovn-loglevel-controller="-vconsole:info" \
-                    --ovn-loglevel-nbctld="-vconsole:info"
+                    --ovn-loglevel-nbctld="-vconsole:info" \
+                    --ovn_nb_raft_election_timer="1000" \
+                    --ovn_sb_raft_election_timer="1000"
 
 # This target expands the daemonset yaml templates into final form
 # Use CLI flags or environment variables to customize its behavior.

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -96,6 +96,12 @@ while [ "$1" != "" ]; do
   --ssl)
     OVN_SSL_ENABLE="yes"
     ;;
+  --ovn_nb_raft_election_timer)
+    OVN_NB_RAFT_ELECTION_TIMER=$VALUE
+    ;;
+  --ovn_sb_raft_election_timer)
+    OVN_SB_RAFT_ELECTION_TIMER=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -147,6 +153,10 @@ ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR}
 echo "ovn_hybrid_overlay_net_cidr: ${ovn_hybrid_overlay_net_cidr}"
 ovn_ssl_en=${OVN_SSL_ENABLE:-"no"}
 echo "ovn_ssl_enable: ${ovn_ssl_en}"
+ovn_nb_raft_election_timer=${OVN_NB_RAFT_ELECTION_TIMER:-1000}
+echo "ovn_nb_raft_election_timer: ${ovn_nb_raft_election_timer}"
+ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
+echo "ovn_sb_raft_election_timer: ${ovn_sb_raft_election_timer}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -189,6 +199,8 @@ ovn_image=${image} \
   ovn_db_minAvailable=${ovn_db_minAvailable} \
   ovn_loglevel_nb=${ovn_loglevel_nb} ovn_loglevel_sb=${ovn_loglevel_sb} \
   ovn_ssl_en=${ovn_ssl_en} \
+  ovn_nb_raft_election_timer=${ovn_nb_raft_election_timer} \
+  ovn_sb_raft_election_timer=${ovn_sb_raft_election_timer} \
   j2 ../templates/ovnkube-db-raft.yaml.j2 -o ../yaml/ovnkube-db-raft.yaml
 
 # ovn-setup.yaml

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -160,6 +160,8 @@ spec:
               fieldPath: status.hostIP
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
+        - name: OVN_NB_RAFT_ELECTION_TIMER
+          value: "{{ ovn_nb_raft_election_timer }}"
       # end of container
 
       # sb-ovsdb - v3
@@ -229,6 +231,8 @@ spec:
               fieldPath: status.hostIP
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
+        - name: OVN_SB_RAFT_ELECTION_TIMER
+          value: "{{ ovn_sb_raft_election_timer }}"
       # end of container
 
       # db-metrics-exporter - v3


### PR DESCRIPTION
Currently ovn-kubernetes support configuring election-timer for NB/SB raft cluster,
but it's not explictly exposed in the raft db deployment yaml. This patch
exposes those environment variables and updates daemonset.sh to
take these parameter at build time to generate the raft db yaml with
non-default values for election-timer.

Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>