### PR TITLE
Refactor Local/Shared Gateway code to simplify watches

### DIFF
--- a/go-controller/pkg/informer/handlers.go
+++ b/go-controller/pkg/informer/handlers.go
@@ -1,0 +1,23 @@
+package informer
+
+import (
+	kapi "k8s.io/api/core/v1"
+)
+
+type ServiceEventHandler interface {
+	AddService(*kapi.Service)
+	DeleteService(*kapi.Service)
+	UpdateService(old, new *kapi.Service)
+	SyncServices([]interface{})
+}
+
+type EndpointsEventHandler interface {
+	AddEndpoints(*kapi.Endpoints)
+	DeleteEndpoints(*kapi.Endpoints)
+	UpdateEndpoints(old, new *kapi.Endpoints)
+}
+
+type ServiceAndEndpointsEventHandler interface {
+	ServiceEventHandler
+	EndpointsEventHandler
+}

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -1,0 +1,187 @@
+package node
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+// Gateway responds to Service and Endpoint K8s events
+// and programs OVN gateway functionality.
+// It may also spawn threads to ensure the flow tables
+// are kept in sync
+type Gateway interface {
+	informer.ServiceAndEndpointsEventHandler
+	Init() error
+	Run(<-chan struct{})
+}
+
+type gateway struct {
+	loadBalancerHealthChecker informer.ServiceAndEndpointsEventHandler
+	portClaimWatcher          informer.ServiceEventHandler
+	nodePortWatcher           informer.ServiceEventHandler
+	localPortWatcher          informer.ServiceEventHandler
+	openflowManager           *openflowManager
+	initFunc                  func() error
+}
+
+func (g *gateway) AddService(svc *kapi.Service) {
+	if g.portClaimWatcher != nil {
+		g.portClaimWatcher.AddService(svc)
+	}
+	if g.loadBalancerHealthChecker != nil {
+		g.loadBalancerHealthChecker.AddService(svc)
+	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.AddService(svc)
+	}
+	if g.localPortWatcher != nil {
+		g.localPortWatcher.AddService(svc)
+	}
+}
+
+func (g *gateway) UpdateService(old, new *kapi.Service) {
+	if g.portClaimWatcher != nil {
+		g.portClaimWatcher.UpdateService(old, new)
+	}
+	if g.loadBalancerHealthChecker != nil {
+		g.loadBalancerHealthChecker.UpdateService(old, new)
+	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.UpdateService(old, new)
+	}
+	if g.localPortWatcher != nil {
+		g.localPortWatcher.UpdateService(old, new)
+	}
+}
+
+func (g *gateway) DeleteService(svc *kapi.Service) {
+	if g.portClaimWatcher != nil {
+		g.portClaimWatcher.DeleteService(svc)
+	}
+	if g.loadBalancerHealthChecker != nil {
+		g.loadBalancerHealthChecker.DeleteService(svc)
+	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.DeleteService(svc)
+	}
+	if g.localPortWatcher != nil {
+		g.localPortWatcher.AddService(svc)
+	}
+}
+
+func (g *gateway) SyncServices(objs []interface{}) {
+	if g.portClaimWatcher != nil {
+		g.portClaimWatcher.SyncServices(objs)
+	}
+	if g.loadBalancerHealthChecker != nil {
+		g.loadBalancerHealthChecker.SyncServices(objs)
+	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.SyncServices(objs)
+	}
+	if g.localPortWatcher != nil {
+		g.localPortWatcher.SyncServices(objs)
+	}
+}
+
+func (g *gateway) AddEndpoints(ep *kapi.Endpoints) {
+	if g.loadBalancerHealthChecker != nil {
+		g.loadBalancerHealthChecker.AddEndpoints(ep)
+	}
+}
+
+func (g *gateway) UpdateEndpoints(old, new *kapi.Endpoints) {
+	if g.loadBalancerHealthChecker != nil {
+		g.loadBalancerHealthChecker.UpdateEndpoints(old, new)
+	}
+}
+
+func (g *gateway) DeleteEndpoints(ep *kapi.Endpoints) {
+	if g.loadBalancerHealthChecker != nil {
+		g.loadBalancerHealthChecker.AddEndpoints(ep)
+	}
+}
+
+func (g *gateway) Init() error {
+	return g.initFunc()
+}
+
+func (g *gateway) Run(stopChan <-chan struct{}) {
+	if g.openflowManager != nil {
+		klog.Info("Spawning Conntrack Rule Check Thread")
+		g.openflowManager.Run(stopChan)
+	}
+}
+
+func gatewayInitInternal(nodeName, gwIntf string, subnets []*net.IPNet, gwNextHops []net.IP, nodeAnnotator kube.Annotator) (string, string, []*net.IPNet, error) {
+	var bridgeName string
+	var uplinkName string
+	var brCreated bool
+	var err error
+
+	if bridgeName, _, err = util.RunOVSVsctl("--", "port-to-br", gwIntf); err == nil {
+		// This is an OVS bridge's internal port
+		uplinkName, err = util.GetNicName(bridgeName)
+		if err != nil {
+			return bridgeName, uplinkName, nil, err
+		}
+	} else if _, _, err := util.RunOVSVsctl("--", "br-exists", gwIntf); err != nil {
+		// This is not a OVS bridge. We need to create a OVS bridge
+		// and add cluster.GatewayIntf as a port of that bridge.
+		bridgeName, err = util.NicToBridge(gwIntf)
+		if err != nil {
+			return bridgeName, uplinkName, nil, fmt.Errorf("failed to convert %s to OVS bridge: %v", gwIntf, err)
+		}
+		uplinkName = gwIntf
+		gwIntf = bridgeName
+		brCreated = true
+	} else {
+		// gateway interface is an OVS bridge
+		uplinkName, err = getIntfName(gwIntf)
+		if err != nil {
+			return bridgeName, uplinkName, nil, err
+		}
+		bridgeName = gwIntf
+	}
+
+	// Now, we get IP addresses from OVS bridge. If IP does not exist,
+	// error out.
+	ips, err := getNetworkInterfaceIPAddresses(gwIntf)
+	if err != nil {
+		return bridgeName, uplinkName, nil, fmt.Errorf("failed to get interface details for %s (%v)",
+			gwIntf, err)
+	}
+	ifaceID, macAddress, err := bridgedGatewayNodeSetup(nodeName, bridgeName, gwIntf,
+		util.PhysicalNetworkName, brCreated)
+	if err != nil {
+		return bridgeName, uplinkName, nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
+	}
+
+	err = setupLocalNodeAccessBridge(nodeName, subnets)
+	if err != nil {
+		return bridgeName, uplinkName, nil, err
+	}
+	chassisID, err := util.GetNodeChassisID()
+	if err != nil {
+		return bridgeName, uplinkName, nil, err
+	}
+
+	err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
+		Mode:           config.GatewayModeShared,
+		ChassisID:      chassisID,
+		InterfaceID:    ifaceID,
+		MACAddress:     macAddress,
+		IPAddresses:    ips,
+		NextHops:       gwNextHops,
+		NodePortEnable: config.Gateway.NodeportEnable,
+		VLANID:         &config.Gateway.VLANID,
+	})
+	return bridgeName, uplinkName, ips, err
+}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -5,11 +5,14 @@ import (
 	"net"
 	"strings"
 
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+	utilnet "k8s.io/utils/net"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"k8s.io/klog"
-	utilnet "k8s.io/utils/net"
 )
 
 // bridgedGatewayNodeSetup makes the bridge's MAC address permanent (if needed), sets up
@@ -156,11 +159,16 @@ func getGatewayNextHops() ([]net.IP, string, error) {
 }
 
 func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator,
-	waiter *startupWaiter) error {
+	waiter *startupWaiter, managementPortConfig *managementPortConfig) error {
+	klog.Info("Initializing Gateway Functionality")
+	var err error
+
+	var loadBalancerHealthChecker *loadBalancerHealthChecker
+	var portClaimWatcher *portClaimWatcher
 
 	if config.Gateway.NodeportEnable {
-		initLoadBalancerHealthChecker(n.name, n.watchFactory)
-		err := initPortClaimWatcher(n.recorder, n.watchFactory)
+		loadBalancerHealthChecker = newLoadBalancerHealthChecker(n.name)
+		portClaimWatcher, err = newPortClaimWatcher(n.recorder)
 		if err != nil {
 			return err
 		}
@@ -178,14 +186,23 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		}
 	}
 
-	var prFn postWaitFunc
-	if config.Gateway.Mode != config.GatewayModeDisabled {
-		prFn, err = n.initSharedGateway(subnets, gatewayNextHops, gatewayIntf, nodeAnnotator)
-	} else {
+	var gw *gateway
+	switch config.Gateway.Mode {
+	case config.GatewayModeLocal:
+		klog.Info("Preparing Local Gateway")
+		gw, err = newLocalGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator, n.recorder, managementPortConfig)
+	case config.GatewayModeShared:
+		klog.Info("Preparing Shared Gateway")
+		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator)
+	case config.GatewayModeDisabled:
+		klog.Info("Gateway Mode is disabled")
+		gw = &gateway{}
 		err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
 			Mode: config.GatewayModeDisabled,
 		})
 	}
+	gw.loadBalancerHealthChecker = loadBalancerHealthChecker
+	gw.portClaimWatcher = portClaimWatcher
 
 	if err != nil {
 		return err
@@ -195,11 +212,47 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	// as that option does not add default SNAT rules on the GR and the gatewayReady function checks
 	// those default NAT rules are present
 	if !config.Gateway.DisableSNATMultipleGWs && config.Gateway.Mode != config.GatewayModeLocal {
-		waiter.AddWait(gatewayReady, prFn)
+		waiter.AddWait(gatewayReady, gw.Init)
 	} else {
-		waiter.AddWait(func() (bool, error) { return true, nil }, prFn)
+		waiter.AddWait(func() (bool, error) { return true, nil }, gw.Init)
 	}
-	return nil
+
+	n.gateway = gw
+	n.watchFactory.AddServiceHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			svc := obj.(*kapi.Service)
+			n.gateway.AddService(svc)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			oldSvc := old.(*kapi.Service)
+			newSvc := new.(*kapi.Service)
+			n.gateway.UpdateService(oldSvc, newSvc)
+		},
+		DeleteFunc: func(obj interface{}) {
+			svc := obj.(*kapi.Service)
+			n.gateway.DeleteService(svc)
+		},
+	}, n.gateway.SyncServices)
+	if err != nil {
+		return err
+	}
+
+	n.watchFactory.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			ep := obj.(*kapi.Endpoints)
+			n.gateway.AddEndpoints(ep)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			oldEp := old.(*kapi.Endpoints)
+			newEp := new.(*kapi.Endpoints)
+			n.gateway.UpdateEndpoints(oldEp, newEp)
+		},
+		DeleteFunc: func(obj interface{}) {
+			ep := obj.(*kapi.Endpoints)
+			n.gateway.DeleteEndpoints(ep)
+		},
+	}, nil)
+	return err
 }
 
 // CleanupClusterNode cleans up OVS resources on the k8s node on ovnkube-node daemonset deletion.
@@ -252,5 +305,6 @@ func gatewayReady() (bool, error) {
 			return false, nil
 		}
 	}
+	klog.Info("Gateway is ready")
 	return true, nil
 }

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 	utilnet "k8s.io/utils/net"
@@ -27,6 +27,60 @@ const (
 	localnetGatewayExternalIDTable = "6"
 )
 
+func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net.IP, gwIntf string, nodeAnnotator kube.Annotator, recorder record.EventRecorder, cfg *managementPortConfig) (*gateway, error) {
+	gw := &gateway{}
+	var gatewayIfAddrs []*net.IPNet
+	for _, hostSubnet := range hostSubnets {
+		// local gateway mode uses mp0 as default path for all ingress traffic into OVN
+		var nextHop *net.IPNet
+		if utilnet.IsIPv6CIDR(hostSubnet) {
+			nextHop = cfg.ipv6.ifAddr
+		} else {
+			nextHop = cfg.ipv4.ifAddr
+		}
+		// gatewayIfAddrs are the OVN next hops via mp0
+		gatewayIfAddrs = append(gatewayIfAddrs, util.GetNodeGatewayIfAddr(hostSubnet))
+
+		// add iptables masquerading for mp0 to exit the host for egress
+		cidr := nextHop.IP.Mask(nextHop.Mask)
+		cidrNet := &net.IPNet{IP: cidr, Mask: nextHop.Mask}
+		err := initLocalGatewayNATRules(util.K8sMgmtIntfName, cidrNet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add local NAT rules for: %s, err: %v", util.K8sMgmtIntfName, err)
+		}
+	}
+
+	bridgeName, uplinkName, _, err := gatewayInitInternal(
+		nodeName, gwIntf, hostSubnets, gwNextHops, nodeAnnotator)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.Gateway.NodeportEnable {
+		localAddrSet, err := getLocalAddrs()
+		if err != nil {
+			return nil, err
+		}
+
+		if err := initLocalGatewayIPTables(); err != nil {
+			return nil, err
+		}
+		if err := initRoutingRules(); err != nil {
+			return nil, err
+		}
+		gw.localPortWatcher = newLocalPortWatcher(gatewayIfAddrs, recorder, localAddrSet)
+	}
+
+	gw.initFunc = func() error {
+		klog.Info("Creating Local Gateway Openflow Manager")
+		var err error
+		gw.openflowManager, err = newLocalGatewayOpenflowManager(nodeName, bridgeName, uplinkName)
+		return err
+	}
+
+	return gw, nil
+}
+
 func getGatewayFamilyAddrs(gatewayIfAddrs []*net.IPNet) (string, string) {
 	var gatewayIPv4, gatewayIPv6 string
 	for _, gatewayIfAddr := range gatewayIfAddrs {
@@ -39,20 +93,48 @@ func getGatewayFamilyAddrs(gatewayIfAddrs []*net.IPNet) (string, string) {
 	return gatewayIPv4, gatewayIPv6
 }
 
-type localPortWatcherData struct {
+type localPortWatcher struct {
 	recorder     record.EventRecorder
 	gatewayIPv4  string
 	gatewayIPv6  string
 	localAddrSet map[string]net.IPNet
 }
 
-func newLocalPortWatcherData(gatewayIfAddrs []*net.IPNet, recorder record.EventRecorder, localAddrSet map[string]net.IPNet) *localPortWatcherData {
+func newLocalPortWatcher(gatewayIfAddrs []*net.IPNet, recorder record.EventRecorder, localAddrSet map[string]net.IPNet) *localPortWatcher {
 	gatewayIPv4, gatewayIPv6 := getGatewayFamilyAddrs(gatewayIfAddrs)
-	return &localPortWatcherData{
+	return &localPortWatcher{
+		recorder:     recorder,
 		gatewayIPv4:  gatewayIPv4,
 		gatewayIPv6:  gatewayIPv6,
-		recorder:     recorder,
 		localAddrSet: localAddrSet,
+	}
+}
+
+func (l *localPortWatcher) AddService(svc *kapi.Service) {
+	err := l.addService(svc)
+	if err != nil {
+		klog.Errorf("Error in adding service: %v", err)
+	}
+}
+
+func (l *localPortWatcher) UpdateService(old, new *kapi.Service) {
+	if reflect.DeepEqual(new.Spec, old.Spec) {
+		return
+	}
+	err := l.deleteService(old)
+	if err != nil {
+		klog.Errorf("Error in deleting service - %v", err)
+	}
+	err = l.addService(new)
+	if err != nil {
+		klog.Errorf("Error in modifying service: %v", err)
+	}
+}
+
+func (l *localPortWatcher) DeleteService(svc *kapi.Service) {
+	err := l.deleteService(svc)
+	if err != nil {
+		klog.Errorf("Error in deleting service - %v", err)
 	}
 }
 
@@ -73,8 +155,8 @@ func getLocalAddrs() (map[string]net.IPNet, error) {
 	return localAddrSet, nil
 }
 
-func (npw *localPortWatcherData) networkHasAddress(ip net.IP) bool {
-	for _, net := range npw.localAddrSet {
+func (l *localPortWatcher) networkHasAddress(ip net.IP) bool {
+	for _, net := range l.localAddrSet {
 		if net.Contains(ip) {
 			return true
 		}
@@ -82,12 +164,12 @@ func (npw *localPortWatcherData) networkHasAddress(ip net.IP) bool {
 	return false
 }
 
-func (npw *localPortWatcherData) addService(svc *kapi.Service) error {
+func (l *localPortWatcher) addService(svc *kapi.Service) error {
 	iptRules := []iptRule{}
 	isIPv6Service := utilnet.IsIPv6String(svc.Spec.ClusterIP)
-	gatewayIP := npw.gatewayIPv4
+	gatewayIP := l.gatewayIPv4
 	if isIPv6Service {
-		gatewayIP = npw.gatewayIPv6
+		gatewayIP = l.gatewayIPv6
 	}
 	// holds map of external ips and if they are currently using routes
 	routeUsage := make(map[string]bool)
@@ -120,20 +202,20 @@ func (npw *localPortWatcherData) addService(svc *kapi.Service) error {
 					externalIP, svc.Namespace, svc.Name, svc.Spec.ClusterIP)
 				continue
 			}
-			if _, exists := npw.localAddrSet[externalIP]; exists {
+			if _, exists := l.localAddrSet[externalIP]; exists {
 				if !util.IsClusterIPSet(svc) {
 					serviceRef := kapi.ObjectReference{
 						Kind:      "Service",
 						Namespace: svc.Namespace,
 						Name:      svc.Name,
 					}
-					npw.recorder.Eventf(&serviceRef, kapi.EventTypeWarning, "UnsupportedServiceDefinition", "Unsupported service definition, headless service: %s with a local ExternalIP is not supported by ovn-kubernetes in local gateway mode", svc.Name)
+					l.recorder.Eventf(&serviceRef, kapi.EventTypeWarning, "UnsupportedServiceDefinition", "Unsupported service definition, headless service: %s with a local ExternalIP is not supported by ovn-kubernetes in local gateway mode", svc.Name)
 					klog.Warningf("UnsupportedServiceDefinition event for service %s in namespace %s", svc.Name, svc.Namespace)
 					continue
 				}
 				iptRules = append(iptRules, getExternalIPTRules(port, externalIP, svc.Spec.ClusterIP)...)
 				klog.V(5).Infof("Will add iptables rule for ExternalIP: %s", externalIP)
-			} else if npw.networkHasAddress(net.ParseIP(externalIP)) {
+			} else if l.networkHasAddress(net.ParseIP(externalIP)) {
 				klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip setup", externalIP)
 			} else {
 				if gatewayIP != "" {
@@ -156,12 +238,12 @@ func (npw *localPortWatcherData) addService(svc *kapi.Service) error {
 	return addIptRules(iptRules)
 }
 
-func (npw *localPortWatcherData) deleteService(svc *kapi.Service) error {
+func (l *localPortWatcher) deleteService(svc *kapi.Service) error {
 	iptRules := []iptRule{}
 	isIPv6Service := utilnet.IsIPv6String(svc.Spec.ClusterIP)
-	gatewayIP := npw.gatewayIPv4
+	gatewayIP := l.gatewayIPv4
 	if isIPv6Service {
-		gatewayIP = npw.gatewayIPv6
+		gatewayIP = l.gatewayIPv6
 	}
 	// holds map of external ips and if they are currently using routes
 	routeUsage := make(map[string]bool)
@@ -181,10 +263,10 @@ func (npw *localPortWatcherData) deleteService(svc *kapi.Service) error {
 			if utilnet.IsIPv6String(externalIP) != isIPv6Service {
 				continue
 			}
-			if _, exists := npw.localAddrSet[externalIP]; exists {
+			if _, exists := l.localAddrSet[externalIP]; exists {
 				iptRules = append(iptRules, getExternalIPTRules(port, externalIP, svc.Spec.ClusterIP)...)
 				klog.V(5).Infof("Will delete iptables rule for ExternalIP: %s", externalIP)
-			} else if npw.networkHasAddress(net.ParseIP(externalIP)) {
+			} else if l.networkHasAddress(net.ParseIP(externalIP)) {
 				klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip cleanup", externalIP)
 			} else {
 				if gatewayIP != "" {
@@ -206,7 +288,7 @@ func (npw *localPortWatcherData) deleteService(svc *kapi.Service) error {
 	return delIptRules(iptRules)
 }
 
-func (npw *localPortWatcherData) syncServices(serviceInterface []interface{}) {
+func (l *localPortWatcher) SyncServices(serviceInterface []interface{}) {
 	removeStaleRoutes := func(keepRoutes []string) {
 		stdout, stderr, err := util.RunIP("route", "list", "table", localnetGatewayExternalIDTable)
 		if err != nil || stdout == "" {
@@ -238,9 +320,9 @@ func (npw *localPortWatcherData) syncServices(serviceInterface []interface{}) {
 			klog.Errorf("Spurious object in syncServices: %v", serviceInterface)
 			continue
 		}
-		gatewayIP := npw.gatewayIPv4
+		gatewayIP := l.gatewayIPv4
 		if utilnet.IsIPv6String(svc.Spec.ClusterIP) {
-			gatewayIP = npw.gatewayIPv6
+			gatewayIP = l.gatewayIPv6
 		}
 		if gatewayIP != "" {
 			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, gatewayIP, nil)...)
@@ -264,48 +346,6 @@ func initRoutingRules() error {
 			return fmt.Errorf("error adding routing rule for ExternalIP table (%s): stdout: %s, stderr: %s, err: %v", localnetGatewayExternalIDTable, stdout, stderr, err)
 		}
 	}
-	return nil
-}
-
-func (n *OvnNode) watchLocalPorts(npw *localPortWatcherData) error {
-	if err := initLocalGatewayIPTables(); err != nil {
-		return err
-	}
-	if err := initRoutingRules(); err != nil {
-		return err
-	}
-	n.watchFactory.AddServiceHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			svc := obj.(*kapi.Service)
-			err := npw.addService(svc)
-			if err != nil {
-				klog.Errorf("Error in adding service: %v", err)
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			svcNew := new.(*kapi.Service)
-			svcOld := old.(*kapi.Service)
-			if reflect.DeepEqual(svcNew.Spec, svcOld.Spec) &&
-				reflect.DeepEqual(svcNew.Status, svcOld.Status) {
-				return
-			}
-			err := npw.deleteService(svcOld)
-			if err != nil {
-				klog.Errorf("Error in deleting service - %v", err)
-			}
-			err = npw.addService(svcNew)
-			if err != nil {
-				klog.Errorf("Error in modifying service: %v", err)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			svc := obj.(*kapi.Service)
-			err := npw.deleteService(svc)
-			if err != nil {
-				klog.Errorf("Error in deleting service - %v", err)
-			}
-		},
-	}, npw.syncServices)
 	return nil
 }
 
@@ -364,7 +404,7 @@ func getLoadBalancerIPTRules(svc *kapi.Service, svcPort kapi.ServicePort, gatewa
 // -- to also connection track the outbound north-south traffic through l3 gateway so that
 //    the return traffic can be steered back to OVN logical topology
 // -- to also handle unDNAT return traffic back out of the host
-func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan chan struct{}) error {
+func newLocalGatewayOpenflowManager(nodeName, gwBridge, gwIntf string) (*openflowManager, error) {
 	// the name of the patch port created by ovn-controller is of the form
 	// patch-<logical_port_name_of_localnet_port>-to-br-int
 	localnetLpName := gwBridge + "_" + nodeName
@@ -374,21 +414,21 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 	ofportPatch, stderr, err := util.RunOVSVsctl("wait-until", "Interface", patchPort, "ofport>0",
 		"--", "get", "Interface", patchPort, "ofport")
 	if err != nil {
-		return fmt.Errorf("failed while waiting on patch port %q to be created by ovn-controller and "+
+		return nil, fmt.Errorf("failed while waiting on patch port %q to be created by ovn-controller and "+
 			"while getting ofport. stderr: %q, error: %v", patchPort, stderr, err)
 	}
 
 	// Get ofport of physical interface
 	ofportPhys, stderr, err := util.RunOVSVsctl("get", "interface", gwIntf, "ofport")
 	if err != nil {
-		return fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
+		return nil, fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
 			gwIntf, stderr, err)
 	}
 
 	// replace the left over OpenFlow flows with the FLOOD action flow
 	_, stderr, err = util.AddOFFlowWithSpecificAction(gwBridge, util.FloodAction)
 	if err != nil {
-		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
+		return nil, fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
 	}
 
 	nFlows := 0
@@ -400,7 +440,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 				"actions=ct(commit, exec(load:0x1->NXM_NX_CT_LABEL), zone=%d), output:%s",
 				defaultOpenFlowCookie, ofportPatch, config.Default.ConntrackZone, ofportPhys))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -411,7 +451,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 			fmt.Sprintf("cookie=%s, priority=50, table=0, in_port=%s, ip, "+
 				"actions=ct(zone=%d, table=1)", defaultOpenFlowCookie, ofportPhys, config.Default.ConntrackZone))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -424,7 +464,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 				"actions=ct(commit, exec(load:0x1->NXM_NX_CT_LABEL), zone=%d), output:%s",
 				defaultOpenFlowCookie, ofportPatch, config.Default.ConntrackZone, ofportPhys))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -435,7 +475,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 			fmt.Sprintf("cookie=%s, priority=50, table=0, in_port=%s, ipv6, "+
 				"actions=ct(zone=%d, table=1)", defaultOpenFlowCookie, ofportPhys, config.Default.ConntrackZone))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -446,7 +486,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 		fmt.Sprintf("cookie=%s, priority=100, table=0, in_port=LOCAL, actions=output:%s",
 			defaultOpenFlowCookie, ofportPhys))
 	if err != nil {
-		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, error: %v", gwBridge, stderr, err)
+		return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, error: %v", gwBridge, stderr, err)
 	}
 	nFlows++
 
@@ -455,7 +495,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 		fmt.Sprintf("cookie=%s, priority=99, table=0, in_port=%s, actions=output:%s",
 			defaultOpenFlowCookie, ofportPatch, ofportPhys))
 	if err != nil {
-		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, error: %v", gwBridge, stderr, err)
+		return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, error: %v", gwBridge, stderr, err)
 	}
 
 	nFlows++
@@ -465,7 +505,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 		fmt.Sprintf("cookie=%s, priority=100, table=1, ct_label=0x1, "+
 			"actions=output:%s", defaultOpenFlowCookie, ofportPatch))
 	if err != nil {
-		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
 	nFlows++
@@ -484,7 +524,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 			fmt.Sprintf("cookie=%s, priority=3, table=1, %s, %s_dst=%s/%d, actions=output:%s",
 				defaultOpenFlowCookie, ipPrefix, ipPrefix, cidr.IP, mask, ofportPatch))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -497,7 +537,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 		_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 			fmt.Sprintf("cookie=%s, priority=1, table=1,icmp6 actions=FLOOD", defaultOpenFlowCookie))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -507,12 +547,13 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 		fmt.Sprintf("cookie=%s, priority=0, table=1, actions=LOCAL", defaultOpenFlowCookie))
 	if err != nil {
-		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
 	nFlows++
 
 	// add health check function to check default OpenFlow flows are on the shared gateway bridge
-	go checkDefaultConntrackRules(gwBridge, gwIntf, patchPort, ofportPhys, ofportPatch, nFlows, stopChan)
-	return nil
+	return &openflowManager{
+		gwBridge, gwIntf, patchPort, ofportPhys, ofportPatch, nFlows,
+	}, nil
 }

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -9,12 +9,10 @@ import (
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 	utilnet "k8s.io/utils/net"
 )
@@ -25,7 +23,16 @@ const (
 	defaultOpenFlowCookie = "0xdeff105"
 )
 
-func addService(service *kapi.Service, inport, outport, gwBridge string, nodeIP *net.IPNet) {
+// nodePortWatcher manages OpenfLow and iptables rules
+// to ensure that services using NodePorts are accessible
+type nodePortWatcher struct {
+	ofportPhys  string
+	ofportPatch string
+	gwBridge    string
+	nodeIP      *net.IPNet
+}
+
+func (npw *nodePortWatcher) AddService(service *kapi.Service) {
 	if !util.ServiceTypeHasNodePort(service) && len(service.Spec.ExternalIPs) == 0 {
 		return
 	}
@@ -39,21 +46,21 @@ func addService(service *kapi.Service, inport, outport, gwBridge string, nodeIP 
 				continue
 			}
 			if config.IPv4Mode {
-				_, stderr, err := util.RunOVSOfctl("add-flow", gwBridge,
+				_, stderr, err := util.RunOVSOfctl("add-flow", npw.gwBridge,
 					fmt.Sprintf("priority=100, in_port=%s, %s, tp_dst=%d, actions=%s",
-						inport, protocol, svcPort.NodePort, outport))
+						npw.ofportPhys, protocol, svcPort.NodePort, npw.ofportPatch))
 				if err != nil {
 					klog.Errorf("Failed to add openflow flow on %s for nodePort: "+
-						"%d, stderr: %q, error: %v", gwBridge, svcPort.NodePort, stderr, err)
+						"%d, stderr: %q, error: %v", npw.gwBridge, svcPort.NodePort, stderr, err)
 				}
 			}
 			if config.IPv6Mode {
-				_, stderr, err := util.RunOVSOfctl("add-flow", gwBridge,
+				_, stderr, err := util.RunOVSOfctl("add-flow", npw.gwBridge,
 					fmt.Sprintf("priority=100, in_port=%s, %s, tp_dst=%d, actions=%s",
-						inport, protocol6, svcPort.NodePort, outport))
+						npw.ofportPhys, protocol6, svcPort.NodePort, npw.ofportPatch))
 				if err != nil {
 					klog.Errorf("Failed to add openflow flow on %s for nodePort: "+
-						"%d, stderr: %q, error: %v", gwBridge, svcPort.NodePort, stderr, err)
+						"%d, stderr: %q, error: %v", npw.gwBridge, svcPort.NodePort, stderr, err)
 				}
 			}
 			// Flows for cloud load balancers on Azure/GCP
@@ -90,20 +97,20 @@ func addService(service *kapi.Service, inport, outport, gwBridge string, nodeIP 
 				flows = append(flows,
 					fmt.Sprintf("cookie=%s,priority=101,in_port=%s,ct_state=-trk,%s,%s=%s,tp_dst=%d,"+
 						"actions=ct(commit,table=0,zone=%d,nat(dst=%s)",
-						cookie, inport, flowProtocol, nw_dst, ing.IP, svcPort.Port, config.Default.ConntrackZone,
-						util.JoinHostPortInt32(nodeIP.IP.String(), svcPort.NodePort)))
+						cookie, npw.ofportPhys, flowProtocol, nw_dst, ing.IP, svcPort.Port, config.Default.ConntrackZone,
+						util.JoinHostPortInt32(npw.nodeIP.IP.String(), svcPort.NodePort)))
 				// Incoming return traffic from pods, send to CT, unDNAT, goto table 2
 				flows = append(flows,
 					fmt.Sprintf("cookie=%s,priority=101,in_port=%s,%s,%s=%s,tp_src=%d,"+
 						"actions=ct(table=2,zone=%d,nat)",
-						cookie, outport, flowProtocol, nw_src, nodeIP.IP, svcPort.NodePort, config.Default.ConntrackZone))
+						cookie, npw.ofportPatch, flowProtocol, nw_src, npw.nodeIP.IP, svcPort.NodePort, config.Default.ConntrackZone))
 			}
 
 			for _, flow := range flows {
-				_, stderr, err := util.RunOVSOfctl("add-flow", gwBridge, flow)
+				_, stderr, err := util.RunOVSOfctl("add-flow", npw.gwBridge, flow)
 				if err != nil {
 					klog.Errorf("Failed to add openflow flow on %s for ingress, stderr: %q, error: %v, flow: %s",
-						gwBridge, stderr, err, flow)
+						npw.gwBridge, stderr, err, flow)
 				}
 			}
 		}
@@ -118,20 +125,28 @@ func addService(service *kapi.Service, inport, outport, gwBridge string, nodeIP 
 				flowProtocol = protocol6
 				nw_dst = "ipv6_dst"
 			}
-			_, stderr, err := util.RunOVSOfctl("add-flow", gwBridge,
+			_, stderr, err := util.RunOVSOfctl("add-flow", npw.gwBridge,
 				fmt.Sprintf("priority=100, in_port=%s, %s, %s=%s, tp_dst=%d, actions=%s",
-					inport, flowProtocol, nw_dst, externalIP, svcPort.Port, outport))
+					npw.ofportPhys, flowProtocol, nw_dst, externalIP, svcPort.Port, npw.ofportPatch))
 			if err != nil {
 				klog.Errorf("Failed to add openflow flow on %s for ExternalIP: "+
-					"%s, stderr: %q, error: %v", gwBridge, externalIP, stderr, err)
+					"%s, stderr: %q, error: %v", npw.gwBridge, externalIP, stderr, err)
 			}
 		}
 	}
 
-	addSharedGatewayIptRules(service, nodeIP)
+	addSharedGatewayIptRules(service, npw.nodeIP)
 }
 
-func deleteService(service *kapi.Service, inport, gwBridge string, nodeIP *net.IPNet) {
+func (npw *nodePortWatcher) UpdateService(new, old *kapi.Service) {
+	if reflect.DeepEqual(new.Spec, old.Spec) {
+		return
+	}
+	npw.DeleteService(old)
+	npw.AddService(new)
+}
+
+func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
 	if !util.ServiceTypeHasNodePort(service) && len(service.Spec.ExternalIPs) == 0 {
 		return
 	}
@@ -145,21 +160,21 @@ func deleteService(service *kapi.Service, inport, gwBridge string, nodeIP *net.I
 				continue
 			}
 			if config.IPv4Mode {
-				_, stderr, err := util.RunOVSOfctl("del-flows", gwBridge,
+				_, stderr, err := util.RunOVSOfctl("del-flows", npw.gwBridge,
 					fmt.Sprintf("in_port=%s, %s, tp_dst=%d",
-						inport, protocol, svcPort.NodePort))
+						npw.ofportPhys, protocol, svcPort.NodePort))
 				if err != nil {
 					klog.Errorf("Failed to delete openflow flow on %s for nodePort: "+
-						"%d, stderr: %q, error: %v", gwBridge, svcPort.NodePort, stderr, err)
+						"%d, stderr: %q, error: %v", npw.gwBridge, svcPort.NodePort, stderr, err)
 				}
 			}
 			if config.IPv6Mode {
-				_, stderr, err := util.RunOVSOfctl("del-flows", gwBridge,
+				_, stderr, err := util.RunOVSOfctl("del-flows", npw.gwBridge,
 					fmt.Sprintf("in_port=%s, %s, tp_dst=%d",
-						inport, protocol6, svcPort.NodePort))
+						npw.ofportPhys, protocol6, svcPort.NodePort))
 				if err != nil {
 					klog.Errorf("Failed to delete openflow flow on %s for nodePort: "+
-						"%d, stderr: %q, error: %v", gwBridge, svcPort.NodePort, stderr, err)
+						"%d, stderr: %q, error: %v", npw.gwBridge, svcPort.NodePort, stderr, err)
 				}
 			}
 		}
@@ -174,12 +189,12 @@ func deleteService(service *kapi.Service, inport, gwBridge string, nodeIP *net.I
 				flowProtocol = protocol6
 				nw_dst = "ipv6_dst"
 			}
-			_, stderr, err := util.RunOVSOfctl("del-flows", gwBridge,
+			_, stderr, err := util.RunOVSOfctl("del-flows", npw.gwBridge,
 				fmt.Sprintf("in_port=%s, %s, %s=%s, tp_dst=%d",
-					inport, flowProtocol, nw_dst, externalIP, svcPort.Port))
+					npw.ofportPhys, flowProtocol, nw_dst, externalIP, svcPort.Port))
 			if err != nil {
 				klog.Errorf("Failed to delete openflow flow on %s for ExternalIP: "+
-					"%s, stderr: %q, error: %v", gwBridge, externalIP, stderr, err)
+					"%s, stderr: %q, error: %v", npw.gwBridge, externalIP, stderr, err)
 			}
 		}
 		for _, ing := range service.Status.LoadBalancer.Ingress {
@@ -196,19 +211,19 @@ func deleteService(service *kapi.Service, inport, gwBridge string, nodeIP *net.I
 				klog.Errorf("Unable to generate cookie for svc: %s, %s, %d, error: %v",
 					service.Name, ingIP.String(), svcPort.Port, err)
 			}
-			_, stderr, err := util.RunOVSOfctl("del-flows", gwBridge,
+			_, stderr, err := util.RunOVSOfctl("del-flows", npw.gwBridge,
 				fmt.Sprintf("cookie=%s/-1", cookie))
 			if err != nil {
 				klog.Errorf("Failed to delete openflow flow on %s for Ingress: "+
-					"%s, stderr: %q, error: %v", gwBridge, ingIP, stderr, err)
+					"%s, stderr: %q, error: %v", npw.gwBridge, ingIP, stderr, err)
 			}
 		}
 	}
 
-	delSharedGatewayIptRules(service, nodeIP)
+	delSharedGatewayIptRules(service, npw.nodeIP)
 }
 
-func syncServices(services []interface{}, inport, gwBridge string, nodeIP *net.IPNet) {
+func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 	ports := make(map[string]string)
 	ingressCookies := make(map[string]struct{})
 	for _, serviceInterface := range services {
@@ -258,10 +273,10 @@ func syncServices(services []interface{}, inport, gwBridge string, nodeIP *net.I
 		}
 	}
 
-	syncSharedGatewayIptRules(services, nodeIP)
+	syncSharedGatewayIptRules(services, npw.nodeIP)
 
 	stdout, stderr, err := util.RunOVSOfctl("dump-flows",
-		gwBridge)
+		npw.gwBridge)
 	if err != nil {
 		klog.Errorf("dump-flows failed: %q (%v)", stderr, err)
 		return
@@ -311,12 +326,12 @@ func syncServices(services []interface{}, inport, gwBridge string, nodeIP *net.I
 					}
 				}
 				stdout, _, err := util.RunOVSOfctl(
-					"del-flows", gwBridge,
+					"del-flows", npw.gwBridge,
 					fmt.Sprintf("in_port=%s, %s, tp_dst=%s",
-						inport, protocol, port))
+						npw.ofportPhys, protocol, port))
 				if err != nil {
 					klog.Errorf("del-flows of %s failed: %q",
-						gwBridge, stdout)
+						npw.gwBridge, stdout)
 				}
 			} else {
 				nw_dst := "nw_dst"
@@ -326,70 +341,16 @@ func syncServices(services []interface{}, inport, gwBridge string, nodeIP *net.I
 					flowProtocol = protocol + "6"
 				}
 				stdout, _, err := util.RunOVSOfctl(
-					"del-flows", gwBridge,
+					"del-flows", npw.gwBridge,
 					fmt.Sprintf("in_port=%s, %s, %s=%s, tp_dst=%s",
-						inport, flowProtocol, nw_dst, externalIP, port))
+						npw.ofportPhys, flowProtocol, nw_dst, externalIP, port))
 				if err != nil {
 					klog.Errorf("del-flows of %s failed: %q",
-						gwBridge, stdout)
+						npw.gwBridge, stdout)
 				}
 			}
 		}
 	}
-}
-
-func nodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet, wf factory.NodeWatchFactory) error {
-	// the name of the patch port created by ovn-controller is of the form
-	// patch-<logical_port_name_of_localnet_port>-to-br-int
-	patchPort := "patch-" + gwBridge + "_" + nodeName + "-to-br-int"
-	// Get ofport of patchPort
-	ofportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get",
-		"interface", patchPort, "ofport")
-	if err != nil {
-		return fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
-			patchPort, stderr, err)
-	}
-
-	// Get ofport of physical interface
-	ofportPhys, stderr, err := util.RunOVSVsctl("--if-exists", "get",
-		"interface", gwIntf, "ofport")
-	if err != nil {
-		return fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
-			gwIntf, stderr, err)
-	}
-
-	// In the shared gateway mode, the NodePort service is handled by the OpenFlow flows configured
-	// on the OVS bridge in the host. These flows act only on the packets coming in from outside
-	// of the node. If someone on the node is trying to access the NodePort service, those packets
-	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
-	// NodePortIP:NodePort to ClusterServiceIP:Port.
-	if err := initSharedGatewayIPTables(); err != nil {
-		return err
-	}
-
-	wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			service := obj.(*kapi.Service)
-			addService(service, ofportPhys, ofportPatch, gwBridge, nodeIP[0])
-		},
-		UpdateFunc: func(old, new interface{}) {
-			svcNew := new.(*kapi.Service)
-			svcOld := old.(*kapi.Service)
-			if reflect.DeepEqual(svcNew.Spec, svcOld.Spec) && reflect.DeepEqual(svcNew.Status, svcOld.Status) {
-				return
-			}
-			deleteService(svcOld, ofportPhys, gwBridge, nodeIP[0])
-			addService(svcNew, ofportPhys, ofportPatch, gwBridge, nodeIP[0])
-		},
-		DeleteFunc: func(obj interface{}) {
-			service := obj.(*kapi.Service)
-			deleteService(service, ofportPhys, gwBridge, nodeIP[0])
-		},
-	}, func(services []interface{}) {
-		syncServices(services, ofportPhys, gwBridge, nodeIP[0])
-	})
-
-	return nil
 }
 
 // since we share the host's k8s node IP, add OpenFlow flows
@@ -397,7 +358,7 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet, wf 
 // -- to also connection track the outbound north-south traffic through l3 gateway so that
 //    the return traffic can be steered back to OVN logical topology
 // -- to also handle unDNAT return traffic back out of the host
-func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan struct{}) error {
+func newSharedGatewayOpenFlowManager(nodeName, gwBridge, gwIntf string) (*openflowManager, error) {
 	// the name of the patch port created by ovn-controller is of the form
 	// patch-<logical_port_name_of_localnet_port>-to-br-int
 	localnetLpName := gwBridge + "_" + nodeName
@@ -407,21 +368,21 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 	ofportPatch, stderr, err := util.RunOVSVsctl("wait-until", "Interface", patchPort, "ofport>0",
 		"--", "get", "Interface", patchPort, "ofport")
 	if err != nil {
-		return fmt.Errorf("failed while waiting on patch port %q to be created by ovn-controller and "+
+		return nil, fmt.Errorf("failed while waiting on patch port %q to be created by ovn-controller and "+
 			"while getting ofport. stderr: %q, error: %v", patchPort, stderr, err)
 	}
 
 	// Get ofport of physical interface
 	ofportPhys, stderr, err := util.RunOVSVsctl("get", "interface", gwIntf, "ofport")
 	if err != nil {
-		return fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
+		return nil, fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
 			gwIntf, stderr, err)
 	}
 
 	// replace the left over OpenFlow flows with the FLOOD action flow
 	_, stderr, err = util.AddOFFlowWithSpecificAction(gwBridge, util.FloodAction)
 	if err != nil {
-		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
+		return nil, fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
 	}
 
 	nFlows := 0
@@ -433,7 +394,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 				"actions=ct(commit, zone=%d), output:%s",
 				defaultOpenFlowCookie, ofportPatch, config.Default.ConntrackZone, ofportPhys))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -444,7 +405,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 			fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ip, "+
 				"actions=ct(zone=%d, table=1)", defaultOpenFlowCookie, ofportPhys, config.Default.ConntrackZone))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -457,7 +418,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 				"actions=ct(commit, zone=%d), output:%s",
 				defaultOpenFlowCookie, ofportPatch, config.Default.ConntrackZone, ofportPhys))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -468,7 +429,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 			fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ipv6, "+
 				"actions=ct(zone=%d, table=1)", defaultOpenFlowCookie, ofportPhys, config.Default.ConntrackZone))
 		if err != nil {
-			return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 				"error: %v", gwBridge, stderr, err)
 		}
 		nFlows++
@@ -479,7 +440,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 		fmt.Sprintf("cookie=%s, priority=100, table=1, ct_state=+trk+est, "+
 			"actions=output:%s", defaultOpenFlowCookie, ofportPatch))
 	if err != nil {
-		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
 	nFlows++
@@ -488,7 +449,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 		fmt.Sprintf("cookie=%s, priority=100, table=1, ct_state=+trk+rel, "+
 			"actions=output:%s", defaultOpenFlowCookie, ofportPatch))
 	if err != nil {
-		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
 	nFlows++
@@ -497,7 +458,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 		fmt.Sprintf("cookie=%s, priority=0, table=1, actions=output:FLOOD", defaultOpenFlowCookie))
 	if err != nil {
-		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
 	nFlows++
@@ -506,105 +467,88 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 		fmt.Sprintf("cookie=%s, priority=0, table=2, actions=output:%s", defaultOpenFlowCookie, ofportPhys))
 	if err != nil {
-		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+		return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
 	}
 	nFlows++
 
 	// add health check function to check default OpenFlow flows are on the shared gateway bridge
-	go checkDefaultConntrackRules(gwBridge, gwIntf, patchPort, ofportPhys, ofportPatch, nFlows, stopChan)
-	return nil
+	return &openflowManager{
+		gwBridge, gwIntf, patchPort, ofportPhys, ofportPatch, nFlows,
+	}, nil
 }
 
-func (n *OvnNode) initSharedGateway(subnets []*net.IPNet, gwNextHops []net.IP, gwIntf string, nodeAnnotator kube.Annotator) (postWaitFunc, error) {
-	var bridgeName string
-	var uplinkName string
-	var brCreated bool
-	var err error
+func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf string, nodeAnnotator kube.Annotator) (*gateway, error) {
+	klog.Info("Creating new shared gateway")
+	gw := &gateway{}
 
-	if bridgeName, _, err = util.RunOVSVsctl("--", "port-to-br", gwIntf); err == nil {
-		// This is an OVS bridge's internal port
-		uplinkName, err = util.GetNicName(bridgeName)
-		if err != nil {
-			return nil, err
-		}
-	} else if _, _, err := util.RunOVSVsctl("--", "br-exists", gwIntf); err != nil {
-		// This is not a OVS bridge. We need to create a OVS bridge
-		// and add cluster.GatewayIntf as a port of that bridge.
-		bridgeName, err = util.NicToBridge(gwIntf)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert %s to OVS bridge: %v",
-				gwIntf, err)
-		}
-		uplinkName = gwIntf
-		gwIntf = bridgeName
-		brCreated = true
-	} else {
-		// gateway interface is an OVS bridge
-		uplinkName, err = getIntfName(gwIntf)
-		if err != nil {
-			return nil, err
-		}
-		bridgeName = gwIntf
-	}
-
-	// Now, we get IP addresses from OVS bridge. If IP does not exist,
-	// error out.
-	ips, err := getNetworkInterfaceIPAddresses(gwIntf)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get interface details for %s (%v)",
-			gwIntf, err)
-	}
-	ifaceID, macAddress, err := bridgedGatewayNodeSetup(n.name, bridgeName, gwIntf,
-		util.PhysicalNetworkName, brCreated)
-	if err != nil {
-		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
-	}
-
-	err = setupLocalNodeAccessBridge(n.name, subnets)
-	if err != nil {
-		return nil, err
-	}
-	chassisID, err := util.GetNodeChassisID()
+	bridgeName, uplinkName, ips, err := gatewayInitInternal(
+		nodeName, gwIntf, subnets, gwNextHops, nodeAnnotator)
 	if err != nil {
 		return nil, err
 	}
 
-	err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
-		Mode:           config.GatewayModeShared,
-		ChassisID:      chassisID,
-		InterfaceID:    ifaceID,
-		MACAddress:     macAddress,
-		IPAddresses:    ips,
-		NextHops:       gwNextHops,
-		NodePortEnable: config.Gateway.NodeportEnable,
-		VLANID:         &config.Gateway.VLANID,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return func() error {
+	gw.initFunc = func() error {
 		if config.Gateway.NodeportEnable {
-			if config.Gateway.Mode == config.GatewayModeLocal {
-				if err := addDefaultConntrackRulesLocal(n.name, bridgeName, uplinkName, n.stopChan); err != nil {
-					return err
-				}
-			} else {
-				// Program cluster.GatewayIntf to let non-pod traffic to go to host
-				// stack
-				if err := addDefaultConntrackRules(n.name, bridgeName, uplinkName, n.stopChan); err != nil {
-					return err
-				}
-				// Program cluster.GatewayIntf to let nodePort traffic to go to pods.
-				if err := nodePortWatcher(n.name, bridgeName, uplinkName, ips,
-					n.watchFactory); err != nil {
-					return err
-				}
+			// Program cluster.GatewayIntf to let non-pod traffic to go to host
+			// stack
+			klog.Info("Creating Shared Gateway Openflow Manager")
+			var err error
+
+			gw.openflowManager, err = newSharedGatewayOpenFlowManager(nodeName, bridgeName, uplinkName)
+			if err != nil {
+				return err
+			}
+
+			klog.Info("Creating Shared Gateway Node Port Watcher")
+			gw.nodePortWatcher, err = newNodePortWatcher(nodeName, bridgeName, uplinkName, ips[0])
+			if err != nil {
+				return err
 			}
 		}
 		return nil
-	}, nil
+	}
+
+	klog.Info("Shared Gateway Creation Complete")
+	return gw, nil
+}
+
+func newNodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP *net.IPNet) (*nodePortWatcher, error) {
+	// the name of the patch port created by ovn-controller is of the form
+	// patch-<logical_port_name_of_localnet_port>-to-br-int
+	patchPort := "patch-" + gwBridge + "_" + nodeName + "-to-br-int"
+	// Get ofport of patchPort
+	ofportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get",
+		"interface", patchPort, "ofport")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
+			patchPort, stderr, err)
+	}
+
+	// Get ofport of physical interface
+	ofportPhys, stderr, err := util.RunOVSVsctl("--if-exists", "get",
+		"interface", gwIntf, "ofport")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
+			gwIntf, stderr, err)
+	}
+
+	// In the shared gateway mode, the NodePort service is handled by the OpenFlow flows configured
+	// on the OVS bridge in the host. These flows act only on the packets coming in from outside
+	// of the node. If someone on the node is trying to access the NodePort service, those packets
+	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
+	// NodePortIP:NodePort to ClusterServiceIP:Port.
+	if err := initSharedGatewayIPTables(); err != nil {
+		return nil, err
+	}
+
+	npw := &nodePortWatcher{
+		ofportPhys:  ofportPhys,
+		ofportPatch: ofportPatch,
+		gwBridge:    gwBridge,
+		nodeIP:      nodeIP,
+	}
+	return npw, nil
 }
 
 func cleanupSharedGateway() error {

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -6,70 +6,77 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/healthcheck"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 )
 
 // initLoadBalancerHealthChecker initializes the health check server for
 // ServiceTypeLoadBalancer services
-func initLoadBalancerHealthChecker(nodeName string, wf factory.NodeWatchFactory) {
-	server := healthcheck.NewServer(nodeName, nil, nil, nil)
-	services := make(map[ktypes.NamespacedName]uint16)
-	endpoints := make(map[ktypes.NamespacedName]int)
 
-	wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			svc := obj.(*kapi.Service)
-			if svc.Spec.HealthCheckNodePort != 0 {
-				name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
-				services[name] = uint16(svc.Spec.HealthCheckNodePort)
-				_ = server.SyncServices(services)
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			// HealthCheckNodePort can't be changed on update
-		},
-		DeleteFunc: func(obj interface{}) {
-			svc := obj.(*kapi.Service)
-			if svc.Spec.HealthCheckNodePort != 0 {
-				name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
-				delete(services, name)
-				delete(endpoints, name)
-				_ = server.SyncServices(services)
-			}
-		},
-	}, nil)
+type loadBalancerHealthChecker struct {
+	nodeName  string
+	server    healthcheck.Server
+	services  map[ktypes.NamespacedName]uint16
+	endpoints map[ktypes.NamespacedName]int
+}
 
-	wf.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			ep := obj.(*kapi.Endpoints)
-			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
-			if _, exists := services[name]; exists {
-				endpoints[name] = countLocalEndpoints(ep, nodeName)
-				_ = server.SyncEndpoints(endpoints)
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			ep := new.(*kapi.Endpoints)
-			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
-			if _, exists := services[name]; exists {
-				endpoints[name] = countLocalEndpoints(ep, nodeName)
-				_ = server.SyncEndpoints(endpoints)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			ep := obj.(*kapi.Endpoints)
-			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
-			delete(endpoints, name)
-			_ = server.SyncEndpoints(endpoints)
-		},
-	}, nil)
+func newLoadBalancerHealthChecker(nodeName string) *loadBalancerHealthChecker {
+	return &loadBalancerHealthChecker{
+		nodeName:  nodeName,
+		server:    healthcheck.NewServer(nodeName, nil, nil, nil),
+		services:  make(map[ktypes.NamespacedName]uint16),
+		endpoints: make(map[ktypes.NamespacedName]int),
+	}
+}
+
+func (l *loadBalancerHealthChecker) AddService(svc *kapi.Service) {
+	if svc.Spec.HealthCheckNodePort != 0 {
+		name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
+		l.services[name] = uint16(svc.Spec.HealthCheckNodePort)
+		_ = l.server.SyncServices(l.services)
+	}
+}
+
+func (l *loadBalancerHealthChecker) UpdateService(old, new *kapi.Service) {
+	// HealthCheckNodePort can't be changed on update
+}
+
+func (l *loadBalancerHealthChecker) DeleteService(svc *kapi.Service) {
+	if svc.Spec.HealthCheckNodePort != 0 {
+		name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
+		delete(l.services, name)
+		delete(l.endpoints, name)
+		_ = l.server.SyncServices(l.services)
+	}
+}
+
+func (l *loadBalancerHealthChecker) SyncServices(svcs []interface{}) {}
+
+func (l *loadBalancerHealthChecker) AddEndpoints(ep *kapi.Endpoints) {
+	name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
+	if _, exists := l.services[name]; exists {
+		l.endpoints[name] = countLocalEndpoints(ep, l.nodeName)
+		_ = l.server.SyncEndpoints(l.endpoints)
+	}
+}
+
+func (l *loadBalancerHealthChecker) UpdateEndpoints(old, new *kapi.Endpoints) {
+	name := ktypes.NamespacedName{Namespace: new.Namespace, Name: new.Name}
+	if _, exists := l.services[name]; exists {
+		l.endpoints[name] = countLocalEndpoints(new, l.nodeName)
+		_ = l.server.SyncEndpoints(l.endpoints)
+	}
+
+}
+
+func (l *loadBalancerHealthChecker) DeleteEndpoints(ep *kapi.Endpoints) {
+	name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
+	delete(l.endpoints, name)
+	_ = l.server.SyncEndpoints(l.endpoints)
 }
 
 func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {
@@ -115,15 +122,23 @@ func checkForStaleOVSInterfaces(stopChan chan struct{}) {
 	}
 }
 
+type openflowManager struct {
+	gwBridge    string
+	physIntf    string
+	patchIntf   string
+	ofportPhys  string
+	ofportPatch string
+	nFlows      int
+}
+
 // checkDefaultOpenFlow checks for the existence of default OpenFlow rules and
 // exits if the output is not as expected
-func checkDefaultConntrackRules(gwBridge string, physIntf, patchIntf, ofportPhys, ofportPatch string,
-	nFlows int, stopChan chan struct{}) {
-	flowCount := fmt.Sprintf("flow_count=%d", nFlows)
+func (c *openflowManager) Run(stopChan <-chan struct{}) {
+	flowCount := fmt.Sprintf("flow_count=%d", c.nFlows)
 	for {
 		select {
 		case <-time.After(15 * time.Second):
-			out, _, err := util.RunOVSOfctl("dump-aggregate", gwBridge,
+			out, _, err := util.RunOVSOfctl("dump-aggregate", c.gwBridge,
 				fmt.Sprintf("cookie=%s/-1", defaultOpenFlowCookie))
 			if err != nil {
 				klog.Errorf("Failed to dump aggregate statistics of the default OpenFlow rules: %v", err)
@@ -132,33 +147,33 @@ func checkDefaultConntrackRules(gwBridge string, physIntf, patchIntf, ofportPhys
 
 			if !strings.Contains(out, flowCount) {
 				klog.Errorf("Fatal error: unexpected default OpenFlows count, expect %d output: %v\n",
-					nFlows, out)
+					c.nFlows, out)
 				os.Exit(1)
 			}
 
 			// it could be that the ovn-controller recreated the patch between the host OVS bridge and
 			// the integration bridge, as a result the ofport number changed for that patch interface
-			curOfportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Interface", patchIntf, "ofport")
+			curOfportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Interface", c.patchIntf, "ofport")
 			if err != nil {
-				klog.Errorf("Failed to get ofport of %s, stderr: %q, error: %v", patchIntf, stderr, err)
+				klog.Errorf("Failed to get ofport of %s, stderr: %q, error: %v", c.patchIntf, stderr, err)
 				continue
 			}
-			if ofportPatch != curOfportPatch {
+			if c.ofportPatch != curOfportPatch {
 				klog.Errorf("Fatal error: ofport of %s has changed from %s to %s",
-					patchIntf, ofportPatch, curOfportPatch)
+					c.patchIntf, c.ofportPatch, curOfportPatch)
 				os.Exit(1)
 			}
 
 			// it could be that someone removed the physical interface and added it back on the OVS host
 			// bridge, as a result the ofport number changed for that physical interface
-			curOfportPhys, stderr, err := util.RunOVSVsctl("--if-exists", "get", "interface", physIntf, "ofport")
+			curOfportPhys, stderr, err := util.RunOVSVsctl("--if-exists", "get", "interface", c.physIntf, "ofport")
 			if err != nil {
-				klog.Errorf("Failed to get ofport of %s, stderr: %q, error: %v", physIntf, stderr, err)
+				klog.Errorf("Failed to get ofport of %s, stderr: %q, error: %v", c.physIntf, stderr, err)
 				continue
 			}
-			if ofportPhys != curOfportPhys {
+			if c.ofportPhys != curOfportPhys {
 				klog.Errorf("Fatal error: ofport of %s has changed from %s to %s",
-					physIntf, ofportPhys, curOfportPhys)
+					c.physIntf, c.ofportPhys, curOfportPhys)
 				os.Exit(1)
 			}
 		case <-stopChan:

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -10,11 +10,10 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	"k8s.io/klog"
-	utilnet "k8s.io/utils/net"
 )
 
-func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator kube.Annotator,
-	waiter *startupWaiter) error {
+func createManagementPort(nodeNameOriginal string, hostSubnets []*net.IPNet, nodeAnnotator kube.Annotator,
+	waiter *startupWaiter) (*managementPortConfig, error) {
 	// Kubernetes emits events when pods are created. The event will contain
 	// only lowercase letters of the hostname even though the kubelet is
 	// started with a hostname that contains lowercase and uppercase letters.
@@ -23,7 +22,7 @@ func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator k
 	// will try to fetch and what kubernetes provides, thus failing to
 	// create the port on the logical switch.
 	// Until the above is changed, switch to a lowercase hostname
-	nodeName := strings.ToLower(n.name)
+	nodeName := strings.ToLower(nodeNameOriginal)
 
 	// Create a OVS internal interface.
 	legacyMgmtIntfName := util.GetLegacyK8sMgmtIntfName(nodeName)
@@ -35,12 +34,12 @@ func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator k
 		"external-ids:iface-id="+util.K8sPrefix+nodeName)
 	if err != nil {
 		klog.Errorf("Failed to add port to br-int, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return err
+		return nil, err
 	}
 	macAddress, err := util.GetOVSPortMACAddress(util.K8sMgmtIntfName)
 	if err != nil {
 		klog.Errorf("Failed to get management port MAC address: %v", err)
-		return err
+		return nil, err
 	}
 	// persist the MAC address so that upon node reboot we get back the same mac address.
 	_, stderr, err = util.RunOVSVsctl("set", "interface", util.K8sMgmtIntfName,
@@ -48,56 +47,20 @@ func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator k
 	if err != nil {
 		klog.Errorf("Failed to persist MAC address %q for %q: stderr:%s (%v)", macAddress.String(),
 			util.K8sMgmtIntfName, stderr, err)
-		return err
+		return nil, err
 	}
 
-	cfg, err := createPlatformManagementPort(util.K8sMgmtIntfName, hostSubnets, n.stopChan)
+	cfg, err := createPlatformManagementPort(util.K8sMgmtIntfName, hostSubnets)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := util.SetNodeManagementPortMACAddress(nodeAnnotator, macAddress); err != nil {
-		return err
-	}
-
-	if config.Gateway.Mode == config.GatewayModeLocal {
-		var gatewayIfAddrs []*net.IPNet
-		for _, hostSubnet := range hostSubnets {
-			// local gateway mode uses mp0 as default path for all ingress traffic into OVN
-			var nextHop *net.IPNet
-			if utilnet.IsIPv6CIDR(hostSubnet) {
-				nextHop = cfg.ipv6.ifAddr
-			} else {
-				nextHop = cfg.ipv4.ifAddr
-			}
-			// gatewayIfAddrs are the OVN next hops via mp0
-			gatewayIfAddrs = append(gatewayIfAddrs, util.GetNodeGatewayIfAddr(hostSubnet))
-
-			// add iptables masquerading for mp0 to exit the host for egress
-			cidr := nextHop.IP.Mask(nextHop.Mask)
-			cidrNet := &net.IPNet{IP: cidr, Mask: nextHop.Mask}
-			err = initLocalGatewayNATRules(util.K8sMgmtIntfName, cidrNet)
-			if err != nil {
-				return fmt.Errorf("failed to add local NAT rules for: %s, err: %v", util.K8sMgmtIntfName, err)
-			}
-		}
-
-		if config.Gateway.NodeportEnable {
-			localAddrSet, err := getLocalAddrs()
-			if err != nil {
-				return err
-			}
-			err = n.watchLocalPorts(
-				newLocalPortWatcherData(gatewayIfAddrs, n.recorder, localAddrSet),
-			)
-			if err != nil {
-				return err
-			}
-		}
+		return nil, err
 	}
 
 	waiter.AddWait(managementPortReady, nil)
-	return nil
+	return cfg, nil
 }
 
 // managementPortReady will check to see if OpenFlow rules for management port has been created
@@ -119,5 +82,6 @@ func managementPortReady() (bool, error) {
 	if !strings.Contains(stdout, "actions=output:"+ofport) {
 		return false, nil
 	}
+	klog.Info("Management port is ready")
 	return true, nil
 }

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -256,7 +256,7 @@ func setupManagementPortConfig(cfg *managementPortConfig) ([]string, error) {
 // createPlatformManagementPort creates a management port attached to the node switch
 // that lets the node access its pods via their private IP address. This is used
 // for health checking and other management tasks.
-func createPlatformManagementPort(interfaceName string, localSubnets []*net.IPNet, stopChan chan struct{}) (*managementPortConfig, error) {
+func createPlatformManagementPort(interfaceName string, localSubnets []*net.IPNet) (*managementPortConfig, error) {
 	var cfg *managementPortConfig
 	var err error
 
@@ -272,8 +272,6 @@ func createPlatformManagementPort(interfaceName string, localSubnets []*net.IPNe
 		return nil, err
 	}
 
-	// start the management port health check
-	go checkManagementPortHealth(cfg, stopChan)
 	return cfg, nil
 }
 

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -137,8 +137,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	err = testNS.Do(func(ns.NetNS) error {
 		defer GinkgoRecover()
 
-		n := OvnNode{name: nodeName, stopChan: make(chan struct{})}
-		err = n.createManagementPort(nodeSubnetCIDRs, nodeAnnotator, waiter)
+		_, err = createManagementPort(nodeName, nodeSubnetCIDRs, nodeAnnotator, waiter)
 		Expect(err).NotTo(HaveOccurred())
 		l, err := netlink.LinkByName(mgtPort)
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/port_claim.go
+++ b/go-controller/pkg/node/port_claim.go
@@ -6,34 +6,14 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 	utilnet "k8s.io/utils/net"
 )
-
-type handler func(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error
-
-type localPortHandler interface {
-	open(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error
-	close(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error
-}
-
-var portHandler localPortHandler
-
-var portOpener utilnet.PortOpener
-
-type portClaimWatcher struct {
-	recorder          record.EventRecorder
-	activeSocketsLock sync.Mutex
-	localAddrSet      map[string]net.IPNet
-	portsMap          map[utilnet.LocalPort]utilnet.Closeable
-}
 
 // Constants for valid LocalHost descriptions:
 const (
@@ -41,59 +21,155 @@ const (
 	externalPortDescr = "externalIP for"
 )
 
-func newPortClaimWatcher(recorder record.EventRecorder, localAddrSet map[string]net.IPNet) localPortHandler {
-	return &portClaimWatcher{
-		recorder:          recorder,
-		activeSocketsLock: sync.Mutex{},
-		portsMap:          make(map[utilnet.LocalPort]utilnet.Closeable),
-		localAddrSet:      localAddrSet,
-	}
+type handler func(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error
+
+type portManager interface {
+	open(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error
+	close(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error
 }
 
-func initPortClaimWatcher(recorder record.EventRecorder, wf factory.NodeWatchFactory) error {
-	localAddrSet, err := getLocalAddrs()
-	if err != nil {
-		return err
+type localPortManager struct {
+	recorder          record.EventRecorder
+	activeSocketsLock sync.Mutex
+	localAddrSet      map[string]net.IPNet
+	portsMap          map[utilnet.LocalPort]utilnet.Closeable
+	portOpener        utilnet.PortOpener
+}
+
+func (p *localPortManager) open(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error {
+	klog.V(5).Infof("Opening socket for service: %s/%s, port: %v and protocol %s", svc.Namespace, svc.Name, port, protocol)
+
+	if ip != "" {
+		if _, exists := p.localAddrSet[ip]; !exists {
+			klog.V(5).Infof("The IP %s is not one of the node local ports", ip)
+			return nil
+		}
 	}
-	portHandler = newPortClaimWatcher(recorder, localAddrSet)
-	portOpener = &utilnet.ListenPortOpener
-	wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			svc := obj.(*kapi.Service)
-			if errors := addServicePortClaim(svc); len(errors) > 0 {
-				for _, err := range errors {
-					klog.Errorf("Error claiming port for service: %s/%s: %v", svc.Namespace, svc.Name, err)
-				}
-			}
-		},
-		UpdateFunc: func(old, new interface{}) {
-			oldSvc := old.(*kapi.Service)
-			newSvc := new.(*kapi.Service)
-			if errors := updateServicePortClaim(oldSvc, newSvc); len(errors) > 0 {
-				for _, err := range errors {
-					klog.Errorf("Error updating port claim for service: %s/%s: %v", oldSvc.Namespace, oldSvc.Name, err)
-				}
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			svc := obj.(*kapi.Service)
-			if errors := deleteServicePortClaim(svc); len(errors) > 0 {
-				for _, err := range errors {
-					klog.Errorf("Error removing port claim for service: %s/%s: %v", svc.Namespace, svc.Name, err)
-				}
-			}
-		},
-	}, nil)
+	var localPort *utilnet.LocalPort
+	var portError error
+	switch protocol {
+	case kapi.ProtocolTCP, kapi.ProtocolUDP:
+		localPort, portError = utilnet.NewLocalPort(desc, ip, "", int(port), utilnet.Protocol(protocol))
+	case kapi.ProtocolSCTP:
+		// Do not open ports for SCTP, ref: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0015-20180614-SCTP-support.md#the-solution-in-the-kubernetes-sctp-support-implementation
+		return nil
+	default:
+		portError = fmt.Errorf("unknown protocol %q", protocol)
+	}
+	if portError != nil {
+		p.emitPortClaimEvent(svc, port, portError)
+		return portError
+	}
+	klog.V(5).Infof("Opening socket for LocalPort %v", localPort)
+	p.activeSocketsLock.Lock()
+	defer p.activeSocketsLock.Unlock()
+
+	if _, exists := p.portsMap[*localPort]; exists {
+		return fmt.Errorf("error try to open socket for svc: %s/%s on port: %v again", svc.Namespace, svc.Name, port)
+	} else {
+		closeable, err := p.portOpener.OpenLocalPort(localPort)
+		if err != nil {
+			p.emitPortClaimEvent(svc, port, err)
+			return err
+		}
+		p.portsMap[*localPort] = closeable
+	}
 	return nil
 }
 
-func addServicePortClaim(svc *kapi.Service) []error {
-	return handleService(svc, portHandler.open)
+func (p *localPortManager) close(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error {
+	klog.V(5).Infof("Closing socket claimed for service: %s/%s and port: %v", svc.Namespace, svc.Name, port)
+
+	if protocol != kapi.ProtocolTCP && protocol != kapi.ProtocolUDP {
+		return nil
+	}
+	if ip != "" {
+		if _, exists := p.localAddrSet[ip]; !exists {
+			klog.V(5).Infof("The IP %s is not one of the node local ports", ip)
+			return nil
+		}
+	}
+	localPort, err := utilnet.NewLocalPort(desc, ip, "", int(port), utilnet.Protocol(protocol))
+	if err != nil {
+		return fmt.Errorf("error localPort creation for svc: %s/%s on port: %v, err: %v", svc.Namespace, svc.Name, port, err)
+	}
+	klog.V(5).Infof("Closing socket for LocalPort %v", localPort)
+
+	p.activeSocketsLock.Lock()
+	defer p.activeSocketsLock.Unlock()
+
+	if _, exists := p.portsMap[*localPort]; exists {
+		if err = p.portsMap[*localPort].Close(); err != nil {
+			return fmt.Errorf("error closing socket for svc: %s/%s on port: %v, err: %v", svc.Namespace, svc.Name, port, err)
+		}
+		delete(p.portsMap, *localPort)
+		return nil
+	}
+	return fmt.Errorf("error closing socket for svc: %s/%s on port: %v, port was never opened...?", svc.Namespace, svc.Name, port)
 }
 
-func deleteServicePortClaim(svc *kapi.Service) []error {
-	return handleService(svc, portHandler.close)
+func (p *localPortManager) emitPortClaimEvent(svc *kapi.Service, port int32, err error) {
+	serviceRef := kapi.ObjectReference{
+		Kind:      "Service",
+		Namespace: svc.Namespace,
+		Name:      svc.Name,
+	}
+	p.recorder.Eventf(&serviceRef, kapi.EventTypeWarning,
+		"PortClaim", "Service: %s/%s requires port: %v to be opened on node, but port cannot be opened, err: %v", svc.Namespace, svc.Name, port, err)
+	klog.Warningf("PortClaim for svc: %s/%s on port: %v, err: %v", svc.Namespace, svc.Name, port, err)
 }
+
+type portClaimWatcher struct {
+	port portManager
+}
+
+func newPortClaimWatcher(recorder record.EventRecorder) (*portClaimWatcher, error) {
+	localAddrSet, err := getLocalAddrs()
+	if err != nil {
+		return nil, err
+	}
+	return &portClaimWatcher{
+		port: &localPortManager{
+			recorder:          recorder,
+			activeSocketsLock: sync.Mutex{},
+			portsMap:          make(map[utilnet.LocalPort]utilnet.Closeable),
+			localAddrSet:      localAddrSet,
+			portOpener:        &utilnet.ListenPortOpener,
+		},
+	}, nil
+}
+
+func (p *portClaimWatcher) AddService(svc *kapi.Service) {
+	if errors := handleService(svc, p.port.open); len(errors) > 0 {
+		for _, err := range errors {
+			klog.Errorf("Error claiming port for service: %s/%s: %v", svc.Namespace, svc.Name, err)
+		}
+	}
+}
+
+func (p *portClaimWatcher) UpdateService(old, new *kapi.Service) {
+	if reflect.DeepEqual(old.Spec.ExternalIPs, new.Spec.ExternalIPs) && reflect.DeepEqual(old.Spec.Ports, new.Spec.Ports) {
+		return
+	}
+	errors := []error{}
+	errors = append(errors, handleService(old, p.port.close)...)
+	errors = append(errors, handleService(new, p.port.open)...)
+	if len(errors) > 0 {
+		for _, err := range errors {
+			klog.Errorf("Error updating port claim for service: %s/%s: %v", old.Namespace, old.Name, err)
+		}
+	}
+}
+
+func (p *portClaimWatcher) DeleteService(svc *kapi.Service) {
+	if errors := handleService(svc, p.port.close); len(errors) > 0 {
+		for _, err := range errors {
+			klog.Errorf("Error removing port claim for service: %s/%s: %v", svc.Namespace, svc.Name, err)
+		}
+	}
+}
+
+func (p *portClaimWatcher) SyncServices(objs []interface{}) {}
 
 func handleService(svc *kapi.Service, handler handler) []error {
 	errors := []error{}
@@ -144,97 +220,4 @@ func handlePort(desc string, svc *kapi.Service, ip string, port int32, protocol 
 		return err
 	}
 	return nil
-}
-
-func updateServicePortClaim(oldSvc, newSvc *kapi.Service) []error {
-	if reflect.DeepEqual(oldSvc.Spec.ExternalIPs, newSvc.Spec.ExternalIPs) && reflect.DeepEqual(oldSvc.Spec.Ports, newSvc.Spec.Ports) {
-		return nil
-	}
-	errors := []error{}
-	errors = append(errors, deleteServicePortClaim(oldSvc)...)
-	errors = append(errors, addServicePortClaim(newSvc)...)
-	return errors
-}
-
-func (p *portClaimWatcher) open(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error {
-	klog.V(5).Infof("Opening socket for service: %s/%s, port: %v and protocol %s", svc.Namespace, svc.Name, port, protocol)
-
-	if ip != "" {
-		if _, exists := p.localAddrSet[ip]; !exists {
-			klog.V(5).Infof("The IP %s is not one of the node local ports", ip)
-			return nil
-		}
-	}
-	var localPort *utilnet.LocalPort
-	var portError error
-	switch protocol {
-	case kapi.ProtocolTCP, kapi.ProtocolUDP:
-		localPort, portError = utilnet.NewLocalPort(desc, ip, "", int(port), utilnet.Protocol(protocol))
-	case kapi.ProtocolSCTP:
-		// Do not open ports for SCTP, ref: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0015-20180614-SCTP-support.md#the-solution-in-the-kubernetes-sctp-support-implementation
-		return nil
-	default:
-		portError = fmt.Errorf("unknown protocol %q", protocol)
-	}
-	if portError != nil {
-		p.emitPortClaimEvent(svc, port, portError)
-		return portError
-	}
-	klog.V(5).Infof("Opening socket for LocalPort %v", localPort)
-	p.activeSocketsLock.Lock()
-	defer p.activeSocketsLock.Unlock()
-
-	if _, exists := p.portsMap[*localPort]; exists {
-		return fmt.Errorf("error try to open socket for svc: %s/%s on port: %v again", svc.Namespace, svc.Name, port)
-	} else {
-		closeable, err := portOpener.OpenLocalPort(localPort)
-		if err != nil {
-			p.emitPortClaimEvent(svc, port, err)
-			return err
-		}
-		p.portsMap[*localPort] = closeable
-	}
-	return nil
-}
-
-func (p *portClaimWatcher) close(desc string, ip string, port int32, protocol kapi.Protocol, svc *kapi.Service) error {
-	klog.V(5).Infof("Closing socket claimed for service: %s/%s and port: %v", svc.Namespace, svc.Name, port)
-
-	if protocol != kapi.ProtocolTCP && protocol != kapi.ProtocolUDP {
-		return nil
-	}
-	if ip != "" {
-		if _, exists := p.localAddrSet[ip]; !exists {
-			klog.V(5).Infof("The IP %s is not one of the node local ports", ip)
-			return nil
-		}
-	}
-	localPort, err := utilnet.NewLocalPort(desc, ip, "", int(port), utilnet.Protocol(protocol))
-	if err != nil {
-		return fmt.Errorf("error localPort creation for svc: %s/%s on port: %v, err: %v", svc.Namespace, svc.Name, port, err)
-	}
-	klog.V(5).Infof("Closing socket for LocalPort %v", localPort)
-
-	p.activeSocketsLock.Lock()
-	defer p.activeSocketsLock.Unlock()
-
-	if _, exists := p.portsMap[*localPort]; exists {
-		if err = p.portsMap[*localPort].Close(); err != nil {
-			return fmt.Errorf("error closing socket for svc: %s/%s on port: %v, err: %v", svc.Namespace, svc.Name, port, err)
-		}
-		delete(p.portsMap, *localPort)
-		return nil
-	}
-	return fmt.Errorf("error closing socket for svc: %s/%s on port: %v, port was never opened...?", svc.Namespace, svc.Name, port)
-}
-
-func (p *portClaimWatcher) emitPortClaimEvent(svc *kapi.Service, port int32, err error) {
-	serviceRef := kapi.ObjectReference{
-		Kind:      "Service",
-		Namespace: svc.Namespace,
-		Name:      svc.Name,
-	}
-	p.recorder.Eventf(&serviceRef, kapi.EventTypeWarning,
-		"PortClaim", "Service: %s/%s requires port: %v to be opened on node, but port cannot be opened, err: %v", svc.Namespace, svc.Name, port, err)
-	klog.Warningf("PortClaim for svc: %s/%s on port: %v, err: %v", svc.Namespace, svc.Name, port, err)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

The current code passes `WatchFactory` everywhere and therefore new callbacks are added to the Service/Endpoint watchers throughout the gateway code.

This PR attempts to refactor the local/shared gateway code such that:
- The watchFactory's AddService/AddEndpoint Handler code is invoked only once
- The gateway code itself is responsible for ensuring all of it's component parts are given a chance to respond to these events.

It's required to make progress on replacing the watchFactory with a workqueue.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

This isn't perfect but it's serviceable.
It moves all of the local gateway code back in to one place so it can easily be removed at a later date (if necessary).

All gateway functionality is accessed via the `Gateway` interface.

This is backed by a `gateway` struct which contains all the components used by shared and local gateway implementations. This conditionally dispatches events to the various struct members depending on whether they have been initialised or not. `newSharedGateway` and `newLocalGateway` are used to create instances of this.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

All existing tests should pass

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->