### PR TITLE
master: Fix slice creation for syncing nodes

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -800,7 +800,7 @@ func (oc *Controller) syncNodesPeriodic() {
 		return
 	}
 
-	nodeNames := make([]string, len(nodes.Items))
+	nodeNames := make([]string, 0, len(nodes.Items))
 
 	for _, node := range nodes.Items {
 		nodeNames = append(nodeNames, node.Name)


### PR DESCRIPTION
There was a bug introduced while fixing the chassis deletes where
the node name slice was pre-created with n copies of empty strings.
Instead what is desired is to pre-create the slice of a given
capacity. This commit fixes that issue.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>