### PR TITLE
Merge e2e test shards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,11 +117,9 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - shard: shard-n
+          - shard: shard-n-other
             hybrid-overlay: false
           - shard: shard-np
-            hybrid-overlay: false
-          - shard: shard-other
             hybrid-overlay: false
           - shard: control-plane
             hybrid-overlay: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,8 +121,6 @@ jobs:
             hybrid-overlay: false
           - shard: shard-np
             hybrid-overlay: false
-          - shard: shard-s
-            hybrid-overlay: false
           - shard: shard-other
             hybrid-overlay: false
           - shard: control-plane

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -29,9 +29,6 @@ the shards (which may change in the future):
   - All E2E tests that match `[sig-network] N` and DO have a P as their sixth
   letter after the N. (i.e. Roughly all `[sig-network] NetworkPolicy ...`
   tests.)
-- shard-s
-  - All E2E tests that match `[sig-network] S`. (i.e. Roughly all
-  `[sig-network] Services ...` tests.)
 - shard-other
   - All remaining E2E tests that didn't match above.
 - shard-test
@@ -207,7 +204,6 @@ $ cd $GOPATH/src/github.com/ovn-org/ovn-kubernetes
 $ pushd test
 $ make shard-n
 $ make shard-np
-$ make shard-s
 $ make shard-other
 $ GITHUB_WORKSPACE=$GOPATH/src/github.com/ovn-org/ovn-kubernetes make control-plane
 $ popd

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -22,15 +22,14 @@ tests locally.
 The tests are broken into a set of shards, which is just a grouping of tests,
 and each shard is run in a separate job in parallel. Below is an example of
 the shards (which may change in the future):
-- shard-n
+- shard-n-other
   - All E2E tests that match `[sig-network] N` and do NOT have P as their sixth
-  letter after the N (i.e. Roughly all `[sig-network] Networking ...` tests.)
+  letter after the N (i.e. Roughly all `[sig-network] Networking ...` tests.), and all other tests
+  that don't match the rule below
 - shard-np
   - All E2E tests that match `[sig-network] N` and DO have a P as their sixth
   letter after the N. (i.e. Roughly all `[sig-network] NetworkPolicy ...`
   tests.)
-- shard-other
-  - All remaining E2E tests that didn't match above.
 - shard-test
   - Single E2E test that matches the name of the test specified with a regex. See bottom of this document for an example.
 - control-plane
@@ -202,9 +201,8 @@ run):
 $ cd $GOPATH/src/github.com/ovn-org/ovn-kubernetes
 
 $ pushd test
-$ make shard-n
+$ make shard-n-other
 $ make shard-np
-$ make shard-other
 $ GITHUB_WORKSPACE=$GOPATH/src/github.com/ovn-org/ovn-kubernetes make control-plane
 $ popd
 ```

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -58,11 +58,8 @@ case "$SHARD" in
 		# all tests that have P as the sixth letter after the N
 		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$'
 		;;
-	shard-s)
-		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[Ss].*'
-		;;
 	shard-other)
-		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[^NnSs].*'
+		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[^Nn].*'
 		;;
 	shard-test)
 		TEST_REGEX_REPR=$(echo ${@:2} | sed 's/ /\\s/g')

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -50,16 +50,13 @@ SKIPPED_TESTS=$(echo "${SKIPPED_TESTS}" | sed -e '/^\($\|#\)/d' -e 's/ /\\s/g' |
 GINKGO_ARGS="--num-nodes=3 --ginkgo.skip=${SKIPPED_TESTS} --disable-log-dump=false"
 
 case "$SHARD" in
-	shard-n)
-		# all tests that don't have P as their sixth letter after the N
-		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[Nn](.{6}[^Pp].*|.{0,6}$)'
+	shard-n-other)
+		# all tests that don't have P as their sixth letter after the N, and all other tests
+		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s([Nn](.{6}[^Pp].*|.{0,6}$)|[^Nn].*)'
 		;;
 	shard-np)
 		# all tests that have P as the sixth letter after the N
 		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$'
-		;;
-	shard-other)
-		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[^Nn].*'
 		;;
 	shard-test)
 		TEST_REGEX_REPR=$(echo ${@:2} | sed 's/ /\\s/g')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR reduces the number of parallel jobs that run in GitHub Actions. We're seeing a combinatorial explosion in the number of jobs that need to be run, and it appears to be causing a backup in the GitHub Actions job queue. This ends up slowing down the test suite due to the overhead of having to install KIND and other dependencies.
