### PR TITLE
Fixes shared gateway mode checks

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -128,7 +128,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: "5",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface eth0 ofport",
+			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -202,7 +202,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 			err = n.initGateway(ovntest.MustParseIPNets(nodeSubnet), nodeAnnotator, waiter)
 			Expect(err).NotTo(HaveOccurred())
 
-			// check if IP adress have assigned to localnetGatewayNextHopPort interface
+			// check if IP addresses have been assigned to localnetGatewayNextHopPort interface
 			link, err := netlink.LinkByName(localnetGatewayNextHopPort)
 			Expect(err).NotTo(HaveOccurred())
 			addresses, err := netlink.AddrList(link, syscall.AF_INET)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -267,8 +267,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 	}
 
 	// Get ofport of physical interface
-	ofportPhys, stderr, err := util.RunOVSVsctl("--if-exists", "get",
-		"interface", gwIntf, "ofport")
+	ofportPhys, stderr, err := util.RunOVSVsctl("get", "interface", gwIntf, "ofport")
 	if err != nil {
 		return fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
 			gwIntf, stderr, err)

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -47,8 +47,7 @@ func getIntfName(gatewayIntf string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	_, stderr, err := util.RunOVSVsctl("--if-exists", "get",
-		"interface", intfName, "ofport")
+	_, stderr, err := util.RunOVSVsctl("get", "interface", intfName, "ofport")
 	if err != nil {
 		return "", fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
 			intfName, stderr, err)

--- a/go-controller/pkg/node/helper_windows.go
+++ b/go-controller/pkg/node/helper_windows.go
@@ -25,8 +25,7 @@ func getIntfName(gatewayIntf string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	_, stderr, err := util.RunOVSVsctl("--if-exists", "get",
-		"interface", intfName, "ofport")
+	_, stderr, err := util.RunOVSVsctl("get", "interface", intfName, "ofport")
 	if err != nil {
 		return "", fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
 			intfName, stderr, err)


### PR DESCRIPTION
The current code for detecting the NIC with shared gateway mode assumes
the naming format of the bridge is "br-<nic name>". This is not always
the case an a typical OVS bridge will use the same name for the OVS port
and interface as the brdige. This patch handles that use case.

Additionally, checks for ofport were using "--if-exists" which will not
return an error if the ofport does not exist for that port.

Signed-off-by: Tim Rozet <trozet@redhat.com>

