### PR TITLE
ip allocator and subnet allocator changes

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/allocator"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/subnetallocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -21,17 +21,17 @@ import (
 // MasterController is the master hybrid overlay controller
 type MasterController struct {
 	kube      kube.Interface
-	allocator *allocator.SubnetAllocator
+	allocator *subnetallocator.SubnetAllocator
 }
 
 // NewMaster a new master controller that listens for node events
 func NewMaster(kube kube.Interface) (*MasterController, error) {
 	m := &MasterController{
 		kube:      kube,
-		allocator: allocator.NewSubnetAllocator(),
+		allocator: subnetallocator.NewSubnetAllocator(),
 	}
 
-	// Add our hybrid overlay CIDRs to the allocator
+	// Add our hybrid overlay CIDRs to the subnetallocator
 	for _, clusterEntry := range config.HybridOverlay.ClusterSubnets {
 		err := m.allocator.AddNetworkRange(clusterEntry.CIDR, 32-clusterEntry.HostSubnetLength)
 		if err != nil {

--- a/go-controller/pkg/ovn/ipallocator/allocator.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipallocator
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator/allocator"
+)
+
+// Interface manages the allocation of IP addresses out of a range. Interface
+// should be threadsafe.
+type Interface interface {
+	Allocate(net.IP) error
+	AllocateNext() (net.IP, error)
+	Release(net.IP) error
+	ForEach(func(net.IP))
+	CIDR() net.IPNet
+
+	// For testing
+	Has(ip net.IP) bool
+}
+
+var (
+	ErrFull              = errors.New("range is full")
+	ErrAllocated         = errors.New("provided IP is already allocated")
+	ErrMismatchedNetwork = errors.New("the provided network does not match the current range")
+)
+
+type ErrNotInRange struct {
+	ValidRange string
+}
+
+func (e *ErrNotInRange) Error() string {
+	return fmt.Sprintf("provided IP is not in the valid range. The range of valid IPs is %s", e.ValidRange)
+}
+
+// Range is a contiguous block of IPs that can be allocated atomically.
+//
+// The internal structure of the range is:
+//
+//   For CIDR 10.0.0.0/24
+//   254 addresses usable out of 256 total (minus base and broadcast IPs)
+//     The number of usable addresses is r.max
+//
+//   CIDR base IP          CIDR broadcast IP
+//   10.0.0.0                     10.0.0.255
+//   |                                     |
+//   0 1 2 3 4 5 ...         ... 253 254 255
+//     |                              |
+//   r.base                     r.base + r.max
+//     |                              |
+//   offset #0 of r.allocated   last offset of r.allocated
+type Range struct {
+	net *net.IPNet
+	// base is a cached version of the start IP in the CIDR range as a *big.Int
+	base *big.Int
+	// max is the maximum size of the usable addresses in the range
+	max int
+
+	alloc allocator.Interface
+}
+
+// NewAllocatorCIDRRange creates a Range over a net.IPNet, calling allocatorFactory to construct the backing store.
+func NewAllocatorCIDRRange(cidr *net.IPNet, allocatorFactory allocator.AllocatorFactory) (*Range, error) {
+	max := RangeSize(cidr)
+	base := bigForIP(cidr.IP)
+	rangeSpec := cidr.String()
+
+	r := Range{
+		net:  cidr,
+		base: base.Add(base, big.NewInt(1)), // don't use the network base
+		max:  maximum(0, int(max-2)),        // don't use the network broadcast,
+	}
+	var err error
+	r.alloc, err = allocatorFactory(r.max, rangeSpec)
+	return &r, err
+}
+
+// Helper that wraps NewAllocatorCIDRRange, for creating a range backed by an in-memory store.
+func NewCIDRRange(cidr *net.IPNet) (*Range, error) {
+	return NewAllocatorCIDRRange(cidr, func(max int, rangeSpec string) (allocator.Interface, error) {
+		return allocator.NewAllocationMap(max, rangeSpec), nil
+	})
+}
+
+func maximum(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// Free returns the count of IP addresses left in the range.
+func (r *Range) Free() int {
+	return r.alloc.Free()
+}
+
+// Used returns the count of IP addresses used in the range.
+func (r *Range) Used() int {
+	return r.max - r.alloc.Free()
+}
+
+// CIDR returns the CIDR covered by the range.
+func (r *Range) CIDR() net.IPNet {
+	return *r.net
+}
+
+// Allocate attempts to reserve the provided IP. ErrNotInRange or
+// ErrAllocated will be returned if the IP is not valid for this range
+// or has already been reserved.  ErrFull will be returned if there
+// are no addresses left.
+func (r *Range) Allocate(ip net.IP) error {
+	ok, offset := r.contains(ip)
+	if !ok {
+		return &ErrNotInRange{r.net.String()}
+	}
+
+	allocated, err := r.alloc.Allocate(offset)
+	if err != nil {
+		return err
+	}
+	if !allocated {
+		return ErrAllocated
+	}
+	return nil
+}
+
+// AllocateNext reserves one of the IPs from the pool. ErrFull may
+// be returned if there are no addresses left.
+func (r *Range) AllocateNext() (net.IP, error) {
+	offset, ok, err := r.alloc.AllocateNext()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrFull
+	}
+	return addIPOffset(r.base, offset), nil
+}
+
+// Release releases the IP back to the pool. Releasing an
+// unallocated IP or an IP out of the range is a no-op and
+// returns no error.
+func (r *Range) Release(ip net.IP) error {
+	ok, offset := r.contains(ip)
+	if !ok {
+		return nil
+	}
+
+	return r.alloc.Release(offset)
+}
+
+// ForEach calls the provided function for each allocated IP.
+func (r *Range) ForEach(fn func(net.IP)) {
+	r.alloc.ForEach(func(offset int) {
+		ip, _ := GetIndexedIP(r.net, offset+1) // +1 because Range doesn't store IP 0
+		fn(ip)
+	})
+}
+
+// Has returns true if the provided IP is already allocated and a call
+// to Allocate(ip) would fail with ErrAllocated.
+func (r *Range) Has(ip net.IP) bool {
+	ok, offset := r.contains(ip)
+	if !ok {
+		return false
+	}
+
+	return r.alloc.Has(offset)
+}
+
+// contains returns true and the offset if the ip is in the range, and false
+// and nil otherwise. The first and last addresses of the CIDR are omitted.
+func (r *Range) contains(ip net.IP) (bool, int) {
+	if !r.net.Contains(ip) {
+		return false, 0
+	}
+
+	offset := calculateIPOffset(r.base, ip)
+	if offset < 0 || offset >= r.max {
+		return false, 0
+	}
+	return true, offset
+}
+
+// bigForIP creates a big.Int based on the provided net.IP
+func bigForIP(ip net.IP) *big.Int {
+	b := ip.To4()
+	if b == nil {
+		b = ip.To16()
+	}
+	return big.NewInt(0).SetBytes(b)
+}
+
+// addIPOffset adds the provided integer offset to a base big.Int representing a
+// net.IP
+func addIPOffset(base *big.Int, offset int) net.IP {
+	return net.IP(big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes())
+}
+
+// calculateIPOffset calculates the integer offset of ip from base such that
+// base + offset = ip. It requires ip >= base.
+func calculateIPOffset(base *big.Int, ip net.IP) int {
+	return int(big.NewInt(0).Sub(bigForIP(ip), base).Int64())
+}
+
+// RangeSize returns the size of a range in valid addresses.
+func RangeSize(subnet *net.IPNet) int64 {
+	ones, bits := subnet.Mask.Size()
+	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
+		return 0
+	}
+	// For IPv6, the max size will be limited to 65536
+	// This is due to the allocator keeping track of all the
+	// allocated IP's in a bitmap. This will keep the size of
+	// the bitmap to 64k.
+	if bits == 128 && (bits-ones) >= 16 {
+		return int64(1) << uint(16)
+	} else {
+		return int64(1) << uint(bits-ones)
+	}
+}
+
+// GetIndexedIP returns a net.IP that is subnet.IP + index in the contiguous IP space.
+func GetIndexedIP(subnet *net.IPNet, index int) (net.IP, error) {
+	ip := addIPOffset(bigForIP(subnet.IP), index)
+	if !subnet.Contains(ip) {
+		return nil, fmt.Errorf("can't generate IP with index %d from subnet. subnet too small. subnet: %q", index, subnet)
+	}
+	return ip, nil
+}

--- a/go-controller/pkg/ovn/ipallocator/allocator/bitmap.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/bitmap.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import (
+	"errors"
+	"math/big"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// AllocationBitmap is a contiguous block of resources that can be allocated atomically.
+//
+// Each resource has an offset.  The internal structure is a bitmap, with a bit for each offset.
+//
+// If a resource is taken, the bit at that offset is set to one.
+// r.count is always equal to the number of set bits and can be recalculated at any time
+// by counting the set bits in r.allocated.
+//
+// TODO: use RLE and compact the allocator to minimize space.
+type AllocationBitmap struct {
+	// strategy carries the details of how to choose the next available item out of the range
+	strategy bitAllocator
+	// max is the maximum size of the usable items in the range
+	max int
+	// rangeSpec is the range specifier, matching RangeAllocation.Range
+	rangeSpec string
+
+	// lock guards the following members
+	lock sync.Mutex
+	// count is the number of currently allocated elements in the range
+	count int
+	// allocated is a bit array of the allocated items in the range
+	allocated *big.Int
+}
+
+// AllocationBitmap implements Interface and Snapshottable
+var _ Interface = &AllocationBitmap{}
+var _ Snapshottable = &AllocationBitmap{}
+
+// bitAllocator represents a search strategy in the allocation map for a valid item.
+type bitAllocator interface {
+	AllocateBit(allocated *big.Int, max, count int) (int, bool)
+}
+
+// NewAllocationMap creates an allocation bitmap using the random scan strategy.
+func NewAllocationMap(max int, rangeSpec string) *AllocationBitmap {
+	a := AllocationBitmap{
+		strategy: randomScanStrategy{
+			rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+		},
+		allocated: big.NewInt(0),
+		count:     0,
+		max:       max,
+		rangeSpec: rangeSpec,
+	}
+	return &a
+}
+
+// NewContiguousAllocationMap creates an allocation bitmap using the contiguous scan strategy.
+func NewContiguousAllocationMap(max int, rangeSpec string) *AllocationBitmap {
+	a := AllocationBitmap{
+		strategy:  contiguousScanStrategy{},
+		allocated: big.NewInt(0),
+		count:     0,
+		max:       max,
+		rangeSpec: rangeSpec,
+	}
+	return &a
+}
+
+// Allocate attempts to reserve the provided item.
+// Returns true if it was allocated, false if it was already in use
+func (r *AllocationBitmap) Allocate(offset int) (bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.allocated.Bit(offset) == 1 {
+		return false, nil
+	}
+	r.allocated = r.allocated.SetBit(r.allocated, offset, 1)
+	r.count++
+	return true, nil
+}
+
+// AllocateNext reserves one of the items from the pool.
+// (0, false, nil) may be returned if there are no items left.
+func (r *AllocationBitmap) AllocateNext() (int, bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	next, ok := r.strategy.AllocateBit(r.allocated, r.max, r.count)
+	if !ok {
+		return 0, false, nil
+	}
+	r.count++
+	r.allocated = r.allocated.SetBit(r.allocated, next, 1)
+	return next, true, nil
+}
+
+// Release releases the item back to the pool. Releasing an
+// unallocated item or an item out of the range is a no-op and
+// returns no error.
+func (r *AllocationBitmap) Release(offset int) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.allocated.Bit(offset) == 0 {
+		return nil
+	}
+
+	r.allocated = r.allocated.SetBit(r.allocated, offset, 0)
+	r.count--
+	return nil
+}
+
+const (
+	// Find the size of a big.Word in bytes.
+	notZero   = uint64(^big.Word(0))
+	wordPower = (notZero>>8)&1 + (notZero>>16)&1 + (notZero>>32)&1
+	wordSize  = 1 << wordPower
+)
+
+// ForEach calls the provided function for each allocated bit.  The
+// AllocationBitmap may not be modified while this loop is running.
+func (r *AllocationBitmap) ForEach(fn func(int)) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	words := r.allocated.Bits()
+	for wordIdx, word := range words {
+		bit := 0
+		for word > 0 {
+			if (word & 1) != 0 {
+				fn((wordIdx * wordSize * 8) + bit)
+				word = word &^ 1
+			}
+			bit++
+			word = word >> 1
+		}
+	}
+}
+
+// Has returns true if the provided item is already allocated and a call
+// to Allocate(offset) would fail.
+func (r *AllocationBitmap) Has(offset int) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.allocated.Bit(offset) == 1
+}
+
+// Free returns the count of items left in the range.
+func (r *AllocationBitmap) Free() int {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	return r.max - r.count
+}
+
+// Snapshot saves the current state of the pool.
+func (r *AllocationBitmap) Snapshot() (string, []byte) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.rangeSpec, r.allocated.Bytes()
+}
+
+// Restore restores the pool to the previously captured state.
+func (r *AllocationBitmap) Restore(rangeSpec string, data []byte) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.rangeSpec != rangeSpec {
+		return errors.New("the provided range does not match the current range")
+	}
+
+	r.allocated = big.NewInt(0).SetBytes(data)
+	r.count = countBits(r.allocated)
+
+	return nil
+}
+
+// randomScanStrategy chooses a random address from the provided big.Int, and then
+// scans forward looking for the next available address (it will wrap the range if
+// necessary).
+type randomScanStrategy struct {
+	rand *rand.Rand
+}
+
+func (rss randomScanStrategy) AllocateBit(allocated *big.Int, max, count int) (int, bool) {
+	if count >= max {
+		return 0, false
+	}
+	offset := rss.rand.Intn(max)
+	for i := 0; i < max; i++ {
+		at := (offset + i) % max
+		if allocated.Bit(at) == 0 {
+			return at, true
+		}
+	}
+	return 0, false
+}
+
+var _ bitAllocator = randomScanStrategy{}
+
+// contiguousScanStrategy tries to allocate starting at 0 and filling in any gaps
+type contiguousScanStrategy struct{}
+
+func (contiguousScanStrategy) AllocateBit(allocated *big.Int, max, count int) (int, bool) {
+	if count >= max {
+		return 0, false
+	}
+	for i := 0; i < max; i++ {
+		if allocated.Bit(i) == 0 {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+var _ bitAllocator = contiguousScanStrategy{}

--- a/go-controller/pkg/ovn/ipallocator/allocator/bitmap_test.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/bitmap_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestAllocate(t *testing.T) {
+	max := 10
+	m := NewAllocationMap(max, "test")
+
+	if _, ok, _ := m.AllocateNext(); !ok {
+		t.Fatalf("unexpected error")
+	}
+	if m.count != 1 {
+		t.Errorf("expect to get %d, but got %d", 1, m.count)
+	}
+	if f := m.Free(); f != max-1 {
+		t.Errorf("expect to get %d, but got %d", max-1, f)
+	}
+}
+
+func TestAllocateMax(t *testing.T) {
+	max := 10
+	m := NewAllocationMap(max, "test")
+	for i := 0; i < max; i++ {
+		if _, ok, _ := m.AllocateNext(); !ok {
+			t.Fatalf("unexpected error")
+		}
+	}
+
+	if _, ok, _ := m.AllocateNext(); ok {
+		t.Errorf("unexpected success")
+	}
+	if f := m.Free(); f != 0 {
+		t.Errorf("expect to get %d, but got %d", 0, f)
+	}
+}
+
+func TestAllocateError(t *testing.T) {
+	m := NewAllocationMap(10, "test")
+	if ok, _ := m.Allocate(3); !ok {
+		t.Errorf("error allocate offset %v", 3)
+	}
+	if ok, _ := m.Allocate(3); ok {
+		t.Errorf("unexpected success")
+	}
+}
+
+func TestRelease(t *testing.T) {
+	offset := 3
+	m := NewAllocationMap(10, "test")
+	if ok, _ := m.Allocate(offset); !ok {
+		t.Errorf("error allocate offset %v", offset)
+	}
+
+	if !m.Has(offset) {
+		t.Errorf("expect offset %v allocated", offset)
+	}
+
+	if err := m.Release(offset); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if m.Has(offset) {
+		t.Errorf("expect offset %v not allocated", offset)
+	}
+}
+
+func TestForEach(t *testing.T) {
+	testCases := []sets.Int{
+		sets.NewInt(),
+		sets.NewInt(0),
+		sets.NewInt(0, 2, 5, 9),
+		sets.NewInt(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+	}
+
+	for i, tc := range testCases {
+		m := NewAllocationMap(10, "test")
+		for offset := range tc {
+			if ok, _ := m.Allocate(offset); !ok {
+				t.Errorf("[%d] error allocate offset %v", i, offset)
+			}
+			if !m.Has(offset) {
+				t.Errorf("[%d] expect offset %v allocated", i, offset)
+			}
+		}
+		calls := sets.NewInt()
+		m.ForEach(func(i int) {
+			calls.Insert(i)
+		})
+		if len(calls) != len(tc) {
+			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
+		}
+		if !calls.Equal(tc) {
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+		}
+	}
+}
+
+func TestSnapshotAndRestore(t *testing.T) {
+	offset := 3
+	m := NewAllocationMap(10, "test")
+	if ok, _ := m.Allocate(offset); !ok {
+		t.Errorf("error allocate offset %v", offset)
+	}
+	spec, bytes := m.Snapshot()
+
+	m2 := NewAllocationMap(10, "test")
+	err := m2.Restore(spec, bytes)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if m2.count != 1 {
+		t.Errorf("expect count to %d, but got %d", 0, m.count)
+	}
+	if !m2.Has(offset) {
+		t.Errorf("expect offset %v allocated", offset)
+	}
+}
+
+func TestContiguousAllocation(t *testing.T) {
+	max := 10
+	m := NewContiguousAllocationMap(max, "test")
+
+	for i := 0; i < max; i++ {
+		next, ok, _ := m.AllocateNext()
+		if !ok {
+			t.Fatalf("unexpected error")
+		}
+		if next != i {
+			t.Fatalf("expect next to %d, but got %d", i, next)
+		}
+	}
+
+	if _, ok, _ := m.AllocateNext(); ok {
+		t.Errorf("unexpected success")
+	}
+}

--- a/go-controller/pkg/ovn/ipallocator/allocator/interfaces.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/interfaces.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+// Interface manages the allocation of items out of a range. Interface
+// should be threadsafe.
+type Interface interface {
+	Allocate(int) (bool, error)
+	AllocateNext() (int, bool, error)
+	Release(int) error
+	ForEach(func(int))
+
+	// For testing
+	Has(int) bool
+
+	// For testing
+	Free() int
+}
+
+// Snapshottable is an Interface that can be snapshotted and restored. Snapshottable
+// should be threadsafe.
+type Snapshottable interface {
+	Interface
+	Snapshot() (string, []byte)
+	Restore(string, []byte) error
+}
+
+type AllocatorFactory func(max int, rangeSpec string) (Interface, error)

--- a/go-controller/pkg/ovn/ipallocator/allocator/utils.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/utils.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import "math/big"
+
+// countBits returns the number of set bits in n
+func countBits(n *big.Int) int {
+	var count int = 0
+	for _, b := range n.Bytes() {
+		count += int(bitCounts[b])
+	}
+	return count
+}
+
+// bitCounts is all of the bits counted for each number between 0-255
+var bitCounts = []int8{
+	0, 1, 1, 2, 1, 2, 2, 3,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	5, 6, 6, 7, 6, 7, 7, 8,
+}

--- a/go-controller/pkg/ovn/ipallocator/allocator/utils_test.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/utils_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestBitCount(t *testing.T) {
+	for i, c := range bitCounts {
+		actual := 0
+		for j := 0; j < 8; j++ {
+			if ((1 << uint(j)) & i) != 0 {
+				actual++
+			}
+		}
+		if actual != int(c) {
+			t.Errorf("%d should have %d bits but recorded as %d", i, actual, c)
+		}
+	}
+}
+
+func TestCountBits(t *testing.T) {
+	tests := []struct {
+		n        *big.Int
+		expected int
+	}{
+		{n: big.NewInt(int64(0)), expected: 0},
+		{n: big.NewInt(int64(0xffffffffff)), expected: 40},
+	}
+	for _, test := range tests {
+		actual := countBits(test.n)
+		if test.expected != actual {
+			t.Errorf("%s should have %d bits but recorded as %d", test.n, test.expected, actual)
+		}
+	}
+}

--- a/go-controller/pkg/ovn/ipallocator/allocator_test.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator_test.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipallocator
+
+import (
+	"net"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestAllocate(t *testing.T) {
+	testCases := []struct {
+		name             string
+		cidr             string
+		free             int
+		released         string
+		outOfRange1      string
+		outOfRange2      string
+		outOfRange3      string
+		alreadyAllocated string
+	}{
+		{
+			name:             "IPv4",
+			cidr:             "192.168.1.0/24",
+			free:             254,
+			released:         "192.168.1.5",
+			outOfRange1:      "192.168.0.1",
+			outOfRange2:      "192.168.1.0",
+			outOfRange3:      "192.168.1.255",
+			alreadyAllocated: "192.168.1.1",
+		},
+		{
+			name:             "IPv6",
+			cidr:             "2001:db8:1::/48",
+			free:             65534,
+			released:         "2001:db8:1::5",
+			outOfRange1:      "2001:db8::1",
+			outOfRange2:      "2001:db8:1::",
+			outOfRange3:      "2001:db8:1::ffff",
+			alreadyAllocated: "2001:db8:1::1",
+		},
+	}
+	for _, tc := range testCases {
+		_, cidr, err := net.ParseCIDR(tc.cidr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		r, err := NewCIDRRange(cidr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("base: %v", r.base.Bytes())
+		if f := r.Free(); f != tc.free {
+			t.Errorf("Test %s unexpected free %d", tc.name, f)
+		}
+
+		rCIDR := r.CIDR()
+		if rCIDR.String() != tc.cidr {
+			t.Errorf("allocator returned a different cidr")
+		}
+
+		if f := r.Used(); f != 0 {
+			t.Errorf("Test %s unexpected used %d", tc.name, f)
+		}
+		found := sets.NewString()
+		count := 0
+		for r.Free() > 0 {
+			ip, err := r.AllocateNext()
+			if err != nil {
+				t.Fatalf("Test %s error @ %d: %v", tc.name, count, err)
+			}
+			count++
+			if !cidr.Contains(ip) {
+				t.Fatalf("Test %s allocated %s which is outside of %s", tc.name, ip, cidr)
+			}
+			if found.Has(ip.String()) {
+				t.Fatalf("Test %s allocated %s twice @ %d", tc.name, ip, count)
+			}
+			found.Insert(ip.String())
+		}
+		if _, err := r.AllocateNext(); err != ErrFull {
+			t.Fatal(err)
+		}
+
+		released := net.ParseIP(tc.released)
+		if err := r.Release(released); err != nil {
+			t.Fatal(err)
+		}
+		if f := r.Free(); f != 1 {
+			t.Errorf("Test %s unexpected free %d", tc.name, f)
+		}
+		if f := r.Used(); f != (tc.free - 1) {
+			t.Errorf("Test %s unexpected free %d", tc.name, f)
+		}
+		ip, err := r.AllocateNext()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !released.Equal(ip) {
+			t.Errorf("Test %s unexpected %s : %s", tc.name, ip, released)
+		}
+
+		if err := r.Release(released); err != nil {
+			t.Fatal(err)
+		}
+		err = r.Allocate(net.ParseIP(tc.outOfRange1))
+		if _, ok := err.(*ErrNotInRange); !ok {
+			t.Fatal(err)
+		}
+		if err := r.Allocate(net.ParseIP(tc.alreadyAllocated)); err != ErrAllocated {
+			t.Fatal(err)
+		}
+		err = r.Allocate(net.ParseIP(tc.outOfRange2))
+		if _, ok := err.(*ErrNotInRange); !ok {
+			t.Fatal(err)
+		}
+		err = r.Allocate(net.ParseIP(tc.outOfRange3))
+		if _, ok := err.(*ErrNotInRange); !ok {
+			t.Fatal(err)
+		}
+		if f := r.Free(); f != 1 {
+			t.Errorf("Test %s unexpected free %d", tc.name, f)
+		}
+		if f := r.Used(); f != (tc.free - 1) {
+			t.Errorf("Test %s unexpected free %d", tc.name, f)
+		}
+		if err := r.Allocate(released); err != nil {
+			t.Fatal(err)
+		}
+		if f := r.Free(); f != 0 {
+			t.Errorf("Test %s unexpected free %d", tc.name, f)
+		}
+		if f := r.Used(); f != tc.free {
+			t.Errorf("Test %s unexpected free %d", tc.name, f)
+		}
+	}
+}
+
+func TestAllocateTiny(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("192.168.1.0/32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewCIDRRange(cidr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f := r.Free(); f != 0 {
+		t.Errorf("free: %d", f)
+	}
+	if _, err := r.AllocateNext(); err != ErrFull {
+		t.Error(err)
+	}
+}
+
+func TestAllocateSmall(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("192.168.1.240/30")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewCIDRRange(cidr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f := r.Free(); f != 2 {
+		t.Errorf("free: %d", f)
+	}
+	found := sets.NewString()
+	for i := 0; i < 2; i++ {
+		ip, err := r.AllocateNext()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if found.Has(ip.String()) {
+			t.Fatalf("already reserved: %s", ip)
+		}
+		found.Insert(ip.String())
+	}
+	for s := range found {
+		if !r.Has(net.ParseIP(s)) {
+			t.Fatalf("missing: %s", s)
+		}
+		if err := r.Allocate(net.ParseIP(s)); err != ErrAllocated {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		if _, err := r.AllocateNext(); err != ErrFull {
+			t.Fatalf("suddenly became not-full: %#v", r)
+		}
+	}
+
+	if r.Free() != 0 && r.max != 2 {
+		t.Fatalf("unexpected range: %v", r)
+	}
+
+	t.Logf("allocated: %v", found)
+}
+
+func TestRangeSize(t *testing.T) {
+	testCases := []struct {
+		name  string
+		cidr  string
+		addrs int64
+	}{
+		{
+			name:  "supported IPv4 cidr",
+			cidr:  "192.168.1.0/24",
+			addrs: 256,
+		},
+		{
+			name:  "supported large IPv4 cidr",
+			cidr:  "10.96.0.0/12",
+			addrs: 1048576,
+		},
+		{
+			name:  "unsupported IPv4 cidr",
+			cidr:  "192.168.1.0/1",
+			addrs: 0,
+		},
+		{
+			name:  "supported IPv6 cidr",
+			cidr:  "2001:db8::/48",
+			addrs: 65536,
+		},
+		{
+			name:  "unsupported IPv6 mask",
+			cidr:  "2001:db8::/1",
+			addrs: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, cidr, err := net.ParseCIDR(tc.cidr)
+		if err != nil {
+			t.Errorf("failed to parse cidr for test %s, unexpected error: '%s'", tc.name, err)
+		}
+		if size := RangeSize(cidr); size != tc.addrs {
+			t.Errorf("test %s failed. %s should have a range size of %d, got %d",
+				tc.name, tc.cidr, tc.addrs, size)
+		}
+	}
+}
+
+func TestForEach(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("192.168.1.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []sets.String{
+		sets.NewString(),
+		sets.NewString("192.168.1.1"),
+		sets.NewString("192.168.1.1", "192.168.1.254"),
+		sets.NewString("192.168.1.1", "192.168.1.128", "192.168.1.254"),
+	}
+
+	for i, tc := range testCases {
+		r, err := NewCIDRRange(cidr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for ips := range tc {
+			ip := net.ParseIP(ips)
+			if err := r.Allocate(ip); err != nil {
+				t.Errorf("[%d] error allocating IP %v: %v", i, ip, err)
+			}
+			if !r.Has(ip) {
+				t.Errorf("[%d] expected IP %v allocated", i, ip)
+			}
+		}
+		calls := sets.NewString()
+		r.ForEach(func(ip net.IP) {
+			calls.Insert(ip.String())
+		})
+		if len(calls) != len(tc) {
+			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
+		}
+		if !calls.Equal(tc) {
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+		}
+	}
+}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -105,8 +105,8 @@ func (oc *Controller) Start(kClient kubernetes.Interface, nodeName string) error
 //  If true, then either quit or perform a complete reconfiguration of the cluster (recreate switches/routers with new subnet values)
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	// The gateway router need to be connected to the distributed router via a per-node join switch.
-	// We need a subnet allocator that allocates subnet for this per-node join switch. Use the 100.64.0.0/16
-	// or fd98::/64 network range with host bits set to 3. The allocator will start allocating subnet that has upto 6
+	// We need a subnetallocator that allocates subnet for this per-node join switch. Use the 100.64.0.0/16
+	// or fd98::/64 network range with host bits set to 3. The subnetallocator will start allocating subnet that has upto 6
 	// host IPs)
 	joinSubnet := config.V4JoinSubnet
 	if config.IPv6Mode {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -105,7 +105,7 @@ func (oc *Controller) Start(kClient kubernetes.Interface, nodeName string) error
 //  If true, then either quit or perform a complete reconfiguration of the cluster (recreate switches/routers with new subnet values)
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	// The gateway router need to be connected to the distributed router via a per-node join switch.
-	// We need a subnetallocator that allocates subnet for this per-node join switch. Use the 100.64.0.0/16
+	// We need a subnet allocator that allocates subnet for this per-node join switch. Use the 100.64.0.0/16
 	// or fd98::/64 network range with host bits set to 3. The subnetallocator will start allocating subnet that has upto 6
 	// host IPs)
 	joinSubnet := config.V4JoinSubnet

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/allocator"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/subnetallocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -77,8 +77,8 @@ type Controller struct {
 	watchFactory *factory.WatchFactory
 	stopChan     <-chan struct{}
 
-	masterSubnetAllocator *allocator.SubnetAllocator
-	joinSubnetAllocator   *allocator.SubnetAllocator
+	masterSubnetAllocator *subnetallocator.SubnetAllocator
+	joinSubnetAllocator   *subnetallocator.SubnetAllocator
 
 	TCPLoadBalancerUUID  string
 	UDPLoadBalancerUUID  string
@@ -169,9 +169,9 @@ func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory,
 		kube:                     &kube.Kube{KClient: kubeClient},
 		watchFactory:             wf,
 		stopChan:                 stopChan,
-		masterSubnetAllocator:    allocator.NewSubnetAllocator(),
+		masterSubnetAllocator:    subnetallocator.NewSubnetAllocator(),
 		logicalSwitchCache:       make(map[string][]*net.IPNet),
-		joinSubnetAllocator:      allocator.NewSubnetAllocator(),
+		joinSubnetAllocator:      subnetallocator.NewSubnetAllocator(),
 		logicalPortCache:         newPortCache(stopChan),
 		namespaces:               make(map[string]*namespaceInfo),
 		namespacesMutex:          sync.Mutex{},

--- a/go-controller/pkg/ovn/subnetallocator/allocator.go
+++ b/go-controller/pkg/ovn/subnetallocator/allocator.go
@@ -1,4 +1,4 @@
-package allocator
+package subnetallocator
 
 import (
 	"fmt"

--- a/go-controller/pkg/ovn/subnetallocator/allocator_test.go
+++ b/go-controller/pkg/ovn/subnetallocator/allocator_test.go
@@ -1,4 +1,4 @@
-package allocator
+package subnetallocator
 
 import (
 	"fmt"
@@ -293,7 +293,7 @@ func TestAllocateSubnetInvalidHostBitsOrCIDR(t *testing.T) {
 func TestMarkAllocatedNetwork(t *testing.T) {
 	sna, err := newSubnetAllocator("10.1.0.0/16", 14)
 	if err != nil {
-		t.Fatal("Failed to initialize IP allocator: ", err)
+		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
 
 	allocSubnets := make([]*net.IPNet, 4)
@@ -328,7 +328,7 @@ func TestMarkAllocatedNetwork(t *testing.T) {
 func TestAllocateReleaseSubnet(t *testing.T) {
 	sna, err := newSubnetAllocator("10.1.0.0/16", 14)
 	if err != nil {
-		t.Fatal("Failed to initialize IP allocator: ", err)
+		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
 
 	var releaseSn *net.IPNet
@@ -372,7 +372,7 @@ func TestAllocateReleaseSubnet(t *testing.T) {
 func TestMultipleSubnets(t *testing.T) {
 	sna, err := newSubnetAllocator("10.1.0.0/16", 14)
 	if err != nil {
-		t.Fatal("Failed to initialize IP allocator: ", err)
+		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
 	err = sna.AddNetworkRange(ovntest.MustParseIPNet("10.2.0.0/16"), 14)
 	if err != nil {
@@ -419,7 +419,7 @@ func TestMultipleSubnets(t *testing.T) {
 func TestDualStack(t *testing.T) {
 	sna, err := newSubnetAllocator("10.1.0.0/16", 14)
 	if err != nil {
-		t.Fatal("Failed to initialize IP allocator: ", err)
+		t.Fatal("Failed to initialize subnet allocator: ", err)
 	}
 	err = sna.AddNetworkRange(ovntest.MustParseIPNet("10.2.0.0/16"), 14)
 	if err != nil {
@@ -468,8 +468,8 @@ func TestDualStack(t *testing.T) {
 		t.Fatalf("Failed to release the subnet %s: %v", sn.String(), err)
 	}
 
-	// The IPv4 allocator will now reuse the freed subnets (since they're all it has
-	// left), but the IPv6 allocator will continue allocating new ones.
+	// The IPv4 subnetallocator will now reuse the freed subnets (since they're all it has
+	// left), but the IPv6 subnetallocator will continue allocating new ones.
 	if err := allocateExpected(sna, -1, "10.1.128.0/18", "fd01:0:0:9::/64"); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The first commit in this PR renames the current `pkg/ovn/allocator` package to `pkg/ovn/subnetallocator`. This is to accommodate the new ipallocator package that we are bringing in to this project from the `kubernetes` project.

The second commit in this PR adds a new `pkg/ovn/ipallocator` package that provides support for IPAM. Given a subnet, ipallocator assigns the next available IP address either in a random fashion or contingous fashion. This functionality is required by PR #1365 and PR #1363 . The files underneath ipallocator folder is copied over from kubernetes' pkg/registry/core/service/{allocator, ipallocator} with some simplification.I have removed the snapshot/restore feature from the ipallocator library as we have our own way of persisting the allocated ip information. This removal further reduced the number of files that had to be copied over.
 