### PR TITLE
expose gateway mode for ovnkube-master process

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -213,6 +213,7 @@ ovn_image=${image} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_master_count=${ovn_master_count} \
+  ovn_gateway_mode=${ovn_gateway_mode} \
   j2 ../templates/ovnkube-master.yaml.j2 -o ../yaml/ovnkube-master.yaml
 
 ovn_image=${image} \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -232,6 +232,8 @@ spec:
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
+        - name: OVN_GATEWAY_MODE
+          value: "{{ ovn_gateway_mode }}"
       # end of container
 
       volumes:


### PR DESCRIPTION
a change was made to OVN logical topology to include distributed gateway
port to provide access to node local services from hostnetwork pods.
this is needed only for the shared gateway mode. there is a check in
place in master startup code to create these ports for shared gateway
mode alone. however, the default value of the gateway mode is 'shared'
and the yamls generated didn't have a way to change this to 'local'
mode and as a result the topology change was happening for the local
gateway mode too.

Fixes issues #1446

Co-authored-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@trozet PTAL