### PR TITLE
NextIP should properly convert IPv4 and IPv6 with leading 0

### DIFF
--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -12,19 +12,19 @@ import (
 
 // NextIP returns IP incremented by 1
 func NextIP(ip net.IP) net.IP {
-	i := ipToInt(ip)
-	return intToIP(i.Add(i, big.NewInt(1)))
-}
-
-func ipToInt(ip net.IP) *big.Int {
-	if v := ip.To4(); v != nil {
-		return big.NewInt(0).SetBytes(v)
+	byteSize := 0
+	v := ip.To4()
+	if v != nil {
+		byteSize = 4
+	} else {
+		v = ip.To16()
+		byteSize = 16
 	}
-	return big.NewInt(0).SetBytes(ip.To16())
-}
-
-func intToIP(i *big.Int) net.IP {
-	return net.IP(i.Bytes())
+	i := big.NewInt(0).SetBytes(v)
+	i.Add(i, big.NewInt(1))
+	bytes := make([]byte, byteSize)
+	copy(bytes[len(bytes)-len(i.Bytes()):], i.Bytes())
+	return net.IP(bytes)
 }
 
 // GetPortAddresses returns the MAC and IP of the given logical switch port

--- a/go-controller/pkg/util/net_test.go
+++ b/go-controller/pkg/util/net_test.go
@@ -180,4 +180,47 @@ var _ = Describe("Util tests", func() {
 			Expect(result).To(Equal(tc.out), " test case \"%s\" returned wrong results for %#v", tc.name, tc.cidrs)
 		}
 	})
+
+	It("test NextIP", func() {
+		type testCase struct {
+			testIP     string
+			expectedIP string
+		}
+		for _, tc := range []testCase{
+			{
+				testIP:     "192.168.126.125",
+				expectedIP: "192.168.126.126",
+			},
+			{
+				testIP:     "0.0.0.0",
+				expectedIP: "0.0.0.1",
+			},
+			{
+				testIP:     "0:0:1:0:0:feff:c0a8:8e56",
+				expectedIP: "0:0:1:0:0:feff:c0a8:8e57",
+			},
+			{
+				testIP:     "0:0:0:0:0:feff:c0a8:8e56",
+				expectedIP: "0:0:0:0:0:feff:c0a8:8e57",
+			},
+			{
+				testIP:     "d:0:0:0:0:feff:c0a8:8e56",
+				expectedIP: "d:0:0:0:0:feff:c0a8:8e57",
+			},
+			{
+				testIP:     "::feff:c0a8:8e54",
+				expectedIP: "::feff:c0a8:8e55",
+			},
+			{
+				testIP:     "f::feff:c0a8:8e54",
+				expectedIP: "f::feff:c0a8:8e55",
+			},
+		} {
+			ip := net.ParseIP(tc.testIP)
+			actualIP := NextIP(ip)
+			expectedIP := net.ParseIP(tc.expectedIP)
+			Expect(actualIP.String()).To(Equal(expectedIP.String()))
+		}
+	})
+
 })


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

During my implementation of EgressIP I noticied incorrectly computed next IPs for IP addresses with leading 0s. This fixes that

/cc @danwinship 

<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->