### PR TITLE
hybrid-overlay: reconcile annotation to DB.

### DIFF
--- a/go-controller/pkg/testing/exec.go
+++ b/go-controller/pkg/testing/exec.go
@@ -156,7 +156,7 @@ func (f *FakeExec) Command(cmd string, args ...string) kexec.Cmd {
 				// Fail if the first unused expected command doesn't
 				// match the one that is being executed
 				if executed != candidate.Cmd {
-					klog.Fatal(f.ErrorDesc())
+					klog.Fatal(f.internalErrorDesc())
 				}
 			}
 		}


### PR DESCRIPTION
This handles the case where, for whatever reason, the nbdb was deleted out from under us. Since we still have the annotations, we can reconstruct as needed.

/cc @JacobTanenbaum @dcbw 