### PR TITLE
Enable race detector for e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: show git history
+      run: git log --oneline -10
+
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         set -x
         pushd go-controller
-           make
+           RACE=1 make
         popd
 
     - name: Build docker image

--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -6,6 +6,7 @@ source "$(dirname "${BASH_SOURCE}")/init.sh"
 # Input:
 #   $@ - targets
 build_binaries() {
+    local args=
     # Check for `go` binary and set ${GOPATH}.
     setup_env
     cd "${OVN_KUBE_ROOT}"
@@ -18,11 +19,14 @@ build_binaries() {
     GIT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
     BUILD_USER=$(whoami)
     BUILD_DATE=$(date +"%Y-%m-%d")
-
+    if [ ! -z "${RACE:-}" ]; then
+        args="-race "
+    fi
     set -x
     for bin in "$@"; do
         binbase=$(basename ${bin})
         go build -v \
+            ${args} \
             -mod vendor \
             -gcflags "${GCFLAGS}" \
             -ldflags "-B ${BUILDID} \


### PR DESCRIPTION
**- What this PR does and why is it needed**

We had multiple issues with race conditions, enabling the race detector for the e2e tests will give us more insights on the problems

Fixes: #1510 

**- Special notes for reviewers**

The race detector shows the problem with a stack trace
```
WARNING: DATA RACE
```
so it's important, when used with the e2e tests, to check the logs of the corresponding binaries, the message is not going to show up in the ginkgo e2e logs.

Example here 

https://github.com/ovn-org/ovn-kubernetes/pull/1570#issuecomment-667679038

xref: https://blog.golang.org/race-detector

**- How to verify it**


**- Description for the changelog**
