### PR TITLE
create the OVN-KUBE-SNAT-MGMTPORT nat chain if it does not exist

### DIFF
--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -12,6 +12,8 @@ import (
 // IPTablesHelper is an interface that wraps go-iptables to allow
 // mock implementations for unit testing
 type IPTablesHelper interface {
+	// List rules in specified table/chain
+	List(table, chain string) ([]string, error)
 	// ListChains returns the names of all chains in the table
 	ListChains(string) ([]string, error)
 	// ClearChain removes all rules in the specified table/chain.
@@ -94,6 +96,19 @@ func (f *FakeIPTables) getTable(tableName string) (*FakeTable, error) {
 		return nil, fmt.Errorf("table %s does not exist", tableName)
 	}
 	return table, nil
+}
+
+// List rules in specified table/chain
+func (f *FakeIPTables) List(tableName, chainName string) ([]string, error) {
+	table, err := f.getTable(tableName)
+	if err != nil {
+		return nil, err
+	}
+	chain, err := table.getChain(chainName)
+	if err != nil {
+		return nil, err
+	}
+	return chain, nil
 }
 
 // ListChains returns the names of all chains in the table

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -41,6 +41,8 @@ Services.+(ESIPP|cleanup finalizer)
 configMap nameserver
 ClusterDns \[Feature:Example\]
 should set default value on new IngressClass
+# RACE CONDITION IN TEST, SEE https://github.com/kubernetes/kubernetes/pull/90254
+should prevent Ingress creation if more than 1 IngressClass marked as default
 "
 
 SKIPPED_TESTS=$(echo "${SKIPPED_TESTS}" | sed -e '/^\($\|#\)/d' -e 's/ /\\s/g' | tr '\n' '|' | sed -e 's/|$//')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

the commit will fix the  following errors that we are seeing in the
ovnkube-node log
--------8<-----------------8<-------------
"E0509 07:24:35.366153 195 management-port_linux.go:215] could not set
up iptables rules for management port: running [/usr/sbin/iptables -t
nat -I OVN-KUBE-SNAT-MGMTPORT 1 -o ovn-k8s-mp0 -j SNAT --to-source
10.192.16.2 -m comment --comment OVN SNAT to Management Port --wait]:
exit status 1: iptables: Index of insertion too big."
--------8<-----------------8<-------------

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

The main issue was that we never created OVN-KUBE-SNAT-MGMTPORT chain, so that was causing the error we are seeing.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Once the k8s cluster is up and running, do the following on the node:
1. iptables -t nat -F OVN-KUBE-SNAT-MGMTPORT 
2. iptables -t nat -D POSTROUTING 1
3. iptables -t nat -X OVN-KUBE-SNAT-MGMTPORT

Without the fix, we fail to recreate the NAT rules again for the management port
