### PR TITLE
WIP : Dual stack support for IP blocks in network policy

### DIFF
--- a/go-controller/pkg/ovn/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set_test.go
@@ -24,6 +24,10 @@ func (asn *testAddressSetName) makeName() string {
 	return fmt.Sprintf("%s.%s.%s", asn.namespace, asn.suffix1, asn.suffix2)
 }
 
+const (
+	fakeUUIDv6 = "8a86f6d8-7972-4253-b0bd-ddbef66e9304"
+)
+
 var _ = Describe("OVN Address Set operations", func() {
 	var (
 		app       *cli.App
@@ -116,7 +120,7 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 					Output: fakeUUID,
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -139,7 +143,7 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 					Output: fakeUUID,
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -167,10 +171,10 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a9625390261332436968 external-ids:name=foobar addresses="` + addr1 + `" "` + addr2 + `"`,
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4 addresses="` + addr1 + `" "` + addr2 + `"`,
 					Output: fakeUUID,
 				})
 
@@ -191,7 +195,7 @@ var _ = Describe("OVN Address Set operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 				Output: fakeUUID,
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -221,10 +225,10 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 create address_set name=a9625390261332436968 external-ids:name=foobar",
+					Cmd:    "ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4",
 					Output: fakeUUID,
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -234,11 +238,8 @@ var _ = Describe("OVN Address Set operations", func() {
 				as, err := asFactory.NewAddressSet("foobar", nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = as.AddIP(net.ParseIP(addr1))
-				Expect(err).NotTo(HaveOccurred())
-
 				// Re-adding is a no-op
-				err = as.AddIP(net.ParseIP(addr1))
+				err = as.AddIPs([]net.IP{net.ParseIP(addr1)})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
@@ -257,10 +258,10 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a9625390261332436968 external-ids:name=foobar addresses="` + addr1 + `"`,
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4 addresses="` + addr1 + `"`,
 					Output: fakeUUID,
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -270,11 +271,264 @@ var _ = Describe("OVN Address Set operations", func() {
 				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1)})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = as.DeleteIP(net.ParseIP(addr1))
+				err = as.DeleteIPs([]net.IP{net.ParseIP(addr1)})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Deleting a non-existent address is a no-op
-				err = as.DeleteIP(net.ParseIP(addr1))
+				err = as.DeleteIPs([]net.IP{net.ParseIP(addr1)})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Dual stack : when creating an address set object", func() {
+		It("re-uses an existing dual stack address set and replaces IPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					addr1 string = "1.2.3.4"
+					addr2 string = "5.6.7.8"
+					addr3 string = "2001:db8::1"
+					addr4 string = "2001:db8::2"
+				)
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 set address_set ` + fakeUUID + ` addresses="` + addr1 + `" "` + addr2 + `"`,
+				})
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+					Output: fakeUUIDv6,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 set address_set ` + fakeUUIDv6 + ` addresses="` + addr3 + `" "` + addr4 + `"`,
+				})
+
+				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2),
+					net.ParseIP(addr3), net.ParseIP(addr4)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("clears an existing address set of dual stack IPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 clear address_set " + fakeUUID + " addresses",
+				})
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+					Output: fakeUUIDv6,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 clear address_set ` + fakeUUIDv6 + " addresses",
+				})
+
+				_, err = asFactory.NewAddressSet("foobar", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates a new address set and sets dual stack IPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					addr1 string = "1.2.3.4"
+					addr2 string = "5.6.7.8"
+					addr3 string = "2001:db8::1"
+					addr4 string = "2001:db8::2"
+				)
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4 addresses="` + addr1 + `" "` + addr2 + `"`,
+					Output: fakeUUID,
+				})
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990493521189787229 external-ids:name=foobar_v6 addresses="` + addr3 + `" "` + addr4 + `"`,
+					Output: fakeUUIDv6,
+				})
+
+				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2),
+					net.ParseIP(addr3), net.ParseIP(addr4)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	It("destroys an dual stack address set", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+			config.IPv6Mode = true
+
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+				Output: fakeUUID,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 clear address_set " + fakeUUID + " addresses",
+			})
+
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+				Output: fakeUUIDv6,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 clear address_set " + fakeUUIDv6 + " addresses",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --if-exists destroy address_set " + fakeUUID,
+				"ovn-nbctl --timeout=15 --if-exists destroy address_set " + fakeUUIDv6,
+			})
+
+			as, err := asFactory.NewAddressSet("foobar", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = as.Destroy()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+			return nil
+		}
+
+		err := app.Run([]string{app.Name})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("Dual Stack : when manipulating IPs in an address set object", func() {
+		It("adds  IP to an empty dual stack address set", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const addr1 string = "1.2.3.4"
+				const addr2 string = "2001:db8::1"
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4",
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 create address_set name=a16990493521189787229 external-ids:name=foobar_v6",
+					Output: fakeUUIDv6,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 add address_set ` + fakeUUID + ` addresses "` + addr1 + `"`,
+				})
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 add address_set ` + fakeUUIDv6 + ` addresses "` + addr2 + `"`,
+				})
+
+				as, err := asFactory.NewAddressSet("foobar", nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = as.AddIPs([]net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Re-adding is a no-op
+				err = as.AddIPs([]net.IP{net.ParseIP(addr1)})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("deletes an IP from an dual stack address set", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const addr1 string = "1.2.3.4"
+				const addr2 string = "2001:db8::1"
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4 addresses="` + addr1 + `"`,
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990493521189787229 external-ids:name=foobar_v6 addresses="` + addr2 + `"`,
+					Output: fakeUUIDv6,
+				})
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 remove address_set ` + fakeUUID + ` addresses "` + addr1 + `"`,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 remove address_set ` + fakeUUIDv6 + ` addresses "` + addr2 + `"`,
+				})
+
+				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = as.DeleteIPs([]net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Deleting a non-existent address is a no-op
+				err = as.DeleteIPs([]net.IP{net.ParseIP(addr1)})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)

--- a/go-controller/pkg/ovn/fake_address_set_test.go
+++ b/go-controller/pkg/ovn/fake_address_set_test.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilnet "k8s.io/utils/net"
+
 	. "github.com/onsi/gomega"
 )
 
@@ -29,26 +34,49 @@ func (f *fakeAddressSetFactory) NewAddressSet(name string, ips []net.IP) (Addres
 	defer f.Unlock()
 	_, ok := f.sets[name]
 	Expect(ok).To(BeFalse())
-	set := newFakeAddressSet(name, ips, f.removeAddressSet)
-	f.sets[name] = set
+	set, err := newFakeAddressSets(name, ips, f.removeAddressSet)
+	if err != nil {
+		return nil, err
+	}
+	if set.ipv4 != nil {
+		f.sets[getIPv4ASNameForNamespace(name)] = set.ipv4
+	}
+	if set.ipv6 != nil {
+		f.sets[getIPv6ASNameForNamespace(name)] = set.ipv6
+	}
 	return set, nil
 }
 
 func (f *fakeAddressSetFactory) ForEachAddressSet(iteratorFn AddressSetIterFunc) error {
-	for name, set := range f.sets {
-		parts := strings.Split(set.GetName(), ".")
+	asNames := sets.String{}
+	for _, set := range f.sets {
+		asName := truncateSuffixFromAddressset(set.getName())
+		if asNames.Has(asName) {
+			continue
+		}
+		asNames.Insert(asName)
+		parts := strings.Split(asName, ".")
 		addrSetNamespace := parts[0]
 		nameSuffix := ""
 		if len(parts) >= 2 {
 			nameSuffix = parts[1]
 		}
-		iteratorFn(name, addrSetNamespace, nameSuffix)
+		iteratorFn(asName, addrSetNamespace, nameSuffix)
 	}
 	return nil
 }
 
 func (f *fakeAddressSetFactory) DestroyAddressSetInBackingStore(name string) error {
-	f.removeAddressSet(name)
+	if _, ok := f.sets[name]; ok {
+		f.removeAddressSet(name)
+		return nil
+	}
+	if config.IPv4Mode {
+		f.removeAddressSet(getIPv4ASNameForNamespace(name))
+	}
+	if config.IPv6Mode {
+		f.removeAddressSet(getIPv6ASNameForNamespace(name))
+	}
 	return nil
 }
 
@@ -67,6 +95,12 @@ func (f *fakeAddressSetFactory) removeAddressSet(name string) {
 	f.Lock()
 	defer f.Unlock()
 	delete(f.sets, name)
+}
+
+// ExpectNoAddressSet ensures the named address set does not exist
+func (f *fakeAddressSetFactory) ExpectNoAddressSet(name string) {
+	_, ok := f.sets[name]
+	Expect(ok).To(BeFalse())
 }
 
 // ExpectAddressSetWithIPs ensures the named address set exists with the given set of IPs
@@ -116,8 +150,35 @@ type fakeAddressSet struct {
 	removeFn  removeFunc
 }
 
+type fakeAddressSets struct {
+	sync.Mutex
+	name string
+	ipv4 *fakeAddressSet
+	ipv6 *fakeAddressSet
+}
+
 // fakeAddressSet implements the AddressSet interface
-var _ AddressSet = &fakeAddressSet{}
+var _ AddressSet = &fakeAddressSets{}
+
+func newFakeAddressSets(name string, ips []net.IP, removeFn removeFunc) (*fakeAddressSets, error) {
+	var v4set, v6set *fakeAddressSet
+	v4Ips := make([]net.IP, 0)
+	v6Ips := make([]net.IP, 0)
+	for _, ip := range ips {
+		if utilnet.IsIPv6(ip) {
+			v6Ips = append(v6Ips, ip)
+		} else {
+			v4Ips = append(v4Ips, ip)
+		}
+	}
+	if config.IPv4Mode {
+		v4set = newFakeAddressSet(getIPv4ASNameForNamespace(name), v4Ips, removeFn)
+	}
+	if config.IPv6Mode {
+		v6set = newFakeAddressSet(getIPv6ASNameForNamespace(name), v6Ips, removeFn)
+	}
+	return &fakeAddressSets{name: name, ipv4: v4set, ipv6: v6set}, nil
+}
 
 func newFakeAddressSet(name string, ips []net.IP, removeFn removeFunc) *fakeAddressSet {
 	as := &fakeAddressSet{
@@ -132,20 +193,83 @@ func newFakeAddressSet(name string, ips []net.IP, removeFn removeFunc) *fakeAddr
 	return as
 }
 
-func (as *fakeAddressSet) GetHashName() string {
+func (as *fakeAddressSets) GetIPv4HashName() string {
+	return as.ipv4.getHashName()
+}
+
+func (as *fakeAddressSets) GetIPv6HashName() string {
+	return as.ipv6.getHashName()
+}
+
+func (as *fakeAddressSets) GetName() string {
+	return as.name
+}
+
+func (as *fakeAddressSets) AddIPs(ips []net.IP) error {
+	as.Lock()
+	defer as.Unlock()
+
+	for _, ip := range ips {
+		if utilnet.IsIPv6(ip) {
+			if err := as.ipv6.addIP(ip); err != nil {
+				return err
+			}
+		} else {
+			if err := as.ipv4.addIP(ip); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (as *fakeAddressSets) DeleteIPs(ips []net.IP) error {
+	as.Lock()
+	defer as.Unlock()
+
+	for _, ip := range ips {
+		if utilnet.IsIPv6(ip) {
+			if err := as.ipv6.deleteIP(ip); err != nil {
+				return err
+			}
+		} else {
+			if err := as.ipv4.deleteIP(ip); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (as *fakeAddressSets) Destroy() error {
+	as.Lock()
+	defer as.Unlock()
+
+	if as.ipv4 != nil {
+		err := as.ipv4.destroy()
+		if err != nil {
+			return err
+		}
+	}
+	if as.ipv6 != nil {
+		err := as.ipv6.destroy()
+		return err
+	}
+	return nil
+}
+
+func (as *fakeAddressSet) getHashName() string {
 	Expect(as.destroyed).To(BeFalse())
 	return as.hashName
 }
 
-func (as *fakeAddressSet) GetName() string {
+func (as *fakeAddressSet) getName() string {
 	Expect(as.destroyed).To(BeFalse())
 	return as.name
 }
 
-func (as *fakeAddressSet) AddIP(ip net.IP) error {
+func (as *fakeAddressSet) addIP(ip net.IP) error {
 	Expect(as.destroyed).To(BeFalse())
-	as.Lock()
-	defer as.Unlock()
 	ipStr := ip.String()
 	if _, ok := as.ips[ipStr]; !ok {
 		as.ips[ip.String()] = ip
@@ -153,10 +277,8 @@ func (as *fakeAddressSet) AddIP(ip net.IP) error {
 	return nil
 }
 
-func (as *fakeAddressSet) DeleteIP(ip net.IP) error {
+func (as *fakeAddressSet) deleteIP(ip net.IP) error {
 	Expect(as.destroyed).To(BeFalse())
-	as.Lock()
-	defer as.Unlock()
 	delete(as.ips, ip.String())
 	return nil
 }
@@ -167,10 +289,8 @@ func (as *fakeAddressSet) destroyInternal() {
 	as.removeFn(as.name)
 }
 
-func (as *fakeAddressSet) Destroy() error {
+func (as *fakeAddressSet) destroy() error {
 	Expect(as.destroyed).To(BeFalse())
-	as.Lock()
-	defer as.Unlock()
 	as.destroyInternal()
 	return nil
 }

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -7,6 +7,7 @@ import (
 
 	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
@@ -47,8 +48,7 @@ func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
 	}
 	defer nsInfo.Unlock()
 
-	// DUAL-STACK FIXME: handle multiple IPs
-	if err := nsInfo.addressSet.AddIP(portInfo.ips[0]); err != nil {
+	if err := nsInfo.addressSet.AddIPs(portInfo.ips); err != nil {
 		return err
 	}
 
@@ -70,8 +70,7 @@ func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) error 
 	}
 	defer nsInfo.Unlock()
 
-	// DUAL-STACK FIXME: handle multiple IPs
-	if err := nsInfo.addressSet.DeleteIP(portInfo.ips[0]); err != nil {
+	if err := nsInfo.addressSet.DeleteIPs(portInfo.ips); err != nil {
 		return err
 	}
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -95,7 +95,7 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 }
 
 func addAllowACLFromNode(logicalSwitch string, mgmtPortIP net.IP) error {
-	match := fmt.Sprintf("%s.src==%s", ipMatch(), mgmtPortIP.String())
+	match := fmt.Sprintf("%s.src==%s", ipMatch(mgmtPortIP), mgmtPortIP.String())
 	_, stderr, err := util.RunOVNNbctl("--may-exist", "acl-add", logicalSwitch,
 		"to-lport", defaultAllowPriority, match, "allow-related")
 	if err != nil {

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -12,6 +12,7 @@ import (
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
+
 	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,22 +106,22 @@ func (n networkPolicy) addNamespaceSelectorCmds(fexec *ovntest.FakeExec, network
 	for i := range networkPolicy.Spec.Ingress {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Ingress_num=%v external-ids:policy_type=Ingress", networkPolicy.Namespace, networkPolicy.Name, i),
-			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" action=allow-related external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group " + readableGroupName + " acls @acl",
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\" action=allow-related external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group " + readableGroupName + " acls @acl",
 		})
 		if findAgain {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
 			})
 		}
 	}
 	for i := range networkPolicy.Spec.Egress {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Egress_num=%v external-ids:policy_type=Egress", networkPolicy.Namespace, networkPolicy.Name, i),
-			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" action=allow external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group " + readableGroupName + " acls @acl",
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.dst == {$a17928043879887565554} && inport == @a14195333570786048679\" action=allow external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group " + readableGroupName + " acls @acl",
 		})
 		if findAgain {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a17928043879887565554} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
 			})
 		}
 	}
@@ -128,7 +129,7 @@ func (n networkPolicy) addNamespaceSelectorCmds(fexec *ovntest.FakeExec, network
 
 func getAddressSetName(namespace, name string, policyType knet.PolicyType, idx int) string {
 	direction := strings.ToLower(string(policyType))
-	return fmt.Sprintf("%s.%s.%s.%d", namespace, name, direction, idx)
+	return fmt.Sprintf("%s.%s.%s.%d%s", namespace, name, direction, idx, iPv4ASSuffix)
 }
 
 func eventuallyExpectNoAddressSets(fakeOvn *FakeOVN, networkPolicy *knet.NetworkPolicy) {
@@ -285,6 +286,15 @@ func (p multicastPolicy) delPodCmds(fExec *ovntest.FakeExec, ns string) {
 }
 
 var _ = Describe("OVN NetworkPolicy Operations", func() {
+	const (
+		namespaceName1    = "namespace1"
+		v4AddressSetName1 = namespaceName1 + iPv4ASSuffix
+		v6AddressSetName1 = namespaceName1 + iPv6ASSuffix
+
+		namespaceName2    = "namespace2"
+		v4AddressSetName2 = namespaceName2 + iPv4ASSuffix
+		v6AddressSetName2 = namespaceName2 + iPv6ASSuffix
+	)
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
@@ -314,8 +324,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 				networkPolicy := newNetworkPolicy("networkpolicy1", namespace1.Name,
 					metav1.LabelSelector{},
 					[]knet.NetworkPolicyIngressRule{
@@ -364,8 +374,11 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
 
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace2.Name)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName1)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName2)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName2)
+
 				eventuallyExpectEmptyAddressSets(fakeOvn, networkPolicy)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
@@ -384,7 +397,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -454,7 +467,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -472,8 +486,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 
 				nPodTest := newTPod(
 					"node2",
@@ -552,9 +566,12 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
 
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName1)
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace2.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName2, []string{nPodTest.podIP})
+
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName2)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -574,7 +591,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := newTPod(
 					"node1",
 					"10.128.1.0/24",
@@ -648,7 +665,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				return nil
 			}
@@ -662,8 +680,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 
 				nPodTest := newTPod(
 					"node1",
@@ -737,23 +755,25 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391, $a6953373268003663638} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a3128014386057836746, $a4615334824109672969} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
 					Output: fakeUUID,
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\"",
+					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\"",
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a6953373268003663638, $a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a17928043879887565554, $a4615334824109672969} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
 				})
 
 				err = fakeOvn.fakeClient.CoreV1().Namespaces().Delete(namespace2.Name, metav1.NewDeleteOptions(0))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.EventuallyExpectNoAddressSet(namespace2.Name)
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v4AddressSetName2)
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v6AddressSetName2)
 
 				return nil
 			}
@@ -767,8 +787,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 				networkPolicy := newNetworkPolicy("networkpolicy1", namespace1.Name,
 					metav1.LabelSelector{},
 					[]knet.NetworkPolicyIngressRule{
@@ -822,21 +842,21 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391, $a6953373268003663638} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a3128014386057836746, $a4615334824109672969} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
 					Output: fakeUUID,
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\"",
+					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\"",
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a6953373268003663638, $a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a17928043879887565554, $a4615334824109672969} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
 				})
 
 				err = fakeOvn.fakeClient.CoreV1().Namespaces().Delete(namespace2.Name, metav1.NewDeleteOptions(0))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.EventuallyExpectNoAddressSet(namespace2.Name)
-
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v4AddressSetName2)
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v6AddressSetName2)
 				return nil
 			}
 
@@ -849,7 +869,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -919,7 +939,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -933,8 +954,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
 				eventuallyExpectEmptyAddressSets(fakeOvn, networkPolicy)
-				fakeOvn.asf.EventuallyExpectEmptyAddressSet(namespace1.Name)
-
+				fakeOvn.asf.EventuallyExpectEmptyAddressSet(v4AddressSetName1)
 				return nil
 			}
 
@@ -947,8 +967,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 
 				nPodTest := newTPod(
 					"node1",
@@ -1027,9 +1047,11 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
 
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName1)
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace2.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName2, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName2)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1043,7 +1065,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				// After deleting the pod all address sets should be empty
 				eventuallyExpectEmptyAddressSets(fakeOvn, networkPolicy)
-				fakeOvn.asf.EventuallyExpectEmptyAddressSet(namespace1.Name)
+				fakeOvn.asf.EventuallyExpectEmptyAddressSet(v4AddressSetName1)
 
 				return nil
 			}
@@ -1057,7 +1079,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -1129,7 +1151,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				npTest.delCmds(fExec, nPodTest, networkPolicy, true)
 
@@ -1147,7 +1170,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 		It("tests enabling/disabling multicast in a namespace", func() {
 			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				fakeOvn.start(ctx,
 					&v1.NamespaceList{
@@ -1190,7 +1213,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 		It("tests enabling multicast in a namespace with a pod", func() {
 			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -1235,7 +1258,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				_, err = fakeOvn.fakeClient.CoreV1().Namespaces().Update(ns)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 				return nil
 			}
 
@@ -1245,7 +1269,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 		It("tests adding a pod to a multicast enabled namespace", func() {
 			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -1292,7 +1316,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 					nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				// Delete the pod from the namespace.
 				mcastPolicy.delPodCmds(fExec, namespace1.Name)
@@ -1304,7 +1329,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 					nPodTest.podName, metav1.NewDeleteOptions(0))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName1)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 				return nil
 			}
 
@@ -1363,6 +1389,7 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		asFactory = newFakeAddressSetFactory()
+		config.IPv4Mode = true
 	})
 
 	It("computes match strings from address sets correctly", func() {
@@ -1382,7 +1409,7 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		gp := newGressPolicy(knet.PolicyTypeIngress, 0, policy.Namespace, policy.Name)
 		err := gp.ensurePeerAddressSet(asFactory)
 		Expect(err).NotTo(HaveOccurred())
-		asName := gp.peerAddressSet.GetName()
+		asName := getIPv4ASNameForNamespace(gp.peerAddressSet.GetName())
 
 		one := fmt.Sprintf("testing.policy.ingress.1")
 		two := fmt.Sprintf("testing.policy.ingress.2")
@@ -1391,16 +1418,23 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		five := fmt.Sprintf("testing.policy.ingress.5")
 		six := fmt.Sprintf("testing.policy.ingress.6")
 
-		cur := addExpectedGressCmds(fExec, gp, pgName, []string{asName}, []string{asName, one})
+		v4One := one + iPv4ASSuffix
+		v4Two := two + iPv4ASSuffix
+		v4Three := three + iPv4ASSuffix
+		v4Four := four + iPv4ASSuffix
+		v4Five := five + iPv4ASSuffix
+		v4Six := six + iPv4ASSuffix
+
+		cur := addExpectedGressCmds(fExec, gp, pgName, []string{asName}, []string{asName, v4One})
 		gp.addNamespaceAddressSet(one, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, one, two})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4One, v4Two})
 		gp.addNamespaceAddressSet(two, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 		// address sets should be alphabetized
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, one, two, three})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4One, v4Two, v4Three})
 		gp.addNamespaceAddressSet(three, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
@@ -1408,12 +1442,12 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		gp.addNamespaceAddressSet(one, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, one, two, three, four})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4One, v4Two, v4Three, v4Four})
 		gp.addNamespaceAddressSet(four, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 		// now delete a set
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, three, four})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Two, v4Three, v4Four})
 		gp.delNamespaceAddressSet(one, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
@@ -1422,11 +1456,11 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 		// add and delete some more...
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, three, four, five})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Two, v4Three, v4Four, v4Five})
 		gp.addNamespaceAddressSet(five, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, four, five})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Two, v4Four, v4Five})
 		gp.delNamespaceAddressSet(three, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
@@ -1434,19 +1468,19 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		gp.delNamespaceAddressSet(one, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, four, five, six})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Two, v4Four, v4Five, v4Six})
 		gp.addNamespaceAddressSet(six, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, four, five, six})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Four, v4Five, v4Six})
 		gp.delNamespaceAddressSet(two, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, four, six})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Four, v4Six})
 		gp.delNamespaceAddressSet(five, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, four})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Four})
 		gp.delNamespaceAddressSet(six, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 


### PR DESCRIPTION
Dual stack support for IP blocks in network policy
    
    Support dual stack for ip blocks and except blocks in network policies.
    Support dual stack for management interface

This PR is dependent on the following PR.  So that should be merged before this. So ai this point of time this is WIP.

https://github.com/ovn-org/ovn-kubernetes/pull/1393