### PR TITLE
pkg/util package should be the leaf package

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -137,7 +137,7 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 	// FIXME DUAL-STACK
 	subnet := subnets[0]
 
-	portName := houtil.GetHybridOverlayPortName(node.Name)
+	portName := util.GetHybridOverlayPortName(node.Name)
 	portMAC, portIPs, _ := util.GetPortAddresses(portName)
 	if portMAC == nil || portIPs == nil {
 		if portIPs == nil {
@@ -175,7 +175,7 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 
 func (m *MasterController) deleteOverlayPort(node *kapi.Node) {
 	klog.Infof("removing node %s hybrid overlay port", node.Name)
-	portName := houtil.GetHybridOverlayPortName(node.Name)
+	portName := util.GetHybridOverlayPortName(node.Name)
 	_, _, _ = util.RunOVNNbctl("--", "--if-exists", "lsp-del", portName)
 }
 

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -520,7 +520,7 @@ func (n *NodeController) ensureHybridOverlayBridge(node *kapi.Node) error {
 		return err
 	}
 
-	portName := houtil.GetHybridOverlayPortName(n.nodeName)
+	portName := util.GetHybridOverlayPortName(n.nodeName)
 	portMACString, haveDRMACAnnotation := node.Annotations[hotypes.HybridOverlayDRMAC]
 	if !haveDRMACAnnotation {
 		klog.Infof("node %s does not have DRMAC annotation yet, failed to ensure hybrid overlay"+

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -31,12 +31,6 @@ func ParseHybridOverlayHostSubnet(node *kapi.Node) (*net.IPNet, error) {
 	return subnet, nil
 }
 
-// GetHybridOverlayPortName returns the name of the hybrid overlay switch port
-// for a given node
-func GetHybridOverlayPortName(nodeName string) string {
-	return "int-" + nodeName
-}
-
 // IsHybridOverlayNode returns true if the node has been labeled as a
 // node which does not participate in the ovn-kubernetes overlay network
 func IsHybridOverlayNode(node *kapi.Node) bool {

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 
 	"github.com/urfave/cli/v2"
@@ -100,7 +99,7 @@ func UpdateNodeSwitchExcludeIPs(nodeName string, subnet *net.IPNet) error {
 		line = strings.TrimSpace(line)
 		if strings.Contains(line, "("+K8sPrefix+nodeName+")") {
 			haveManagementPort = true
-		} else if strings.Contains(line, "("+houtil.GetHybridOverlayPortName(nodeName)+")") {
+		} else if strings.Contains(line, "("+GetHybridOverlayPortName(nodeName)+")") {
 			// we always need to set to false because we do not reserve the IP on the LSP for HO
 			haveHybridOverlayPort = false
 		}
@@ -138,4 +137,10 @@ func UpdateNodeSwitchExcludeIPs(nodeName string, subnet *net.IPNet) error {
 			"stderr: %q, error: %v", nodeName, stderr, err)
 	}
 	return nil
+}
+
+// GetHybridOverlayPortName returns the name of the hybrid overlay switch port
+// for a given node
+func GetHybridOverlayPortName(nodeName string) string {
+	return "int-" + nodeName
 }


### PR DESCRIPTION
pkg/util right now has a dependency on hybrid-overay/pkg/util package.
it shouldn't be the case and pkg/util should be a leaf package that
doesn't depend on any other ovn-kubernetes packages.

this creates circular dependency in certain cases. for example: when we
make pkg/factory package depend on pkg/metrics package to export some
factory related prometheus metric, the circular dependecny is created
like so:

factory -> metrics -> util -> hybrid-overlay/pkg/util -> factory

the dependency on hybrid-overlay/pkg/util package is for one simple
function, so move that function ot pkg/util package

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>