### PR TITLE
pkg/factory: increase QueuedHandler queue size

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -337,7 +337,7 @@ func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 	i.events = make([]chan *event, numEventQueues)
 	i.shutdownWg.Add(len(i.events))
 	for j := range i.events {
-		i.events[j] = make(chan *event, 1)
+		i.events[j] = make(chan *event, 10)
 		go i.processEvents(i.events[j], stopChan)
 	}
 	i.initialAddFunc = func(h *Handler, items []interface{}) {
@@ -349,7 +349,7 @@ func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 		queueWg := &sync.WaitGroup{}
 		queueWg.Add(len(adds))
 		for j := range adds {
-			adds[j] = make(chan interface{}, 1)
+			adds[j] = make(chan interface{}, 10)
 			go func(addChan chan interface{}) {
 				defer queueWg.Done()
 				for {


### PR DESCRIPTION
If two updates come in for the same pod in short succession, they will block all other pod updates, since the function that muxes updates will be blocked.

I saw this while running some simple benchmarks.

So, increase the queue size to 10, just to prevent most cases of head-of-line blocking.

Signed-off-by: Casey Callendrello <cdc@redhat.com>