### PR TITLE
config: fix unit test under go 1.14

### DIFF
--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -1185,7 +1185,7 @@ mode=shared
 			}
 			err := runInit(app, runType, cfgFile, finalArgs...)
 			if match != "" {
-				Expect(err).To(MatchError(match))
+				Expect(err.Error()).To(ContainSubstring(match))
 			} else {
 				Expect(err).NotTo(HaveOccurred())
 			}
@@ -1224,7 +1224,7 @@ mode=shared
 				"-k8s-apiserver=gggggg://localhost:8443")
 
 			generateTestsSimple("apiserver URL is invalid",
-				"kubernetes API server address \"http://a b.com/\" invalid: parse http://a b.com/: invalid character \" \" in host name",
+				"invalid character \" \" in host name",
 				"-k8s-apiserver=http://a b.com/")
 
 			generateTestsSimple("kubeconfig file does not exist",


### PR DESCRIPTION
An url.Parse() error string message changed a bit in go 1.14 (a `"%s"` became a `"%q"`), breaking a test that depended on an exact string match. Fix it to do a substring test instead so it works with either version.

Fixes "make test" on my laptop.

@dcbw @girishmg 