### PR TITLE
Egress Firewall make 0.0.0.0/0 and 0.0.0.0/32 have same effect

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -83,6 +83,12 @@ func (oc *Controller) addEgressFirewall(egressFirewall *egressfirewallapi.Egress
 	var errList []error
 	for i, egressFirewallRule := range egressFirewall.Spec.Egress {
 		//process Rules into egressFirewallRules for egressFirewall struct
+
+		if egressFirewallRule.To.CIDRSelector == "0.0.0.0/32" {
+			egressFirewallRule.To.CIDRSelector = "0.0.0.0/0"
+			klog.Warningf("Correcting CIDRSelector '0.0.0.0/32' to '0.0.0.0/0' in EgressNetworkPolicy %s:%s", ef.namespace, ef.name)
+		}
+
 		efr, err := newEgressFirewallRule(egressFirewallRule, i)
 		if err != nil {
 			errList = append(errList, fmt.Errorf("error: cannot create EgressFirewall Rule for destination %s to namespace %s - %v",


### PR DESCRIPTION
Fixes BZ issue https://bugzilla.redhat.com/show_bug.cgi?id=1862863

Mimics behavior seen in OVS
https://github.com/openshift/sdn/blob/ad213377dc552a71bb91435aca939b0f
028da52c/pkg/network/node/ovscontroller.go#L540

Replaces CIDR 0.0.0.0/32 with 0.0.0.0/0 and logs as such in ovnkube-mas
ter

Signed-off-by: Andrew Stoycos <astoycos@redhat.com>