### PR TITLE
Testipv6 DO NOT REVIEW TEST ONLY

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ env:
   K8S_VERSION: v1.18.2
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true
+  KIND_UPDATE_SYSTEM: true
+  #KIND_HOST_INTERFACE: "eth0"
 
 jobs:
   build:
@@ -121,6 +123,8 @@ jobs:
             hybrid-overlay: false
           - shard: shard-np
             hybrid-overlay: false
+          - shard: shard-ipv4
+            hybrid-overlay: false
           - shard: control-plane
             hybrid-overlay: true
         ha:
@@ -129,10 +133,38 @@ jobs:
          - enabled: "false"
            name: "noHA"
         gateway-mode: [local, shared]
+        ipfamily:
+         - ip: ipv4
+           name: "IPv4"
+           ipv4: true
+           ipv6: false
+         - ip: ipv6
+           name: "IPv6"
+           ipv4: false
+           ipv6: true
+         - ip: dualstack
+           name: "Dualstack"
+           ipv4: true
+           ipv6: true
+        exclude:
+         - {"ipfamily": {"ip": dualstack}}
+         - {"ipfamily": {"ip": ipv6}, "target": {"shard": shard-ipv4}}
+         - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "true"}, "gateway-mode": shared}
+         - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "false"}, "gateway-mode": local}
+         - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "true"}, "gateway-mode": local, "target": {"shard": shard-np}}
+         - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "false"}, "gateway-mode": shared, "target": {"shard": shard-n-other}}
+         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": shared}
+         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "true"}, "gateway-mode": local}
+         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": local, "target": {"shard": shard-n-other}}
+         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "true"}, "gateway-mode": shared, "target": {"shard": shard-np}}
+         - {"ipfamily": {"ip": ipv4}, "target": {"shard": shard-ipv4}}
+         - {"target": {"shard": control-plane}}
     needs: k8s
     env:
-      JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}"
+      JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
       KIND_HA: "${{ matrix.ha.enabled }}"
+      KIND_IPV4_SUPPORT: "${{ matrix.ipfamily.ipv4 }}"
+      KIND_IPV6_SUPPORT: "${{ matrix.ipfamily.ipv6 }}"
       OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target.hybrid-overlay }}"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
     steps:
@@ -155,6 +187,11 @@ jobs:
         echo "::set-env name=GOPATH::$GOPATH"
         export PATH=$GOPATH/bin:$PATH
         echo "::add-path::$GOPATH/bin"
+  
+    - name: IPv6 Disable firewall
+      if: matrix.ipfamily.ipv6 == true && matrix.ipfamily.ipv4 == false
+      run: |
+        sudo ufw disable
 
     - name: Restore Kubernetes from cache
       id: cache-k8s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,16 +149,7 @@ jobs:
         exclude:
          - {"ipfamily": {"ip": dualstack}}
          - {"ipfamily": {"ip": ipv6}, "target": {"shard": shard-ipv4}}
-         - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "true"}, "gateway-mode": shared}
-         - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "false"}, "gateway-mode": local}
-         - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "true"}, "gateway-mode": local, "target": {"shard": shard-np}}
-         - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "false"}, "gateway-mode": shared, "target": {"shard": shard-n-other}}
-         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": shared}
-         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "true"}, "gateway-mode": local}
-         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": local, "target": {"shard": shard-n-other}}
-         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "true"}, "gateway-mode": shared, "target": {"shard": shard-np}}
-         - {"ipfamily": {"ip": ipv4}, "target": {"shard": shard-ipv4}}
-         - {"target": {"shard": control-plane}}
+         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "true"}}
     needs: k8s
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -109,7 +109,6 @@ print_params()
      echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
      echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
      echo "KIND_UPDATE_SYSTEM = $KIND_UPDATE_SYSTEM"
-     echo "KIND_HOST_INTERFACE = $KIND_HOST_INTERFACE"
      echo ""
 }
 
@@ -127,8 +126,6 @@ KIND_IPV4_SUPPORT=${KIND_IPV4_SUPPORT:-true}
 KIND_IPV6_SUPPORT=${KIND_IPV6_SUPPORT:-false}
 OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
 KIND_UPDATE_SYSTEM=${KIND_UPDATE_SYSTEM:-false}
-KIND_HOST_INTERFACE=${KIND_HOST_INTERFACE:-""}
-#KIND_HOST_INTERFACE="docker0"
 
 # Input not currently validated. Modify outside script at your own risk.
 # These are the same values defaulted to in KIND code (kind/default.go).
@@ -151,27 +148,9 @@ print_params
 
 set -euxo pipefail
 
-# Detect IP to use as API server
-API_IPV4=""
-if [ "$KIND_IPV4_SUPPORT" == true ]; then
-  # ip -4 addr -> Run ip command for IPv4
-  # grep -oP '(?<=inet\s)\d+(\.\d+){3}' -> Use only the lines with the
-  #   IPv4 Addresses and strip off the trailing subnet mask, /xx
-  # grep -v "127.0.0.1" -> Remove local host
-  # head -n 1 -> Of the remaining, use first entry
-  API_IPV4=$(ip -4 addr | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v "127.0.0.1" | head -n 1)
-  if [ -z "$API_IPV4" ]; then
-    echo "Error detecting machine IPv4 to use as API server"
-    exit 1
-  fi
-fi
-
-API_IPV6=""
-if [ "$KIND_IPV6_SUPPORT" == true ]; then
+check_ipv6() {
   # Collect additional IPv6 data on test environment
   # TEST-BEGIN
-  ERROR_FOUND=false
-  RESTART_DOCKER=false
   TMPVAR=`sysctl net.ipv6.conf.all.forwarding | awk '{print $3}'`
   echo "net.ipv6.conf.all.forwarding is equal to $TMPVAR"
   if [ "$TMPVAR" != 1 ]; then
@@ -193,85 +172,8 @@ if [ "$KIND_IPV6_SUPPORT" == true ]; then
     fi
   fi
 
-  DOCKER_DAEMON_FILE=/etc/docker/daemon.json
-  if [ -f $DOCKER_DAEMON_FILE ]; then
-    DOCKER_APPEND_STR=""
-    if ! grep -q "\"ipv6\": true" $DOCKER_DAEMON_FILE; then
-      echo "'\"ipv6\": true' NOT found!"
-      DOCKER_APPEND_STR="${DOCKER_APPEND_STR} \"ipv6\": true,"
-    fi
-    if ! grep -q "\"fixed-cidr-v6\":" $DOCKER_DAEMON_FILE ; then
-      echo "'\"fixed-cidr-v6\":' NOT found!"
-      DOCKER_APPEND_STR="${DOCKER_APPEND_STR} \"fixed-cidr-v6\": \"2001:db8:1::/64\","
-    fi
-
-    if [ "$DOCKER_APPEND_STR" != "" ]; then
-      if [ "$KIND_UPDATE_SYSTEM" == true ]; then
-        echo "Updating '$DOCKER_DAEMON_FILE' with DOCKER_APPEND_STR=$DOCKER_APPEND_STR"
-        RESTART_DOCKER=true
-        # The awk command:
-        #   Matches on '{' at the beginning of a line via: /^{/
-        #   On a match: 
-        #     Copy the first field (the '{') to awk variable out via: out=$1;
-        #     Then copy the generated string which is in awk variable DCKSTR to awk variable out via: out=out DCKSTR;
-        #     Then copy remaining fields to awk variable out via: for(i=2;i<=NF;i++) out=out" "$i;
-        #     Then print the awk variable out: print out;
-        #     Then move to the next input string
-        #   On NO match, perform default action of print line via: }1
-        # Write output to a temp file and move that file back to original.
-        sudo awk -v DCKSTR="$DOCKER_APPEND_STR" \
-           '/^{/{out=$1; out=out DCKSTR; for(i=2;i<=NF;i++) out=out" "$i; print out; next}1' $DOCKER_DAEMON_FILE > kind.tmp && \
-           sudo mv kind.tmp $DOCKER_DAEMON_FILE
-        echo "Dumping edited $DOCKER_DAEMON_FILE"
-        sudo cat $DOCKER_DAEMON_FILE
-      else
-        ERROR_FOUND=true
-        echo "Add: '$DOCKER_APPEND_STR' to '$DOCKER_DAEMON_FILE' to use IPv6."
-      fi
-    else
-      echo "'$DOCKER_DAEMON_FILE' NOT updated."
-     fi
-
-  else
-    if [ "$KIND_UPDATE_SYSTEM" == true ]; then
-      RESTART_DOCKER=true
-      cat << EOF | sudo tee -a "${DOCKER_DAEMON_FILE}" >/dev/null
-{
-  "ipv6": true,
-  "fixed-cidr-v6": "2001:db8:1::/64"
-}
-EOF
-    else
-      ERROR_FOUND=true
-      echo "Create '$DOCKER_DAEMON_FILE' with '{ \"ipv6\": true, \"fixed-cidr-v6\": \"2001:db8:1::/64\" }' to use IPv6."
-    fi
-  fi
-  if [ "$ERROR_FOUND" == true ]; then
-    exit 1
-  fi
-  if [ "$RESTART_DOCKER" == true ]; then
-    echo "Restarting Docker"
-    sudo systemctl restart docker
-    LOOPCNT=5
-    while true
-    do
-      echo "$LOOPCNT"
-      sudo systemctl status docker | grep -q "Active: active (running)"
-      if [ $? -eq 0 ] ; then
-         break
-      fi
-      let "LOOPCNT--"
-      if [ $LOOPCNT == 0 ] ; then
-        echo "Docker NOT restarting. Exiting ..."
-        exit 1
-      fi
-      sleep 1
-    done
-  fi
-
   # REMOVE: Verify docker has ipv6 enabled
   docker run --rm busybox ip a
-
 
   echo ""
   echo "Running: ip a"
@@ -284,57 +186,28 @@ EOF
   echo ""
   echo "Running: lsmod"
   lsmod | grep -qw ipv6 && echo "IPv6 kernel driver loaded and configured." || echo "IPv6 not configured and/or driver loaded on the system."
+}
 
-  # TEST-END
-
-  # ip -6 addr -> Run ip command for IPv6
-  # grep "inet6" -> Use only the lines with the IPv6 Address
-  # sed 's@/.*@@g' -> Strip off the trailing subnet mask, /xx
-  # grep -v "^::1$" -> Remove local host
-  # sed '/^fe80:/ d' -> Remove Link-Local Addresses
-  # head -n 1 -> Of the remaining, use first entry
-  if [[ ${KIND_HOST_INTERFACE} != "" ]]; then
-    KIND_HOST_INTERFACE="show dev ${KIND_HOST_INTERFACE}"
-  fi
-  echo "KIND_HOST_INTERFACE=${KIND_HOST_INTERFACE}"
-  API_IPV6=$(ip -6 addr ${KIND_HOST_INTERFACE} | grep "inet6" | awk -F' ' '{print $2}' | \
-             sed 's@/.*@@g' | grep -v "^::1$" | sed '/^fe80:/ d' | head -n 1)
-  # TO REPRODUCE CI Local IPv6 Failure
-  #API_IPV6=$(ip -6 addr ${KIND_HOST_INTERFACE} | grep "inet6" | awk -F' ' '{print $2}' | \
-  #           sed 's@/.*@@g' | grep -v "^::1$" | grep "fe80:" | head -n 1)
-  if [ -z "$API_IPV6" ]; then
-    # No IPv6 global addresses, Repeat but allow local address
-    API_IPV6=$(ip -6 addr ${KIND_HOST_INTERFACE} | grep "inet6" | awk -F' ' '{print $2}' | \
-               sed 's@/.*@@g' | grep -v "^::1$" | head -n 1)
-    if [ -z "$API_IPV6" ]; then
-      echo "Error detecting machine IPv6 to use as API server"
-      exit 1
-    else
-      echo "Using IPv6 LOCAL for API_IPV6"
-    fi
-  fi
+if [ "$KIND_IPV6_SUPPORT" == true ]; then 
+  check_ipv6
 fi
 
 if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == false ]; then
-  API_IP=${API_IPV4}
   IP_FAMILY=""
   NET_CIDR=$NET_CIDR_IPV4
   SVC_CIDR=$SVC_CIDR_IPV4
-  echo "IPv4 Only Support: API_IP=$API_IP --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
+  echo "IPv4 Only Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
 elif [ "$KIND_IPV4_SUPPORT" == false ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
-  API_IP=${API_IPV6}
   IP_FAMILY="ipv6"
   NET_CIDR=$NET_CIDR_IPV6
   SVC_CIDR=$SVC_CIDR_IPV6
-  echo "IPv6 Only Support: API_IP=$API_IP --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
+  echo "IPv6 Only Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
 elif [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
   #TODO DUALSTACK: Multiple IP Addresses for APIServer not currently supported.
-  #API_IP=${API_IPV4},${API_IPV6}
-  API_IP=${API_IPV4}
   IP_FAMILY="DualStack"
   NET_CIDR=$NET_CIDR_IPV4,$NET_CIDR_IPV6
   SVC_CIDR=$SVC_CIDR_IPV4,$SVC_CIDR_IPV6
-  echo "Dual Stack Support: API_IP=$API_IP --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
+  echo "Dual Stack Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
 else
   echo "Invalid setup. KIND_IPV4_SUPPORT and/or KIND_IPV6_SUPPORT must be true."
   exit 1
@@ -343,8 +216,7 @@ fi
 # Output of the j2 command
 KIND_CONFIG_LCL=./kind.yaml
 
-ovn_apiServerAddress=${API_IP} \
-  ovn_ip_family=${IP_FAMILY} \
+ovn_ip_family=${IP_FAMILY} \
   ovn_ha=${KIND_HA} \
   ovn_num_master=${KIND_NUM_MASTER} \
   ovn_num_worker=${KIND_NUM_WORKER} \
@@ -354,21 +226,6 @@ ovn_apiServerAddress=${API_IP} \
 kind create cluster --name ${KIND_CLUSTER_NAME} --verbosity 5 --kubeconfig ${HOME}/admin.conf --image kindest/node:${K8S_VERSION} --config=${KIND_CONFIG_LCL}
 export KUBECONFIG=${HOME}/admin.conf
 cat ${KUBECONFIG}
-mkdir -p /tmp/kind
-sudo chmod 777 /tmp/kind
-count=0
-until kubectl get secrets -o jsonpath='{.items[].data.ca\.crt}'
-do
-  if [ $count -gt 10 ]; then
-    echo "Failed to get k8s crt/token"
-    exit 1
-  fi
-  count=$((count+1))
-  echo "secrets not available on attempt $count"
-  sleep 5
-done
-kubectl get secrets -o jsonpath='{.items[].data.ca\.crt}' > /tmp/kind/ca.crt
-kubectl get secrets -o jsonpath='{.items[].data.token}' > /tmp/kind/token
 
 if [[ "$IP_FAMILY" == "ipv6" ]]; then
   echo "BILLY: IPv6 Only - UPDATE CoreDNS"
@@ -398,25 +255,41 @@ if [[ "$IP_FAMILY" == "ipv6" ]]; then
   printf '%s' "${fixed_coredns}" | kubectl apply -f -
 fi
 
+# Build the ovn-kube controller
 pushd ../go-controller
 make
 popd
+
+# Create the ovn-kube image
 pushd ../dist/images
 sudo cp -f ../../go-controller/_output/go/bin/* .
 echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
 docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
-./daemonset.sh \
-  --image=docker.io/library/ovn-daemonset-f:dev \
+
+# Detect API IP address for OVN
+
+# Despite OVN run in pod they will only obtain the VIRTUAL apiserver address
+# and since OVN has to provide the connectivity to service
+# it can not be bootstrapped
+
+# This is the address of the node with the control-plane
+# If HA, multiple control-plane nodes, KIND deploys
+API_URL=$(kind get kubeconfig --internal --name ${KIND_CLUSTER_NAME} | grep server | awk '{ print $2 }')
+# Create ovn-kube manifests
+./daemonset.sh --image=docker.io/library/ovn-daemonset-f:dev \
   --net-cidr=${NET_CIDR} \
   --svc-cidr=${SVC_CIDR} \
   --gateway-mode=${OVN_GATEWAY_MODE} \
-  --hybrid-enabled=${OVN_HYBRID_OVERLAY_ENABLE} \
-  --k8s-apiserver=https://[${API_IP}]:11337 \
+  --k8s-apiserver=${API_URL} \
   --ovn-master-count=${KIND_NUM_MASTER} \
   --kind \
   --master-loglevel=5
 popd
+
+# Preload ovn-kube images in the kind cluster
 kind load docker-image ovn-daemonset-f:dev --name ${KIND_CLUSTER_NAME}
+
+# Deploy ovn-kube
 pushd ../dist/yaml
 run_kubectl create -f ovn-setup.yaml
 CONTROL_NODES=$(docker ps -f name=ovn-control | grep -v NAMES | awk '{ print $NF }')
@@ -434,26 +307,29 @@ fi
 run_kubectl create -f ovnkube-master.yaml
 run_kubectl create -f ovnkube-node.yaml
 popd
+
+# We can delete kube-proxy
 run_kubectl -n kube-system delete ds kube-proxy
 kind get clusters
 kind get nodes --name ${KIND_CLUSTER_NAME}
-kind export kubeconfig --name ovn
+kind export kubeconfig --name ${KIND_CLUSTER_NAME}
 if [ "$KIND_INSTALL_INGRESS" == true ]; then
   run_kubectl apply -f ingress/mandatory.yaml
   run_kubectl apply -f ingress/service-nodeport.yaml
 fi
 
-count=1
-until [ -z "$(kubectl get pod -A -o custom-columns=NAME:metadata.name,STATUS:.status.phase | tail -n +2 | grep -v Running)" ];do
-  if [ $count -gt 20 ]; then
-    echo "Some pods are not running after timeout"
-    exit 1
-  fi
-  echo "All pods not available yet on attempt $count:"
-  kubectl get pod -A || true
-  count=$((count+1))
-  sleep 10
-done
+# Check that everything is fine and running
+
+if ! kubectl wait -n ovn-kubernetes --for=condition=ready pods --all --timeout=300s ; then
+  echo "some pods in OVN Kubernetes are not running"
+  exit 1
+fi
+
+if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=300s ; then
+  echo "some pods in the system are not running"
+  exit 1
+fi
+
 echo "Pods are all up, allowing things settle for 30 seconds..."
 sleep 30
 

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -108,6 +108,8 @@ print_params()
      echo "KIND_NUM_WORKER = $KIND_NUM_WORKER"
      echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
      echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
+     echo "KIND_UPDATE_SYSTEM = $KIND_UPDATE_SYSTEM"
+     echo "KIND_HOST_INTERFACE = $KIND_HOST_INTERFACE"
      echo ""
 }
 
@@ -124,6 +126,9 @@ KIND_REMOVE_TAINT=${KIND_REMOVE_TAINT:-true}
 KIND_IPV4_SUPPORT=${KIND_IPV4_SUPPORT:-true}
 KIND_IPV6_SUPPORT=${KIND_IPV6_SUPPORT:-false}
 OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
+KIND_UPDATE_SYSTEM=${KIND_UPDATE_SYSTEM:-false}
+KIND_HOST_INTERFACE=${KIND_HOST_INTERFACE:-""}
+#KIND_HOST_INTERFACE="docker0"
 
 # Input not currently validated. Modify outside script at your own risk.
 # These are the same values defaulted to in KIND code (kind/default.go).
@@ -163,17 +168,150 @@ fi
 
 API_IPV6=""
 if [ "$KIND_IPV6_SUPPORT" == true ]; then
+  # Collect additional IPv6 data on test environment
+  # TEST-BEGIN
+  ERROR_FOUND=false
+  RESTART_DOCKER=false
+  TMPVAR=`sysctl net.ipv6.conf.all.forwarding | awk '{print $3}'`
+  echo "net.ipv6.conf.all.forwarding is equal to $TMPVAR"
+  if [ "$TMPVAR" != 1 ]; then
+    if [ "$KIND_UPDATE_SYSTEM" == true ]; then
+      sudo sysctl -w net.ipv6.conf.all.forwarding=1
+    else
+      echo "RUN: 'sudo sysctl -w net.ipv6.conf.all.forwarding=1' to use IPv6."
+      ERROR_FOUND=true
+    fi
+  fi
+  TMPVAR=`sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}'`
+  echo "net.ipv6.conf.all.disable_ipv6 is equal to $TMPVAR"
+  if [ "$TMPVAR" != 0 ]; then
+    if [ "$KIND_UPDATE_SYSTEM" == true ]; then
+      sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
+    else
+      echo "RUN: 'sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0' to use IPv6."
+      ERROR_FOUND=true
+    fi
+  fi
+
+  DOCKER_DAEMON_FILE=/etc/docker/daemon.json
+  if [ -f $DOCKER_DAEMON_FILE ]; then
+    DOCKER_APPEND_STR=""
+    if ! grep -q "\"ipv6\": true" $DOCKER_DAEMON_FILE; then
+      echo "'\"ipv6\": true' NOT found!"
+      DOCKER_APPEND_STR="${DOCKER_APPEND_STR} \"ipv6\": true,"
+    fi
+    if ! grep -q "\"fixed-cidr-v6\":" $DOCKER_DAEMON_FILE ; then
+      echo "'\"fixed-cidr-v6\":' NOT found!"
+      DOCKER_APPEND_STR="${DOCKER_APPEND_STR} \"fixed-cidr-v6\": \"2001:db8:1::/64\","
+    fi
+
+    if [ "$DOCKER_APPEND_STR" != "" ]; then
+      if [ "$KIND_UPDATE_SYSTEM" == true ]; then
+        echo "Updating '$DOCKER_DAEMON_FILE' with DOCKER_APPEND_STR=$DOCKER_APPEND_STR"
+        RESTART_DOCKER=true
+        # The awk command:
+        #   Matches on '{' at the beginning of a line via: /^{/
+        #   On a match: 
+        #     Copy the first field (the '{') to awk variable out via: out=$1;
+        #     Then copy the generated string which is in awk variable DCKSTR to awk variable out via: out=out DCKSTR;
+        #     Then copy remaining fields to awk variable out via: for(i=2;i<=NF;i++) out=out" "$i;
+        #     Then print the awk variable out: print out;
+        #     Then move to the next input string
+        #   On NO match, perform default action of print line via: }1
+        # Write output to a temp file and move that file back to original.
+        sudo awk -v DCKSTR="$DOCKER_APPEND_STR" \
+           '/^{/{out=$1; out=out DCKSTR; for(i=2;i<=NF;i++) out=out" "$i; print out; next}1' $DOCKER_DAEMON_FILE > kind.tmp && \
+           sudo mv kind.tmp $DOCKER_DAEMON_FILE
+        echo "Dumping edited $DOCKER_DAEMON_FILE"
+        sudo cat $DOCKER_DAEMON_FILE
+      else
+        ERROR_FOUND=true
+        echo "Add: '$DOCKER_APPEND_STR' to '$DOCKER_DAEMON_FILE' to use IPv6."
+      fi
+    else
+      echo "'$DOCKER_DAEMON_FILE' NOT updated."
+     fi
+
+  else
+    if [ "$KIND_UPDATE_SYSTEM" == true ]; then
+      RESTART_DOCKER=true
+      cat << EOF | sudo tee -a "${DOCKER_DAEMON_FILE}" >/dev/null
+{
+  "ipv6": true,
+  "fixed-cidr-v6": "2001:db8:1::/64"
+}
+EOF
+    else
+      ERROR_FOUND=true
+      echo "Create '$DOCKER_DAEMON_FILE' with '{ \"ipv6\": true, \"fixed-cidr-v6\": \"2001:db8:1::/64\" }' to use IPv6."
+    fi
+  fi
+  if [ "$ERROR_FOUND" == true ]; then
+    exit 1
+  fi
+  if [ "$RESTART_DOCKER" == true ]; then
+    echo "Restarting Docker"
+    sudo systemctl restart docker
+    LOOPCNT=5
+    while true
+    do
+      echo "$LOOPCNT"
+      sudo systemctl status docker | grep -q "Active: active (running)"
+      if [ $? -eq 0 ] ; then
+         break
+      fi
+      let "LOOPCNT--"
+      if [ $LOOPCNT == 0 ] ; then
+        echo "Docker NOT restarting. Exiting ..."
+        exit 1
+      fi
+      sleep 1
+    done
+  fi
+
+  # REMOVE: Verify docker has ipv6 enabled
+  docker run --rm busybox ip a
+
+
+  echo ""
+  echo "Running: ip a"
+  ip a
+
+  echo ""
+  echo "Running: Check for /proc/net/if_inet6"
+  [ -f /proc/net/if_inet6 ] && echo '  IPv6 ready system!' || echo '  No IPv6 support found! Compile the kernel!!'
+
+  echo ""
+  echo "Running: lsmod"
+  lsmod | grep -qw ipv6 && echo "IPv6 kernel driver loaded and configured." || echo "IPv6 not configured and/or driver loaded on the system."
+
+  # TEST-END
+
   # ip -6 addr -> Run ip command for IPv6
   # grep "inet6" -> Use only the lines with the IPv6 Address
   # sed 's@/.*@@g' -> Strip off the trailing subnet mask, /xx
   # grep -v "^::1$" -> Remove local host
   # sed '/^fe80:/ d' -> Remove Link-Local Addresses
   # head -n 1 -> Of the remaining, use first entry
-  API_IPV6=$(ip -6 addr  | grep "inet6" | awk -F' ' '{print $2}' | \
+  if [[ ${KIND_HOST_INTERFACE} != "" ]]; then
+    KIND_HOST_INTERFACE="show dev ${KIND_HOST_INTERFACE}"
+  fi
+  echo "KIND_HOST_INTERFACE=${KIND_HOST_INTERFACE}"
+  API_IPV6=$(ip -6 addr ${KIND_HOST_INTERFACE} | grep "inet6" | awk -F' ' '{print $2}' | \
              sed 's@/.*@@g' | grep -v "^::1$" | sed '/^fe80:/ d' | head -n 1)
+  # TO REPRODUCE CI Local IPv6 Failure
+  #API_IPV6=$(ip -6 addr ${KIND_HOST_INTERFACE} | grep "inet6" | awk -F' ' '{print $2}' | \
+  #           sed 's@/.*@@g' | grep -v "^::1$" | grep "fe80:" | head -n 1)
   if [ -z "$API_IPV6" ]; then
-    echo "Error detecting machine IPv6 to use as API server"
-    exit 1
+    # No IPv6 global addresses, Repeat but allow local address
+    API_IPV6=$(ip -6 addr ${KIND_HOST_INTERFACE} | grep "inet6" | awk -F' ' '{print $2}' | \
+               sed 's@/.*@@g' | grep -v "^::1$" | head -n 1)
+    if [ -z "$API_IPV6" ]; then
+      echo "Error detecting machine IPv6 to use as API server"
+      exit 1
+    else
+      echo "Using IPv6 LOCAL for API_IPV6"
+    fi
   fi
 fi
 
@@ -213,7 +351,7 @@ ovn_apiServerAddress=${API_IP} \
   j2 ${KIND_CONFIG} -o ${KIND_CONFIG_LCL}
 
 # Create KIND cluster. For additional debug, add '--verbosity <int>': 0 None .. 3 Debug
-kind create cluster --name ${KIND_CLUSTER_NAME} --kubeconfig ${HOME}/admin.conf --image kindest/node:${K8S_VERSION} --config=${KIND_CONFIG_LCL}
+kind create cluster --name ${KIND_CLUSTER_NAME} --verbosity 5 --kubeconfig ${HOME}/admin.conf --image kindest/node:${K8S_VERSION} --config=${KIND_CONFIG_LCL}
 export KUBECONFIG=${HOME}/admin.conf
 cat ${KUBECONFIG}
 mkdir -p /tmp/kind
@@ -231,6 +369,35 @@ do
 done
 kubectl get secrets -o jsonpath='{.items[].data.ca\.crt}' > /tmp/kind/ca.crt
 kubectl get secrets -o jsonpath='{.items[].data.token}' > /tmp/kind/token
+
+if [[ "$IP_FAMILY" == "ipv6" ]]; then
+  echo "BILLY: IPv6 Only - UPDATE CoreDNS"
+  # IPv6 clusters need some CoreDNS changes in order to work in k8s CI:
+  # 1. k8s CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
+  # to work in an offline environment:
+  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
+  # 2. k8s CI adds following domains to resolv.conf search field:
+  # c.k8s-prow-builds.internal google.internal.
+  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
+  # otherwise pods stops trying to resolve the domain.
+  # Get the current config
+  original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
+  echo "Original CoreDNS config:"
+  echo "${original_coredns}"
+  # Patch it
+  fixed_coredns=$(
+    printf '%s' "${original_coredns}" | sed \
+      -e 's/^.*kubernetes cluster\.local/& internal/' \
+      -e '/^.*upstream$/d' \
+      -e '/^.*fallthrough.*$/d' \
+      -e '/^.*forward . \/etc\/resolv.conf$/d' \
+      -e '/^.*loop$/d' \
+  )
+  echo "Patched CoreDNS config:"
+  echo "${fixed_coredns}"
+  printf '%s' "${fixed_coredns}" | kubectl apply -f -
+fi
+
 pushd ../go-controller
 make
 popd

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -3,8 +3,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   # the default CNI will not be installed
   disableDefaultCNI: true
-  apiServerAddress: {{ ovn_apiServerAddress | default('11.12.13.1') }}
-  apiServerPort: 11337
 {%- if ovn_ip_family %}
   ipFamily: {{ ovn_ip_family }}
 {%- endif %}
@@ -18,9 +16,6 @@ kubeadmConfigPatches:
       "feature-gates": "SCTPSupport=true"
 nodes:
  - role: control-plane
-   extraMounts:
-     - hostPath: /tmp/kind
-       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
    kubeadmConfigPatches:
    - |
      kind: InitConfiguration
@@ -31,15 +26,9 @@ nodes:
 {%- if ovn_ha is equalto "true" %}
 {%- for _ in range(1, ovn_num_master | int) %}
  - role: control-plane
-   extraMounts:
-     - hostPath: /tmp/kind
-       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
 {%- endfor %}
 {%- endif %}
 {%- for _ in range(ovn_num_worker | int) %}
  - role: worker
-   extraMounts:
-     - hostPath: /tmp/kind
-       containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
 {%- endfor %}
 

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -74,7 +74,7 @@ ovn_loglevel_northd=${OVN_LOGLEVEL_NORTHD:-"-vconsole:info"}
 ovn_loglevel_nb=${OVN_LOGLEVEL_NB:-"-vconsole:info"}
 ovn_loglevel_sb=${OVN_LOGLEVEL_SB:-"-vconsole:info"}
 ovn_loglevel_controller=${OVN_LOGLEVEL_CONTROLLER:-"-vconsole:info"}
-ovn_loglevel_nbctld= ${OVN_LOGLEVEL_NBCTLD:"-vconsole:info"}
+ovn_loglevel_nbctld=${OVN_LOGLEVEL_NBCTLD:"-vconsole:info"}
 
 ovnkubelogdir=/var/log/ovn-kubernetes
 
@@ -764,6 +764,12 @@ ovn-master() {
   }
 
   echo "=============== ovn-master ========== MASTER ONLY"
+  ovn_metrics_bind_address="0.0.0.0"
+  if [[ "${net_cidr}" == *":"* ]]; then
+    ovn_metrics_bind_address="[::]"
+  fi
+  echo "BILLY: ovn_metrics_bind_address=${ovn_metrics_bind_address} net_cidr=${net_cidr} svc_cidr=${svc_cidr} ovn_nbdb=${ovn_nbdb}"
+
   /usr/bin/ovnkube \
     --init-master ${K8S_NODE} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
@@ -775,7 +781,7 @@ ovn-master() {
     --pidfile ${OVN_RUNDIR}/ovnkube-master.pid \
     --logfile /var/log/ovn-kubernetes/ovnkube-master.log \
     ${ovn_master_ssl_opts} \
-    --metrics-bind-address "0.0.0.0:9409" &
+    --metrics-bind-address "${ovn_metrics_bind_address}:9409" &
   echo "=============== ovn-master ========== running"
   wait_for_event attempts=3 process_ready ovnkube-master
 
@@ -873,6 +879,11 @@ ovn-node() {
   }
 
   echo "=============== ovn-node   --init-node"
+  ovn_metrics_bind_address="0.0.0.0"
+  if [[ "${net_cidr}" == *":"* ]]; then
+    ovn_metrics_bind_address="[::]"
+  fi
+  echo "BILLY: ovn_metrics_bind_address=${ovn_metrics_bind_address} net_cidr=${net_cidr} svc_cidr=${svc_cidr} ovn_nbdb=${ovn_nbdb}"
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
@@ -886,7 +897,7 @@ ovn-node() {
     --logfile /var/log/ovn-kubernetes/ovnkube.log \
     ${ovn_node_ssl_opts} \
     --inactivity-probe=${ovn_remote_probe_interval} \
-    --metrics-bind-address "0.0.0.0:9410" &
+    --metrics-bind-address "${ovn_metrics_bind_address}:9410" &
 
   wait_for_event attempts=3 process_ready ovnkube
   setup_cni

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/klog"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -186,6 +187,6 @@ func (cs *configSubnets) checkIPFamilies() (usingIPv4, usingIPv6 bool, err error
 	if cs.v4[configSubnetHybrid] || cs.v6[configSubnetHybrid] {
 		netConfig += ", " + cs.describeSubnetType(configSubnetHybrid)
 	}
-
+	klog.Errorf("BILLY: checkIPFamilies() - configSubnetHybrid  v4=%v  v6=%v", cs.v4[configSubnetHybrid], cs.v6[configSubnetHybrid])
 	return false, false, fmt.Errorf("illegal network configuration: %s", netConfig)
 }

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -45,6 +45,27 @@ should set default value on new IngressClass
 should prevent Ingress creation if more than 1 IngressClass marked as default
 "
 
+IPV4_ONLY_TESTS="
+# shard-n Tests
+Network.+should resolve connrection reset issue
+\[Feature:Networking-IPv4\]
+
+# shard-np Tests
+NetworkPolicy.+should allow egress access to server in CIDR block
+
+# shard-s Tests
+Services.+should create endpoints for unready pods
+
+# shard-other Tests
+DNS.+should provide DNS
+DNS.+should resolve DNS
+DNS.+should provide /etc/hosts entries
+"
+
+if [ "$SHARD" != shard-ipv4 ]; then
+	SKIPPED_TESTS=$SKIPPED_TESTS$IPV4_ONLY_TESTS
+fi
+
 SKIPPED_TESTS=$(echo "${SKIPPED_TESTS}" | sed -e '/^\($\|#\)/d' -e 's/ /\\s/g' | tr '\n' '|' | sed -e 's/|$//')
 
 GINKGO_ARGS="--num-nodes=3 --ginkgo.skip=${SKIPPED_TESTS} --disable-log-dump=false"
@@ -57,6 +78,10 @@ case "$SHARD" in
 	shard-np)
 		# all tests that have P as the sixth letter after the N
 		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$'
+		;;
+	shard-ipv4)
+		IPV4_ONLY_TESTS=$(echo "${IPV4_ONLY_TESTS}" | sed -e '/^\($\|#\)/d' -e 's/ /\\s/g' | tr '\n' '|' | sed -e 's/|$//')
+		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\].*'$IPV4_ONLY_TESTS'.*'
 		;;
 	shard-test)
 		TEST_REGEX_REPR=$(echo ${@:2} | sed 's/ /\\s/g')

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -10,7 +10,7 @@ sudo ln ./_output/local/go/bin/e2e.test /usr/local/bin/e2e.test
 popd
 
 mkdir -p $GOPATH/bin
-wget -O $GOPATH/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
+wget -O $GOPATH/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64
 chmod +x $GOPATH/bin/kind
 pushd ../contrib
 ./kind.sh


### PR DESCRIPTION
  KIND IPv6 support for nonHA environments
    
    - move to KIND v8.1
    - leverage KIND to detected the API_URL
    - avoid mount propagation to get the credentials
      since all components are running on pods
    - use kubectl wait to detect the pods status
    
    Signed-off-by: Antonio Ojea <aojea@redhat.com>
