### PR TITLE
trivial: remove needless debug message in NodeUpdate handler function

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -618,8 +618,6 @@ func (oc *Controller) WatchNodes() error {
 				return
 			}
 
-			klog.V(5).Infof("Updated event for Node %q", node.Name)
-
 			_, failed := mgmtPortFailed.Load(node.Name)
 			if failed || macAddressChanged(oldNode, node) {
 				err := oc.syncNodeManagementPort(node, nil)


### PR DESCRIPTION
As can be seen below

$ grep 'Updated event for Node' ovnkube-master.log  |wc -l
332162
$ wc -l ovnkube-master.log
595708 ovnkube-master.log

Nearly 50% of the log messages are just

Updated event for Node "node1"
Updated event for Node "node2"
Updated event for Node "node3"
Updated event for Node "node2"
Updated event for Node "node2"
Updated event for Node "node2"
Updated event for Node "node4"

@ovn-org/ovn-kubernetes-committers PTAL