### PR TITLE
Fix leader election timers

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -97,8 +97,8 @@ var (
 	// MasterHA holds master HA related config options.
 	MasterHA = MasterHAConfig{
 		ElectionLeaseDuration: 60,
-		ElectionRenewDeadline: 30,
-		ElectionRetryPeriod:   20,
+		ElectionRenewDeadline: 5,
+		ElectionRetryPeriod:   30,
 	}
 
 	// HybridOverlay holds hybrid overlay feature config options.


### PR DESCRIPTION
The current timers are backwards for RetryPeriod and RenewDeadline. The
RetryPeriod is the overall time it should wait to try to renew, while
RenewDeadline is the time each renew can take. RetryPeriod should be
much bigger than RenewDeadline, or else we will only try to renew one
time.

Signed-off-by: Tim Rozet <trozet@redhat.com>

