### PR TITLE
Simplify SubnetAllocator ranges, fix hybrid overlay problem

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -95,7 +95,7 @@ func NewMaster(kube kube.Interface,
 
 	// Add our hybrid overlay CIDRs to the subnetallocator
 	for _, clusterEntry := range config.HybridOverlay.ClusterSubnets {
-		err := m.allocator.AddNetworkRange(clusterEntry.CIDR, 32-clusterEntry.HostSubnetLength)
+		err := m.allocator.AddNetworkRange(clusterEntry.CIDR, clusterEntry.HostSubnetLength)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -32,7 +32,7 @@ const DefaultAPIServer = "http://localhost:8443"
 // IP address range from which subnet is allocated for per-node join switch
 const (
 	V4JoinSubnet = "100.64.0.0/16"
-	V6JoinSubnet = "fd98::/64"
+	V6JoinSubnet = "fd98::/48"
 )
 
 // Default IANA-assigned UDP port number for VXLAN

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -13,12 +13,7 @@ import (
 // CIDRNetworkEntry is the object that holds the definition for a single network CIDR range
 type CIDRNetworkEntry struct {
 	CIDR             *net.IPNet
-	HostSubnetLength uint32
-}
-
-func (e CIDRNetworkEntry) HostBits() uint32 {
-	_, addrLen := e.CIDR.Mask.Size()
-	return uint32(addrLen) - e.HostSubnetLength
+	HostSubnetLength int
 }
 
 // ParseClusterSubnetEntries returns the parsed set of CIDRNetworkEntries passed by the user on the command line
@@ -50,11 +45,11 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 
 		entryMaskLength, _ := parsedClusterEntry.CIDR.Mask.Size()
 		if len(splitClusterEntry) == 3 {
-			tmp, err := strconv.ParseUint(splitClusterEntry[2], 10, 32)
+			tmp, err := strconv.Atoi(splitClusterEntry[2])
 			if err != nil {
 				return nil, err
 			}
-			parsedClusterEntry.HostSubnetLength = uint32(tmp)
+			parsedClusterEntry.HostSubnetLength = tmp
 
 			if ipv6 && parsedClusterEntry.HostSubnetLength != 64 {
 				return nil, fmt.Errorf("IPv6 only supports /64 host subnets")
@@ -68,7 +63,7 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 			}
 		}
 
-		if parsedClusterEntry.HostSubnetLength <= uint32(entryMaskLength) {
+		if parsedClusterEntry.HostSubnetLength <= entryMaskLength {
 			return nil, fmt.Errorf("cannot use a host subnet length mask shorter than or equal to the cluster subnet mask. "+
 				"host subnet length: %d, cluster subnet length: %d", parsedClusterEntry.HostSubnetLength, entryMaskLength)
 		}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -612,7 +612,7 @@ subnet=%s
 			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
 
-			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 3)
+			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 29)
 
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()
@@ -833,7 +833,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
 
-			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 3)
+			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 29)
 
 			// Let the real code run and ensure OVN database sync
 			err = clusterController.WatchNodes()
@@ -1025,7 +1025,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
 
-			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 3)
+			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 29)
 			clusterController.nodeLocalNatIPAllocator, _ = ipallocator.NewCIDRRange(ovntest.MustParseIPNet(util.V4NodeLocalNatSubnet))
 
 			// Let the real code run and ensure OVN database sync


### PR DESCRIPTION
The configuration always specifies networks as base CIDR plus `HostSubnetLength`, but the allocator (for historical reasons) required the `HostSubnetLength` to be converted to its inverse, which then requires the caller to unnecessarily take into account whether it's an IPv4 or IPv6 range (which the hybrid overlay code was not doing).

Fix this by just making `SubnetAllocator.AddNetworkRange()` take a `HostSubnetLength` instead, and also make it an int rather than uint32, for ease of use, and then update everything for that.


(So to clarify, this is a dual-stack bugfix in the hybrid overlay code, and just a cleanup everywhere else.)