### PR TITLE
ho: Don't handle Namespace updates on Node

### DIFF
--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
@@ -97,7 +97,6 @@ func runHybridOverlay(ctx *cli.Context) error {
 		nodeName,
 		f.Core().V1().Nodes().Informer(),
 		f.Core().V1().Pods().Informer(),
-		f.Core().V1().Namespaces().Informer(),
 	)
 	if err != nil {
 		return err

--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -346,3 +346,18 @@ func (m *MasterController) AddPod(pod *kapi.Pod) error {
 	}
 	return nil
 }
+
+// nsHybridAnnotationChanged returns true if any relevant NS attributes changed
+func nsHybridAnnotationChanged(old, new interface{}) bool {
+	oldNs := old.(*kapi.Namespace)
+	newNs := new.(*kapi.Namespace)
+
+	nsExGwOld := oldNs.GetAnnotations()[hotypes.HybridOverlayExternalGw]
+	nsVTEPOld := oldNs.GetAnnotations()[hotypes.HybridOverlayVTEP]
+	nsExGwNew := newNs.GetAnnotations()[hotypes.HybridOverlayExternalGw]
+	nsVTEPNew := newNs.GetAnnotations()[hotypes.HybridOverlayVTEP]
+	if nsExGwOld != nsExGwNew || nsVTEPOld != nsVTEPNew {
+		return true
+	}
+	return false
+}

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -18,7 +18,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	kapi "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog"
@@ -645,18 +644,4 @@ func (n *NodeController) updateFlowCacheEntry(cookie string, flows []string, ign
 	defer n.flowMutex.Unlock()
 	n.flowCache[cookie] = &flowCacheEntry{flows: flows}
 	n.flowCache[cookie].ignoreLearn = ignoreLearn
-}
-
-// AddNamespace handles the namespace add event
-func (n *NodeController) AddNamespace(ns *kapi.Namespace) error {
-	pods, err := n.podLister.Pods(ns.Namespace).List(labels.Everything())
-	if err != nil {
-		klog.Errorf("failed to get pods for NS update in hybrid overlay: %v", err)
-	}
-	for _, pod := range pods {
-		if err := n.AddPod(pod); err != nil {
-			klog.Warningf("failed to handle pod %v update: %v", pod, err)
-		}
-	}
-	return nil
 }

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -265,7 +265,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
-				f.Core().V1().Namespaces().Informer(),
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -311,7 +310,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
-				f.Core().V1().Namespaces().Informer(),
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -356,7 +354,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
-				f.Core().V1().Namespaces().Informer(),
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -409,7 +406,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
-				f.Core().V1().Namespaces().Informer(),
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -458,7 +454,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
-				f.Core().V1().Namespaces().Informer(),
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -506,7 +501,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
-				f.Core().V1().Namespaces().Informer(),
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -576,7 +570,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
-				f.Core().V1().Namespaces().Informer(),
 			)
 			Expect(err).NotTo(HaveOccurred())
 			// FIXME: DT Why are these needed?

--- a/go-controller/hybrid-overlay/pkg/controller/node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_windows.go
@@ -383,10 +383,6 @@ func (n *NodeController) DeletePod(pod *kapi.Pod) error {
 	return nil
 }
 
-func (n *NodeController) AddNamespace(ns *kapi.Namespace) error {
-	return nil
-}
-
 func (n *NodeController) RunFlowSync(stopCh <-chan struct{}) {}
 
 func (n *NodeController) EnsureHybridOverlayBridge(node *kapi.Node) error {

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -240,7 +240,6 @@ func (n *OvnNode) Start() error {
 			n.name,
 			factory.Core().V1().Nodes().Informer(),
 			factory.Core().V1().Pods().Informer(),
-			factory.Core().V1().Namespaces().Informer(),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit removes the Namespace event handler from the Node
controller. Nodes don't need to respond to these events as the
master will update pods with the necessary annotations if a
namespace changes.