### PR TITLE
Make metrics scraping go-routines to exit using stopChan construct & make Metrics scraping interval as configurable value

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -43,6 +43,8 @@ OVN_MULTICAST_ENABLE=""
 OVN_EGRESSIP_ENABLE=
 OVN_V4_JOIN_SUBNET=""
 OVN_V6_JOIN_SUBNET=""
+OVN_METRICS_SCRAPE_INTERVAL=""
+OVS_METRICS_SCRAPE_INTERVAL=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -163,6 +165,12 @@ while [ "$1" != "" ]; do
   --v6-join-subnet)
     OVN_V6_JOIN_SUBNET=$VALUE
     ;;
+  --ovn-metrics-interval)
+    OVN_METRICS_SCRAPE_INTERVAL=$VALUE
+    ;;
+  --ovs-metrics-interval)
+    OVS_METRICS_SCRAPE_INTERVAL=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -250,6 +258,10 @@ ovn_v4_join_subnet=${OVN_V4_JOIN_SUBNET}
 echo "ovn_v4_join_subnet: ${ovn_v4_join_subnet}"
 ovn_v6_join_subnet=${OVN_V6_JOIN_SUBNET}
 echo "ovn_v6_join_subnet: ${ovn_v6_join_subnet}"
+ovn_metrics_scrape_interval=${OVN_METRICS_SCRAPE_INTERVAL:-30}
+echo "ovn_metrics_scrape_interval: ${ovn_metrics_scrape_interval}"
+ovs_metrics_scrape_interval=${OVS_METRICS_SCRAPE_INTERVAL:-30}
+echo "ovs_metrics_scrape_interval: ${ovs_metrics_scrape_interval}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -271,6 +283,8 @@ ovn_image=${image} \
   ovn_egress_ip_enable=${ovn_egress_ip_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_remote_probe_interval=${ovn_remote_probe_interval} \
+  ovn_metrics_scrape_interval=${ovn_metrics_scrape_interval} \
+  ovs_metrics_scrape_interval=${ovs_metrics_scrape_interval} \
   j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node.yaml
 
 ovn_image=${image} \
@@ -293,6 +307,7 @@ ovn_image=${image} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_master_count=${ovn_master_count} \
   ovn_gateway_mode=${ovn_gateway_mode} \
+  ovn_metrics_scrape_interval=${ovn_metrics_scrape_interval} \
   j2 ../templates/ovnkube-master.yaml.j2 -o ../yaml/ovnkube-master.yaml
 
 ovn_image=${image} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -69,6 +69,8 @@ fi
 # OVN_REMOTE_PROBE_INTERVAL - ovn remote probe interval in ms (default 100000)
 # OVN_EGRESSIP_ENABLE - enable egress IP for ovn-kubernetes
 # OVN_UNPRIVILEGED_MODE - execute CNI ovs/netns commands from host (default no)
+# OVN_METRICS_SCRAPE_INTERVAL - ovn & ovnkube metrics scrape interval in sec (default 30)
+# OVS_METRICS_SCRAPE_INTERVAL - ovs metrics scrape interval in sec (default 30)
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -190,6 +192,10 @@ ovn_multicast_enable=${OVN_MULTICAST_ENABLE:-}
 #OVN_EGRESSIP_ENABLE - enable egress IP for ovn-kubernetes
 ovn_egressip_enable=${OVN_EGRESSIP_ENABLE:-false}
 ovn_acl_logging_rate_limit=${OVN_ACL_LOGGING_RATE_LIMIT:-"20"}
+# OVN_METRICS_SCRAPE_INTERVAL - metrics scrape interval in sec (default 30)
+ovn_metrics_scrape_interval=${OVN_METRICS_SCRAPE_INTERVAL:-30}
+# OVS_METRICS_SCRAPE_INTERVAL - metrics scrape interval in sec (default 30)
+ovs_metrics_scrape_interval=${OVS_METRICS_SCRAPE_INTERVAL:-30}
 
 # Determine the ovn rundir.
 if [[ -f /usr/bin/ovn-appctl ]]; then
@@ -902,6 +908,7 @@ ovn-master() {
     ${multicast_enabled_flag} \
     ${ovn_acl_logging_rate_limit_flag} \
     ${egressip_enabled_flag} \
+    --metrics-interval ${ovn_metrics_scrape_interval} \
     --metrics-bind-address ${ovnkube_master_metrics_bind_address} &
   echo "=============== ovn-master ========== running"
   wait_for_event attempts=3 process_ready ovnkube-master
@@ -1045,6 +1052,7 @@ ovn-node() {
     --inactivity-probe=${ovn_remote_probe_interval} \
     ${multicast_enabled_flag} \
     ${egressip_enabled_flag} \
+    --metrics-interval ${ovn_metrics_scrape_interval} \
     --ovn-metrics-bind-address ${ovn_metrics_bind_address} \
     --metrics-bind-address ${ovnkube_node_metrics_bind_address} &
 
@@ -1119,6 +1127,7 @@ ovs-metrics() {
   /usr/bin/ovn-kube-util \
     --loglevel=${ovnkube_loglevel} \
     ovs-exporter \
+    --metrics-interval ${ovs_metrics_scrape_interval} \
     --metrics-bind-address ${ovs_exporter_bind_address}
 
   echo "=============== ovs-metrics with pid ${?} terminated ========== "

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -258,6 +258,8 @@ spec:
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_ACL_LOGGING_RATE_LIMIT
           value: "{{ ovn_acl_logging_rate_limit }}"
+        - name: OVN_METRICS_SCRAPE_INTERVAL
+          value: "{{ ovn_metrics_scrape_interval }}"
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -213,6 +213,8 @@ spec:
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_UNPRIVILEGED_MODE
           value: "{{ ovn_unprivileged_mode }}"
+        - name: OVN_METRICS_SCRAPE_INTERVAL
+          value: "{{ ovn_metrics_scrape_interval }}"
 
         lifecycle:
           preStop:
@@ -259,6 +261,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: OVS_METRICS_SCRAPE_INTERVAL
+          value: "{{ ovs_metrics_scrape_interval }}"
         # end of container
 
       nodeSelector:

--- a/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
@@ -11,6 +11,7 @@ import (
 	kexec "k8s.io/utils/exec"
 )
 
+var metricsScrapeInterval int
 var OvsExporterCommand = cli.Command{
 	Name:  "ovs-exporter",
 	Usage: "",
@@ -18,6 +19,12 @@ var OvsExporterCommand = cli.Command{
 		&cli.StringFlag{
 			Name:  "metrics-bind-address",
 			Usage: `The IP address and port for the metrics server to serve on (default ":9310")`,
+		},
+		&cli.IntFlag{
+			Name:        "metrics-interval",
+			Usage:       "The Interval at which ovs metrics are collected",
+			Value:       30,
+			Destination: &metricsScrapeInterval,
 		},
 	},
 	Action: func(ctx *cli.Context) error {
@@ -34,7 +41,7 @@ var OvsExporterCommand = cli.Command{
 		mux.Handle("/metrics", promhttp.Handler())
 
 		// register ovs metrics that will be served off of /metrics path
-		metrics.RegisterOvsMetrics()
+		metrics.RegisterOvsMetrics(metricsScrapeInterval)
 
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {

--- a/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
+++ b/go-controller/cmd/ovn-kube-util/ovn-kube-util.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/cmd/ovn-kube-util/app"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
 	"k8s.io/klog/v2"
 )
@@ -41,7 +43,13 @@ func main() {
 		return nil
 	}
 
-	if err := c.Run(os.Args); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		util.ContextShutdownHandler(ctx, cancel)
+	}()
+
+	if err := c.RunContext(ctx, os.Args); err != nil {
 		klog.Exit(err)
 	}
 }

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -55,14 +55,15 @@ var (
 
 	// Default holds parsed config file parameters and command-line overrides
 	Default = DefaultConfig{
-		MTU:               1400,
-		ConntrackZone:     64000,
-		EncapType:         "geneve",
-		EncapIP:           "",
-		EncapPort:         DefaultEncapPort,
-		InactivityProbe:   100000, // in Milliseconds
-		OpenFlowProbe:     180,    // in Seconds
-		RawClusterSubnets: "10.128.0.0/14/23",
+		MTU:                   1400,
+		ConntrackZone:         64000,
+		EncapType:             "geneve",
+		EncapIP:               "",
+		EncapPort:             DefaultEncapPort,
+		InactivityProbe:       100000, // in Milliseconds
+		OpenFlowProbe:         180,    // in Seconds
+		RawClusterSubnets:     "10.128.0.0/14/23",
+		MetricsScrapeInterval: 30, // in seconds
 	}
 
 	// Logging holds logging-related parsed config file parameters and command-line overrides
@@ -167,6 +168,9 @@ type DefaultConfig struct {
 	// ClusterSubnets holds parsed cluster subnet entries and may be used
 	// outside the config module.
 	ClusterSubnets []CIDRNetworkEntry
+	// MetricsScrapeInterval captures the interval at which
+	// ovnkube & ovn metrics should be collected.
+	MetricsScrapeInterval int `gcfg:"metrics-scrape-interval"`
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides
@@ -550,6 +554,12 @@ var CommonFlags = []cli.Flag{
 		Name:        "enable-multicast",
 		Usage:       "Adds multicast support. Valid only with --init-master option.",
 		Destination: &EnableMulticast,
+	},
+	&cli.IntFlag{
+		Name:        "metrics-interval",
+		Usage:       "The Interval at which ovnkube & ovn metrics are collected",
+		Destination: &cliConfig.Default.MetricsScrapeInterval,
+		Value:       Default.MetricsScrapeInterval,
 	},
 	// Logging options
 	&cli.IntFlag{

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -114,9 +114,9 @@ func getCoverageShowOutputMap(component string) (map[string]string, error) {
 
 // coverageShowMetricsUpdater updates the metric
 // by obtaining values from getCoverageShowOutputMap for specified component.
-func coverageShowMetricsUpdater(component string) {
+func coverageShowMetricsUpdater(component string, metricsScrapeInterval int) {
 	for {
-		time.Sleep(30 * time.Second)
+		time.Sleep(time.Duration(metricsScrapeInterval) * time.Second)
 		coverageShowOutputMap, err := getCoverageShowOutputMap(component)
 		if err != nil {
 			klog.Errorf("%s", err.Error())

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -275,7 +276,7 @@ func ovnControllerConfigurationMetricsUpdater() {
 		if err != nil {
 			klog.Errorf("%s", err.Error())
 		}
-		time.Sleep(30 * time.Second)
+		time.Sleep(time.Duration(config.Default.MetricsScrapeInterval) * time.Second)
 	}
 }
 
@@ -379,5 +380,5 @@ func RegisterOvnControllerMetrics() {
 	// ovn-controller configuration metrics updater
 	go ovnControllerConfigurationMetricsUpdater()
 	// ovn-controller coverage show metrics updater
-	go coverageShowMetricsUpdater(ovnController)
+	go coverageShowMetricsUpdater(ovnController, config.Default.MetricsScrapeInterval)
 }

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -425,7 +426,7 @@ func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 				ovnDBSizeMetricsUpdater(direction, database)
 				ovnE2eTimeStampUpdater(direction, database)
 			}
-			time.Sleep(30 * time.Second)
+			time.Sleep(time.Duration(config.Default.MetricsScrapeInterval) * time.Second)
 		}
 	}()
 }

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -74,7 +74,7 @@ var ovnNorthdCoverageShowMetricsMap = map[string]*metricDetails{
 	},
 }
 
-func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string) {
+func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string, stopChan chan struct{}) {
 	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
 		return checkPodRunsOnGivenNode(clientset, "name=ovnkube-master", k8sNodeName, true)
 	})
@@ -154,5 +154,5 @@ func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string
 	// Register the ovn-northd coverage/show metrics with prometheus
 	componentCoverageShowMetricsMap[ovnNorthd] = ovnNorthdCoverageShowMetricsMap
 	registerCoverageShowMetrics(ovnNorthd, MetricOvnNamespace, MetricOvnSubsystemNorthd)
-	go coverageShowMetricsUpdater(ovnNorthd, config.Default.MetricsScrapeInterval)
+	go coverageShowMetricsUpdater(ovnNorthd, config.Default.MetricsScrapeInterval, stopChan)
 }

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -153,5 +154,5 @@ func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string
 	// Register the ovn-northd coverage/show metrics with prometheus
 	componentCoverageShowMetricsMap[ovnNorthd] = ovnNorthdCoverageShowMetricsMap
 	registerCoverageShowMetrics(ovnNorthd, MetricOvnNamespace, MetricOvnSubsystemNorthd)
-	go coverageShowMetricsUpdater(ovnNorthd)
+	go coverageShowMetricsUpdater(ovnNorthd, config.Default.MetricsScrapeInterval)
 }

--- a/go-controller/pkg/metrics/ovs.go
+++ b/go-controller/pkg/metrics/ovs.go
@@ -409,9 +409,9 @@ func setOvsDatapathMetrics(datapaths []string) (err error) {
 }
 
 // ovsDatapathMetricsUpdate updates the ovs datapath metrics for every 30 sec
-func ovsDatapathMetricsUpdate() {
+func ovsDatapathMetricsUpdate(metricsScrapeInterval int) {
 	for {
-		time.Sleep(30 * time.Second)
+		time.Sleep(time.Duration(metricsScrapeInterval) * time.Second)
 		datapaths, err := getOvsDatapaths()
 		if err != nil {
 			klog.Errorf("%s", err.Error())
@@ -534,9 +534,9 @@ func getOvsBridgeInfo() (bridgePortCount map[string]float64, portToBridgeMap map
 
 // ovsBridgeMetricsUpdate updates bridgeMetrics &
 // ovsInterface metrics & geneveInterface metrics for every 30sec
-func ovsBridgeMetricsUpdate() {
+func ovsBridgeMetricsUpdate(metricsScrapeInterval int) {
 	for {
-		time.Sleep(30 * time.Second)
+		time.Sleep(time.Duration(metricsScrapeInterval) * time.Second)
 		// set geneve interface metrics
 		err := geneveInterfaceMetricsUpdate()
 		if err != nil {
@@ -864,13 +864,13 @@ func setOvsMemoryMetrics() (err error) {
 	return nil
 }
 
-func ovsMemoryMetricsUpdate() {
+func ovsMemoryMetricsUpdate(metricsScrapeInterval int) {
 	for {
 		err := setOvsMemoryMetrics()
 		if err != nil {
 			klog.Errorf("%s", err.Error())
 		}
-		time.Sleep(30 * time.Second)
+		time.Sleep(time.Duration(metricsScrapeInterval) * time.Second)
 	}
 }
 
@@ -917,13 +917,13 @@ func setOvsHwOffloadMetrics() (err error) {
 	return nil
 }
 
-func ovsHwOffloadMetricsUpdate() {
+func ovsHwOffloadMetricsUpdate(metricsScrapeInterval int) {
 	for {
 		err := setOvsHwOffloadMetrics()
 		if err != nil {
 			klog.Errorf("%s", err.Error())
 		}
-		time.Sleep(30 * time.Second)
+		time.Sleep(time.Duration(metricsScrapeInterval) * time.Second)
 	}
 }
 
@@ -1182,7 +1182,7 @@ var ovsVswitchdCoverageShowMetricsMap = map[string]*metricDetails{
 }
 var registerOvsMetricsOnce sync.Once
 
-func RegisterOvsMetrics() {
+func RegisterOvsMetrics(metricsScrapeInterval int) {
 	registerOvsMetricsOnce.Do(func() {
 		getOvsVersionInfo()
 		prometheus.MustRegister(prometheus.NewGaugeFunc(
@@ -1231,14 +1231,14 @@ func RegisterOvsMetrics() {
 		registerCoverageShowMetrics(ovsVswitchd, MetricOvsNamespace, MetricOvsSubsystemVswitchd)
 
 		// OVS datapath metrics updater
-		go ovsDatapathMetricsUpdate()
+		go ovsDatapathMetricsUpdate(metricsScrapeInterval)
 		// OVS bridge metrics updater
-		go ovsBridgeMetricsUpdate()
+		go ovsBridgeMetricsUpdate(metricsScrapeInterval)
 		// OVS memory metrics updater
-		go ovsMemoryMetricsUpdate()
+		go ovsMemoryMetricsUpdate(metricsScrapeInterval)
 		// OVS hw Offload metrics updater
-		go ovsHwOffloadMetricsUpdate()
+		go ovsHwOffloadMetricsUpdate(metricsScrapeInterval)
 		// OVS coverage/show metrics updater.
-		go coverageShowMetricsUpdater(ovsVswitchd)
+		go coverageShowMetricsUpdater(ovsVswitchd, metricsScrapeInterval)
 	})
 }


### PR DESCRIPTION
This PR does changes to make 
1) Metrics scraping interval as configurable value through CLI/env variable
2) Allowing the metrics scraping go-routines to exit using stopChan construct when 
correspoding daemons exits.   