### PR TITLE
 ovn-kubernetes #1294 : Provide command line arguments support for kind deployment

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-#set -euxo pipefail
 
 run_kubectl() {
   local retries=0
@@ -50,10 +49,10 @@ parse_args()
             -kt | --keep-taint )       KIND_REMOVE_TAINT=false
                                        ;;
             -h | --help )              usage
-                                       exit 0
+                                       exit
                                        ;;
             * )                        usage
-                                       exit 0
+                                       exit 1
         esac
         shift
     done
@@ -70,6 +69,8 @@ print_params()
      echo ""
 }
 
+parse_args $*
+
 K8S_VERSION=${K8S_VERSION:-v1.17.2}
 KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS:-false}
 KIND_HA=${KIND_HA:-false}
@@ -81,8 +82,9 @@ fi
 KIND_CONFIG=${KIND_CONFIG:-$DEFAULT_KIND_CONFIG}
 KIND_REMOVE_TAINT=${KIND_REMOVE_TAINT:-true}
 
-parse_args $*
 print_params
+
+set -euxo pipefail
 
 # Detect IP to use as API server
 API_IP=$(ip -4 addr | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v "127.0.0.1" | head -n 1)

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -23,16 +23,9 @@ func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator k
 	// Until the above is changed, switch to a lowercase hostname
 	nodeName := strings.ToLower(n.name)
 
-	// Make sure br-int is created.
-	stdout, stderr, err := util.RunOVSVsctl("--", "--may-exist", "add-br", "br-int")
-	if err != nil {
-		klog.Errorf("Failed to create br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return err
-	}
-
 	// Create a OVS internal interface.
 	legacyMgmtIntfName := util.GetLegacyK8sMgmtIntfName(nodeName)
-	stdout, stderr, err = util.RunOVSVsctl(
+	stdout, stderr, err := util.RunOVSVsctl(
 		"--", "--if-exists", "del-port", "br-int", legacyMgmtIntfName,
 		"--", "--may-exist", "add-port", "br-int", util.K8sMgmtIntfName,
 		"--", "set", "interface", util.K8sMgmtIntfName,

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -69,7 +69,6 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 
 	// generic setup
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-vsctl --timeout=15 -- --may-exist add-br br-int",
 		"ovs-vsctl --timeout=15 -- --if-exists del-port br-int " + legacyMgtPort + " -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + legacyMgtPort,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/node/management-port_windows_test.go
+++ b/go-controller/pkg/node/management-port_windows_test.go
@@ -74,7 +74,6 @@ var _ = Describe("Management Port Operations", func() {
 
 			// generic setup
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 -- --may-exist add-br br-int",
 				"ovs-vsctl --timeout=15 -- --may-exist add-port br-int " + mgtPort + " -- set interface " + mgtPort + " type=internal mtu_request=" + mtu + " external-ids:iface-id=" + mgtPort,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{


### PR DESCRIPTION
Provided command line parameters for the following parametsrs.
    KIND_INSTALL_INGRESS
    KIND_HA
    KIND_CONFIG
    KIND_REMOVE_TAINT
    
    These parameters will override the environment variables if given.
    SCript will continue to work without commandline parameters as well.
    
    Idea is to provide ease of use and automation.