### PR TITLE
fix network policies for dual stack

### DIFF
--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
@@ -177,7 +177,7 @@ func (gp *gressPolicy) constructMatchString(v4AddressSets, v6AddressSets []strin
 		matchStr = v6MatchStr
 	}
 	if len(v4AddressSets) > 0 && len(v6AddressSets) > 0 {
-		matchStr = v4MatchStr + "||" + v6MatchStr
+		matchStr = fmt.Sprintf("(%s || %s)", v4MatchStr, v6MatchStr)
 	}
 	return matchStr
 }
@@ -405,7 +405,7 @@ func constructIPStringForACL(direction string, ipCIDRs []string) string {
 		matchStr = v6MatchStr
 	}
 	if len(v4CIDRs) > 0 && len(v6CIDRs) > 0 {
-		matchStr = v4MatchStr + "||" + v6MatchStr
+		matchStr = fmt.Sprintf("(%s || %s)", v4MatchStr, v6MatchStr)
 	}
 	return matchStr
 }


### PR DESCRIPTION
**- What this PR does and why is it needed**

Current match logic was breaking dual stack network policies.

The match logic needs parenthesis to aggregate the corresponding
fields matches.

**- Special notes for reviewers**


**- How to verify it**

https://github.com/ovn-org/ovn-kubernetes/actions?query=workflow%3Aovn-ci-periodic

**- Description for the changelog**
