### PR TITLE
go.mod: sync golang.org/x/sys to v0.0.0-20200323222414-85ca7c5b95cd

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v0.0.0-20200625175047-bca67dfc8220
-	golang.org/x/sys v0.0.0-20200121082415-34d275377bf9
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7
 	gopkg.in/gcfg.v1 v1.2.3


### PR DESCRIPTION
Prevents the following error, likely because I'm using Go 1.14.6 instead of 1.13 like CI:

```
go: inconsistent vendoring in /path/to/ovn-kubernetes/go-controller:
	golang.org/x/sys@v0.0.0-20200121082415-34d275377bf9: is explicitly required in go.mod, but vendor/modules.txt indicates golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
```