### PR TITLE
Fix IPv6-vs-multicast check

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -192,8 +192,8 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 				"Disabling Multicast Support")
 			oc.multicastSupport = false
 		}
-		if config.IPv6Mode {
-			klog.Warningf("Multicast support enabled, but can not be used along with IPv6. Disabling Multicast Support")
+		if !config.IPv4Mode {
+			klog.Warningf("Multicast support enabled, but can not be used with single-stack IPv6. Disabling Multicast Support")
 			oc.multicastSupport = false
 		}
 	}


### PR DESCRIPTION
the multicast code all got updated to only work with IPv4 subnets, but we were accidentally still disabling it in dual-stack mode

@dcbw 