### PR TITLE
Fixes inconsistent address set tests + Disable test code race detector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         set -x
         pushd go-controller
-           RACE=1 make check
+        make check
         popd
 
     - name: Build

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1383,6 +1383,7 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 
 		asFactory = newFakeAddressSetFactory()
 		config.IPv4Mode = true
+		config.IPv6Mode = false
 	})
 
 	It("computes match strings from address sets correctly", func() {


### PR DESCRIPTION
Test was failing because the actual command was using ipv6:
||ip6.src == {$a4417939400419858459}

Closes: #1543

Signed-off-by: Tim Rozet <trozet@redhat.com>

