### PR TITLE
WIP: Dual stack support for name space address sets

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -47,7 +47,8 @@ func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
 	}
 	defer nsInfo.Unlock()
 
-	if err := nsInfo.addressSet.AddIP(portInfo.ip); err != nil {
+	// DUAL-STACK FIXME: handle multiple IPs
+	if err := nsInfo.addressSet.AddIP(portInfo.ips[0]); err != nil {
 		return err
 	}
 
@@ -69,7 +70,8 @@ func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) error 
 	}
 	defer nsInfo.Unlock()
 
-	if err := nsInfo.addressSet.DeleteIP(portInfo.ip); err != nil {
+	// DUAL-STACK FIXME: handle multiple IPs
+	if err := nsInfo.addressSet.DeleteIP(portInfo.ips[0]); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -36,6 +36,10 @@ func newNamespace(namespace string) *v1.Namespace {
 }
 
 var _ = Describe("OVN Namespace Operations", func() {
+	const (
+		namespaceName    = "namespace1"
+		v4AddressSetName = namespaceName + iPv4AddressSetSuffix
+	)
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
@@ -60,7 +64,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 
 		It("reconciles an existing namespace with pods", func() {
 			app.Action = func(ctx *cli.Context) error {
-				namespaceT := *newNamespace("namespace1")
+				namespaceT := *newNamespace(namespaceName)
 				tP := newTPod(
 					"node1",
 					"10.128.1.0/24",
@@ -91,7 +95,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceT.Name, []string{tP.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName, []string{tP.podIP})
 
 				return nil
 			}
@@ -102,7 +106,6 @@ var _ = Describe("OVN Namespace Operations", func() {
 
 		It("creates an empty address set for the namespace without pods", func() {
 			app.Action = func(ctx *cli.Context) error {
-				const namespaceName string = "namespace1"
 				fakeOvn.start(ctx, &v1.NamespaceList{
 					Items: []v1.Namespace{
 						*newNamespace("namespace1"),
@@ -113,7 +116,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName)
 
 				return nil
 			}
@@ -126,18 +129,17 @@ var _ = Describe("OVN Namespace Operations", func() {
 	Context("during execution", func() {
 		It("deletes an empty namespace's resources", func() {
 			app.Action = func(ctx *cli.Context) error {
-				const namespaceName string = "namespace1"
 				fakeOvn.start(ctx, &v1.NamespaceList{
 					Items: []v1.Namespace{
 						*newNamespace(namespaceName),
 					},
 				})
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName)
 
 				err := fakeOvn.fakeClient.CoreV1().Namespaces().Delete(namespaceName, metav1.NewDeleteOptions(1))
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvn.asf.EventuallyExpectNoAddressSet(namespaceName)
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v4AddressSetName)
 				return nil
 			}
 

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -1,6 +1,8 @@
 package ovn
 
 import (
+	"net"
+
 	"github.com/urfave/cli/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -83,7 +85,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 					},
 				)
 				podMAC := ovntest.MustParseMAC(tP.podMAC)
-				fakeOvn.controller.logicalPortCache.add(tP.nodeName, tP.portName, fakeUUID, podMAC, ovntest.MustParseIP(tP.podIP))
+				fakeOvn.controller.logicalPortCache.add(tP.nodeName, tP.portName, fakeUUID, podMAC, []net.IP{ovntest.MustParseIP(tP.podIP)})
 				fakeOvn.controller.WatchNamespaces()
 
 				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -53,7 +53,8 @@ type namespaceInfo struct {
 
 	// addressSet is an address set object that holds the IP addresses
 	// of all pods in the namespace.
-	addressSet AddressSet
+	v4AddressSet AddressSet
+	v6AddressSet AddressSet
 
 	// map from NetworkPolicy name to namespacePolicy. You must hold the
 	// namespaceInfo's mutex to add/delete/lookup policies, but must hold the

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"net"
 	"sync"
 
@@ -892,7 +893,15 @@ func (oc *Controller) handlePeerNamespaceSelector(
 				np.Lock()
 				defer np.Unlock()
 				if !np.deleted {
-					gress.addNamespaceAddressSet(namespace.Name, np.portGroupName)
+					//FIXME :  Dual stack . We need to first fix ACL generation in case of dual stack
+					// Then we will remove the if logic and add both address sets.
+					// Will be fixed in next set of PRs
+
+					if config.IPv6Mode {
+						gress.addNamespaceAddressSet(getIPv6AddressSetName(namespace.Name), np.portGroupName)
+					} else {
+						gress.addNamespaceAddressSet(getIPv4AddressSetName(namespace.Name), np.portGroupName)
+					}
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -900,7 +909,15 @@ func (oc *Controller) handlePeerNamespaceSelector(
 				np.Lock()
 				defer np.Unlock()
 				if !np.deleted {
-					gress.delNamespaceAddressSet(namespace.Name, np.portGroupName)
+					//FIXME :  Dual stack . We need to first fix ACL generation in case of dual stack
+					// Then we will remove the if logic and delete both address sets.
+					// Will be fixed in next set of PRs
+
+					if config.IPv6Mode {
+						gress.delNamespaceAddressSet(getIPv6AddressSetName(namespace.Name), np.portGroupName)
+					} else {
+						gress.delNamespaceAddressSet(getIPv4AddressSetName(namespace.Name), np.portGroupName)
+					}
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {

--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -19,7 +19,7 @@ type lpInfo struct {
 	name          string
 	uuid          string
 	logicalSwitch string
-	ip            net.IP
+	ips           []net.IP
 	mac           net.HardwareAddr
 	// expires, if non-nil, indicates that this object is scheduled to be
 	// removed at the given time
@@ -42,14 +42,14 @@ func (c *portCache) get(logicalPort string) (*lpInfo, error) {
 	return nil, fmt.Errorf("logical port %s not found in cache", logicalPort)
 }
 
-func (c *portCache) add(logicalSwitch, logicalPort, uuid string, mac net.HardwareAddr, ip net.IP) *lpInfo {
+func (c *portCache) add(logicalSwitch, logicalPort, uuid string, mac net.HardwareAddr, ips []net.IP) *lpInfo {
 	c.Lock()
 	defer c.Unlock()
 	portInfo := &lpInfo{
 		logicalSwitch: logicalSwitch,
 		name:          logicalPort,
 		uuid:          uuid,
-		ip:            ip,
+		ips:           ips,
 		mac:           mac,
 	}
 	klog.V(5).Infof("port-cache(%s): added port %+v", logicalPort, portInfo)

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -27,7 +27,7 @@ func intToIP(i *big.Int) net.IP {
 	return net.IP(i.Bytes())
 }
 
-// GetPortAddresses returns the MAC and IP of the given logical switch port
+// GetPortAddresses returns the MAC and IPs of the given logical switch port
 func GetPortAddresses(portName string) (net.HardwareAddr, []net.IP, error) {
 	out, stderr, err := RunOVNNbctl("get", "logical_switch_port", portName, "dynamic_addresses", "addresses")
 	if err != nil {


### PR DESCRIPTION
Dual stack support for adding address sets to Namespaces
    
    1. Support for adding and deleting dual stack POD IP addresses to Namespace address sets.
    2. Support for dual stack IP addresses while adding Namespace.