### PR TITLE
ovn-nbctl calls to table address_set need quotes for IPv6

### DIFF
--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -63,8 +63,9 @@ func (oc *Controller) forEachAddressSetUnhashedName(iteratorFn func(
 func addToAddressSet(hashName string, address string) {
 	klog.V(5).Infof("addToAddressSet for %s with %s", hashName, address)
 
+	// IPv6 addresses need to be quoted, IPv4 work either way.
 	_, stderr, err := util.RunOVNNbctl("add", "address_set",
-		hashName, "addresses", address)
+		hashName, "addresses", `"`+address+`"`)
 	if err != nil {
 		klog.Errorf("failed to add an address %q to address_set %q, stderr: %q (%v)",
 			address, hashName, stderr, err)
@@ -74,8 +75,9 @@ func addToAddressSet(hashName string, address string) {
 func removeFromAddressSet(hashName string, address string) {
 	klog.V(5).Infof("removeFromAddressSet for %s with %s", hashName, address)
 
+	// IPv6 addresses need to be quoted, IPv4 work either way.
 	_, stderr, err := util.RunOVNNbctl("remove", "address_set",
-		hashName, "addresses", address)
+		hashName, "addresses", `"`+address+`"`)
 	if err != nil {
 		klog.Errorf("failed to remove an address %q from address_set %q, stderr: %q (%v)",
 			address, hashName, stderr, err)

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -73,7 +73,7 @@ func (n namespace) addPodCmds(fexec *ovntest.FakeExec, tP pod, namespace v1.Name
 		})
 	} else {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf(`ovn-nbctl --timeout=15 add address_set %s addresses %s`, hashedAddressSet(namespace.Name), tP.podIP),
+			fmt.Sprintf(`ovn-nbctl --timeout=15 add address_set %s addresses "%s"`, hashedAddressSet(namespace.Name), tP.podIP),
 		})
 	}
 }
@@ -85,7 +85,7 @@ func (n namespace) delPodCmds(fexec *ovntest.FakeExec, tP pod, namespace v1.Name
 		})
 	} else {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedAddressSet(namespace.Name), tP.podIP),
+			fmt.Sprintf(`ovn-nbctl --timeout=15 remove address_set %s addresses "%s"`, hashedAddressSet(namespace.Name), tP.podIP),
 		})
 	}
 }

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -148,7 +148,7 @@ func (p pod) delCmds(fexec *ovntest.FakeExec) {
 
 func (p pod) delFromNamespaceCmds(fexec *ovntest.FakeExec, pod pod, isMulticastEnabled bool) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedAddressSet(pod.namespace), pod.podIP),
+		fmt.Sprintf(`ovn-nbctl --timeout=15 remove address_set %s addresses "%s"`, hashedAddressSet(pod.namespace), pod.podIP),
 	})
 	if isMulticastEnabled {
 		fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -100,13 +100,13 @@ func (n networkPolicy) addPodSelectorCmds(fexec *ovntest.FakeExec, pod pod, netw
 	for i := range networkPolicy.Spec.Ingress {
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "ingress", i))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 add address_set %s addresses %s", hashedOVNName, pod.podIP),
+			fmt.Sprintf(`ovn-nbctl --timeout=15 add address_set %s addresses "%s"`, hashedOVNName, pod.podIP),
 		})
 	}
 	for i := range networkPolicy.Spec.Egress {
 		hashedOVNName := hashedAddressSet(fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "egress", i))
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 add address_set %s addresses %s", hashedOVNName, pod.podIP),
+			fmt.Sprintf(`ovn-nbctl --timeout=15 add address_set %s addresses "%s"`, hashedOVNName, pod.podIP),
 		})
 	}
 	if hasLocalPods {
@@ -177,14 +177,14 @@ func (n networkPolicy) delPodCmds(fexec *ovntest.FakeExec, networkPolicy knet.Ne
 		localPeerPods := fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "ingress", i)
 		hashedLocalAddressSet := hashedAddressSet(localPeerPods)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedLocalAddressSet, podIP),
+			fmt.Sprintf(`ovn-nbctl --timeout=15 remove address_set %s addresses "%s"`, hashedLocalAddressSet, podIP),
 		})
 	}
 	for i := range networkPolicy.Spec.Egress {
 		localPeerPods := fmt.Sprintf("%s.%s.%s.%d", networkPolicy.Namespace, networkPolicy.Name, "egress", i)
 		hashedLocalAddressSet := hashedAddressSet(localPeerPods)
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 remove address_set %s addresses %s", hashedLocalAddressSet, podIP),
+			fmt.Sprintf(`ovn-nbctl --timeout=15 remove address_set %s addresses "%s"`, hashedLocalAddressSet, podIP),
 		})
 	}
 	if withLocal {


### PR DESCRIPTION
Calls ovn-nbctl to add IPv6 addresses to the address_set table require quotes
around the IPv6 addresses.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>