### PR TITLE
Add sleep timer to HO test

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 
@@ -723,6 +724,7 @@ var _ = Describe("OVN Pod Operations", func() {
 					}
 					return updatedNs.Annotations
 				}).Should(BeEmpty())
+				time.Sleep(time.Second)
 				// Create new pod
 				tP = newTPod(
 					"node1",


### PR DESCRIPTION
There's a race between when the namespace is updated and the new pod
that gets created right after. The problem is nsInfo in the ovn-k8s
backend may not be updated (has to wait for lock) by the time the new
pod gets created. A 1 second sleep fixes the issue.

Signed-off-by: Tim Rozet <trozet@redhat.com>
