### PR TITLE
run e2e_timestamp metrics updater only on the active master node

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -53,7 +53,7 @@ var MetricMasterReadyDuration = prometheus.NewGauge(prometheus.GaugeOpts{
 })
 
 var registerMasterMetricsOnce sync.Once
-var startMasterUpdaterOnce sync.Once
+var startE2ETimeStampUpdaterOnce sync.Once
 
 // RegisterMasterMetrics registers some ovnkube master metrics with the Prometheus
 // registry
@@ -61,7 +61,7 @@ func RegisterMasterMetrics() {
 	registerMasterMetricsOnce.Do(func() {
 		prometheus.MustRegister(metricE2ETimestamp)
 		// following go routine is directly responsible for collecting the metric above.
-		startMasterMetricsUpdater()
+		StartE2ETimeStampMetricUpdater()
 
 		prometheus.MustRegister(metricPodCreationLatency)
 		prometheus.MustRegister(prometheus.NewCounterFunc(
@@ -121,10 +121,10 @@ func scrapeOvnTimestamp() float64 {
 	return out
 }
 
-// startMasterMetricsUpdater adds a goroutine that updates a "timestamp" value in the
+// StartE2ETimeStampMetricUpdater adds a goroutine that updates a "timestamp" value in the
 // nbdb every 30 seconds. This is so we can determine freshness of the database
-func startMasterMetricsUpdater() {
-	startMasterUpdaterOnce.Do(func() {
+func StartE2ETimeStampMetricUpdater() {
+	startE2ETimeStampUpdaterOnce.Do(func() {
 		go func() {
 			for {
 				t := time.Now().Unix()

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -62,6 +62,9 @@ func (oc *Controller) Start(kClient kubernetes.Interface, nodeName string) error
 					end := time.Since(start)
 					metrics.MetricMasterReadyDuration.Set(end.Seconds())
 				}()
+				// run the End-to-end timestamp metric updater only on the
+				// active master node.
+				metrics.StartE2ETimeStampMetricUpdater()
 				if err := oc.StartClusterMaster(nodeName); err != nil {
 					panic(err.Error())
 				}


### PR DESCRIPTION
the way it is now, the NB_Global table gets updated with this timestamp
from three different places and it gets overwritten by these updates.
we just want the active master node to set this metric value in the OVN
NB table

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>
