### PR TITLE
informer: fix testcase races with hybrid overlay event handlers

### DIFF
--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/urfave/cli/v2"
@@ -115,15 +116,16 @@ func runHybridOverlay(ctx *cli.Context) error {
 	}
 
 	f.Start(stopChan)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
-		err := n.Run(stopChan)
-		if err != nil {
-			klog.Error(err)
-		}
+		defer wg.Done()
+		n.Run(stopChan)
 	}()
 
 	// run until cancelled
 	<-ctx.Context.Done()
 	close(stopChan)
+	wg.Wait()
 	return nil
 }

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
 	goovn "github.com/ebay/go-ovn"
 	"github.com/urfave/cli/v2"
@@ -70,6 +71,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 	var (
 		app      *cli.App
 		stopChan chan struct{}
+		wg       *sync.WaitGroup
 	)
 
 	BeforeEach(func() {
@@ -80,10 +82,12 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 		stopChan = make(chan struct{})
+		wg = &sync.WaitGroup{}
 	})
 
 	AfterEach(func() {
 		close(stopChan)
+		wg.Wait()
 	})
 
 	const hybridOverlayClusterCIDR string = "11.1.0.0/16/24"
@@ -122,7 +126,11 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go m.Run(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				m.Run(stopChan)
+			}()
 
 			// Windows node should be allocated a subnet
 			Eventually(func() (map[string]string, error) {
@@ -193,7 +201,11 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go m.Run(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				m.Run(stopChan)
+			}()
 
 			Eventually(func() (map[string]string, error) {
 				updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
@@ -262,7 +274,11 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go m.Run(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				m.Run(stopChan)
+			}()
 
 			k := &kube.Kube{KClient: fakeClient}
 			updatedNode, err := k.GetNode(nodeName)
@@ -343,7 +359,11 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go m.Run(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				m.Run(stopChan)
+			}()
 
 			Eventually(func() error {
 				pod, err := fakeClient.CoreV1().Pods(nsName).Get(context.TODO(), pod1Name, metav1.GetOptions{})
@@ -423,7 +443,11 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go m.Run(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				m.Run(stopChan)
+			}()
 
 			updatedNs, err := fakeClient.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -176,6 +177,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		fexec    *ovntest.FakeExec
 		netns    ns.NetNS
 		stopChan chan struct{}
+		wg       *sync.WaitGroup
 	)
 	const (
 		thisNode   string = "mynode"
@@ -191,6 +193,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		app.Flags = config.Flags
 
 		stopChan = make(chan struct{})
+		wg = &sync.WaitGroup{}
 
 		fexec = ovntest.NewLooseCompareFakeExec()
 		err := util.SetExec(fexec)
@@ -217,6 +220,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 	AfterEach(func() {
 		close(stopChan)
+		wg.Wait()
 		Expect(netns.Close()).To(Succeed())
 		Expect(testutils.UnmountNS(netns)).To(Succeed())
 	})
@@ -254,7 +258,11 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go n.nodeEventHandler.Run(1, stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				n.nodeEventHandler.Run(1, stopChan)
+			}()
 
 			// FIXME
 			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
@@ -298,7 +306,11 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go n.nodeEventHandler.Run(1, stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				n.nodeEventHandler.Run(1, stopChan)
+			}()
 
 			// FIXME
 			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
@@ -443,7 +455,11 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go n.nodeEventHandler.Run(1, stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				n.nodeEventHandler.Run(1, stopChan)
+			}()
 
 			// FIXME
 			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
@@ -490,7 +506,11 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go n.nodeEventHandler.Run(1, stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				n.nodeEventHandler.Run(1, stopChan)
+			}()
 
 			//FIXME
 			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
@@ -536,7 +556,11 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go n.Run(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				n.Run(stopChan)
+			}()
 
 			// Wait for the controller to start
 			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.ready == true, nil })
@@ -608,7 +632,11 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			// Expect(err).NotTo(HaveOccurred())
 
 			f.Start(stopChan)
-			go n.Run(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				n.Run(stopChan)
+			}()
 
 			// Wait for the controller to start
 			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.ready == true, nil })

--- a/go-controller/pkg/informer/informer_test.go
+++ b/go-controller/pkg/informer/informer_test.go
@@ -2,6 +2,7 @@ package informer
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -55,6 +56,20 @@ var _ = Describe("Informer Event Handler Tests", func() {
 	const (
 		namespace string = "test"
 	)
+	var (
+		stopChan chan struct{}
+		wg       *sync.WaitGroup
+	)
+
+	BeforeEach(func() {
+		stopChan = make(chan struct{})
+		wg = &sync.WaitGroup{}
+	})
+
+	AfterEach(func() {
+		close(stopChan)
+		wg.Wait()
+	})
 
 	It("processes an add event", func() {
 		adds := int32(0)
@@ -87,11 +102,12 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			ReceiveAllUpdates,
 		)
 
-		stopChan := make(chan struct{})
-		defer close(stopChan)
-
 		f.Start(stopChan)
-		go e.Run(1, stopChan)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			e.Run(1, stopChan)
+		}()
 
 		wait.PollImmediate(
 			500*time.Millisecond,
@@ -152,11 +168,12 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			ReceiveAllUpdates,
 		)
 
-		stopChan := make(chan struct{})
-		defer close(stopChan)
-
 		f.Start(stopChan)
-		go e.Run(1, stopChan)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			e.Run(1, stopChan)
+		}()
 
 		wait.PollImmediate(
 			500*time.Millisecond,
@@ -219,11 +236,12 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			ReceiveAllUpdates,
 		)
 
-		stopChan := make(chan struct{})
-		defer close(stopChan)
-
 		f.Start(stopChan)
-		go e.Run(1, stopChan)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			e.Run(1, stopChan)
+		}()
 
 		wait.PollImmediate(
 			500*time.Millisecond,
@@ -285,11 +303,12 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			DiscardAllUpdates,
 		)
 
-		stopChan := make(chan struct{})
-		defer close(stopChan)
-
 		f.Start(stopChan)
-		go e.Run(1, stopChan)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			e.Run(1, stopChan)
+		}()
 
 		wait.PollImmediate(
 			500*time.Millisecond,

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	kapi "k8s.io/api/core/v1"
@@ -20,7 +21,7 @@ import (
 	"k8s.io/klog"
 	utilnet "k8s.io/utils/net"
 
-	homaster "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
+	hocontroller "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
@@ -50,7 +51,7 @@ func (_ ovnkubeMasterLeaderMetricsProvider) NewLeaderMetric() leaderelection.Swi
 }
 
 // Start waits until this process is the leader before starting master functions
-func (oc *Controller) Start(kClient kubernetes.Interface, nodeName string) error {
+func (oc *Controller) Start(kClient kubernetes.Interface, nodeName string, wg *sync.WaitGroup) error {
 	// Set up leader election process first
 	rl, err := resourcelock.New(
 		resourcelock.ConfigMapsResourceLock,
@@ -84,7 +85,7 @@ func (oc *Controller) Start(kClient kubernetes.Interface, nodeName string) error
 				if err := oc.StartClusterMaster(nodeName); err != nil {
 					panic(err.Error())
 				}
-				if err := oc.Run(); err != nil {
+				if err := oc.Run(wg); err != nil {
 					panic(err.Error())
 				}
 			},
@@ -205,7 +206,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 
 	if config.HybridOverlay.Enabled {
 		factory := oc.watchFactory.GetFactory()
-		nodeMaster, err := homaster.NewMaster(
+		oc.hoMaster, err = hocontroller.NewMaster(
 			oc.kube,
 			factory.Core().V1().Nodes().Informer(),
 			factory.Core().V1().Namespaces().Informer(),
@@ -216,7 +217,6 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		if err != nil {
 			return fmt.Errorf("failed to set up hybrid overlay master: %v", err)
 		}
-		go nodeMaster.Run(oc.stopChan)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 
 	goovn "github.com/ebay/go-ovn"
 	"github.com/urfave/cli/v2"
@@ -244,6 +245,7 @@ var _ = Describe("Master Operations", func() {
 		app      *cli.App
 		f        *factory.WatchFactory
 		stopChan chan struct{}
+		wg       *sync.WaitGroup
 	)
 
 	BeforeEach(func() {
@@ -254,11 +256,13 @@ var _ = Describe("Master Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 		stopChan = make(chan struct{})
+		wg = &sync.WaitGroup{}
 	})
 
 	AfterEach(func() {
 		close(stopChan)
 		f.Shutdown()
+		wg.Wait()
 	})
 
 	It("creates logical network elements for a 2-node cluster", func() {
@@ -328,6 +332,12 @@ var _ = Describe("Master Operations", func() {
 
 			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				clusterController.hoMaster.Run(stopChan)
+			}()
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
@@ -421,6 +431,12 @@ var _ = Describe("Master Operations", func() {
 			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
 
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				clusterController.hoMaster.Run(stopChan)
+			}()
+
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -510,6 +526,12 @@ var _ = Describe("Master Operations", func() {
 
 			err = clusterController.WatchNodes()
 			Expect(err).NotTo(HaveOccurred())
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				clusterController.hoMaster.Run(stopChan)
+			}()
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})


### PR DESCRIPTION
There was no way to wait until the hybrid overlay informer event handlers
had stopped processing events. Narrow the race window by ensuring that
the informers themselves are done processing events before continuing
to the next test. Otherwise we hit testcase races where an informer for
a previous testcase hasn't finished yet and is accessing data that was
modified by a subsequent testcase's BeforeEach().

See https://github.com/ovn-org/ovn-kubernetes/pull/1512#issuecomment-664414658

@dave-tucker @aojea 