### PR TITLE
make HO unit test wait for namespace update

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -715,6 +715,14 @@ var _ = Describe("OVN Pod Operations", func() {
 				// Update namespace to remove annotation
 				namespaceT.Annotations = nil
 				_, err = fakeOvn.fakeClient.CoreV1().Namespaces().Update(&namespaceT)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() map[string]string {
+					updatedNs, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})
+					if err != nil {
+						return map[string]string{"ns": "error"}
+					}
+					return updatedNs.Annotations
+				}).Should(BeEmpty())
 				// Create new pod
 				tP = newTPod(
 					"node1",


### PR DESCRIPTION
The unit test resets the annotations on the NS then expects a new pod to
be configured with the normal default gw. We need to ensure we wait for
the namespace to be updated before we create the new pod.

Closes: #1413

Signed-off-by: Tim Rozet <trozet@redhat.com>

