### PR TITLE
consistent naming of the feature flag

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -82,7 +82,7 @@ var (
 
 	// OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
 	OVNKubernetesFeature = OVNKubernetesFeatureConfig{
-		EgressIPEnabled: true,
+		EnableEgressIP: true,
 	}
 
 	// OvnNorth holds northbound OVN database client and server authentication and location details
@@ -206,7 +206,7 @@ type KubernetesConfig struct {
 
 // OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
 type OVNKubernetesFeatureConfig struct {
-	EgressIPEnabled bool `gcfg:"egress-ip-enable"`
+	EnableEgressIP bool `gcfg:"enable-egress-ip"`
 }
 
 // GatewayMode holds the node gateway mode
@@ -586,10 +586,10 @@ var CNIFlags = []cli.Flag{
 // OVNK8sFeatureFlags capture OVN-Kubernetes feature related options
 var OVNK8sFeatureFlags = []cli.Flag{
 	&cli.BoolFlag{
-		Name:        "egress-ip-enable",
+		Name:        "enable-egress-ip",
 		Usage:       "Configure to use EgressIP CRD feature with ovn-kubernetes.",
-		Destination: &cliConfig.OVNKubernetesFeature.EgressIPEnabled,
-		Value:       OVNKubernetesFeature.EgressIPEnabled,
+		Destination: &cliConfig.OVNKubernetesFeature.EnableEgressIP,
+		Value:       OVNKubernetesFeature.EnableEgressIP,
 	},
 }
 

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -535,7 +535,7 @@ func NewWatchFactory(c kubernetes.Interface, eip egressipclientset.Interface, ec
 			return nil, fmt.Errorf("error in syncing cache for %v informer", oType)
 		}
 	}
-	if config.OVNKubernetesFeature.EgressIPEnabled {
+	if config.OVNKubernetesFeature.EnableEgressIP {
 		wf.eipFactory.Start(wf.stopChan)
 		for oType, synced := range wf.eipFactory.WaitForCacheSync(wf.stopChan) {
 			if !synced {

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -478,7 +478,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			wf.removeHandler(objType, h)
 		}
 		It("does not call ADD for each existing egressIP", func() {
-			config.OVNKubernetesFeature.EgressIPEnabled = false
+			config.OVNKubernetesFeature.EnableEgressIP = false
 			egressIPs = append(egressIPs, newEgressIP("myEgressIP", "default"))
 			egressIPs = append(egressIPs, newEgressIP("myEgressIP1", "default"))
 			testExisting(egressIPType)

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -180,7 +180,7 @@ func (n *OvnNode) initLocalEgressIP(gatewayIfAddrs []*net.IPNet, defaultGatewayI
 		nodeName:           n.name,
 		defaultGatewayIntf: defaultGatewayIntf,
 	}
-	if config.OVNKubernetesFeature.EgressIPEnabled {
+	if config.OVNKubernetesFeature.EnableEgressIP {
 		if err := n.watchEgressIP(egressIPLocal); err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -303,7 +303,7 @@ func (oc *Controller) Run() error {
 		}
 	}
 
-	if config.OVNKubernetesFeature.EgressIPEnabled {
+	if config.OVNKubernetesFeature.EnableEgressIP {
 		if err := oc.WatchEgressNodes(); err != nil {
 			return err
 		}


### PR DESCRIPTION
renamed the egress ip flag to be consistent with other feature flags.
since it is boolean value, the presence/absence of the flag will
determine if the feature needs to be enabled or not

@alexanderConstantinescu @JacobTanenbaum FYI
@ovn-org/ovn-kubernetes-committers PTAL
