### PR TITLE
Update KIND deployment to allow configurable number of workers.

### DIFF
--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -29,22 +29,17 @@ nodes:
          node-labels: "ingress-ready=true"
          authorization-mode: "AlwaysAllow"
 {%- if ovn_ha is equalto "true" %}
+{%- for _ in range(1, ovn_num_master | int) %}
  - role: control-plane
    extraMounts:
      - hostPath: /tmp/kind
        containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
- - role: control-plane
-   extraMounts:
-     - hostPath: /tmp/kind
-       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
-{%- else %}
- - role: worker
-   extraMounts:
-     - hostPath: /tmp/kind
-       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
- - role: worker
-   extraMounts:
-     - hostPath: /tmp/kind
-       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
+{%- endfor %}
 {%- endif %}
+{%- for _ in range(ovn_num_worker | int) %}
+ - role: worker
+   extraMounts:
+     - hostPath: /tmp/kind
+       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
+{%- endfor %}
 


### PR DESCRIPTION
Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
This PR allows the number of Worker nodes to be configured when running a KIND deployment.

**- Special notes for reviewers**
If no additional input is passed to the kind.sh script, the script behaves same as before.

**- How to verify it**
There are two ways to set each variable, and they are equivalent. Either via environmental variable or via CLI parameter. Examples:
   $ ./kind.sh -wk 4
   $ KIND_NUM_WORKER=4 ./kind.sh

**- Description for the changelog**
Update KIND deployment to allow configurable number of workers