### PR TITLE
trivial: use the right array index in --version output string parsing

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/ovn-db-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovn-db-exporter.go
@@ -315,7 +315,7 @@ var (
 func getOvnDbVersionInfo() {
 	stdout, _, err := util.RunOVSDBClient("-V")
 	if err == nil && strings.HasPrefix(stdout, "ovsdb-client (Open vSwitch) ") {
-		ovnDbVersion = strings.Fields(stdout)[2]
+		ovnDbVersion = strings.Fields(stdout)[3]
 	}
 	sockPath := "unix:/var/run/openvswitch/ovnnb_db.sock"
 	stdout, _, err = util.RunOVSDBClient("get-schema-version", sockPath, "OVN_Northbound")


### PR DESCRIPTION
@ovn-org/ovn-kubernetes-committers PTAL