### PR TITLE
clear the portGroupUUID when deleting the namespace port group

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -143,6 +143,7 @@ func (nsInfo *namespaceInfo) updateNamespacePortGroup(ns string) error {
 		nsInfo.portGroupUUID = portGroupUUID
 	} else {
 		deletePortGroup(hashedPortGroup(ns))
+		nsInfo.portGroupUUID = ""
 	}
 	return nil
 }


### PR DESCRIPTION
when deleting the namespace port group if you do not reset the portGroupUUID on
the namespaceInfo struct updateNamespacePortGroup() will never create a new namespace
port wide port_group if it is needed again

