### PR TITLE
add observability into some of the ovnkube-master daemon tasks

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"k8s.io/klog"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 )
 
 // Handler represents an event handler and is private to the factory module
@@ -219,6 +220,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
+			metrics.MetricResourceUpdateCount.WithLabelValues(i.oType.Elem().Name()).Inc()
 			i.enqueueEvent(oldObj, newObj, func(e *event) {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnUpdate(e.oldObj, e.obj)
@@ -248,6 +250,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
+			metrics.MetricResourceUpdateCount.WithLabelValues(i.oType.Elem().Name()).Inc()
 			i.forEachHandler(newObj, func(h *Handler) {
 				h.OnUpdate(oldObj, newObj)
 			})

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	kapi "k8s.io/api/core/v1"
-
 	"github.com/prometheus/client_golang/prometheus"
+
+	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog"
 )
 
@@ -43,6 +43,17 @@ var metricOvnCliLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
 	// labels
 	[]string{"command"},
+)
+
+// metricResourceUpdateCount is the number of times a particular resource's UpdateFunc has been called.
+var MetricResourceUpdateCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "resource_update_total",
+	Help:      "A metric that captures the number of times a particular resource's UpdateFunc has been called"},
+	[]string{
+		"resource_name",
+	},
 )
 
 var MetricMasterReadyDuration = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -84,6 +95,7 @@ func RegisterMasterMetrics() {
 		prometheus.MustRegister(metricOvnCliLatency)
 		// this is to not to create circular import between metrics and util package
 		util.MetricOvnCliLatency = metricOvnCliLatency
+		prometheus.MustRegister(MetricResourceUpdateCount)
 		prometheus.MustRegister(prometheus.NewGaugeFunc(
 			prometheus.GaugeOpts{
 				Namespace: MetricOvnkubeNamespace,


### PR DESCRIPTION
This PR adds following two commits:

- capture latency values in starting all the watchers
   we add watchers for nodes, pods, namespaces, services, endpoints, and
network policies. almost all of these watches does the following two
things 
  - for all of the existing objects in K8s it calls OnAdd() function
  - for all of the objects that is present in OVN but not is K8s, that is
   stale entries, it removes them from OVN

  we don't have observability into how long does each of these task take,
so adding that observability through log messages. there is no point
in creating a prometheus metric for this since it only applies on the
ovnkube-master start


2. add a metric to capture the number of times a resource is being updated
    this metric will give insight into how often a UpdateFun for resource,
(pod, services, endpoints, and so on) that we care about gets called.
very recently we found an istance of an operator going rogue and calling
node updates every 5s, and the ovnkube-master CPU peaked since it was
constantly executing Node UpdateFunc.

@ovn-org/ovn-kubernetes-committers PTAL
