### PR TITLE
Make the multicast port_group more general

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -63,6 +63,9 @@ type namespaceInfo struct {
 	hybridOverlayExternalGW net.IP
 	hybridOverlayVTEP       net.IP
 
+	// The UUID of the namespace-wide port group that contains all the pods in the namespace.
+	portGroupUUID string
+
 	multicastEnabled bool
 }
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -203,7 +203,8 @@ func (n networkPolicy) delPodCmds(fexec *ovntest.FakeExec, networkPolicy knet.Ne
 type multicastPolicy struct{}
 
 func (p multicastPolicy) enableCmds(fExec *ovntest.FakeExec, ns string) {
-	pg_name, pg_hash := getMulticastPortGroup(ns)
+	pg_name := ns
+	pg_hash := hashedPortGroup(ns)
 
 	fExec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=" + pg_hash,
@@ -238,7 +239,7 @@ func (p multicastPolicy) enableCmds(fExec *ovntest.FakeExec, ns string) {
 }
 
 func (p multicastPolicy) disableCmds(fExec *ovntest.FakeExec, ns string) {
-	_, pg_hash := getMulticastPortGroup(ns)
+	pg_hash := hashedPortGroup(ns)
 
 	match := getACLMatch(pg_hash, "ip4.mcast", knet.PolicyTypeEgress)
 	fExec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -271,7 +272,7 @@ func (p multicastPolicy) disableCmds(fExec *ovntest.FakeExec, ns string) {
 }
 
 func (p multicastPolicy) addPodCmds(fExec *ovntest.FakeExec, ns string) {
-	_, pg_hash := getMulticastPortGroup(ns)
+	pg_hash := hashedPortGroup(ns)
 	fExec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 " +
 			"--if-exists remove port_group " + pg_hash + " ports " + fakeUUID + " " +
@@ -280,7 +281,7 @@ func (p multicastPolicy) addPodCmds(fExec *ovntest.FakeExec, ns string) {
 }
 
 func (p multicastPolicy) delPodCmds(fExec *ovntest.FakeExec, ns string) {
-	_, pg_hash := getMulticastPortGroup(ns)
+	pg_hash := hashedPortGroup(ns)
 	fExec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 " +
 			"--if-exists remove port_group " + pg_hash + " ports " + fakeUUID,


### PR DESCRIPTION
In preparation for the egressFirewall that would use a namespace wide port_group
generalize the multicast port_group code so that egressFirewall or other objects
could use the namespace wide port_group as opposed to creating another port_group
that contains the same information.

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>