### PR TITLE
add logging support to cnishim

### DIFF
--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -9,7 +9,11 @@ import (
 type NetConf struct {
 	types.NetConf
 	// PciAddrs in case of using sriov
-	DeviceID string `json:"deviceID"`
+	DeviceID string `json:"deviceID,omitempty"`
+	// LogFile to log all the messages from cni shim binary to
+	LogFile string `json:"logFile,omitempty"`
+	// Level is the logging verbosity level
+	LogLevel string `json:"logLevel,omitempty"`
 }
 
 // NetworkSelectionElement represents one element of the JSON format

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -14,28 +14,34 @@ import (
 )
 
 // WriteCNIConfig writes a CNI JSON config file to directory given by global config
-func WriteCNIConfig(ConfDir string, fileName string) error {
-	bytes, err := json.Marshal(&types.NetConf{
-		CNIVersion: "0.4.0",
-		Name:       "ovn-kubernetes",
-		Type:       CNI.Plugin,
-	})
+func WriteCNIConfig() error {
+	netConf := &ovntypes.NetConf{
+		NetConf: types.NetConf{
+			CNIVersion: "0.4.0",
+			Name:       "ovn-kubernetes",
+			Type:       CNI.Plugin,
+		},
+		LogFile:  Logging.CNIFile,
+		LogLevel: fmt.Sprintf("%d", Logging.Level),
+	}
+
+	bytes, err := json.Marshal(netConf)
 	if err != nil {
 		return fmt.Errorf("failed to marshal CNI config JSON: %v", err)
 	}
 
 	// Install the CNI config file after all initialization is done
 	// MkdirAll() returns no error if the path already exists
-	err = os.MkdirAll(ConfDir, os.ModeDir)
+	err = os.MkdirAll(CNI.ConfDir, os.ModeDir)
 	if err != nil {
 		return err
 	}
 
 	// Always create the CNI config for consistency.
-	confFile := filepath.Join(ConfDir, fileName)
+	confFile := filepath.Join(CNI.ConfDir, CNIConfFileName)
 
 	var f *os.File
-	f, err = ioutil.TempFile(ConfDir, "ovnkube-")
+	f, err = ioutil.TempFile(CNI.ConfDir, "ovnkube-")
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -57,8 +57,9 @@ var (
 
 	// Logging holds logging-related parsed config file parameters and command-line overrides
 	Logging = LoggingConfig{
-		File:  "", // do not log to a file by default
-		Level: 4,
+		File:    "", // do not log to a file by default
+		CNIFile: "",
+		Level:   4,
 	}
 
 	// CNI holds CNI-related parsed config file parameters and command-line overrides
@@ -153,6 +154,8 @@ type DefaultConfig struct {
 type LoggingConfig struct {
 	// File is the path of the file to log to
 	File string `gcfg:"logfile"`
+	// CNIFile is the path of the file for the CNI shim to log to
+	CNIFile string `gcfg:"cnilogfile"`
 	// Level is the logging verbosity level
 	Level int `gcfg:"loglevel"`
 }
@@ -504,6 +507,12 @@ var CommonFlags = []cli.Flag{
 		Name:        "logfile",
 		Usage:       "path of a file to direct log output to",
 		Destination: &cliConfig.Logging.File,
+	},
+	&cli.StringFlag{
+		Name:        "cnilogfile",
+		Usage:       "path of a file to direct log from cni shim to output to (default: /var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log)",
+		Destination: &cliConfig.Logging.CNIFile,
+		Value:       "/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log",
 	},
 }
 

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -239,7 +239,7 @@ func (n *OvnNode) Start() error {
 	confFile := filepath.Join(config.CNI.ConfDir, config.CNIConfFileName)
 	_, err = os.Stat(confFile)
 	if os.IsNotExist(err) {
-		err = config.WriteCNIConfig(config.CNI.ConfDir, config.CNIConfFileName)
+		err = config.WriteCNIConfig()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
currently it is very hard to debug any issues with cnishim. the error
messages gets captured in the kubelet's log and its hard to just filter
out ovn cni shim specific messages.

this commit adds support to log all of the cni shim specific messages
to configurable log file (by default it is
/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log). the ovnkube-node adds
two fields to 10-ovn-kubernetes.conf file, namely logFile and logLevel
that is passed onto the cni shim either by kubelet or multus. using the
information from os.STDIN, the cnishim setups logging

@ovn-org/ovn-kubernetes-committers 