### PR TITLE
CI: Make tests run in both shared and local gateway modes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,11 +132,13 @@ jobs:
            name: "HA"
          - enabled: "false"
            name: "noHA"
+        gateway-mode: [local, shared]
     needs: k8s
     env:
-      JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}"
+      JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}"
       KIND_HA: "${{ matrix.ha.enabled }}"
       OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target.hybrid-overlay }}"
+      OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
     steps:
 
     - name: Free up disk space


### PR DESCRIPTION
Currently the e2e tests in the CI are run only in the local gateway
mode. It would be good to have all tests run in both modes. So a
new flag has been added to the kind.sh script to accept the shared
mode as well.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
