### PR TITLE
ovnkube master leader and resource update histogram metrics

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -250,9 +250,12 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			metrics.MetricResourceUpdateCount.WithLabelValues(i.oType.Elem().Name()).Inc()
+			name := i.oType.Elem().Name()
+			metrics.MetricResourceUpdateCount.WithLabelValues(name).Inc()
 			i.forEachHandler(newObj, func(h *Handler) {
+				start := time.Now()
 				h.OnUpdate(oldObj, newObj)
+				metrics.MetricResourceUpdateLatency.WithLabelValues(name).Observe(time.Since(start).Seconds())
 			})
 		},
 		DeleteFunc: func(obj interface{}) {

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -74,6 +74,14 @@ var MetricMasterReadyDuration = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help:      "The duration for the master to get to ready state",
 })
 
+// MetricMasterLeader identifies whether this instance of ovnkube-master is a leader or not
+var MetricMasterLeader = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "leader",
+	Help:      "Identifies whether the instance of ovnkube-master is a leader(1) or not(0).",
+})
+
 var registerMasterMetricsOnce sync.Once
 var startE2ETimeStampUpdaterOnce sync.Once
 
@@ -85,6 +93,7 @@ func RegisterMasterMetrics() {
 		// following go routine is directly responsible for collecting the metric above.
 		StartE2ETimeStampMetricUpdater()
 
+		prometheus.MustRegister(MetricMasterLeader)
 		prometheus.MustRegister(metricPodCreationLatency)
 		prometheus.MustRegister(prometheus.NewCounterFunc(
 			prometheus.CounterOpts{

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -45,15 +45,26 @@ var metricOvnCliLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	[]string{"command"},
 )
 
-// metricResourceUpdateCount is the number of times a particular resource's UpdateFunc has been called.
+// MetricResourceUpdateCount is the number of times a particular resource's UpdateFunc has been called.
 var MetricResourceUpdateCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "resource_update_total",
 	Help:      "A metric that captures the number of times a particular resource's UpdateFunc has been called"},
 	[]string{
-		"resource_name",
+		"name",
 	},
+)
+
+// MetricResourceUpdateLatency is the time taken to complete resource update by an handler.
+// This measures the latency for all of the handlers for a given resource.
+var MetricResourceUpdateLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "resource_update_latency_seconds",
+	Help:      "The latency of various update handlers for a given resource",
+	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
+	[]string{"name"},
 )
 
 var MetricMasterReadyDuration = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -96,6 +107,7 @@ func RegisterMasterMetrics() {
 		// this is to not to create circular import between metrics and util package
 		util.MetricOvnCliLatency = metricOvnCliLatency
 		prometheus.MustRegister(MetricResourceUpdateCount)
+		prometheus.MustRegister(MetricResourceUpdateLatency)
 		prometheus.MustRegister(prometheus.NewGaugeFunc(
 			prometheus.GaugeOpts{
 				Namespace: MetricOvnkubeNamespace,

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -90,9 +90,6 @@ var startE2ETimeStampUpdaterOnce sync.Once
 func RegisterMasterMetrics() {
 	registerMasterMetricsOnce.Do(func() {
 		prometheus.MustRegister(metricE2ETimestamp)
-		// following go routine is directly responsible for collecting the metric above.
-		StartE2ETimeStampMetricUpdater()
-
 		prometheus.MustRegister(MetricMasterLeader)
 		prometheus.MustRegister(metricPodCreationLatency)
 		prometheus.MustRegister(prometheus.NewCounterFunc(


### PR DESCRIPTION
Adds following metrics
1. metric to capture whether a given ovnkube-master is leader or not

the leaderelection module provides hooks that gets called when an
instance becomes a leader or looses an election. use those hooks to
capture the appropriate state

2. metric to capture resource update duration histogram

this metric captures the latency of various UpdateFunc handlers
registered for a given resource plotted as a histogram. should be
helpful in knowing what the 95% percentile of various resource updates
are.

@squeed FYI
@ovn-org/ovn-kubernetes-committers PTAl