### PR TITLE
ovn-node: Use workqueues

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -98,18 +98,11 @@ func getIPv4Address(iface string) (*net.IPNet, error) {
 func (n *OvnNode) initGateway(subnet *net.IPNet, nodeAnnotator kube.Annotator,
 	waiter *startupWaiter) error {
 
-	if config.Gateway.NodeportEnable {
-		err := initLoadBalancerHealthChecker(n.name, n.watchFactory)
-		if err != nil {
-			return err
-		}
-	}
-
 	var err error
 	var prFn postWaitFunc
 	switch config.Gateway.Mode {
 	case config.GatewayModeLocal:
-		err = initLocalnetGateway(n.name, subnet, n.watchFactory, nodeAnnotator)
+		err = n.initLocalnetGateway(n.name, subnet, nodeAnnotator)
 	case config.GatewayModeShared:
 		gatewayNextHop := net.ParseIP(config.Gateway.NextHop)
 		gatewayIntf := config.Gateway.Interface

--- a/go-controller/pkg/node/gateway_localnet_windows.go
+++ b/go-controller/pkg/node/gateway_localnet_windows.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 )
 
-func initLocalnetGateway(nodeName string, subnet *net.IPNet,
-	wf *factory.WatchFactory, nodeAnnotator kube.Annotator) error {
+func (n *OvnNode) initLocalnetGateway(nodeName string, subnet *net.IPNet, nodeAnnotator kube.Annotator) error {
 	// TODO: Implement this
 	return fmt.Errorf("Not implemented yet on Windows")
 }

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -3,17 +3,13 @@ package node
 import (
 	"fmt"
 	"net"
-	"reflect"
-	"regexp"
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 )
 
@@ -23,9 +19,9 @@ const (
 	defaultOpenFlowCookie = "0xdeff105"
 )
 
-func addService(service *kapi.Service, inport, outport, gwBridge string, nodeIP *net.IPNet) {
+func (npw *sharedGatewayNodePortWatcher) AddService(service *kapi.Service) error {
 	if !util.ServiceTypeHasNodePort(service) {
-		return
+		return nil
 	}
 
 	for _, svcPort := range service.Spec.Ports {
@@ -36,22 +32,23 @@ func addService(service *kapi.Service, inport, outport, gwBridge string, nodeIP 
 		}
 		protocol := strings.ToLower(string(svcPort.Protocol))
 
-		_, stderr, err := util.RunOVSOfctl("add-flow", gwBridge,
+		_, stderr, err := util.RunOVSOfctl("add-flow", npw.gwBridge,
 			fmt.Sprintf("priority=100, in_port=%s, %s, tp_dst=%d, actions=%s",
-				inport, protocol, svcPort.NodePort, outport))
+				npw.ofPortPhys, protocol, svcPort.NodePort, npw.ofPortPatch))
 		if err != nil {
-			klog.Errorf("Failed to add openflow flow on %s for nodePort "+
-				"%d, stderr: %q, error: %v", gwBridge,
+			return fmt.Errorf("Failed to add openflow flow on %s for nodePort "+
+				"%d, stderr: %q, error: %v", npw.gwBridge,
 				svcPort.NodePort, stderr, err)
 		}
 	}
 
-	addSharedGatewayIptRules(service, nodeIP)
+	addSharedGatewayIptRules(service, npw.nodeIP[0])
+	return nil
 }
 
-func deleteService(service *kapi.Service, inport, gwBridge string, nodeIP *net.IPNet) {
+func (npw *sharedGatewayNodePortWatcher) DeleteService(service *kapi.Service) error {
 	if !util.ServiceTypeHasNodePort(service) {
-		return
+		return nil
 	}
 
 	for _, svcPort := range service.Spec.Ports {
@@ -63,115 +60,55 @@ func deleteService(service *kapi.Service, inport, gwBridge string, nodeIP *net.I
 
 		protocol := strings.ToLower(string(svcPort.Protocol))
 
-		_, stderr, err := util.RunOVSOfctl("del-flows", gwBridge,
+		_, stderr, err := util.RunOVSOfctl("del-flows", npw.gwBridge,
 			fmt.Sprintf("in_port=%s, %s, tp_dst=%d",
-				inport, protocol, svcPort.NodePort))
+				npw.ofPortPhys, protocol, svcPort.NodePort))
 		if err != nil {
-			klog.Errorf("Failed to delete openflow flow on %s for nodePort "+
-				"%d, stderr: %q, error: %v", gwBridge,
+			return fmt.Errorf("Failed to delete openflow flow on %s for nodePort "+
+				"%d, stderr: %q, error: %v", npw.gwBridge,
 				svcPort.NodePort, stderr, err)
 		}
 	}
-
-	delSharedGatewayIptRules(service, nodeIP)
+	delSharedGatewayIptRules(service, npw.nodeIP[0])
+	return nil
 }
 
-func syncServices(services []interface{}, inport, gwBridge string) {
-	nodePorts := make(map[string]bool)
-	for _, serviceInterface := range services {
-		service, ok := serviceInterface.(*kapi.Service)
-		if !ok {
-			klog.Errorf("Spurious object in syncServices: %v",
-				serviceInterface)
-			continue
-		}
-
-		if !util.ServiceTypeHasNodePort(service) ||
-			len(service.Spec.Ports) == 0 {
-			continue
-		}
-
-		for _, svcPort := range service.Spec.Ports {
-			port := svcPort.NodePort
-			if port == 0 {
-				continue
-			}
-
-			proto, err := util.ValidateProtocol(svcPort.Protocol)
-			if err != nil {
-				klog.Errorf("syncServices error for service port %s: %v", svcPort.Name, err)
-				continue
-			}
-			protocol := strings.ToLower(string(proto))
-			nodePortKey := fmt.Sprintf("%s_%d", protocol, port)
-			nodePorts[nodePortKey] = true
-		}
-	}
-
-	stdout, stderr, err := util.RunOVSOfctl("dump-flows",
-		gwBridge)
-	if err != nil {
-		klog.Errorf("dump-flows failed: %q (%v)", stderr, err)
-		return
-	}
-	flows := strings.Split(stdout, "\n")
-
-	re, err := regexp.Compile(`tp_dst=(.*?)[, ]`)
-	if err != nil {
-		klog.Errorf("regexp compile failed: %v", err)
-		return
-	}
-
-	for _, flow := range flows {
-		group := re.FindStringSubmatch(flow)
-		if group == nil {
-			continue
-		}
-
-		var key string
-		if strings.Contains(flow, "tcp") {
-			key = fmt.Sprintf("tcp_%s", group[1])
-		} else if strings.Contains(flow, "udp") {
-			key = fmt.Sprintf("udp_%s", group[1])
-		} else if strings.Contains(flow, "sctp") {
-			key = fmt.Sprintf("sctp_%s", group[1])
-		} else {
-			continue
-		}
-
-		if _, ok := nodePorts[key]; !ok {
-			pair := strings.Split(key, "_")
-			protocol, port := pair[0], pair[1]
-
-			stdout, _, err := util.RunOVSOfctl(
-				"del-flows", gwBridge,
-				fmt.Sprintf("in_port=%s, %s, tp_dst=%s",
-					inport, protocol, port))
-			if err != nil {
-				klog.Errorf("del-flows of %s failed: %q",
-					gwBridge, stdout)
-			}
-		}
-	}
+type sharedGatewayNodePortWatcher struct {
+	nodeName    string
+	gwBridge    string
+	gwIntf      string
+	nodeIP      []*net.IPNet
+	patchPort   string
+	ofPortPatch string
+	ofPortPhys  string
 }
 
-func nodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet, wf *factory.WatchFactory) error {
+func newSharedGatewayNodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet) (nodePortWatcher, error) {
+	npw := &sharedGatewayNodePortWatcher{
+		nodeName: nodeName,
+		gwBridge: gwBridge,
+		gwIntf:   gwIntf,
+		nodeIP:   nodeIP,
+	}
+
 	// the name of the patch port created by ovn-controller is of the form
 	// patch-<logical_port_name_of_localnet_port>-to-br-int
-	patchPort := "patch-" + gwBridge + "_" + nodeName + "-to-br-int"
+	npw.patchPort = "patch-" + gwBridge + "_" + nodeName + "-to-br-int"
 	// Get ofport of patchPort
-	ofportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get",
-		"interface", patchPort, "ofport")
+	var stderr string
+	var err error
+	npw.ofPortPatch, stderr, err = util.RunOVSVsctl("--if-exists", "get",
+		"interface", npw.patchPort, "ofport")
 	if err != nil {
-		return fmt.Errorf("Failed to get ofport of %s, stderr: %q, error: %v",
-			patchPort, stderr, err)
+		return nil, fmt.Errorf("Failed to get ofport of %s, stderr: %q, error: %v",
+			npw.patchPort, stderr, err)
 	}
 
 	// Get ofport of physical interface
-	ofportPhys, stderr, err := util.RunOVSVsctl("--if-exists", "get",
+	npw.ofPortPhys, stderr, err = util.RunOVSVsctl("--if-exists", "get",
 		"interface", gwIntf, "ofport")
 	if err != nil {
-		return fmt.Errorf("Failed to get ofport of %s, stderr: %q, error: %v",
+		return nil, fmt.Errorf("Failed to get ofport of %s, stderr: %q, error: %v",
 			gwIntf, stderr, err)
 	}
 
@@ -182,121 +119,113 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet, wf 
 	// NodePortIP:NodePort to ClusterServiceIP:Port.
 	err = createNodePortIptableChain()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			service := obj.(*kapi.Service)
-			addService(service, ofportPhys, ofportPatch, gwBridge, nodeIP[0])
-		},
-		UpdateFunc: func(old, new interface{}) {
-			svcNew := new.(*kapi.Service)
-			svcOld := old.(*kapi.Service)
-			if reflect.DeepEqual(svcNew.Spec, svcOld.Spec) {
-				return
-			}
-			deleteService(svcOld, ofportPhys, gwBridge, nodeIP[0])
-			addService(svcNew, ofportPhys, ofportPatch, gwBridge, nodeIP[0])
-		},
-		DeleteFunc: func(obj interface{}) {
-			service := obj.(*kapi.Service)
-			deleteService(service, ofportPhys, gwBridge, nodeIP[0])
-		},
-	}, func(services []interface{}) {
-		syncServices(services, ofportPhys, gwBridge)
-	})
-
-	return err
+	return npw, nil
 }
 
 // since we share the host's k8s node IP, add OpenFlow flows
 // -- to steer the NodePort traffic arriving on the host to the OVN logical topology and
 // -- to also connection track the outbound north-south traffic through l3 gateway so that
 //    the return traffic can be steered back to OVN logical topology
-func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan struct{}) error {
+func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string) (*sharedGatewayHealthcheck, error) {
+	hc := &sharedGatewayHealthcheck{
+		gwBridge: gwBridge,
+		gwIntf:   gwIntf,
+	}
+
 	// the name of the patch port created by ovn-controller is of the form
 	// patch-<logical_port_name_of_localnet_port>-to-br-int
 	localnetLpName := gwBridge + "_" + nodeName
-	patchPort := "patch-" + localnetLpName + "-to-br-int"
+	hc.patchPort = "patch-" + localnetLpName + "-to-br-int"
 	// Get ofport of patchPort, but before that make sure ovn-controller created
 	// one for us (waits for about ovsCommandTimeout seconds)
-	ofportPatch, stderr, err := util.RunOVSVsctl("wait-until", "Interface", patchPort, "ofport>0",
-		"--", "get", "Interface", patchPort, "ofport")
+	var stderr string
+	var err error
+	hc.ofPortPatch, stderr, err = util.RunOVSVsctl("wait-until", "Interface", hc.patchPort, "ofport>0",
+		"--", "get", "Interface", hc.patchPort, "ofport")
 	if err != nil {
-		return fmt.Errorf("Failed while waiting on patch port %q to be created by ovn-controller and "+
-			"while getting ofport. stderr: %q, error: %v", patchPort, stderr, err)
+		return nil, fmt.Errorf("Failed while waiting on patch port %q to be created by ovn-controller and "+
+			"while getting ofport. stderr: %q, error: %v", hc.patchPort, stderr, err)
 	}
 
 	// Get ofport of physical interface
-	ofportPhys, stderr, err := util.RunOVSVsctl("--if-exists", "get",
+	hc.ofPortPhys, stderr, err = util.RunOVSVsctl("--if-exists", "get",
 		"interface", gwIntf, "ofport")
 	if err != nil {
-		return fmt.Errorf("Failed to get ofport of %s, stderr: %q, error: %v",
+		return nil, fmt.Errorf("Failed to get ofport of %s, stderr: %q, error: %v",
 			gwIntf, stderr, err)
 	}
 
 	// replace the left over OpenFlow flows with the NORMAL action flow
 	_, stderr, err = util.AddNormalActionOFFlow(gwBridge)
 	if err != nil {
-		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
+		return nil, fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
 	}
 
-	nFlows := 0
+	hc.nFlows = 0
 	// table 0, packets coming from pods headed externally. Commit connections
 	// so that reverse direction goes back to the pods.
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 		fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ip, "+
 			"actions=ct(commit, zone=%d), output:%s",
-			defaultOpenFlowCookie, ofportPatch, config.Default.ConntrackZone, ofportPhys))
+			defaultOpenFlowCookie, hc.ofPortPatch, config.Default.ConntrackZone, hc.ofPortPhys))
 	if err != nil {
-		return fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
-	nFlows++
+	hc.nFlows++
 
 	// table 0, packets coming from external. Send it through conntrack and
 	// resubmit to table 1 to know the state of the connection.
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 		fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ip, "+
-			"actions=ct(zone=%d, table=1)", defaultOpenFlowCookie, ofportPhys, config.Default.ConntrackZone))
+			"actions=ct(zone=%d, table=1)", defaultOpenFlowCookie, hc.ofPortPhys, config.Default.ConntrackZone))
 	if err != nil {
-		return fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
-	nFlows++
+	hc.nFlows++
 
 	// table 1, established and related connections go to pod
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 		fmt.Sprintf("cookie=%s, priority=100, table=1, ct_state=+trk+est, "+
-			"actions=output:%s", defaultOpenFlowCookie, ofportPatch))
+			"actions=output:%s", defaultOpenFlowCookie, hc.ofPortPatch))
 	if err != nil {
-		return fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
-	nFlows++
+	hc.nFlows++
 
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 		fmt.Sprintf("cookie=%s, priority=100, table=1, ct_state=+trk+rel, "+
-			"actions=output:%s", defaultOpenFlowCookie, ofportPatch))
+			"actions=output:%s", defaultOpenFlowCookie, hc.ofPortPatch))
 	if err != nil {
-		return fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
-	nFlows++
+	hc.nFlows++
 
 	// table 1, all other connections do normal processing
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 		fmt.Sprintf("cookie=%s, priority=0, table=1, actions=output:NORMAL", defaultOpenFlowCookie))
 	if err != nil {
-		return fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("Failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
-	nFlows++
+	hc.nFlows++
 
-	// add health check function to check default OpenFlow flows are on the shared gateway bridge
-	go checkDefaultConntrackRules(gwBridge, gwIntf, patchPort, ofportPhys, ofportPatch, nFlows, stopChan)
-	return nil
+	return hc, nil
+}
+
+type sharedGatewayHealthcheck struct {
+	gwBridge    string
+	gwIntf      string
+	patchPort   string
+	ofPortPhys  string
+	ofPortPatch string
+	nFlows      int
 }
 
 func (n *OvnNode) initSharedGateway(subnet *net.IPNet, gwNextHop net.IP, gwIntf string,
@@ -375,14 +304,15 @@ func (n *OvnNode) initSharedGateway(subnet *net.IPNet, gwNextHop net.IP, gwIntf 
 	return func() error {
 		// Program cluster.GatewayIntf to let non-pod traffic to go to host
 		// stack
-		if err := addDefaultConntrackRules(n.name, bridgeName, uplinkName, n.stopChan); err != nil {
+		var err error
+		if n.sharedGatewayHealthcheck, err = addDefaultConntrackRules(n.name, bridgeName, uplinkName); err != nil {
 			return err
 		}
 
 		if config.Gateway.NodeportEnable {
 			// Program cluster.GatewayIntf to let nodePort traffic to go to pods.
-			if err := nodePortWatcher(n.name, bridgeName, uplinkName, []*net.IPNet{ipAddress},
-				n.watchFactory); err != nil {
+			n.npw, err = newSharedGatewayNodePortWatcher(n.name, bridgeName, uplinkName, []*net.IPNet{ipAddress})
+			if err != nil {
 				return err
 			}
 		}

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -6,75 +6,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/healthcheck"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
-	ktypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 )
-
-// initLoadBalancerHealthChecker initializes the health check server for
-// ServiceTypeLoadBalancer services
-func initLoadBalancerHealthChecker(nodeName string, wf *factory.WatchFactory) error {
-	server := healthcheck.NewServer(nodeName, nil, nil, nil)
-	services := make(map[ktypes.NamespacedName]uint16)
-	endpoints := make(map[ktypes.NamespacedName]int)
-
-	_, err := wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			svc := obj.(*kapi.Service)
-			if svc.Spec.HealthCheckNodePort != 0 {
-				name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
-				services[name] = uint16(svc.Spec.HealthCheckNodePort)
-				_ = server.SyncServices(services)
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			// HealthCheckNodePort can't be changed on update
-		},
-		DeleteFunc: func(obj interface{}) {
-			svc := obj.(*kapi.Service)
-			if svc.Spec.HealthCheckNodePort != 0 {
-				name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
-				delete(services, name)
-				delete(endpoints, name)
-				_ = server.SyncServices(services)
-			}
-		},
-	}, nil)
-	if err != nil {
-		return err
-	}
-
-	_, err = wf.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			ep := obj.(*kapi.Endpoints)
-			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
-			if _, exists := services[name]; exists {
-				endpoints[name] = countLocalEndpoints(ep, nodeName)
-				_ = server.SyncEndpoints(endpoints)
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			ep := new.(*kapi.Endpoints)
-			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
-			if _, exists := services[name]; exists {
-				endpoints[name] = countLocalEndpoints(ep, nodeName)
-				_ = server.SyncEndpoints(endpoints)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			ep := obj.(*kapi.Endpoints)
-			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
-			delete(endpoints, name)
-			_ = server.SyncEndpoints(endpoints)
-		},
-	}, nil)
-	return err
-}
 
 func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {
 	num := 0
@@ -91,7 +27,7 @@ func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {
 }
 
 // check for OVS internal ports without any ofport assigned, they are stale ports that must be deleted
-func checkForStaleOVSInterfaces(stopChan chan struct{}) {
+func checkForStaleOVSInterfaces(stopChan <-chan struct{}) {
 	for {
 		select {
 		case <-time.After(60 * time.Second):
@@ -121,13 +57,12 @@ func checkForStaleOVSInterfaces(stopChan chan struct{}) {
 
 // checkDefaultOpenFlow checks for the existence of default OpenFlow rules and
 // exits if the output is not as expected
-func checkDefaultConntrackRules(gwBridge string, physIntf, patchIntf, ofportPhys, ofportPatch string,
-	nFlows int, stopChan chan struct{}) {
-	flowCount := fmt.Sprintf("flow_count=%d", nFlows)
+func checkDefaultConntrackRules(hc *sharedGatewayHealthcheck, stopChan <-chan struct{}) {
+	flowCount := fmt.Sprintf("flow_count=%d", hc.nFlows)
 	for {
 		select {
 		case <-time.After(15 * time.Second):
-			out, _, err := util.RunOVSOfctl("dump-aggregate", gwBridge,
+			out, _, err := util.RunOVSOfctl("dump-aggregate", hc.gwBridge,
 				fmt.Sprintf("cookie=%s/-1", defaultOpenFlowCookie))
 			if err != nil {
 				klog.Errorf("failed to dump aggregate statistics of the default OpenFlow rules: %v", err)
@@ -136,33 +71,33 @@ func checkDefaultConntrackRules(gwBridge string, physIntf, patchIntf, ofportPhys
 
 			if !strings.Contains(out, flowCount) {
 				klog.Errorf("fatal error: unexpected default OpenFlows count, expect %d output: %v\n",
-					nFlows, out)
+					hc.nFlows, out)
 				os.Exit(1)
 			}
 
 			// it could be that the ovn-controller recreated the patch between the host OVS bridge and
 			// the integration bridge, as a result the ofport number changed for that patch interface
-			curOfportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Interface", patchIntf, "ofport")
+			curOfportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Interface", hc.patchPort, "ofport")
 			if err != nil {
-				klog.Errorf("Failed to get ofport of %s, stderr: %q, error: %v", patchIntf, stderr, err)
+				klog.Errorf("Failed to get ofport of %s, stderr: %q, error: %v", hc.patchPort, stderr, err)
 				continue
 			}
-			if ofportPatch != curOfportPatch {
+			if hc.ofPortPatch != curOfportPatch {
 				klog.Errorf("fatal error: ofport of %s has changed from %s to %s",
-					patchIntf, ofportPatch, curOfportPatch)
+					hc.patchPort, hc.ofPortPatch, curOfportPatch)
 				os.Exit(1)
 			}
 
 			// it could be that someone removed the physical interface and added it back on the OVS host
 			// bridge, as a result the ofport number changed for that physical interface
-			curOfportPhys, stderr, err := util.RunOVSVsctl("--if-exists", "get", "interface", physIntf, "ofport")
+			curOfportPhys, stderr, err := util.RunOVSVsctl("--if-exists", "get", "interface", hc.gwIntf, "ofport")
 			if err != nil {
-				klog.Errorf("Failed to get ofport of %s, stderr: %q, error: %v", physIntf, stderr, err)
+				klog.Errorf("Failed to get ofport of %s, stderr: %q, error: %v", hc.gwIntf, stderr, err)
 				continue
 			}
-			if ofportPhys != curOfportPhys {
+			if hc.ofPortPhys != curOfportPhys {
 				klog.Errorf("fatal error: ofport of %s has changed from %s to %s",
-					physIntf, ofportPhys, curOfportPhys)
+					hc.gwIntf, hc.ofPortPhys, curOfportPhys)
 				os.Exit(1)
 			}
 		case <-stopChan:

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -49,7 +49,7 @@ func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator k
 		return err
 	}
 
-	err = createPlatformManagementPort(util.K8sMgmtIntfName, hostSubnets, n.stopChan)
+	n.mgmtPortHealtCheck, err = createPlatformManagementPort(util.K8sMgmtIntfName, hostSubnets)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -128,7 +128,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	err = testNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
-		n := OvnNode{name: nodeName, stopChan: make(chan struct{})}
+		n := OvnNode{name: nodeName}
 		err = n.createManagementPort(nodeSubnetCIDRs, nodeAnnotator, waiter)
 		Expect(err).NotTo(HaveOccurred())
 		l, err := netlink.LinkByName(mgtPort)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

Changes the ovn node controller from using `WatchFactory` to using workqueues from the client-go package. This builds on the foundation laid in #1314 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
I had to refactor a lot of how the management ports, shared/local gateways etc.. were spawning go routines so everything launches from the central `Run` method. While `Run` is quite nice, there appears to be a lot of overlap in the healtcheck/mgmt port check/openflow check go routines and it probably should be consolidated. I viewed that as out-of-scope for getting this change in

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
All unit tests passing locally, behaviour should be as before.
But with the following caveats as always.

- There is no Update, Only Add - ergo Add must be idempotent.
- There is no Sync function as the Informer sends events initially and cad do again by adjusting the re-sync interval if required.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->