### PR TITLE
Ci improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,9 +149,6 @@ jobs:
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
     steps:
 
-    - name: Free up disk space
-      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
-
     - name: Set up Go
       uses: actions/setup-go@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,17 @@ jobs:
         ln -sf $(pwd) src/github.com/ovn-org/ovn-kubernetes
         GOPATH=$(pwd) gcov2lcov -infile gover.coverprofile -outfile coverage.lcov
 
+    - name: Build docker image
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+        pushd dist/images
+          sudo cp -f ../../go-controller/_output/go/bin/ovn* .
+          echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
+          docker build -t docker.pkg.github.com/${GITHUB_REPOSITORY}/ovn-daemonset-f:dev -f Dockerfile.fedora .
+          docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/ovn-daemonset-f:dev
+        popd
+
+
     - name: Upload Junit Reports
       if: always()
       uses: actions/upload-artifact@v2
@@ -179,6 +190,8 @@ jobs:
 
     - name: kind setup
       run: |
+        export OVN_IMAGE="docker.pkg.github.com/${GITHUB_REPOSITORY}/ovn-daemonset-f:dev"
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
         make -C test install-kind
 
     - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,9 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - shard: shard-n-other
-            hybrid-overlay: false
-          - shard: shard-np
+          - shard: shard-network
             hybrid-overlay: false
           - shard: control-plane
             hybrid-overlay: true

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -18,6 +18,7 @@ Networking IPerf IPv[46]
 # FEATURES NOT AVAILABLE IN OUR CI ENVIRONMENT
 \[Feature:Networking-IPv6\]
 \[Feature:Federation\]
+GCE
 
 # TESTS THAT ASSUME KUBE-PROXY
 kube-proxy


### PR DESCRIPTION
**- What this PR does and why is it needed**

Improves the CI, and it saves a minimum of 5 mins per job

- Build the ovn-kube image only once
- run tests in parallel in the same cluster, instead of running in parallel clusters but serially
it runs the test in 7 mins instead of 50 mins
- save 2 minutes in each job not freeing space

**- Special notes for reviewers**

**- How to verify it**

**- Description for the changelog**
