### PR TITLE
 IPv6 and dual stack tests for Localnet

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
+	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -298,13 +299,167 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 	Expect(err).NotTo(HaveOccurred())
 }
 
+func localNetInterfaceTest(app *cli.App, testNS ns.NetNS,
+	subnets []*net.IPNet, brNextHopCIDRs []*netlink.Addr, ipts []*util.FakeIPTables,
+	expectedIPTablesRules []map[string]util.FakeTable) {
+
+	const mtu string = "1234"
+
+	app.Action = func(ctx *cli.Context) error {
+		const (
+			nodeName      string = "node1"
+			brLocalnetMAC string = "11:22:33:44:55:66"
+			systemID      string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
+		)
+
+		fexec := ovntest.NewFakeExec()
+		fakeOvnNode := NewFakeOVNNode(fexec)
+
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovs-vsctl --timeout=15 --may-exist add-br br-local",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface br-local mac_in_use",
+			Output: brLocalnetMAC,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovs-vsctl --timeout=15 set bridge br-local other-config:hwaddr=" + brLocalnetMAC,
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
+			Output: "",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + util.PhysicalNetworkName + ":br-local",
+			"ovs-vsctl --timeout=15 --if-exists del-port br-local " + legacyLocalnetGatewayNextHopPort +
+				" -- --may-exist add-port br-local " + localnetGatewayNextHopPort + " -- set interface " + localnetGatewayNextHopPort + " type=internal mtu_request=" + mtu + " mac=00\\:00\\:a9\\:fe\\:21\\:01",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
+			Output: systemID,
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ip rule",
+			Output: "0:	from all lookup local\n32766:	from all lookup main\n32767:	from all lookup default\n",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ip rule add from all table " + localnetGatewayExternalIDTable,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ip route list table " + localnetGatewayExternalIDTable,
+		})
+
+		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		}}
+
+		fakeOvnNode.start(ctx,
+			&v1.NodeList{
+				Items: []v1.Node{
+					existingNode,
+				},
+			},
+		)
+
+		nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeOvnNode.fakeClient}, &existingNode)
+		err := util.SetNodeHostSubnetAnnotation(nodeAnnotator, subnets)
+		Expect(err).NotTo(HaveOccurred())
+		err = nodeAnnotator.Run()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = testNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			config.IPv4Mode = false
+			config.IPv6Mode = false
+			for _, subnet := range subnets {
+				if utilnet.IsIPv6CIDR(subnet) {
+					config.IPv6Mode = true
+				} else {
+					config.IPv4Mode = true
+				}
+			}
+
+			err = fakeOvnNode.node.initLocalnetGateway(subnets, nodeAnnotator)
+			Expect(err).NotTo(HaveOccurred())
+			// Check if IP has been assigned to LocalnetGatewayNextHopPort
+			link, err := netlink.LinkByName(localnetGatewayNextHopPort)
+			Expect(err).NotTo(HaveOccurred())
+			addrs, err := netlink.AddrList(link, syscall.AF_UNSPEC)
+			Expect(err).NotTo(HaveOccurred())
+
+			var foundAddr bool
+			for _, expectedAddr := range brNextHopCIDRs {
+				foundAddr = false
+				for _, a := range addrs {
+					if a.IP.Equal(expectedAddr.IP) && bytes.Equal(a.Mask, expectedAddr.Mask) {
+						foundAddr = true
+						break
+					}
+				}
+				Expect(foundAddr).To(BeTrue())
+			}
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+
+		for i := 0; i < len(ipts); i++ {
+			err = ipts[i].MatchState(expectedIPTablesRules[i])
+			Expect(err).NotTo(HaveOccurred())
+		}
+		return nil
+	}
+
+	err := app.Run([]string{
+		app.Name,
+		"--init-gateways",
+		"--gateway-local",
+		"--nodeport",
+		"--mtu=" + mtu,
+	})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func expectedIPTablesRules(gatewayIP string) map[string]util.FakeTable {
+	return map[string]util.FakeTable{
+		"filter": {
+			"INPUT": []string{
+				"-i " + localnetGatewayNextHopPort + " -m comment --comment from OVN to localhost -j ACCEPT",
+			},
+			"FORWARD": []string{
+				"-j OVN-KUBE-EXTERNALIP",
+				"-j OVN-KUBE-NODEPORT",
+				"-o " + localnetGatewayNextHopPort + " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
+				"-i " + localnetGatewayNextHopPort + " -j ACCEPT",
+			},
+			"OVN-KUBE-NODEPORT":   []string{},
+			"OVN-KUBE-EXTERNALIP": []string{},
+		},
+		"nat": {
+			"POSTROUTING": []string{
+				"-s " + gatewayIP + " -j MASQUERADE",
+			},
+			"PREROUTING": []string{
+				"-j OVN-KUBE-EXTERNALIP",
+				"-j OVN-KUBE-NODEPORT",
+			},
+			"OUTPUT": []string{
+				"-j OVN-KUBE-EXTERNALIP",
+				"-j OVN-KUBE-NODEPORT",
+			},
+			"OVN-KUBE-NODEPORT":   []string{},
+			"OVN-KUBE-EXTERNALIP": []string{},
+		},
+	}
+}
+
 var _ = Describe("Gateway Init Operations", func() {
 
 	var (
-		testNS      ns.NetNS
-		app         *cli.App
-		fakeOvnNode *FakeOVNNode
-		fexec       *ovntest.FakeExec
+		testNS ns.NetNS
+		app    *cli.App
 	)
 
 	BeforeEach(func() {
@@ -318,9 +473,6 @@ var _ = Describe("Gateway Init Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
-
-		fexec = ovntest.NewFakeExec()
-		fakeOvnNode = NewFakeOVNNode(fexec)
 
 		// Set up a fake br-local & LocalnetGatewayNextHopPort
 		testNS, err = testutils.NewNS()
@@ -350,143 +502,65 @@ var _ = Describe("Gateway Init Operations", func() {
 		Expect(testNS.Close()).To(Succeed())
 	})
 
-	It("sets up a localnet gateway", func() {
-		const mtu string = "1234"
+	Context("for localnet operations", func() {
+		const (
+			v4BrNextHopIP       = "169.254.33.1"
+			v4BrNextHopCIDR     = v4BrNextHopIP + "/24"
+			v4NodeSubnet        = "10.1.1.0/24"
+			v4localnetGatewayIP = "169.254.33.2"
 
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				nodeName      string = "node1"
-				brLocalnetMAC string = "11:22:33:44:55:66"
-				brNextHopIP   string = "169.254.33.1"
-				brNextHopCIDR string = brNextHopIP + "/24"
-				systemID      string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
-				nodeSubnet    string = "10.1.1.0/24"
-			)
+			v6BrNextHopIP       = "fd99::1"
+			v6BrNextHopCIDR     = v6BrNextHopIP + "/64"
+			v6NodeSubnet        = "2001:db8:abcd:0012::0/64"
+			v6localnetGatewayIP = "fd99::2"
+		)
+		var (
+			brNextHopCIDRs []*netlink.Addr
+			ipts           []*util.FakeIPTables
+			ipTablesRules  []map[string]util.FakeTable
+		)
 
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 --may-exist add-br br-local",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface br-local mac_in_use",
-				Output: brLocalnetMAC,
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set bridge br-local other-config:hwaddr=" + brLocalnetMAC,
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-				Output: "",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + util.PhysicalNetworkName + ":br-local",
-				"ovs-vsctl --timeout=15 --if-exists del-port br-local " + legacyLocalnetGatewayNextHopPort +
-					" -- --may-exist add-port br-local " + localnetGatewayNextHopPort + " -- set interface " + localnetGatewayNextHopPort + " type=internal mtu_request=" + mtu + " mac=00\\:00\\:a9\\:fe\\:21\\:01",
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
-				Output: systemID,
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ip rule",
-				Output: "0:	from all lookup local\n32766:	from all lookup main\n32767:	from all lookup default\n",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ip rule add from all table " + localnetGatewayExternalIDTable,
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ip route list table " + localnetGatewayExternalIDTable,
-			})
-
-			existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
-				Name: nodeName,
-			}}
-
-			fakeOvnNode.start(ctx,
-				&v1.NodeList{
-					Items: []v1.Node{
-						existingNode,
-					},
-				},
-			)
-
-			iptV4, _ := util.SetFakeIPTablesHelpers()
-
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeOvnNode.fakeClient}, &existingNode)
-			err := util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(nodeSubnet))
+		It("sets up a IPv4 localnet gateway", func() {
+			nextHopCIDRIPv4, err := netlink.ParseAddr(v4BrNextHopCIDR)
 			Expect(err).NotTo(HaveOccurred())
-			err = nodeAnnotator.Run()
-			Expect(err).NotTo(HaveOccurred())
+			brNextHopCIDRs := append(brNextHopCIDRs, nextHopCIDRIPv4)
 
-			err = testNS.Do(func(ns.NetNS) error {
-				defer GinkgoRecover()
+			v4ipt, _ := util.SetFakeIPTablesHelpers()
+			ipts := append(ipts, v4ipt.(*util.FakeIPTables))
+			ipTablesRules := append(ipTablesRules, expectedIPTablesRules(v4localnetGatewayIP))
 
-				err = fakeOvnNode.node.initLocalnetGateway(ovntest.MustParseIPNets(nodeSubnet), nodeAnnotator)
-				Expect(err).NotTo(HaveOccurred())
-				// Check if IP has been assigned to LocalnetGatewayNextHopPort
-				link, err := netlink.LinkByName(localnetGatewayNextHopPort)
-				Expect(err).NotTo(HaveOccurred())
-				addrs, err := netlink.AddrList(link, syscall.AF_INET)
-				Expect(err).NotTo(HaveOccurred())
-				var foundAddr bool
-				expectedAddr, err := netlink.ParseAddr(brNextHopCIDR)
-				Expect(err).NotTo(HaveOccurred())
-				for _, a := range addrs {
-					if a.IP.Equal(expectedAddr.IP) && bytes.Equal(a.Mask, expectedAddr.Mask) {
-						foundAddr = true
-						break
-					}
-				}
-				Expect(foundAddr).To(BeTrue())
-				return nil
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
-
-			expectedTables := map[string]util.FakeTable{
-				"filter": {
-					"INPUT": []string{
-						"-i " + localnetGatewayNextHopPort + " -m comment --comment from OVN to localhost -j ACCEPT",
-					},
-					"FORWARD": []string{
-						"-j OVN-KUBE-EXTERNALIP",
-						"-j OVN-KUBE-NODEPORT",
-						"-o " + localnetGatewayNextHopPort + " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
-						"-i " + localnetGatewayNextHopPort + " -j ACCEPT",
-					},
-					"OVN-KUBE-NODEPORT":   []string{},
-					"OVN-KUBE-EXTERNALIP": []string{},
-				},
-				"nat": {
-					"POSTROUTING": []string{
-						"-s 169.254.33.2 -j MASQUERADE",
-					},
-					"PREROUTING": []string{
-						"-j OVN-KUBE-EXTERNALIP",
-						"-j OVN-KUBE-NODEPORT",
-					},
-					"OUTPUT": []string{
-						"-j OVN-KUBE-EXTERNALIP",
-						"-j OVN-KUBE-NODEPORT",
-					},
-					"OVN-KUBE-NODEPORT":   []string{},
-					"OVN-KUBE-EXTERNALIP": []string{},
-				},
-			}
-			f4 := iptV4.(*util.FakeIPTables)
-			err = f4.MatchState(expectedTables)
-			Expect(err).NotTo(HaveOccurred())
-			return nil
-		}
-
-		err := app.Run([]string{
-			app.Name,
-			"--init-gateways",
-			"--gateway-local",
-			"--nodeport",
-			"--mtu=" + mtu,
+			localNetInterfaceTest(app, testNS, ovntest.MustParseIPNets(v4NodeSubnet), brNextHopCIDRs, ipts, ipTablesRules)
 		})
-		Expect(err).NotTo(HaveOccurred())
+
+		It("sets up a IPv6 localnet gateway", func() {
+			nextHopCIDRIPv6, err := netlink.ParseAddr(v6BrNextHopCIDR)
+			Expect(err).NotTo(HaveOccurred())
+			brNextHopCIDRs := append(brNextHopCIDRs, nextHopCIDRIPv6)
+
+			_, v6ipt := util.SetFakeIPTablesHelpers()
+			ipts := append(ipts, v6ipt.(*util.FakeIPTables))
+			ipTablesRules := append(ipTablesRules, expectedIPTablesRules(v6localnetGatewayIP))
+
+			localNetInterfaceTest(app, testNS, ovntest.MustParseIPNets(v6NodeSubnet), brNextHopCIDRs, ipts, ipTablesRules)
+		})
+
+		It("sets up a dual stack localnet gateway", func() {
+			nextHopCIDRIPv4, err := netlink.ParseAddr(v4BrNextHopCIDR)
+			Expect(err).NotTo(HaveOccurred())
+			brNextHopCIDRs := append(brNextHopCIDRs, nextHopCIDRIPv4)
+			nextHopCIDRIPv6, err := netlink.ParseAddr(v6BrNextHopCIDR)
+			Expect(err).NotTo(HaveOccurred())
+			brNextHopCIDRs = append(brNextHopCIDRs, nextHopCIDRIPv6)
+
+			v4ipt, v6ipt := util.SetFakeIPTablesHelpers()
+			ipts := append(ipts, v4ipt.(*util.FakeIPTables))
+			ipts = append(ipts, v6ipt.(*util.FakeIPTables))
+			ipTablesRules := append(ipTablesRules, expectedIPTablesRules(v4localnetGatewayIP))
+			ipTablesRules = append(ipTablesRules, expectedIPTablesRules(v6localnetGatewayIP))
+
+			localNetInterfaceTest(app, testNS, ovntest.MustParseIPNets(v4NodeSubnet, v6NodeSubnet), brNextHopCIDRs,
+				ipts, ipTablesRules)
+		})
 	})
 
 	Context("for NIC-based operations", func() {


### PR DESCRIPTION
Tests for IPv6 and dual-stack for localnet.
We had tests for IPv4. This PR reuses and refactored  that code to create  tests for IPv6 and dual-stack.

Created a ginkgo Context for localnet tests and have one test each for IPv4, IPv6 ,and dual-stack.
cc: @danwinship 
