### PR TITLE
kind: run etcd in standalone mode no need for RAFT

### DIFF
--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -15,6 +15,7 @@ kubeadmConfigPatches:
     name: config
   apiServer:
     extraArgs:
+      "etcd-servers": "https://ovn-control-plane:2379"
       "feature-gates": "SCTPSupport=true"
 nodes:
  - role: control-plane


### PR DESCRIPTION
we are seeing lot of breakage in our CI because of flakiness in etcd
server’s RAFT configuration. Like I said early on in this thread that
the API requests are failing with "etcdserver: leader changed" error
quite often. For our CI runs, it is just sufficient for us to use a
single instance of etcd server but 3 instances of API server. something
like below
```
+--------------+  +--------------+  +--------------+
|control-plane |  |control-plane2|  |control-plane3|
|              |  |              |  |              |
|+-----------+ |  |+-----------+ |  |+-----------+ |
||api-server | |  ||api-server | |  ||api-server | |
||   :6443   | |  ||   :6443   | |  ||   :6443   | |
|+-----------+ |  |+-----------+ |  |+-----------+ |
|+-----------+ |  +--172.18.0.4--+  +--172.18.0.5--+
||etcd-server| |
||   :2379   | |
|+-----------+ |
|              |
+---172.18.0.3-+
 +------------------------------------------------+
 |   load balancer (192.168.56.102:11337)         |
 +----------------------^-------------------------+
                        |
                        |
                     kubectl
```
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>