### PR TITLE
Correct the way that externalGateway and VTEP IP are copied

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -98,17 +98,17 @@ func (n *NodeController) AddPod(pod *kapi.Pod) error {
 		return n.DeletePod(pod)
 	}
 
-	externalGw := pod.Annotations[hotypes.HybridOverlayExternalGw]
-	// validate the external gateway is a valid IP address
-	if ip := net.ParseIP(externalGw); ip == nil {
+	externalGw, ok := pod.Annotations[hotypes.HybridOverlayExternalGw]
+	// validate the external gateway (if any) is a valid IP address
+	if ip := net.ParseIP(externalGw); ok && ip == nil {
 		klog.Warningf("Failed parse a valid external gateway ip address from %v: %v", externalGw, err)
 		return fmt.Errorf("failed to validate a valid external gateway ip address %s: %v", externalGw, err)
 	}
 
-	VTEP := pod.Annotations[hotypes.HybridOverlayVTEP]
-	// validate the VTEP is a valid IP address
+	VTEP, ok := pod.Annotations[hotypes.HybridOverlayVTEP]
+	// validate the VTEP (if any) is a valid IP address
 	VTEPIP := net.ParseIP(VTEP)
-	if VTEPIP == nil {
+	if ok && VTEPIP == nil {
 		klog.Warningf("Failed parse a valid vtep ip address from %v: %v", VTEP, err)
 		return fmt.Errorf("failed to validate a valid vtep ip address %s: %v", VTEP, err)
 	}

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -84,14 +84,18 @@ func StartNodeWatch(h types.NodeHandler, wf *factory.WatchFactory) error {
 
 // CopyNamespaceAnnotationsToPod copies annotations from a namespace to a pod
 func CopyNamespaceAnnotationsToPod(k kube.Interface, ns *kapi.Namespace, pod *kapi.Pod) error {
-	nsGw := ns.Annotations[types.HybridOverlayExternalGw]
-	nsVTEP := ns.Annotations[types.HybridOverlayVTEP]
+	nsGw, nsGwExists := ns.Annotations[types.HybridOverlayExternalGw]
+	nsVTEP, nsVTEPExists := ns.Annotations[types.HybridOverlayVTEP]
 	annotator := kube.NewPodAnnotator(k, pod)
-	if err := annotator.Set(types.HybridOverlayExternalGw, nsGw); err != nil {
-		return err
+	if nsGwExists {
+		if err := annotator.Set(types.HybridOverlayExternalGw, nsGw); err != nil {
+			return err
+		}
 	}
-	if err := annotator.Set(types.HybridOverlayVTEP, nsVTEP); err != nil {
-		return err
+	if nsVTEPExists {
+		if err := annotator.Set(types.HybridOverlayVTEP, nsVTEP); err != nil {
+			return err
+		}
 	}
 	return annotator.Run()
 }


### PR DESCRIPTION
not all hybrid network cases will have externalGateway and VTEP IPs.
Correct the functionality of CopyNamespaceAnnotationToPod() to only
copy annotations types.HybridOverlayExternalGw and
types.HybridOverlayVTEP to a pod if they exist on the namespace.
Then the AddPod() can correctly deal with unset values.

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->