### PR TITLE
CI: Build e2e test resources with k8s master version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,6 @@ jobs:
       if: steps.cache-k8s.outputs.cache-hit != 'true'
 
     - name: Build and install Kubernetes
-      if: steps.cache-k8s.outputs.cache-hit != 'true'
       run: |
         set -x
         rm -rf $GOPATH/src/k8s.io/kubernetes
@@ -162,7 +161,6 @@ jobs:
     # https://github.com/actions/cache/issues/107#issuecomment-598188250
     # https://github.com/actions/cache/issues/208#issuecomment-596664572
     - name: Build and install Kubernetes
-      if: steps.cache-k8s.outputs.cache-hit != 'true'
       run: |
         set -x
         rm -rf $GOPATH/src/k8s.io/kubernetes/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
       run: |
         set -x
         rm -rf $GOPATH/src/k8s.io/kubernetes
-        git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
+        git clone --single-branch https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
         pushd $GOPATH/src/k8s.io/kubernetes/
         make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
         rm -rf .git
@@ -166,7 +166,7 @@ jobs:
       run: |
         set -x
         rm -rf $GOPATH/src/k8s.io/kubernetes/
-        git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
+        git clone --single-branch https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
         pushd $GOPATH/src/k8s.io/kubernetes/
         make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
         rm -rf .git

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -70,5 +70,7 @@ case "$SHARD" in
 	;;
 esac
 
+echo Running e2e.test version: $(e2e.test -version)
+
 e2e.test ${GINKGO_ARGS}
 


### PR DESCRIPTION
Supersedes https://github.com/ovn-org/ovn-kubernetes/pull/1337    

When running e2e tests I have seen that using a Kubernetes master version of e2e.test and ginkgo cuts down the flakes we have been seeing (#1321) I am not sure this will fix all flakes always. But any improvement is a good one, and there's no reason not to use the latest infra from Kubernetes to run our tests.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>

@trozet 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->