### PR TITLE
ovn/allocator: use round-robin IP allocation strategy

### DIFF
--- a/go-controller/pkg/ovn/ipallocator/allocator/bitmap.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/bitmap.go
@@ -253,7 +253,8 @@ var _ bitAllocator = contiguousScanStrategy{}
 // last allocation and will try to allocate all other addresses before re-allocating
 // the most recently allocated address.
 type roundRobinScanStrategy struct {
-	lastAllocated int
+	// holds the offset of the next bit to attempt to allocate
+	nextAlloc int
 }
 
 func (wss *roundRobinScanStrategy) AllocateBit(allocated *big.Int, max, count int) (int, bool) {
@@ -261,9 +262,9 @@ func (wss *roundRobinScanStrategy) AllocateBit(allocated *big.Int, max, count in
 		return 0, false
 	}
 	for i := 0; i < max; i++ {
-		at := (wss.lastAllocated + i) % max
+		at := (wss.nextAlloc + i) % max
 		if allocated.Bit(at) == 0 {
-			wss.lastAllocated = at
+			wss.nextAlloc = (at + 1) % max
 			return at, true
 		}
 	}

--- a/go-controller/pkg/ovn/ipallocator/allocator/bitmap_test.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator/bitmap_test.go
@@ -166,12 +166,12 @@ func TestRoundRobinAllocation(t *testing.T) {
 			t.Fatalf("unexpected error")
 		}
 		if next != i {
-			t.Fatalf("expect next to %d, but got %d", i, next)
+			t.Fatalf("expect next to be %d, but got %d", i, next)
 		}
 	}
 
 	if _, ok, _ := m.AllocateNext(); ok {
-		t.Errorf("unexpected success")
+		t.Fatalf("unexpected success")
 	}
 }
 
@@ -179,10 +179,10 @@ func TestRoundRobinAllocationOrdering(t *testing.T) {
 	max := 10
 	m := NewRoundRobinAllocationMap(max, "test")
 
-	// Pre-allocate a couple entries at the start of themap
+	// Pre-allocate 3 entries at the start of the map
 	for i := 0; i < 3; i++ {
 		if ok, _ := m.Allocate(i); !ok {
-			t.Errorf("error allocate offset %v", i)
+			t.Fatalf("error allocating offset %d", i)
 		}
 	}
 
@@ -197,7 +197,7 @@ func TestRoundRobinAllocationOrdering(t *testing.T) {
 
 	// Release one of the pre-allocated entries
 	if err := m.Release(0); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Next allocation should be after the most recently allocated entry,
@@ -219,10 +219,10 @@ func TestRoundRobinAllocate(t *testing.T) {
 		t.Fatalf("unexpected error")
 	}
 	if m.count != 1 {
-		t.Errorf("expect to get %d, but got %d", 1, m.count)
+		t.Fatalf("expect to get %d, but got %d", 1, m.count)
 	}
 	if f := m.Free(); f != max-1 {
-		t.Errorf("expect to get %d, but got %d", max-1, f)
+		t.Fatalf("expect to get %d, but got %d", max-1, f)
 	}
 }
 
@@ -236,20 +236,20 @@ func TestRoundRobinAllocateMax(t *testing.T) {
 	}
 
 	if _, ok, _ := m.AllocateNext(); ok {
-		t.Errorf("unexpected success")
+		t.Fatalf("unexpected success")
 	}
 	if f := m.Free(); f != 0 {
-		t.Errorf("expect to get %d, but got %d", 0, f)
+		t.Fatalf("expect to get %d, but got %d", 0, f)
 	}
 }
 
 func TestRoundRobinAllocateError(t *testing.T) {
 	m := NewRoundRobinAllocationMap(10, "test")
 	if ok, _ := m.Allocate(3); !ok {
-		t.Errorf("error allocate offset %v", 3)
+		t.Fatalf("error allocate offset %d", 3)
 	}
 	if ok, _ := m.Allocate(3); ok {
-		t.Errorf("unexpected success")
+		t.Fatalf("unexpected success")
 	}
 }
 
@@ -257,19 +257,41 @@ func TestRoundRobinRelease(t *testing.T) {
 	offset := 3
 	m := NewRoundRobinAllocationMap(10, "test")
 	if ok, _ := m.Allocate(offset); !ok {
-		t.Errorf("error allocate offset %v", offset)
+		t.Fatalf("error allocate offset %d", offset)
 	}
 
 	if !m.Has(offset) {
-		t.Errorf("expect offset %v allocated", offset)
+		t.Fatalf("expect offset %d allocated", offset)
 	}
 
 	if err := m.Release(offset); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if m.Has(offset) {
-		t.Errorf("expect offset %v not allocated", offset)
+		t.Fatalf("expect offset %d not allocated", offset)
+	}
+}
+
+func TestRoundRobinWrapAround(t *testing.T) {
+	const maxOffsets = 10
+	m := NewRoundRobinAllocationMap(maxOffsets, "test")
+
+	// Allocate next offset and release it, expecting that the offset
+	// continues to increment
+	for i := 0; i < maxOffsets*2; i++ {
+		offset, ok, err := m.AllocateNext()
+		if !ok {
+			t.Fatalf("unexpected AllocateNext error: %v", err)
+		}
+
+		if offset != (i % maxOffsets) {
+			t.Fatalf("got offset %d but expected offset %d", offset, i)
+		}
+
+		if err := m.Release(offset); err != nil {
+			t.Fatalf("unexpected release error: %v", err)
+		}
 	}
 }
 
@@ -285,21 +307,21 @@ func TestRoundRobinForEach(t *testing.T) {
 		m := NewRoundRobinAllocationMap(10, "test")
 		for offset := range tc {
 			if ok, _ := m.Allocate(offset); !ok {
-				t.Errorf("[%d] error allocate offset %v", i, offset)
+				t.Fatalf("[%d] error allocate offset %d", i, offset)
 			}
 			if !m.Has(offset) {
-				t.Errorf("[%d] expect offset %v allocated", i, offset)
+				t.Fatalf("[%d] expect offset %d allocated", i, offset)
 			}
 		}
 		calls := sets.NewInt()
-		m.ForEach(func(i int) {
-			calls.Insert(i)
+		m.ForEach(func(j int) {
+			calls.Insert(j)
 		})
 		if len(calls) != len(tc) {
-			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
+			t.Fatalf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Fatalf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
 		}
 	}
 }
@@ -308,20 +330,20 @@ func TestRoundRobinSnapshotAndRestore(t *testing.T) {
 	offset := 3
 	m := NewRoundRobinAllocationMap(10, "test")
 	if ok, _ := m.Allocate(offset); !ok {
-		t.Errorf("error allocate offset %v", offset)
+		t.Fatalf("error allocate offset %d", offset)
 	}
 	spec, bytes := m.Snapshot()
 
 	m2 := NewRoundRobinAllocationMap(10, "test")
 	err := m2.Restore(spec, bytes)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if m2.count != 1 {
-		t.Errorf("expect count to %d, but got %d", 0, m.count)
+		t.Fatalf("expect count to %d, but got %d", 0, m.count)
 	}
 	if !m2.Has(offset) {
-		t.Errorf("expect offset %v allocated", offset)
+		t.Fatalf("expect offset %d allocated", offset)
 	}
 }

--- a/go-controller/pkg/ovn/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager.go
@@ -38,7 +38,7 @@ type logicalSwitchManager struct {
 // addresses as reserved.
 func NewIPAMAllocator(cidr *net.IPNet) (ipam.Interface, error) {
 	subnetRange, err := ipam.NewAllocatorCIDRRange(cidr, func(max int, rangeSpec string) (allocator.Interface, error) {
-		return allocator.NewContiguousAllocationMap(max, rangeSpec), nil
+		return allocator.NewRoundRobinAllocationMap(max, rangeSpec), nil
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Short-lived pods on a given node may re-use the same IP address in
quick succession, which leads to auditing/logging confusion and race
conditions where a pod delete/add event may not arrive before the new
pod is up and using the same IP.

Instead of using the first free address for a node, switch to
round-robin allocation where all IPs are allocated before any IP
is re-allocated. This doesn't fix the audit/race problems but makes
them less likely until a given node is close to IP exhaustion.

@abhat @danwinship @girishmg 