### PR TITLE
fix ipv6 support

### DIFF
--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -29,7 +29,7 @@ ready_to_join_cluster() {
   if [[ $? != 0 ]]; then
     return 1
   fi
-  target=$(ovn-${db}ctl --db=${transport}:${init_ip}:${port} ${ovndb_ctl_ssl_opts} --data=bare --no-headings \
+  target=$(ovn-${db}ctl --db=${transport}:[${init_ip}]:${port} ${ovndb_ctl_ssl_opts} --data=bare --no-headings \
     --columns=target list connection)
   if [[ "${target}" != "p${transport}:${port}" ]]; then
     return 1
@@ -43,7 +43,7 @@ check_ovnkube_db_ep() {
 
   # TODO: Right now only checks for NB ovsdb instances
   echo "======= checking ${dbaddr}:${dbport} OVSDB instance ==============="
-  ovsdb-client ${ovndb_ctl_ssl_opts} list-dbs ${transport}:${dbaddr}:${dbport} >/dev/null
+  ovsdb-client ${ovndb_ctl_ssl_opts} list-dbs ${transport}:[${dbaddr}]:${dbport} >/dev/null
   if [[ $? != 0 ]]; then
     return 1
   fi


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

ovn-kubernetes/dist/images/ovndb-raft-functions.sh was not using
square brackets for IPv6 addresses, so ovn-kube could not work
in an IPv6 only cluster.

This went unnoticed because we were not importing that functions
until recently.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

after https://github.com/ovn-org/ovn-kubernetes/commit/c10cd0d30ebeb7b69bd2b49e9484c13e755234d8 we were using the check_ovnkube_db_ep() that was not using square brackets for IPv6 addresses

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

I tested it locally, but there is a PR to add IPv6 tests on presubmits to avoid these regressions

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->