### PR TITLE
kind: improve run time for test runs

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -237,7 +237,7 @@ popd
 pushd ../dist/images
 sudo cp -f ../../go-controller/_output/go/bin/* .
 echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
-docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
+docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora.kind .
 ./daemonset.sh \
   --image=docker.io/library/ovn-daemonset-f:dev \
   --net-cidr=${NET_CIDR} \

--- a/dist/images/Dockerfile.fedora.base
+++ b/dist/images/Dockerfile.fedora.base
@@ -1,0 +1,25 @@
+FROM fedora:31
+
+USER root
+
+ENV PYTHONDONTWRITEBYTECODE yes
+
+# install needed rpms - openvswitch must be 2.10.4 or higher
+RUN INSTALL_PKGS=" \
+	PyYAML bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
+	libpcap hostname kubernetes-client \
+        ovn ovn-central ovn-host \
+	iptables iproute strace socat \
+        " && \
+	dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+	dnf clean all && rm -rf /var/cache/dnf/*
+
+# ensure we pick up ovn-20.03.0-2.fc31 for SCTP fixes/support
+# this should have no effect in the future once the
+# RPM has propagated to all stable mirrors and can be removed
+RUN dnf install -y ovn --best --advisory=FEDORA-2020-b570bbc33b || true
+
+LABEL io.k8s.display-name="ovn-kubernetes-fedora-base-image" \
+      io.k8s.description="This is an image based off of Fedora plus OVN \
+        required for running OVN K8sCI on Kind faster" \
+      maintainer="OVN Kubernetes Community"

--- a/dist/images/Dockerfile.fedora.kind
+++ b/dist/images/Dockerfile.fedora.kind
@@ -1,0 +1,45 @@
+#
+# This is the OpenShift ovn overlay network image.
+# it provides an overlay network using ovs/ovn/ovn-kube
+#
+# The standard name for this image is ovn-kube
+
+# Notes:
+# This is for a development build where the ovn-kubernetes utilities
+# are built locally and included in the image (instead of the rpm)
+#
+
+FROM ovnkube/ovn-fedora:31
+
+USER root
+
+RUN mkdir -p /var/run/openvswitch
+
+# Built in ../../go_controller, then the binaries are copied here.
+# put things where they are in the pkg
+RUN mkdir -p /usr/libexec/cni/
+COPY ovnkube ovn-kube-util /usr/bin/
+COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+
+# ovnkube.sh is the entry point. This script examines environment
+# variables to direct operation and configure ovn
+COPY ovnkube.sh /root/
+COPY ovndb-raft-functions.sh /root/
+
+# copy git commit number into image
+COPY git_info /root
+
+# iptables wrappers
+COPY ./iptables-scripts/iptables /usr/sbin/
+COPY ./iptables-scripts/iptables-save /usr/sbin/
+COPY ./iptables-scripts/iptables-restore /usr/sbin/
+COPY ./iptables-scripts/ip6tables /usr/sbin/
+COPY ./iptables-scripts/ip6tables-save /usr/sbin/
+COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
+
+LABEL io.k8s.display-name="ovn-kubernetes" \
+      io.k8s.description="This is a Kubernetes network plugin that provides an overlay network using OVN." \
+      maintainer="Phil Cameron <pcameron@redhat.com>"
+
+WORKDIR /root
+ENTRYPOINT /root/ovnkube.sh


### PR DESCRIPTION
the majority of the time is spent on following two things for each run
1. setting up kind (about 12 minutes)
2. running actual tests (time varies based on run tests)

While setting up kind we spend around 3 minutes building the required
docker image with OVN and OVN K8s utilities. Lot of test runs fail in
this step because of non-availability of Fedora RPM repo and such.

The majority of the contents in this image is constant - Fedora 31,
network utilities required, and OVN. The only thing that changes are OVN
K8s utilities. So, I have moved all of the common layer into its own
image called ovn-fedora:31 maintained by Dockerfile.fedora.base and then
the variable component is in Dockerfile.fedora.kind that the kind.sh
will build.

The ovn-fedora:31 that changes very infrequently is build and maintained
by us and pushed to the ovnkube hub.docker.com account that we already
have.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>