### PR TITLE
Add arm64 and multi-arch support for ubuntu image

### DIFF
--- a/dist/images/Dockerfile.ubuntu.arm64
+++ b/dist/images/Dockerfile.ubuntu.arm64
@@ -1,0 +1,53 @@
+#
+# The standard name for this image is ovn-kube-u
+
+# Notes:
+# This is for a development build where the ovn-kubernetes utilities
+# are built in this Dockerfile and included in the image (instead of the deb package)
+#
+#
+# So this file will change over time.
+
+FROM ubuntu:19.10
+
+USER root
+
+RUN apt-get update && apt-get install -y iproute2 curl software-properties-common util-linux
+
+RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
+# Install OVS and OVN packages.
+RUN apt-get update && apt-get install -y openvswitch-switch openvswitch-common ovn-central ovn-common ovn-host kubectl
+
+RUN mkdir -p /var/run/openvswitch
+
+# Built in ../../go_controller, then the binaries are copied here.
+# put things where they are in the pkg
+RUN mkdir -p /usr/libexec/cni/
+COPY ovnkube ovn-kube-util /usr/bin/
+COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+
+# ovnkube.sh is the entry point. This script examines environment
+# variables to direct operation and configure ovn
+COPY ovnkube.sh /root/
+COPY ovndb-raft-functions.sh /root/
+# override the pkg's ovn_k8s.conf with this local copy
+COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
+
+# copy git commit number into image
+COPY git_info /root
+
+# iptables wrappers
+COPY ./iptables-scripts/iptables /usr/sbin/
+COPY ./iptables-scripts/iptables-save /usr/sbin/
+COPY ./iptables-scripts/iptables-restore /usr/sbin/
+COPY ./iptables-scripts/ip6tables /usr/sbin/
+COPY ./iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
+
+LABEL io.k8s.display-name="ovn kubernetes" \
+      io.k8s.description="ovnkube ubuntu image"
+
+WORKDIR /root
+ENTRYPOINT /root/ovnkube.sh

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -10,8 +10,21 @@
 
 all: ubuntu centos fedora
 
+SLASH = -
+ARCH = $(subst aarch64,arm64,$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))))
+IMAGE_ARCH = $(SLASH)$(ARCH)
+DOCKERFILE_ARCH =
+ifeq ($(ARCH),arm64)
+        DOCKERFILE_ARCH=.arm64
+endif
+
+# The image of ovnkube/ovn-daemonset-u should be multi-arched before using it on arm64
 ubuntu: bld
-	docker build -t ovn-kube-u -f Dockerfile.ubuntu .
+	docker build -t ovn-kube-u$(IMAGE_ARCH) -f Dockerfile.ubuntu$(DOCKERFILE_ARCH) .
+ifeq ($(ARCH),amd64)
+	docker tag "ovn-kube-u$(IMAGE_ARCH):latest" \
+              "ovn-kube-u:latest"
+endif
 	# This is the default in the ovnkube*.yaml files
 	# docker login -u ovnkube docker.io/ovnkube
 	# docker push docker.io/ovnkube/ovn-daemonset-u:latest
@@ -58,6 +71,12 @@ fedora-dev: bld
                     --ovn-loglevel-nbctld="-vconsole:info" \
                     --ovn_nb_raft_election_timer="1000" \
                     --ovn_sb_raft_election_timer="1000"
+
+DOCKER_IMAGE_TAG = latest
+
+# Multi-arch the ubuntu based image with fat-manifest
+ubuntu-image-multi-arch:
+	./push_manifest.sh ovn-daemonset-u $(DOCKER_IMAGE_TAG)
 
 # This target expands the daemonset yaml templates into final form
 # Use CLI flags or environment variables to customize its behavior.

--- a/dist/images/push_manifest.sh
+++ b/dist/images/push_manifest.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Currently supported platforms of multi-arch images are: amd64 arm64
+LINUX_ARCH=(amd64 arm64)
+PLATFORMS=linux/${LINUX_ARCH[0]}
+for i in $(seq 1  $[${#LINUX_ARCH[@]}-1])
+do
+    PLATFORMS=$PLATFORMS,linux/${LINUX_ARCH[$i]}
+done
+
+IMAGES_OVN=${1:-ovn-daemonset-u}
+BRANCH_TAG=${2:-latest}
+DOCKER_REPOSITORY=${3:-docker.io/ovnkube}
+MANITOOL_VERSION=${4:-v1.0.0}
+
+if [ `uname -m` = 'aarch64' ]
+then
+	BUILDARCH=arm64
+elif [ `uname -m` = 'x86_64' ]
+then
+	BUILDARCH=amd64
+fi
+
+
+#Before push, 'docker login' is needed
+push_multi_arch(){
+
+       if [ ! -f "./manifest-tool" ]
+       then
+                sudo apt-get install -y jq
+                wget https://github.com/estesp/manifest-tool/releases/download/${MANITOOL_VERSION}/manifest-tool-linux-${BUILDARCH} \
+                -O manifest-tool && \
+                chmod +x ./manifest-tool
+       fi
+
+       for IMAGE in "${IMAGES_OVN[@]}"
+       do
+         echo "multi arch image: ""${DOCKER_REPOSITORY}/${IMAGE}"
+         ./manifest-tool push from-args --platforms ${PLATFORMS} --template ${DOCKER_REPOSITORY}/${IMAGE}-ARCH:${BRANCH_TAG} \
+                --target ${DOCKER_REPOSITORY}/${IMAGE}:${BRANCH_TAG}
+       done
+}
+
+echo "Push fat manifest for multi-arch ovnkube images:"
+push_multi_arch
+


### PR DESCRIPTION
Add a ubuntu-based arm64 image building support,
including the Dockerfile and related Makefile changes.

Add multi-arch support for ovn-daemonset-u images for amd64
and arm64 platforms by fat manifest with manifest_tool which
can also be used for other type of images in the future.

Signed-off-by: Trevor Tao <trevor.tao@arm.com>