### PR TITLE
fix an IPv6 problem, and some error messages

### DIFF
--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -210,7 +210,8 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb string, sourceIP string, s
 		l3Prefix = "ip4"
 	}
 	vip := util.JoinHostPortInt32(sourceIP, sourcePort)
-	aclName := fmt.Sprintf("%s-%s", lb, vip)
+	// NOTE: doesn't use vip, to avoid having brackets in the name with IPv6
+	aclName := fmt.Sprintf("%s-%s:%d", lb, sourceIP, sourcePort)
 	// If ovn-k8s was restarted, we lost the cache, and an ACL may already exist in OVN. In that case we need to check
 	// using ACL name
 	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -578,12 +578,12 @@ func (oc *Controller) WatchNodes() error {
 
 			err = oc.syncNodeManagementPort(node, hostSubnet)
 			if err != nil {
-				klog.Errorf("error creating management port for node %s: %v", node.Name, err)
+				klog.Warningf("error creating management port for node %s: %v", node.Name, err)
 				mgmtPortFailed.Store(node.Name, true)
 			}
 
 			if err := oc.syncNodeGateway(node, hostSubnet); err != nil {
-				klog.Errorf(err.Error())
+				klog.Warningf(err.Error())
 				gatewaysFailed.Store(node.Name, true)
 			}
 		},

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -230,7 +230,7 @@ func (ovn *Controller) createService(service *kapi.Service) error {
 					} else if ovn.svcQualifiesForReject(service) {
 						aclUUID, err := ovn.createLoadBalancerRejectACL(loadBalancer, physicalIP, port, protocol)
 						if err != nil {
-							return fmt.Errorf("failed to create service ACL")
+							return fmt.Errorf("failed to create service ACL: %v", err)
 						}
 						klog.V(5).Infof("Service Reject ACL created for physical gateway: %s", aclUUID)
 					}
@@ -253,7 +253,7 @@ func (ovn *Controller) createService(service *kapi.Service) error {
 					aclUUID, err := ovn.createLoadBalancerRejectACL(loadBalancer, service.Spec.ClusterIP,
 						svcPort.Port, protocol)
 					if err != nil {
-						return fmt.Errorf("failed to create service ACL")
+						return fmt.Errorf("failed to create service ACL: %v", err)
 					} else {
 						klog.V(5).Infof("Service Reject ACL created for cluster IP: %s", aclUUID)
 					}

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -224,7 +224,7 @@ func SetNodeManagementPortMACAddress(nodeAnnotator kube.Annotator, macAddress ne
 func ParseNodeManagementPortMACAddress(node *kapi.Node) (net.HardwareAddr, error) {
 	macAddress, ok := node.Annotations[ovnNodeManagementPortMacAddress]
 	if !ok {
-		klog.Errorf("macAddress annotation not found for node %q ", node.Name)
+		klog.Warningf("macAddress annotation not found for node %q ", node.Name)
 		return nil, nil
 	}
 


### PR DESCRIPTION
After @Billy99 discovered that we were totally failing to set address_sets correctly on IPv6:

`ovnkube-master-wz8zz.txt:E0421 18:04:59.791761       1 common.go:69] failed to add an address "fd01::4:d802:fff:fe00:93" to address_set "a8947133929095949878", stderr: "ovn-nbctl: fd01::4:d802:fff:fe00:93: unexpected \":\" parsing set of 1 or more strings\n" (OVN command '/usr/bin/ovn-nbctl --timeout=15 add address_set a8947133929095949878 addresses fd01::4:d802:fff:fe00:93' failed: exit status 1)`

I decided to see if there were any other similar problems, and found one, with ACL names on IPv6:

`E0421 17:58:53.417985       1 loadbalancer.go:219] Error while querying ACLs by name: ovn-nbctl: f824f04e-dd70-486d-8f68-f2745fe0fc35-[fd02\:\:347d]\:3000: unexpected "[" parsing set of up to 1 strings`

This fixes that, and also some unrelated issues found while looking at error logs

@ovn-org/ovn-kubernetes-committers 