### PR TITLE
[wip] policy: address set objects and code consolidation

### DIFF
--- a/go-controller/pkg/ovn/address_set.go
+++ b/go-controller/pkg/ovn/address_set.go
@@ -1,0 +1,234 @@
+package ovn
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+type addressSet struct {
+	sync.Mutex
+
+	name      string
+	hashName  string
+	ports     map[string]net.IP // logical port :: pod IP
+	destroyed bool
+}
+
+// hash the provided input to make it a valid addressSet name.
+func hashedAddressSet(s string) string {
+	return hashForOVN(s)
+}
+
+type addressSetIterFn func(name, namespace, suffix string)
+
+// forEachAddressSetUnhashedName will pass the unhashedName, namespaceName and
+// the first suffix in the name to the 'iteratorFn' for every address_set in
+// OVN. (Each unhashed name for an addressSet can be of the form
+// namespaceName.suffix1.suffix2. .suffixN)
+func forEachAddressSetUnhashedName(iteratorFn addressSetIterFn) error {
+	output, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=external_ids", "find", "address_set")
+	if err != nil {
+		return fmt.Errorf("error reading address sets: "+
+			"stdout: %q, stderr: %q err: %v", output, stderr, err)
+	}
+	for _, addrSet := range strings.Fields(output) {
+		if !strings.HasPrefix(addrSet, "name=") {
+			continue
+		}
+		addrSetName := addrSet[5:]
+		names := strings.Split(addrSetName, ".")
+		addrSetNamespace := names[0]
+		nameSuffix := ""
+		if len(names) >= 2 {
+			nameSuffix = names[1]
+		}
+		iteratorFn(addrSetName, addrSetNamespace, nameSuffix)
+	}
+	return nil
+}
+
+func NewAddressSet(name string, ports map[string]net.IP) (*addressSet, error) {
+	if ports == nil {
+		ports = make(map[string]net.IP)
+	}
+	as := &addressSet{
+		name:     name,
+		hashName: hashedAddressSet(name),
+		ports:    ports,
+	}
+
+	klog.V(5).Infof("New(%s/%s) with %v", as.hashName, as.name, ports)
+
+	addressSet, stderr, err := util.RunOVNNbctl("--data=bare",
+		"--no-heading", "--columns=_uuid", "find", "address_set",
+		"name="+as.hashName)
+	if err != nil {
+		return nil, fmt.Errorf("find failed to get address set %q, stderr: %q (%v)",
+			as.name, stderr, err)
+	}
+
+	// addressSet has already been created in the database and nothing to set.
+	if addressSet != "" {
+		if err := as.setOrClear(); err != nil {
+			return nil, err
+		}
+	} else {
+		// addressSet has not been created yet. Create it.
+		args := []string{
+			"create",
+			"address_set",
+			"name=" + as.hashName,
+			"external-ids:name=" + as.name,
+		}
+		joinedIPs := as.joinIPs()
+		if len(joinedIPs) > 0 {
+			args = append(args, "addresses="+joinedIPs)
+		}
+		_, stderr, err = util.RunOVNNbctl(args...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create address set %q, stderr: %q (%v)",
+				as.name, stderr, err)
+		}
+	}
+
+	return as, nil
+}
+
+func (as *addressSet) joinIPs() string {
+	list := make([]string, 0, len(as.ports))
+	for _, ip := range as.ports {
+		list = append(list, `"`+ip.String()+`"`)
+	}
+	return strings.Join(list, " ")
+}
+
+// setOrClear updates the OVN database with the address set's addresses or
+// clears the address set if there are no addresses in the address set
+func (as *addressSet) setOrClear() error {
+	joinedIPs := as.joinIPs()
+	if len(joinedIPs) > 0 {
+		_, stderr, err := util.RunOVNNbctl("set", "address_set", as.hashName, "addresses="+joinedIPs)
+		if err != nil {
+			return fmt.Errorf("failed to set address set %q, stderr: %q (%v)",
+				as.name, stderr, err)
+		}
+	} else {
+		_, stderr, err := util.RunOVNNbctl("clear", "address_set", as.hashName, "addresses")
+		if err != nil {
+			return fmt.Errorf("failed to clear address set %q, stderr: %q (%v)",
+				as.name, stderr, err)
+		}
+	}
+	return nil
+}
+
+func (as *addressSet) ReplacePorts(ports map[string]net.IP) error {
+	as.Lock()
+	defer as.Unlock()
+	if as.destroyed {
+		return nil
+	}
+
+	klog.V(5).Infof("ReplacePorts(%s/%s) with %v", as.hashName, as.name, ports)
+	as.ports = ports
+	return as.setOrClear()
+}
+
+func (as *addressSet) AddPort(logicalPort string, ip net.IP) error {
+	as.Lock()
+	defer as.Unlock()
+	if as.destroyed || as.ports[logicalPort] != nil {
+		return nil
+	}
+
+	klog.V(5).Infof("AddPort(%s/%s) %s=%s", as.hashName, as.name, logicalPort, ip)
+	as.ports[logicalPort] = ip
+
+	_, stderr, err := util.RunOVNNbctl("add", "address_set", as.hashName, "addresses", `"`+ip.String()+`"`)
+	if err != nil {
+		return fmt.Errorf("failed to add port %q address %q to address_set %q, stderr: %q (%v)",
+			logicalPort, ip, as.hashName, stderr, err)
+	}
+	return nil
+}
+
+func (as *addressSet) DeletePort(logicalPort string) error {
+	as.Lock()
+	defer as.Unlock()
+	if as.destroyed || as.ports[logicalPort] == nil {
+		return nil
+	}
+
+	ip := as.ports[logicalPort]
+	klog.V(5).Infof("DeletePort(%s/%s) %s=%s", as.hashName, as.name, logicalPort, ip)
+	delete(as.ports, logicalPort)
+
+	_, stderr, err := util.RunOVNNbctl("remove", "address_set", as.hashName, "addresses", `"`+ip.String()+`"`)
+	if err != nil {
+		return fmt.Errorf("failed to remove port %q address %q from address_set %q, stderr: %q (%v)",
+			logicalPort, ip, as.hashName, stderr, err)
+	}
+	return nil
+}
+
+func getPodIP(pod *kapi.Pod) net.IP {
+	annotation, _ := util.UnmarshalPodAnnotation(pod.Annotations)
+	if annotation != nil {
+		return annotation.IPs[0].IP
+	}
+	if pod.Status.PodIP != "" {
+		return net.ParseIP(pod.Status.PodIP)
+	}
+	return nil
+}
+
+func (as *addressSet) AddPod(pod *kapi.Pod) error {
+	if ip := getPodIP(pod); ip != nil {
+		return as.AddPort(podLogicalPortName(pod), ip)
+	}
+	return fmt.Errorf("failed to determine pod %s/%s IP", pod.Namespace, pod.Name)
+}
+
+func (as *addressSet) DelPod(pod *kapi.Pod) error {
+	return as.DeletePort(podLogicalPortName(pod))
+}
+
+// PortIterFn will be called once per port and should return an error to stop
+// iteration.
+type PortIterFn func(logicalPort string, ip net.IP)
+
+func (as *addressSet) ForEachPort(iterFn PortIterFn) {
+	as.Lock()
+	defer as.Unlock()
+	if !as.destroyed {
+		for logicalPort, ip := range as.ports {
+			iterFn(logicalPort, ip)
+		}
+	}
+}
+
+func destroyAddressSet(name string) {
+	_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy", "address_set", hashedAddressSet(name))
+	if err != nil {
+		klog.Errorf("failed to destroy address set %q, stderr: %q, (%v)", name, stderr, err)
+	}
+}
+
+func (as *addressSet) Destroy() {
+	as.Lock()
+	defer as.Unlock()
+
+	klog.V(5).Infof("Destroy(%s/%s)", as.hashName, as.name)
+	if !as.destroyed {
+		destroyAddressSet(as.name)
+		as.destroyed = true
+	}
+}

--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strconv"
-	"strings"
 
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/klog"
@@ -21,133 +20,9 @@ func hashForOVN(s string) string {
 	return fmt.Sprintf("a%s", hashString)
 }
 
-// hash the provided input to make it a valid addressSet name.
-func hashedAddressSet(s string) string {
-	return hashForOVN(s)
-}
-
 // hash the provided input to make it a valid portGroup name.
 func hashedPortGroup(s string) string {
 	return hashForOVN(s)
-}
-
-// forEachAddressSetUnhashedName will pass the unhashedName, namespaceName and
-// the first suffix in the name to the 'iteratorFn' for every address_set in
-// OVN. (Each unhashed name for an addressSet can be of the form
-// namespaceName.suffix1.suffix2. .suffixN)
-func (oc *Controller) forEachAddressSetUnhashedName(iteratorFn func(
-	string, string, string)) error {
-	output, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=external_ids", "find", "address_set")
-	if err != nil {
-		klog.Errorf("Error in obtaining list of address sets from OVN: "+
-			"stdout: %q, stderr: %q err: %v", output, stderr, err)
-		return err
-	}
-	for _, addrSet := range strings.Fields(output) {
-		if !strings.HasPrefix(addrSet, "name=") {
-			continue
-		}
-		addrSetName := addrSet[5:]
-		names := strings.Split(addrSetName, ".")
-		addrSetNamespace := names[0]
-		nameSuffix := ""
-		if len(names) >= 2 {
-			nameSuffix = names[1]
-		}
-		iteratorFn(addrSetName, addrSetNamespace, nameSuffix)
-	}
-	return nil
-}
-
-func addToAddressSet(hashName string, address string) {
-	klog.V(5).Infof("addToAddressSet for %s with %s", hashName, address)
-
-	// IPv6 addresses need to be quoted, IPv4 work either way.
-	_, stderr, err := util.RunOVNNbctl("add", "address_set",
-		hashName, "addresses", `"`+address+`"`)
-	if err != nil {
-		klog.Errorf("failed to add an address %q to address_set %q, stderr: %q (%v)",
-			address, hashName, stderr, err)
-	}
-}
-
-func removeFromAddressSet(hashName string, address string) {
-	klog.V(5).Infof("removeFromAddressSet for %s with %s", hashName, address)
-
-	// IPv6 addresses need to be quoted, IPv4 work either way.
-	_, stderr, err := util.RunOVNNbctl("remove", "address_set",
-		hashName, "addresses", `"`+address+`"`)
-	if err != nil {
-		klog.Errorf("failed to remove an address %q from address_set %q, stderr: %q (%v)",
-			address, hashName, stderr, err)
-	}
-}
-
-func createAddressSet(name string, hashName string,
-	addresses []string) {
-	klog.V(5).Infof("createAddressSet with %s and %s", name, addresses)
-	addressSet, stderr, err := util.RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=_uuid", "find", "address_set",
-		fmt.Sprintf("name=%s", hashName))
-	if err != nil {
-		klog.Errorf("find failed to get address set, stderr: %q (%v)",
-			stderr, err)
-		return
-	}
-
-	// addressSet has already been created in the database and nothing to set.
-	if addressSet != "" && len(addresses) == 0 {
-		_, stderr, err = util.RunOVNNbctl("clear", "address_set",
-			hashName, "addresses")
-		if err != nil {
-			klog.Errorf("failed to clear address_set, stderr: %q (%v)",
-				stderr, err)
-		}
-		return
-	}
-
-	ips := `"` + strings.Join(addresses, `" "`) + `"`
-
-	// An addressSet has already been created. Just set addresses.
-	if addressSet != "" {
-		// Set the addresses
-		_, stderr, err = util.RunOVNNbctl("set", "address_set",
-			hashName, fmt.Sprintf("addresses=%s", ips))
-		if err != nil {
-			klog.Errorf("failed to set address_set, stderr: %q (%v)",
-				stderr, err)
-		}
-		return
-	}
-
-	// addressSet has not been created yet. Create it.
-	if len(addresses) == 0 {
-		_, stderr, err = util.RunOVNNbctl("create", "address_set",
-			fmt.Sprintf("name=%s", hashName),
-			fmt.Sprintf("external-ids:name=%s", name))
-	} else {
-		_, stderr, err = util.RunOVNNbctl("create", "address_set",
-			fmt.Sprintf("name=%s", hashName),
-			fmt.Sprintf("external-ids:name=%s", name),
-			fmt.Sprintf("addresses=%s", ips))
-	}
-	if err != nil {
-		klog.Errorf("failed to create address_set %s, stderr: %q (%v)",
-			name, stderr, err)
-	}
-}
-
-func deleteAddressSet(hashName string) {
-	klog.V(5).Infof("deleteAddressSet %s", hashName)
-
-	_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy",
-		"address_set", hashName)
-	if err != nil {
-		klog.Errorf("failed to destroy address set %s, stderr: %q, (%v)",
-			hashName, stderr, err)
-		return
-	}
 }
 
 func createPortGroup(name string, hashName string) (string, error) {

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -1,0 +1,188 @@
+package ovn
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	knet "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type gressPolicy struct {
+	namespace  string
+	name       string
+	policyType knet.PolicyType
+	idx        int
+
+	// peerAddressSet points to the addressSet that holds all peer pod
+	// IP addresess.
+	peerAddressSet *addressSet
+
+	// nsAddressSets holds the names of all namespace address sets
+	nsAddressSets sets.String
+
+	// sortedPeerAddressSets has the sorted peerAddressSets
+	sortedPeerAddressSets []string
+
+	// portPolicies represents all the ports to which traffic is allowed for
+	// the rule in question.
+	portPolicies []*portPolicy
+
+	// ipBlockCidr represents the CIDR from which traffic is allowed
+	// except the IP block in the except, which should be dropped.
+	ipBlockCidr   []string
+	ipBlockExcept []string
+}
+
+type portPolicy struct {
+	protocol string
+	port     int32
+}
+
+func (pp *portPolicy) getL4Match() (string, error) {
+	if pp.protocol == TCP {
+		return fmt.Sprintf("tcp && tcp.dst==%d", pp.port), nil
+	} else if pp.protocol == UDP {
+		return fmt.Sprintf("udp && udp.dst==%d", pp.port), nil
+	} else if pp.protocol == SCTP {
+		return fmt.Sprintf("sctp && sctp.dst==%d", pp.port), nil
+	}
+	return "", fmt.Errorf("unknown port protocol %v", pp.protocol)
+}
+
+func newGressPolicy(policyType knet.PolicyType, idx int, namespace, name string) *gressPolicy {
+	return &gressPolicy{
+		namespace:             namespace,
+		name:                  name,
+		policyType:            policyType,
+		idx:                   idx,
+		nsAddressSets:         sets.String{},
+		sortedPeerAddressSets: make([]string, 0),
+		portPolicies:          make([]*portPolicy, 0),
+		ipBlockCidr:           make([]string, 0),
+		ipBlockExcept:         make([]string, 0),
+	}
+}
+
+func (gp *gressPolicy) ensurePeerAddressSet() error {
+	if gp.peerAddressSet != nil {
+		return nil
+	}
+
+	direction := strings.ToLower(string(gp.policyType))
+	asName := fmt.Sprintf("%s.%s.%s.%d", gp.namespace, gp.name, direction, gp.idx)
+	as, err := NewAddressSet(asName, nil)
+	if err != nil {
+		return err
+	}
+
+	gp.peerAddressSet = as
+	gp.sortedPeerAddressSets = append(gp.sortedPeerAddressSets, as.hashName)
+	sort.Strings(gp.sortedPeerAddressSets)
+	return nil
+}
+
+func (gp *gressPolicy) addPortPolicy(portJSON *knet.NetworkPolicyPort) {
+	gp.portPolicies = append(gp.portPolicies, &portPolicy{
+		protocol: string(*portJSON.Protocol),
+		port:     portJSON.Port.IntVal,
+	})
+}
+
+func (gp *gressPolicy) addIPBlock(ipblockJSON *knet.IPBlock) {
+	gp.ipBlockCidr = append(gp.ipBlockCidr, ipblockJSON.CIDR)
+	gp.ipBlockExcept = append(gp.ipBlockExcept, ipblockJSON.Except...)
+}
+
+func ipMatch() string {
+	if config.IPv6Mode {
+		return "ip6"
+	}
+	return "ip4"
+}
+
+func (gp *gressPolicy) getL3MatchFromAddressSet() string {
+	addressSets := make([]string, 0, len(gp.sortedPeerAddressSets))
+	for _, hashName := range gp.sortedPeerAddressSets {
+		addressSets = append(addressSets, fmt.Sprintf("$%s", hashName))
+	}
+
+	var l3Match string
+	if len(addressSets) == 0 {
+		l3Match = ipMatch()
+	} else {
+		addresses := strings.Join(addressSets, ", ")
+		if gp.policyType == knet.PolicyTypeIngress {
+			l3Match = fmt.Sprintf("%s.src == {%s}", ipMatch(), addresses)
+		} else {
+			l3Match = fmt.Sprintf("%s.dst == {%s}", ipMatch(), addresses)
+		}
+	}
+	return l3Match
+}
+
+func (gp *gressPolicy) getMatchFromIPBlock(lportMatch, l4Match string) string {
+	var match string
+	ipBlockCidr := fmt.Sprintf("{%s}", strings.Join(gp.ipBlockCidr, ", "))
+	if gp.policyType == knet.PolicyTypeIngress {
+		if l4Match == noneMatch {
+			match = fmt.Sprintf("match=\"%s.src == %s && %s\"",
+				ipMatch(), ipBlockCidr, lportMatch)
+		} else {
+			match = fmt.Sprintf("match=\"%s.src == %s && %s && %s\"",
+				ipMatch(), ipBlockCidr, l4Match, lportMatch)
+		}
+	} else {
+		if l4Match == noneMatch {
+			match = fmt.Sprintf("match=\"%s.dst == %s && %s\"",
+				ipMatch(), ipBlockCidr, lportMatch)
+		} else {
+			match = fmt.Sprintf("match=\"%s.dst == %s && %s && %s\"",
+				ipMatch(), ipBlockCidr, l4Match, lportMatch)
+		}
+	}
+	return match
+}
+
+func (gp *gressPolicy) addNamespaceAddressSet(name string) (string, string, bool) {
+	hashName := hashedAddressSet(name)
+	if gp.nsAddressSets.Has(hashName) {
+		return "", "", false
+	}
+
+	oldL3Match := gp.getL3MatchFromAddressSet()
+
+	gp.nsAddressSets.Insert(hashName)
+	gp.sortedPeerAddressSets = append(gp.sortedPeerAddressSets, hashName)
+	sort.Strings(gp.sortedPeerAddressSets)
+
+	return oldL3Match, gp.getL3MatchFromAddressSet(), true
+}
+
+func (gp *gressPolicy) delNamespaceAddressSet(name string) (string, string, bool) {
+	hashName := hashedAddressSet(name)
+	if !gp.nsAddressSets.Has(hashName) {
+		return "", "", false
+	}
+
+	oldL3Match := gp.getL3MatchFromAddressSet()
+
+	for i, addressSet := range gp.sortedPeerAddressSets {
+		if addressSet == hashName {
+			gp.sortedPeerAddressSets = append(
+				gp.sortedPeerAddressSets[:i],
+				gp.sortedPeerAddressSets[i+1:]...)
+			break
+		}
+	}
+	gp.nsAddressSets.Delete(hashName)
+
+	return oldL3Match, gp.getL3MatchFromAddressSet(), true
+}
+
+func (gp *gressPolicy) destroy() {
+	gp.peerAddressSet.Destroy()
+	gp.peerAddressSet = nil
+}


### PR DESCRIPTION
Move most address set handling code into an object which can
be locked independently of namespace object and locks. This
makes pod addition locking finer grained by replacing the double
namespaceMutexMutex & namespaceMutex locking required with an
overall adress set map lock to retreive the address set object,
and a lock on the address set object itself. Address set operations
do not actually require holding the entire namespace lock.

It also encapsulates most address set handling code in a single
object and source file, cleaning up the code.

Signed-off-by: Dan Williams <dcbw@redhat.com>