### PR TITLE
dist: harmonize Fedora dockerfile with Ubuntu

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -30,19 +30,29 @@ RUN INSTALL_PKGS=" \
 # RPM has propagated to all stable mirrors and can be removed
 RUN dnf install -y ovn --best --advisory=FEDORA-2020-b570bbc33b || true
 
-RUN mkdir -p /var/run/openvswitch && \
-    mkdir -p /usr/libexec/cni/
+RUN mkdir -p /var/run/openvswitch
 
+# Built in ../../go_controller, then the binaries are copied here.
+# put things where they are in the pkg
+RUN mkdir -p /usr/libexec/cni/
 COPY ovnkube ovn-kube-util /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
-
-# copy git commit number into image
-COPY git_info /root
 
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
 COPY ovndb-raft-functions.sh /root/
+
+# copy git commit number into image
+COPY git_info /root
+
+# iptables wrappers
+COPY ./iptables-scripts/iptables /usr/sbin/
+COPY ./iptables-scripts/iptables-save /usr/sbin/
+COPY ./iptables-scripts/iptables-restore /usr/sbin/
+COPY ./iptables-scripts/ip6tables /usr/sbin/
+COPY ./iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
 
 LABEL io.k8s.display-name="ovn-kubernetes" \
       io.k8s.description="This is a Kubernetes network plugin that provides an overlay network using OVN." \


### PR DESCRIPTION
Specifically, let's start using the iptables wrapper scripts so we don't have as many problems running upstream "make fedora" images in OpenShift clusters.  Avoids:

```
F0423 16:14:01.771395  207236 ovnkube.go:104] Failed to add NAT rules for localnet gateway (failed to ensure filter/FORWARD: failed to list iptables chains: running [/usr/sbin/iptables -t filter -S --wait]: exit status 3: modprobe: FATAL: Module ip_tables not found in directory /lib/modules/4.18.0-147.8.1.el8_1.x86_64
iptables v1.8.3 (legacy): can't initialize iptables table `filter': Table does not exist (do you need to insmod?)
Perhaps iptables or your kernel needs to be upgraded.
)
```