### PR TITLE
Add A Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md
+
+** Make sure all your commits include a signature generated with `git commit -s` **
+
+If this is a bug fix, make sure your description includes "fixes #xxxx", or
+"closes #xxxx"
+
+Trivial changes are exempt from following this template.
+If your change is non-trivial, please provide the following information:
+-->
+
+**- What this PR does and why is it needed**
+<!--
+A summary of the changes within this pull request and some context
+as to why they were made
+-->
+
+**- Special notes for reviewers**
+<!--
+What exactly did you change - you may also defer to information
+contained in commit messages. At a bare minimum it's worth highlighting
+which areas of the code were changed as it's easier to assign reviewers
+-->
+
+
+**- How to verify it**
+<!--
+Did you include unit tests? or end-to-end tests?
+How can I manually verify that this patch achieves its objective
+-->
+
+
+**- Description for the changelog**
+<!--
+Write a short (one line) summary that describes the changes in this
+pull request for inclusion in the changelog:
+-->


### PR DESCRIPTION
@girishmg @danwinship @trozet @danwinship 
Based on the discussion we had last night I pulled this together.

It's certainly not a substitute for good commit messages - they will persist in the git log after merge and haunt us forever.

What it does do though is make sure that reviewers have all of the necessary context at review time.