### PR TITLE
The ErrorDesc method returns no error messages when number of expected and executed commands are same

### DIFF
--- a/go-controller/pkg/testing/exec.go
+++ b/go-controller/pkg/testing/exec.go
@@ -57,9 +57,6 @@ func (f *FakeExec) CommandContext(ctx context.Context, cmd string, args ...strin
 }
 
 func (f *FakeExec) ErrorDesc() string {
-	if len(f.executedCommands) == len(f.expectedCommands) {
-		return ""
-	}
 	return f.internalErrorDesc()
 }
 


### PR DESCRIPTION
The ErrorDesc method returns no error messages when number of expected and executed commands are same even though their contents may be different. 
This makes debugging build errors difficult
Fix is to check the contents always if there are any errors.

Signed-off-by: Balaji Varadaraju <bvaradar@redhat.com>

