### PR TITLE
ovn: pod testcase fix

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -217,10 +217,10 @@ var _ = Describe("OVN Pod Operations", func() {
 				t.nodeName = "node1"
 				t.portName = t.namespace + "_" + t.podName
 				t.populateLogicalSwitchCache(fakeOvn)
+				t.addPodDenyMcast(fExec)
 
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(t.namespace).Update(context.TODO(), newPod(t.namespace, t.podName, t.nodeName, t.podIP), metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				t.addPodDenyMcast(fExec)
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 
 				Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient, t.namespace, t.podName) }, 2).Should(MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))


### PR DESCRIPTION
Fix a race conditions in one pod testcase.

```
2020-07-27T21:36:57.3433180Z [0mOVN Pod Operations[0m [90mduring execution[0m
2020-07-27T21:36:57.3433620Z   [1mreconciles an existing pod[0m
2020-07-27T21:36:57.3434378Z   [37m/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/pods_test.go:182[0m
2020-07-27T21:36:57.4530660Z F0727 21:36:57.452872   11453 exec.go:168] Unexpected command: /fake-bin/ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports 8a86f6d8-7972-4253-b0bd-ddbef66e9303 -- add port_group mcastPortGroupDeny ports 8a86f6d8-7972-4253-b0bd-ddbef66e9303
2020-07-27T21:36:57.4531071Z
2020-07-27T21:36:57.4531547Z Executed commands do not match expected commands!
2020-07-27T21:36:57.4532670Z [00]   /fake-bin/ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_switch_port external_ids:pod=true
2020-07-27T21:36:57.4533548Z [01] + /fake-bin/ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports 8a86f6d8-7972-4253-b0bd-ddbef66e9303 -- add port_group mcastPortGroupDeny ports 8a86f6d8-7972-4253-b0bd-ddbef66e9303
2020-07-27T21:36:57.4582418Z FAIL	github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn	3.724s
```