### PR TITLE
Downgrade OVN to ovn-20.03.0-3.fc31

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -30,6 +30,18 @@ RUN INSTALL_PKGS=" \
 # RPM has propagated to all stable mirrors and can be removed
 RUN dnf install -y ovn --best --advisory=FEDORA-2020-b570bbc33b || true
 
+# ovn-20.06.1-0.fc31 and ovn-20.06.1-4.fc31 are failing CI. So force OVN to
+# run ovn-20.03.0-3.fc31. 'dnf downgrade -y ovn ovn-central ovn-host' drops
+# OVN back to ovn-2.12.0-1.fc31, so download the RPMs first.
+RUN curl -Lo ovn-20.03.0-3.fc31.x86_64.rpm \
+https://kojipkgs.fedoraproject.org//packages/ovn/20.03.0/3.fc31/x86_64/ovn-20.03.0-3.fc31.x86_64.rpm && \
+curl -Lo ovn-central-20.03.0-3.fc31.x86_64.rpm \
+https://kojipkgs.fedoraproject.org//packages/ovn/20.03.0/3.fc31/x86_64/ovn-central-20.03.0-3.fc31.x86_64.rpm && \
+curl -Lo ovn-host-20.03.0-3.fc31.x86_64.rpm \
+https://kojipkgs.fedoraproject.org//packages/ovn/20.03.0/3.fc31/x86_64/ovn-host-20.03.0-3.fc31.x86_64.rpm && \
+dnf downgrade -y ovn-20.03.0-3.fc31.x86_64.rpm ovn-central-20.03.0-3.fc31.x86_64.rpm ovn-host-20.03.0-3.fc31.x86_64.rpm && \
+rm *.rpm
+
 RUN mkdir -p /var/run/openvswitch
 
 # Built in ../../go_controller, then the binaries are copied here.


### PR DESCRIPTION
ovn-20.06.1-0.fc31 and ovn-20.06.1-4.fc31 are failing CI. So force OVN to
run ovn-20.03.0-3.fc31 while root cause is determined.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->