### PR TITLE
Egress IP fixes

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -252,8 +252,8 @@ func (oc *Controller) deleteNamespacePodsEgressIP(eIP *egressipv1.EgressIP, name
 }
 
 func (oc *Controller) assignEgressIPs(eIP *egressipv1.EgressIP) error {
-	assignments := []egressipv1.EgressIPStatusItem{}
 	oc.eIPAllocatorMutex.Lock()
+	assignments := []egressipv1.EgressIPStatusItem{}
 	defer func() {
 		eIP.Status.Items = assignments
 		oc.eIPAllocatorMutex.Unlock()
@@ -543,6 +543,7 @@ func (oc *Controller) addEgressNode(egressNode *kapi.Node) error {
 			klog.Errorf("Re-assignment for EgressIP: unable to retrieve EgressIP: %s from the api-server, err: %v", eIPName, err)
 			return true
 		}
+		eIP = eIP.DeepCopy()
 		if err := oc.addEgressIP(eIP); err != nil {
 			klog.Errorf("Re-assignment for EgressIP: unable to assign EgressIP: %s, err: %v", eIP.Name, err)
 			return true
@@ -579,6 +580,7 @@ func (oc *Controller) deleteEgressNode(egressNode *kapi.Node) error {
 			if err := oc.deleteEgressIP(&eIP); err != nil {
 				klog.Errorf("EgressIP: %s re-assignmnent error: old egress IP deletion failed, err: %v", eIP.Name, err)
 			}
+			eIP = *(eIP.DeepCopy())
 			eIP.Status = egressipv1.EgressIPStatus{
 				Items: []egressipv1.EgressIPStatusItem{},
 			}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -447,7 +447,7 @@ func (e *egressIPMode) createEgressPolicy(podIps []net.IP, status egressipv1.Egr
 					fmt.Sprintf("priority=%v", egressIPReroutePriority),
 					fmt.Sprintf("nexthop=%s", gatewayRouterIP),
 					fmt.Sprintf("external_ids:name=%s", egressIPName),
-					fmt.Sprintf("pkt_mark=%v", packetMark),
+					fmt.Sprintf("options:pkt_mark=%v", packetMark),
 					"--",
 					"add",
 					"logical_router",

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	defaultNoRereoutePriority = "101"
-	egressIPRereoutePriority  = "100"
+	egressIPReroutePriority   = "100"
 )
 
 type modeEgressIP interface {
@@ -417,10 +417,10 @@ func (e *egressIPMode) createEgressPolicy(podIps []net.IP, status egressipv1.Egr
 			var stderr string
 			var err error
 			if packetMark == 0 {
-				_, stderr, err = util.RunOVNNbctl("lr-policy-add", ovnClusterRouter, egressIPRereoutePriority,
+				_, stderr, err = util.RunOVNNbctl("lr-policy-add", ovnClusterRouter, egressIPReroutePriority,
 					fmt.Sprintf("ip6.src == %s && ip6.dst == ::/0", podIP.String()), "reroute", gatewayRouterIP.String())
 			} else {
-				_, stderr, err = util.RunOVNNbctl("lr-policy-add", ovnClusterRouter, egressIPRereoutePriority,
+				_, stderr, err = util.RunOVNNbctl("lr-policy-add", ovnClusterRouter, egressIPReroutePriority,
 					fmt.Sprintf("ip6.src == %s && ip6.dst == ::/0", podIP.String()), "reroute", gatewayRouterIP.String(), fmt.Sprintf("pkt_mark=%v", packetMark))
 			}
 			if err != nil && !strings.Contains(stderr, policyAlreadyExistsMsg) {
@@ -430,10 +430,10 @@ func (e *egressIPMode) createEgressPolicy(podIps []net.IP, status egressipv1.Egr
 			var stderr string
 			var err error
 			if packetMark == 0 {
-				_, stderr, err = util.RunOVNNbctl("lr-policy-add", ovnClusterRouter, egressIPRereoutePriority,
+				_, stderr, err = util.RunOVNNbctl("lr-policy-add", ovnClusterRouter, egressIPReroutePriority,
 					fmt.Sprintf("ip4.src == %s && ip4.dst == 0.0.0.0/0", podIP.String()), "reroute", gatewayRouterIP.String())
 			} else {
-				_, stderr, err = util.RunOVNNbctl("lr-policy-add", ovnClusterRouter, egressIPRereoutePriority,
+				_, stderr, err = util.RunOVNNbctl("lr-policy-add", ovnClusterRouter, egressIPReroutePriority,
 					fmt.Sprintf("ip4.src == %s && ip4.dst == 0.0.0.0/0", podIP.String()), "reroute", gatewayRouterIP.String(), fmt.Sprintf("pkt_mark=%v", packetMark))
 			}
 			if err != nil && !strings.Contains(stderr, policyAlreadyExistsMsg) {
@@ -447,12 +447,12 @@ func (e *egressIPMode) createEgressPolicy(podIps []net.IP, status egressipv1.Egr
 func (e *egressIPMode) deleteEgressPolicy(podIps []net.IP, status egressipv1.EgressIPStatusItem) error {
 	for _, podIP := range podIps {
 		if utilnet.IsIPv6(podIP) && utilnet.IsIPv6String(status.EgressIP) {
-			_, _, err := util.RunOVNNbctl("lr-policy-del", ovnClusterRouter, egressIPRereoutePriority, fmt.Sprintf("ip6.src == %s && ip6.dst == ::/0", podIP.String()))
+			_, _, err := util.RunOVNNbctl("lr-policy-del", ovnClusterRouter, egressIPReroutePriority, fmt.Sprintf("ip6.src == %s && ip6.dst == ::/0", podIP.String()))
 			if err != nil {
 				return fmt.Errorf("unable to delete logical router policy for pod IP: %s, err: %v", podIP.String(), err)
 			}
 		} else if !utilnet.IsIPv6(podIP) && !utilnet.IsIPv6String(status.EgressIP) {
-			_, _, err := util.RunOVNNbctl("lr-policy-del", ovnClusterRouter, egressIPRereoutePriority, fmt.Sprintf("ip4.src == %s && ip4.dst == 0.0.0.0/0", podIP.String()))
+			_, _, err := util.RunOVNNbctl("lr-policy-del", ovnClusterRouter, egressIPReroutePriority, fmt.Sprintf("ip4.src == %s && ip4.dst == 0.0.0.0/0", podIP.String()))
 			if err != nil {
 				return fmt.Errorf("unable to delete logical router policy for pod IP: %s, err: %v", podIP.String(), err)
 			}

--- a/go-controller/pkg/ovn/egressip_local.go
+++ b/go-controller/pkg/ovn/egressip_local.go
@@ -8,11 +8,6 @@ import (
 	kapi "k8s.io/api/core/v1"
 )
 
-const (
-	// In case we restart we need accept executing ovn-nbctl commands with this error.
-	policyAlreadyExistsMsg = "Same routing policy already existed"
-)
-
 type egressIPLocal struct {
 	egressIPMode
 }
@@ -28,7 +23,7 @@ func (e *egressIPLocal) addPodEgressIP(eIP *egressipv1.EgressIP, pod *kapi.Pod) 
 	}
 	for _, status := range eIP.Status.Items {
 		mark := util.IPToUint32(status.EgressIP)
-		if err := e.createEgressPolicy(podIPs, status, mark); err != nil {
+		if err := e.createEgressPolicy(podIPs, status, mark, eIP.Name); err != nil {
 			return fmt.Errorf("unable to create logical router policy for status: %v, err: %v", status, err)
 		}
 	}
@@ -41,7 +36,7 @@ func (e *egressIPLocal) deletePodEgressIP(eIP *egressipv1.EgressIP, pod *kapi.Po
 		return nil
 	}
 	for _, status := range eIP.Status.Items {
-		if err := e.deleteEgressPolicy(podIPs, status); err != nil {
+		if err := e.deleteEgressPolicy(podIPs, status, eIP.Name); err != nil {
 			return fmt.Errorf("unable to delete logical router policy for status: %v, err: %v", status, err)
 		}
 	}

--- a/go-controller/pkg/ovn/egressip_local_test.go
+++ b/go-controller/pkg/ovn/egressip_local_test.go
@@ -111,7 +111,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -129,9 +130,15 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				podUpdate := newPod(namespace, podName, node1Name, podV6IP)
 
+				fakeOvn.fakeExec.AddFakeCmd(
+					&ovntest.ExpectedCmd{
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
+						Output: policyID,
+					},
+				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-del ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0", egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 remove logical_router %s policies %s", ovnClusterRouter, policyID),
 					},
 				)
 
@@ -195,7 +202,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -291,7 +299,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", podUpdate.Status.PodIP, nodeLogicalRouterIPv6, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", podV6IP), egressIPReroutePriority, eIP.Name),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", podV6IP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -419,7 +428,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -437,9 +447,15 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				namespaceUpdate := newNamespace(namespace)
 
+				fakeOvn.fakeExec.AddFakeCmd(
+					&ovntest.ExpectedCmd{
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
+						Output: policyID,
+					},
+				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-del ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0", egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 remove logical_router %s policies %s", ovnClusterRouter, policyID),
 					},
 				)
 
@@ -566,7 +582,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -599,14 +616,21 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				mark = util.IPToUint32(updatedEgressIP.String())
 
-				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
-					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-del ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0", egressPod.Status.PodIP),
+				fakeOvn.fakeExec.AddFakeCmd(
+					&ovntest.ExpectedCmd{
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
+						Output: policyID,
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 remove logical_router %s policies %s", ovnClusterRouter, policyID),
+					},
+				)
+				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
+					[]string{
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 

--- a/go-controller/pkg/ovn/egressip_local_test.go
+++ b/go-controller/pkg/ovn/egressip_local_test.go
@@ -103,9 +103,6 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				mark := util.IPToUint32(egressIP.String())
 
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", egressPod.Status.PodIP, fakeOvn.ovnNBClient)
-
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
@@ -190,9 +187,6 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				mark := util.IPToUint32(egressIP.String())
 
-				// Mock the fact that we have an IP in the OVN DB for this pod
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", egressPod.Status.PodIP, fakeOvn.ovnNBClient)
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
@@ -273,10 +267,6 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 					},
 				}
 
-				// Mock no IP in OVN DB for this pod
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", "", fakeOvn.ovnNBClient)
-
 				fakeOvn.controller.WatchEgressIP()
 
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
@@ -292,12 +282,6 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				podUpdate := newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
 
 				mark := util.IPToUint32(egressIP.String())
-
-				// Mock pod IP found in OVN DB
-				cmd, err := fakeOvn.ovnNBClient.LSPSetDynamicAddresses(lsp, fmt.Sprintf("0a:00:00:00:00:01 %s", podUpdate.Status.PodIP))
-				Expect(err).NotTo(HaveOccurred())
-				err = cmd.Execute()
-				Expect(err).NotTo(HaveOccurred())
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
@@ -360,10 +344,6 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 						},
 					},
 				}
-
-				// Mock no pod IP in OVN DB
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", "", fakeOvn.ovnNBClient)
 
 				fakeOvn.controller.WatchEgressIP()
 
@@ -430,9 +410,6 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				}
 
 				mark := util.IPToUint32(egressIP.String())
-
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", egressPod.Status.PodIP, fakeOvn.ovnNBClient)
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
@@ -513,9 +490,6 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 					},
 				}
 
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", "", fakeOvn.ovnNBClient)
-
 				fakeOvn.controller.WatchEgressIP()
 
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
@@ -584,8 +558,6 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				mark := util.IPToUint32(egressIP.String())
 
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", egressPod.Status.PodIP, fakeOvn.ovnNBClient)
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),

--- a/go-controller/pkg/ovn/egressip_local_test.go
+++ b/go-controller/pkg/ovn/egressip_local_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s options:pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -203,7 +203,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s options:pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -300,7 +300,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", podV6IP), egressIPReroutePriority, eIP.Name),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", podV6IP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s options:pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", podV6IP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -429,7 +429,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s options:pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -583,7 +583,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s options:pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 
@@ -630,7 +630,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s options:pkt_mark=%v -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, mark, ovnClusterRouter),
 					},
 				)
 

--- a/go-controller/pkg/ovn/egressip_local_test.go
+++ b/go-controller/pkg/ovn/egressip_local_test.go
@@ -106,12 +106,12 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeGatewayRouterIP, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
 					},
 				)
 
@@ -190,12 +190,12 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeGatewayRouterIP, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
 					},
 				)
 
@@ -286,12 +286,12 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", podUpdate.Status.PodIP, nodeGatewayRouterIP, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", podUpdate.Status.PodIP, nodeLogicalRouterIPv6, mark),
 					},
 				)
 
@@ -414,12 +414,12 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeGatewayRouterIP, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
 					},
 				)
 
@@ -561,12 +561,12 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeGatewayRouterIP, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
 					},
 				)
 
@@ -606,7 +606,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeGatewayRouterIP, mark),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s pkt_mark=%v", egressPod.Status.PodIP, nodeLogicalRouterIPv6, mark),
 					},
 				)
 

--- a/go-controller/pkg/ovn/egressip_local_test.go
+++ b/go-controller/pkg/ovn/egressip_local_test.go
@@ -23,19 +23,15 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 		tExec   *ovntest.FakeExec
 	)
 
-	getEgressIPStatusLenSafely := func(egressIPName string) func() int {
+	getEgressIPStatusLen := func(egressIPName string) func() int {
 		return func() int {
-			fakeOvn.controller.eIPAllocatorMutex.Lock()
-			defer fakeOvn.controller.eIPAllocatorMutex.Unlock()
 			tmp, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			return len(tmp.Status.Items)
 		}
 	}
 
-	getEgressIPStatusSafely := func(egressIPName string) []egressipv1.EgressIPStatusItem {
-		fakeOvn.controller.eIPAllocatorMutex.Lock()
-		defer fakeOvn.controller.eIPAllocatorMutex.Unlock()
+	getEgressIPStatus := func(egressIPName string) []egressipv1.EgressIPStatusItem {
 		tmp, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		return tmp.Status.Items
@@ -121,10 +117,10 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -144,7 +140,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(egressPod.Namespace).Update(context.TODO(), podUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -212,10 +208,10 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -227,7 +223,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(egressPod.Namespace).Update(context.TODO(), podUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -280,10 +276,10 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -306,7 +302,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(egressPod.Namespace).Update(context.TODO(), podUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -359,17 +355,17 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
 				// Should not perform any ovn-nbctl commands as we never really added it to begin with
 				err = fakeOvn.fakeClient.CoreV1().Pods(egressPod.Namespace).Delete(context.TODO(), egressPod.Name, *metav1.NewDeleteOptions(0))
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -438,10 +434,10 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -461,7 +457,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Namespaces().Update(context.TODO(), namespaceUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -511,10 +507,10 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -522,7 +518,7 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Namespaces().Update(context.TODO(), namespaceUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -592,10 +588,10 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -637,9 +633,9 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 				_, err = fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Update(context.TODO(), updateEIP, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 
-				statuses = getEgressIPStatusSafely(eIP.Name)
+				statuses = getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(updatedEgressIP.String()))
 				return nil

--- a/go-controller/pkg/ovn/egressip_shared.go
+++ b/go-controller/pkg/ovn/egressip_shared.go
@@ -11,11 +11,6 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-const (
-	// If we restart we need accept executing ovn-nbctl commands with this error.
-	natAlreadyExistsMsg = "a NAT with this external_ip and logical_ip already exists"
-)
-
 type egressIPShared struct {
 	egressIPMode
 }
@@ -30,10 +25,10 @@ func (e *egressIPShared) addPodEgressIP(eIP *egressipv1.EgressIP, pod *kapi.Pod)
 		e.podRetry.Delete(getPodKey(pod))
 	}
 	for _, status := range eIP.Status.Items {
-		if err := e.createEgressPolicy(podIPs, status, 0); err != nil {
+		if err := e.createEgressPolicy(podIPs, status, 0, eIP.Name); err != nil {
 			return fmt.Errorf("unable to create logical router policy for status: %v, err: %v", status, err)
 		}
-		if err := createNATRule(podIPs, status); err != nil {
+		if err := createNATRule(podIPs, status, eIP.Name); err != nil {
 			return fmt.Errorf("unable to create NAT rule for status: %v, err: %v", status, err)
 		}
 	}
@@ -46,36 +41,90 @@ func (e *egressIPShared) deletePodEgressIP(eIP *egressipv1.EgressIP, pod *kapi.P
 		return nil
 	}
 	for _, status := range eIP.Status.Items {
-		if err := e.deleteEgressPolicy(podIPs, status); err != nil {
+		if err := e.deleteEgressPolicy(podIPs, status, eIP.Name); err != nil {
 			return fmt.Errorf("unable to delete logical router policy for status: %v, err: %v", status, err)
 		}
-		if err := deleteNATRule(podIPs, status); err != nil {
+		if err := deleteNATRule(podIPs, status, eIP.Name); err != nil {
 			return fmt.Errorf("unable to delete NAT rule for status: %v, err: %v", status, err)
 		}
 	}
 	return nil
 }
 
-func createNATRule(podIPs []net.IP, status egressipv1.EgressIPStatusItem) error {
+func createNATRule(podIPs []net.IP, status egressipv1.EgressIPStatusItem, egressIPName string) error {
 	for _, podIP := range podIPs {
 		if (utilnet.IsIPv6String(status.EgressIP) && utilnet.IsIPv6(podIP)) || (!utilnet.IsIPv6String(status.EgressIP) && !utilnet.IsIPv6(podIP)) {
-			_, stderr, err := util.RunOVNNbctl("lr-nat-add", fmt.Sprintf("GR_%s", status.Node), "snat", status.EgressIP, podIP.String())
-			if err != nil && !strings.Contains(stderr, natAlreadyExistsMsg) {
-				return fmt.Errorf("OVN transaction error, stderr: %s, err: %v", stderr, err)
+			natIDs, err := findNatIDs(egressIPName, podIP.String(), status.EgressIP)
+			if err != nil {
+				return err
+			}
+			if natIDs == nil {
+				_, stderr, err := util.RunOVNNbctl(
+					"--id=@nat",
+					"create",
+					"nat",
+					"type=snat",
+					fmt.Sprintf("logical_port=k8s-%s", status.Node),
+					fmt.Sprintf("external_ip=%s", status.EgressIP),
+					fmt.Sprintf("logical_ip=%s", podIP),
+					fmt.Sprintf("external_ids:name=%s", egressIPName),
+					"--",
+					"add",
+					"logical_router",
+					fmt.Sprintf("GR_%s", status.Node),
+					"nat",
+					"@nat",
+				)
+				if err != nil {
+					return fmt.Errorf("unable to create nat rule, stderr: %s, err: %v", stderr, err)
+				}
 			}
 		}
 	}
 	return nil
 }
 
-func deleteNATRule(podIPs []net.IP, status egressipv1.EgressIPStatusItem) error {
+func deleteNATRule(podIPs []net.IP, status egressipv1.EgressIPStatusItem, egressIPName string) error {
 	for _, podIP := range podIPs {
 		if (utilnet.IsIPv6String(status.EgressIP) && utilnet.IsIPv6(podIP)) || (!utilnet.IsIPv6String(status.EgressIP) && !utilnet.IsIPv6(podIP)) {
-			_, stderr, err := util.RunOVNNbctl("lr-nat-del", fmt.Sprintf("GR_%s", status.Node), "snat", podIP.String())
+			natIDs, err := findNatIDs(egressIPName, podIP.String(), status.EgressIP)
 			if err != nil {
-				return fmt.Errorf("OVN transaction error, stderr: %s, err: %v", stderr, err)
+				return err
+			}
+			for _, natID := range natIDs {
+				_, stderr, err := util.RunOVNNbctl(
+					"remove",
+					"logical_router",
+					fmt.Sprintf("GR_%s", status.Node),
+					"nat",
+					natID,
+				)
+				if err != nil {
+					return fmt.Errorf("unable to remove nat from logical_router, stderr: %s, err: %v", stderr, err)
+				}
 			}
 		}
 	}
 	return nil
+}
+
+func findNatIDs(egressIPName, podIP, egressIP string) ([]string, error) {
+	natIDs, stderr, err := util.RunOVNNbctl(
+		"--format=csv",
+		"--data=bare",
+		"--no-heading",
+		"--columns=_uuid",
+		"find",
+		"nat",
+		fmt.Sprintf("external_ids:name=%s", egressIPName),
+		fmt.Sprintf("logical_ip=%s", podIP),
+		fmt.Sprintf("external_ip=%s", egressIP),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find nat ID, stderr: %s, err: %v", stderr, err)
+	}
+	if natIDs == "" {
+		return nil, nil
+	}
+	return strings.Split(natIDs, "\n"), nil
 }

--- a/go-controller/pkg/ovn/egressip_shared_test.go
+++ b/go-controller/pkg/ovn/egressip_shared_test.go
@@ -33,19 +33,15 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 		return len(fakeOvn.controller.eIPAllocator)
 	}
 
-	getEgressIPStatusLenSafely := func(egressIPName string) func() int {
+	getEgressIPStatusLen := func(egressIPName string) func() int {
 		return func() int {
-			fakeOvn.controller.eIPAllocatorMutex.Lock()
-			defer fakeOvn.controller.eIPAllocatorMutex.Unlock()
 			tmp, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			return len(tmp.Status.Items)
 		}
 	}
 
-	getEgressIPStatusSafely := func(egressIPName string) []egressipv1.EgressIPStatusItem {
-		fakeOvn.controller.eIPAllocatorMutex.Lock()
-		defer fakeOvn.controller.eIPAllocatorMutex.Unlock()
+	getEgressIPStatus := func(egressIPName string) []egressipv1.EgressIPStatusItem {
 		tmp, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		return tmp.Status.Items
@@ -137,8 +133,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
 
 				fakeOvn.controller.WatchEgressIP()
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node1.Name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
@@ -153,13 +149,13 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				nodeSwitch := func() string {
-					statuses = getEgressIPStatusSafely(egressIPName)
+					statuses = getEgressIPStatus(egressIPName)
 					return statuses[0].Node
 				}
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
 				Eventually(nodeSwitch).Should(Equal(node2.Name))
-				statuses = getEgressIPStatusSafely(egressIPName)
+				statuses = getEgressIPStatus(egressIPName)
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
 				fakeOvn.fakeExec.AddFakeCmd(
@@ -249,8 +245,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
 
 				fakeOvn.controller.WatchEgressIP()
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node1.Name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
@@ -265,13 +261,13 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				nodeSwitch := func() string {
-					statuses = getEgressIPStatusSafely(egressIPName)
+					statuses = getEgressIPStatus(egressIPName)
 					return statuses[0].Node
 				}
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
 				Eventually(nodeSwitch).Should(Equal(node2.Name))
-				statuses = getEgressIPStatusSafely(egressIPName)
+				statuses = getEgressIPStatus(egressIPName)
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
 				fakeOvn.fakeExec.AddFakeCmd(
@@ -366,10 +362,10 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -399,7 +395,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				)
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(egressPod.Namespace).Update(context.TODO(), podUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -467,10 +463,10 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -481,7 +477,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(egressPod.Namespace).Update(context.TODO(), podUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -534,10 +530,10 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -560,7 +556,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(egressPod.Namespace).Update(context.TODO(), podUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -612,16 +608,16 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
 				err = fakeOvn.fakeClient.CoreV1().Pods(egressPod.Namespace).Delete(context.TODO(), egressPod.Name, *metav1.NewDeleteOptions(0))
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -689,10 +685,10 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -723,7 +719,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Namespaces().Update(context.TODO(), namespaceUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -774,10 +770,10 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -785,7 +781,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Namespaces().Update(context.TODO(), namespaceUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 				return nil
 			}
@@ -854,10 +850,10 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -909,9 +905,9 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err = fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Update(context.TODO(), eIPUpdate, metav1.UpdateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 
-				statuses = getEgressIPStatusSafely(eIP.Name)
+				statuses = getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(updatedEgressIP.String()))
 				return nil
@@ -977,10 +973,10 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
 
-				statuses := getEgressIPStatusSafely(eIP.Name)
+				statuses := getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
@@ -1002,9 +998,9 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				_, err = fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Update(context.TODO(), eIPUpdate, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(fakeOvn.fakeExec.CalledMatchesExpected).Should(BeTrue(), fakeOvn.fakeExec.ErrorDesc)
-				Eventually(getEgressIPStatusLenSafely(eIP.Name)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(eIP.Name)).Should(Equal(1))
 
-				statuses = getEgressIPStatusSafely(eIP.Name)
+				statuses = getEgressIPStatus(eIP.Name)
 				Expect(statuses[0].Node).To(Equal(bogusNode))
 				Expect(statuses[0].EgressIP).To(Equal(bogusIP))
 

--- a/go-controller/pkg/ovn/egressip_shared_test.go
+++ b/go-controller/pkg/ovn/egressip_shared_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip4.src == %s && ip4.dst == 0.0.0.0/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv4),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.Name, egressIP, egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s snat %s %s", node2.Name, egressIP, egressPod.Status.PodIP),
 					},
 				)
 				_, err = fakeOvn.fakeClient.CoreV1().Pods(egressPod.Namespace).Create(context.TODO(), &egressPod, metav1.CreateOptions{})
@@ -276,7 +276,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip4.src == %s && ip4.dst == 0.0.0.0/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv4),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.Name, egressIP, egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s snat %s %s", node2.Name, egressIP, egressPod.Status.PodIP),
 					},
 				)
 				_, err = fakeOvn.fakeClient.CoreV1().Namespaces().Create(context.TODO(), egressNamespace, metav1.CreateOptions{})
@@ -346,7 +346,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)
 
@@ -367,7 +367,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-del ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0", egressPod.Status.PodIP),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-del GR_%s dnat_and_snat %s", node2.name, egressIP.String()),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-del GR_%s snat %s", node2.name, egressPod.Status.PodIP),
 					},
 				)
 
@@ -430,7 +430,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)
 
@@ -524,7 +524,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", podUpdate.Status.PodIP, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), podUpdate.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s snat %s %s", node2.name, egressIP.String(), podUpdate.Status.PodIP),
 					},
 				)
 
@@ -648,7 +648,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)
 
@@ -669,7 +669,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-del ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0", egressPod.Status.PodIP),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-del GR_%s dnat_and_snat %s", node2.name, egressIP.String()),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-del GR_%s snat %s", node2.name, egressPod.Status.PodIP),
 					},
 				)
 
@@ -795,7 +795,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)
 
@@ -828,14 +828,14 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-del ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0", egressPod.Status.PodIP),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-del GR_%s dnat_and_snat %s", node2.name, egressIP.String()),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-del GR_%s snat %s", node2.name, egressPod.Status.PodIP),
 					},
 				)
 
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, updatedEgressIP.String(), egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s snat %s %s", node2.name, updatedEgressIP.String(), egressPod.Status.PodIP),
 					},
 				)
 
@@ -899,7 +899,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)
 

--- a/go-controller/pkg/ovn/egressip_shared_test.go
+++ b/go-controller/pkg/ovn/egressip_shared_test.go
@@ -98,8 +98,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 					},
 				}
 
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", egressPod.Status.PodIP, fakeOvn.ovnNBClient)
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
@@ -184,8 +182,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 					},
 				}
 
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", egressPod.Status.PodIP, fakeOvn.ovnNBClient)
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
@@ -265,8 +261,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 						},
 					},
 				}
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", "", fakeOvn.ovnNBClient)
 
 				fakeOvn.controller.WatchEgressIP()
 
@@ -281,12 +275,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				Expect(statuses[0].EgressIP).To(Equal(egressIP.String()))
 
 				podUpdate := newPodWithLabels(namespace, podName, node1Name, podV6IP, egressPodLabel)
-
-				// Mock pod IP found in OVN DB
-				cmd, err := fakeOvn.ovnNBClient.LSPSetDynamicAddresses(lsp, fmt.Sprintf("0a:00:00:00:00:01 %s", podUpdate.Status.PodIP))
-				Expect(err).NotTo(HaveOccurred())
-				err = cmd.Execute()
-				Expect(err).NotTo(HaveOccurred())
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
@@ -350,9 +338,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 					},
 				}
 
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", "", fakeOvn.ovnNBClient)
-
 				fakeOvn.controller.WatchEgressIP()
 
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
@@ -414,9 +399,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 						},
 					},
 				}
-
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", egressPod.Status.PodIP, fakeOvn.ovnNBClient)
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
@@ -500,9 +482,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 					},
 				}
 
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", "", fakeOvn.ovnNBClient)
-
 				fakeOvn.controller.WatchEgressIP()
 
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
@@ -568,8 +547,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 					},
 				}
 
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", egressPod.Status.PodIP, fakeOvn.ovnNBClient)
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
@@ -675,8 +652,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 					},
 				}
 
-				lsp := fmt.Sprintf("%s_%s", egressPod.Namespace, egressPod.Name)
-				populatePortAddresses(node1Name, lsp, "0a:00:00:00:00:01", egressPod.Status.PodIP, fakeOvn.ovnNBClient)
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),

--- a/go-controller/pkg/ovn/egressip_shared_test.go
+++ b/go-controller/pkg/ovn/egressip_shared_test.go
@@ -101,12 +101,12 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeGatewayRouterIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)
@@ -185,12 +185,12 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeGatewayRouterIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)
@@ -279,12 +279,12 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", podUpdate.Status.PodIP, nodeGatewayRouterIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", podUpdate.Status.PodIP, nodeLogicalRouterIPv6),
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), podUpdate.Status.PodIP),
 					},
 				)
@@ -403,12 +403,12 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeGatewayRouterIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)
@@ -550,12 +550,12 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeGatewayRouterIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)
@@ -586,7 +586,6 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 						MatchLabels: egressPodLabel,
 					},
 				}
-
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-del ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0", egressPod.Status.PodIP),
@@ -596,7 +595,7 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeGatewayRouterIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, updatedEgressIP.String(), egressPod.Status.PodIP),
 					},
 				)
@@ -655,12 +654,12 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
 						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeGatewayRouterIP),
+						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeGatewayRouterIP),
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 100 ip6.src == %s && ip6.dst == ::/0 reroute %s", egressPod.Status.PodIP, nodeLogicalRouterIPv6),
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-nat-add GR_%s dnat_and_snat %s %s", node2.name, egressIP.String(), egressPod.Status.PodIP),
 					},
 				)

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -18,14 +18,16 @@ import (
 )
 
 const (
-	namespace           = "egressip-namespace"
-	nodeGatewayRouterIP = "fef0::56"
-	nodeInternalIP      = "def0::56"
-	podV6IP             = "ae70::66"
-	v6ClusterSubnet     = "ae70::66/64"
-	v4ClusterSubnet     = "10.128.0.0/14"
-	podName             = "egress_pod"
-	egressIPName        = "egressip"
+	namespace             = "egressip-namespace"
+	nodeLogicalRouterIPv6 = "fef0::56"
+	nodeLogicalRouterIPv4 = "100.64.0.2"
+	nodeInternalIP        = "def0::56"
+	podV4IP               = "10.128.0.15"
+	podV6IP               = "ae70::66"
+	v6ClusterSubnet       = "ae70::66/64"
+	v4ClusterSubnet       = "10.128.0.0/14"
+	podName               = "egress_pod"
+	egressIPName          = "egressip"
 )
 
 func newEgressIPMeta(name string) metav1.ObjectMeta {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -84,19 +84,15 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 		return len(fakeOvn.controller.eIPAllocator)
 	}
 
-	getEgressIPStatusLenSafely := func(egressIPName string) func() int {
+	getEgressIPStatusLen := func(egressIPName string) func() int {
 		return func() int {
-			fakeOvn.controller.eIPAllocatorMutex.Lock()
-			defer fakeOvn.controller.eIPAllocatorMutex.Unlock()
 			tmp, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			return len(tmp.Status.Items)
 		}
 	}
 
-	getEgressIPStatusSafely := func(egressIPName string) []egressipv1.EgressIPStatusItem {
-		fakeOvn.controller.eIPAllocatorMutex.Lock()
-		defer fakeOvn.controller.eIPAllocatorMutex.Unlock()
+	getEgressIPStatus := func(egressIPName string) []egressipv1.EgressIPStatusItem {
 		tmp, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		return tmp.Status.Items
@@ -282,8 +278,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				_, err = fakeOvn.fakeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node.Name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
@@ -370,7 +366,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				_, err = fakeOvn.fakeClient.CoreV1().Nodes().Update(context.TODO(), &node1, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(0))
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(0))
 				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(1))
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
 				Expect(fakeOvn.controller.eIPAllocator[node1.Name].v4Subnet).To(Equal(ip1V4Sub))
@@ -393,9 +389,9 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				_, err = fakeOvn.fakeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
 
-				statuses := getEgressIPStatusSafely(egressIPName)
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.Name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveLen(2))
@@ -468,16 +464,16 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(1))
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node1.Name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
 				_, err := fakeOvn.fakeClient.CoreV1().Nodes().Create(context.TODO(), &node2, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses = getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses = getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node1.Name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(2))
@@ -489,15 +485,15 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(1))
 				Expect(fakeOvn.controller.eIPAllocator).ToNot(HaveKey(node1.Name))
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node2.Name))
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
 
 				getNewNode := func() string {
-					statuses = getEgressIPStatusSafely(egressIPName)
+					statuses = getEgressIPStatus(egressIPName)
 					return statuses[0].Node
 				}
 
 				Eventually(getNewNode).Should(Equal(node2.Name))
-				statuses = getEgressIPStatusSafely(egressIPName)
+				statuses = getEgressIPStatus(egressIPName)
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
 				return nil
@@ -936,8 +932,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 				return nil
@@ -975,8 +971,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(net.ParseIP(egressIP).String()))
 				return nil
@@ -1015,8 +1011,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(2))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(2))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(net.ParseIP(egressIPv4).String()))
 				Expect(statuses[1].Node).To(Equal(node1.name))
@@ -1074,8 +1070,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(2))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(2))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(eIP.Status.Items[0].Node))
 				Expect(statuses[0].EgressIP).To(Equal(eIP.Status.Items[0].EgressIP))
 				Expect(statuses[1].Node).To(Equal(eIP.Status.Items[1].Node))
@@ -1129,8 +1125,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(2))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(2))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(eIP.Status.Items[0].EgressIP))
 				Expect(statuses[1].Node).To(Equal(eIP.Status.Items[1].Node))
@@ -1179,8 +1175,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(eIP.Status.Items[0].EgressIP))
 				return nil
@@ -1235,8 +1231,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(2))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(2))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(eIP.Status.Items[0].EgressIP))
 				Expect(statuses[1].Node).To(Equal(node1.name))
@@ -1286,8 +1282,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP1))
 				return nil
@@ -1335,8 +1331,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP1))
 				return nil
@@ -1383,8 +1379,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node1.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP1))
 				return nil
@@ -1430,15 +1426,15 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP1, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP1.Name)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(eIP1.Name)
+				Eventually(getEgressIPStatusLen(eIP1.Name)).Should(Equal(1))
+				statuses := getEgressIPStatus(eIP1.Name)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP1))
 
 				_, err = fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP2, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(eIP2.Name)).Should(Equal(0))
+				Eventually(getEgressIPStatusLen(eIP2.Name)).Should(Equal(0))
 
 				return nil
 			}
@@ -1476,8 +1472,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP1, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
@@ -1520,8 +1516,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP1, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatusSafely(egressIPName)
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
@@ -1533,7 +1529,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				getEgressIP := func() string {
-					statuses = getEgressIPStatusSafely(egressIPName)
+					statuses = getEgressIPStatus(egressIPName)
 					if len(statuses) == 0 {
 						return "try again"
 					}
@@ -1541,7 +1537,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				}
 
 				Eventually(getEgressIP).Should(Equal(updateEgressIP))
-				statuses = getEgressIPStatusSafely(egressIPName)
+				statuses = getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.name))
 
 				return nil

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -820,7 +820,7 @@ func (oc *Controller) WatchEgressNodes() {
 func (oc *Controller) WatchEgressIP() {
 	oc.watchFactory.AddEgressIPHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			eIP := obj.(*egressipv1.EgressIP)
+			eIP := obj.(*egressipv1.EgressIP).DeepCopy()
 			if err := oc.addEgressIP(eIP); err != nil {
 				klog.Error(err)
 			}
@@ -830,7 +830,7 @@ func (oc *Controller) WatchEgressIP() {
 		},
 		UpdateFunc: func(old, new interface{}) {
 			oldEIP := old.(*egressipv1.EgressIP)
-			newEIP := new.(*egressipv1.EgressIP)
+			newEIP := new.(*egressipv1.EgressIP).DeepCopy()
 			if !reflect.DeepEqual(oldEIP.Spec, newEIP.Spec) {
 				if err := oc.deleteEgressIP(oldEIP); err != nil {
 					klog.Error(err)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -250,7 +250,7 @@ func NewOvnController(kubeClient kubernetes.Interface, egressIPClient egressipap
 	if addressSetFactory == nil {
 		addressSetFactory = NewOvnAddressSetFactory()
 	}
-	modeEgressIP := newModeEgressIP(ovnNBClient)
+	modeEgressIP := newModeEgressIP()
 	return &Controller{
 		kube: &kube.Kube{
 			KClient:              kubeClient,
@@ -344,19 +344,11 @@ type emptyLBBackendEvent struct {
 	uuid     string
 }
 
-func newModeEgressIP(ovnNBClient goovn.Client) modeEgressIP {
+func newModeEgressIP() modeEgressIP {
 	if config.Gateway.Mode == config.GatewayModeLocal {
-		return &egressIPLocal{
-			egressIPMode: egressIPMode{
-				ovnNBClient: ovnNBClient,
-			},
-		}
+		return &egressIPLocal{}
 	}
-	return &egressIPShared{
-		egressIPMode: egressIPMode{
-			ovnNBClient: ovnNBClient,
-		},
-	}
+	return &egressIPShared{}
 }
 
 func extractEmptyLBBackendsEvents(out []byte) ([]emptyLBBackendEvent, error) {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -48,6 +48,10 @@ func newPodMeta(namespace, name string, additionalLabels map[string]string) meta
 }
 
 func newPodWithLabels(namespace, name, node, podIP string, additionalLabels map[string]string) *v1.Pod {
+	podIPs := []v1.PodIP{}
+	if podIP != "" {
+		podIPs = append(podIPs, v1.PodIP{IP: podIP})
+	}
 	return &v1.Pod{
 		ObjectMeta: newPodMeta(namespace, name, additionalLabels),
 		Spec: v1.PodSpec{
@@ -60,16 +64,18 @@ func newPodWithLabels(namespace, name, node, podIP string, additionalLabels map[
 			NodeName: node,
 		},
 		Status: v1.PodStatus{
-			Phase: v1.PodRunning,
-			PodIP: podIP,
-			PodIPs: []v1.PodIP{
-				{IP: podIP},
-			},
+			Phase:  v1.PodRunning,
+			PodIP:  podIP,
+			PodIPs: podIPs,
 		},
 	}
 }
 
 func newPod(namespace, name, node, podIP string) *v1.Pod {
+	podIPs := []v1.PodIP{}
+	if podIP != "" {
+		podIPs = append(podIPs, v1.PodIP{IP: podIP})
+	}
 	return &v1.Pod{
 		ObjectMeta: newPodMeta(namespace, name, nil),
 		Spec: v1.PodSpec{
@@ -82,11 +88,9 @@ func newPod(namespace, name, node, podIP string) *v1.Pod {
 			NodeName: node,
 		},
 		Status: v1.PodStatus{
-			Phase: v1.PodRunning,
-			PodIP: podIP,
-			PodIPs: []v1.PodIP{
-				{IP: podIP},
-			},
+			Phase:  v1.PodRunning,
+			PodIP:  podIP,
+			PodIPs: podIPs,
 		},
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

This PR fixes a couple of issues with the egress IP feature that merged yesterday with PR:  https://github.com/ovn-org/ovn-kubernetes/pull/1484. There is no real rush to get this in today and it can wait until next week. I didn't have time to do this yesterday with all the things going on.

Problems solved:

- When deleting the pod's egress setup (upon a pod delete) we were retrieving the IP from the OVN database and subsequently racing with `deleteLogicalPort`, in case we lost: we never cleaned up. I thus changed that to only look at the `pod.Status` instead, this resolves the race condition. Since a pod IP can't change we thus never really need to look in the OVN DB for that. This also simplified the code as I didn't need to pull in `ovnNBClient` into the data containers intended at managing egress IP assignments. 

- I never properly removed any watch handlers from the namespace / pod handlers used for egress IP assignment. This lead to very strange corner cases which have now been fixed. I've also added tests taking into account those cases.    

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->