### PR TITLE
run etcd in memory

### DIFF
--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -16,6 +16,9 @@ kubeadmConfigPatches:
   apiServer:
     extraArgs:
       "feature-gates": "SCTPSupport=true"
+  etcd:
+    local:
+      dataDir: "/tmp/lib/etcd"
 nodes:
  - role: control-plane
    extraMounts:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

etcd suffers with slow disks, because it has to sync data
frequently to offer consistency.
Since we don't need to persist the data, we can use RAM
for storage to have a fast storage.
IMPORTANT: data will not survive reboots.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->