### PR TITLE
Ci improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,21 @@ jobs:
         ln -sf $(pwd) src/github.com/ovn-org/ovn-kubernetes
         GOPATH=$(pwd) gcov2lcov -infile gover.coverprofile -outfile coverage.lcov
 
+    - name: Build docker image
+      run: |
+        pushd dist/images
+          sudo cp -f ../../go-controller/_output/go/bin/ovn* .
+          echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
+          docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
+          mkdir _output
+          docker save ovn-daemonset-f:dev > _output/image.tar
+        popd
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: test-image
+        path: dist/images/_output/image.tar
+
     - name: Upload Junit Reports
       if: always()
       uses: actions/upload-artifact@v2
@@ -227,8 +242,16 @@ jobs:
         make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
         rm -rf .git
 
+    - uses: actions/download-artifact@v2
+      with:
+        name: test-image
+    - name: Load docker image
+      run: |
+        docker load --input image.tar
+
     - name: kind setup
       run: |
+        export OVN_IMAGE="ovn-daemonset-f:dev"
         make -C test install-kind
 
     - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,9 +141,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - shard: shard-n-other
-            hybrid-overlay: false
-          - shard: shard-np
+          - shard: shard-network
             hybrid-overlay: false
           - shard: control-plane
             hybrid-overlay: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ env:
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true
   KIND_ALLOW_SYSTEM_WRITES: true
+  # This skips tests tagged as Serial
+  # Current Serial tests are not relevant for OVN
+  PARALLEL: true
 
 jobs:
   build:
@@ -213,10 +216,10 @@ jobs:
         echo "::set-env name=GOPATH::$GOPATH"
         export PATH=$GOPATH/bin:$PATH
         echo "::add-path::$GOPATH/bin"
-  
+
     - name: Disable ufw
       # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
-      # Not needed for KIND deployments, so just disable all the time. 
+      # Not needed for KIND deployments, so just disable all the time.
       run: |
         sudo ufw disable
 

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -106,8 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - shard: shard-n-other
-          - shard: shard-np
+          - shard: shard-network
           - shard: control-plane
         ha:
          - enabled: "true"

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -6,6 +6,7 @@ pushd e2e
 go mod download
 popd
 
+# setting this env prevents ginkgo e2e from trying to run provider setup
 export KUBERNETES_CONFORMANCE_TEST=y
 export KUBECONFIG=${HOME}/admin.conf
 export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
@@ -17,5 +18,17 @@ export E2E_REPORT_PREFIX=${E2E_REPORT_PREFIX}
 sed -E -i 's/"\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}" "\$\{e2e_test\}"/pushd \$GITHUB_WORKSPACE\/test\/e2e\nGO111MODULE=on "\$\{ginkgo\}" "\$\{ginkgo_args\[\@\]\:\+\$\{ginkgo_args\[\@\]\}\}"/' ${GOPATH}/src/k8s.io/kubernetes/hack/ginkgo-e2e.sh
 
 pushd ${GOPATH}/src/k8s.io/kubernetes
-hack/ginkgo-e2e.sh --disable-log-dump=false
+# setting these is required to make RuntimeClass tests work ... :/
+export KUBE_CONTAINER_RUNTIME=remote
+export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
+export KUBE_CONTAINER_RUNTIME_NAME=containerd
+# FIXME we should not tolerate flakes
+# but until then, we retry the test in the same job
+# to stop PR retriggers for totally broken code
+export GINKGO_TOLERATE_FLAKES='y'
+export FLAKE_ATTEMPTS=2
+NUM_NODES=2
+./hack/ginkgo-e2e.sh \
+'--provider=skeleton' "--num-nodes=${NUM_NODES}" \
+"--report-dir=${E2E_REPORT_DIR}" '--disable-log-dump=true'
 popd

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -36,6 +36,9 @@ EndpointSlices
 # NOT IMPLEMENTED; SEE DISCUSSION IN https://github.com/ovn-org/ovn-kubernetes/pull/1225
 named port.+\[Feature:NetworkPolicy\]
 
+# TO BE FIXED BY https://github.com/kubernetes/kubernetes/pull/93119
+GCE
+
 # ???
 \[Feature:NoSNAT\]
 Services.+(ESIPP|cleanup finalizer)

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -5,7 +5,6 @@ set -ex
 SHARD=$1
 
 pushd $GOPATH/src/k8s.io/kubernetes/
-export KUBERNETES_CONFORMANCE_TEST=y
 export KUBECONFIG=${HOME}/admin.conf
 export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
 export NODE_NAMES=${MASTER_NAME}
@@ -92,20 +91,22 @@ fi
 
 SKIPPED_TESTS="$(groomTestList "${SKIPPED_TESTS}")"
 
-GINKGO_ARGS="--num-nodes=3 --ginkgo.skip=${SKIPPED_TESTS} --disable-log-dump=false --report-dir=${E2E_REPORT_DIR} --report-prefix=${E2E_REPORT_PREFIX}"
+# if we set PARALLEL=true, skip serial test
+if [ "${PARALLEL:-false}" = "true" ]; then
+  export GINKGO_PARALLEL=y
+  export GINKGO_PARALLEL_NODES=4
+  SKIPPED_TESTS="${SKIPPED_TESTS}|\\[Serial\\]"
+fi
 
 case "$SHARD" in
-	shard-n-other)
-		# all tests that don't have P as their sixth letter after the N, and all other tests
-		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s([Nn](.{6}[^Pp].*|.{0,6}$)|[^Nn].*)'
+	shard-network)
+		FOCUS="\\[sig-network\\]"
 		;;
-	shard-np)
-		# all tests that have P as the sixth letter after the N
-		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\]\s[Nn].{6}[Pp].*$'
+	shard-conformance)
+		FOCUS="\\[Conformance\\]"
 		;;
 	shard-test)
-		TEST_REGEX_REPR=$(echo ${@:2} | sed 's/ /\\s/g')
-		GINKGO_ARGS="${GINKGO_ARGS} "'--ginkgo.focus=\[sig-network\].*'$TEST_REGEX_REPR'.*'
+		FOCUS=$(echo ${@:2} | sed 's/ /\\s/g')
 		;;
 	*)
 		echo "unknown shard"
@@ -113,4 +114,19 @@ case "$SHARD" in
 	;;
 esac
 
-e2e.test ${GINKGO_ARGS}
+# setting this env prevents ginkgo e2e from trying to run provider setup
+export KUBERNETES_CONFORMANCE_TEST='y'
+# setting these is required to make RuntimeClass tests work ... :/
+export KUBE_CONTAINER_RUNTIME=remote
+export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
+export KUBE_CONTAINER_RUNTIME_NAME=containerd
+# FIXME we should not tolerate flakes
+# but until then, we retry the test in the same job
+# to stop PR retriggers for totally broken code
+export GINKGO_TOLERATE_FLAKES='y'
+export FLAKE_ATTEMPTS=2
+NUM_NODES=2
+./hack/ginkgo-e2e.sh \
+'--provider=skeleton' "--num-nodes=${NUM_NODES}" \
+"--ginkgo.focus=${FOCUS}" "--ginkgo.skip=${SKIPPED_TESTS}" \
+"--report-dir=${E2E_REPORT_DIR}" '--disable-log-dump=true'


### PR DESCRIPTION
**- What this PR does and why is it needed**

It runs all the [sig-network] tests in the same job, removing current sharding. We are constrained on number of parallel jobs and the new features we are adding, require new independent jobs.

It allows to run the tests in parallel, right now we run with 4 tests in parallel, running a job in 20 minutes less
> 7 completed jobs  in 40m 56s
vs previously that it took few minutes more than 1 hour.

It build the ovn-kubernetes image only once, and share it using github actions artifacts with the multiple jobs.

**- Special notes for reviewers**

**- How to verify it**

**- Description for the changelog**
