### PR TITLE
Create Junit Reports for all test suites that support it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,13 @@ jobs:
         ln -sf $(pwd) src/github.com/ovn-org/ovn-kubernetes
         GOPATH=$(pwd) gcov2lcov -infile gover.coverprofile -outfile coverage.lcov
 
+    - name: Upload Junit Reports
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: junit-${{ github.run_id }}
+        path: '**/_artifacts/**.xml'
+
     - name: Submit code coverage to Coveralls
       uses: coverallsapp/github-action@master
       with:
@@ -178,6 +185,13 @@ jobs:
       run: |
         make -C test ${{ matrix.target.shard }}
 
+    - name: Upload Junit Reports
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
+        path: '**/_artifacts/**.xml'
+
     - name: Export logs
       if: always()
       run: |
@@ -186,7 +200,7 @@ jobs:
 
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs

--- a/go-controller/.gitignore
+++ b/go-controller/.gitignore
@@ -1,1 +1,2 @@
 _output
+_artifacts

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -7,7 +7,8 @@ GCFLAGS ?=
 export GCFLAGS
 PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
-
+TEST_REPORT_DIR?=$(CURDIR)/_artifacts
+export TEST_REPORT_DIR
 
 .PHONY: all build check test
 
@@ -38,6 +39,7 @@ install:
 
 clean:
 	rm -rf ${OUT_DIR}
+	rm -rf ${TEST_REPORT_DIR}
 
 .PHONY: install.tools lint gofmt
 

--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -15,12 +15,18 @@ function testrun {
     local pkg="${2}"
     local otherargs="${@:3} "
     local args=
+    local ginkgoargs=
+    local path=${pkg#github.com/ovn-org/ovn-kubernetes/go-controller}
     if [ ! -z "${COVERALLS:-}" ]; then
         args="-covermode set -coverprofile ${idx}.coverprofile "
     fi
+    if [ -n "${TEST_REPORT_DIR}" ] && grep -q -r "ginkgo" .${path}; then
+	prefix=$( echo ${path} | cut -c 2- | sed 's,/,_,g')
+	ginkgoargs="-ginkgo.reportFile ${TEST_REPORT_DIR}/junit-${prefix}.xml"
+    fi
     args="${args}${otherargs}${pkg}"
 
-    go test -mod vendor ${args}
+    go test -mod vendor ${args} ${ginkgoargs}
 }
 
 # These packages requires root for network namespace maniuplation in unit tests

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+_artifacts

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,11 +1,14 @@
+E2E_REPORT_DIR:=$(CURDIR)/_artifacts
+JOB_NAME?="$@"
+
 .PHONY: install-kind
 install-kind:
 	./scripts/install-kind.sh
 
 .PHONY: shard-%
 shard-%:
-	./scripts/e2e-kind.sh $@ $(WHAT) 
+	E2E_REPORT_DIR=$(E2E_REPORT_DIR) E2E_REPORT_PREFIX=$(JOB_NAME)_ ./scripts/e2e-kind.sh $@ $(WHAT)
 
 .PHONY: control-plane
 control-plane:
-	./scripts/e2e-cp.sh
+	E2E_REPORT_DIR=$(E2E_REPORT_DIR) E2E_REPORT_PREFIX=$(JOB_NAME)_ ./scripts/e2e-cp.sh

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -4,24 +4,27 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 	"testing"
 
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/gomega"
+	"k8s.io/klog"
 	"k8s.io/kubectl/pkg/generated"
 	"k8s.io/kubernetes/test/e2e/framework"
-	"k8s.io/kubernetes/test/e2e/framework/config"
+	e2econfig "k8s.io/kubernetes/test/e2e/framework/config"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/framework/viperconfig"
 	"k8s.io/kubernetes/test/utils/image"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 // https://github.com/kubernetes/kubernetes/blob/v1.16.4/test/e2e/e2e_test.go#L62
 
 // handleFlags sets up all flags and parses the command line.
 func handleFlags() {
-	config.CopyFlags(config.Flags, flag.CommandLine)
+	e2econfig.CopyFlags(e2econfig.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
 	flag.Parse()
@@ -69,6 +72,18 @@ func TestMain(m *testing.M) {
 }
 
 func TestE2e(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "E2e Suite")
+	// Run tests through the Ginkgo runner with output to console + JUnit for reporting
+	var r []ginkgo.Reporter
+	if framework.TestContext.ReportDir != "" {
+		klog.Infof("Saving reports to %s", framework.TestContext.ReportDir)
+		// TODO: we should probably only be trying to create this directory once
+		// rather than once-per-Ginkgo-node.
+		if err := os.MkdirAll(framework.TestContext.ReportDir, 0755); err != nil {
+			klog.Errorf("Failed creating report directory: %v", err)
+		} else {
+			r = append(r, reporters.NewJUnitReporter(path.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%v%02d.xml", framework.TestContext.ReportPrefix, config.GinkgoConfig.ParallelNode))))
+		}
+	}
+	gomega.RegisterFailHandler(framework.Fail)
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "E2e Suite", r)
 }

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/onsi/gomega v1.9.0
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
+	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.0.0
 	k8s.io/kubernetes v1.17.2
 )

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -11,6 +11,8 @@ export KUBECONFIG=${HOME}/admin.conf
 export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
 export NODE_NAMES=${MASTER_NAME}
 export KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS}
+export E2E_REPORT_DIR=${E2E_REPORT_DIR}
+export E2E_REPORT_PREFIX=${E2E_REPORT_PREFIX}
 
 sed -E -i 's/"\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}" "\$\{e2e_test\}"/pushd \$GITHUB_WORKSPACE\/test\/e2e\nGO111MODULE=on "\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}"/' ${GOPATH}/src/k8s.io/kubernetes/hack/ginkgo-e2e.sh
 

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -47,7 +47,7 @@ should prevent Ingress creation if more than 1 IngressClass marked as default
 
 SKIPPED_TESTS=$(echo "${SKIPPED_TESTS}" | sed -e '/^\($\|#\)/d' -e 's/ /\\s/g' | tr '\n' '|' | sed -e 's/|$//')
 
-GINKGO_ARGS="--num-nodes=3 --ginkgo.skip=${SKIPPED_TESTS} --disable-log-dump=false"
+GINKGO_ARGS="--num-nodes=3 --ginkgo.skip=${SKIPPED_TESTS} --disable-log-dump=false --report-dir=${E2E_REPORT_DIR} --report-prefix=${E2E_REPORT_PREFIX}"
 
 case "$SHARD" in
 	shard-n-other)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

To help automatic identification of flakes we need to start collecting data from our test runs.
As most suites support Junit output, we can generate this and upload to GitHub as artifacts.
This PR:

- Passes correct arguments to `e2e.test` to generate junit reports
- Adds a reporter to the `e2e_suite_test.go` file to generate junit reports
- Conditionally adds ginkgo arguments to all unit test suites which can produce reports
- Adjust GitHub Actions to archive the reports as artifacts

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
N/A

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Artifacts for this run should include Junit reports.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->