### PR TITLE
some minor fixes in the AddressSet object code.

### DIFF
--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -241,6 +241,7 @@ func GetAllPodIPs(pod *v1.Pod) ([]net.IP, error) {
 		ip := net.ParseIP(podIP.IP)
 		if ip == nil {
 			klog.Warningf("failed to parse pod IP %q", podIP)
+			continue
 		}
 		ips = append(ips, ip)
 	}


### PR DESCRIPTION
This PR has two commits

1. GetAllPodIPs() was not skipping over the `nil` net.IP address (in one scenario) and was including the nil object in the returned array. There is a fix for this.

2. We were sorting the IPs that were being added to the address_set. I don’t know how efficient this
sort is going to be when we have 1000s of pods in a single namespace. Furthermore, the sorting is lost as new pods gets added to namespace later on, so just removed the sorting

@dcbw FYI
@ovn-org/ovn-kubernetes-committers PTAL. Thanks
