### PR TITLE
WIP support ClientIP session affinity (partially)

### DIFF
--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -126,6 +126,21 @@ func (ovn *Controller) configureLoadBalancer(lb, sourceIP string, sourcePort int
 	return nil
 }
 
+// configureLoadBalancerClientIPSessionAffinity updates the load balancer with the specified session
+// timeoutSeconds is a noop until it is implemented in OVN
+func (ovn *Controller) configureLoadBalancerClientIPSessionAffinity(lb string, timeoutSeconds int) error {
+	ovn.serviceLBLock.Lock()
+	defer ovn.serviceLBLock.Unlock()
+
+	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, `selection_fields="ip_src"`)
+	if err != nil {
+		return fmt.Errorf("error in configuring load balancer: %s "+
+			"stdout: %q, stderr: %q, error: %v", lb, out, stderr, err)
+	}
+	klog.V(5).Infof("lb session affinity set for %s", lb)
+	return nil
+}
+
 // createLoadBalancerVIPs either creates or updates a set of load balancer VIPs mapping
 // from sourcePort on each IP of a given address family in sourceIPs, to targetPort on
 // each IP of the same address family in targetIPs, removing the reject ACL for any

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -316,8 +316,9 @@ func (ovn *Controller) updateService(oldSvc, newSvc *kapi.Service) error {
 	if reflect.DeepEqual(newSvc.Spec.Ports, oldSvc.Spec.Ports) &&
 		reflect.DeepEqual(newSvc.Spec.ExternalIPs, oldSvc.Spec.ExternalIPs) &&
 		reflect.DeepEqual(newSvc.Spec.ClusterIP, oldSvc.Spec.ClusterIP) &&
+		reflect.DeepEqual(newSvc.Spec.SessionAffinity, oldSvc.Spec.SessionAffinity) &&
 		reflect.DeepEqual(newSvc.Spec.Type, oldSvc.Spec.Type) {
-		klog.V(5).Infof("skipping service update for: %s as change does not apply to any of .Spec.Ports, .Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type", newSvc.Name)
+		klog.V(5).Infof("skipping service update for: %s as change does not apply to any of .Spec.Ports, .Spec.ExternalIP, .Spec.ClusterIP, .Spec.SessionAffinity, .Spec.Type", newSvc.Name)
 		return nil
 	}
 

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -26,8 +26,8 @@ should set TCP CLOSE_WAIT timeout
 # TO BE IMPLEMENTED: https://github.com/ovn-org/ovn-kubernetes/issues/1142
 \[Feature:IPv6DualStackAlphaFeature\]
 
-# TO BE IMPLEMENTED: https://github.com/ovn-org/ovn-kubernetes/issues/819
-Services.+session affinity
+-# TO BE IMPLEMENTED: https://github.com/ovn-org/ovn-kubernetes/issues/819
+-Services.+session affinity timeout
 
 # TO BE IMPLEMENTED: https://github.com/ovn-org/ovn-kubernetes/issues/1116
 EndpointSlices


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

Supports "ClientIP" session affinity, however it does not support
affinity timeout, that means that the session is always sticky.

https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies

Fixes partially: #819 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

It depends on OVN 0.20.6

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

Automatically tested with the e2e framework

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

support Kubernetes services ClientIP affinity without a timeout, sessions are always sticky