### PR TITLE
consolidate exporting of all OVN metrics under one process

### DIFF
--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -288,21 +288,3 @@ ovsdb-raft() {
   process_healthy ovn${db}_db ${ovn_tail_pid}
   echo "=============== run ${db}_ovsdb-raft ========== terminated"
 }
-
-# v3 - Runs ovn-kube-util in daemon mode to export prometheus metrics related to OVN clustered db
-db-raft-metrics() {
-  check_ovn_daemonset_version "3"
-
-  echo "=============== db-raft-metrics - (wait for ready_to_start_node)"
-  wait_for_event ready_to_start_node
-
-  ovndb_exporter_bind_address=${OVNDB_EXPORTER_BIND_ADDRESS:-"0.0.0.0:9476"}
-
-  /usr/bin/ovn-kube-util \
-    --loglevel=${ovnkube_loglevel} \
-    ovn-db-exporter \
-    --metrics-bind-address ${ovndb_exporter_bind_address}
-
-  echo "=============== db-raft-metrics with pid ${?} terminated ========== "
-  exit 1
-}

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -923,6 +923,7 @@ ovn-node() {
     ${ovn_node_ssl_opts} \
     --inactivity-probe=${ovn_remote_probe_interval} \
     ${multicast_enabled_flag} \
+    --ovn-metrics-bind-address "0.0.0.0:9476" \
     --metrics-bind-address "0.0.0.0:9410" &
 
   wait_for_event attempts=3 process_ready ovnkube
@@ -1073,9 +1074,6 @@ case ${cmd} in
 "sb-ovsdb-raft")
   ovsdb-raft sb ${ovn_sb_port} ${ovn_sb_raft_port} ${ovn_sb_raft_election_timer}
   ;;
-"db-raft-metrics")
-  db-raft-metrics
-  ;;
 "ovs-metrics")
   ovs-metrics
   ;;
@@ -1083,7 +1081,7 @@ case ${cmd} in
   echo "invalid command ${cmd}"
   echo "valid v3 commands: ovs-server nb-ovsdb sb-ovsdb run-ovn-northd ovn-master " \
     "ovn-controller ovn-node display_env display ovn_debug cleanup-ovs-server " \
-    "cleanup-ovn-node nb-ovsdb-raft sb-ovsdb-raft db-raft-metrics"
+    "cleanup-ovn-node nb-ovsdb-raft sb-ovsdb-raft"
   exit 0
   ;;
 esac

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -243,54 +243,6 @@ spec:
           value: "{{ ovn_sb_raft_port }}"
       # end of container
 
-      # db-metrics-exporter - v3
-      - name: db-metrics-exporter
-        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
-        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
-        command: ["/root/ovnkube.sh", "db-raft-metrics"]
-
-        securityContext:
-          runAsUser: 0
-          capabilities:
-            add: ["NET_ADMIN"]
-
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-          # ovn db is stored in the pod in /etc/openvswitch
-          # (or in /etc/ovn if OVN from new repository is used)
-          # and on the host in /var/lib/openvswitch/
-          - mountPath: /etc/openvswitch/
-            name: host-var-lib-ovs
-          - mountPath: /etc/ovn/
-            name: host-var-lib-ovs
-          - mountPath: /var/run/openvswitch/
-            name: host-var-run-ovs
-          - mountPath: /var/run/ovn/
-            name: host-var-run-ovs
-          - mountPath: /ovn-cert
-            name: host-ovn-cert
-            readOnly: true
-
-        resources:
-          requests:
-            cpu: 100m
-            memory: 300Mi
-        env:
-          - name: OVN_DAEMONSET_VERSION
-            value: "3"
-          - name: K8S_APISERVER
-            valueFrom:
-              configMapKeyRef:
-                name: ovn-config
-                key: k8s_apiserver
-          - name: OVN_KUBERNETES_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: OVN_SSL_ENABLE
-            value: "{{ ovn_ssl_en }}"
-      # end of container
-
       volumes:
       - name: host-var-log-ovs
         hostPath:

--- a/dist/templates/ovnkube-monitor.yaml.j2
+++ b/dist/templates/ovnkube-monitor.yaml.j2
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   labels:
     k8s-app: ovnkube-master
-  name: ovn-kubernetes-master-prometheus-discovery
+  name: ovnkube-master-prometheus-discovery
   namespace: ovn-kubernetes
 spec:
   selector:
@@ -52,7 +52,15 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
-    port: http-metrics
+    port: ovnkube-node-metrics
+    path: /metrics
+    scheme: http
+  - interval: 30s
+    port: ovs-metrics
+    path: /metrics
+    scheme: http
+  - interval: 30s
+    port: ovn-metrics
     path: /metrics
     scheme: http
   jobLabel: k8s-app
@@ -68,7 +76,7 @@ kind: Service
 metadata:
   labels:
     k8s-app: ovnkube-node
-  name: ovn-kubernetes-node-prometheus-discovery
+  name: ovnkube-node-prometheus-discovery
   namespace: ovn-kubernetes
 spec:
   selector:
@@ -77,48 +85,16 @@ spec:
   clusterIP: None
   publishNotReadyAddresses: true
   ports:
-  - name: http-metrics
+  - name: ovnkube-node-metrics
     port: 9410
     protocol: TCP
     targetPort: 9410
+  - name: ovn-metrics
+    port: 9476
+    protocol: TCP
+    targetPort: 9476
+  - name: ovs-metrics
+    port: 9310
+    protocol: TCP
+    targetPort: 9310
 
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    k8s-app: ovnkube-db
-  name: monitor-ovnkube-db
-  namespace: ovn-kubernetes
-spec:
-  endpoints:
-    - interval: 30s
-      port: http-metrics
-      path: /metrics
-      scheme: http
-  jobLabel: k8s-app
-  namespaceSelector:
-    matchNames:
-      - ovn-kubernetes
-  selector:
-    matchLabels:
-      k8s-app: ovnkube-db
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    k8s-app: ovnkube-db
-  name: ovn-kubernetes-db-prometheus-discovery
-  namespace: ovn-kubernetes
-spec:
-  selector:
-    name: ovnkube-db
-  type: ClusterIP
-  clusterIP: None
-  publishNotReadyAddresses: true
-  ports:
-    - name: http-metrics
-      port: 9476
-      protocol: TCP
-      targetPort: 9476

--- a/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
+++ b/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
@@ -28,7 +28,6 @@ func main() {
 		&app.NicsToBridgeCommand,
 		&app.BridgesToNicCommand,
 		&app.ReadinessProbeCommand,
-		&app.OvnDBExporterCommand,
 		&app.OvsExporterCommand,
 	}
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -186,20 +186,21 @@ type CNIConfig struct {
 
 // KubernetesConfig holds Kubernetes-related parsed config file parameters and command-line overrides
 type KubernetesConfig struct {
-	Kubeconfig           string `gcfg:"kubeconfig"`
-	CACert               string `gcfg:"cacert"`
-	APIServer            string `gcfg:"apiserver"`
-	Token                string `gcfg:"token"`
-	CompatServiceCIDR    string `gcfg:"service-cidr"`
-	RawServiceCIDRs      string `gcfg:"service-cidrs"`
-	ServiceCIDRs         []*net.IPNet
-	OVNConfigNamespace   string `gcfg:"ovn-config-namespace"`
-	MetricsBindAddress   string `gcfg:"metrics-bind-address"`
-	MetricsEnablePprof   bool   `gcfg:"metrics-enable-pprof"`
-	OVNEmptyLbEvents     bool   `gcfg:"ovn-empty-lb-events"`
-	PodIP                string `gcfg:"pod-ip"` // UNUSED
-	RawNoHostSubnetNodes string `gcfg:"no-hostsubnet-nodes"`
-	NoHostSubnetNodes    *metav1.LabelSelector
+	Kubeconfig            string `gcfg:"kubeconfig"`
+	CACert                string `gcfg:"cacert"`
+	APIServer             string `gcfg:"apiserver"`
+	Token                 string `gcfg:"token"`
+	CompatServiceCIDR     string `gcfg:"service-cidr"`
+	RawServiceCIDRs       string `gcfg:"service-cidrs"`
+	ServiceCIDRs          []*net.IPNet
+	OVNConfigNamespace    string `gcfg:"ovn-config-namespace"`
+	MetricsBindAddress    string `gcfg:"metrics-bind-address"`
+	OVNMetricsBindAddress string `gcfg:"ovn-metrics-bind-address"`
+	MetricsEnablePprof    bool   `gcfg:"metrics-enable-pprof"`
+	OVNEmptyLbEvents      bool   `gcfg:"ovn-empty-lb-events"`
+	PodIP                 string `gcfg:"pod-ip"` // UNUSED
+	RawNoHostSubnetNodes  string `gcfg:"no-hostsubnet-nodes"`
+	NoHostSubnetNodes     *metav1.LabelSelector
 }
 
 // GatewayMode holds the node gateway mode
@@ -624,8 +625,13 @@ var K8sFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "metrics-bind-address",
-		Usage:       "The IP address and port for the metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces)",
+		Usage:       "The IP address and port for the OVN K8s metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces)",
 		Destination: &cliConfig.Kubernetes.MetricsBindAddress,
+	},
+	&cli.StringFlag{
+		Name:        "ovn-metrics-bind-address",
+		Usage:       "The IP address and port for the OVN metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces)",
+		Destination: &cliConfig.Kubernetes.OVNMetricsBindAddress,
 	},
 	&cli.BoolFlag{
 		Name:        "metrics-enable-pprof",

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"fmt"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -86,45 +85,6 @@ var MetricMasterLeader = prometheus.NewGauge(prometheus.GaugeOpts{
 var registerMasterMetricsOnce sync.Once
 var startE2ETimeStampUpdaterOnce sync.Once
 
-var ovnNorthdCoverageShowMetricsMap = map[string]*metricDetails{
-	"pstream_open": {
-		help: "Specifies the number of time passive connections " +
-			"were opened for the remote peer to connect.",
-	},
-	"stream_open": {
-		help: "Specifies the number of attempts to connect " +
-			"to a remote peer (active connection).",
-	},
-	"txn_success": {
-		help: "Specifies the number of times the OVSDB " +
-			"transaction has successfully completed.",
-	},
-	"txn_error": {
-		help: "Specifies the number of times the OVSDB " +
-			"transaction has errored out.",
-	},
-	"txn_uncommitted": {
-		help: "Specifies the number of times the OVSDB " +
-			"transaction were uncommitted.",
-	},
-	"txn_unchanged": {
-		help: "Specifies the number of times the OVSDB transaction " +
-			"resulted in no change to the database.",
-	},
-	"txn_incomplete": {
-		help: "Specifies the number of times the OVSDB transaction " +
-			"did not complete and the client had to re-try.",
-	},
-	"txn_aborted": {
-		help: "Specifies the number of times the OVSDB " +
-			" transaction has been aborted.",
-	},
-	"txn_try_again": {
-		help: "Specifies the number of times the OVSDB " +
-			"transaction failed and the client had to re-try.",
-	},
-}
-
 // RegisterMasterMetrics registers some ovnkube master metrics with the Prometheus
 // registry
 func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
@@ -187,58 +147,6 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 			},
 			func() float64 { return 1 },
 		))
-
-		// ovn-northd metrics
-		prometheus.MustRegister(prometheus.NewGaugeFunc(
-			prometheus.GaugeOpts{
-				Namespace: MetricOvnNamespace,
-				Subsystem: MetricOvnSubsystemNorthd,
-				Name:      "probe_interval",
-				Help: "The maximum number of milliseconds of idle time on connection to the OVN SB " +
-					"and NB DB before sending an inactivity probe message",
-			}, func() float64 {
-				stdout, stderr, err := util.RunOVNNbctlWithTimeout(5, "get", "NB_Global", ".",
-					"options:northd_probe_interval")
-				if err != nil {
-					klog.Errorf("Failed to get northd_probe_interval value "+
-						"stderr(%s) :(%v)", stderr, err)
-					return 0
-				}
-				return parseMetricToFloat(MetricOvnSubsystemNorthd, "probe_interval", stdout)
-			},
-		))
-		prometheus.MustRegister(prometheus.NewGaugeFunc(
-			prometheus.GaugeOpts{
-				Namespace: MetricOvnNamespace,
-				Subsystem: MetricOvnSubsystemNorthd,
-				Name:      "status",
-				Help:      "Specifies whether this instance of ovn-northd is standby(0) or active(1) or paused(2).",
-			}, func() float64 {
-				stdout, stderr, err := util.RunOVNNorthAppCtl("status")
-				if err != nil {
-					klog.Errorf("Failed to get ovn-northd status "+
-						"stderr(%s) :(%v)", stderr, err)
-					return -1
-				}
-				northdStatusMap := map[string]float64{
-					"standby": 0,
-					"active":  1,
-					"paused":  2,
-				}
-				if strings.HasPrefix(stdout, "Status:") {
-					output := strings.TrimSpace(strings.Split(stdout, ":")[1])
-					if value, ok := northdStatusMap[output]; ok {
-						return value
-					}
-				}
-				return -1
-			},
-		))
-
-		// Register the ovn-northd coverage/show metrics with prometheus
-		componentCoverageShowMetricsMap[ovnNorthd] = ovnNorthdCoverageShowMetricsMap
-		registerCoverageShowMetrics(ovnNorthd, MetricOvnNamespace, MetricOvnSubsystemNorthd)
-		go coverageShowMetricsUpdater(ovnNorthd)
 	})
 }
 

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -1,0 +1,157 @@
+package metrics
+
+import (
+	"strings"
+	"time"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+var (
+	ovnNorthdVersion       string
+	ovnNorthdOvsLibVersion string
+)
+
+func getOvnNorthdVersionInfo() {
+	stdout, _, err := util.RunOVNNorthAppCtl("version")
+	if err != nil {
+		return
+	}
+
+	// the output looks like:
+	// ovn-northd 20.06.0.86f64fc1
+	// Open vSwitch Library 2.13.0.f945b5c5
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.HasPrefix("ovn-northd ", line) {
+			ovnNorthdVersion = strings.Fields(line)[1]
+		} else if strings.HasPrefix("Open vSwitch Library ", line) {
+			ovnNorthdOvsLibVersion = strings.Fields(line)[3]
+		}
+	}
+}
+
+var ovnNorthdCoverageShowMetricsMap = map[string]*metricDetails{
+	"pstream_open": {
+		help: "Specifies the number of time passive connections " +
+			"were opened for the remote peer to connect.",
+	},
+	"stream_open": {
+		help: "Specifies the number of attempts to connect " +
+			"to a remote peer (active connection).",
+	},
+	"txn_success": {
+		help: "Specifies the number of times the OVSDB " +
+			"transaction has successfully completed.",
+	},
+	"txn_error": {
+		help: "Specifies the number of times the OVSDB " +
+			"transaction has errored out.",
+	},
+	"txn_uncommitted": {
+		help: "Specifies the number of times the OVSDB " +
+			"transaction were uncommitted.",
+	},
+	"txn_unchanged": {
+		help: "Specifies the number of times the OVSDB transaction " +
+			"resulted in no change to the database.",
+	},
+	"txn_incomplete": {
+		help: "Specifies the number of times the OVSDB transaction " +
+			"did not complete and the client had to re-try.",
+	},
+	"txn_aborted": {
+		help: "Specifies the number of times the OVSDB " +
+			" transaction has been aborted.",
+	},
+	"txn_try_again": {
+		help: "Specifies the number of times the OVSDB " +
+			"transaction failed and the client had to re-try.",
+	},
+}
+
+func RegisterOvnNorthdMetrics(clientset *kubernetes.Clientset, k8sNodeName string) {
+	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
+		return checkPodRunsOnGivenNode(clientset, "name=ovnkube-master", k8sNodeName, true)
+	})
+	if err != nil {
+		if err == wait.ErrWaitTimeout {
+			klog.Errorf("Timed out while checking if OVNKube Master Pod runs on this %q K8s Node: %v. "+
+				"Not registering OVN North Metrics on this Node", k8sNodeName, err)
+		} else {
+			klog.Infof("Not registering OVN North Metrics on this Node since ovn-northd is not running on this node.")
+		}
+		return
+	}
+	klog.Info("Found OVNKube Master Pod running on this node. Registering OVN North Metrics")
+
+	// ovn-northd metrics
+	getOvnNorthdVersionInfo()
+	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: MetricOvnNamespace,
+			Subsystem: MetricOvnSubsystemNorthd,
+			Name:      "build_info",
+			Help: "A metric with a constant '1' value labeled by version and library " +
+				"from which ovn binaries were built",
+			ConstLabels: prometheus.Labels{
+				"version":         ovnNorthdVersion,
+				"ovs_lib_version": ovnNorthdOvsLibVersion,
+			},
+		},
+		func() float64 { return 1 },
+	))
+	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: MetricOvnNamespace,
+			Subsystem: MetricOvnSubsystemNorthd,
+			Name:      "probe_interval",
+			Help: "The maximum number of milliseconds of idle time on connection to the OVN SB " +
+				"and NB DB before sending an inactivity probe message",
+		}, func() float64 {
+			stdout, stderr, err := util.RunOVNNbctlWithTimeout(5, "get", "NB_Global", ".",
+				"options:northd_probe_interval")
+			if err != nil {
+				klog.Errorf("Failed to get northd_probe_interval value "+
+					"stderr(%s) :(%v)", stderr, err)
+				return 0
+			}
+			return parseMetricToFloat(MetricOvnSubsystemNorthd, "probe_interval", stdout)
+		},
+	))
+	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: MetricOvnNamespace,
+			Subsystem: MetricOvnSubsystemNorthd,
+			Name:      "status",
+			Help:      "Specifies whether this instance of ovn-northd is standby(0) or active(1) or paused(2).",
+		}, func() float64 {
+			stdout, stderr, err := util.RunOVNNorthAppCtl("status")
+			if err != nil {
+				klog.Errorf("Failed to get ovn-northd status "+
+					"stderr(%s) :(%v)", stderr, err)
+				return -1
+			}
+			northdStatusMap := map[string]float64{
+				"standby": 0,
+				"active":  1,
+				"paused":  2,
+			}
+			if strings.HasPrefix(stdout, "Status:") {
+				output := strings.TrimSpace(strings.Split(stdout, ":")[1])
+				if value, ok := northdStatusMap[output]; ok {
+					return value
+				}
+			}
+			return -1
+		},
+	))
+
+	// Register the ovn-northd coverage/show metrics with prometheus
+	componentCoverageShowMetricsMap[ovnNorthd] = ovnNorthdCoverageShowMetricsMap
+	registerCoverageShowMetrics(ovnNorthd, MetricOvnNamespace, MetricOvnSubsystemNorthd)
+	go coverageShowMetricsUpdater(ovnNorthd)
+}


### PR DESCRIPTION
We have allocated following TCP ports to export metrics from OVN K8s
software components
```
|----------------+----------|
| software       | tcp port |
|----------------+----------|
| ovnkube-master |     9410 |
| ovnkube-node   |     9409 |
| ovn            |     9476 |
| ovs            |     9310 |
|----------------+----------|
```
However, in reality we are exporting metrics for OVN components from
various daemons and at different ports
```
|----------------+------------------------+------|
| OVN component  | Exported By            | Port |
|----------------+------------------------+------|
| OVN North      | ovnkbue-master process | 9410 |
| OVN Controller | ovnkube-node process   | 9409 |
| OVN DB         | ovn-db-exporter POD    | 9476 |
|----------------+------------------------+------|
```
The goal of this commit is to export all of the OVN metrics from
ovnkube-node daemonset and at the designated TCP port of 9476. To that
effect, the commit does the following

1) group all the OVN Northd metrics into pkg/metrics/ovn_northd.go
2) group all the OVN DB metrics into pkg/metrics/ovn_db.go
3) all OVN controller metrics are in the existing pkg/metrics/ovn.go
4) all the OVN metrics are now exported off of ovnkube-node process
   and it starts a new HTTPServer and listens on port 9476
5) all the OVN metrics are gathered under a new Prometheus registry
   called ovnRegistry
6) all the ovnkbue-node metrics are gathered udner the default
   Prometheus registry
7) We don't need the ovn-db-exporter Pod and everything related to that
   Pod is removed

With all these changes in place, we now have all OVN metrics available
under '/metrics' path at port 9476.

@ovn-org/ovn-kubernetes-committers @aojea PTAL