### PR TITLE
Run single k8s test, if specified

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -34,6 +34,8 @@ the shards (which may change in the future):
   `[sig-network] Services ...` tests.)
 - shard-other
   - All remaining E2E tests that didn't match above.
+- shard-test
+  - Single E2E test that matches the name of the test specified with a regex. See bottom of this document for an example.
 - control-plane
   - All locally defined tests.
 
@@ -208,5 +210,14 @@ $ make shard-np
 $ make shard-s
 $ make shard-other
 $ GITHUB_WORKSPACE=$GOPATH/src/github.com/ovn-org/ovn-kubernetes make control-plane
+$ popd
+```
+
+To run a single test instead, target the shard-test action, as follows:
+
+```
+$ cd $GOPATH/src/github.com/ovn-org/ovn-kubernetes
+$ pushd test
+$ make shard-test WHAT="should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector"
 $ popd
 ```

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,7 +4,7 @@ install-kind:
 
 .PHONY: shard-%
 shard-%:
-	./scripts/e2e-kind.sh $@
+	./scripts/e2e-kind.sh $@ $(WHAT) 
 
 .PHONY: control-plane
 control-plane:

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -64,6 +64,10 @@ case "$SHARD" in
 	shard-other)
 		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[^NnSs].*'
 		;;
+	shard-test)
+		TEST_REGEX_REPR=$(echo ${@:2} | sed 's/ /\\s/g')
+		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\].*'$TEST_REGEX_REPR'.*'
+		;;
 	*)
 		echo "unknown shard"
 		exit 1


### PR DESCRIPTION
I don't want to run an entire test suite when debugging one test. This will allow us to run a single test by doing:

```
github.com/ovn-org/ovn-kubernetes $ make -C test shard-test WHAT="should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector"
```

Once https://github.com/ovn-org/ovn-kubernetes/pull/1301 we might even have the bot run the one test that failed during our builds.