### PR TITLE
ovn: don't log spurious warnings/errors on node creation

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -371,16 +371,6 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 		return err
 	}
 
-	if macAddress == nil {
-		// When macAddress was removed, delete the switch port
-		stdout, stderr, err := util.RunOVNNbctl("--", "--if-exists", "lsp-del", util.K8sPrefix+node.Name)
-		if err != nil {
-			klog.Errorf("Failed to delete logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		}
-
-		return nil
-	}
-
 	if hostSubnets == nil {
 		hostSubnets, err = util.ParseNodeHostSubnetAnnotation(node)
 		if err != nil {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -621,12 +621,16 @@ func (oc *Controller) WatchNodes() error {
 
 			err = oc.syncNodeManagementPort(node, hostSubnets)
 			if err != nil {
-				klog.Warningf("Error creating management port for node %s: %v", node.Name, err)
+				if !util.IsAnnotationNotSetError(err) {
+					klog.Warningf("Error creating management port for node %s: %v", node.Name, err)
+				}
 				mgmtPortFailed.Store(node.Name, true)
 			}
 
 			if err := oc.syncNodeGateway(node, hostSubnets); err != nil {
-				klog.Warningf(err.Error())
+				if !util.IsAnnotationNotSetError(err) {
+					klog.Warningf(err.Error())
+				}
 				gatewaysFailed.Store(node.Name, true)
 			}
 		},
@@ -658,7 +662,9 @@ func (oc *Controller) WatchNodes() error {
 			if failed || macAddressChanged(oldNode, node) {
 				err := oc.syncNodeManagementPort(node, hostSubnets)
 				if err != nil {
-					klog.Errorf("Error updating management port for node %s: %v", node.Name, err)
+					if !util.IsAnnotationNotSetError(err) {
+						klog.Errorf("Error updating management port for node %s: %v", node.Name, err)
+					}
 					mgmtPortFailed.Store(node.Name, true)
 				} else {
 					mgmtPortFailed.Delete(node.Name)
@@ -671,7 +677,9 @@ func (oc *Controller) WatchNodes() error {
 			if failed || gatewayChanged(oldNode, node) {
 				err := oc.syncNodeGateway(node, nil)
 				if err != nil {
-					klog.Errorf(err.Error())
+					if !util.IsAnnotationNotSetError(err) {
+						klog.Errorf(err.Error())
+					}
 					gatewaysFailed.Store(node.Name, true)
 				} else {
 					gatewaysFailed.Delete(node.Name)

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	kapi "k8s.io/api/core/v1"
-	"k8s.io/klog"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -194,7 +193,7 @@ func SetL3GatewayConfig(nodeAnnotator kube.Annotator, cfg *L3GatewayConfig) erro
 func ParseNodeL3GatewayAnnotation(node *kapi.Node) (*L3GatewayConfig, error) {
 	l3GatewayAnnotation, ok := node.Annotations[ovnNodeL3GatewayConfig]
 	if !ok {
-		return nil, fmt.Errorf("%s annotation not found for node %q", ovnNodeL3GatewayConfig, node.Name)
+		return nil, newAnnotationNotSetError("%s annotation not found for node %q", ovnNodeL3GatewayConfig, node.Name)
 	}
 
 	var cfgs map[string]*L3GatewayConfig
@@ -224,8 +223,7 @@ func SetNodeManagementPortMACAddress(nodeAnnotator kube.Annotator, macAddress ne
 func ParseNodeManagementPortMACAddress(node *kapi.Node) (net.HardwareAddr, error) {
 	macAddress, ok := node.Annotations[ovnNodeManagementPortMacAddress]
 	if !ok {
-		klog.Warningf("macAddress annotation not found for node %q ", node.Name)
-		return nil, nil
+		return nil, newAnnotationNotSetError("macAddress annotation not found for node %q ", node.Name)
 	}
 
 	return net.ParseMAC(macAddress)

--- a/go-controller/pkg/util/node_annotations_test.go
+++ b/go-controller/pkg/util/node_annotations_test.go
@@ -148,4 +148,34 @@ var _ = Describe("Node annotation tests", func() {
 			Expect(l3gc).To(Equal(tc.out))
 		}
 	})
+
+	It("returns a distinguishable error when a node annotation is not set", func() {
+		testNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node",
+			Annotations: make(map[string]string),
+		}}
+
+		cfg, err := ParseNodeL3GatewayAnnotation(testNode)
+		Expect(cfg).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeTrue())
+
+		mac, err := ParseNodeManagementPortMACAddress(testNode)
+		Expect(mac).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeTrue())
+
+		testNode.Annotations[ovnNodeL3GatewayConfig] = "blah"
+		testNode.Annotations[ovnNodeManagementPortMacAddress] = "blah"
+
+		cfg, err = ParseNodeL3GatewayAnnotation(testNode)
+		Expect(cfg).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeFalse())
+
+		mac, err = ParseNodeManagementPortMACAddress(testNode)
+		Expect(mac).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeFalse())
+	})
 })

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -138,7 +138,7 @@ func MarshalPodAnnotation(podInfo *PodAnnotation) (map[string]string, error) {
 func UnmarshalPodAnnotation(annotations map[string]string) (*PodAnnotation, error) {
 	ovnAnnotation, ok := annotations[OvnPodAnnotationName]
 	if !ok {
-		return nil, fmt.Errorf("could not find OVN pod annotation in %v", annotations)
+		return nil, newAnnotationNotSetError("could not find OVN pod annotation in %v", annotations)
 	}
 
 	podNetworks := make(map[string]podAnnotation)

--- a/go-controller/pkg/util/pod_annotation_test.go
+++ b/go-controller/pkg/util/pod_annotation_test.go
@@ -111,6 +111,22 @@ var _ = Describe("Pod annotation tests", func() {
 		}
 	})
 
+	It("returns a distinguishable error when the pod annotation is not set", func() {
+		annotations := make(map[string]string)
+
+		ann, err := UnmarshalPodAnnotation(annotations)
+		Expect(ann).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeTrue())
+
+		annotations[OvnPodAnnotationName] = "blah"
+
+		ann, err = UnmarshalPodAnnotation(annotations)
+		Expect(ann).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeFalse())
+	})
+
 	It("return all pod IPs", func() {
 		type testcase struct {
 			name string

--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -89,7 +89,7 @@ func setSubnetAnnotation(nodeAnnotator kube.Annotator, annotationName string, de
 func parseSubnetAnnotation(node *kapi.Node, annotationName string) ([]*net.IPNet, error) {
 	annotation, ok := node.Annotations[annotationName]
 	if !ok {
-		return nil, fmt.Errorf("node %q has no %q annotation", node.Name, annotationName)
+		return nil, newAnnotationNotSetError("node %q has no %q annotation", node.Name, annotationName)
 	}
 
 	var subnets []string
@@ -194,7 +194,7 @@ func SetNodeLocalNatAnnotation(nodeAnnotator kube.Annotator, defaultNodeLocalNat
 func ParseNodeLocalNatIPAnnotation(node *kapi.Node) ([]net.IP, error) {
 	annotationJson, ok := node.Annotations[ovnNodeLocalNatIP]
 	if !ok {
-		return nil, fmt.Errorf("node %q has no %q annotation", node.Name, ovnNodeLocalNatIP)
+		return nil, newAnnotationNotSetError("node %q has no %q annotation", node.Name, ovnNodeLocalNatIP)
 	}
 
 	annotationMap := make(map[string][]string)

--- a/go-controller/pkg/util/subnet_annotations_test.go
+++ b/go-controller/pkg/util/subnet_annotations_test.go
@@ -81,4 +81,34 @@ var _ = Describe("subnet annotation tests", func() {
 			Expect(subnet).To(Equal(tc.joinIn))
 		}
 	})
+
+	It("returns a distinguishable error when the node-subnets or node-join-subnets annotation is not set", func() {
+		testNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-node",
+			Annotations: make(map[string]string),
+		}}
+
+		subnets, err := ParseNodeHostSubnetAnnotation(testNode)
+		Expect(subnets).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeTrue())
+
+		subnets, err = ParseNodeJoinSubnetAnnotation(testNode)
+		Expect(subnets).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeTrue())
+
+		testNode.Annotations[ovnNodeSubnets] = "blah"
+		testNode.Annotations[ovnNodeJoinSubnets] = "blah"
+
+		subnets, err = ParseNodeHostSubnetAnnotation(testNode)
+		Expect(subnets).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeFalse())
+
+		subnets, err = ParseNodeJoinSubnetAnnotation(testNode)
+		Expect(subnets).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(IsAnnotationNotSetError(err)).To(BeFalse())
+	})
 })

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -143,3 +143,22 @@ func UpdateNodeSwitchExcludeIPs(nodeName string, subnet *net.IPNet) error {
 func GetHybridOverlayPortName(nodeName string) string {
 	return "int-" + nodeName
 }
+
+type annotationNotSetError struct {
+	msg string
+}
+
+func (anse annotationNotSetError) Error() string {
+	return anse.msg
+}
+
+// newAnnotationNotSetError returns an error for an annotation that is not set
+func newAnnotationNotSetError(format string, args ...interface{}) error {
+	return annotationNotSetError{msg: fmt.Sprintf(format, args...)}
+}
+
+// IsAnnotationNotSetError returns true if the error indicates that an annotation is not set
+func IsAnnotationNotSetError(err error) bool {
+	_, ok := err.(annotationNotSetError)
+	return ok
+}


### PR DESCRIPTION
After a new Node is created, it will take a while before the
ovn-kubernetes process on that node annotates the node with the
information the master needs. The master should not repeatedly log
"errors" about the annotations not being set, because this is
completely expected.

Also, make ParseNodeManagementPortMACAddress() consistent with all of
the other annotation-parsing methods, and have it return an error when
the annotation is unset. This requires updating one caller, which was
confused anyway because it thought it was checking if the annotation
was removed, but we never remove the annotation after setting it;
really it was only checking if the annotation had not been set yet.