### PR TITLE
ovnkube.sh: ready_to_start_node() fails at scale

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -246,10 +246,9 @@ wait_for_event() {
   done
 }
 
-# OVN DBs must be up and initialized before ovn-master and ovn-node PODs can come up
-# This waits for ovnkube-db POD to come up
+# The ovnkube-db kubernetes service must be populated with OVN DB service endpoints
+# before various OVN K8s containers can come up. This functions checks for that.
 ready_to_start_node() {
-
   # See if ep is available ...
   IFS=" " read -a ovn_db_hosts <<<"$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
     get ep -n ${ovn_kubernetes_namespace} ovnkube-db -o=jsonpath='{range .subsets[0].addresses[*]}{.ip}{" "}')"
@@ -257,13 +256,6 @@ ready_to_start_node() {
     return 1
   fi
   get_ovn_db_vars
-  # cannot use ovsdb-client in the case of raft, since it will succeed even if one of the
-  # instance of DB is up and running. HOwever, ovn-nbctl always connects to the leader in the clustered
-  # database, so use it.
-  ovn-nbctl --db=${ovn_nbdb_conn} ${ovndb_ctl_ssl_opts} list NB_Global >/dev/null
-  if [[ $? != 0 ]]; then
-    return 1
-  fi
   return 0
 }
 # wait_for_event ready_to_start_node
@@ -678,7 +670,8 @@ sb-ovsdb() {
   }
   ovn-sbctl --inactivity-probe=0 set-connection p${transport}:${ovn_sb_port}:[${ovn_db_host}]
 
-  # create the ovnkube_db endpoint for other pods to query the OVN DB IP
+  # create the ovnkube-db endpoints
+  wait_for_event attempts=10 check_ovnkube_db_ep ${ovn_db_host} ${ovn_nb_port}
   set_ovnkube_db_ep ${ovn_db_host}
 
   tail --follow=name ${OVN_LOGDIR}/ovsdb-server-sb.log &


### PR DESCRIPTION
the entrypoint script for various ovn k8s containers call
ready_to_start_node() to see if they can continue starting the process
for that container. This function makes a call to ovn-nbctl CLI and this
call fails, timeouts, at scale with 100s of nodes in the cluster.

The call to ovn-nbctl is not required. All we need to check in this
function is to see if ovnkube-db kubernetes service has ovnkube-db
endpoints populated. The logic that populates these endpoints would
have already ensured that the OVN DBs are available at the said
endpoints, so there is no need to check again.

@ovn-org/ovn-kubernetes-committers PTAL