### PR TITLE
trivial: incorrect prefix used for the port connecting switch to router

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -340,7 +340,7 @@ func addDistributedGWPort() error {
 		"--", "set", "logical_switch_port", lclNetPortname, "addresses=unknown", "type=localnet",
 		"options:network_name="+util.LocalNetworkName)
 	// connect the switch to the distributed router
-	lspName := "ltos-" + nodeLocalSwitch
+	lspName := switchToRouterPrefix + nodeLocalSwitch
 	nbctlArgs = append(nbctlArgs,
 		"--", "--may-exist", "lsp-add", nodeLocalSwitch, lspName,
 		"--", "set", "logical_switch_port", lspName, "type=router", "addresses=router",

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -122,8 +122,8 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		"ovn-nbctl --timeout=15 --may-exist ls-add " + nodeLocalSwitch +
 			" -- --may-exist lsp-add " + nodeLocalSwitch + " lnet-" + nodeLocalSwitch +
 			" -- set logical_switch_port lnet-" + nodeLocalSwitch + " addresses=unknown type=localnet options:network_name=locnet" +
-			" -- --may-exist lsp-add " + nodeLocalSwitch + " ltos-" + nodeLocalSwitch +
-			" -- set logical_switch_port ltos-" + nodeLocalSwitch + " type=router addresses=router options:nat-addresses=router options:router-port=" + dgpName,
+			" -- --may-exist lsp-add " + nodeLocalSwitch + " " + switchToRouterPrefix + nodeLocalSwitch +
+			" -- set logical_switch_port " + switchToRouterPrefix + nodeLocalSwitch + " type=router addresses=router options:nat-addresses=router options:router-port=" + dgpName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-sbctl --timeout=15 --data=bare --no-heading --columns=_uuid find MAC_Binding logical_port=" + dgpName + " mac=\"" + nextHopMAC + "\"",


### PR DESCRIPTION
during the code review of edb24e6a7114 (topology changes to enable
Node-Local Services Access in Shared GW Mode) it was decided to use
the prefix of rtos- and stor- for the ports connecting node_local_switch
and the ovn_cluster_router. however, for the switch port we are still
using a different convention.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@trozet FYI-