### PR TITLE
Dual stack support for address set and network policies.

### DIFF
--- a/go-controller/pkg/ovn/address_set.go
+++ b/go-controller/pkg/ovn/address_set.go
@@ -7,9 +7,17 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
+	utilnet "k8s.io/utils/net"
+)
+
+const (
+	ipv4AddressSetSuffix = "_v4"
+	ipv6AddressSetSuffix = "_v6"
 )
 
 type AddressSetIterFunc func(hashedName, namespace, suffix string)
@@ -18,7 +26,8 @@ type AddressSetDoFunc func(as AddressSet) error
 // AddressSetFactory is an interface for managing address set objects
 type AddressSetFactory interface {
 	// NewAddressSet returns a new object that implements AddressSet
-	// and contains the given IPs, or an error
+	// and contains the given IPs, or an error. Internally it creates
+	// an address set for IPv4 and IPv6 each.
 	NewAddressSet(name string, ips []net.IP) (AddressSet, error)
 	// ForEachAddressSet calls the given function for each address set
 	// known to the factory
@@ -31,12 +40,14 @@ type AddressSetFactory interface {
 
 // AddressSet is an interface for address set objects
 type AddressSet interface {
-	// GetHashName returns the hashed name of the address set
-	GetHashName() string
+	// GetIPv4HashName returns the hashed name for v4 address set
+	GetIPv4HashName() string
+	// GetIPv6HashName returns the hashed name for v4 address set
+	GetIPv6HashName() string
 	// GetName returns the descriptive name of the address set
 	GetName() string
-	AddIP(ip net.IP) error
-	DeleteIP(ip net.IP) error
+	AddIPs(ip []net.IP) error
+	DeleteIPs(ip []net.IP) error
 	Destroy() error
 }
 
@@ -53,7 +64,7 @@ var _ AddressSetFactory = &ovnAddressSetFactory{}
 
 // NewAddressSet returns a new address set object
 func (asf *ovnAddressSetFactory) NewAddressSet(name string, ips []net.IP) (AddressSet, error) {
-	return newOvnAddressSet(name, ips)
+	return newOvnAddressSets(name, ips)
 }
 
 // ForEachAddressSet will pass the unhashed address set name, namespace name
@@ -66,6 +77,8 @@ func (asf *ovnAddressSetFactory) ForEachAddressSet(iteratorFn AddressSetIterFunc
 		return fmt.Errorf("error reading address sets: "+
 			"stdout: %q, stderr: %q err: %v", output, stderr, err)
 	}
+
+	processedAddressSets := sets.String{}
 	for _, line := range strings.Split(output, "\n") {
 		parts := strings.Split(line, ",")
 		if len(parts) != 2 {
@@ -75,7 +88,15 @@ func (asf *ovnAddressSetFactory) ForEachAddressSet(iteratorFn AddressSetIterFunc
 			if !strings.HasPrefix(externalID, "name=") {
 				continue
 			}
-			addrSetName := externalID[5:]
+			// Remove the suffix from the address set name and normalize
+			addrSetName := truncateSuffixFromAddressSet(externalID[5:])
+			if processedAddressSets.Has(addrSetName) {
+				// We have already processed the address set. In case of dual stack we will have _v4 and _v6
+				// suffixes for address sets. Since we are normalizing these two address sets through this API
+				// we will process only one normalized address set name.
+				break
+			}
+			processedAddressSets.Insert(addrSetName)
 			names := strings.Split(addrSetName, ".")
 			addrSetNamespace := names[0]
 			nameSuffix := ""
@@ -89,7 +110,36 @@ func (asf *ovnAddressSetFactory) ForEachAddressSet(iteratorFn AddressSetIterFunc
 	return nil
 }
 
+func truncateSuffixFromAddressSet(asName string) string {
+	// Legacy address set names will not have v4 or v6 suffixes.
+	// truncate them for the new ones
+	if strings.HasSuffix(asName, ipv4AddressSetSuffix) {
+		return strings.TrimSuffix(asName, ipv4AddressSetSuffix)
+	}
+	if strings.HasSuffix(asName, ipv6AddressSetSuffix) {
+		return strings.TrimSuffix(asName, ipv6AddressSetSuffix)
+	}
+	return asName
+}
+
 func (asf *ovnAddressSetFactory) DestroyAddressSetInBackingStore(name string) error {
+	// We need to handle both legacy and new address sets in this method. Legacy names
+	// will not have v4 and v6 suffix as they were same as namespace name. Hence we will always try to destroy
+	// the address set with raw name(namespace name), v4 name and v6 name.  The method destroyAddressSet uses
+	// --if-exists parameter which will take care of deleting the address set only if it exists.
+	err := destroyAddressSet(name)
+	if err != nil {
+		return err
+	}
+	err = destroyAddressSet(getIPv4ASName(name))
+	if err != nil {
+		return err
+	}
+	err = destroyAddressSet(getIPv6ASName(name))
+	return err
+}
+
+func destroyAddressSet(name string) error {
 	hashName := hashedAddressSet(name)
 	_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy", "address_set", hashName)
 	if err != nil {
@@ -100,15 +150,21 @@ func (asf *ovnAddressSetFactory) DestroyAddressSetInBackingStore(name string) er
 }
 
 type ovnAddressSet struct {
-	sync.RWMutex
 	name     string
 	hashName string
 	uuid     string
 	ips      map[string]net.IP
 }
 
-// ovnAddressSet implements the AddressSet interface
-var _ AddressSet = &ovnAddressSet{}
+type ovnAddressSets struct {
+	sync.RWMutex
+	name string
+	ipv4 *ovnAddressSet
+	ipv6 *ovnAddressSet
+}
+
+// ovnAddressSets implements the AddressSet interface
+var _ AddressSet = &ovnAddressSets{}
 
 // hash the provided input to make it a valid ovnAddressSet name.
 func hashedAddressSet(s string) string {
@@ -117,6 +173,36 @@ func hashedAddressSet(s string) string {
 
 func asDetail(as *ovnAddressSet) string {
 	return fmt.Sprintf("%s/%s/%s", as.uuid, as.name, as.hashName)
+}
+
+func newOvnAddressSets(name string, ips []net.IP) (*ovnAddressSets, error) {
+	var (
+		v4set, v6set *ovnAddressSet
+		err          error
+	)
+	v4IPs := make([]net.IP, 0)
+	v6IPs := make([]net.IP, 0)
+
+	for _, ip := range ips {
+		if utilnet.IsIPv6(ip) {
+			v6IPs = append(v6IPs, ip)
+		} else {
+			v4IPs = append(v4IPs, ip)
+		}
+	}
+	if config.IPv4Mode {
+		v4set, err = newOvnAddressSet(getIPv4ASName(name), v4IPs)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if config.IPv6Mode {
+		v6set, err = newOvnAddressSet(getIPv6ASName(name), v6IPs)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &ovnAddressSets{name: name, ipv4: v4set, ipv6: v6set}, nil
 }
 
 func newOvnAddressSet(name string, ips []net.IP) (*ovnAddressSet, error) {
@@ -168,12 +254,77 @@ func newOvnAddressSet(name string, ips []net.IP) (*ovnAddressSet, error) {
 	return as, nil
 }
 
-func (as *ovnAddressSet) GetHashName() string {
-	return as.hashName
+func (as *ovnAddressSets) GetIPv4HashName() string {
+	if as.ipv4 != nil {
+		return as.ipv4.hashName
+	}
+	return ""
 }
 
-func (as *ovnAddressSet) GetName() string {
+func (as *ovnAddressSets) GetIPv6HashName() string {
+	if as.ipv6 != nil {
+		return as.ipv6.hashName
+	}
+	return ""
+}
+
+func (as *ovnAddressSets) GetName() string {
 	return as.name
+}
+
+func (as *ovnAddressSets) AddIPs(ips []net.IP) error {
+	var err error
+	as.Lock()
+	defer as.Unlock()
+
+	for _, ip := range ips {
+		if utilnet.IsIPv6(ip) {
+			err = as.ipv6.addIP(ip)
+		} else {
+			err = as.ipv4.addIP(ip)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (as *ovnAddressSets) DeleteIPs(ips []net.IP) error {
+	var err error
+	as.Lock()
+	defer as.Unlock()
+
+	for _, ip := range ips {
+		if utilnet.IsIPv6(ip) {
+			err = as.ipv6.deleteIP(ip)
+		} else {
+			err = as.ipv4.deleteIP(ip)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (as *ovnAddressSets) Destroy() error {
+	as.Lock()
+	defer as.Unlock()
+
+	if as.ipv4 != nil {
+		err := as.ipv4.destroy()
+		if err != nil {
+			return err
+		}
+	}
+	if as.ipv6 != nil {
+		err := as.ipv6.destroy()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (as *ovnAddressSet) joinIPs() string {
@@ -205,10 +356,7 @@ func (as *ovnAddressSet) setOrClear() error {
 	return nil
 }
 
-func (as *ovnAddressSet) AddIP(ip net.IP) error {
-	as.Lock()
-	defer as.Unlock()
-
+func (as *ovnAddressSet) addIP(ip net.IP) error {
 	ipStr := ip.String()
 	if _, ok := as.ips[ipStr]; ok {
 		return nil
@@ -226,10 +374,7 @@ func (as *ovnAddressSet) AddIP(ip net.IP) error {
 	return nil
 }
 
-func (as *ovnAddressSet) DeleteIP(ip net.IP) error {
-	as.Lock()
-	defer as.Unlock()
-
+func (as *ovnAddressSet) deleteIP(ip net.IP) error {
 	ipStr := ip.String()
 	if _, ok := as.ips[ipStr]; !ok {
 		return nil
@@ -247,10 +392,8 @@ func (as *ovnAddressSet) DeleteIP(ip net.IP) error {
 	return nil
 }
 
-func (as *ovnAddressSet) Destroy() error {
-	as.Lock()
-	defer as.Unlock()
-	klog.V(5).Infof("Destroy(%s)", asDetail(as))
+func (as *ovnAddressSet) destroy() error {
+	klog.V(5).Infof("destroy(%s)", asDetail(as))
 	_, stderr, err := util.RunOVNNbctl("--if-exists", "destroy", "address_set", as.uuid)
 	if err != nil {
 		return fmt.Errorf("failed to destroy address set %q, stderr: %q, (%v)",
@@ -258,4 +401,20 @@ func (as *ovnAddressSet) Destroy() error {
 	}
 	as.ips = nil
 	return nil
+}
+
+func getIPv4ASName(name string) string {
+	return name + ipv4AddressSetSuffix
+}
+
+func getIPv6ASName(name string) string {
+	return name + ipv6AddressSetSuffix
+}
+
+func getIPv4ASHashedName(name string) string {
+	return hashedAddressSet(name + ipv4AddressSetSuffix)
+}
+
+func getIPv6ASHashedName(name string) string {
+	return hashedAddressSet(name + ipv6AddressSetSuffix)
 }

--- a/go-controller/pkg/ovn/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set_test.go
@@ -116,7 +116,7 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 					Output: fakeUUID,
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -139,7 +139,7 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 					Output: fakeUUID,
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -167,10 +167,10 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a9625390261332436968 external-ids:name=foobar addresses="` + addr1 + `" "` + addr2 + `"`,
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4 addresses="` + addr1 + `" "` + addr2 + `"`,
 					Output: fakeUUID,
 				})
 
@@ -191,7 +191,7 @@ var _ = Describe("OVN Address Set operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 				Output: fakeUUID,
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -221,10 +221,10 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 create address_set name=a9625390261332436968 external-ids:name=foobar",
+					Cmd:    "ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4",
 					Output: fakeUUID,
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -234,11 +234,8 @@ var _ = Describe("OVN Address Set operations", func() {
 				as, err := asFactory.NewAddressSet("foobar", nil)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = as.AddIP(net.ParseIP(addr1))
-				Expect(err).NotTo(HaveOccurred())
-
 				// Re-adding is a no-op
-				err = as.AddIP(net.ParseIP(addr1))
+				err = as.AddIPs([]net.IP{net.ParseIP(addr1)})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
@@ -257,10 +254,10 @@ var _ = Describe("OVN Address Set operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a9625390261332436968",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
 				})
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a9625390261332436968 external-ids:name=foobar addresses="` + addr1 + `"`,
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4 addresses="` + addr1 + `"`,
 					Output: fakeUUID,
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -270,11 +267,264 @@ var _ = Describe("OVN Address Set operations", func() {
 				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1)})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = as.DeleteIP(net.ParseIP(addr1))
+				err = as.DeleteIPs([]net.IP{net.ParseIP(addr1)})
 				Expect(err).NotTo(HaveOccurred())
 
 				// Deleting a non-existent address is a no-op
-				err = as.DeleteIP(net.ParseIP(addr1))
+				err = as.DeleteIPs([]net.IP{net.ParseIP(addr1)})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Dual stack : when creating an address set object", func() {
+		It("re-uses an existing dual stack address set and replaces IPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					addr1 string = "1.2.3.4"
+					addr2 string = "5.6.7.8"
+					addr3 string = "2001:db8::1"
+					addr4 string = "2001:db8::2"
+				)
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 set address_set ` + fakeUUID + ` addresses="` + addr1 + `" "` + addr2 + `"`,
+				})
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+					Output: fakeUUIDv6,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 set address_set ` + fakeUUIDv6 + ` addresses="` + addr3 + `" "` + addr4 + `"`,
+				})
+
+				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2),
+					net.ParseIP(addr3), net.ParseIP(addr4)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("clears an existing address set of dual stack IPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 clear address_set " + fakeUUID + " addresses",
+				})
+
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+					Output: fakeUUIDv6,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 clear address_set ` + fakeUUIDv6 + " addresses",
+				})
+
+				_, err = asFactory.NewAddressSet("foobar", nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates a new address set and sets dual stack IPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					addr1 string = "1.2.3.4"
+					addr2 string = "5.6.7.8"
+					addr3 string = "2001:db8::1"
+					addr4 string = "2001:db8::2"
+				)
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4 addresses="` + addr1 + `" "` + addr2 + `"`,
+					Output: fakeUUID,
+				})
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990493521189787229 external-ids:name=foobar_v6 addresses="` + addr3 + `" "` + addr4 + `"`,
+					Output: fakeUUIDv6,
+				})
+
+				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2),
+					net.ParseIP(addr3), net.ParseIP(addr4)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	It("destroys an dual stack address set", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+			config.IPv6Mode = true
+
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+				Output: fakeUUID,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 clear address_set " + fakeUUID + " addresses",
+			})
+
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+				Output: fakeUUIDv6,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 clear address_set " + fakeUUIDv6 + " addresses",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --if-exists destroy address_set " + fakeUUID,
+				"ovn-nbctl --timeout=15 --if-exists destroy address_set " + fakeUUIDv6,
+			})
+
+			as, err := asFactory.NewAddressSet("foobar", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = as.Destroy()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+			return nil
+		}
+
+		err := app.Run([]string{app.Name})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("Dual Stack : when manipulating IPs in an address set object", func() {
+		It("adds  IP to an empty dual stack address set", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const addr1 string = "1.2.3.4"
+				const addr2 string = "2001:db8::1"
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4",
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 create address_set name=a16990493521189787229 external-ids:name=foobar_v6",
+					Output: fakeUUIDv6,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 add address_set ` + fakeUUID + ` addresses "` + addr1 + `"`,
+				})
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 add address_set ` + fakeUUIDv6 + ` addresses "` + addr2 + `"`,
+				})
+
+				as, err := asFactory.NewAddressSet("foobar", nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = as.AddIPs([]net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Re-adding is a no-op
+				err = as.AddIPs([]net.IP{net.ParseIP(addr1)})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("deletes an IP from an dual stack address set", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const addr1 string = "1.2.3.4"
+				const addr2 string = "2001:db8::1"
+
+				_, err := config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.IPv6Mode = true
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990491322166530807",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990491322166530807 external-ids:name=foobar_v4 addresses="` + addr1 + `"`,
+					Output: fakeUUID,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find address_set name=a16990493521189787229",
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    `ovn-nbctl --timeout=15 create address_set name=a16990493521189787229 external-ids:name=foobar_v6 addresses="` + addr2 + `"`,
+					Output: fakeUUIDv6,
+				})
+
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 remove address_set ` + fakeUUID + ` addresses "` + addr1 + `"`,
+				})
+				fexec.AddFakeCmdsNoOutputNoError([]string{
+					`ovn-nbctl --timeout=15 remove address_set ` + fakeUUIDv6 + ` addresses "` + addr2 + `"`,
+				})
+
+				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = as.DeleteIPs([]net.IP{net.ParseIP(addr1), net.ParseIP(addr2)})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Deleting a non-existent address is a no-op
+				err = as.DeleteIPs([]net.IP{net.ParseIP(addr1)})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -2,11 +2,11 @@ package ovn
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	"k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -23,11 +23,10 @@ type gressPolicy struct {
 	// IP addresess.
 	peerAddressSet AddressSet
 
-	// nsAddressSets holds the names of all namespace address sets
-	nsAddressSets sets.String
-
-	// sortedPeerAddressSets has the sorted peerAddressSets
-	sortedPeerAddressSets []string
+	// peerV4AddressSets has Address sets for all namespaces and pod selectors for IPv4
+	peerV4AddressSets sets.String
+	// peerV6AddressSets has Address sets for all namespaces and pod selectors for IPv6
+	peerV6AddressSets sets.String
 
 	// portPolicies represents all the ports to which traffic is allowed for
 	// the rule in question.
@@ -57,15 +56,15 @@ func (pp *portPolicy) getL4Match() (string, error) {
 
 func newGressPolicy(policyType knet.PolicyType, idx int, namespace, name string) *gressPolicy {
 	return &gressPolicy{
-		policyNamespace:       namespace,
-		policyName:            name,
-		policyType:            policyType,
-		idx:                   idx,
-		nsAddressSets:         sets.String{},
-		sortedPeerAddressSets: make([]string, 0),
-		portPolicies:          make([]*portPolicy, 0),
-		ipBlockCidr:           make([]string, 0),
-		ipBlockExcept:         make([]string, 0),
+		policyNamespace:   namespace,
+		policyName:        name,
+		policyType:        policyType,
+		idx:               idx,
+		peerV4AddressSets: sets.String{},
+		peerV6AddressSets: sets.String{},
+		portPolicies:      make([]*portPolicy, 0),
+		ipBlockCidr:       make([]string, 0),
+		ipBlockExcept:     make([]string, 0),
 	}
 }
 
@@ -82,8 +81,12 @@ func (gp *gressPolicy) ensurePeerAddressSet(factory AddressSetFactory) error {
 	}
 
 	gp.peerAddressSet = as
-	gp.sortedPeerAddressSets = append(gp.sortedPeerAddressSets, as.GetHashName())
-	sort.Strings(gp.sortedPeerAddressSets)
+	if config.IPv4Mode {
+		gp.peerV4AddressSets.Insert("$" + as.GetIPv4HashName())
+	}
+	if config.IPv6Mode {
+		gp.peerV6AddressSets.Insert("$" + as.GetIPv6HashName())
+	}
 	return nil
 }
 
@@ -92,8 +95,7 @@ func (gp *gressPolicy) addPeerPod(pod *v1.Pod) error {
 	if err != nil {
 		return err
 	}
-	// FIXME dual-stack
-	return gp.peerAddressSet.AddIP(ips[0])
+	return gp.peerAddressSet.AddIPs(ips)
 }
 
 func (gp *gressPolicy) deletePeerPod(pod *v1.Pod) error {
@@ -101,8 +103,7 @@ func (gp *gressPolicy) deletePeerPod(pod *v1.Pod) error {
 	if err != nil {
 		return err
 	}
-	// FIXME dual-stack
-	return gp.peerAddressSet.DeleteIP(ips[0])
+	return gp.peerAddressSet.DeleteIPs(ips)
 }
 
 func (gp *gressPolicy) addPortPolicy(portJSON *knet.NetworkPolicyPort) {
@@ -125,23 +126,57 @@ func ipMatch() string {
 }
 
 func (gp *gressPolicy) getL3MatchFromAddressSet() string {
-	addressSets := make([]string, 0, len(gp.sortedPeerAddressSets))
-	for _, hashName := range gp.sortedPeerAddressSets {
-		addressSets = append(addressSets, fmt.Sprintf("$%s", hashName))
-	}
-
 	var l3Match string
-	if len(addressSets) == 0 {
-		l3Match = ipMatch()
+	if len(gp.peerV4AddressSets) == 0 && len(gp.peerV6AddressSets) == 0 {
+		l3Match = constructEmptyMatchString()
 	} else {
-		addresses := strings.Join(addressSets, ", ")
-		if gp.policyType == knet.PolicyTypeIngress {
-			l3Match = fmt.Sprintf("%s.src == {%s}", ipMatch(), addresses)
-		} else {
-			l3Match = fmt.Sprintf("%s.dst == {%s}", ipMatch(), addresses)
-		}
+		// List() method on the set will return the sorted strings
+		// Hence we'll be constructing the sorted adress set string here
+		l3Match = gp.constructMatchString(gp.peerV4AddressSets.List(), gp.peerV6AddressSets.List())
 	}
 	return l3Match
+}
+
+func constructEmptyMatchString() string {
+	switch {
+	case config.IPv4Mode && config.IPv6Mode:
+		return "ip4 || ip6"
+	case config.IPv6Mode:
+		return "ip6"
+	default:
+		return "ip4"
+	}
+}
+
+func (gp *gressPolicy) constructMatchString(v4AddressSets, v6AddressSets []string) string {
+	var direction, v4MatchStr, v6MatchStr, matchStr string
+	if gp.policyType == knet.PolicyTypeIngress {
+		direction = "src"
+	} else {
+		direction = "dst"
+	}
+
+	//  At this point there will be address sets in one or both of them.
+	//  Contents in both address sets mean dual stack, else one will be empty because we will only populate
+	//  entries for enabled stacks
+	if len(v4AddressSets) > 0 {
+		v4AddressSetStr := strings.Join(v4AddressSets, ", ")
+		v4MatchStr = fmt.Sprintf("%s.%s == {%s}", "ip4", direction, v4AddressSetStr)
+		matchStr = v4MatchStr
+	}
+	if len(v6AddressSets) > 0 {
+		v6AddressSetStr := strings.Join(v6AddressSets, ", ")
+		v6MatchStr = fmt.Sprintf("%s.%s == {%s}", "ip6", direction, v6AddressSetStr)
+		matchStr = v6MatchStr
+	}
+	if len(v4AddressSets) > 0 && len(v6AddressSets) > 0 {
+		matchStr = v4MatchStr + "||" + v6MatchStr
+	}
+	return matchStr
+}
+
+func (gp *gressPolicy) sizeOfAddressSet() int {
+	return gp.peerV4AddressSets.Len() + gp.peerV6AddressSets.Len()
 }
 
 func (gp *gressPolicy) getMatchFromIPBlock(lportMatch, l4Match string) string {
@@ -168,36 +203,40 @@ func (gp *gressPolicy) getMatchFromIPBlock(lportMatch, l4Match string) string {
 }
 
 // addNamespaceAddressSet adds a new namespace address set to the gress policy
+
 func (gp *gressPolicy) addNamespaceAddressSet(name, portGroupName string) {
-	hashName := hashedAddressSet(name)
-	if gp.nsAddressSets.Has(hashName) {
+	v4HashName := "$" + getIPv4ASHashedName(name)
+	v6HashName := "$" + getIPv6ASHashedName(name)
+
+	if gp.peerV4AddressSets.Has(v4HashName) || gp.peerV6AddressSets.Has(v6HashName) {
 		return
 	}
-
 	oldL3Match := gp.getL3MatchFromAddressSet()
-	gp.nsAddressSets.Insert(hashName)
-	gp.sortedPeerAddressSets = append(gp.sortedPeerAddressSets, hashName)
-	sort.Strings(gp.sortedPeerAddressSets)
+	if config.IPv4Mode {
+		gp.peerV4AddressSets.Insert(v4HashName)
+	}
+	if config.IPv6Mode {
+		gp.peerV6AddressSets.Insert(v6HashName)
+	}
 	gp.localPodUpdateACL(oldL3Match, gp.getL3MatchFromAddressSet(), portGroupName)
 }
 
 // delNamespaceAddressSet removes a namespace address set from the gress policy
+
 func (gp *gressPolicy) delNamespaceAddressSet(name, portGroupName string) {
-	hashName := hashedAddressSet(name)
-	if !gp.nsAddressSets.Has(hashName) {
+	v4HashName := "$" + getIPv4ASHashedName(name)
+	v6HashName := "$" + getIPv6ASHashedName(name)
+
+	if !gp.peerV4AddressSets.Has(v4HashName) && !gp.peerV6AddressSets.Has(v6HashName) {
 		return
 	}
-
 	oldL3Match := gp.getL3MatchFromAddressSet()
-	for i, addressSet := range gp.sortedPeerAddressSets {
-		if addressSet == hashName {
-			gp.sortedPeerAddressSets = append(
-				gp.sortedPeerAddressSets[:i],
-				gp.sortedPeerAddressSets[i+1:]...)
-			break
-		}
+	if config.IPv4Mode {
+		gp.peerV4AddressSets.Delete(v4HashName)
 	}
-	gp.nsAddressSets.Delete(hashName)
+	if config.IPv6Mode {
+		gp.peerV6AddressSets.Delete(v6HashName)
+	}
 	gp.localPodUpdateACL(oldL3Match, gp.getL3MatchFromAddressSet(), portGroupName)
 }
 
@@ -236,7 +275,7 @@ func (gp *gressPolicy) localPodAddACL(portGroupName, portGroupUUID string) {
 		}
 		// if there are pod/namespace selector, then allow packets from/to that address_set or
 		// if the NetworkPolicyPeer is empty, then allow from all sources or to all destinations.
-		if len(gp.sortedPeerAddressSets) > 0 || len(gp.ipBlockCidr) == 0 {
+		if gp.sizeOfAddressSet() > 0 || len(gp.ipBlockCidr) == 0 {
 			if err := gp.addACLAllow(match, l4Match, portGroupUUID, false); err != nil {
 				klog.Warningf(err.Error())
 			}
@@ -255,7 +294,7 @@ func (gp *gressPolicy) localPodAddACL(portGroupName, portGroupUUID string) {
 				klog.Warningf(err.Error())
 			}
 		}
-		if len(gp.sortedPeerAddressSets) > 0 || len(gp.ipBlockCidr) == 0 {
+		if gp.sizeOfAddressSet() > 0 || len(gp.ipBlockCidr) == 0 {
 			if err := gp.addACLAllow(match, l4Match, portGroupUUID, false); err != nil {
 				klog.Warningf(err.Error())
 			}

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -36,6 +36,11 @@ func newNamespace(namespace string) *v1.Namespace {
 }
 
 var _ = Describe("OVN Namespace Operations", func() {
+	const (
+		namespaceName    = "namespace1"
+		v4AddressSetName = namespaceName + ipv4AddressSetSuffix
+		v6AddressSetName = namespaceName + ipv6AddressSetSuffix
+	)
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
@@ -60,7 +65,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 
 		It("reconciles an existing namespace with pods", func() {
 			app.Action = func(ctx *cli.Context) error {
-				namespaceT := *newNamespace("namespace1")
+				namespaceT := *newNamespace(namespaceName)
 				tP := newTPod(
 					"node1",
 					"10.128.1.0/24",
@@ -92,7 +97,8 @@ var _ = Describe("OVN Namespace Operations", func() {
 				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceT.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceT.Name, []string{tP.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName, []string{tP.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName)
 
 				return nil
 			}
@@ -103,7 +109,6 @@ var _ = Describe("OVN Namespace Operations", func() {
 
 		It("creates an empty address set for the namespace without pods", func() {
 			app.Action = func(ctx *cli.Context) error {
-				const namespaceName string = "namespace1"
 				fakeOvn.start(ctx, &v1.NamespaceList{
 					Items: []v1.Namespace{
 						*newNamespace("namespace1"),
@@ -114,7 +119,8 @@ var _ = Describe("OVN Namespace Operations", func() {
 				_, err := fakeOvn.fakeClient.CoreV1().Namespaces().Get(namespaceName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName)
 
 				return nil
 			}
@@ -127,18 +133,18 @@ var _ = Describe("OVN Namespace Operations", func() {
 	Context("during execution", func() {
 		It("deletes an empty namespace's resources", func() {
 			app.Action = func(ctx *cli.Context) error {
-				const namespaceName string = "namespace1"
 				fakeOvn.start(ctx, &v1.NamespaceList{
 					Items: []v1.Namespace{
 						*newNamespace(namespaceName),
 					},
 				})
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName)
 
 				err := fakeOvn.fakeClient.CoreV1().Namespaces().Delete(namespaceName, metav1.NewDeleteOptions(1))
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvn.asf.EventuallyExpectNoAddressSet(namespaceName)
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v4AddressSetName)
 				return nil
 			}
 

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -16,6 +16,7 @@ const (
 	k8sUDPLoadBalancerIP  = "k8s_udp_load_balancer"
 	k8sSCTPLoadBalancerIP = "k8s_sctp_load_balancer"
 	fakeUUID              = "8a86f6d8-7972-4253-b0bd-ddbef66e9303"
+	fakeUUIDv6            = "8a86f6d8-7972-4253-b0bd-ddbef66e9304"
 )
 
 type FakeOVN struct {

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -12,6 +12,7 @@ import (
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
+
 	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,22 +106,22 @@ func (n networkPolicy) addNamespaceSelectorCmds(fexec *ovntest.FakeExec, network
 	for i := range networkPolicy.Spec.Ingress {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Ingress_num=%v external-ids:policy_type=Ingress", networkPolicy.Namespace, networkPolicy.Name, i),
-			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" action=allow-related external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group " + readableGroupName + " acls @acl",
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\" action=allow-related external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress -- add port_group " + readableGroupName + " acls @acl",
 		})
 		if findAgain {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
 			})
 		}
 	}
 	for i := range networkPolicy.Spec.Egress {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=%s external-ids:policy=%s external-ids:Egress_num=%v external-ids:policy_type=Egress", networkPolicy.Namespace, networkPolicy.Name, i),
-			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" action=allow external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group " + readableGroupName + " acls @acl",
+			"ovn-nbctl --timeout=15 --id=@acl create acl priority=1001 direction=to-lport match=\"ip4.dst == {$a17928043879887565554} && inport == @a14195333570786048679\" action=allow external-ids:l4Match=\"None\" external-ids:ipblock_cidr=false external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress -- add port_group " + readableGroupName + " acls @acl",
 		})
 		if findAgain {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a17928043879887565554} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
 			})
 		}
 	}
@@ -128,7 +129,7 @@ func (n networkPolicy) addNamespaceSelectorCmds(fexec *ovntest.FakeExec, network
 
 func getAddressSetName(namespace, name string, policyType knet.PolicyType, idx int) string {
 	direction := strings.ToLower(string(policyType))
-	return fmt.Sprintf("%s.%s.%s.%d", namespace, name, direction, idx)
+	return fmt.Sprintf("%s.%s.%s.%d%s", namespace, name, direction, idx, ipv4AddressSetSuffix)
 }
 
 func eventuallyExpectNoAddressSets(fakeOvn *FakeOVN, networkPolicy *knet.NetworkPolicy) {
@@ -285,6 +286,15 @@ func (p multicastPolicy) delPodCmds(fExec *ovntest.FakeExec, ns string) {
 }
 
 var _ = Describe("OVN NetworkPolicy Operations", func() {
+	const (
+		namespaceName1    = "namespace1"
+		v4AddressSetName1 = namespaceName1 + ipv4AddressSetSuffix
+		v6AddressSetName1 = namespaceName1 + ipv6AddressSetSuffix
+
+		namespaceName2    = "namespace2"
+		v4AddressSetName2 = namespaceName2 + ipv4AddressSetSuffix
+		v6AddressSetName2 = namespaceName2 + ipv6AddressSetSuffix
+	)
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
@@ -314,8 +324,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 				networkPolicy := newNetworkPolicy("networkpolicy1", namespace1.Name,
 					metav1.LabelSelector{},
 					[]knet.NetworkPolicyIngressRule{
@@ -364,8 +374,11 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
 
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace2.Name)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName1)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName2)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName2)
+
 				eventuallyExpectEmptyAddressSets(fakeOvn, networkPolicy)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
@@ -384,7 +397,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -454,7 +467,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -472,8 +486,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 
 				nPodTest := newTPod(
 					"node2",
@@ -552,9 +566,12 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
 
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName1)
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace2.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName2, []string{nPodTest.podIP})
+
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName2)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -574,7 +591,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := newTPod(
 					"node1",
 					"10.128.1.0/24",
@@ -648,7 +665,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				return nil
 			}
@@ -662,8 +680,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 
 				nPodTest := newTPod(
 					"node1",
@@ -737,23 +755,25 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391, $a6953373268003663638} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a3128014386057836746, $a4615334824109672969} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
 					Output: fakeUUID,
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\"",
+					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\"",
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a6953373268003663638, $a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a17928043879887565554, $a4615334824109672969} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
 				})
 
 				err = fakeOvn.fakeClient.CoreV1().Namespaces().Delete(namespace2.Name, metav1.NewDeleteOptions(0))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.EventuallyExpectNoAddressSet(namespace2.Name)
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v4AddressSetName2)
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v6AddressSetName2)
 
 				return nil
 			}
@@ -767,8 +787,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 				networkPolicy := newNetworkPolicy("networkpolicy1", namespace1.Name,
 					metav1.LabelSelector{},
 					[]knet.NetworkPolicyIngressRule{
@@ -822,21 +842,21 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a10148211500778908391, $a6953373268003663638} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.src == {$a3128014386057836746, $a4615334824109672969} && outport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Ingress_num=0 external-ids:policy_type=Ingress",
 					Output: fakeUUID,
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a10148211500778908391} && outport == @a14195333570786048679\"",
+					"ovn-nbctl --timeout=15 set acl " + fakeUUID + " match=\"ip4.src == {$a3128014386057836746} && outport == @a14195333570786048679\"",
 				})
 				fExec.AddFakeCmdsNoOutputNoError([]string{
-					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a6953373268003663638, $a9824637386382239951} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
+					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.dst == {$a17928043879887565554, $a4615334824109672969} && inport == @a14195333570786048679\" external-ids:namespace=namespace1 external-ids:policy=networkpolicy1 external-ids:Egress_num=0 external-ids:policy_type=Egress",
 				})
 
 				err = fakeOvn.fakeClient.CoreV1().Namespaces().Delete(namespace2.Name, metav1.NewDeleteOptions(0))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.EventuallyExpectNoAddressSet(namespace2.Name)
-
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v4AddressSetName2)
+				fakeOvn.asf.EventuallyExpectNoAddressSet(v6AddressSetName2)
 				return nil
 			}
 
@@ -849,7 +869,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -919,7 +939,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -933,8 +954,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
 				eventuallyExpectEmptyAddressSets(fakeOvn, networkPolicy)
-				fakeOvn.asf.EventuallyExpectEmptyAddressSet(namespace1.Name)
-
+				fakeOvn.asf.EventuallyExpectEmptyAddressSet(v4AddressSetName1)
 				return nil
 			}
 
@@ -947,8 +967,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
-				namespace2 := *newNamespace("namespace2")
+				namespace1 := *newNamespace(namespaceName1)
+				namespace2 := *newNamespace(namespaceName2)
 
 				nPodTest := newTPod(
 					"node1",
@@ -1027,9 +1047,11 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchNetworkPolicy()
 
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName1)
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace2.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName2, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName2)
 
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1043,7 +1065,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				// After deleting the pod all address sets should be empty
 				eventuallyExpectEmptyAddressSets(fakeOvn, networkPolicy)
-				fakeOvn.asf.EventuallyExpectEmptyAddressSet(namespace1.Name)
+				fakeOvn.asf.EventuallyExpectEmptyAddressSet(v4AddressSetName1)
 
 				return nil
 			}
@@ -1057,7 +1079,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 				npTest := networkPolicy{}
 
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -1129,7 +1151,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				_, err := fakeOvn.fakeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(networkPolicy.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				npTest.delCmds(fExec, nPodTest, networkPolicy, true)
 
@@ -1147,7 +1170,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 		It("tests enabling/disabling multicast in a namespace", func() {
 			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				fakeOvn.start(ctx,
 					&v1.NamespaceList{
@@ -1190,7 +1213,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 		It("tests enabling multicast in a namespace with a pod", func() {
 			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -1235,7 +1258,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				_, err = fakeOvn.fakeClient.CoreV1().Namespaces().Update(ns)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 				return nil
 			}
 
@@ -1245,7 +1269,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 
 		It("tests adding a pod to a multicast enabled namespace", func() {
 			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace("namespace1")
+				namespace1 := *newNamespace(namespaceName1)
 
 				nPodTest := newTPod(
 					"node1",
@@ -1292,7 +1316,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 					nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectAddressSetWithIPs(v4AddressSetName1, []string{nPodTest.podIP})
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 
 				// Delete the pod from the namespace.
 				mcastPolicy.delPodCmds(fExec, namespace1.Name)
@@ -1304,7 +1329,8 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 					nPodTest.podName, metav1.NewDeleteOptions(0))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
+				fakeOvn.asf.ExpectEmptyAddressSet(v4AddressSetName1)
+				fakeOvn.asf.ExpectNoAddressSet(v6AddressSetName1)
 				return nil
 			}
 
@@ -1363,6 +1389,7 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		asFactory = newFakeAddressSetFactory()
+		config.IPv4Mode = true
 	})
 
 	It("computes match strings from address sets correctly", func() {
@@ -1382,7 +1409,7 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		gp := newGressPolicy(knet.PolicyTypeIngress, 0, policy.Namespace, policy.Name)
 		err := gp.ensurePeerAddressSet(asFactory)
 		Expect(err).NotTo(HaveOccurred())
-		asName := gp.peerAddressSet.GetName()
+		asName := getIPv4ASName(gp.peerAddressSet.GetName())
 
 		one := fmt.Sprintf("testing.policy.ingress.1")
 		two := fmt.Sprintf("testing.policy.ingress.2")
@@ -1391,16 +1418,23 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		five := fmt.Sprintf("testing.policy.ingress.5")
 		six := fmt.Sprintf("testing.policy.ingress.6")
 
-		cur := addExpectedGressCmds(fExec, gp, pgName, []string{asName}, []string{asName, one})
+		v4One := one + ipv4AddressSetSuffix
+		v4Two := two + ipv4AddressSetSuffix
+		v4Three := three + ipv4AddressSetSuffix
+		v4Four := four + ipv4AddressSetSuffix
+		v4Five := five + ipv4AddressSetSuffix
+		v4Six := six + ipv4AddressSetSuffix
+
+		cur := addExpectedGressCmds(fExec, gp, pgName, []string{asName}, []string{asName, v4One})
 		gp.addNamespaceAddressSet(one, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, one, two})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4One, v4Two})
 		gp.addNamespaceAddressSet(two, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 		// address sets should be alphabetized
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, one, two, three})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4One, v4Two, v4Three})
 		gp.addNamespaceAddressSet(three, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
@@ -1408,12 +1442,12 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		gp.addNamespaceAddressSet(one, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, one, two, three, four})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4One, v4Two, v4Three, v4Four})
 		gp.addNamespaceAddressSet(four, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 		// now delete a set
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, three, four})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Two, v4Three, v4Four})
 		gp.delNamespaceAddressSet(one, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
@@ -1422,11 +1456,11 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
 		// add and delete some more...
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, three, four, five})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Two, v4Three, v4Four, v4Five})
 		gp.addNamespaceAddressSet(five, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, four, five})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Two, v4Four, v4Five})
 		gp.delNamespaceAddressSet(three, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
@@ -1434,19 +1468,19 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		gp.delNamespaceAddressSet(one, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, two, four, five, six})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Two, v4Four, v4Five, v4Six})
 		gp.addNamespaceAddressSet(six, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, four, five, six})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Four, v4Five, v4Six})
 		gp.delNamespaceAddressSet(two, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, four, six})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Four, v4Six})
 		gp.delNamespaceAddressSet(five, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 
-		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, four})
+		cur = addExpectedGressCmds(fExec, gp, pgName, cur, []string{asName, v4Four})
 		gp.delNamespaceAddressSet(six, pgName)
 		Expect(fExec.CalledMatchesExpected()).To(BeTrue(), fExec.ErrorDesc)
 


### PR DESCRIPTION
Now dual stack is supported as first class candidate in Address Set APIs
Internally Address set api will always create Ipv4 and Ipv6 address sets for each create.
Changes to the policies to support the new API structure and dual stack.
Tried to reuse existing address set code as much as possible.
Only minimal changes to the tests as required to make the build except a few test cases added to address new Address Set scenarios. More tests will follow in a separate PR.
Not addressed ip-blocks in policies yet. Will be done in separate PR.

Signed-off-by: Balaji Varadaraju <bvaradar@redhat.com>

