### PR TITLE
add metrics for OVN's ovn-northd components

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"fmt"
 	"runtime"
-	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -85,10 +85,50 @@ var MetricMasterLeader = prometheus.NewGauge(prometheus.GaugeOpts{
 var registerMasterMetricsOnce sync.Once
 var startE2ETimeStampUpdaterOnce sync.Once
 
+var ovnNorthdCoverageShowMetricsMap = map[string]*metricDetails{
+	"pstream_open": {
+		help: "Specifies the number of time passive connections " +
+			"were opened for the remote peer to connect.",
+	},
+	"stream_open": {
+		help: "Specifies the number of attempts to connect " +
+			"to a remote peer (active connection).",
+	},
+	"txn_success": {
+		help: "Specifies the number of times the OVSDB " +
+			"transaction has successfully completed.",
+	},
+	"txn_error": {
+		help: "Specifies the number of times the OVSDB " +
+			"transaction has errored out.",
+	},
+	"txn_uncommitted": {
+		help: "Specifies the number of times the OVSDB " +
+			"transaction were uncommitted.",
+	},
+	"txn_unchanged": {
+		help: "Specifies the number of times the OVSDB transaction " +
+			"resulted in no change to the database.",
+	},
+	"txn_incomplete": {
+		help: "Specifies the number of times the OVSDB transaction " +
+			"did not complete and the client had to re-try.",
+	},
+	"txn_aborted": {
+		help: "Specifies the number of times the OVSDB " +
+			" transaction has been aborted.",
+	},
+	"txn_try_again": {
+		help: "Specifies the number of times the OVSDB " +
+			"transaction failed and the client had to re-try.",
+	},
+}
+
 // RegisterMasterMetrics registers some ovnkube master metrics with the Prometheus
 // registry
 func RegisterMasterMetrics() {
 	registerMasterMetricsOnce.Do(func() {
+		// ovnkube-master metrics
 		prometheus.MustRegister(metricE2ETimestamp)
 		prometheus.MustRegister(MetricMasterLeader)
 		prometheus.MustRegister(metricPodCreationLatency)
@@ -132,6 +172,58 @@ func RegisterMasterMetrics() {
 			},
 			func() float64 { return 1 },
 		))
+
+		// ovn-northd metrics
+		prometheus.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: MetricOvnNamespace,
+				Subsystem: MetricOvnSubsystemNorthd,
+				Name:      "probe_interval",
+				Help: "The maximum number of milliseconds of idle time on connection to the OVN SB " +
+					"and NB DB before sending an inactivity probe message",
+			}, func() float64 {
+				stdout, stderr, err := util.RunOVNNbctlWithTimeout(5, "get", "NB_Global", ".",
+					"options:northd_probe_interval")
+				if err != nil {
+					klog.Errorf("Failed to get northd_probe_interval value "+
+						"stderr(%s) :(%v)", stderr, err)
+					return 0
+				}
+				return parseMetricToFloat(MetricOvnSubsystemNorthd, "probe_interval", stdout)
+			},
+		))
+		prometheus.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: MetricOvnNamespace,
+				Subsystem: MetricOvnSubsystemNorthd,
+				Name:      "status",
+				Help:      "Specifies whether this instance of ovn-northd is standby(0) or active(1) or paused(2).",
+			}, func() float64 {
+				stdout, stderr, err := util.RunOVNNorthAppCtl("status")
+				if err != nil {
+					klog.Errorf("Failed to get ovn-northd status "+
+						"stderr(%s) :(%v)", stderr, err)
+					return -1
+				}
+				northdStatusMap := map[string]float64{
+					"standby": 0,
+					"active":  1,
+					"paused":  2,
+				}
+				if strings.HasPrefix(stdout, "Status:") {
+					output := strings.TrimSpace(strings.Split(stdout, ":")[1])
+					if value, ok := northdStatusMap[output]; ok {
+						return value
+					}
+				}
+				return -1
+			},
+		))
+
+		// Register the ovn-northd coverage/show metrics with prometheus
+		componentCoverageShowMetricsMap[ovnNorthd] = ovnNorthdCoverageShowMetricsMap
+		registerCoverageShowMetrics(ovnNorthd, MetricOvnNamespace, MetricOvnSubsystemNorthd)
+		go coverageShowMetricsUpdater(ovnNorthd)
 	})
 }
 
@@ -142,13 +234,7 @@ func scrapeOvnTimestamp() float64 {
 		klog.Errorf("Failed to scrape timestamp: %s (%v)", stderr, err)
 		return 0
 	}
-
-	out, err := strconv.ParseFloat(output, 64)
-	if err != nil {
-		klog.Errorf("Failed to parse timestamp %s: %v", output, err)
-		return 0
-	}
-	return out
+	return parseMetricToFloat(MetricOvnkubeSubsystemMaster, "sb_e2e_timestamp", output)
 }
 
 // StartE2ETimeStampMetricUpdater adds a goroutine that updates a "timestamp" value in the

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/klog"
 )
 
 const (
@@ -18,6 +22,9 @@ const (
 	MetricOvnkubeSubsystemNode   = "node"
 	MetricOvnNamespace           = "ovn"
 	MetricOvnSubsystemDBRaft     = "db_raft"
+	MetricOvnSubsystemNorthd     = "northd"
+
+	ovnNorthd = "ovn-northd"
 )
 
 // Build information. Populated at build-time.
@@ -27,6 +34,97 @@ var (
 	BuildUser string
 	BuildDate string
 )
+
+type metricDetails struct {
+	help   string
+	metric prometheus.Gauge
+}
+
+// OVN/OVS components, namely ovn-northd, ovn-controller, and ovs-vswitchd provide various
+// metrics through the 'coverage/show' command. The following data structure holds all the
+// metrics we are interested in that output for a given component. We generalize capturing
+// these metrics across all OVN/OVS components.
+var componentCoverageShowMetricsMap = map[string]map[string]*metricDetails{}
+
+func parseMetricToFloat(componentName, metricName, value string) float64 {
+	f64Value, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		klog.Errorf("Failed to parse value %s into float for metric %s_%s :(%v)",
+			value, componentName, metricName, err)
+		return 0
+	}
+	return f64Value
+}
+
+// registerCoverageShowMetrics registers coverage/show metricss for
+// various components(ovn-northd, ovn-controller, and ovs-vswitchd) with prometheus
+func registerCoverageShowMetrics(target string, metricNamespace string, metricSubsystem string) {
+	coverageShowMetricsMap := componentCoverageShowMetricsMap[target]
+	for metricName, metricInfo := range coverageShowMetricsMap {
+		metricInfo.metric = prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      metricName,
+			Help:      metricInfo.help,
+		})
+		prometheus.MustRegister(metricInfo.metric)
+	}
+}
+
+// getCoverageShowOutputMap obtains the coverage/show metric values for the specified component.
+func getCoverageShowOutputMap(component string) (map[string]string, error) {
+	var stdout, stderr string
+	var err error
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovering from a panic while parsing the coverage/show output "+
+				"for %s: %v", component, r)
+		}
+	}()
+
+	if component == ovnNorthd {
+		stdout, stderr, err = util.RunOVNNorthAppCtl("coverage/show")
+	} else {
+		err = fmt.Errorf("component is unknown, and it isn't %s", ovnNorthd)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get coverage/show output for %s "+
+			"stderr(%s): (%v)", component, stderr, err)
+	}
+
+	coverageShowMetricsMap := make(map[string]string)
+	output := strings.Split(stdout, "\n")
+	for _, kvPair := range output {
+		if strings.Contains(kvPair, "total:") {
+			fields := strings.Fields(kvPair)
+			coverageShowMetricsMap[fields[0]] = fields[len(fields)-1]
+		}
+	}
+	return coverageShowMetricsMap, nil
+}
+
+// coverageShowMetricsUpdater updates the metric
+// by obtaining values from getCoverageShowOutputMap for specified target.
+func coverageShowMetricsUpdater(component string) {
+	for {
+		time.Sleep(30 * time.Second)
+		coverageShowOutputMap, err := getCoverageShowOutputMap(component)
+		if err != nil {
+			klog.Errorf("%s", err.Error())
+			continue
+		}
+		coverageShowMetricsMap := componentCoverageShowMetricsMap[component]
+		for metricName, metricInfo := range coverageShowMetricsMap {
+			if value, ok := coverageShowOutputMap[metricName]; ok {
+				count := parseMetricToFloat(component, metricName, value)
+				metricInfo.metric.Set(count)
+			} else {
+				metricInfo.metric.Set(0)
+			}
+		}
+	}
+}
 
 // StartMetricsServer runs the prometheus listner so that metrics can be collected
 func StartMetricsServer(bindAddress string, enablePprof bool) {


### PR DESCRIPTION
The coverage/show command against ovn-northd provides metrics that
captures various aspects of ovn-northd's functionality. This commit
is going to capture those values and export it.

In addition to those metrics, the output of "status" command is exported
as well.

Please see below document for more information:
https://docs.google.com/document/d/\
1BAsjLOpAeSyIq2UcyukPK7PgKCqgAKuHcz3962DtoUo/edit?usp=sharing

Co-authored-by: Pardhakeswar Pacha <ppacha@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@squeed @ovn-org/ovn-kubernetes-committers PTAL