### PR TITLE
Fix DB metrics detection for ovnkube-node

### DIFF
--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -92,6 +92,8 @@ spec:
         - mountPath: /ovn-cert
           name: host-ovn-cert
           readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
 
         resources:
           requests:
@@ -155,6 +157,8 @@ spec:
         - mountPath: /ovn-cert
           name: host-ovn-cert
           readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
 
         resources:
           requests:
@@ -205,5 +209,8 @@ spec:
         hostPath:
           path: /etc/ovn
           type: DirectoryOrCreate
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
       tolerations:
       - operator: "Exists"

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -193,6 +193,12 @@ spec:
         - mountPath: /ovn-cert
           name: host-ovn-cert
           readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+          readOnly: true
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
         {% if kind is defined and kind -%}
         - mountPath: /var/run/netns
           name: host-netns
@@ -344,6 +350,9 @@ spec:
       - name: host-config-openvswitch
         hostPath:
           path: /etc/origin/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
       {% if kind is defined and kind -%}
       - name: host-netns
         hostPath:

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -25,7 +25,7 @@ const (
 	MetricOvnkubeSubsystemMaster = "master"
 	MetricOvnkubeSubsystemNode   = "node"
 	MetricOvnNamespace           = "ovn"
-	MetricOvnSubsystemDBRaft     = "db_raft"
+	MetricOvnSubsystemDB         = "db"
 	MetricOvnSubsystemNorthd     = "northd"
 	MetricOvnSubsystemController = "controller"
 	MetricOvsNamespace           = "ovs"

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -16,7 +16,7 @@ import (
 
 var metricOVNDBSessions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "jsonrpc_server_sessions",
 	Help:      "Active number of JSON RPC Server sessions to the DB"},
 	[]string{
@@ -26,7 +26,7 @@ var metricOVNDBSessions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricOVNDBMonitor = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "ovsdb_monitors",
 	Help:      "Number of OVSDB Monitors on the server"},
 	[]string{
@@ -36,7 +36,7 @@ var metricOVNDBMonitor = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "db_size",
 	Help:      "The size of the database file associated with the OVN DB component."},
 	[]string{
@@ -47,7 +47,7 @@ var metricDBSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 // ClusterStatus metrics
 var metricDBClusterCID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_id",
 	Help:      "A metric with a constant '1' value labeled by database name and cluster uuid"},
 	[]string{
@@ -58,7 +58,7 @@ var metricDBClusterCID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterSID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_server_id",
 	Help: "A metric with a constant '1' value labeled by database name, cluster uuid " +
 		"and server uuid"},
@@ -71,7 +71,7 @@ var metricDBClusterSID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterServerStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_server_status",
 	Help: "A metric with a constant '1' value labeled by database name, cluster uuid, server uuid " +
 		"server status"},
@@ -85,7 +85,7 @@ var metricDBClusterServerStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterServerRole = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_server_role",
 	Help: "A metric with a constant '1' value labeled by database name, cluster uuid, server uuid " +
 		"and server role"},
@@ -99,7 +99,7 @@ var metricDBClusterServerRole = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterTerm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_term",
 	Help: "A metric that returns the current election term value labeled by database name, cluster uuid, and " +
 		"server uuid"},
@@ -112,7 +112,7 @@ var metricDBClusterTerm = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterServerVote = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_server_vote",
 	Help: "A metric with a constant '1' value labeled by database name, cluster uuid, server uuid " +
 		"and server vote"},
@@ -126,7 +126,7 @@ var metricDBClusterServerVote = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterElectionTimer = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_election_timer",
 	Help: "A metric that returns the current election timer value labeled by database name, cluster uuid, " +
 		"and server uuid"},
@@ -139,7 +139,7 @@ var metricDBClusterElectionTimer = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterLogIndexStart = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_log_index_start",
 	Help: "A metric that returns the log entry index start value labeled by database name, cluster uuid, " +
 		"and server uuid"},
@@ -152,7 +152,7 @@ var metricDBClusterLogIndexStart = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterLogIndexNext = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_log_index_next",
 	Help: "A metric that returns the log entry index next value labeled by database name, cluster uuid, " +
 		"and server uuid"},
@@ -165,7 +165,7 @@ var metricDBClusterLogIndexNext = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterLogNotCommitted = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_log_not_committed",
 	Help: "A metric that returns the number of log entries not committed labeled by database name, cluster uuid, " +
 		"and server uuid"},
@@ -178,7 +178,7 @@ var metricDBClusterLogNotCommitted = prometheus.NewGaugeVec(prometheus.GaugeOpts
 
 var metricDBClusterLogNotApplied = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_log_not_applied",
 	Help: "A metric that returns the number of log entries not applied labeled by database name, cluster uuid, " +
 		"and server uuid"},
@@ -191,7 +191,7 @@ var metricDBClusterLogNotApplied = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterConnIn = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_inbound_connections_total",
 	Help: "A metric that returns the total number of inbound  connections to the server labeled by " +
 		"database name, cluster uuid, and server uuid"},
@@ -204,7 +204,7 @@ var metricDBClusterConnIn = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterConnOut = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_outbound_connections_total",
 	Help: "A metric that returns the total number of outbound connections from the server labeled by " +
 		"database name, cluster uuid, and server uuid"},
@@ -217,7 +217,7 @@ var metricDBClusterConnOut = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterConnInErr = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_inbound_connections_error_total",
 	Help: "A metric that returns the total number of failed inbound connections to the server labeled by " +
 		" database name, cluster uuid, and server uuid"},
@@ -230,7 +230,7 @@ var metricDBClusterConnInErr = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBClusterConnOutErr = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "cluster_outbound_connections_error_total",
 	Help: "A metric that returns the total number of failed  outbound connections from the server labeled by " +
 		"database name, cluster uuid, and server uuid"},
@@ -243,7 +243,7 @@ var metricDBClusterConnOutErr = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 
 var metricDBE2eTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
-	Subsystem: MetricOvnSubsystemDBRaft,
+	Subsystem: MetricOvnSubsystemDB,
 	Name:      "e2e_timestamp",
 	Help:      "The current e2e-timestamp value as observed in this instance of the database"},
 	[]string{
@@ -373,7 +373,7 @@ func RegisterOvnDBMetrics(clientset *kubernetes.Clientset, k8sNodeName string) {
 	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace: MetricOvnNamespace,
-			Subsystem: MetricOvnSubsystemDBRaft,
+			Subsystem: MetricOvnSubsystemDB,
 			Name:      "build_info",
 			Help: "A metric with a constant '1' value labeled by ovsdb-server version and " +
 				"NB and SB schema version",
@@ -385,21 +385,29 @@ func RegisterOvnDBMetrics(clientset *kubernetes.Clientset, k8sNodeName string) {
 		},
 		func() float64 { return 1 },
 	))
-	ovnRegistry.MustRegister(metricDBClusterCID)
-	ovnRegistry.MustRegister(metricDBClusterSID)
-	ovnRegistry.MustRegister(metricDBClusterServerStatus)
-	ovnRegistry.MustRegister(metricDBClusterTerm)
-	ovnRegistry.MustRegister(metricDBClusterServerRole)
-	ovnRegistry.MustRegister(metricDBClusterServerVote)
-	ovnRegistry.MustRegister(metricDBClusterElectionTimer)
-	ovnRegistry.MustRegister(metricDBClusterLogIndexStart)
-	ovnRegistry.MustRegister(metricDBClusterLogIndexNext)
-	ovnRegistry.MustRegister(metricDBClusterLogNotCommitted)
-	ovnRegistry.MustRegister(metricDBClusterLogNotApplied)
-	ovnRegistry.MustRegister(metricDBClusterConnIn)
-	ovnRegistry.MustRegister(metricDBClusterConnOut)
-	ovnRegistry.MustRegister(metricDBClusterConnInErr)
-	ovnRegistry.MustRegister(metricDBClusterConnOutErr)
+	// check if DB is clustered or not
+	dbIsClustered := true
+	_, _, err = util.RunOVSDBTool("db-is-standalone", "/etc/openvswitch/ovnsb_db.db")
+	if err == nil {
+		dbIsClustered = false
+	}
+	if dbIsClustered {
+		ovnRegistry.MustRegister(metricDBClusterCID)
+		ovnRegistry.MustRegister(metricDBClusterSID)
+		ovnRegistry.MustRegister(metricDBClusterServerStatus)
+		ovnRegistry.MustRegister(metricDBClusterTerm)
+		ovnRegistry.MustRegister(metricDBClusterServerRole)
+		ovnRegistry.MustRegister(metricDBClusterServerVote)
+		ovnRegistry.MustRegister(metricDBClusterElectionTimer)
+		ovnRegistry.MustRegister(metricDBClusterLogIndexStart)
+		ovnRegistry.MustRegister(metricDBClusterLogIndexNext)
+		ovnRegistry.MustRegister(metricDBClusterLogNotCommitted)
+		ovnRegistry.MustRegister(metricDBClusterLogNotApplied)
+		ovnRegistry.MustRegister(metricDBClusterConnIn)
+		ovnRegistry.MustRegister(metricDBClusterConnOut)
+		ovnRegistry.MustRegister(metricDBClusterConnInErr)
+		ovnRegistry.MustRegister(metricDBClusterConnOutErr)
+	}
 	ovnRegistry.MustRegister(metricDBE2eTimestamp)
 
 	// functions responsible for collecting the values and updating the prometheus metrics
@@ -410,7 +418,9 @@ func RegisterOvnDBMetrics(clientset *kubernetes.Clientset, k8sNodeName string) {
 		}
 		for {
 			for direction, database := range dirDbMap {
-				ovnDBClusterStatusMetricsUpdater(direction, database)
+				if dbIsClustered {
+					ovnDBClusterStatusMetricsUpdater(direction, database)
+				}
 				ovnDBMemoryMetricsUpdater(direction, database)
 				ovnDBSizeMetricsUpdater(direction, database)
 				ovnE2eTimeStampUpdater(direction, database)

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -34,6 +34,7 @@ const (
 	ovnSbctlCommand    = "ovn-sbctl"
 	ovnAppctlCommand   = "ovn-appctl"
 	ovsdbClientCommand = "ovsdb-client"
+	ovsdbToolCommand   = "ovsdb-tool"
 	arpingCommand      = "arping"
 	ipCommand          = "ip"
 	powershellCommand  = "powershell"
@@ -119,6 +120,7 @@ type execHelper struct {
 	sbctlPath       string
 	ovnctlPath      string
 	ovsdbClientPath string
+	ovsdbToolPath   string
 	ovnRunDir       string
 	ipPath          string
 	arpingPath      string
@@ -216,6 +218,10 @@ func SetExec(exec kexec.Interface) error {
 		return err
 	}
 	runner.ovsdbClientPath, err = exec.LookPath(ovsdbClientCommand)
+	if err != nil {
+		return err
+	}
+	runner.ovsdbToolPath, err = exec.LookPath(ovsdbToolCommand)
 	if err != nil {
 		return err
 	}
@@ -511,6 +517,12 @@ func RunOVNSbctlWithTimeout(timeout int, args ...string) (string, string,
 // RunOVSDBClient runs an 'ovsdb-client [OPTIONS] COMMAND [ARG...] command'.
 func RunOVSDBClient(args ...string) (string, string, error) {
 	stdout, stderr, err := runOVNretry(runner.ovsdbClientPath, nil, args...)
+	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
+}
+
+// RunOVSDBTool runs an 'ovsdb-tool [OPTIONS] COMMAND [ARG...] command'.
+func RunOVSDBTool(args ...string) (string, string, error) {
+	stdout, stderr, err := run(runner.ovsdbToolPath, args...)
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -98,14 +98,14 @@ func TestSetExec(t *testing.T) {
 			desc:         "positive, test when 'runner' is nil",
 			expectedErr:  nil,
 			onRetArgs:    &onCallReturnArgs{"LookPath", []string{"string"}, []interface{}{"ip", nil, "arping", nil}},
-			fnCallTimes:  10,
+			fnCallTimes:  11,
 			setRunnerNil: true,
 		},
 		{
 			desc:         "positive, test when 'runner' is not nil",
 			expectedErr:  nil,
 			onRetArgs:    &onCallReturnArgs{"LookPath", []string{"string"}, []interface{}{"", nil, "", nil}},
-			fnCallTimes:  10,
+			fnCallTimes:  11,
 			setRunnerNil: false,
 		},
 	}


### PR DESCRIPTION
ovnkube-node was trying to scrape DB stats and had no mounted volume to
access the NB or SB DB. Additionally, the node was always trying to get
cluster DB stats even when we were not running in HA.

Signed-off-by: Tim Rozet <trozet@redhat.com>



**- How to verify it**
On ovn-k8s master nodes (where db runs) look at the log for ovnkube-node. Without correct paths messages will appear in the log like:

contrib/logs.txt:, err: (OVN command '/usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 cluster/status OVN_Northbound' failed: exit status 1)
contrib/logs.txt:E0805 18:56:15.422051    2212 ovn_db.go:535] OVN command '/usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 cluster/status OVN_Northbound' failed: exit status 1
contrib/logs.txt:E0805 18:56:15.438053    2212 ovn_db.go:460] Failed to retrieve cluster/status info for database "OVN_Southbound", stderr: 2020-08-05T18:56:15Z|00001|unixctl|WARN|failed to connect to /var/run/ovn/ovnsb_db.ctl

contrib/logs.txt:, err: (OVN command '/usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 memory/show' failed: exit status 1)
contrib/logs.txt:E0805 18:54:00.250102    2212 ovn_db.go:302] Failed retrieving memory/show output for "OVN_SOUTHBOUND", stderr: 2020-08-05T18:54:00Z|00001|unixctl|WARN|failed to connect to /var/run/ovn/ovnsb_db.ctl

