### PR TITLE
Fixes to linkneigh utility methods

### DIFF
--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -142,7 +142,7 @@ func LinkNeighAdd(link netlink.Link, neighIP net.IP, neighMAC net.HardwareAddr) 
 		IP:           neighIP,
 		HardwareAddr: neighMAC,
 	}
-	err := netlink.NeighSet(neigh)
+	err := netlink.NeighAdd(neigh)
 	if err != nil {
 		return fmt.Errorf("failed to add neighbour entry %+v: %v", neigh, err)
 	}


### PR DESCRIPTION
Fixes to linkneigh utility methods

 1. Fixed LinkNeighAdd to add the binding instead of setting it.
 2.  Added a helper method for LinkNeighSet