### PR TITLE
Expose NB/SB OVN DB TCP db and raft port numbers

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -107,6 +107,18 @@ while [ "$1" != "" ]; do
   --ovn-master-count)
     OVN_MASTER_COUNT=$VALUE
     ;;
+  --ovn-nb-port)
+    OVN_NB_PORT=$VALUE
+    ;;
+  --ovn-sb-port)
+    OVN_SB_PORT=$VALUE
+    ;;
+  --ovn-nb-raft-port)
+    OVN_NB_RAFT_PORT=$VALUE
+    ;;
+  --ovn-sb-raft-port)
+    OVN_SB_RAFT_PORT=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -166,6 +178,14 @@ ovn_master_count=${OVN_MASTER_COUNT:-"1"}
 echo "ovn_master_count: ${ovn_master_count}"
 ovn_remote_probe_interval=${OVN_REMOTE_PROBE_INTERVAL:-"100000"}
 echo "ovn_remote_probe_interval: ${ovn_remote_probe_interval}"
+ovn_nb_port=${OVN_NB_PORT:-6641}
+echo "ovn_nb_port: ${ovn_nb_port}"
+ovn_sb_port=${OVN_SB_PORT:-6642}
+echo "ovn_sb_port: ${ovn_sb_port}"
+ovn_nb_raft_port=${OVN_NB_RAFT_PORT:-6643}
+echo "ovn_nb_raft_port: ${ovn_nb_raft_port}"
+ovn_sb_raft_port=${OVN_SB_RAFT_PORT:-6644}
+echo "ovn_sb_raft_port: ${ovn_sb_raft_port}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -196,6 +216,8 @@ ovn_image=${image} \
   ovn_loglevel_nb=${ovn_loglevel_nb} \
   ovn_loglevel_sb=${ovn_loglevel_sb} \
   ovn_ssl_en=${ovn_ssl_en} \
+  ovn_nb_port=${ovn_nb_port} \
+  ovn_sb_port=${ovn_sb_port} \
   j2 ../templates/ovnkube-db.yaml.j2 -o ../yaml/ovnkube-db.yaml
 
 ovn_db_vip_image=${ovn_db_vip_image} \
@@ -212,6 +234,10 @@ ovn_image=${image} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_nb_raft_election_timer=${ovn_nb_raft_election_timer} \
   ovn_sb_raft_election_timer=${ovn_sb_raft_election_timer} \
+  ovn_nb_port=${ovn_nb_port} \
+  ovn_sb_port=${ovn_sb_port} \
+  ovn_nb_raft_port=${ovn_nb_raft_port} \
+  ovn_sb_raft_port=${ovn_sb_raft_port} \
   j2 ../templates/ovnkube-db-raft.yaml.j2 -o ../yaml/ovnkube-db-raft.yaml
 
 # ovn-setup.yaml

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -7,13 +7,13 @@ metadata:
 spec:
   ports:
   - name: north
-    port: 6641
+    port: {{ ovn_nb_port }}
     protocol: TCP
-    targetPort: 6641
+    targetPort: {{ ovn_nb_port }}
   - name: south
-    port: 6642
+    port: {{ ovn_sb_port }}
     protocol: TCP
-    targetPort: 6642
+    targetPort: {{ ovn_sb_port }}
   sessionAffinity: None
   clusterIP: None
   type: ClusterIP
@@ -162,6 +162,10 @@ spec:
           value: "{{ ovn_ssl_en }}"
         - name: OVN_NB_RAFT_ELECTION_TIMER
           value: "{{ ovn_nb_raft_election_timer }}"
+        - name: OVN_NB_PORT
+          value: "{{ ovn_nb_port }}"
+        - name: OVN_NB_RAFT_PORT
+          value: "{{ ovn_nb_raft_port }}"
       # end of container
 
       # sb-ovsdb - v3
@@ -233,6 +237,10 @@ spec:
           value: "{{ ovn_ssl_en }}"
         - name: OVN_SB_RAFT_ELECTION_TIMER
           value: "{{ ovn_sb_raft_election_timer }}"
+        - name: OVN_SB_PORT
+          value: "{{ ovn_sb_port }}"
+        - name: OVN_SB_RAFT_PORT
+          value: "{{ ovn_sb_raft_port }}"
       # end of container
 
       # db-metrics-exporter - v3

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -7,13 +7,13 @@ metadata:
 spec:
   ports:
   - name: north
-    port: 6641
+    port: {{ ovn_nb_port }}
     protocol: TCP
-    targetPort: 6641
+    targetPort: {{ ovn_nb_port }}
   - name: south
-    port: 6642
+    port: {{ ovn_sb_port }}
     protocol: TCP
-    targetPort: 6642
+    targetPort: {{ ovn_sb_port }}
   sessionAffinity: None
   clusterIP: None
   type: ClusterIP
@@ -117,6 +117,8 @@ spec:
               fieldPath: status.hostIP
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
+        - name: OVN_NB_PORT
+          value: "{{ ovn_nb_port }}"
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
@@ -178,6 +180,8 @@ spec:
               fieldPath: status.hostIP
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
+        - name: OVN_SB_PORT
+          value: "{{ ovn_sb_port }}"
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]


### PR DESCRIPTION
Currently ovn-kubernetes supports configuring tcp port, for both the DB
and Raft control plane for both NB/SB DB, however it is not explictly
called out in the yaml files. This patch exposes those environment
variables and updates daemonset.sh to take these parameter at build
time to generate the db yaml with non-default values.

@ovn-org/ovn-kubernetes-committers trivial fix, PTAL. Thanks.