### PR TITLE
feat: added the .golangci.yml file that lists the linters enabled

### DIFF
--- a/go-controller/.golangci.yml
+++ b/go-controller/.golangci.yml
@@ -1,0 +1,22 @@
+run:
+  skip-dirs:
+    - vendor
+
+  skip-files:
+    - ".*\\_test.go$"
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - deadcode
+    - errcheck
+    - gofmt
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck

--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 GO111MODULE=on ${GOPATH}/bin/golangci-lint run \
-    --tests=false --enable gofmt \
     --timeout=15m0s --verbose --print-resources-usage --modules-download-mode=vendor \
     && echo "lint OK!"


### PR DESCRIPTION
This commit adds the .golangci.yml file that lists the linters enabled.
This allows for viewing enabled and disabled linters and also allow to add
more linters in the future. This PR addresses https://github.com/ovn-org/ovn-kubernetes/issues/1247