### PR TITLE
ovn: add multiple pod IPs to port cache

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -47,7 +47,8 @@ func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
 	}
 	defer nsInfo.Unlock()
 
-	if err := nsInfo.addressSet.AddIP(portInfo.ip); err != nil {
+	// DUAL-STACK FIXME: handle multiple IPs
+	if err := nsInfo.addressSet.AddIP(portInfo.ips[0]); err != nil {
 		return err
 	}
 
@@ -69,7 +70,8 @@ func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) error 
 	}
 	defer nsInfo.Unlock()
 
-	if err := nsInfo.addressSet.DeleteIP(portInfo.ip); err != nil {
+	// DUAL-STACK FIXME: handle multiple IPs
+	if err := nsInfo.addressSet.DeleteIP(portInfo.ips[0]); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -1,6 +1,8 @@
 package ovn
 
 import (
+	"net"
+
 	"github.com/urfave/cli/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -83,7 +85,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 					},
 				)
 				podMAC := ovntest.MustParseMAC(tP.podMAC)
-				fakeOvn.controller.logicalPortCache.add(tP.nodeName, tP.portName, fakeUUID, podMAC, ovntest.MustParseIP(tP.podIP))
+				fakeOvn.controller.logicalPortCache.add(tP.nodeName, tP.portName, fakeUUID, podMAC, []net.IP{ovntest.MustParseIP(tP.podIP)})
 				fakeOvn.controller.WatchNamespaces()
 
 				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})

--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -19,7 +19,7 @@ type lpInfo struct {
 	name          string
 	uuid          string
 	logicalSwitch string
-	ip            net.IP
+	ips           []net.IP
 	mac           net.HardwareAddr
 	// expires, if non-nil, indicates that this object is scheduled to be
 	// removed at the given time
@@ -42,14 +42,14 @@ func (c *portCache) get(logicalPort string) (*lpInfo, error) {
 	return nil, fmt.Errorf("logical port %s not found in cache", logicalPort)
 }
 
-func (c *portCache) add(logicalSwitch, logicalPort, uuid string, mac net.HardwareAddr, ip net.IP) *lpInfo {
+func (c *portCache) add(logicalSwitch, logicalPort, uuid string, mac net.HardwareAddr, ips []net.IP) *lpInfo {
 	c.Lock()
 	defer c.Unlock()
 	portInfo := &lpInfo{
 		logicalSwitch: logicalSwitch,
 		name:          logicalPort,
 		uuid:          uuid,
-		ip:            ip,
+		ips:           ips,
 		mac:           mac,
 	}
 	klog.V(5).Infof("port-cache(%s): added port %+v", logicalPort, portInfo)

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -27,7 +27,7 @@ func intToIP(i *big.Int) net.IP {
 	return net.IP(i.Bytes())
 }
 
-// GetPortAddresses returns the MAC and IP of the given logical switch port
+// GetPortAddresses returns the MAC and IPs of the given logical switch port
 func GetPortAddresses(portName string) (net.HardwareAddr, []net.IP, error) {
 	out, stderr, err := RunOVNNbctl("get", "logical_switch_port", portName, "dynamic_addresses", "addresses")
 	if err != nil {


### PR DESCRIPTION
fairly minimal; just pushes the "dual-stack barrier" from one side of the port cache to the other...

(note, if #1372 merges first the test case change here should be updated to match that)