### PR TITLE
.github: Don't run utility workflows on forks

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   cleanup:
+    if: github.repository == 'ovn-org/ovn-kubernetes'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   retest:
+    if: github.repository == 'ovn-org/ovn-kubernetes'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
This should stop the cron trigger and issue comment workflows
from running on forks,