### PR TITLE
ovndb-raft-functions.sh:ovndb Loglevel option still set to ovn_log_db

### DIFF
--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -197,7 +197,7 @@ ovsdb-raft() {
   local initialize="false"
 
   ovn_db_pidfile=${OVN_RUNDIR}/ovn${db}_db.pid
-  eval ovn_log_db=\$ovn_log_${db}
+  eval ovn_loglevel_db=\$ovn_loglevel_${db}
   ovn_db_file=${OVN_ETCDIR}/ovn${db}_db.db
 
   trap 'ovsdb_cleanup ${db}' TERM
@@ -237,7 +237,7 @@ ovsdb-raft() {
       --db-${db}-cluster-local-port=${raft_port} \
       --db-${db}-cluster-local-proto=${transport} \
       ${db_ssl_opts} \
-      --ovn-${db}-log="${ovn_log_db}" &
+      --ovn-${db}-log="${ovn_loglevel_db}" &
   else
     # join the remote cluster node if the DB is not created
     if [[ "${initialize}" == "true" ]]; then
@@ -249,7 +249,7 @@ ovsdb-raft() {
       --db-${db}-cluster-local-port=${raft_port} --db-${db}-cluster-remote-port=${raft_port} \
       --db-${db}-cluster-local-proto=${transport} --db-${db}-cluster-remote-proto=${transport} \
       ${db_ssl_opts} \
-      --ovn-${db}-log="${ovn_log_db}" &
+      --ovn-${db}-log="${ovn_loglevel_db}" &
   fi
 
   # Following command waits for the database on server to enter a `connected` state


### PR DESCRIPTION
ovn_db_log(Loglevel) option is being set to ovn_log_nb & ovn_log_sb in ovndb-raft-functions.sh
which have been renamed to ovn_loglevel_nb & ovn_loglevel_sb. So, correcting it.

Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>