### PR TITLE
Add a GitHub Action To Re-Test PR's

### DIFF
--- a/.github/actions/retest-action/Dockerfile
+++ b/.github/actions/retest-action/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.10
+
+RUN apk add --no-cache curl jq
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/retest-action/action.yml
+++ b/.github/actions/retest-action/action.yml
@@ -1,0 +1,11 @@
+name: 'Re-Test'
+description: 'Re-Runs the last workflow for a PR'
+inputs:
+  token:
+    description: 'GitHub API Token'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/retest-action/entrypoint.sh
+++ b/.github/actions/retest-action/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -ex
+
+if ! jq -e '.issue.pull_request' ${GITHUB_EVENT_PATH}; then
+    echo "Not a PR... Exiting."
+    exit 0
+fi
+
+if [ "$(jq -r '.comment.body' ${GITHUB_EVENT_PATH})" != "/retest" ]; then
+    echo "Nothing to do... Exiting."
+    exit 0
+fi
+
+PR_URL=$(jq -r '.issue.pull_request.url' ${GITHUB_EVENT_PATH})
+
+curl --request GET \
+    --url "${PR_URL}" \
+    --header "authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "content-type: application/json" > pr.json
+
+ACTOR=$(jq -r '.user.login' pr.json)
+BRANCH=$(jq -r '.head.ref' pr.json)
+
+curl --request GET \
+    --url "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs?event=pull_request&actor=${ACTOR}&branch=${BRANCH}" \
+    --header "authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "content-type: application/json" | jq '.workflow_runs | max_by(.run_number)' > run.json
+
+RERUN_URL=$(jq -r '.rerun_url' run.json)
+
+curl --request POST \
+    --url "${RERUN_URL}" \
+    --header "authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "content-type: application/json"
+
+
+REACTION_URL="$(jq -r '.comment.url' ${GITHUB_EVENT_PATH})/reactions"
+
+curl --request POST \
+    --url "${REACTION_URL}" \
+    --header "authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "accept: application/vnd.github.squirrel-girl-preview+json" \
+    --header "content-type: application/json" \
+    --data '{ "content" : "rocket" }'

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,0 +1,16 @@
+name: commands
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  retest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Re-Test Action
+        uses: ./.github/actions/retest-action
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [ master ]
 
+
 env:
   GO_VERSION: 1.13.4
   K8S_VERSION: v1.17.2
@@ -27,14 +28,14 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-      
+
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
         echo "::set-env name=GOPATH::$GOPATH"
         export PATH=$GOPATH/bin:$PATH
         echo "::add-path::$GOPATH/bin"
-    
+
     - name: Verify
       run: |
         pushd go-controller
@@ -55,17 +56,17 @@ jobs:
         pushd dist/images
            if [ -n "$(git diff --stat origin/master.. | grep dist/images/Dockerfile)" ]; then make all; fi
         popd
-        
+
         # Combine separate code coverage profiles into one
         go get github.com/modocache/gover
         gover go-controller/ gover.coverprofile
-        
+
         # Convert coverage profile to LCOV format for coveralls github action
         go get github.com/jandelgado/gcov2lcov
         mkdir -p src/github.com/ovn-org
         ln -sf $(pwd) src/github.com/ovn-org/ovn-kubernetes
         GOPATH=$(pwd) gcov2lcov -infile gover.coverprofile -outfile coverage.lcov
-        
+
     - name: Submit code coverage to Coveralls
       uses: coverallsapp/github-action@master
       with:
@@ -76,14 +77,14 @@ jobs:
     name: Build k8s
     runs-on: ubuntu-latest
     steps:
-    
+
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
         echo "::set-env name=GOPATH::$GOPATH"
         export PATH=$GOPATH/bin:$PATH
         echo "::add-path::$GOPATH/bin"
-    
+
     - name: Cache Kubernetes
       id: cache-k8s
       if: github.event_name == 'push' || github.event_name == 'pull_request'
@@ -131,26 +132,26 @@ jobs:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha.name }}"
       KIND_HA: "${{ matrix.ha.enabled }}"
     steps:
-    
+
     - name: Free up disk space
       run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
-    
+
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-    
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-    
+
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
         echo "::set-env name=GOPATH::$GOPATH"
         export PATH=$GOPATH/bin:$PATH
         echo "::add-path::$GOPATH/bin"
-  
+
     - name: Restore Kubernetes from cache
       id: cache-k8s
       uses: actions/cache@v1
@@ -169,7 +170,7 @@ jobs:
         pushd $GOPATH/src/k8s.io/kubernetes/
         make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
         rm -rf .git
-    
+
     - name: kind setup
       run: |
         make -C test install-kind
@@ -181,7 +182,7 @@ jobs:
     - name: Export logs
       if: always()
       run: |
-        mkdir -p /tmp/kind/logs 
+        mkdir -p /tmp/kind/logs
         kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
 
     - name: Upload logs


### PR DESCRIPTION
Fixes #1216 

Before this merges someone with admin on this repo will need to:

1. Create a `ovn-robot` GitHub User and grant them `write` access to this repo.
2. Create a Personal Access Token with `repo` scope and add it as a secret called `REPO_ACCESS_TOKEN` ([docs](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets))

Once it's merged, a comment with `/retest` will attempt to re-run the the CI workflow.
This could fail if, for example, the tests were all green - GH doesn't allow you to re-run in that case.
Or perhaps for other reasons that we'll find out later.

If it was successful, the action will add a :rocket: to the comment.
