### PR TITLE
Add support for enabling multicast via cli/env variable flag

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -61,6 +61,8 @@ parse_args()
                                        ;;
             -ha | --ha-enabled )       KIND_HA=true
                                        ;;
+            -me | --multicast-enabled) OVN_MULTICAST_ENABLE=true
+                                       ;;
             -ho | --hybrid-enabled )   OVN_HYBRID_OVERLAY_ENABLE=true
                                        ;;
             -kt | --keep-taint )       KIND_REMOVE_TAINT=false
@@ -108,6 +110,7 @@ print_params()
      echo "KIND_NUM_WORKER = $KIND_NUM_WORKER"
      echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
      echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
+     echo "OVN_MULTICAST_ENABLE = $OVN_MULTICAST_ENABLE"
      echo ""
 }
 
@@ -124,6 +127,7 @@ KIND_REMOVE_TAINT=${KIND_REMOVE_TAINT:-true}
 KIND_IPV4_SUPPORT=${KIND_IPV4_SUPPORT:-true}
 KIND_IPV6_SUPPORT=${KIND_IPV6_SUPPORT:-false}
 OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
+OVN_MULTICAST_ENABLE=${OVN_MULTICAST_ENABLE:-false}
 
 # Input not currently validated. Modify outside script at your own risk.
 # These are the same values defaulted to in KIND code (kind/default.go).
@@ -244,6 +248,7 @@ docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
   --svc-cidr=${SVC_CIDR} \
   --gateway-mode=${OVN_GATEWAY_MODE} \
   --hybrid-enabled=${OVN_HYBRID_OVERLAY_ENABLE} \
+  --multicast-enabled=${OVN_MULTICAST_ENABLE} \
   --k8s-apiserver=https://[${API_IP}]:11337 \
   --ovn-master-count=${KIND_NUM_MASTER} \
   --kind \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -34,6 +34,7 @@ OVNKUBE_LOGFILE_MAXAGE=""
 OVN_MASTER_COUNT=""
 OVN_REMOTE_PROBE_INTERVAL=""
 OVN_HYBRID_OVERLAY_ENABLE=""
+OVN_MULTICAST_ENABLE=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -127,6 +128,9 @@ while [ "$1" != "" ]; do
   --hybrid-enabled)
     OVN_HYBRID_OVERLAY_ENABLE=$VALUE
     ;;
+  --multicast-enabled)
+    OVN_MULTICAST_ENABLE=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -196,6 +200,8 @@ ovn_nb_raft_port=${OVN_NB_RAFT_PORT:-6643}
 echo "ovn_nb_raft_port: ${ovn_nb_raft_port}"
 ovn_sb_raft_port=${OVN_SB_RAFT_PORT:-6644}
 echo "ovn_sb_raft_port: ${ovn_sb_raft_port}"
+ovn_multicast_enable=${OVN_MULTICAST_ENABLE}
+echo "ovn_multicast_enable: ${ovn_multicast_enable}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -209,6 +215,7 @@ ovn_image=${image} \
   ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
+  ovn_multicast_enable=${ovn_multicast_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_remote_probe_interval=${ovn_remote_probe_interval} \
   j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node.yaml
@@ -223,6 +230,7 @@ ovn_image=${image} \
   ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
+  ovn_multicast_enable=${ovn_multicast_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_master_count=${ovn_master_count} \
   ovn_gateway_mode=${ovn_gateway_mode} \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -240,6 +240,8 @@ spec:
           value: "{{ ovn_ssl_en }}"
         - name: OVN_GATEWAY_MODE
           value: "{{ ovn_gateway_mode }}"
+        - name: OVN_MULTICAST_ENABLE
+          value: "{{ ovn_multicast_enable }}"
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -250,6 +250,8 @@ spec:
           value: "{{ ovn_ssl_en }}"
         - name: OVN_REMOTE_PROBE_INTERVAL
           value: "{{ ovn_remote_probe_interval }}"
+        - name: OVN_MULTICAST_ENABLE
+          value: "{{ ovn_multicast_enable }}"
 
         lifecycle:
           preStop:


### PR DESCRIPTION
Multicast as a feature is enabled via a config flag that needs to
be passed in. This PR adds support in the start-up scripts for kind
and daemonset files to allow the flag to be passed in.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>

