### PR TITLE
run tests with race detector enabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,13 @@ jobs:
           make lint
         popd
 
+    - name: Test
+      run: |
+        set -x
+        pushd go-controller
+           RACE=1 make check
+        popd
+
     - name: Build
       run: |
         set -x

--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -17,16 +17,24 @@ function testrun {
     local args=
     local ginkgoargs=
     local path=${pkg#github.com/ovn-org/ovn-kubernetes/go-controller}
+    # enable go race detector
+    if [ ! -z "${RACE:-}" ]; then
+    # FIXME race detector fails with hybrid-overlay tests
+        if [[ "${pkg}" != github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller ]]; then
+            args="-race "
+        fi
+    fi
+    # coverage is incompatible with the race detector
     if [ ! -z "${COVERALLS:-}" ]; then
         args="-covermode set -coverprofile ${idx}.coverprofile "
     fi
     if [ -n "${TEST_REPORT_DIR}" ] && grep -q -r "ginkgo" .${path}; then
-	prefix=$( echo ${path} | cut -c 2- | sed 's,/,_,g')
-	ginkgoargs="-ginkgo.reportFile ${TEST_REPORT_DIR}/junit-${prefix}.xml"
+	    prefix=$( echo ${path} | cut -c 2- | sed 's,/,_,g')
+	    ginkgoargs="-ginkgo.v -ginkgo.reportFile ${TEST_REPORT_DIR}/junit-${prefix}.xml"
     fi
     args="${args}${otherargs}${pkg}"
 
-    go test -mod vendor ${args} ${ginkgoargs}
+    go test -v ${args} ${ginkgoargs} -mod vendor
 }
 
 # These packages requires root for network namespace maniuplation in unit tests

--- a/go-controller/pkg/informer/informer_test.go
+++ b/go-controller/pkg/informer/informer_test.go
@@ -113,8 +113,8 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		_, err := k.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		Consistently(deletes).Should(Equal(int32(0)), "deletes")
-		Eventually(adds, 3).Should(Equal(int32(1)), "adds")
+		Consistently(func() int32 { return atomic.LoadInt32(&deletes) }).Should(Equal(int32(0)), "deletes")
+		Eventually(func() int32 { return atomic.LoadInt32(&adds) }).Should(Equal(int32(1)), "adds")
 	})
 
 	It("adds existing pod and processes an update event", func() {
@@ -179,11 +179,10 @@ var _ = Describe("Informer Event Handler Tests", func() {
 
 		_, err := k.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-
 		// no deletes
-		Consistently(deletes).Should(Equal(int32(0)), "deletes")
+		Consistently(func() int32 { return atomic.LoadInt32(&deletes) }).Should(Equal(int32(0)), "deletes")
 		// two updates, initial add from cache + update event
-		Eventually(adds, 3).Should(Equal(int32(2)), "adds")
+		Eventually(func() int32 { return atomic.LoadInt32(&adds) }).Should(Equal(int32(2)), "adds")
 	})
 
 	It("adds existing pod and processes a delete event", func() {
@@ -246,9 +245,9 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// initial add from the cache
-		Consistently(adds).Should(Equal(int32(1)), "adds")
+		Consistently(func() int32 { return atomic.LoadInt32(&adds) }).Should(Equal(int32(1)), "adds")
 		// one delete event
-		Eventually(deletes, 3).Should(Equal(int32(1)), "deletes")
+		Eventually(func() int32 { return atomic.LoadInt32(&deletes) }).Should(Equal(int32(1)), "deletes")
 	})
 
 	It("ignores updates using DiscardAllUpdates", func() {
@@ -314,9 +313,9 @@ var _ = Describe("Informer Event Handler Tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// no deletes
-		Consistently(deletes).Should(Equal(int32(0)), "deletes")
+		Consistently(func() int32 { return atomic.LoadInt32(&deletes) }).Should(Equal(int32(0)), "deletes")
 		// only initial add, no further updates
-		Eventually(adds, 3).Should(Equal(int32(1)), "adds")
+		Eventually(func() int32 { return atomic.LoadInt32(&adds) }).Should(Equal(int32(1)), "adds")
 	})
 
 })

--- a/go-controller/pkg/ovn/fake_address_set_test.go
+++ b/go-controller/pkg/ovn/fake_address_set_test.go
@@ -283,6 +283,8 @@ func (as *fakeAddressSet) addIP(ip net.IP) error {
 }
 
 func (as *fakeAddressSet) deleteIP(ip net.IP) error {
+	as.Lock()
+	defer as.Unlock()
 	Expect(as.destroyed).To(BeFalse())
 	delete(as.ips, ip.String())
 	return nil

--- a/go-controller/pkg/testing/exec.go
+++ b/go-controller/pkg/testing/exec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"k8s.io/klog"
 	kexec "k8s.io/utils/exec"
@@ -22,6 +23,7 @@ type FakeExec struct {
 	looseCompare     bool
 	expectedCommands []*ExpectedCmd
 	executedCommands []string
+	mu               sync.Mutex
 }
 
 var _ kexec.Interface = &FakeExec{}
@@ -57,6 +59,8 @@ func (f *FakeExec) CommandContext(ctx context.Context, cmd string, args ...strin
 }
 
 func (f *FakeExec) ErrorDesc() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if len(f.executedCommands) == len(f.expectedCommands) {
 		return ""
 	}
@@ -108,6 +112,8 @@ func (f *FakeExec) internalErrorDesc() string {
 // CalledMatchesExpected returns true if the number of commands the code under
 // test called matches the number of expected commands in the FakeExec's list
 func (f *FakeExec) CalledMatchesExpected() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	return len(f.executedCommands) == len(f.expectedCommands)
 }
 
@@ -134,6 +140,8 @@ func getExecutedCommandline(cmd string, args ...string) string {
 
 func (f *FakeExec) Command(cmd string, args ...string) kexec.Cmd {
 	executed := getExecutedCommandline(cmd, args...)
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.executedCommands = append(f.executedCommands, executed)
 
 	var expected *ExpectedCmd
@@ -185,6 +193,8 @@ func (f *FakeExec) Command(cmd string, args ...string) kexec.Cmd {
 // a fake command action list of the FakeExec
 func (f *FakeExec) AddFakeCmd(expected *ExpectedCmd) {
 	expected.Cmd = fakeBinPrefix + expected.Cmd
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.expectedCommands = append(f.expectedCommands, expected)
 }
 


### PR DESCRIPTION
**- What this PR does and why is it needed**

Enable the golang race detector for tests and fixes the race conditions detected.

Fixes: https://github.com/ovn-org/ovn-kubernetes/issues/1368

**- Special notes for reviewers**

**- How to verify it**

Test should pass

**- Description for the changelog**
