### PR TITLE
shared-gw: fix access to nodeport services from the node itself

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -23,7 +23,7 @@ const (
 	defaultOpenFlowCookie = "0xdeff105"
 )
 
-func addService(service *kapi.Service, inport, outport, gwBridge string) {
+func addService(service *kapi.Service, inport, outport, gwBridge string, nodeIP *net.IPNet) {
 	if !util.ServiceTypeHasNodePort(service) {
 		return
 	}
@@ -45,9 +45,11 @@ func addService(service *kapi.Service, inport, outport, gwBridge string) {
 				svcPort.NodePort, stderr, err)
 		}
 	}
+
+	addSharedGatewayIptRules(service, nodeIP)
 }
 
-func deleteService(service *kapi.Service, inport, gwBridge string) {
+func deleteService(service *kapi.Service, inport, gwBridge string, nodeIP *net.IPNet) {
 	if !util.ServiceTypeHasNodePort(service) {
 		return
 	}
@@ -70,6 +72,8 @@ func deleteService(service *kapi.Service, inport, gwBridge string) {
 				svcPort.NodePort, stderr, err)
 		}
 	}
+
+	delSharedGatewayIptRules(service, nodeIP)
 }
 
 func syncServices(services []interface{}, inport, gwBridge string) {
@@ -151,7 +155,7 @@ func syncServices(services []interface{}, inport, gwBridge string) {
 	}
 }
 
-func nodePortWatcher(nodeName, gwBridge, gwIntf string, wf *factory.WatchFactory) error {
+func nodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet, wf *factory.WatchFactory) error {
 	// the name of the patch port created by ovn-controller is of the form
 	// patch-<logical_port_name_of_localnet_port>-to-br-int
 	patchPort := "patch-" + gwBridge + "_" + nodeName + "-to-br-int"
@@ -171,10 +175,20 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, wf *factory.WatchFactory
 			gwIntf, stderr, err)
 	}
 
+	// In the shared gateway mode, the NodePort service is handled by the OpenFlow flows configured
+	// on the OVS bridge in the host. These flows act only on the packets coming in from outside
+	// of the node. If someone on the node is trying to access the NodePort service, those packets
+	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
+	// NodePortIP:NodePort to ClusterServiceIP:Port.
+	err = createNodePortIptableChain()
+	if err != nil {
+		return err
+	}
+
 	_, err = wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			service := obj.(*kapi.Service)
-			addService(service, ofportPhys, ofportPatch, gwBridge)
+			addService(service, ofportPhys, ofportPatch, gwBridge, nodeIP[0])
 		},
 		UpdateFunc: func(old, new interface{}) {
 			svcNew := new.(*kapi.Service)
@@ -182,12 +196,12 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, wf *factory.WatchFactory
 			if reflect.DeepEqual(svcNew.Spec, svcOld.Spec) {
 				return
 			}
-			deleteService(svcOld, ofportPhys, gwBridge)
-			addService(svcNew, ofportPhys, ofportPatch, gwBridge)
+			deleteService(svcOld, ofportPhys, gwBridge, nodeIP[0])
+			addService(svcNew, ofportPhys, ofportPatch, gwBridge, nodeIP[0])
 		},
 		DeleteFunc: func(obj interface{}) {
 			service := obj.(*kapi.Service)
-			deleteService(service, ofportPhys, gwBridge)
+			deleteService(service, ofportPhys, gwBridge, nodeIP[0])
 		},
 	}, func(services []interface{}) {
 		syncServices(services, ofportPhys, gwBridge)
@@ -362,7 +376,8 @@ func (n *OvnNode) initSharedGateway(subnet *net.IPNet, gwNextHop net.IP, gwIntf 
 
 		if config.Gateway.NodeportEnable {
 			// Program cluster.GatewayIntf to let nodePort traffic to go to pods.
-			if err := nodePortWatcher(n.name, bridgeName, uplinkName, n.watchFactory); err != nil {
+			if err := nodePortWatcher(n.name, bridgeName, uplinkName, []*net.IPNet{ipAddress},
+				n.watchFactory); err != nil {
 				return err
 			}
 		}
@@ -409,5 +424,7 @@ func cleanupSharedGateway() error {
 	if err != nil {
 		return fmt.Errorf("Failed to replace-flows on bridge %q stderr:%s (%v)", bridgeName, stderr, err)
 	}
+
+	deleteNodePortIptableChain()
 	return nil
 }

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -1,0 +1,117 @@
+package node
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	utilnet "k8s.io/utils/net"
+)
+
+func createNodePortIptableChain() error {
+	for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
+		ipt, err := util.GetIPTablesHelper(proto)
+		if err != nil {
+			return err
+		}
+		// delete all the existing OVN-KUBE-NODEPORT rules
+		_ = ipt.ClearChain("nat", iptableNodePortChain)
+		_ = ipt.ClearChain("filter", iptableNodePortChain)
+
+		rules := make([]iptRule, 0)
+		rules = append(rules, iptRule{
+			table: "nat",
+			chain: "OUTPUT",
+			args:  []string{"-j", iptableNodePortChain},
+		})
+		rules = append(rules, iptRule{
+			table: "filter",
+			chain: "OUTPUT",
+			args:  []string{"-j", iptableNodePortChain},
+		})
+
+		if err := addIptRules(ipt, rules); err != nil {
+			return fmt.Errorf("failed to add iptable rules %v: %v", rules, err)
+		}
+	}
+	return nil
+}
+
+func deleteNodePortIptableChain() {
+	for _, proto := range []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
+		ipt, err := util.GetIPTablesHelper(proto)
+		if err != nil {
+			return
+		}
+		// delete all the existing OVN-NODEPORT rules
+		_ = ipt.ClearChain("nat", iptableNodePortChain)
+		_ = ipt.ClearChain("filter", iptableNodePortChain)
+		_ = ipt.DeleteChain("nat", iptableNodePortChain)
+		_ = ipt.DeleteChain("filter", iptableNodePortChain)
+	}
+}
+
+func getSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) []iptRule {
+	rules := make([]iptRule, 0)
+
+	for _, svcPort := range service.Spec.Ports {
+		protocol, err := util.ValidateProtocol(svcPort.Protocol)
+		if err != nil {
+			klog.Errorf("Skipping service add. Invalid service port %s: %v", svcPort.Name, err)
+			continue
+		}
+		nodePort := fmt.Sprintf("%d", svcPort.NodePort)
+		port := fmt.Sprintf("%d", svcPort.Port)
+
+		rules = append(rules, iptRule{
+			table: "nat",
+			chain: iptableNodePortChain,
+			args: []string{
+				"-p", string(protocol), "--dport", nodePort, "-d", nodeIP.IP.String(),
+				"-j", "DNAT", "--to-destination", net.JoinHostPort(service.Spec.ClusterIP, port),
+			},
+		})
+		rules = append(rules, iptRule{
+			table: "filter",
+			chain: iptableNodePortChain,
+			args: []string{
+				"-p", string(protocol), "--dport", nodePort, "-d", nodeIP.IP.String(),
+				"-j", "ACCEPT",
+			},
+		})
+	}
+	return rules
+}
+
+func addSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
+	var ipt util.IPTablesHelper
+
+	rules := getSharedGatewayIptRules(service, nodeIP)
+	// we've already checked/created iptableHelper in initNodePortIptableChain, no need to check error here.
+	if utilnet.IsIPv6String(service.Spec.ClusterIP) {
+		ipt, _ = util.GetIPTablesHelper(iptables.ProtocolIPv6)
+	} else {
+		ipt, _ = util.GetIPTablesHelper(iptables.ProtocolIPv4)
+	}
+	if err := addIptRules(ipt, rules); err != nil {
+		klog.Errorf("Failed to set up iptables rules for nodePort service %s/%s: %v",
+			service.Namespace, service.Name, err)
+	}
+}
+
+func delSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
+	var ipt util.IPTablesHelper
+
+	rules := getSharedGatewayIptRules(service, nodeIP)
+	// we've already checked/created iptableHelper in initNodePortIptableChain, no need to check error here.
+	if utilnet.IsIPv6String(service.Spec.ClusterIP) {
+		ipt, _ = util.GetIPTablesHelper(iptables.ProtocolIPv6)
+	} else {
+		ipt, _ = util.GetIPTablesHelper(iptables.ProtocolIPv4)
+	}
+	delIptRules(ipt, rules)
+}

--- a/go-controller/pkg/node/gateway_shared_intf_windows.go
+++ b/go-controller/pkg/node/gateway_shared_intf_windows.go
@@ -1,0 +1,19 @@
+package node
+
+import (
+	kapi "k8s.io/api/core/v1"
+	"net"
+)
+
+func createNodePortIptableChain() error {
+	return nil
+}
+
+func deleteNodePortIptableChain() {
+}
+
+func addSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
+}
+
+func delSharedGatewayIptRules(service *kapi.Service, nodeIP *net.IPNet) {
+}

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -41,6 +41,8 @@ Services.+(ESIPP|cleanup finalizer)
 configMap nameserver
 ClusterDns \[Feature:Example\]
 should set default value on new IngressClass
+# RACE CONDITION IN TEST, SEE https://github.com/kubernetes/kubernetes/pull/90254
+should prevent Ingress creation if more than 1 IngressClass marked as default
 "
 
 SKIPPED_TESTS=$(echo "${SKIPPED_TESTS}" | sed -e '/^\($\|#\)/d' -e 's/ /\\s/g' | tr '\n' '|' | sed -e 's/|$//')


### PR DESCRIPTION
In the shared gateway mode, the NodePort service is handled by the
OpenFlow flows configured on the OVS bridge in the host. These flows
act only on the packets coming in from outside of the node. If someone
on the node is trying to access the NodePort service, those packets
will not be processed by the OpenFlow flows, so we need to add iptable
rules that DNATs the NodePortIP:NodePort to ClusterServiceIP:Port.

    +---------------------------------------+
    |                 Node1                 |
    |             (10.8.51.51)              |
    |                                       |
    |                          +----------+ |
    |                          |  br-int  | |
    |   +--------+             +----+-----+ |
    |   |  Node  |             SNAT: NodeIP |
    |   |   IP   |                  |       |
    |   +--------+                  |       |
    | +-----------------------+     |       |
    | |        breth0         |   patch     |
    | |   NodePort OpenFlow   +-- cable     |
    | |         Flows         |             |
    | +-----------------------+             |
    |         +------+                      |
    +---------+ eth0 +----------------------+
              +------+

A DNAT rule in the OUTPUT chain (wrapped in ONV-KUBE-NODEPORT chain)
translates the packets to cluster ip and port. There are routes already
on the host to forward the packets to management port, and thus access
to NodePort backed service is achieved.

Signed-off-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>