### PR TITLE
fix dual stack network policy (2)

### DIFF
--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -147,7 +147,7 @@ func (gp *gressPolicy) getL3MatchFromAddressSet() string {
 func constructEmptyMatchString() string {
 	switch {
 	case config.IPv4Mode && config.IPv6Mode:
-		return "ip4 || ip6"
+		return "(ip4 || ip6)"
 	case config.IPv6Mode:
 		return "ip6"
 	default:


### PR DESCRIPTION

**- What this PR does and why is it needed**

the match string should use parenthesis for the OR logic.
Otherwise, the acls fail in dual-stack mode

**- How to verify it**

This time I ran the tests and are green for the network-policy ones
https://github.com/aojea/ovn-kubernetes/runs/928738628?check_suite_focus=true


**- Description for the changelog**
