### PR TITLE
shared-gw: the ofport number can change under your feet

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -281,7 +281,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 	nFlows++
 
 	// add health check function to check default OpenFlow flows are on the shared gateway bridge
-	go checkDefaultConntrackRules(gwBridge, nFlows, stopChan)
+	go checkDefaultConntrackRules(gwBridge, gwIntf, patchPort, ofportPhys, ofportPatch, nFlows, stopChan)
 	return nil
 }
 


### PR DESCRIPTION
in shared gaetway mode, we install openflow flows to connection track
all the packets leaving the logical network toward physical network so
that we can steer the reply packets back to the logical network. the
flows related to this logic are added using the `ofport` number of the
patch cable that connects the OVS bridge and integration bridge

it so happens that ovn-controller, when it hits a snag, it can tear
down this patch cable under the foot of ovnkube-node and add it back.
this changes the `ofport` number and all that openflow rules are now
invalid

this commit adds a check to ensure that the `ofport` number didn't
change underneat onvkube-node

@ovn-org/ovn-kubernetes-committers PTAL