### PR TITLE
Adding log rotation parameters as configurable values.

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -30,6 +30,9 @@ OVN_LOGLEVEL_NB=""
 OVN_LOGLEVEL_SB=""
 OVN_LOGLEVEL_CONTROLLER=""
 OVN_LOGLEVEL_NBCTLD=""
+OVNKUBE_LOGFILE_MAXSIZE=""
+OVNKUBE_LOGFILE_MAXBACKUPS=""
+OVNKUBE_LOGFILE_MAXAGE=""
 OVN_MASTER_COUNT=""
 OVN_REMOTE_PROBE_INTERVAL=""
 OVN_HYBRID_OVERLAY_ENABLE=""
@@ -95,6 +98,15 @@ while [ "$1" != "" ]; do
     ;;
   --ovn-loglevel-nbctld)
     OVN_LOGLEVEL_NBCTLD=$VALUE
+    ;;
+  --ovnkube-logfile-maxsize)
+    OVNKUBE_LOGFILE_MAXSIZE=$VALUE
+    ;;
+  --ovnkube-logfile-maxbackups)
+    OVNKUBE_LOGFILE_MAXBACKUPS=$VALUE
+    ;;
+  --ovnkube-logfile-maxage)
+    OVNKUBE_LOGFILE_MAXAGE=$VALUE
     ;;
   --ssl)
     OVN_SSL_ENABLE="yes"
@@ -168,6 +180,12 @@ ovn_loglevel_controller=${OVN_LOGLEVEL_CONTROLLER:-"-vconsole:info"}
 echo "ovn_loglevel_controller: ${ovn_loglevel_controller}"
 ovn_loglevel_nbctld=${OVN_LOGLEVEL_NBCTLD:-"-vconsole:info"}
 echo "ovn_loglevel_nbctld: ${ovn_loglevel_nbctld}"
+ovnkube_logfile_maxsize=${OVNKUBE_LOGFILE_MAXSIZE:-"100"}
+echo "ovnkube_logfile_maxsize: ${ovnkube_logfile_maxsize}"
+ovnkube_logfile_maxbackups=${OVNKUBE_LOGFILE_MAXBACKUPS:-"5"}
+echo "ovnkube_logfile_maxbackups: ${ovnkube_logfile_maxbackups}"
+ovnkube_logfile_maxage=${OVNKUBE_LOGFILE_MAXAGE:-"5"}
+echo "ovnkube_logfile_maxage: ${ovnkube_logfile_maxage}"
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE}
 echo "ovn_hybrid_overlay_enable: ${ovn_hybrid_overlay_enable}"
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR}
@@ -198,6 +216,9 @@ ovn_image=${image} \
   ovn_gateway_opts=${ovn_gateway_opts} \
   ovnkube_node_loglevel=${node_loglevel} \
   ovn_loglevel_controller=${ovn_loglevel_controller} \
+  ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
+  ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
+  ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
@@ -209,6 +230,9 @@ ovn_image=${image} \
   ovnkube_master_loglevel=${master_loglevel} \
   ovn_loglevel_northd=${ovn_loglevel_northd} \
   ovn_loglevel_nbctld=${ovn_loglevel_nbctld} \
+  ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
+  ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
+  ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_ssl_en=${ovn_ssl_en} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -55,6 +55,9 @@ fi
 # OVN_LOGLEVEL_SB - log level (ovn-ctl default: -vconsole:off -vfile:info) - v3
 # OVN_LOGLEVEL_CONTROLLER - log level (ovn-ctl default: -vconsole:off -vfile:info) - v3
 # OVN_LOGLEVEL_NBCTLD - log level (ovn-ctl default: -vconsole:off -vfile:info) - v3
+# OVNKUBE_LOGFILE_MAXSIZE - log file max size in MB(default 100 MB)
+# OVNKUBE_LOGFILE_MAXBACKUPS - log file max backups (default 5)
+# OVNKUBE_LOGFILE_MAXAGE - log file max age in days (default 5 days)
 # OVN_NB_PORT - ovn north db port (default 6641)
 # OVN_SB_PORT - ovn south db port (default 6642)
 # OVN_NB_RAFT_PORT - ovn north db raft port (default 6643)
@@ -77,6 +80,11 @@ ovn_loglevel_controller=${OVN_LOGLEVEL_CONTROLLER:-"-vconsole:info"}
 ovn_loglevel_nbctld=${OVN_LOGLEVEL_NBCTLD:-"-vconsole:info"}
 
 ovnkubelogdir=/var/log/ovn-kubernetes
+
+# logfile rotation parameters
+ovnkube_logfile_maxsize=${OVNKUBE_LOGFILE_MAXSIZE:-"100"}
+ovnkube_logfile_maxbackups=${OVNKUBE_LOGFILE_MAXBACKUPS:-"5"}
+ovnkube_logfile_maxage=${OVNKUBE_LOGFILE_MAXAGE:-"5"}
 
 # ovnkube.sh version (update when API between daemonset and script changes - v.x.y)
 ovnkube_version="3"
@@ -772,6 +780,9 @@ ovn-master() {
     --gateway-mode=${ovn_gateway_mode} \
     --nbctl-daemon-mode \
     --loglevel=${ovnkube_loglevel} \
+    --logfile-maxsize=${ovnkube_logfile_maxsize} \
+    --logfile-maxbackups=${ovnkube_logfile_maxbackups} \
+    --logfile-maxage=${ovnkube_logfile_maxage} \
     ${hybrid_overlay_flags} \
     --pidfile ${OVN_RUNDIR}/ovnkube-master.pid \
     --logfile /var/log/ovn-kubernetes/ovnkube-master.log \
@@ -884,6 +895,10 @@ ovn-node() {
     --mtu=${mtu} \
     ${OVN_ENCAP_IP} \
     --loglevel=${ovnkube_loglevel} \
+    --loglevel=${ovnkube_loglevel} \
+    --logfile-maxsize=${ovnkube_logfile_maxsize} \
+    --logfile-maxbackups=${ovnkube_logfile_maxbackups} \
+    --logfile-maxage=${ovnkube_logfile_maxage} \
     ${hybrid_overlay_flags} \
     --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
     --pidfile ${OVN_RUNDIR}/ovnkube.pid \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -203,6 +203,12 @@ spec:
           value: "3"
         - name: OVNKUBE_LOGLEVEL
           value: "{{ ovnkube_master_loglevel }}"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "{{ ovnkube_logfile_maxsize }}"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "{{ ovnkube_logfile_maxbackups }}"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "{{ ovnkube_logfile_maxage }}"
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -208,6 +208,12 @@ spec:
           value: "3"
         - name: OVNKUBE_LOGLEVEL
           value: "{{ ovnkube_node_loglevel }}"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "{{ ovnkube_logfile_maxsize }}"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "{{ ovnkube_logfile_maxbackups }}"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "{{ ovnkube_logfile_maxage }}"
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -14,6 +14,15 @@ type NetConf struct {
 	LogFile string `json:"logFile,omitempty"`
 	// Level is the logging verbosity level
 	LogLevel string `json:"logLevel,omitempty"`
+	// LogFileMaxSize is the maximum size in bytes of the logfile
+	// before it gets rolled.
+	LogFileMaxSize int `json:"logfile-maxsize"`
+	// LogFileMaxBackups represents the the maximum number of
+	// old log files to retain
+	LogFileMaxBackups int `json:"logfile-maxbackups"`
+	// LogFileMaxAge represents the maximum number
+	// of days to retain old log files
+	LogFileMaxAge int `json:"logfile-maxage"`
 }
 
 // NetworkSelectionElement represents one element of the JSON format

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -21,8 +21,11 @@ func WriteCNIConfig() error {
 			Name:       "ovn-kubernetes",
 			Type:       CNI.Plugin,
 		},
-		LogFile:  Logging.CNIFile,
-		LogLevel: fmt.Sprintf("%d", Logging.Level),
+		LogFile:           Logging.CNIFile,
+		LogLevel:          fmt.Sprintf("%d", Logging.Level),
+		LogFileMaxSize:    Logging.LogFileMaxSize,
+		LogFileMaxBackups: Logging.LogFileMaxBackups,
+		LogFileMaxAge:     Logging.LogFileMaxAge,
 	}
 
 	bytes, err := json.Marshal(netConf)


### PR DESCRIPTION
Adds log rotation support for ovn-k8s-cni-overlay.log file.
Making (MaxBackups, MaxAge, MaxSize) as a configurable values
through yaml files.

Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>
