### PR TITLE
ovn: fix setting addresses on logical switch ports

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -346,7 +346,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	for idx, podIfAddr := range podIfAddrs {
 		addresses[idx+1] = podIfAddr.IP.String()
 	}
-	cmd, err = oc.ovnNBClient.LSPSetAddress(portName, addresses...)
+	// LSP addresses in OVN are a single space-separated value
+	cmd, err = oc.ovnNBClient.LSPSetAddress(portName, strings.Join(addresses, " "))
 	if err != nil {
 		return fmt.Errorf("unable to create LSPSetAddress command for port: %s", portName)
 	}
@@ -361,7 +362,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	cmds = append(cmds, cmd)
 
 	// add port security addresses
-	cmd, err = oc.ovnNBClient.LSPSetPortSecurity(portName, addresses...)
+	cmd, err = oc.ovnNBClient.LSPSetPortSecurity(portName, strings.Join(addresses, " "))
 	if err != nil {
 		return fmt.Errorf("unable to create LSPSetPortSecurity command for port: %s", portName)
 	}

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -43,7 +43,9 @@ func GetPortAddresses(portName string, ovnNBClient goovn.Client) (net.HardwareAd
 	var addresses []string
 
 	if lsp.DynamicAddresses == "" {
-		addresses = lsp.Addresses
+		if len(lsp.Addresses) > 0 {
+			addresses = strings.Split(lsp.Addresses[0], " ")
+		}
 	} else {
 		// dynamic addresses have format "0a:00:00:00:00:01 192.168.1.3"
 		// static addresses have format ["0a:00:00:00:00:01 192.168.1.3"]

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -106,18 +106,18 @@ func TestGetPortAddresses(t *testing.T) {
 			desc:                 "test the code path where ParseMAC fails",
 			inpPort:              "TEST_PORT",
 			errMatch:             fmt.Errorf("failed to parse logical switch port"),
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"192.168.1.3", "0a:00:00:00:00:01"}}, nil}},
+			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"192.168.1.3 0a:00:00:00:00:01"}}, nil}},
 		},
 		{
 			desc:                 "test code path where IP address parsing fails",
 			inpPort:              "TEST_PORT",
 			errMatch:             fmt.Errorf("failed to parse logical switch port"),
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"192.168.1.3", "0a:00:00:00:00:01"}}, nil}},
+			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"192.168.1.3 0a:00:00:00:00:01"}}, nil}},
 		},
 		{
 			desc:                 "test success path where MAC, IPs are returned",
 			inpPort:              "TEST_PORT",
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"0a:00:00:00:00:01", "192.168.1.3"}}, nil}},
+			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"0a:00:00:00:00:01 192.168.1.3"}}, nil}},
 		},
 	}
 	for i, tc := range tests {


### PR DESCRIPTION
Addresses must be a space-separated string sent as a single value.
The slice passed to LSPSetAddress() turns into an OvsSet in which
has special semantics for the second and later elements and causes
OVSDB to insert a newline between the MAC and IPs, leading to
northd complaints that the address is malformed.

@trozet @abhat 