### PR TITLE
factory: remove unecessary locking for enqueueEevent

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -194,8 +194,7 @@ func runOvnKube(ctx *cli.Context) error {
 	}
 
 	// create factory and start the controllers asked for
-	stopChan := make(chan struct{})
-	factory, err := factory.NewWatchFactory(clientset, stopChan)
+	factory, err := factory.NewWatchFactory(clientset)
 	if err != nil {
 		return err
 	}
@@ -224,6 +223,8 @@ func runOvnKube(ctx *cli.Context) error {
 	if err := watchForChanges(configFile); err != nil {
 		return fmt.Errorf("unable to setup configuration watch: %v", err)
 	}
+
+	stopChan := make(chan struct{})
 
 	if master != "" {
 		if runtime.GOOS == "windows" {
@@ -262,7 +263,8 @@ func runOvnKube(ctx *cli.Context) error {
 
 	// run until cancelled
 	<-ctx.Context.Done()
-	stopChan <- struct{}{}
+	close(stopChan)
+	factory.Shutdown()
 	return nil
 }
 

--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
@@ -87,14 +87,12 @@ func runHybridOverlay(ctx *cli.Context) error {
 		return err
 	}
 
-	stopChan := make(chan struct{})
-	defer close(stopChan)
-
-	factory, err := factory.NewWatchFactory(clientset, stopChan)
+	factory, err := factory.NewWatchFactory(clientset)
 	if err != nil {
 		return err
 	}
 
+	stopChan := make(chan struct{})
 	kube := &kube.Kube{KClient: clientset}
 	if err := controller.StartNode(nodeName, kube, factory, stopChan); err != nil {
 		return err
@@ -102,6 +100,7 @@ func runHybridOverlay(ctx *cli.Context) error {
 
 	// run until cancelled
 	<-ctx.Context.Done()
-	stopChan <- struct{}{}
+	close(stopChan)
+	factory.Shutdown()
 	return nil
 }

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -59,7 +59,11 @@ func newTestNode(name, os, ovnHostSubnet, hybridHostSubnet, drMAC string) v1.Nod
 }
 
 var _ = Describe("Hybrid SDN Master Operations", func() {
-	var app *cli.App
+	var (
+		app      *cli.App
+		f        *factory.WatchFactory
+		stopChan chan struct{}
+	)
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -68,6 +72,13 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		stopChan = make(chan struct{})
+	})
+
+	AfterEach(func() {
+		close(stopChan)
+		f.Shutdown()
 	})
 
 	const hybridOverlayClusterCIDR string = "11.1.0.0/16/24"
@@ -90,10 +101,8 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			err = StartMaster(&kube.Kube{KClient: fakeClient}, f)
 			Expect(err).NotTo(HaveOccurred())
@@ -141,10 +150,8 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			err = StartMaster(&kube.Kube{KClient: fakeClient}, f)
 			Expect(err).NotTo(HaveOccurred())
@@ -200,10 +207,8 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			err = StartMaster(&kube.Kube{KClient: fakeClient}, f)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -171,9 +171,11 @@ func appRun(app *cli.App, netns ns.NetNS) {
 
 var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 	var (
-		app   *cli.App
-		fexec *ovntest.FakeExec
-		netns ns.NetNS
+		app      *cli.App
+		fexec    *ovntest.FakeExec
+		netns    ns.NetNS
+		f        *factory.WatchFactory
+		stopChan chan struct{}
 	)
 	const thisNode string = "mynode"
 
@@ -184,6 +186,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		stopChan = make(chan struct{})
 
 		fexec = ovntest.NewLooseCompareFakeExec()
 		err := util.SetExec(fexec)
@@ -202,6 +206,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 	})
 
 	AfterEach(func() {
+		close(stopChan)
+		f.Shutdown()
 		Expect(netns.Close()).To(Succeed())
 		Expect(testutils.UnmountNS(netns)).To(Succeed())
 	})
@@ -228,10 +234,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
@@ -277,10 +281,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
@@ -319,10 +321,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
@@ -369,10 +369,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
@@ -417,10 +415,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
@@ -459,10 +455,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())
@@ -514,10 +508,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			n, err := NewNode(&kube.Kube{KClient: fakeClient}, thisNode, stopChan)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -78,6 +78,7 @@ type informer struct {
 	// initialAddFunc will be called to deliver the initial list of objects
 	// when a handler is added
 	initialAddFunc initialAddFn
+	shutdownWg     sync.WaitGroup
 }
 
 func (i *informer) forEachQueuedHandler(f func(h *Handler)) {
@@ -150,6 +151,7 @@ func (i *informer) removeHandler(handler *Handler) error {
 }
 
 func (i *informer) processEvents(events chan *event, stopChan <-chan struct{}) {
+	defer i.shutdownWg.Done()
 	for {
 		select {
 		case e, ok := <-events:
@@ -182,18 +184,12 @@ func getQueueNum(oType reflect.Type, obj interface{}) uint32 {
 	return h.Sum32() % uint32(numEventQueues)
 }
 
-// enqueueEvent adds an event to the queue. Caller must hold at least a read lock
-// on the informer.
+// enqueueEvent adds an event to the appropriate queue for the object
 func (i *informer) enqueueEvent(oldObj, obj interface{}, processFunc func(*event)) {
-	i.RLock()
-	defer i.RUnlock()
-	queueIdx := getQueueNum(i.oType, obj)
-	if i.events[queueIdx] != nil {
-		i.events[queueIdx] <- &event{
-			obj:     obj,
-			oldObj:  oldObj,
-			process: processFunc,
-		}
+	i.events[getQueueNum(i.oType, obj)] <- &event{
+		obj:     obj,
+		oldObj:  oldObj,
+		process: processFunc,
 	}
 }
 
@@ -269,19 +265,19 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 	}
 }
 
-func (i *informer) shutdown() {
+func (i *informer) removeAllHandlers() {
 	i.Lock()
 	defer i.Unlock()
-
 	for _, handler := range i.handlers {
 		_ = i.removeHandler(handler)
 	}
+}
 
-	// Close all event channels for queued informers
-	for idx := range i.events {
-		close(i.events[idx])
-		i.events[idx] = nil
-	}
+func (i *informer) shutdown() {
+	i.removeAllHandlers()
+
+	// Wait for all event processors to finish
+	i.shutdownWg.Wait()
 }
 
 func newInformerLister(oType reflect.Type, sharedInformer cache.SharedIndexInformer) (listerInterface, error) {
@@ -311,10 +307,11 @@ func newBaseInformer(oType reflect.Type, sharedInformer cache.SharedIndexInforme
 	}
 
 	return &informer{
-		oType:    oType,
-		inf:      sharedInformer,
-		lister:   lister,
-		handlers: make(map[uint64]*Handler),
+		oType:      oType,
+		inf:        sharedInformer,
+		lister:     lister,
+		handlers:   make(map[uint64]*Handler),
+		shutdownWg: sync.WaitGroup{},
 	}, nil
 }
 
@@ -338,13 +335,16 @@ func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 		return nil, err
 	}
 	i.events = make([]chan *event, numEventQueues)
+	i.shutdownWg.Add(len(i.events))
 	for j := range i.events {
 		i.events[j] = make(chan *event, 1)
 		go i.processEvents(i.events[j], stopChan)
 	}
 	i.initialAddFunc = func(h *Handler, items []interface{}) {
 		// Make a handler-specific channel array across which the
-		// initial add events will be distributed.
+		// initial add events will be distributed. When a new handler
+		// is added, only that handler should receive events for all
+		// existing objects.
 		adds := make([]chan interface{}, numEventQueues)
 		queueWg := &sync.WaitGroup{}
 		queueWg.Add(len(adds))
@@ -386,6 +386,8 @@ type WatchFactory struct {
 
 	iFactory  informerfactory.SharedInformerFactory
 	informers map[reflect.Type]*informer
+
+	stopChan chan struct{}
 }
 
 // ObjectCacheInterface represents the exported methods for getting
@@ -424,7 +426,7 @@ var (
 )
 
 // NewWatchFactory initializes a new watch factory
-func NewWatchFactory(c kubernetes.Interface, stopChan chan struct{}) (*WatchFactory, error) {
+func NewWatchFactory(c kubernetes.Interface) (*WatchFactory, error) {
 	// resync time is 12 hours, none of the resources being watched in ovn-kubernetes have
 	// any race condition where a resync may be required e.g. cni executable on node watching for
 	// events on pods and assuming that an 'ADD' event will contain the annotations put in by
@@ -433,10 +435,11 @@ func NewWatchFactory(c kubernetes.Interface, stopChan chan struct{}) (*WatchFact
 	wf := &WatchFactory{
 		iFactory:  informerfactory.NewSharedInformerFactory(c, resyncInterval),
 		informers: make(map[reflect.Type]*informer),
+		stopChan:  make(chan struct{}),
 	}
 	var err error
 	// Create shared informers we know we'll use
-	wf.informers[podType], err = newQueuedInformer(podType, wf.iFactory.Core().V1().Pods().Informer(), stopChan)
+	wf.informers[podType], err = newQueuedInformer(podType, wf.iFactory.Core().V1().Pods().Informer(), wf.stopChan)
 	if err != nil {
 		return nil, err
 	}
@@ -456,28 +459,28 @@ func NewWatchFactory(c kubernetes.Interface, stopChan chan struct{}) (*WatchFact
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[nodeType], err = newQueuedInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer(), stopChan)
+	wf.informers[nodeType], err = newQueuedInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer(), wf.stopChan)
 	if err != nil {
 		return nil, err
 	}
 
-	wf.iFactory.Start(stopChan)
-	for oType, synced := range wf.iFactory.WaitForCacheSync(stopChan) {
+	wf.iFactory.Start(wf.stopChan)
+	for oType, synced := range wf.iFactory.WaitForCacheSync(wf.stopChan) {
 		if !synced {
 			return nil, fmt.Errorf("error in syncing cache for %v informer", oType)
 		}
 	}
 
-	go func() {
-		<-stopChan
-
-		// Remove all informer handlers
-		for _, inf := range wf.informers {
-			inf.shutdown()
-		}
-	}()
-
 	return wf, nil
+}
+
+func (wf *WatchFactory) Shutdown() {
+	close(wf.stopChan)
+
+	// Remove all informer handlers
+	for _, inf := range wf.informers {
+		inf.shutdown()
+	}
 }
 
 func getObjectMeta(objType reflect.Type, obj interface{}) (*metav1.ObjectMeta, error) {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -137,9 +137,12 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		})
 
 		stop := make(chan struct{})
-		wf, err := factory.NewWatchFactory(fakeClient, stop)
+		wf, err := factory.NewWatchFactory(fakeClient)
 		Expect(err).NotTo(HaveOccurred())
-		defer close(stop)
+		defer func() {
+			close(stop)
+			wf.Shutdown()
+		}()
 
 		n := NewNode(nil, wf, existingNode.Name, stop)
 
@@ -295,10 +298,9 @@ var _ = Describe("Gateway Init Operations", func() {
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
 				Items: []v1.Node{existingNode},
 			})
-			stop := make(chan struct{})
-			wf, err := factory.NewWatchFactory(fakeClient, stop)
+			wf, err := factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stop)
+			defer wf.Shutdown()
 
 			ipt, err := util.NewFakeWithProtocol(iptables.ProtocolIPv4)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -204,7 +204,11 @@ func addGetPortAddressesCmds(fexec *ovntest.FakeExec, nodeName, hybMAC, hybIP st
 }
 
 var _ = Describe("Master Operations", func() {
-	var app *cli.App
+	var (
+		app      *cli.App
+		f        *factory.WatchFactory
+		stopChan chan struct{}
+	)
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
@@ -213,6 +217,13 @@ var _ = Describe("Master Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		stopChan = make(chan struct{})
+	})
+
+	AfterEach(func() {
+		close(stopChan)
+		f.Shutdown()
 	})
 
 	It("creates logical network elements for a 2-node cluster", func() {
@@ -258,10 +269,8 @@ var _ = Describe("Master Operations", func() {
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
@@ -343,10 +352,8 @@ var _ = Describe("Master Operations", func() {
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
@@ -429,10 +436,8 @@ var _ = Describe("Master Operations", func() {
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
@@ -612,10 +617,8 @@ subnet=%s
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			stopChan := make(chan struct{})
-			f, err := factory.NewWatchFactory(fakeClient, stopChan)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stopChan)
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
@@ -645,7 +648,11 @@ subnet=%s
 })
 
 var _ = Describe("Gateway Init Operations", func() {
-	var app *cli.App
+	var (
+		app      *cli.App
+		f        *factory.WatchFactory
+		stopChan chan struct{}
+	)
 
 	const (
 		clusterIPNet string = "10.1.0.0"
@@ -659,6 +666,13 @@ var _ = Describe("Gateway Init Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
+
+		stopChan = make(chan struct{})
+	})
+
+	AfterEach(func() {
+		close(stopChan)
+		f.Shutdown()
 	})
 
 	It("sets up a localnet gateway", func() {
@@ -809,12 +823,10 @@ var _ = Describe("Gateway Init Operations", func() {
 				Output: "169.254.33.2",
 			})
 
-			stop := make(chan struct{})
-			wf, err := factory.NewWatchFactory(fakeClient, stop)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stop)
 
-			clusterController := NewOvnController(fakeClient, wf, stop, newFakeAddressSetFactory())
+			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
@@ -1003,12 +1015,10 @@ var _ = Describe("Gateway Init Operations", func() {
 				Output: "169.254.33.2",
 			})
 
-			stop := make(chan struct{})
-			wf, err := factory.NewWatchFactory(fakeClient, stop)
+			f, err = factory.NewWatchFactory(fakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			defer close(stop)
 
-			clusterController := NewOvnController(fakeClient, wf, stop, newFakeAddressSetFactory())
+			clusterController := NewOvnController(fakeClient, f, stopChan, newFakeAddressSetFactory())
 			Expect(clusterController).NotTo(BeNil())
 			clusterController.TCPLoadBalancerUUID = tcpLBUUID
 			clusterController.UDPLoadBalancerUUID = udpLBUUID

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -52,13 +52,14 @@ func (o *FakeOVN) restart() {
 
 func (o *FakeOVN) shutdown() {
 	close(o.stopChan)
+	o.watcher.Shutdown()
 }
 
 func (o *FakeOVN) init() {
 	var err error
 
 	o.stopChan = make(chan struct{})
-	o.watcher, err = factory.NewWatchFactory(o.fakeClient, o.stopChan)
+	o.watcher, err = factory.NewWatchFactory(o.fakeClient)
 	Expect(err).NotTo(HaveOccurred())
 
 	o.controller = NewOvnController(o.fakeClient, o.watcher, o.stopChan, o.asf)


### PR DESCRIPTION
The only reason to lock the events array was to ensure that informer
shutdown worked correctly (mostly for unit tests), and that when
a nil event queue was found to stop distributing events to it.

Instead wait for all processEvent() goroutines for each event queue
to terminate before returning from Shutdown(), which handles stopping
event distribution. Just leave the event queues open as there is no
way to safely close now, because the shared informer may still be
delivering events to the factories handler before it notices that
the stop channel has been closed. This isn't a problem though, since
we only ever stop the informer on exit anyway.

@squeed @trozet @abhat 

**- Description for the changelog**
Fixed a deadlock in handling multiple pod updates.