### PR TITLE
dualstack support for GetPortAddresses

### DIFF
--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	utilnet "k8s.io/utils/net"
 	"math/big"
 	"net"
 	"runtime"
@@ -167,4 +168,24 @@ func JoinIPNetIPs(ipnets []*net.IPNet, sep string) string {
 		b.WriteString(ipnet.IP.String())
 	}
 	return b.String()
+}
+
+// IPFamilyName returns IP Family string based on input flag.
+func IPFamilyName(isIPv6 bool) string {
+	if isIPv6 {
+		return "IPv6"
+	} else {
+		return "IPv4"
+	}
+}
+
+// MatchIPFamily loops through the array of *net.IPNet and returns the
+// first entry in the list in the same IP Family, based on input flag isIPv6.
+func MatchIPFamily(isIPv6 bool, subnets []*net.IPNet) (*net.IPNet, error) {
+	for _, subnet := range subnets {
+		if utilnet.IsIPv6CIDR(subnet) == isIPv6 {
+			return subnet, nil
+		}
+	}
+	return nil, fmt.Errorf("no %s subnet available", IPFamilyName(isIPv6))
 }

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -150,3 +150,16 @@ func JoinIPNets(ipnets []*net.IPNet, sep string) string {
 	}
 	return b.String()
 }
+
+// JoinIPNetIPs joins the string forms of an array of *net.IPNet,
+// as with strings.Join, but does not include the IP mask.
+func JoinIPNetIPs(ipnets []*net.IPNet, sep string) string {
+	b := &strings.Builder{}
+	for i, ipnet := range ipnets {
+		if i != 0 {
+			b.WriteString(sep)
+		}
+		b.WriteString(ipnet.IP.String())
+	}
+	return b.String()
+}

--- a/go-controller/pkg/util/net_test.go
+++ b/go-controller/pkg/util/net_test.go
@@ -137,4 +137,47 @@ var _ = Describe("Util tests", func() {
 			Expect(result).To(Equal(tc.out), " test case \"%s\" returned wrong results for %#v", tc.name, tc.cidrs)
 		}
 	})
+
+	It("test JoinIPNetIPs", func() {
+		type testcase struct {
+			name  string
+			cidrs []*net.IPNet
+			out   string
+		}
+
+		testcases := []testcase{
+			{
+				name:  "empty list",
+				cidrs: nil,
+				out:   "",
+			},
+			{
+				name:  "single CIDR",
+				cidrs: []*net.IPNet{ovntest.MustParseIPNet("10.1.2.3/24")},
+				out:   "10.1.2.3",
+			},
+			{
+				name: "two CIDRs",
+				cidrs: []*net.IPNet{
+					ovntest.MustParseIPNet("10.1.2.3/24"),
+					ovntest.MustParseIPNet("10.4.5.6/24"),
+				},
+				out: "10.1.2.3, 10.4.5.6",
+			},
+			{
+				name: "three CIDRs, mixed families",
+				cidrs: []*net.IPNet{
+					ovntest.MustParseIPNet("10.1.2.3/24"),
+					ovntest.MustParseIPNet("fd01::1234/64"),
+					ovntest.MustParseIPNet("10.4.5.6/24"),
+				},
+				out: "10.1.2.3, fd01::1234, 10.4.5.6",
+			},
+		}
+
+		for _, tc := range testcases {
+			result := JoinIPNetIPs(tc.cidrs, ", ")
+			Expect(result).To(Equal(tc.out), " test case \"%s\" returned wrong results for %#v", tc.name, tc.cidrs)
+		}
+	})
 })


### PR DESCRIPTION
Add "Pods" support for "pkg/ovn/pods.go:getPodAddresses() /
waitForPodAddresses() / pkg/util/net.go:GetPortAddresses() need to handle
multiple IPs".

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>