### PR TITLE
Fix abrupt exit of Windows service

### DIFF
--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/init_others.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/init_others.go
@@ -15,7 +15,14 @@ limitations under the License.
 
 package main
 
+import (
+	"context"
+
+	"github.com/urfave/cli/v2"
+)
+
 // initForOS performs non-Windows specific app initialization
-func initForOS(service bool) error {
+func initForOS(c *cli.Context, ctx context.Context) error {
+	signalHandler(ctx)
 	return nil
 }

--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/init_windows.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/init_windows.go
@@ -16,15 +16,19 @@ limitations under the License.
 package main
 
 import (
+	"context"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/windows/service"
+	"github.com/urfave/cli/v2"
 	"k8s.io/klog"
 )
 
 // initForOS performs Windows specific app initialization
-func initForOS(windowsService bool) error {
-	if windowsService {
+func initForOS(c *cli.Context, ctx context.Context) error {
+	if c.Bool(windowServiceArgName) {
 		klog.Infof("Initializing Windows service")
-		return service.InitService(appName)
+		return service.InitService(appName, ctx)
 	}
+	signalHandler(ctx)
 	return nil
 }


### PR DESCRIPTION
This PR introduces a fix for the issue addressed in https://github.com/ovn-org/ovn-kubernetes/issues/1562
As of now, running hybrid-overlay-node as a Windows service relies on os.Exit() to stop the service, this PR 
removes abrupt exit by instead cancelling the context on svc.Stop.

Signed-off-by: mansikulkarni96 <mankulka@redhat.com>
