### PR TITLE
ci: remove an existing $GOPATH/src/k8s.io/kubernetes/

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,7 @@ jobs:
       if: steps.cache-k8s.outputs.cache-hit != 'true'
       run: |
         set -x
+        rm -rf $GOPATH/src/k8s.io/kubernetes/
         git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
         pushd $GOPATH/src/k8s.io/kubernetes/
         make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"


### PR DESCRIPTION
Sometimes CI reports:
```
    + git clone --single-branch --branch v1.17.2 https://github.com/kubernetes/kubernetes.git /home/runner/go/src/k8s.io/kubernetes/
    fatal: destination path '/home/runner/go/src/k8s.io/kubernetes' already exists and is not an empty directory.
```
We should only get to this step if the cache didn't restore the directory, so we can't really trust it's contents.