### PR TITLE
Fix pod add

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -351,6 +351,10 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 		klog.Warningf("Failed to settle addresses: %q", err)
 	}
 
+	if err = waitForPodFlows(ifInfo.MAC.String()); err != nil {
+		return nil, fmt.Errorf("timed out waiting for pod flows for pod: %s, error: %v", podName, err)
+	}
+
 	return []*current.Interface{hostIface, contIface}, nil
 }
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -46,9 +46,9 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 }
 
 func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
-	nsInfo := oc.getNamespaceLocked(ns)
-	if nsInfo == nil {
-		return nil
+	nsInfo, err := oc.waitForNamespaceLocked(ns)
+	if err != nil {
+		return err
 	}
 	defer nsInfo.Unlock()
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1241,7 +1241,7 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 					context.TODO(), namespace1.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ns).NotTo(BeNil())
-
+				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 				// Enable multicast in the namespace
 				mcastPolicy := multicastPolicy{}
 				mcastPolicy.enableCmds(fExec, namespace1.Name)


### PR DESCRIPTION
**- What this PR does and why is it needed**
This PR adds ability for CNI to wait for openflow flows to be present for the pod, and modifies add_logical_port to annotate the pod before we issue OVN commands. Since most of the time logical port add failures are due to the pod being removed in k8s and we can no longer set the annotation, it ends up leaving OVN config which we have to manually roll back. This PR moves the annotation to before OVN config is done.
