### PR TITLE
Clear port addresses when releasing IPAM IPs

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -239,7 +239,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	var cmds []*goovn.OvnCommand
 	var addresses []string
 	var cmd *goovn.OvnCommand
-	var releaseIPs bool
+	var releaseIPs, clearAddressesFromNB bool
 
 	// Check if the pod's logical switch port already exists. If it
 	// does don't re-add the port to OVN as this will change its
@@ -274,7 +274,29 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 				klog.Errorf("Error when releasing IPs for node: %s, err: %q",
 					logicalSwitch, relErr)
 			} else {
-				klog.V(5).Infof("Released IPs: %s for node: %s", util.JoinIPNetIPs(podIfAddrs, " "), logicalSwitch)
+				klog.Infof("Released IPs: %s for node: %s", util.JoinIPNetIPs(podIfAddrs, " "), logicalSwitch)
+			}
+		}
+		if clearAddressesFromNB && err != nil {
+			var rollBackCmds []*goovn.OvnCommand
+			rollBackCmd, rollBackErr := oc.ovnNBClient.LSPSetAddress(portName, "")
+			if rollBackErr != nil {
+				klog.Errorf("Unable to create LSPSetAddress command for "+
+					"rolling back addresses on port: %s, switch :%s",
+					portName, logicalSwitch)
+			}
+			rollBackCmds = append(rollBackCmds, rollBackCmd)
+			rollBackCmd, rollBackErr = oc.ovnNBClient.LSPSetPortSecurity(portName, "")
+			if rollBackErr != nil {
+				klog.Errorf("Unable to create LSPSetPortSecurity command for "+
+					"rolling back port security addresses on port: %s, switch: %s",
+					portName, logicalSwitch)
+			}
+			rollBackCmds = append(rollBackCmds, rollBackCmd)
+			rollBackErr = oc.ovnNBClient.Execute(rollBackCmds...)
+			if rollBackErr != nil {
+				klog.Errorf("Error executing roll back commands for port: %s on switch: %s",
+					portName, logicalSwitch)
 			}
 		}
 	}()
@@ -306,12 +328,12 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		} else {
 			if len(podIfAddrs) > 0 {
 				if err = oc.lsManager.AllocateIPs(logicalSwitch, podIfAddrs); err != nil {
-					klog.Errorf("Failed to block off already allocated IPs: %s for pod %s on node: %s"+
+					klog.Warningf("Failed to block off already allocated IPs: %s for pod %s on node: %s"+
 						" error: %v", util.JoinIPNetIPs(podIfAddrs, " "), portName,
 						logicalSwitch, err)
-					return fmt.Errorf("failed to block off already allocated IPs %s: for node: %s, error: %v",
-						util.JoinIPNetIPs(podIfAddrs, " "), logicalSwitch, err)
 				}
+				// this should also be treated as an allocation for purposes of error handling
+				releaseIPs = true
 			}
 		}
 
@@ -357,7 +379,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	extIds := map[string]string{"namespace": pod.Namespace, "pod": "true"}
 	cmd, err = oc.ovnNBClient.LSPSetExternalIds(portName, extIds)
 	if err != nil {
-		return fmt.Errorf("unable to create LSPSetAddress command for port: %s", portName)
+		return fmt.Errorf("unable to create LSPSetExternalIds command for port: %s", portName)
 	}
 	cmds = append(cmds, cmd)
 
@@ -374,7 +396,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		return fmt.Errorf("error while creating logical port %s error: %v",
 			portName, err)
 	}
-
+	clearAddressesFromNB = true
 	lsp, err = oc.ovnNBClient.LSPGet(portName)
 	if err != nil || lsp == nil {
 		return fmt.Errorf("failed to get the logical switch port: %s from the ovn client, error: %s", portName, err)


### PR DESCRIPTION
ReleaseIPs should also cause the port addresses on nbdb to get
cleared out in case of error so that the state of a logical port
is in sync between nbdb and ovnkube-master.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>