### PR TITLE
increase kubernetes verbosity on CI and set reasonable timeouts for jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,7 @@ jobs:
   e2e:
     name: e2e
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -102,6 +102,7 @@ jobs:
   e2e-dual:
     name: e2e-dual
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -271,6 +271,7 @@ ovn_apiServerAddress=${API_IP} \
   ovn_ha=${KIND_HA} \
   ovn_num_master=${KIND_NUM_MASTER} \
   ovn_num_worker=${KIND_NUM_WORKER} \
+  cluster_log_level=${KIND_CLUSTER_LOGLEVEL:-4} \
   j2 ${KIND_CONFIG} -o ${KIND_CONFIG_LCL}
 
 # Create KIND cluster. For additional debug, add '--verbosity <int>': 0 None .. 3 Debug
@@ -350,7 +351,7 @@ kind load docker-image ${OVN_IMAGE} --name ${KIND_CLUSTER_NAME}
 
 pushd ../dist/yaml
 run_kubectl apply -f k8s.ovn.org_egressfirewalls.yaml
-run_kubectl apply -f k8s.ovn.org_egressips.yaml 
+run_kubectl apply -f k8s.ovn.org_egressips.yaml
 run_kubectl apply -f ovn-setup.yaml
 CONTROL_NODES=$(docker ps -f name=ovn-control | grep -v NAMES | awk '{ print $NF }')
 for n in $CONTROL_NODES; do

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -18,6 +18,25 @@ kubeadmConfigPatches:
   etcd:
     local:
       dataDir: "/tmp/lib/etcd"
+  apiServer:
+    extraArgs:
+      "v": "{{ cluster_log_level }}"
+  controllerManager:
+    extraArgs:
+      "v": "{{ cluster_log_level }}"
+  scheduler:
+    extraArgs:
+      "v": "{{ cluster_log_level }}"
+  ---
+  kind: InitConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+      "v": "{{ cluster_log_level }}"
+  ---
+  kind: JoinConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+      "v": "{{ cluster_log_level }}"
 nodes:
  - role: control-plane
    kubeadmConfigPatches:
@@ -35,4 +54,3 @@ nodes:
 {%- for _ in range(ovn_num_worker | int) %}
  - role: worker
 {%- endfor %}
-


### PR DESCRIPTION
**- What this PR does and why is it needed**

This addresses 2 issues with the CI:

* lack of detail in kubernetes logs to troubleshoot issues
* timing out on test, the average time for an e2e job is around 30 minutes,
but if there are issues it hangs forever and default timeout is 360 minutes.
We can timeout after 1 hour.

**- Special notes for reviewers**


**- How to verify it**


**- Description for the changelog**
