### PR TITLE
fix local e2e for dual-stack

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -6,6 +6,12 @@ set -ex
 export KUBERNETES_CONFORMANCE_TEST=y
 export KUBECONFIG=${HOME}/admin.conf
 
+SKIPPED_TESTS=""
+if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
+    # No support for these features in dual-stack yet
+    SKIPPED_TESTS="hybrid.overlay|external.gateway"
+fi
+
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote
 export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
@@ -18,6 +24,7 @@ go mod download
 go test -timeout=0 -v . \
         -ginkgo.v \
         -ginkgo.flakeAttempts ${FLAKE_ATTEMPTS:-2} \
+        -ginkgo.skip=${SKIPPED_TESTS}" \
         -provider skeleton \
         -kubeconfig ${KUBECONFIG} \
         ${CONTAINER_RUNTIME:+"--container-runtime=${CONTAINER_RUNTIME}"} \


### PR DESCRIPTION
Our own e2e tests are failing in the dual-stack CI job because they were only parsing the single-stack form of the node-subnets annotation.

I didn't pull in `util.ParseNodeHostSubnetAnnotation` because (a) nothing else in this file was using any ovn-kubernetes code, and (b) that would require constructing a `Node` object anyway and would end up being overall more complicated than this.

@aojea is there any way to run the dual-stack CI job against this PR?