### PR TITLE
hybrid overlay cleanups and fixes

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -229,14 +229,13 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = n.startNodeWatch(f)
+			err = n.startNodeWatch()
 			Expect(err).NotTo(HaveOccurred())
 
 			//FIXME
@@ -278,14 +277,13 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = n.startNodeWatch(f)
+			err = n.startNodeWatch()
 			Expect(err).NotTo(HaveOccurred())
 
 			//FIXME
@@ -320,14 +318,13 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = n.startNodeWatch(f)
+			err = n.startNodeWatch()
 			Expect(err).NotTo(HaveOccurred())
 
 			//FIXME
@@ -370,14 +367,13 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = n.startNodeWatch(f)
+			err = n.startNodeWatch()
 			Expect(err).NotTo(HaveOccurred())
 
 			//FIXME
@@ -418,14 +414,13 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = n.startNodeWatch(f)
+			err = n.startNodeWatch()
 			Expect(err).NotTo(HaveOccurred())
 			//FIXME
 			//Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -60,8 +60,7 @@ type namespaceInfo struct {
 	// the policy itself.
 	networkPolicies map[string]*namespacePolicy
 
-	hybridOverlayExternalGW net.IP
-	hybridOverlayVTEP       net.IP
+	hasHybridOverlayExternalGW bool
 
 	multicastEnabled bool
 }


### PR DESCRIPTION
1. don't start pod/namespace watches until hybrid overlay is initialized; fixes a case where pods may not be set up right after restart

2. splits pods out of the learn action to simplify its logic; gets rid of the tun map entirely

@trozet @rcarrillocruz 