### PR TITLE
node: don't create br-int from management port code

### DIFF
--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -23,16 +23,9 @@ func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator k
 	// Until the above is changed, switch to a lowercase hostname
 	nodeName := strings.ToLower(n.name)
 
-	// Make sure br-int is created.
-	stdout, stderr, err := util.RunOVSVsctl("--", "--may-exist", "add-br", "br-int")
-	if err != nil {
-		klog.Errorf("Failed to create br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return err
-	}
-
 	// Create a OVS internal interface.
 	legacyMgmtIntfName := util.GetLegacyK8sMgmtIntfName(nodeName)
-	stdout, stderr, err = util.RunOVSVsctl(
+	stdout, stderr, err := util.RunOVSVsctl(
 		"--", "--if-exists", "del-port", "br-int", legacyMgmtIntfName,
 		"--", "--may-exist", "add-port", "br-int", util.K8sMgmtIntfName,
 		"--", "set", "interface", util.K8sMgmtIntfName,

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -69,7 +69,6 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 
 	// generic setup
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-vsctl --timeout=15 -- --may-exist add-br br-int",
 		"ovs-vsctl --timeout=15 -- --if-exists del-port br-int " + legacyMgtPort + " -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + legacyMgtPort,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/node/management-port_windows_test.go
+++ b/go-controller/pkg/node/management-port_windows_test.go
@@ -74,7 +74,6 @@ var _ = Describe("Management Port Operations", func() {
 
 			// generic setup
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 -- --may-exist add-br br-int",
 				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mgtPort,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{


### PR DESCRIPTION
It's not management port specific so it shouldn't be done there. Plus ovn-controller will create it for us, and we already wait for ovn-controller to create it.  Just let that happen.

@ovn-org/ovn-kubernetes-committers 