### PR TITLE
hybrid-overlay: Annotate Pods on Ns update

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -20,7 +20,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	kapi "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
@@ -86,54 +85,32 @@ func podIPToCookie(podIP net.IP) string {
 	return fmt.Sprintf("%02x%02x%02x%02x", ip4[0], ip4[1], ip4[2], ip4[3])
 }
 
-func (n *NodeController) waitForNamespace(name string) (*kapi.Namespace, error) {
-	var namespaceBackoff = wait.Backoff{Duration: 1 * time.Second, Steps: 7, Factor: 1.5, Jitter: 0.1}
-	var namespace *kapi.Namespace
-	if err := wait.ExponentialBackoff(namespaceBackoff, func() (bool, error) {
-		var err error
-		namespace, err = n.wf.GetNamespace(name)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				// Namespace not found; retry
-				return false, nil
-			}
-			klog.Warningf("error getting namespace: %v", err)
-			return false, err
-		}
-		return true, nil
-	}); err != nil {
-		return nil, fmt.Errorf("failed to get namespace object: %v", err)
-	}
-	return namespace, nil
-}
-
-func (n *NodeController) addOrUpdatePod(pod *kapi.Pod, ignoreLearn bool) error {
+func (n *NodeController) addOrUpdatePod(pod *kapi.Pod) error {
 	podIPs, podMAC, err := getPodDetails(pod, n.nodeName)
 	if err != nil {
 		klog.V(5).Infof("cleaning up hybrid overlay pod %s/%s because %v", pod.Namespace, pod.Name, err)
 		return n.deletePod(pod)
 	}
 
-	namespace, err := n.waitForNamespace(pod.Namespace)
-	if err != nil {
-		return err
-	}
-	namespaceExternalGwRaw := namespace.GetAnnotations()[hotypes.HybridOverlayExternalGw]
+	externalGw := pod.Annotations[hotypes.HybridOverlayExternalGw]
 	// validate the external gateway is a valid IP address
-	namespaceExternalGwIP := net.ParseIP(namespaceExternalGwRaw)
-	if namespaceExternalGwIP == nil {
-		klog.Warningf("failed parse a valid external gateway ip address from %v: %v", namespaceExternalGwRaw, err)
-		return fmt.Errorf("failed to validate a valid external gateway ip address %s: %v", namespaceExternalGwRaw, err)
+	if ip := net.ParseIP(externalGw); ip == nil {
+		klog.Warningf("failed parse a valid external gateway ip address from %v: %v", externalGw, err)
+		return fmt.Errorf("failed to validate a valid external gateway ip address %s: %v", externalGw, err)
 	}
-	namespaceExternalGw := namespaceExternalGwIP.String()
-	namespaceVTEPRaw := namespace.GetAnnotations()[hotypes.HybridOverlayVTEP]
-	// validate the vtep is a valid IP address
-	namespaceVTEPIP := net.ParseIP(namespaceVTEPRaw)
-	if namespaceVTEPIP == nil {
-		klog.Warningf("failed parse a valid vtep ip address from %v: %v", namespaceVTEPRaw, err)
-		return fmt.Errorf("failed to validate a valid vtep ip address %s: %v", namespaceVTEPRaw, err)
+
+	VTEP := pod.Annotations[hotypes.HybridOverlayVTEP]
+	// validate the VTEP is a valid IP address
+	VTEPIP := net.ParseIP(VTEP)
+	if VTEPIP == nil {
+		klog.Warningf("failed parse a valid vtep ip address from %v: %v", VTEP, err)
+		return fmt.Errorf("failed to validate a valid vtep ip address %s: %v", VTEP, err)
 	}
-	namespaceVTEP := namespaceVTEPIP.String()
+
+	// It's always safe to ignore the learn flow as we only process and add or update
+	// if the IP/MAC or Annotations have changed
+	ignoreLearn := true
+
 	if !n.initialized {
 		node, err := n.wf.GetNode(n.nodeName)
 		if err != nil {
@@ -160,23 +137,23 @@ func (n *NodeController) addOrUpdatePod(pod *kapi.Pod, ignoreLearn bool) error {
 				"actions=set_field:%s->eth_src,set_field:%s->eth_dst,output:ext",
 			cookie, podIP.IP, n.drMAC.String(), podMAC))
 
-		if namespaceExternalGwRaw == "" || namespaceVTEPRaw == "" {
+		if externalGw == "" || VTEP == "" {
 			klog.Infof("Hybrid Overlay Gateway mode not enabled for pod %s, namespace does not have hybrid"+
-				"annotations, external gw: %s, VTEP: %s", pod.Name, namespaceVTEPRaw, namespaceVTEPRaw)
+				"annotations, external gw: %s, VTEP: %s", pod.Name, externalGw, VTEP)
 			n.updateFlowCacheEntry(cookie, flows, ignoreLearn)
 			continue
 		}
 
 		portMACRaw := strings.Replace(n.drMAC.String(), ":", "", -1)
-		vtepIPRaw := getIPAsHexString(namespaceVTEPIP)
+		vtepIPRaw := getIPAsHexString(VTEPIP)
 
 		// update map for tun to pod
 		n.tunMapMutex.Lock()
-		n.tunMap[podIP.IP.String()] = namespaceVTEP
+		n.tunMap[podIP.IP.String()] = VTEP
 		// iterate and find all pods that belong to this VTEP and create learn actions
 		learnActions := ""
 		for pod, tun := range n.tunMap {
-			if tun == namespaceVTEP {
+			if tun == VTEP {
 				if len(learnActions) > 0 {
 					learnActions += ","
 				}
@@ -198,10 +175,10 @@ func (n *NodeController) addOrUpdatePod(pod *kapi.Pod, ignoreLearn bool) error {
 		// so need proper locking around tunMap
 		// after learning actions, we need to resubmit the flow to the gw arp response table (2) so that we can respond
 		// back if this was an arp request
-		tunCookie := podIPToCookie(namespaceVTEPIP)
+		tunCookie := podIPToCookie(VTEPIP)
 		tunFlow := fmt.Sprintf("table=0,cookie=0x%s,priority=120,in_port=%s,arp,arp_spa=%s,tun_src=%s,"+
 			"actions=%s,resubmit(,2)",
-			tunCookie, extVXLANName, namespaceExternalGw, namespaceVTEP, learnActions)
+			tunCookie, extVXLANName, externalGw, VTEP, learnActions)
 		n.updateFlowCacheEntry(tunCookie, []string{tunFlow}, false)
 		n.tunMapMutex.Unlock()
 
@@ -228,8 +205,8 @@ func (n *NodeController) addOrUpdatePod(pod *kapi.Pod, ignoreLearn bool) error {
 				"load:%d->NXM_NX_TUN_ID[0..31],"+
 				"set_field:%s->tun_dst,"+
 				"output:%s",
-				cookie, podIP.IP, n.drMAC.String(), n.drMAC.String(), n.drIP, namespaceExternalGw, hotypes.HybridOverlayVNI,
-				namespaceVTEP, extVXLANName))
+				cookie, podIP.IP, n.drMAC.String(), n.drMAC.String(), n.drIP, externalGw, hotypes.HybridOverlayVNI,
+				VTEP, extVXLANName))
 		n.updateFlowCacheEntry(cookie, flows, ignoreLearn)
 	}
 	n.requestFlowSync()
@@ -297,27 +274,18 @@ func getPodDetails(pod *kapi.Pod, nodeName string) ([]*net.IPNet, net.HardwareAd
 func podChanged(pod1 *kapi.Pod, pod2 *kapi.Pod, nodeName string) bool {
 	podIPs1, mac1, _ := getPodDetails(pod1, nodeName)
 	podIPs2, mac2, _ := getPodDetails(pod2, nodeName)
+	podExGw1 := pod1.Annotations[hotypes.HybridOverlayExternalGw]
+	podVTEP1 := pod1.Annotations[hotypes.HybridOverlayVTEP]
+	podExGw2 := pod2.Annotations[hotypes.HybridOverlayExternalGw]
+	podVTEP2 := pod2.Annotations[hotypes.HybridOverlayVTEP]
 
-	if len(podIPs1) != len(podIPs2) || !reflect.DeepEqual(mac1, mac2) {
+	if len(podIPs1) != len(podIPs2) || !reflect.DeepEqual(mac1, mac2) || !reflect.DeepEqual(podExGw1, podExGw2) || !reflect.DeepEqual(podVTEP1, podVTEP2) {
 		return true
 	}
 	for i := range podIPs1 {
 		if podIPs1[i].String() != podIPs2[i].String() {
 			return true
 		}
-	}
-	return false
-}
-
-// nsHybridAnnotationChanged returns true if any relevant NS attributes changed
-func nsHybridAnnotationChanged(ns1 *kapi.Namespace, ns2 *kapi.Namespace) bool {
-	nsExGw1 := ns1.GetAnnotations()[hotypes.HybridOverlayExternalGw]
-	nsVTEP1 := ns1.GetAnnotations()[hotypes.HybridOverlayVTEP]
-	nsExGw2 := ns2.GetAnnotations()[hotypes.HybridOverlayExternalGw]
-	nsVTEP2 := ns2.GetAnnotations()[hotypes.HybridOverlayVTEP]
-
-	if nsExGw1 != nsExGw2 || nsVTEP1 != nsVTEP2 {
-		return true
 	}
 	return false
 }
@@ -355,7 +323,7 @@ func (n *NodeController) startPodWatch(wf *factory.WatchFactory) error {
 	_, err := wf.AddPodHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
-			if err := n.addOrUpdatePod(pod, false); err != nil {
+			if err := n.addOrUpdatePod(pod); err != nil {
 				klog.Warningf("failed to handle pod %v addition: %v", pod, err)
 			}
 		},
@@ -363,7 +331,7 @@ func (n *NodeController) startPodWatch(wf *factory.WatchFactory) error {
 			podNew := newer.(*kapi.Pod)
 			podOld := old.(*kapi.Pod)
 			if podChanged(podOld, podNew, n.nodeName) {
-				if err := n.addOrUpdatePod(podNew, false); err != nil {
+				if err := n.addOrUpdatePod(podNew); err != nil {
 					klog.Warningf("failed to handle pod %v update: %v", podNew, err)
 				}
 			}
@@ -382,30 +350,18 @@ func (n *NodeController) startNamespaceWatch(wf *factory.WatchFactory) error {
 	n.wf = wf
 	_, err := wf.AddNamespaceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			// dont care about namespace addition, we already wait for the annotation
+			// don't care about namespace add, masters controllers will update annotations
 		},
 		UpdateFunc: func(old, newer interface{}) {
 			nsNew := newer.(*kapi.Namespace)
 			nsOld := old.(*kapi.Namespace)
-
 			if nsHybridAnnotationChanged(nsOld, nsNew) {
 				// tunnel is unique per NS, if there is an annotation change, delete old tunnel flow
 				oldTunCookie := podIPToCookie(net.ParseIP(nsOld.Annotations[hotypes.HybridOverlayVTEP]))
 				if len(oldTunCookie) > 0 {
 					n.deleteFlowsByCookie(oldTunCookie)
 				}
-				pods, err := wf.GetPods(nsNew.Namespace)
-				if err != nil {
-					klog.Errorf("failed to get pods for NS update in hybrid overlay: %v", err)
-				}
-				for _, pod := range pods {
-					// we need to ignore learning cookie flow from table 20 during this pod update
-					// this is because the VTEP/GW may have changed, and now we need to get rid of the
-					// corresponding table 20 flow and not cache it
-					if err := n.addOrUpdatePod(pod, true); err != nil {
-						klog.Warningf("failed to handle pod %v update: %v", pod, err)
-					}
-				}
+				// master controllers will update annotations, pod updates will get picked up later
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -415,9 +371,8 @@ func (n *NodeController) startNamespaceWatch(wf *factory.WatchFactory) error {
 	return err
 }
 
-func (n *NodeController) Sync(objs []*kapi.Node) {
-	//just needed to implement the interface
-}
+// Sync is not needed but must be implemented to fulfill the interface
+func (n *NodeController) Sync(objs []*kapi.Node) {}
 
 func (n *NodeController) startNodeWatch(wf *factory.WatchFactory) error {
 	return houtil.StartNodeWatch(n, wf)

--- a/go-controller/hybrid-overlay/pkg/types/types.go
+++ b/go-controller/hybrid-overlay/pkg/types/types.go
@@ -11,10 +11,10 @@ const (
 	HybridOverlayNodeSubnet = HybridOverlayAnnotationBase + "node-subnet"
 	// HybridOverlayDRMAC holds the MAC address of the Distributed Router/gateway
 	HybridOverlayDRMAC = HybridOverlayAnnotationBase + "distributed-router-gateway-mac"
-	// HybridOverlayExternalGW is a namespace annotation that holds the IP address of the external gateway to route default traffic
+	// HybridOverlayExternalGw is a namespace annotation that holds the IP address of the external gateway to route default traffic
 	HybridOverlayExternalGw = HybridOverlayAnnotationBase + "external-gw"
-	HybridOverlayVTEP       = HybridOverlayAnnotationBase + "vtep"
-
+	// HybridOverlayVTEP is a namespace annotation that holds the IP address of the VTEP
+	HybridOverlayVTEP = HybridOverlayAnnotationBase + "vtep"
 	// HybridOverlayVNI is the VNI for VXLAN tunnels between nodes/endpoints
 	HybridOverlayVNI = 4097
 )

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,4 +86,18 @@ func StartNodeWatch(h types.NodeHandler, wf *factory.WatchFactory) error {
 		},
 	}, nil)
 	return err
+}
+
+// CopyNamespaceAnnotationsToPod copies annotations from a namespace to a pod
+func CopyNamespaceAnnotationsToPod(k kube.Interface, ns *kapi.Namespace, pod *kapi.Pod) error {
+	nsGw := ns.Annotations[types.HybridOverlayExternalGw]
+	nsVTEP := ns.Annotations[types.HybridOverlayVTEP]
+	annotator := kube.NewPodAnnotator(k, pod)
+	if err := annotator.Set(types.HybridOverlayExternalGw, nsGw); err != nil {
+		return err
+	}
+	if err := annotator.Set(types.HybridOverlayVTEP, nsVTEP); err != nil {
+		return err
+	}
+	return annotator.Run()
 }

--- a/go-controller/pkg/kube/annotator.go
+++ b/go-controller/pkg/kube/annotator.go
@@ -17,7 +17,7 @@ type Annotator interface {
 }
 
 // FailureHandlerFn is a function called when adding an annotation fails
-type FailureHandlerFn func(node *kapi.Node, key string, val interface{})
+type FailureHandlerFn func(obj interface{}, key string, val interface{})
 
 type action struct {
 	key     string
@@ -97,6 +97,160 @@ func (na *nodeAnnotator) Run() error {
 		for _, act := range na.changes {
 			if act.failFn != nil {
 				act.failFn(na.node, act.key, act.origVal)
+			}
+		}
+	}
+	return err
+}
+
+// NewPodAnnotator returns a new annotator for Pod objects
+func NewPodAnnotator(kube Interface, pod *kapi.Pod) Annotator {
+	return &podAnnotator{
+		kube:    kube,
+		pod:     pod,
+		changes: make(map[string]*action),
+	}
+}
+
+type podAnnotator struct {
+	kube Interface
+	pod  *kapi.Pod
+
+	changes map[string]*action
+}
+
+func (pa *podAnnotator) Set(key string, val interface{}) error {
+	return pa.SetWithFailureHandler(key, val, nil)
+}
+
+func (pa *podAnnotator) SetWithFailureHandler(key string, val interface{}, failFn FailureHandlerFn) error {
+	act := &action{
+		key:     key,
+		origVal: val,
+		failFn:  failFn,
+	}
+	if val != nil {
+		// Annotations must be either a valid string value or nil; coerce
+		// any non-empty values to string
+		if reflect.TypeOf(val).Kind() == reflect.String {
+			act.val = val.(string)
+		} else {
+			bytes, err := json.Marshal(val)
+			if err != nil {
+				return fmt.Errorf("failed to marshal %q value %v to string: %v", key, val, err)
+			}
+			act.val = string(bytes)
+		}
+	}
+	pa.changes[key] = act
+	return nil
+}
+
+func (pa *podAnnotator) Delete(key string) {
+	pa.changes[key] = &action{key: key}
+}
+
+func (pa *podAnnotator) Run() error {
+	annotations := make(map[string]string)
+	for k, act := range pa.changes {
+		// Ignore annotations that already exist with the same value
+		if existing, ok := pa.pod.Annotations[k]; existing != act.val || !ok {
+			if act.origVal != nil {
+				// Annotation should be updated to new value
+				annotations[k] = act.val
+			} else {
+				// Annotation should be deleted
+				annotations[k] = ""
+			}
+		}
+	}
+	if len(annotations) == 0 {
+		return nil
+	}
+
+	err := pa.kube.SetAnnotationsOnPod(pa.pod, annotations)
+	if err != nil {
+		// Let failure handlers clean up
+		for _, act := range pa.changes {
+			if act.failFn != nil {
+				act.failFn(pa.pod, act.key, act.origVal)
+			}
+		}
+	}
+	return err
+}
+
+// NewNamespaceAnnotator returns a new annotator for Namespace objects
+func NewNamespaceAnnotator(kube Interface, namespace *kapi.Namespace) Annotator {
+	return &namespaceAnnotator{
+		kube:      kube,
+		namespace: namespace,
+		changes:   make(map[string]*action),
+	}
+}
+
+type namespaceAnnotator struct {
+	kube      Interface
+	namespace *kapi.Namespace
+
+	changes map[string]*action
+}
+
+func (na *namespaceAnnotator) Set(key string, val interface{}) error {
+	return na.SetWithFailureHandler(key, val, nil)
+}
+
+func (na *namespaceAnnotator) SetWithFailureHandler(key string, val interface{}, failFn FailureHandlerFn) error {
+	act := &action{
+		key:     key,
+		origVal: val,
+		failFn:  failFn,
+	}
+	if val != nil {
+		// Annotations must be either a valid string value or nil; coerce
+		// any non-empty values to string
+		if reflect.TypeOf(val).Kind() == reflect.String {
+			act.val = val.(string)
+		} else {
+			bytes, err := json.Marshal(val)
+			if err != nil {
+				return fmt.Errorf("failed to marshal %q value %v to string: %v", key, val, err)
+			}
+			act.val = string(bytes)
+		}
+	}
+	na.changes[key] = act
+	return nil
+}
+
+func (na *namespaceAnnotator) Delete(key string) {
+	na.changes[key] = &action{key: key}
+}
+
+func (na *namespaceAnnotator) Run() error {
+	annotations := make(map[string]string)
+	for k, act := range na.changes {
+		// Ignore annotations that already exist with the same value
+		if existing, ok := na.namespace.Annotations[k]; existing != act.val || !ok {
+			if act.origVal != nil {
+				// Annotation should be updated to new value
+				annotations[k] = act.val
+			} else {
+				// Annotation should be deleted
+				annotations[k] = ""
+			}
+		}
+	}
+	if len(annotations) == 0 {
+		return nil
+	}
+
+	err := na.kube.SetAnnotationsOnNamespace(na.namespace, annotations)
+	if err != nil {
+		// Let failure handlers clean up
+		for _, act := range na.changes {
+			if act.failFn != nil {
+				act.failFn(na.namespace, act.key, act.origVal)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

Copies External Gateway namespace annotations on to pods, as this is where they are actually consumed. This may enable us to avoid a) waiting for the namespace to be available before processing pod updates, b) having namespace update code calling `addOrUpdatePod` in sequence as it could potentially cause races, lock contention and it's not threaded (neither are pod updates for now but they are likely to be in future).


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
There are no tests so this will need manual verification that existing behaviour is preserved before merge.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
:man_shrugging: 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->