### PR TITLE
change kind-install to support GOBIN environment variable

### DIFF
--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -5,13 +5,23 @@ set -ex
 export GO111MODULE="on"
 
 pushd $GOPATH/src/k8s.io/kubernetes/
-sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
-sudo ln ./_output/local/go/bin/e2e.test /usr/local/bin/e2e.test
+if [[ ! -f /usr/local/bin/kubectl ]]; then
+  sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
+fi
+if [[ ! -f /usr/local/bin/e2e.test ]]; then
+  sudo ln ./_output/local/go/bin/e2e.test /usr/local/bin/e2e.test
+fi
 popd
 
-mkdir -p $GOPATH/bin
-wget -O $GOPATH/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
-chmod +x $GOPATH/bin/kind
+if [[ -n "$(go env GOBIN)" ]]; then
+  INSTALL_PATH=$(go env GOBIN)
+else
+  mkdir -p $GOPATH/bin
+  INSTALL_PATH=$GOPATH/bin
+fi
+
+curl -Lo $INSTALL_PATH/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
+chmod +x $INSTALL_PATH/kind
 pushd ../contrib
 ./kind.sh
 popd


### PR DESCRIPTION
currently the kind-install.sh assumes that you are using a
standard golang installation and the GOBIN is at GOPATH/bin.
I added some logic in the install to check if a GOBIN is present
and use that allowing a greater number of configurations to use
kind for testing

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->