### PR TITLE
Validate container before cleanup in e2e

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -599,9 +599,10 @@ var _ = Describe("e2e external gateway validation", func() {
 
 	AfterEach(func() {
 		// tear down the container simulating the gateway
-		_, err := runCommand("docker", "rm", "-f", gwContainerName)
-		if err != nil {
-			framework.Failf("failed to delete the gateway test container %v", err)
+		if cid, _ := runCommand("docker", "ps", "-qaf", fmt.Sprintf("name=%s",gwContainerName)); cid != "" {
+			if _, err := runCommand("docker", "rm", "-f", gwContainerName); err != nil {
+				framework.Logf("failed to delete the gateway test container %s %v", gwContainerName, err)
+			}
 		}
 	})
 
@@ -723,13 +724,15 @@ var _ = Describe("e2e multiple external gateway update validation", func() {
 
 	AfterEach(func() {
 		// tear down the containers simulating the gateways
-		_, err := runCommand("docker", "rm", "-f", gwContainerNameAlt1)
-		if err != nil {
-			framework.Failf("failed to delete the gateway test container %s %v", gwContainerNameAlt1, err)
+		if cid, _ := runCommand("docker", "ps", "-qaf", fmt.Sprintf("name=%s",gwContainerNameAlt1)); cid != "" {
+			if _, err := runCommand("docker", "rm", "-f", gwContainerNameAlt1); err != nil {
+				framework.Logf("failed to delete the gateway test container %s %v", gwContainerNameAlt1, err)
+			}
 		}
-		_, err = runCommand("docker", "rm", "-f", gwContainerNameAlt2)
-		if err != nil {
-			framework.Failf("failed to delete the gateway test container %s %v", gwContainerNameAlt2, err)
+		if cid, _ := runCommand("docker", "ps", "-qaf", fmt.Sprintf("name=%s",gwContainerNameAlt2)); cid != "" {
+			if _, err := runCommand("docker", "rm", "-f", gwContainerNameAlt2); err != nil {
+				framework.Logf("failed to delete the gateway test container %s %v", gwContainerNameAlt2, err)
+			}
 		}
 	})
 


### PR DESCRIPTION
- this commit verifies the mock external gateway containers exist
  before attempting to delete them in AfterEach().
- it also changes the framework err handling to logf instead of failing
  the test to cut down on confusion when troubleshooting a test failure.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>

**- How to verify it**
Can be verified locally with the following or observed in CI actions:
```
# Start ovn-kube kind
pushd $GOPATH/src/github.com/ovn-org/ovn-kubernetes/contrib
./kind.sh -ho
./kind.sh -ho -ha
# From the Kubernetes repo run 
pushd $GOPATH/src/k8s.io/kubernetes
kubetest --provider=local --deployment=kind --kind-cluster-name=ovn --test
```

**- Description for the changelog**
Validate gateway containers before cleanup in e2e and change any errors to log only
