### PR TITLE
provide a way to configure --unprivileged-mode

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -343,6 +343,7 @@ pushd ../dist/images
   --k8s-apiserver=${API_URL} \
   --ovn-master-count=${KIND_NUM_MASTER} \
   --kind \
+  --ovn-unprivileged-mode=no \
   --master-loglevel=5 \
   --egress-ip-enable=true
 popd

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -21,6 +21,7 @@ OVN_DB_REPLICAS=""
 OVN_MTU=""
 OVN_SSL_ENABLE=""
 KIND=""
+OVN_UNPRIVILEGED_MODE=""
 MASTER_LOGLEVEL=""
 NODE_LOGLEVEL=""
 OVN_LOGLEVEL_NORTHD=""
@@ -72,6 +73,9 @@ while [ "$1" != "" ]; do
     ;;
   --kind)
     KIND=true
+    ;;
+  --ovn-unprivileged-mode)
+    OVN_UNPRIVILEGED_MODE=$VALUE
     ;;
   --master-loglevel)
     MASTER_LOGLEVEL=$VALUE
@@ -196,6 +200,8 @@ ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS}
 echo "ovn_disable_snat_multiple_gws: ${ovn_disable_snat_multiple_gws}"
 ovn_ssl_en=${OVN_SSL_ENABLE:-"no"}
 echo "ovn_ssl_enable: ${ovn_ssl_en}"
+ovn_unprivileged_mode=${OVN_UNPRIVILEGED_MODE:-"no"}
+echo "ovn_unprivileged_mode: ${ovn_unprivileged_mode}"
 ovn_nb_raft_election_timer=${OVN_NB_RAFT_ELECTION_TIMER:-1000}
 echo "ovn_nb_raft_election_timer: ${ovn_nb_raft_election_timer}"
 ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
@@ -218,6 +224,7 @@ echo "ovn_multicast_enable: ${ovn_multicast_enable}"
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
   kind=${KIND} \
+  ovn_unprivileged_mode=${ovn_unprivileged_mode} \
   ovn_gateway_mode=${ovn_gateway_mode} \
   ovn_gateway_opts=${ovn_gateway_opts} \
   ovnkube_node_loglevel=${node_loglevel} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -67,6 +67,7 @@ fi
 # OVN_SSL_ENABLE - use SSL transport to NB/SB db and northd (default: no)
 # OVN_REMOTE_PROBE_INTERVAL - ovn remote probe interval in ms (default 100000)
 # OVN_EGRESSIP_ENABLE - enable egress IP for ovn-kubernetes
+# OVN_UNPRIVILEGED_MODE - execute CNI ovs/netns commands from host (default no)
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -929,10 +930,16 @@ ovn-node() {
       "
   }
 
+  ovn_unprivileged_flag="--unprivileged-mode"
+  if test -z "${OVN_UNPRIVILEGED_MODE+x}" -o "x${OVN_UNPRIVILEGED_MODE}" = xno; then
+    ovn_unprivileged_flag=""
+  fi
+
   echo "=============== ovn-node   --init-node"
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
+    ${ovn_unprivileged_flag} \
     --nodeport \
     --mtu=${mtu} \
     ${OVN_ENCAP_IP} \

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -33,7 +33,7 @@ spec:
       # as all pods.
       serviceAccountName: ovn
       hostNetwork: true
-      hostPID: true
+      {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}
       containers:
 
       # ovsdb-server and ovs-switchd daemons
@@ -161,10 +161,12 @@ spec:
 
         securityContext:
           runAsUser: 0
-          capabilities:
-            add: ["NET_ADMIN", "SYS_ADMIN", "SYS_PTRACE"]
-          {% if kind is defined and kind -%}
+          {% if ovn_unprivileged_mode=="no" -%}
           privileged: true
+          {% else -%}
+          capabilities:
+            add:
+            - NET_ADMIN
           {% endif %}
 
         terminationMessagePolicy: FallbackToLogsOnError
@@ -262,6 +264,8 @@ spec:
           value: "{{ ovn_remote_probe_interval }}"
         - name: OVN_MULTICAST_ENABLE
           value: "{{ ovn_multicast_enable }}"
+        - name: OVN_UNPRIVILEGED_MODE
+          value: "{{ ovn_unprivileged_mode }}"
 
         lifecycle:
           preStop:


### PR DESCRIPTION
it is impossible to use non-kind cluster virtualization mechanisms and also
there are some ways to improve the current netns access logic, as such
this change provides:

* generic way to configure ovnkube-node --unprivileged-mode
* convert kind to use new configurable rather then specific
* eliminate the need to mount /var/lib/netns

Signed-off-by: Dmitry Yusupov <dyusupov@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->