### PR TITLE
Add e2e test to simulate a reboot of the control plane node

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -317,7 +317,7 @@ var _ = Describe("e2e control plane", func() {
 
 		podList, _ := podClient.List(metav1.ListOptions{})
 		for _, pod := range podList.Items {
-			if pod.Spec.NodeName == "ovn-control-plane" && pod.Name != "connectivity-test-continuous" {
+			if pod.Spec.NodeName == "ovn-control-plane" && pod.Name != "connectivity-test-continuous" && pod.Name != "etcd-ovn-control-plane" {
 				framework.Logf("%q", pod.Namespace)
 				podClient2 := f.ClientSet.CoreV1().Pods(pod.Namespace)
 				err := podClient2.Delete(pod.Name, metav1.NewDeleteOptions(0))


### PR DESCRIPTION
Signed-off-by: Andrew Sun <asun@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Adds an end-to-end test to simulate rebooting the ovn-control-plane node. Note that we do not actually reboot the node, as kind does not like it for some reason when we do `docker restart` on any of the nodes. Instead, we kill all the pods running on the node at the same time to simulate a reboot.
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
cc @trozet 
