### PR TITLE
hybrid-overlay: fix host route to hybrid overlay subnets

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -20,8 +20,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const hoNodeCliArg string = "-no-hostsubnet-nodes=" + v1.LabelOSStable + "=windows"
-
 func addGetPortAddressesCmds(fexec *ovntest.FakeExec, nodeName, hybMAC, hybIP string) {
 	addresses := hybMAC + " " + hybIP
 	addresses = strings.TrimSpace(addresses)


### PR DESCRIPTION
Don't use direct byte manipulation of the node subnet, otherwise
it's changed for all subsequent uses and that causes the host route
via the management port for the hybrid overlay cluster subnet to
get a .6 address instead of the expected .3.

@trozet @rcarrillocruz @dave-tucker