### PR TITLE
store tests xml artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,18 +192,25 @@ jobs:
       run: |
         make -C test ${{ matrix.target.shard }}
 
-    - name: Generate Report
+    - name: Upload Junit Reports
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
+        path: './test/_artifacts/*.xml'
+
+    - name: Generate Test Report
       id: xunit-viewer
       if: always()
       uses: AutoModality/action-xunit-viewer@v1
       with:
         results: ./test/_artifacts/
 
-    - name: Upload Junit Reports
+    - name: Upload Test Report
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
+        name: test-report-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: './test/_artifacts/index.html'
 
     - name: Export logs


### PR DESCRIPTION
**- What this PR does and why is it needed**

The junit xml fails will be needed to improve the reporting, we need to store them so we can reuse it later

**- Special notes for reviewers**

**- How to verify it**

**- Description for the changelog**
