### PR TITLE
kind: use memory backend for etcd storage

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -212,6 +212,10 @@ ovn_apiServerAddress=${API_IP} \
   ovn_num_worker=${KIND_NUM_WORKER} \
   j2 ${KIND_CONFIG} -o ${KIND_CONFIG_LCL}
 
+# use memory storage for etcd
+sudo mkdir /tmp/etcd
+sudo mount -t tmpfs /tmp/etcd /tmp/etcd
+
 # Create KIND cluster. For additional debug, add '--verbosity <int>': 0 None .. 3 Debug
 kind create cluster --name ${KIND_CLUSTER_NAME} --kubeconfig ${HOME}/admin.conf --image kindest/node:${K8S_VERSION} --config=${KIND_CONFIG_LCL}
 export KUBECONFIG=${HOME}/admin.conf

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -16,11 +16,16 @@ kubeadmConfigPatches:
   apiServer:
     extraArgs:
       "feature-gates": "SCTPSupport=true"
+  etcd:
+    local:
+      dataDir: "/var/lib/etcd"
 nodes:
  - role: control-plane
    extraMounts:
      - hostPath: /tmp/kind
        containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
+     - hostPath: /tmp/etcd
+       containerPath: /var/lib/etcd
    kubeadmConfigPatches:
    - |
      kind: InitConfiguration
@@ -34,6 +39,8 @@ nodes:
    extraMounts:
      - hostPath: /tmp/kind
        containerPath: /var/run/secrets/kubernetes.io/serviceaccount/
+     - hostPath: /tmp/etcd
+       containerPath: /var/lib/etcd
 {%- endfor %}
 {%- endif %}
 {%- for _ in range(ovn_num_worker | int) %}


### PR DESCRIPTION
we are seeing lot of breakage in our CI because of flakiness in etcd
server’s RAFT configuration. the API requests are failing with
"etcdserver: leader changed" error quite often.

the Github Actions CI runs on Azure, and Azure disks are very slow in
the free instances that GH Actions use (even though they have SSDs?),
and because etcd really, really doesn't like slow disk and leader
elections are happening too often

having memory backend for etcd storage should solve the slow disk
writes.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>
