### PR TITLE
Delete logical switch port first when cleanup the pod

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -141,10 +141,10 @@ func (p pod) addCmdsForNonExistingPod(fexec *ovntest.FakeExec) {
 
 func (p pod) delCmds(fexec *ovntest.FakeExec) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID,
+		"ovn-nbctl --timeout=15 --if-exists lsp-del " + p.portName,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists lsp-del " + p.portName,
+		"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID,
 	})
 }
 


### PR DESCRIPTION
Today, when a Pod is deleted, its logical switch port is only deleted if
the port is in the logicalPortCache. We need to delete Pods' logical
switch ports regardless to avoid stale logical entities.

Signed-off-by: Yun Zhou <yunz@nvidia.com>