### PR TITLE
Fixes resetting hybrid annotation on namespace update

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -219,6 +219,8 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 		} else {
 			nsInfo.hybridOverlayExternalGW = parsedAnnotation
 		}
+	} else {
+		nsInfo.hybridOverlayExternalGW = nil
 	}
 	annotation = newer.Annotations[hotypes.HybridOverlayVTEP]
 	if annotation != "" {
@@ -228,6 +230,8 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 		} else {
 			nsInfo.hybridOverlayVTEP = parsedAnnotation
 		}
+	} else {
+		nsInfo.hybridOverlayVTEP = nil
 	}
 	oc.multicastUpdateNamespace(newer, nsInfo)
 }


### PR DESCRIPTION
When namespace is updated to remove hybrid annotation, we were not
updating the nsInfo fields so a new pod would get the hybrid gw .3
address route accidentally.

Signed-off-by: Tim Rozet <trozet@redhat.com>
