### PR TITLE
Make output of testing functions mirror the real functions

### DIFF
--- a/go-controller/pkg/ovn/fake_address_set_test.go
+++ b/go-controller/pkg/ovn/fake_address_set_test.go
@@ -194,11 +194,17 @@ func newFakeAddressSet(name string, ips []net.IP, removeFn removeFunc) *fakeAddr
 }
 
 func (as *fakeAddressSets) GetIPv4HashName() string {
-	return as.ipv4.getHashName()
+	if as.ipv4 != nil {
+		return as.ipv4.getHashName()
+	}
+	return ""
 }
 
 func (as *fakeAddressSets) GetIPv6HashName() string {
-	return as.ipv6.getHashName()
+	if as.ipv6 != nil {
+		return as.ipv6.getHashName()
+	}
+	return ""
 }
 
 func (as *fakeAddressSets) GetName() string {


### PR DESCRIPTION
Currently the output of GetIPv4HashName() and GetIPv6HashName() in the
fakeAddressSet implementation do not mirror the functionality of the
GetIPv4HashName() and GetIPv6HashName() in the OvnAddressSet implementation
of the AddressSet interface. This will cause functions that call GetIPvXHashName()
to behave differently under test then under normal operating conditions.

This patch corrects that and makes the output the same

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->