### PR TITLE
scale: revert back to one single join switch

### DIFF
--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -237,7 +237,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_%s", node2.Name),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_%s networks", node2.Name),
 						Output: nodeLogicalRouterIfAddrV4,
 					},
 				)
@@ -352,7 +352,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_%s", node2.Name),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_%s networks", node2.Name),
 						Output: nodeLogicalRouterIfAddrV4,
 					},
 				)
@@ -424,7 +424,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_%s", node2.name),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_%s networks", node2.name),
 						Output: nodeLogicalRouterIfAddrV6,
 					},
 				)
@@ -525,7 +525,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_%s", node2.name),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_%s networks", node2.name),
 						Output: nodeLogicalRouterIfAddrV6,
 					},
 				)
@@ -621,7 +621,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_%s", node2.name),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_%s networks", node2.name),
 						Output: nodeLogicalRouterIfAddrV6,
 					},
 				)
@@ -747,7 +747,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_%s", node2.name),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_%s networks", node2.name),
 						Output: nodeLogicalRouterIfAddrV6,
 					},
 				)
@@ -912,7 +912,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_%s", node2.name),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_%s networks", node2.name),
 						Output: nodeLogicalRouterIfAddrV6,
 					},
 				)
@@ -1036,7 +1036,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_%s", node2.name),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_%s networks", node2.name),
 						Output: nodeLogicalRouterIfAddrV6,
 					},
 				)

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -11,7 +12,7 @@ import (
 )
 
 const (
-	// prority of logical router policies on the util.OVNClusterRouter
+	// priority of logical router policies on the ovnClusterRouter
 	egressFirewallStartPriority           = "10000"
 	minimumReservedEgressFirewallPriority = "2000"
 	mgmtPortPolicyPriority                = "1005"
@@ -175,4 +176,36 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, string, erro
 			"load balancer, stderr: %q, error: %v", gatewayRouter, stderr, err)
 	}
 	return lbTCP, lbUDP, lbSCTP, nil
+}
+
+// check if IPs of gateway logical router port are within the join switch IP range, and return them if true.
+func (oc *Controller) getJoinLRPAddresses(nodeName string) []*net.IPNet {
+	// try to get the IPs from the logical router port
+	gwLRPIPs := []*net.IPNet{}
+	gwLrpName := util.GwRouterToJoinSwitchPrefix + util.GwRouterPrefix + nodeName
+	joinSubnets := oc.joinSwIPManager.lsm.GetSwitchSubnets(nodeName)
+	ifAddrs, err := util.GetLRPAddrs(gwLrpName)
+	if err == nil {
+		for _, ifAddr := range ifAddrs {
+			for _, subnet := range joinSubnets {
+				if subnet.Contains(ifAddr.IP) {
+					gwLRPIPs = append(gwLRPIPs, &net.IPNet{IP: ifAddr.IP, Mask: subnet.Mask})
+					break
+				}
+			}
+		}
+	}
+
+	if len(gwLRPIPs) != len(joinSubnets) {
+		var errStr string
+		if len(gwLRPIPs) == 0 {
+			errStr = fmt.Sprintf("Failed to get IPs for logical router port %s", gwLrpName)
+		} else {
+			errStr = fmt.Sprintf("Invalid IPs %s (possibly not in the range of subnet %s)",
+				util.JoinIPNetIPs(gwLRPIPs, " "), util.JoinIPNetIPs(joinSubnets, " "))
+		}
+		klog.Warningf("%s for logical router port %s", errStr, gwLrpName)
+		return []*net.IPNet{}
+	}
+	return gwLRPIPs
 }

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -50,7 +50,8 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 	It("creates an IPv4 gateway in OVN", func() {
 		clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")
 		hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23")
-		joinSubnets := ovntest.MustParseIPNets("100.64.0.0/29")
+		joinLRPIPs := ovntest.MustParseIPNets("100.64.0.3/16")
+		defLRPIPs := ovntest.MustParseIPNets("100.64.0.1/16")
 		nodeName := "test-node"
 		l3GatewayConfig := &util.L3GatewayConfig{
 			Mode:           config.GatewayModeLocal,
@@ -69,13 +70,12 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add GR_test-node -- set logical_router GR_test-node options:chassis=SYSTEM-ID external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2",
-			"ovn-nbctl --timeout=15 -- --may-exist ls-add join_test-node",
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
-			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:64:40:00:01 100.64.0.1/29",
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtod-test-node -- set logical_switch_port jtod-test-node type=router options:router-port=dtoj-test-node addresses=router",
-			"ovn-nbctl --timeout=15 -- --if-exists lrp-del dtoj-test-node -- lrp-add ovn_cluster_router dtoj-test-node 0a:58:64:40:00:02 100.64.0.2/29",
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=100.64.0.1",
-			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node 10.128.0.0/14 100.64.0.2",
+			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OVNJoinSwitch + " jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
+			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:64:40:00:03 100.64.0.3/16",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=100.64.0.3",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:always_learn_from_arp_request=false",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:dynamic_neigh_routers=true",
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node 10.128.0.0/14 100.64.0.1",
 		})
 
 		const (
@@ -107,11 +107,12 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoe-GR_test-node -- lrp-add GR_test-node rtoe-GR_test-node 11:22:33:44:55:66 169.254.33.2/24 -- set logical_router_port rtoe-GR_test-node external-ids:gateway-physical-ip=yes",
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_test-node etor-GR_test-node -- set logical_switch_port etor-GR_test-node type=router options:router-port=rtoe-GR_test-node addresses=\"11:22:33:44:55:66\"",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node 0.0.0.0/0 169.254.33.1 rtoe-GR_test-node",
-			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router 10.130.0.0/23 100.64.0.1",
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add ovn_cluster_router 100.64.0.3 100.64.0.3",
+			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router 10.130.0.0/23 100.64.0.3",
 			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat 10.128.0.0/14 -- lr-nat-add GR_test-node snat 169.254.33.2 10.128.0.0/14",
 		})
 
-		err = gatewayInit(nodeName, clusterIPSubnets, hostSubnets, joinSubnets, l3GatewayConfig, sctpSupport)
+		err = gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fexec.CalledMatchesExpected()).To(BeTrue())
 	})
@@ -119,7 +120,8 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 	It("creates an IPv6 gateway in OVN", func() {
 		clusterIPSubnets := ovntest.MustParseIPNets("fd01::/48")
 		hostSubnets := ovntest.MustParseIPNets("fd01:0:0:2::/64")
-		joinSubnets := ovntest.MustParseIPNets("fd98::/125")
+		joinLRPIPs := ovntest.MustParseIPNets("fd98::3/64")
+		defLRPIPs := ovntest.MustParseIPNets("fd98::1/64")
 		nodeName := "test-node"
 		l3GatewayConfig := &util.L3GatewayConfig{
 			Mode:           config.GatewayModeLocal,
@@ -140,13 +142,12 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		// 0a:58:5f:8a:48:8c generated from util.IPAddrToHWAddr(net.ParseIP("fd98::2")).String()
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add GR_test-node -- set logical_router GR_test-node options:chassis=SYSTEM-ID external_ids:physical_ip=fd99::2 external_ids:physical_ips=fd99::2",
-			"ovn-nbctl --timeout=15 -- --may-exist ls-add join_test-node",
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
-			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:ee:33:fc:1a fd98::1/125",
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtod-test-node -- set logical_switch_port jtod-test-node type=router options:router-port=dtoj-test-node addresses=router",
-			"ovn-nbctl --timeout=15 -- --if-exists lrp-del dtoj-test-node -- lrp-add ovn_cluster_router dtoj-test-node 0a:58:5f:8a:48:8c fd98::2/125",
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=fd98::1",
-			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node fd01::/48 fd98::2",
+			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OVNJoinSwitch + " jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
+			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:87:f0:33:ca fd98::3/64",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=fd98::3",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:always_learn_from_arp_request=false",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:dynamic_neigh_routers=true",
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node fd01::/48 fd98::1",
 		})
 
 		const (
@@ -178,11 +179,12 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoe-GR_test-node -- lrp-add GR_test-node rtoe-GR_test-node 11:22:33:44:55:66 fd99::2/64 -- set logical_router_port rtoe-GR_test-node external-ids:gateway-physical-ip=yes",
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_test-node etor-GR_test-node -- set logical_switch_port etor-GR_test-node type=router options:router-port=rtoe-GR_test-node addresses=\"11:22:33:44:55:66\"",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node ::/0 fd99::1 rtoe-GR_test-node",
-			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router fd01:0:0:2::/64 fd98::1",
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add ovn_cluster_router fd98::3 fd98::3",
+			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router fd01:0:0:2::/64 fd98::3",
 			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat fd01::/48 -- lr-nat-add GR_test-node snat fd99::2 fd01::/48",
 		})
 
-		err = gatewayInit(nodeName, clusterIPSubnets, hostSubnets, joinSubnets, l3GatewayConfig, sctpSupport)
+		err = gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fexec.CalledMatchesExpected()).To(BeTrue())
 	})
@@ -190,7 +192,8 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 	It("creates a dual-stack gateway in OVN", func() {
 		clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14", "fd01::/48")
 		hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23", "fd01:0:0:2::/64")
-		joinSubnets := ovntest.MustParseIPNets("100.64.0.0/29", "fd98::/125")
+		joinLRPIPs := ovntest.MustParseIPNets("100.64.0.3/16", "fd98::3/64")
+		defLRPIPs := ovntest.MustParseIPNets("100.64.0.1/16", "fd98::1/64")
 		nodeName := "test-node"
 		l3GatewayConfig := &util.L3GatewayConfig{
 			Mode:           config.GatewayModeLocal,
@@ -209,14 +212,13 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add GR_test-node -- set logical_router GR_test-node options:chassis=SYSTEM-ID external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2,fd99::2",
-			"ovn-nbctl --timeout=15 -- --may-exist ls-add join_test-node",
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
-			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:64:40:00:01 100.64.0.1/29 fd98::1/125",
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtod-test-node -- set logical_switch_port jtod-test-node type=router options:router-port=dtoj-test-node addresses=router",
-			"ovn-nbctl --timeout=15 -- --if-exists lrp-del dtoj-test-node -- lrp-add ovn_cluster_router dtoj-test-node 0a:58:64:40:00:02 100.64.0.2/29 fd98::2/125",
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=100.64.0.1 fd98::1",
-			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node 10.128.0.0/14 100.64.0.2",
-			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node fd01::/48 fd98::2",
+			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OVNJoinSwitch + " jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
+			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:64:40:00:03 100.64.0.3/16 fd98::3/64",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=100.64.0.3 fd98::3",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:always_learn_from_arp_request=false",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:dynamic_neigh_routers=true",
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node 10.128.0.0/14 100.64.0.1",
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node fd01::/48 fd98::1",
 		})
 
 		const (
@@ -249,13 +251,15 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add ext_test-node etor-GR_test-node -- set logical_switch_port etor-GR_test-node type=router options:router-port=rtoe-GR_test-node addresses=\"11:22:33:44:55:66\"",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node 0.0.0.0/0 169.254.33.1 rtoe-GR_test-node",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node ::/0 fd99::1 rtoe-GR_test-node",
-			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router 10.130.0.0/23 100.64.0.1",
-			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router fd01:0:0:2::/64 fd98::1",
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add ovn_cluster_router 100.64.0.3 100.64.0.3",
+			"ovn-nbctl --timeout=15 --may-exist lr-route-add ovn_cluster_router fd98::3 fd98::3",
+			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router 10.130.0.0/23 100.64.0.3",
+			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router fd01:0:0:2::/64 fd98::3",
 			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat 10.128.0.0/14 -- lr-nat-add GR_test-node snat 169.254.33.2 10.128.0.0/14",
 			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat fd01::/48 -- lr-nat-add GR_test-node snat fd99::2 fd01::/48",
 		})
 
-		err = gatewayInit(nodeName, clusterIPSubnets, hostSubnets, joinSubnets, l3GatewayConfig, sctpSupport)
+		err = gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fexec.CalledMatchesExpected()).To(BeTrue())
 	})
@@ -273,8 +277,8 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		Expect(err).NotTo(HaveOccurred())
 
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_test-node",
-			Output: "100.64.0.1/29",
+			Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_test-node networks",
+			Output: "[\"100.64.0.1/16\"]",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=\"100.64.0.1\"",
@@ -284,10 +288,9 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --if-exists remove logical_router ovn_cluster_router static_routes " + nodeRouteUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --if-exist ls-del join_test-node",
+			"ovn-nbctl --timeout=15 --if-exist lsp-del jtor-GR_test-node",
 			"ovn-nbctl --timeout=15 --if-exist lr-del GR_test-node",
 			"ovn-nbctl --timeout=15 --if-exist ls-del ext_test-node",
-			"ovn-nbctl --timeout=15 --if-exist lrp-del dtoj-test-node",
 		})
 
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -328,8 +331,8 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		Expect(err).NotTo(HaveOccurred())
 
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --format=table --data=bare --no-heading --columns=networks find logical_router_port name=rtoj-GR_test-node",
-			Output: "100.64.0.1/29 fd98::1/125",
+			Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_test-node networks",
+			Output: "[\"100.64.0.1/16\", \"fd98::1/64\"]",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=\"100.64.0.1\"",
@@ -347,10 +350,9 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		})
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --if-exist ls-del join_test-node",
+			"ovn-nbctl --timeout=15 --if-exist lsp-del jtor-GR_test-node",
 			"ovn-nbctl --timeout=15 --if-exist lr-del GR_test-node",
 			"ovn-nbctl --timeout=15 --if-exist ls-del ext_test-node",
-			"ovn-nbctl --timeout=15 --if-exist lrp-del dtoj-test-node",
 		})
 
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -156,7 +156,7 @@ func (ovn *Controller) getLogicalSwitchesForLoadBalancer(lb string) ([]string, e
 	// case
 	if strings.HasPrefix(out, util.GwRouterPrefix) {
 		routerName := strings.TrimPrefix(out, util.GwRouterPrefix)
-		return []string{util.JoinSwitchPrefix + routerName, util.ExternalSwitchPrefix + routerName}, nil
+		return []string{util.OVNJoinSwitch, util.ExternalSwitchPrefix + routerName}, nil
 	}
 	return nil, fmt.Errorf("router detected with load balancer that is not a GR")
 }

--- a/go-controller/pkg/ovn/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager.go
@@ -261,3 +261,130 @@ func (manager *logicalSwitchManager) ReleaseIPs(nodeName string, ipnets []*net.I
 	}
 	return nil
 }
+
+// IP allocator manager for join switch's IPv4 and IPv6 subnets.
+type joinSwitchIPManager struct {
+	lsm            *logicalSwitchManager
+	lrpIPCache     map[string][]*net.IPNet
+	lrpIPCacheLock sync.Mutex
+}
+
+// NewJoinIPAMAllocator provides an ipam interface which can be used for join switch IPAM
+// allocations for the specified cidr using a contiguous allocation strategy.
+func NewJoinIPAMAllocator(cidr *net.IPNet) (ipam.Interface, error) {
+	subnetRange, err := ipam.NewAllocatorCIDRRange(cidr, func(max int, rangeSpec string) (allocator.Interface, error) {
+		return allocator.NewContiguousAllocationMap(max, rangeSpec), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return subnetRange, nil
+}
+
+// Initializes a new join switch logical switch manager.
+// This IPmanager guaranteed to always have both IPv4 and IPv6 regardless of dual-stack
+func initJoinLogicalSwitchIPManager() (*joinSwitchIPManager, error) {
+	j := joinSwitchIPManager{
+		lsm: &logicalSwitchManager{
+			cache:    make(map[string]logicalSwitchInfo),
+			ipamFunc: NewJoinIPAMAllocator,
+		},
+		lrpIPCache: make(map[string][]*net.IPNet),
+	}
+	var joinSubnets []*net.IPNet
+	for _, joinSubnetString := range []string{util.V4JoinSubnetCidr, util.V6JoinSubnetCidr} {
+		_, joinSubnet, err := net.ParseCIDR(joinSubnetString)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing join subnet string %s: %v", joinSubnetString, err)
+		}
+		joinSubnets = append(joinSubnets, joinSubnet)
+	}
+	err := j.lsm.AddNode(util.OVNJoinSwitch, joinSubnets)
+	if err != nil {
+		return nil, err
+	}
+	return &j, nil
+}
+
+func (jsIPManager *joinSwitchIPManager) getJoinLRPCacheIPs(nodeName string) ([]*net.IPNet, bool) {
+	jsIPManager.lrpIPCacheLock.Lock()
+	defer jsIPManager.lrpIPCacheLock.Unlock()
+	gwLRPIPs, ok := jsIPManager.lrpIPCache[nodeName]
+	return gwLRPIPs, ok
+}
+
+func (jsIPManager *joinSwitchIPManager) setJoinLRPCacheIPs(nodeName string, gwLRPIPs []*net.IPNet) error {
+	jsIPManager.lrpIPCacheLock.Lock()
+	defer jsIPManager.lrpIPCacheLock.Unlock()
+	if _, ok := jsIPManager.lrpIPCache[nodeName]; ok {
+		return fmt.Errorf("join switch IPs already allocated for node %s", nodeName)
+	}
+	jsIPManager.lrpIPCache[nodeName] = gwLRPIPs
+	return nil
+}
+
+func (jsIPManager *joinSwitchIPManager) delJoinLRPCacheIPs(nodeName string) {
+	jsIPManager.lrpIPCacheLock.Lock()
+	defer jsIPManager.lrpIPCacheLock.Unlock()
+	delete(jsIPManager.lrpIPCache, nodeName)
+}
+
+// reserveJoinLRPIPs tries to add the LRP IPs to the joinSwitchIPManager, then they will be stored in the cache;
+func (jsIPManager *joinSwitchIPManager) reserveJoinLRPIPs(nodeName string, gwLRPIPs []*net.IPNet) (err error) {
+	// reserve the given IP in the allocator
+	if err = jsIPManager.lsm.AllocateIPs(util.OVNJoinSwitch, gwLRPIPs); err == nil {
+		defer func() {
+			if err != nil {
+				if relErr := jsIPManager.lsm.ReleaseIPs(util.OVNJoinSwitch, gwLRPIPs); relErr != nil {
+					klog.Errorf("Failed to release logical router port IPs %v just reserved for node %s: %q",
+						util.JoinIPNetIPs(gwLRPIPs, " "), nodeName, relErr)
+				}
+			}
+		}()
+		if err = jsIPManager.setJoinLRPCacheIPs(nodeName, gwLRPIPs); err != nil {
+			klog.Errorf("Failed to add reserved IPs to the join switch IP cache: %s", err.Error())
+		}
+	}
+	return err
+}
+
+// ensureJoinLRPIPs tries to allocate the LRP IPs if it is not yet allocated, then they will be stored in the cache
+func (jsIPManager *joinSwitchIPManager) ensureJoinLRPIPs(nodeName string) (gwLRPIPs []*net.IPNet, err error) {
+	var ok bool
+	// first check the IP cache, return if an entry already exists
+	gwLRPIPs, ok = jsIPManager.getJoinLRPCacheIPs(nodeName)
+	if ok {
+		return gwLRPIPs, nil
+	}
+	gwLRPIPs, err = jsIPManager.lsm.AllocateNextIPs(util.OVNJoinSwitch)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil {
+			if relErr := jsIPManager.lsm.ReleaseIPs(util.OVNJoinSwitch, gwLRPIPs); relErr != nil {
+				klog.Errorf("Failed to release logical router port IPs %v for node %s: %q",
+					util.JoinIPNetIPs(gwLRPIPs, " "), nodeName, relErr)
+			}
+		}
+	}()
+
+	if err = jsIPManager.setJoinLRPCacheIPs(nodeName, gwLRPIPs); err != nil {
+		klog.Errorf("Failed to add allocated IPs to the join switch IP cache: %s", err.Error())
+		return nil, err
+	}
+
+	return gwLRPIPs, nil
+}
+
+func (jsIPManager *joinSwitchIPManager) releaseJoinLRPIPs(nodeName string) error {
+	var err error
+
+	gwLRPIPs, ok := jsIPManager.getJoinLRPCacheIPs(nodeName)
+	if ok {
+		err = jsIPManager.lsm.ReleaseIPs(util.OVNJoinSwitch, gwLRPIPs)
+		jsIPManager.delJoinLRPCacheIPs(nodeName)
+	}
+	return err
+}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -133,10 +133,6 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	// The gateway router need to be connected to the distributed router via a per-node join switch.
 	// We need a subnet allocator that allocates subnet for this per-node join switch.
 	if config.IPv4Mode {
-		// Use 100.64.0.0/16 with /29 subnets, allowing 8192 nodes with 6 IPs on each. (The join
-		// switches currently only have 2 IPs on them, so this leaves some room for expansion.)
-		_, joinSubnetCIDR, _ := net.ParseCIDR(config.V4JoinSubnet)
-		_ = oc.joinSubnetAllocator.AddNetworkRange(joinSubnetCIDR, 29)
 		// initialize the subnet required for DNAT and SNAT ip for the shared gateway mode
 		_, nodeLocalNatSubnetCIDR, _ := net.ParseCIDR(util.V4NodeLocalNatSubnet)
 		oc.nodeLocalNatIPv4Allocator, _ = ipallocator.NewCIDRRange(nodeLocalNatSubnetCIDR)
@@ -145,9 +141,6 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		_ = oc.nodeLocalNatIPv4Allocator.Allocate(net.ParseIP(util.V4NodeLocalDistributedGwPortIP))
 	}
 	if config.IPv6Mode {
-		// Use fd98::/48 with /64 subnets
-		_, joinSubnetCIDR, _ := net.ParseCIDR(config.V6JoinSubnet)
-		_ = oc.joinSubnetAllocator.AddNetworkRange(joinSubnetCIDR, 64)
 		// initialize the subnet required for DNAT and SNAT ip for the shared gateway mode
 		_, nodeLocalNatSubnetCIDR, _ := net.ParseCIDR(util.V6NodeLocalNatSubnet)
 		oc.nodeLocalNatIPv6Allocator, _ = ipallocator.NewCIDRRange(nodeLocalNatSubnetCIDR)
@@ -158,9 +151,10 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 
 	existingNodes, err := oc.kube.GetNodes()
 	if err != nil {
-		klog.Errorf("Error in initializing/fetching subnets: %v", err)
+		klog.Errorf("Error in fetching nodes: %v", err)
 		return err
 	}
+
 	for _, clusterEntry := range config.Default.ClusterSubnets {
 		err := oc.masterSubnetAllocator.AddNetworkRange(clusterEntry.CIDR, clusterEntry.HostSubnetLength)
 		if err != nil {
@@ -171,13 +165,6 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		hostSubnets, _ := util.ParseNodeHostSubnetAnnotation(&node)
 		for _, hostSubnet := range hostSubnets {
 			err := oc.masterSubnetAllocator.MarkAllocatedNetwork(hostSubnet)
-			if err != nil {
-				utilruntime.HandleError(err)
-			}
-		}
-		joinsubnets, _ := util.ParseNodeJoinSubnetAnnotation(&node)
-		for _, joinsubnet := range joinsubnets {
-			err := oc.joinSubnetAllocator.MarkAllocatedNetwork(joinsubnet)
 			if err != nil {
 				utilruntime.HandleError(err)
 			}
@@ -327,60 +314,55 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 			return err
 		}
 	}
-	return nil
-}
 
-func (oc *Controller) addNodeJoinSubnetAnnotations(node *kapi.Node, subnets []*net.IPNet) error {
-	nodeAnnotations, err := util.CreateNodeJoinSubnetAnnotation(subnets)
+	// Initialize the OVNJoinSwitch switch IP manager
+	// The OVNJoinSwitch will be allocated IP addresses in the range 100.64.0.0/16 or fd98::/64.
+	oc.joinSwIPManager, err = initJoinLogicalSwitchIPManager()
 	if err != nil {
-		return fmt.Errorf("failed to marshal node %q join subnets annotation for subnet %s",
-			node.Name, util.JoinIPNets(subnets, ","))
+		return err
 	}
-	err = oc.kube.SetAnnotationsOnNode(node, nodeAnnotations)
+
+	// Allocate IPs for logical router port "GwRouterToJoinSwitchPrefix + OVNClusterRouter". This should always
+	// allocate the first IPs in the join switch subnets
+	gwLRPIfAddrs, err := oc.joinSwIPManager.ensureJoinLRPIPs(util.OVNClusterRouter)
 	if err != nil {
-		return fmt.Errorf("failed to set node-join-subnets annotation on node %s: %v",
-			node.Name, err)
-	}
-	return nil
-}
-
-func (oc *Controller) allocateJoinSubnet(node *kapi.Node) ([]*net.IPNet, error) {
-	joinSubnets, err := util.ParseNodeJoinSubnetAnnotation(node)
-	if err == nil {
-		return joinSubnets, nil
+		return fmt.Errorf("failed to allocate join switch IP address connected to %s: %v", util.OVNClusterRouter, err)
 	}
 
-	// Allocate a new network for the join switch
-	joinSubnets, err = oc.joinSubnetAllocator.AllocateNetworks()
+	// Create OVNJoinSwitch that will be used to connect gateway routers to the distributed router.
+	_, stderr, err = util.RunOVNNbctl("--may-exist", "ls-add", util.OVNJoinSwitch)
 	if err != nil {
-		return nil, fmt.Errorf("error allocating subnet for join switch for node %s: %v", node.Name, err)
+		klog.Errorf("Failed to create logical switch %s, stderr: %q, error: %v", util.OVNJoinSwitch, stderr, err)
+		return err
 	}
 
-	defer func() {
-		// Release the allocation on error
-		if err != nil {
-			for _, joinSubnet := range joinSubnets {
-				_ = oc.joinSubnetAllocator.ReleaseNetwork(joinSubnet)
-			}
-		}
-	}()
-
-	// Set annotation on the node
-	err = oc.addNodeJoinSubnetAnnotations(node, joinSubnets)
+	// Connect the distributed router to OVNJoinSwitch.
+	drSwitchPort := util.JoinSwitchToGwRouterPrefix + util.OVNClusterRouter
+	drRouterPort := util.GwRouterToJoinSwitchPrefix + util.OVNClusterRouter
+	gwLRPMAC := util.IPAddrToHWAddr(gwLRPIfAddrs[0].IP)
+	args := []string{
+		"--", "--if-exists", "lrp-del", drRouterPort,
+		"--", "lrp-add", util.OVNClusterRouter, drRouterPort, gwLRPMAC.String(),
+	}
+	for _, gwLRPIfAddr := range gwLRPIfAddrs {
+		args = append(args, gwLRPIfAddr.String())
+	}
+	_, stderr, err = util.RunOVNNbctl(args...)
 	if err != nil {
-		return nil, err
+		klog.Errorf("Failed to add logical router port %s, stderr: %q, error: %v", drRouterPort, stderr, err)
+		return err
 	}
 
-	klog.Infof("Allocated join subnet %q for node %q", util.JoinIPNets(joinSubnets, ","), node.Name)
-	return joinSubnets, nil
-}
-
-func (oc *Controller) deleteNodeJoinSubnet(nodeName string, subnet *net.IPNet) error {
-	err := oc.joinSubnetAllocator.ReleaseNetwork(subnet)
+	// Connect the switch OVNJoinSwitch to the router.
+	_, stderr, err = util.RunOVNNbctl("--may-exist", "lsp-add", util.OVNJoinSwitch,
+		drSwitchPort, "--", "set", "logical_switch_port", drSwitchPort, "type=router",
+		"options:router-port="+drRouterPort, "addresses=router")
 	if err != nil {
-		return fmt.Errorf("error deleting join subnet %v for node %q: %s", subnet, nodeName, err)
+		klog.Errorf("Failed to add router-type logical switch port %s to %s, stderr: %q, error: %v",
+			drSwitchPort, util.OVNJoinSwitch, stderr, err)
+		return err
 	}
-	klog.Infof("Deleted JoinSubnet %v for node %s", subnet, nodeName)
+
 	return nil
 }
 
@@ -467,18 +449,18 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig *util.L3GatewayConfig,
 	hostSubnets []*net.IPNet) error {
 	var err error
-	var clusterSubnets []*net.IPNet
+	var gwLRPIPs, clusterSubnets []*net.IPNet
 	for _, clusterSubnet := range config.Default.ClusterSubnets {
 		clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR)
 	}
 
-	// get a subnet for the per-node join switch
-	joinSubnets, err := oc.allocateJoinSubnet(node)
+	gwLRPIPs, err = oc.joinSwIPManager.ensureJoinLRPIPs(node.Name)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to allocate join switch port IP address for node %s: %v", node.Name, err)
 	}
 
-	err = gatewayInit(node.Name, clusterSubnets, hostSubnets, joinSubnets, l3GatewayConfig, oc.SCTPSupport)
+	drLRPIPs, _ := oc.joinSwIPManager.getJoinLRPCacheIPs(util.OVNClusterRouter)
+	err = gatewayInit(node.Name, clusterSubnets, hostSubnets, l3GatewayConfig, oc.SCTPSupport, gwLRPIPs, drLRPIPs)
 	if err != nil {
 		return fmt.Errorf("failed to init shared interface gateway: %v", err)
 	}
@@ -788,17 +770,12 @@ func (oc *Controller) deleteNodeLogicalNetwork(nodeName string) error {
 	return nil
 }
 
-func (oc *Controller) deleteNode(nodeName string, hostSubnets, joinSubnets []*net.IPNet,
+func (oc *Controller) deleteNode(nodeName string, hostSubnets []*net.IPNet,
 	nodeLocalNatIPs []net.IP) error {
 	// Clean up as much as we can but don't hard error
 	for _, hostSubnet := range hostSubnets {
 		if err := oc.deleteNodeHostSubnet(nodeName, hostSubnet); err != nil {
 			klog.Errorf("Error deleting node %s HostSubnet %v: %v", nodeName, hostSubnet, err)
-		}
-	}
-	for _, joinSubnet := range joinSubnets {
-		if err := oc.deleteNodeJoinSubnet(nodeName, joinSubnet); err != nil {
-			klog.Errorf("Error deleting node %s JoinSubnet %v: %v", nodeName, joinSubnet, err)
 		}
 	}
 	for _, nodeLocalNatIP := range nodeLocalNatIPs {
@@ -819,6 +796,10 @@ func (oc *Controller) deleteNode(nodeName string, hostSubnets, joinSubnets []*ne
 
 	if err := gatewayCleanup(nodeName); err != nil {
 		return fmt.Errorf("failed to clean up node %s gateway: (%v)", nodeName, err)
+	}
+
+	if err := oc.joinSwIPManager.releaseJoinLRPIPs(nodeName); err != nil {
+		return err
 	}
 
 	if err := oc.deleteNodeChassis(nodeName); err != nil {
@@ -946,6 +927,9 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 			continue
 		}
 		foundNodes[node.Name] = node
+		// For each existing node, reserve its joinSwitch LRP IPs if they already exist.
+		gwLRPIPs := oc.getJoinLRPAddresses(node.Name)
+		_ = oc.joinSwIPManager.reserveJoinLRPIPs(node.Name, gwLRPIPs)
 	}
 
 	// We only deal with cleaning up nodes that shouldn't exist here, since
@@ -969,30 +953,20 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 	}
 
 	nodeSwitches, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=name,other-config", "find", "logical_switch")
+		"--format=csv", "--columns=name,other-config", "find", "logical_switch")
 	if err != nil {
 		klog.Errorf("Failed to get node logical switches: stderr: %q, error: %v",
 			stderr, err)
 		return
 	}
 
-	type NodeSubnets struct {
-		hostSubnets []*net.IPNet
-		joinSubnets []*net.IPNet
-	}
-	NodeSubnetsMap := make(map[string]*NodeSubnets)
-	for _, result := range strings.Split(nodeSwitches, "\n\n") {
+	for _, result := range strings.Split(nodeSwitches, "\n") {
 		// Split result into name and other-config
-		items := strings.Split(result, "\n")
+		items := strings.Split(result, ",")
 		if len(items) != 2 || len(items[0]) == 0 {
 			continue
 		}
-		isJoinSwitch := false
 		nodeName := items[0]
-		if strings.HasPrefix(items[0], util.JoinSwitchPrefix) {
-			isJoinSwitch = true
-			nodeName = strings.Split(items[0], "_")[1]
-		}
 		if _, ok := foundNodes[nodeName]; ok {
 			// node still exists, no cleanup to do
 			continue
@@ -1017,21 +991,7 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 			continue
 		}
 
-		var tmp NodeSubnets
-		nodeSubnets, ok := NodeSubnetsMap[nodeName]
-		if !ok {
-			nodeSubnets = &tmp
-			NodeSubnetsMap[nodeName] = nodeSubnets
-		}
-		if isJoinSwitch {
-			nodeSubnets.joinSubnets = subnets
-		} else {
-			nodeSubnets.hostSubnets = subnets
-		}
-	}
-
-	for nodeName, nodeSubnets := range NodeSubnetsMap {
-		if err := oc.deleteNode(nodeName, nodeSubnets.hostSubnets, nodeSubnets.joinSubnets, nil); err != nil {
+		if err := oc.deleteNode(nodeName, subnets, nil); err != nil {
 			klog.Error(err)
 		}
 		//remove the node from the chassis map so we don't delete it twice

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -122,7 +122,7 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --columns=_uuid list port_group",
 		"ovn-sbctl --timeout=15 --columns=_uuid list IGMP_Group",
-		"ovn-nbctl --timeout=15 -- --may-exist lr-add ovn_cluster_router -- set logical_router ovn_cluster_router external_ids:k8s-cluster-router=yes",
+		"ovn-nbctl --timeout=15 -- --may-exist lr-add ovn_cluster_router -- set logical_router ovn_cluster_router external_ids:k8s-cluster-router=yes external_ids:k8s-ovn-topo-version=1",
 	})
 	if sctpSupport {
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -80,20 +80,19 @@ func cleanupGateway(fexec *ovntest.FakeExec, nodeName string, nodeSubnet string,
 
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port " + util.GwRouterToJoinSwitchPrefix + util.GwRouterPrefix + nodeName + " networks",
-		Output: "[\"100.64.0.1/29\"]",
+		Output: "[\"100.64.0.3/16\"]",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=\"100.64.0.1\"",
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_static_route nexthop=\"100.64.0.3\"",
 		Output: node1RouteUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists remove logical_router " + util.OVNClusterRouter + " static_routes " + node1RouteUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exist ls-del " + util.JoinSwitchPrefix + nodeName,
+		"ovn-nbctl --timeout=15 --if-exist lsp-del " + util.JoinSwitchToGwRouterPrefix + util.GwRouterPrefix + nodeName,
 		"ovn-nbctl --timeout=15 --if-exist lr-del " + util.GwRouterPrefix + nodeName,
 		"ovn-nbctl --timeout=15 --if-exist ls-del " + util.ExternalSwitchPrefix + nodeName,
-		"ovn-nbctl --timeout=15 --if-exist lrp-del " + util.DistRouterToJoinSwitchPrefix + nodeName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=" + util.GwRouterPrefix + nodeName,
@@ -171,6 +170,20 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 			Output: sctpLBUUID,
 		})
 	}
+	drSwitchPort := util.JoinSwitchToGwRouterPrefix + util.OVNClusterRouter
+	drRouterPort := util.GwRouterToJoinSwitchPrefix + util.OVNClusterRouter
+	joinSubnetV4 := ovntest.MustParseIPNet("100.64.0.1/16")
+	joinLRPMAC := util.IPAddrToHWAddr(joinSubnetV4.IP)
+	joinSubnetV6 := ovntest.MustParseIPNet("fd98::1/64")
+
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --may-exist ls-add " + util.OVNJoinSwitch,
+		"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + drRouterPort + " -- lrp-add " + util.OVNClusterRouter + " " + drRouterPort +
+			" " + joinLRPMAC.String() + " " + joinSubnetV4.String() + " " + joinSubnetV6.String(),
+		"ovn-nbctl --timeout=15 --may-exist lsp-add " + util.OVNJoinSwitch + " " + drSwitchPort + " -- set logical_switch_port " +
+			drSwitchPort + " type=router options:router-port=" + drRouterPort + " addresses=router",
+	})
+
 	// Node-related logical network stuff
 	cidr := ovntest.MustParseIPNet(nodeSubnet)
 	cidr.IP = util.NextIP(cidr.IP)
@@ -181,7 +194,8 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	hybridOverlayIP := util.NextIP(nodeMgmtPortIP)
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch",
+		"ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + nodeName + " networks",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --format=csv --columns=name,other-config find logical_switch",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists lrp-del " + util.RouterToSwitchPrefix + nodeName + " -- lrp-add ovn_cluster_router " + util.RouterToSwitchPrefix + nodeName + " " + lrpMAC + " " + gwCIDR,
@@ -612,6 +626,9 @@ var _ = Describe("Master Operations", func() {
 			)
 
 			fexec := ovntest.NewFakeExec()
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + masterName + " networks",
+			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch",
 				// Return two nodes
@@ -719,8 +736,8 @@ subnet=%s
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
 			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
-
-			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 29)
+			clusterController.joinSwIPManager, _ = initJoinLogicalSwitchIPManager()
+			_, _ = clusterController.joinSwIPManager.ensureJoinLRPIPs(util.OVNClusterRouter)
 
 			// Let the real code run and ensure OVN database sync
 			clusterController.WatchNodes()
@@ -790,11 +807,10 @@ var _ = Describe("Gateway Init Operations", func() {
 			const (
 				nodeName               string = "node1"
 				nodeLRPMAC             string = "0a:58:0a:01:01:01"
-				joinSubnet             string = "100.64.0.0/29"
-				lrpMAC                 string = "0a:58:64:40:00:01"
-				lrpIP                  string = "100.64.0.1"
-				drLrpMAC               string = "0a:58:64:40:00:02"
-				drLrpIP                string = "100.64.0.2"
+				lrpMAC                 string = "0a:58:64:40:00:02"
+				lrpIP                  string = "100.64.0.2"
+				lrpIPv6                string = "fd98::2"
+				drLrpIP                string = "100.64.0.1"
 				brLocalnetMAC          string = "11:22:33:44:55:66"
 				systemID               string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 				tcpLBUUID              string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
@@ -854,8 +870,6 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(nodeSubnet))
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeJoinSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(joinSubnet))
-			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -865,6 +879,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + nodeName + " networks",
 				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch",
 			})
 
@@ -889,15 +904,11 @@ var _ = Describe("Gateway Init Operations", func() {
 				Cmd:    "ovn-nbctl --timeout=15 lsp-list " + nodeName,
 				Output: "29df5ce5-2802-4ee5-891f-4fb27ca776e9 (" + util.K8sPrefix + nodeName + ")",
 			})
-			joinSwitch := util.JoinSwitchPrefix + nodeName
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2",
-				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " " + util.JoinSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.JoinSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToJoinSwitchPrefix + gwRouter + " addresses=router",
-				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToJoinSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToJoinSwitchPrefix + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " " + util.JoinSwitchToDistRouterPrefix + nodeName + " -- set logical_switch_port " + util.JoinSwitchToDistRouterPrefix + nodeName + " type=router options:router-port=" + util.DistRouterToJoinSwitchPrefix + nodeName + " addresses=router",
-				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.DistRouterToJoinSwitchPrefix + nodeName + " -- lrp-add " + util.OVNClusterRouter + " " + util.DistRouterToJoinSwitchPrefix + nodeName + " " + drLrpMAC + " " + drLrpIP + "/29",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OvnJoinSwitch + " " + util.JoinSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.JoinSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToJoinSwitchPrefix + gwRouter + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToJoinSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToJoinSwitchPrefix + gwRouter + " " + lrpMAC + " " + lrpIP + "/16" + " " + lrpIPv6 + "/64",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
@@ -912,6 +923,8 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToExtSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToExtSwitchPrefix + gwRouter + " " + brLocalnetMAC + " 169.254.33.2/24 -- set logical_router_port " + util.GwRouterToExtSwitchPrefix + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.ExternalSwitchPrefix + nodeName + " " + util.ExtSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.ExtSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToExtSwitchPrefix + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 " + util.GwRouterToExtSwitchPrefix + gwRouter,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + util.OVNClsuterRouter + " " + lrpIP + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + util.OVNClusterRouter + " " + lrpIPv6 + " " + lrpIPv6,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + util.OVNClusterRouter + " " + nodeSubnet + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + gwRouter + " snat " + clusterCIDR + " -- lr-nat-add " +
 					gwRouter + " snat 169.254.33.2 " + clusterCIDR,
@@ -922,11 +935,8 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2",
-				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " " + util.JoinSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.JoinSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToJoinSwitchPrefix + gwRouter + " addresses=router",
-				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToJoinSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToJoinSwitchPrefix + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " " + util.JoinSwitchToDistRouterPrefix + nodeName + " -- set logical_switch_port " + util.JoinSwitchToDistRouterPrefix + nodeName + " type=router options:router-port=" + util.DistRouterToJoinSwitchPrefix + nodeName + " addresses=router",
-				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.DistRouterToJoinSwitchPrefix + nodeName + " -- lrp-add " + util.OVNClusterRouter + " " + util.DistRouterToJoinSwitchPrefix + nodeName + " " + drLrpMAC + " " + drLrpIP + "/29",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OVNJoinSwitch + " " + util.JoinSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.JoinSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToJoinSwitchPrefix + gwRouter + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToJoinSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToJoinSwitchPrefix + gwRouter + " " + lrpMAC + " " + lrpIP + "/16" + " " + lrpIPv6 + "/64",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
@@ -941,6 +951,8 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToExtSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToExtSwitchPrefix + gwRouter + " " + brLocalnetMAC + " 169.254.33.2/24 -- set logical_router_port " + util.GwRouterToExtSwitchPrefix + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.ExternalSwitchPrefix + nodeName + " " + util.ExtSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.ExtSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToExtSwitchPrefix + gwRouter + " addresses=\"" + brLocalnetMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 169.254.33.1 " + util.GwRouterToExtSwitchPrefix + gwRouter,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + util.OVNClusterRouter + " " + lrpIP + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + util.OVNClusterRouter + " " + lrpIPv6 + " " + lrpIPv6,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + util.OVNClusterRouter + " " + nodeSubnet + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + gwRouter + " snat " + clusterCIDR +
 					" -- lr-nat-add " + gwRouter + " snat 169.254.33.2 " + clusterCIDR,
@@ -961,8 +973,8 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
 			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
-
-			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 29)
+			clusterController.joinSwIPManager, _ = initJoinLogicalSwitchIPManager()
+			_, _ = clusterController.joinSwIPManager.ensureJoinLRPIPs(util.OVNClusterRouter)
 
 			// Let the real code run and ensure OVN database sync
 			clusterController.WatchNodes()
@@ -991,11 +1003,10 @@ var _ = Describe("Gateway Init Operations", func() {
 			const (
 				nodeName             string = "node1"
 				nodeLRPMAC           string = "0a:58:0a:01:01:01"
-				joinSubnet           string = "100.64.0.0/29"
-				lrpMAC               string = "0a:58:64:40:00:01"
-				lrpIP                string = "100.64.0.1"
-				drLrpMAC             string = "0a:58:64:40:00:02"
-				drLrpIP              string = "100.64.0.2"
+				lrpMAC               string = "0a:58:64:40:00:02"
+				lrpIP                string = "100.64.0.2"
+				lrpIPv6              string = "fd98::2"
+				drLrpIP              string = "100.64.0.1"
 				physicalBridgeMAC    string = "11:22:33:44:55:66"
 				systemID             string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 				tcpLBUUID            string = "d2e858b2-cb5a-441b-a670-ed450f79a91f"
@@ -1056,8 +1067,6 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(nodeSubnet))
 			Expect(err).NotTo(HaveOccurred())
-			err = util.SetNodeJoinSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(joinSubnet))
-			Expect(err).NotTo(HaveOccurred())
 			err = util.SetNodeLocalNatAnnotation(nodeAnnotator, []net.IP{ovntest.MustParseIP(dnatSnatIP)})
 			Expect(err).NotTo(HaveOccurred())
 			err = nodeAnnotator.Run()
@@ -1069,7 +1078,8 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch",
+				"ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_" + nodeName + " networks",
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --format=csv --columns=name,other-config find logical_switch",
 			})
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -1093,18 +1103,16 @@ var _ = Describe("Gateway Init Operations", func() {
 				Cmd:    "ovn-nbctl --timeout=15 lsp-list " + nodeName,
 				Output: "29df5ce5-2802-4ee5-891f-4fb27ca776e9 (" + util.K8sPrefix + nodeName + ")",
 			})
-			joinSwitch := util.JoinSwitchPrefix + nodeName
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + gatewayRouterIP + " external_ids:physical_ips=" + gatewayRouterIP,
-				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " " + util.JoinSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.JoinSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToJoinSwitchPrefix + gwRouter + " addresses=router",
-				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToJoinSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToJoinSwitchPrefix + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " " + util.JoinSwitchToDistRouterPrefix + nodeName + " -- set logical_switch_port " + util.JoinSwitchToDistRouterPrefix + nodeName + " type=router options:router-port=" + util.DistRouterToJoinSwitchPrefix + nodeName + " addresses=router",
-				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.DistRouterToJoinSwitchPrefix + nodeName + " -- lrp-add " + util.OVNClusterRouter + " " + util.DistRouterToJoinSwitchPrefix + nodeName + " " + drLrpMAC + " " + drLrpIP + "/29",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OVNJoinSwitch + " " + util.JoinSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.JoinSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToJoinSwitchPrefix + gwRouter + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToJoinSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToJoinSwitchPrefix + gwRouter + " " + lrpMAC + " " + lrpIP + "/16" + " " + lrpIPv6 + "/64",
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
+				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP + " " + lrpIPv6,
+				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:always_learn_from_arp_request=false",
+				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:dynamic_neigh_routers=true",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " " + drLrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID, sctpLBUUID)
@@ -1116,6 +1124,8 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToExtSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToExtSwitchPrefix + gwRouter + " " + physicalBridgeMAC + " " + gatewayRouterIPMask + " -- set logical_router_port " + util.GwRouterToExtSwitchPrefix + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.ExternalSwitchPrefix + nodeName + " " + util.ExtSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.ExtSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToExtSwitchPrefix + gwRouter + " addresses=\"" + physicalBridgeMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + gatewayRouterNextHop + " " + util.GwRouterToExtSwitchPrefix + gwRouter,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + util.OVNClusterRouter + " " + lrpIP + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + util.OVNClusterRouter + " " + lrpIPv6 + " " + lrpIPv6,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + util.OVNClusterRouter + " " + nodeSubnet + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + gwRouter + " snat " + clusterCIDR +
 					" -- lr-nat-add " + gwRouter + " snat " + gatewayRouterIP + " " + clusterCIDR,
@@ -1129,15 +1139,14 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + gatewayRouterIP + " external_ids:physical_ips=" + gatewayRouterIP,
-				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " " + util.JoinSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.JoinSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToJoinSwitchPrefix + gwRouter + " addresses=router",
-				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToJoinSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToJoinSwitchPrefix + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " " + util.JoinSwitchToDistRouterPrefix + nodeName + " -- set logical_switch_port " + util.JoinSwitchToDistRouterPrefix + nodeName + " type=router options:router-port=" + util.DistRouterToJoinSwitchPrefix + nodeName + " addresses=router",
-				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.DistRouterToJoinSwitchPrefix + nodeName + " -- lrp-add " + util.OVNClusterRouter + " " + util.DistRouterToJoinSwitchPrefix + nodeName + " " + drLrpMAC + " " + drLrpIP + "/29",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OVNJoinSwitch + " " + util.JoinSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.JoinSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToJoinSwitchPrefix + gwRouter + " addresses=router",
+				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToJoinSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToJoinSwitchPrefix + gwRouter + " " + lrpMAC + " " + lrpIP + "/16" + " " + lrpIPv6 + "/64",
 			})
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP,
+				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:lb_force_snat_ip=" + lrpIP + " " + lrpIPv6,
+				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:always_learn_from_arp_request=false",
+				"ovn-nbctl --timeout=15 set logical_router " + gwRouter + " options:dynamic_neigh_routers=true",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " " + clusterCIDR + " " + drLrpIP,
 			})
 			addNodeportLBs(fexec, nodeName, tcpLBUUID, udpLBUUID, sctpLBUUID)
@@ -1149,6 +1158,8 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + util.GwRouterToExtSwitchPrefix + gwRouter + " -- lrp-add " + gwRouter + " " + util.GwRouterToExtSwitchPrefix + gwRouter + " " + physicalBridgeMAC + " " + gatewayRouterIPMask + " -- set logical_router_port " + util.GwRouterToExtSwitchPrefix + gwRouter + " external-ids:gateway-physical-ip=yes",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.ExternalSwitchPrefix + nodeName + " " + util.ExtSwitchToGwRouterPrefix + gwRouter + " -- set logical_switch_port " + util.ExtSwitchToGwRouterPrefix + gwRouter + " type=router options:router-port=" + util.GwRouterToExtSwitchPrefix + gwRouter + " addresses=\"" + physicalBridgeMAC + "\"",
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + gwRouter + " 0.0.0.0/0 " + gatewayRouterNextHop + " " + util.GwRouterToExtSwitchPrefix + gwRouter,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + util.OVNClusterRouter + " " + lrpIP + " " + lrpIP,
+				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + util.OVNClusterRouter + " " + lrpIPv6 + " " + lrpIPv6,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + util.OVNClusterRouter + " " + nodeSubnet + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + gwRouter + " snat " + clusterCIDR +
 					" -- lr-nat-add " + gwRouter + " snat " + gatewayRouterIP + " " + clusterCIDR,
@@ -1172,8 +1183,9 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.UDPLoadBalancerUUID = udpLBUUID
 			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
+			clusterController.joinSwIPManager, _ = initJoinLogicalSwitchIPManager()
+			_, _ = clusterController.joinSwIPManager.ensureJoinLRPIPs(util.OVNClusterRouter)
 
-			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 29)
 			clusterController.nodeLocalNatIPv4Allocator, _ = ipallocator.NewCIDRRange(ovntest.MustParseIPNet(util.V4NodeLocalNatSubnet))
 
 			// Let the real code run and ensure OVN database sync

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -29,32 +29,6 @@ func intToIP(i *big.Int) net.IP {
 	return net.IP(i.Bytes())
 }
 
-// GetNodeGatewayRouterIPs returns the IPs (IPv4 and/or IPv6) of the provided node's logical router
-// Expected output from the ovn-nbctl command, which will need to be parsed is:
-// `100.64.1.1/29 fd98:1::/125`
-func GetNodeGatewayRouterIPs(nodeName string) ([]net.IP, error) {
-	stdout, _, err := RunOVNNbctl(
-		"--format=table",
-		"--data=bare",
-		"--no-heading",
-		"--columns=networks",
-		"find", "logical_router_port",
-		fmt.Sprintf("name=%s%s%s", GwRouterToJoinSwitchPrefix, GwRouterPrefix, nodeName),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve the logical router for node: %s, err: %v", nodeName, err)
-	}
-	var ips []net.IP
-	for _, gatewayRouterIfAddr := range strings.Fields(stdout) {
-		if ip, _, err := net.ParseCIDR(gatewayRouterIfAddr); err == nil {
-			ips = append(ips, ip)
-		} else {
-			return nil, fmt.Errorf("unable to parse the found gateway router IP address: %s", gatewayRouterIfAddr)
-		}
-	}
-	return ips, nil
-}
-
 // GetPortAddresses returns the MAC and IPs of the given logical switch port
 func GetPortAddresses(portName string, ovnNBClient goovn.Client) (net.HardwareAddr, []net.IP, error) {
 	lsp, err := ovnNBClient.LSPGet(portName)
@@ -98,6 +72,31 @@ func GetPortAddresses(portName string, ovnNBClient goovn.Client) (net.HardwareAd
 		ips = append(ips, ip)
 	}
 	return mac, ips, nil
+}
+
+// GetLRPAddrs returns the addresses for the given logical router port
+func GetLRPAddrs(portName string) ([]*net.IPNet, error) {
+	networks := []*net.IPNet{}
+	output, stderr, err := RunOVNNbctl("--if-exist", "get", "logical_router_port", portName, "networks")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get logical router port %s, "+
+			"stderr: %q, error: %v", portName, stderr, err)
+	}
+
+	// eg: `["100.64.0.3/16", "fd98::3/64"]`
+	output = strings.Trim(output, "[]")
+	if output != "" {
+		for _, ipNetStr := range strings.Split(output, ", ") {
+			ipNetStr = strings.Trim(ipNetStr, "\"")
+			ip, cidr, err := net.ParseCIDR(ipNetStr)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse logical router port %q: %v",
+					ipNetStr, err)
+			}
+			networks = append(networks, &net.IPNet{IP: ip, Mask: cidr.Mask})
+		}
+	}
+	return networks, nil
 }
 
 // GetOVSPortMACAddress returns the MAC address of a given OVS port

--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -19,10 +19,6 @@ import (
 //       {
 //         "default": "10.130.0.0/23"
 //       }
-//     k8s.ovn.org/node-join-subnets: |
-//       {
-//         "default": "100.64.2.0/29"
-//       }
 //     k8s.ovn.org/node-local-nat-ip: |
 //       {
 //         "default": ["169.254.16.21", "fd99::10:21"]
@@ -38,16 +34,10 @@ import (
 //       {
 //         "default": ["10.130.0.0/23", "fd01:0:0:2::/64"]
 //       }
-//     k8s.ovn.org/node-join-subnets: |
-//       {
-//         "default": ["100.64.2.0/29", "fd99::10/125"]
-//       }
 
 const (
 	// ovnNodeSubnets is the constant string representing the node subnets annotation key
 	ovnNodeSubnets = "k8s.ovn.org/node-subnets"
-	// ovnNodeJoinSubnets is the constant string representing the node's join switch subnets annotation key
-	ovnNodeJoinSubnets = "k8s.ovn.org/node-join-subnets"
 	// ovnNodeLocalNatIP is the constant string representing the node management port's NAT IP
 	// used in the case of the shared gateway mode
 	ovnNodeLocalNatIP = "k8s.ovn.org/node-local-nat-ip"
@@ -143,24 +133,6 @@ func DeleteNodeHostSubnetAnnotation(nodeAnnotator kube.Annotator) {
 // on a node and returns the "default" host subnet.
 func ParseNodeHostSubnetAnnotation(node *kapi.Node) ([]*net.IPNet, error) {
 	return parseSubnetAnnotation(node, ovnNodeSubnets)
-}
-
-// CreateNodeJoinSubnetAnnotation creates a "k8s.ovn.org/node-join-subnets" annotation,
-// with a single "default" network, suitable for passing to kube.SetAnnotationsOnNode
-func CreateNodeJoinSubnetAnnotation(defaultSubnets []*net.IPNet) (map[string]interface{}, error) {
-	return createSubnetAnnotation(ovnNodeJoinSubnets, defaultSubnets)
-}
-
-// SetNodeJoinSubnetAnnotation sets a "k8s.ovn.org/node-join-subnets" annotation
-// using a kube.Annotator
-func SetNodeJoinSubnetAnnotation(nodeAnnotator kube.Annotator, defaultSubnets []*net.IPNet) error {
-	return setSubnetAnnotation(nodeAnnotator, ovnNodeJoinSubnets, defaultSubnets)
-}
-
-// ParseNodeJoinSubnetAnnotation parses the "k8s.ovn.org/node-join-subnets" annotation on
-// a node and returns the "default" join subnet.
-func ParseNodeJoinSubnetAnnotation(node *kapi.Node) ([]*net.IPNet, error) {
-	return parseSubnetAnnotation(node, ovnNodeJoinSubnets)
 }
 
 // CreateNodeLocalNatAnnotation creates a "k8s.ovn.org/node-local-nat-ip" annotation,

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -30,18 +30,19 @@ const (
 	// OVNClusterRouter is the name of the distributed router
 	OVNClusterRouter = "ovn_cluster_router"
 
-	JoinSwitchPrefix             = "join_"
-	ExternalSwitchPrefix         = "ext_"
-	GwRouterPrefix               = "GR_"
-	RouterToSwitchPrefix         = "rtos-"
-	InterPrefix                  = "inter-"
-	SwitchToRouterPrefix         = "stor-"
-	JoinSwitchToGwRouterPrefix   = "jtor-"
-	GwRouterToJoinSwitchPrefix   = "rtoj-"
-	DistRouterToJoinSwitchPrefix = "dtoj-"
-	JoinSwitchToDistRouterPrefix = "jtod-"
-	ExtSwitchToGwRouterPrefix    = "etor-"
-	GwRouterToExtSwitchPrefix    = "rtoe-"
+	// OVNJoinSwitch is the name of the join switch
+	OVNJoinSwitch = "join"
+
+	JoinSwitchPrefix           = "join_"
+	ExternalSwitchPrefix       = "ext_"
+	GwRouterPrefix             = "GR_"
+	RouterToSwitchPrefix       = "rtos-"
+	InterPrefix                = "inter-"
+	SwitchToRouterPrefix       = "stor-"
+	JoinSwitchToGwRouterPrefix = "jtor-"
+	GwRouterToJoinSwitchPrefix = "rtoj-"
+	ExtSwitchToGwRouterPrefix  = "etor-"
+	GwRouterToExtSwitchPrefix  = "rtoe-"
 
 	NodeLocalSwitch = "node_local_switch"
 
@@ -54,6 +55,9 @@ const (
 	V4NodeLocalNatSubnetPrefix     = 20
 	V4NodeLocalNatSubnetNextHop    = "169.254.0.1"
 	V4NodeLocalDistributedGwPortIP = "169.254.0.2"
+
+	V4JoinSubnetCidr = "100.64.0.0/16"
+	V6JoinSubnetCidr = "fd98::/64"
 )
 
 // StringArg gets the named command-line argument or returns an error if it is empty


### PR DESCRIPTION
We used to have single join switch and commit c372 changed to use
per-node join switch to reduce logical flows in the SB's
lr_in_arp_resolve table.

Since then, there are several OVN patches to provide options to change
the default behavior of OVN and reduce the logical flows in the SB.
In particular, the "dynamic_neigh_routers" option can be set to "true"
and the "learn_from_arp_request" option can be set to "false" to avoid
static neighbor flows and diabling neighbor learning from ARP request,
which minimizes the SB logical flows explosion.

With all the patches, we can now revert back to single join switch
implementation. Furture changes will be needed to set those options to
the gateway routers once OVN patches are avaible.

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->