### PR TITLE
Making ovn-remote-probe-interval value configurable from YAML file.

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -31,6 +31,7 @@ OVN_LOGLEVEL_SB=""
 OVN_LOGLEVEL_CONTROLLER=""
 OVN_LOGLEVEL_NBCTLD=""
 OVN_MASTER_COUNT=""
+OVN_REMOTE_PROBE_INTERVAL=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -163,6 +164,8 @@ ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
 echo "ovn_sb_raft_election_timer: ${ovn_sb_raft_election_timer}"
 ovn_master_count=${OVN_MASTER_COUNT:-"1"}
 echo "ovn_master_count: ${ovn_master_count}"
+ovn_remote_probe_interval=${OVN_REMOTE_PROBE_INTERVAL:-"100000"}
+echo "ovn_remote_probe_interval: ${ovn_remote_probe_interval}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -174,6 +177,7 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
+  ovn_remote_probe_interval=${ovn_remote_probe_interval} \
   j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node.yaml
 
 ovn_image=${image} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -62,6 +62,7 @@ fi
 # OVN_NB_RAFT_ELECTION_TIMER - ovn north db election timer in ms (default 1000)
 # OVN_SB_RAFT_ELECTION_TIMER - ovn south db election timer in ms (default 1000)
 # OVN_SSL_ENABLE - use SSL transport to NB/SB db and northd (default: no)
+# OVN_REMOTE_PROBE_INTERVAL - ovn remote probe interval in ms (default 100000)
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -162,6 +163,8 @@ ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
 
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE:-}
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR:-}
+#OVN_REMOTE_PROBE_INTERVAL - ovn remote probe interval in ms (default 100000)
+ovn_remote_probe_interval=${OVN_REMOTE_PROBE_INTERVAL:-100000}
 
 # Determine the ovn rundir.
 if [[ -f /usr/bin/ovn-appctl ]]; then
@@ -882,6 +885,7 @@ ovn-node() {
     --pidfile ${OVN_RUNDIR}/ovnkube.pid \
     --logfile /var/log/ovn-kubernetes/ovnkube.log \
     ${ovn_node_ssl_opts} \
+    --inactivity-probe=${ovn_remote_probe_interval} \
     --metrics-bind-address "0.0.0.0:9410" &
 
   wait_for_event attempts=3 process_ready ovnkube

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -242,6 +242,8 @@ spec:
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
+        - name: OVN_REMOTE_PROBE_INTERVAL
+          value: "{{ ovn_remote_probe_interval }}"
 
         lifecycle:
           preStop:


### PR DESCRIPTION
Currently, the ovn-remote-probe-interval value is set to a constant value of
100s in the code. If it needs to be changed for varying cluster size and DB type,
needed to change code. So, making this value configurable through ovnkube-node.yaml.j2.

Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>