### PR TITLE
simplify factory error handling

### DIFF
--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -63,8 +63,8 @@ func GetNodeInternalIP(node *kapi.Node) (string, error) {
 }
 
 // StartNodeWatch starts a node event handler
-func StartNodeWatch(h types.NodeHandler, wf *factory.WatchFactory) error {
-	_, err := wf.AddNodeHandler(cache.ResourceEventHandlerFuncs{
+func StartNodeWatch(h types.NodeHandler, wf *factory.WatchFactory) {
+	wf.AddNodeHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			node := obj.(*kapi.Node)
 			h.Add(node)
@@ -79,7 +79,6 @@ func StartNodeWatch(h types.NodeHandler, wf *factory.WatchFactory) error {
 			h.Delete(node)
 		},
 	}, nil)
-	return err
 }
 
 // CopyNamespaceAnnotationsToPod copies annotations from a namespace to a pod

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -621,7 +621,7 @@ func getObjectMeta(objType reflect.Type, obj interface{}) (*metav1.ObjectMeta, e
 func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, lsel *metav1.LabelSelector, funcs cache.ResourceEventHandler, processExisting func([]interface{})) (*Handler, error) {
 	inf, ok := wf.informers[objType]
 	if !ok {
-		return nil, fmt.Errorf("unknown object type %v", objType)
+		klog.Fatalf("Tried to add handler of unknown object type %v", objType)
 	}
 
 	sel, err := metav1.LabelSelectorAsSelector(lsel)
@@ -670,10 +670,7 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, lsel 
 }
 
 func (wf *WatchFactory) removeHandler(objType reflect.Type, handler *Handler) error {
-	if inf, ok := wf.informers[objType]; ok {
-		return inf.removeHandler(handler)
-	}
-	return fmt.Errorf("tried to remove unknown object type %v event handler", objType)
+	return wf.informers[objType].removeHandler(handler)
 }
 
 // AddPodHandler adds a handler function that will be executed on Pod object changes

--- a/go-controller/pkg/node/egressip.go
+++ b/go-controller/pkg/node/egressip.go
@@ -25,8 +25,8 @@ type egressIPLocal struct {
 	defaultGatewayIntf string
 }
 
-func (n *OvnNode) watchEgressIP(egressIPLocal *egressIPLocal) error {
-	_, err := n.watchFactory.AddEgressIPHandler(cache.ResourceEventHandlerFuncs{
+func (n *OvnNode) watchEgressIP(egressIPLocal *egressIPLocal) {
+	n.watchFactory.AddEgressIPHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			eIP := obj.(*egressipv1.EgressIP)
 			if err := egressIPLocal.addEgressIP(eIP); err != nil {
@@ -52,7 +52,6 @@ func (n *OvnNode) watchEgressIP(egressIPLocal *egressIPLocal) error {
 			}
 		},
 	}, egressIPLocal.syncEgressIPs)
-	return err
 }
 
 func (e *egressIPLocal) isNodeIP(link netlink.Link, addr *netlink.Addr) (bool, error) {

--- a/go-controller/pkg/node/egressip_test.go
+++ b/go-controller/pkg/node/egressip_test.go
@@ -101,8 +101,7 @@ var _ = Describe("EgressIP Operations", func() {
 					},
 				)
 
-				err = fakeOvnNode.node.watchEgressIP(egressIPLocal)
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvnNode.node.watchEgressIP(egressIPLocal)
 
 				addrs := func() []netlink.Addr {
 					addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
@@ -156,8 +155,7 @@ var _ = Describe("EgressIP Operations", func() {
 				link, err := netlink.LinkByName(primaryLinkName)
 				mockAddPrimaryIP(link)
 
-				err = fakeOvnNode.node.watchEgressIP(egressIPLocal)
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvnNode.node.watchEgressIP(egressIPLocal)
 
 				addrs := func() []netlink.Addr {
 					addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
@@ -214,8 +212,7 @@ var _ = Describe("EgressIP Operations", func() {
 				link, err := netlink.LinkByName(primaryLinkName)
 				mockAddPrimaryIP(link)
 
-				err = fakeOvnNode.node.watchEgressIP(egressIPLocal)
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvnNode.node.watchEgressIP(egressIPLocal)
 
 				addrs := func() []netlink.Addr {
 					addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
@@ -268,8 +265,7 @@ var _ = Describe("EgressIP Operations", func() {
 				link, err := netlink.LinkByName(primaryLinkName)
 				mockAddPrimaryIP(link)
 
-				err = fakeOvnNode.node.watchEgressIP(egressIPLocal)
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvnNode.node.watchEgressIP(egressIPLocal)
 
 				addrs := func() []netlink.Addr {
 					addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
@@ -336,8 +332,7 @@ var _ = Describe("EgressIP Operations", func() {
 				link, err := netlink.LinkByName(primaryLinkName)
 				mockAddPrimaryIP(link)
 
-				err = fakeOvnNode.node.watchEgressIP(egressIPLocal)
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvnNode.node.watchEgressIP(egressIPLocal)
 
 				addrs := func() []netlink.Addr {
 					addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
@@ -428,8 +423,7 @@ var _ = Describe("EgressIP Operations", func() {
 				link, err := netlink.LinkByName(primaryLinkName)
 				mockAddPrimaryIP(link)
 
-				err = fakeOvnNode.node.watchEgressIP(egressIPLocal)
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvnNode.node.watchEgressIP(egressIPLocal)
 
 				addrs := func() []netlink.Addr {
 					addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
@@ -507,8 +501,7 @@ var _ = Describe("EgressIP Operations", func() {
 				link, err := netlink.LinkByName(primaryLinkName)
 				mockAddPrimaryIP(link)
 
-				err = fakeOvnNode.node.watchEgressIP(egressIPLocal)
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvnNode.node.watchEgressIP(egressIPLocal)
 
 				addrs := func() []netlink.Addr {
 					addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -97,12 +97,8 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	waiter *startupWaiter) error {
 
 	if config.Gateway.NodeportEnable {
-		if err := initLoadBalancerHealthChecker(n.name, n.watchFactory); err != nil {
-			return err
-		}
-		if err := initPortClaimWatcher(n.recorder, n.watchFactory); err != nil {
-			return err
-		}
+		initLoadBalancerHealthChecker(n.name, n.watchFactory)
+		initPortClaimWatcher(n.recorder, n.watchFactory)
 	}
 
 	gatewayNextHop := net.ParseIP(config.Gateway.NextHop)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -310,7 +310,7 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet, wf 
 		return err
 	}
 
-	_, err = wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
+	wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			service := obj.(*kapi.Service)
 			addService(service, ofportPhys, ofportPatch, gwBridge, nodeIP[0])
@@ -332,7 +332,7 @@ func nodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP []*net.IPNet, wf 
 		syncServices(services, ofportPhys, gwBridge, nodeIP[0])
 	})
 
-	return err
+	return nil
 }
 
 // since we share the host's k8s node IP, add OpenFlow flows

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -18,12 +18,12 @@ import (
 
 // initLoadBalancerHealthChecker initializes the health check server for
 // ServiceTypeLoadBalancer services
-func initLoadBalancerHealthChecker(nodeName string, wf *factory.WatchFactory) error {
+func initLoadBalancerHealthChecker(nodeName string, wf *factory.WatchFactory) {
 	server := healthcheck.NewServer(nodeName, nil, nil, nil)
 	services := make(map[ktypes.NamespacedName]uint16)
 	endpoints := make(map[ktypes.NamespacedName]int)
 
-	_, err := wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
+	wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			svc := obj.(*kapi.Service)
 			if svc.Spec.HealthCheckNodePort != 0 {
@@ -45,11 +45,8 @@ func initLoadBalancerHealthChecker(nodeName string, wf *factory.WatchFactory) er
 			}
 		},
 	}, nil)
-	if err != nil {
-		return err
-	}
 
-	_, err = wf.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
+	wf.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ep := obj.(*kapi.Endpoints)
 			name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
@@ -73,7 +70,6 @@ func initLoadBalancerHealthChecker(nodeName string, wf *factory.WatchFactory) er
 			_ = server.SyncEndpoints(endpoints)
 		},
 	}, nil)
-	return err
 }
 
 func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -272,10 +272,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 	if !ok {
 		return fmt.Errorf("cannot get kubeclient for starting CNI server")
 	}
-	err = n.WatchEndpoints()
-	if err != nil {
-		return err
-	}
+	n.WatchEndpoints()
 
 	// start the cni server
 	cniServer := cni.NewCNIServer("", kclient.KClient)
@@ -284,8 +281,8 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 	return err
 }
 
-func (n *OvnNode) WatchEndpoints() error {
-	_, err := n.watchFactory.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
+func (n *OvnNode) WatchEndpoints() {
+	n.watchFactory.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
 			epNew := new.(*kapi.Endpoints)
 			epOld := old.(*kapi.Endpoints)
@@ -313,7 +310,6 @@ func (n *OvnNode) WatchEndpoints() error {
 			}
 		},
 	}, nil)
-	return err
 }
 
 type epAddressItem struct {

--- a/go-controller/pkg/node/port_claim.go
+++ b/go-controller/pkg/node/port_claim.go
@@ -41,9 +41,9 @@ func newPortClaimWatcher(recorder record.EventRecorder) localPort {
 	}
 }
 
-func initPortClaimWatcher(recorder record.EventRecorder, wf *factory.WatchFactory) error {
+func initPortClaimWatcher(recorder record.EventRecorder, wf *factory.WatchFactory) {
 	port = newPortClaimWatcher(recorder)
-	_, err := wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
+	wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			svc := obj.(*kapi.Service)
 			if errors := addServicePortClaim(svc); len(errors) > 0 {
@@ -70,7 +70,6 @@ func initPortClaimWatcher(recorder record.EventRecorder, wf *factory.WatchFactor
 			}
 		},
 	}, nil)
-	return err
 }
 
 func addServicePortClaim(svc *kapi.Service) []error {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -145,8 +145,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 101 ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14 allow"),
 					},
 				)
-				err := fakeOvn.controller.WatchEgressNodes()
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvn.controller.WatchEgressNodes()
 				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(0))
 				node1.Labels = map[string]string{
 					"k8s.ovn.org/egress-assignable": "",
@@ -206,15 +205,14 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					return len(fakeOvn.controller.eIPAllocator)
 				}
 
-				err := fakeOvn.controller.WatchEgressNodes()
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvn.controller.WatchEgressNodes()
 				Eventually(allocatorItems).Should(Equal(0))
 
 				node.Labels = map[string]string{
 					"k8s.ovn.org/egress-assignable": "",
 				}
 
-				_, err = fakeOvn.fakeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+				_, err := fakeOvn.fakeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(allocatorItems).Should(Equal(0))
 
@@ -266,11 +264,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 101 ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14 allow"),
 					},
 				)
-				err := fakeOvn.controller.WatchEgressNodes()
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeOvn.controller.WatchEgressIP()
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvn.controller.WatchEgressNodes()
+				fakeOvn.controller.WatchEgressIP()
 
 				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(0))
 				Eventually(eIP.Status.Items).Should(HaveLen(0))
@@ -356,11 +351,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 101 ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14 allow"),
 					},
 				)
-				err := fakeOvn.controller.WatchEgressNodes()
-				Expect(err).NotTo(HaveOccurred())
-
-				err = fakeOvn.controller.WatchEgressIP()
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvn.controller.WatchEgressNodes()
+				fakeOvn.controller.WatchEgressIP()
 
 				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(0))
 				Eventually(eIP.Status.Items).Should(HaveLen(0))
@@ -469,10 +461,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					},
 				)
 
-				err := fakeOvn.controller.WatchEgressNodes()
-				Expect(err).NotTo(HaveOccurred())
-				err = fakeOvn.controller.WatchEgressIP()
-				Expect(err).NotTo(HaveOccurred())
+				fakeOvn.controller.WatchEgressNodes()
+				fakeOvn.controller.WatchEgressIP()
 
 				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(1))
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
@@ -481,7 +471,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				Expect(statuses[0].Node).To(Equal(node1.Name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
 
-				_, err = fakeOvn.fakeClient.CoreV1().Nodes().Create(context.TODO(), &node2, metav1.CreateOptions{})
+				_, err := fakeOvn.fakeClient.CoreV1().Nodes().Create(context.TODO(), &node2, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(getEgressIPStatusLenSafely(egressIPName)).Should(Equal(1))

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -330,8 +330,7 @@ var _ = Describe("Master Operations", func() {
 			err = clusterController.StartClusterMaster("master")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = clusterController.WatchNodes()
-			Expect(err).NotTo(HaveOccurred())
+			clusterController.WatchNodes()
 
 			wg.Add(1)
 			go func() {
@@ -428,8 +427,7 @@ var _ = Describe("Master Operations", func() {
 			err = clusterController.StartClusterMaster("master")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = clusterController.WatchNodes()
-			Expect(err).NotTo(HaveOccurred())
+			clusterController.WatchNodes()
 
 			wg.Add(1)
 			go func() {
@@ -524,8 +522,7 @@ var _ = Describe("Master Operations", func() {
 			err = clusterController.StartClusterMaster("master")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = clusterController.WatchNodes()
-			Expect(err).NotTo(HaveOccurred())
+			clusterController.WatchNodes()
 
 			wg.Add(1)
 			go func() {
@@ -680,8 +677,7 @@ subnet=%s
 			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 29)
 
 			// Let the real code run and ensure OVN database sync
-			err = clusterController.WatchNodes()
-			Expect(err).NotTo(HaveOccurred())
+			clusterController.WatchNodes()
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
 
@@ -905,8 +901,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			_ = clusterController.joinSubnetAllocator.AddNetworkRange(ovntest.MustParseIPNet("100.64.0.0/16"), 29)
 
 			// Let the real code run and ensure OVN database sync
-			err = clusterController.WatchNodes()
-			Expect(err).NotTo(HaveOccurred())
+			clusterController.WatchNodes()
 
 			subnet := ovntest.MustParseIPNet(nodeSubnet)
 			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet})
@@ -1103,8 +1098,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			clusterController.nodeLocalNatIPAllocator, _ = ipallocator.NewCIDRRange(ovntest.MustParseIPNet(util.V4NodeLocalNatSubnet))
 
 			// Let the real code run and ensure OVN database sync
-			err = clusterController.WatchNodes()
-			Expect(err).NotTo(HaveOccurred())
+			clusterController.WatchNodes()
 
 			subnet := ovntest.MustParseIPNet(nodeSubnet)
 			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet})

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -295,31 +295,22 @@ func (oc *Controller) Run(wg *sync.WaitGroup) error {
 
 	// WatchNamespaces() should be started first because it has no other
 	// dependencies, and WatchNodes() depends on it
-	if err := oc.WatchNamespaces(); err != nil {
-		return err
-	}
+	oc.WatchNamespaces()
 
 	// WatchNodes must be started next because it creates the node switch
 	// which most other watches depend on.
 	// https://github.com/ovn-org/ovn-kubernetes/pull/859
-	if err := oc.WatchNodes(); err != nil {
-		return err
-	}
+	oc.WatchNodes()
 
-	for _, f := range []func() error{oc.WatchPods, oc.WatchServices,
-		oc.WatchEndpoints, oc.WatchNetworkPolicy, oc.WatchCRD} {
-		if err := f(); err != nil {
-			return err
-		}
-	}
+	oc.WatchPods()
+	oc.WatchServices()
+	oc.WatchEndpoints()
+	oc.WatchNetworkPolicy()
+	oc.WatchCRD()
 
 	if config.OVNKubernetesFeature.EnableEgressIP {
-		if err := oc.WatchEgressNodes(); err != nil {
-			return err
-		}
-		if err := oc.WatchEgressIP(); err != nil {
-			return err
-		}
+		oc.WatchEgressNodes()
+		oc.WatchEgressIP()
 	}
 
 	klog.Infof("Completing all the Watchers took %v", time.Since(start))
@@ -544,11 +535,11 @@ func (oc *Controller) recordPodEvent(addErr error, pod *kapi.Pod) {
 }
 
 // WatchPods starts the watching of Pod resource and calls back the appropriate handler logic
-func (oc *Controller) WatchPods() error {
+func (oc *Controller) WatchPods() {
 	var retryPods sync.Map
 
 	start := time.Now()
-	_, err := oc.watchFactory.AddPodHandler(cache.ResourceEventHandlerFuncs{
+	oc.watchFactory.AddPodHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*kapi.Pod)
 			if !podWantsNetwork(pod) {
@@ -603,18 +594,14 @@ func (oc *Controller) WatchPods() error {
 			retryPods.Delete(pod.UID)
 		},
 	}, oc.syncPods)
-	if err == nil {
-		klog.Infof("Bootstrapping existing pods and cleaning stale pods took %v",
-			time.Since(start))
-	}
-	return err
+	klog.Infof("Bootstrapping existing pods and cleaning stale pods took %v", time.Since(start))
 }
 
 // WatchServices starts the watching of Service resource and calls back the
 // appropriate handler logic
-func (oc *Controller) WatchServices() error {
+func (oc *Controller) WatchServices() {
 	start := time.Now()
-	_, err := oc.watchFactory.AddServiceHandler(cache.ResourceEventHandlerFuncs{
+	oc.watchFactory.AddServiceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			service := obj.(*kapi.Service)
 			err := oc.createService(service)
@@ -635,17 +622,13 @@ func (oc *Controller) WatchServices() error {
 			oc.deleteService(service)
 		},
 	}, oc.syncServices)
-	if err == nil {
-		klog.Infof("Bootstrapping existing services and cleaning stale services took %v",
-			time.Since(start))
-	}
-	return err
+	klog.Infof("Bootstrapping existing services and cleaning stale services took %v", time.Since(start))
 }
 
 // WatchEndpoints starts the watching of Endpoint resource and calls back the appropriate handler logic
-func (oc *Controller) WatchEndpoints() error {
+func (oc *Controller) WatchEndpoints() {
 	start := time.Now()
-	_, err := oc.watchFactory.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
+	oc.watchFactory.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ep := obj.(*kapi.Endpoints)
 			err := oc.AddEndpoints(ep)
@@ -679,18 +662,14 @@ func (oc *Controller) WatchEndpoints() error {
 			}
 		},
 	}, nil)
-	if err == nil {
-		klog.Infof("Bootstrapping existing endpoints and cleaning stale endpoints took %v",
-			time.Since(start))
-	}
-	return err
+	klog.Infof("Bootstrapping existing endpoints and cleaning stale endpoints took %v", time.Since(start))
 }
 
 // WatchNetworkPolicy starts the watching of network policy resource and calls
 // back the appropriate handler logic
-func (oc *Controller) WatchNetworkPolicy() error {
+func (oc *Controller) WatchNetworkPolicy() {
 	start := time.Now()
-	_, err := oc.watchFactory.AddPolicyHandler(cache.ResourceEventHandlerFuncs{
+	oc.watchFactory.AddPolicyHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			policy := obj.(*kapisnetworking.NetworkPolicy)
 			oc.addNetworkPolicy(policy)
@@ -708,17 +687,13 @@ func (oc *Controller) WatchNetworkPolicy() error {
 			oc.deleteNetworkPolicy(policy)
 		},
 	}, oc.syncNetworkPolicies)
-	if err == nil {
-		klog.Infof("Bootstrapping existing policies and cleaning stale policies took %v",
-			time.Since(start))
-	}
-	return err
+	klog.Infof("Bootstrapping existing policies and cleaning stale policies took %v", time.Since(start))
 }
 
 // WatchCRD starts the watching of the CRD resource and calls back to the
 // appropriate handler logic
-func (oc *Controller) WatchCRD() error {
-	_, err := oc.watchFactory.AddCRDHandler(cache.ResourceEventHandlerFuncs{
+func (oc *Controller) WatchCRD() {
+	oc.watchFactory.AddCRDHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			crd := obj.(*apiextension.CustomResourceDefinition)
 			klog.Infof("Adding CRD %s to cluster", crd.Name)
@@ -728,12 +703,7 @@ func (oc *Controller) WatchCRD() error {
 					klog.Errorf("Error Creating EgressFirewallWatchFactory: %v", err)
 					return
 				}
-				h, err := oc.WatchEgressFirewall()
-				if err != nil {
-					klog.Errorf("Error watching CRD - %v", err)
-					return
-				}
-				oc.egressFirewallHandler = h
+				oc.egressFirewallHandler = oc.WatchEgressFirewall()
 
 			}
 		},
@@ -749,14 +719,12 @@ func (oc *Controller) WatchCRD() error {
 			}
 		},
 	}, nil)
-	return err
-
 }
 
 // WatchEgressFirewall starts the watching of egressfirewall resource and calls
 // back the appropriate handler logic
-func (oc *Controller) WatchEgressFirewall() (*factory.Handler, error) {
-	h, err := oc.watchFactory.AddEgressFirewallHandler(cache.ResourceEventHandlerFuncs{
+func (oc *Controller) WatchEgressFirewall() *factory.Handler {
+	return oc.watchFactory.AddEgressFirewallHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			egressFirewall := obj.(*egressfirewall.EgressFirewall)
 			errList := oc.addEgressFirewall(egressFirewall)
@@ -800,14 +768,13 @@ func (oc *Controller) WatchEgressFirewall() (*factory.Handler, error) {
 			}
 		},
 	}, nil)
-	return h, err
 }
 
 // WatchEgressNodes starts the watching of egress assignable nodes and calls
 // back the appropriate handler logic.
-func (oc *Controller) WatchEgressNodes() error {
+func (oc *Controller) WatchEgressNodes() {
 	nodeEgressLabel := util.GetNodeEgressLabel()
-	_, err := oc.watchFactory.AddNodeHandler(cache.ResourceEventHandlerFuncs{
+	oc.watchFactory.AddNodeHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			node := obj.(*kapi.Node)
 			if err := oc.addNodeForEgress(node); err != nil {
@@ -851,13 +818,12 @@ func (oc *Controller) WatchEgressNodes() error {
 			}
 		},
 	}, oc.initClusterEgressPolicies)
-	return err
 }
 
 // WatchEgressIP starts the watching of egressip resource and calls
 // back the appropriate handler logic.
-func (oc *Controller) WatchEgressIP() error {
-	_, err := oc.watchFactory.AddEgressIPHandler(cache.ResourceEventHandlerFuncs{
+func (oc *Controller) WatchEgressIP() {
+	oc.watchFactory.AddEgressIPHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			eIP := obj.(*egressipv1.EgressIP)
 			if err := oc.addEgressIP(eIP); err != nil {
@@ -892,14 +858,13 @@ func (oc *Controller) WatchEgressIP() error {
 			}
 		},
 	}, oc.syncEgressIPs)
-	return err
 }
 
 // WatchNamespaces starts the watching of namespace resource and calls
 // back the appropriate handler logic
-func (oc *Controller) WatchNamespaces() error {
+func (oc *Controller) WatchNamespaces() {
 	start := time.Now()
-	_, err := oc.watchFactory.AddNamespaceHandler(cache.ResourceEventHandlerFuncs{
+	oc.watchFactory.AddNamespaceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ns := obj.(*kapi.Namespace)
 			oc.AddNamespace(ns)
@@ -913,11 +878,7 @@ func (oc *Controller) WatchNamespaces() error {
 			oc.deleteNamespace(ns)
 		},
 	}, oc.syncNamespaces)
-	if err == nil {
-		klog.Infof("Bootstrapping existing namespaces and cleaning stale namespaces took %v",
-			time.Since(start))
-	}
-	return err
+	klog.Infof("Bootstrapping existing namespaces and cleaning stale namespaces took %v", time.Since(start))
 }
 
 func (oc *Controller) syncNodeGateway(node *kapi.Node, hostSubnets []*net.IPNet) error {
@@ -943,13 +904,13 @@ func (oc *Controller) syncNodeGateway(node *kapi.Node, hostSubnets []*net.IPNet)
 
 // WatchNodes starts the watching of node resource and calls
 // back the appropriate handler logic
-func (oc *Controller) WatchNodes() error {
+func (oc *Controller) WatchNodes() {
 	var gatewaysFailed sync.Map
 	var mgmtPortFailed sync.Map
 	var addNodeFailed sync.Map
 
 	start := time.Now()
-	_, err := oc.watchFactory.AddNodeHandler(cache.ResourceEventHandlerFuncs{
+	oc.watchFactory.AddNodeHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			node := obj.(*kapi.Node)
 			if noHostSubnet := noHostSubnet(node); noHostSubnet {
@@ -1077,11 +1038,7 @@ func (oc *Controller) WatchNodes() error {
 			gatewaysFailed.Delete(node.Name)
 		},
 	}, oc.syncNodes)
-	if err == nil {
-		klog.Infof("Bootstrapping existing nodes and cleaning stale nodes took %v",
-			time.Since(start))
-	}
-	return err
+	klog.Infof("Bootstrapping existing nodes and cleaning stale nodes took %v", time.Since(start))
 }
 
 // AddServiceVIPToName associates a k8s service name with a load balancer VIP

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -743,10 +743,7 @@ func (oc *Controller) WatchCRD() error {
 			crd := obj.(*apiextension.CustomResourceDefinition)
 			klog.Infof("Deleting CRD %s from cluster", crd.Name)
 			if crd.Name == egressfirewallCRD {
-				err := oc.watchFactory.RemoveEgressFirewallHandler(oc.egressFirewallHandler)
-				if err != nil {
-					klog.Errorf("Error removing EgressFirewallHandler: %v", err)
-				}
+				oc.watchFactory.RemoveEgressFirewallHandler(oc.egressFirewallHandler)
 				oc.egressFirewallHandler = nil
 				oc.watchFactory.ShutdownEgressFirewallWatchFactory()
 			}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -558,8 +558,10 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 func (oc *Controller) handleLocalPodSelector(
 	policy *knet.NetworkPolicy, np *namespacePolicy) {
 
-	h, err := oc.watchFactory.AddFilteredPodHandler(policy.Namespace,
-		&policy.Spec.PodSelector,
+	// NetworkPolicy is validated by the apiserver; this can't fail.
+	sel, _ := metav1.LabelSelectorAsSelector(&policy.Spec.PodSelector)
+
+	h := oc.watchFactory.AddFilteredPodHandler(policy.Namespace, sel,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				oc.handleLocalPodSelectorAddFunc(policy, np, obj)
@@ -571,11 +573,6 @@ func (oc *Controller) handleLocalPodSelector(
 				oc.handleLocalPodSelectorAddFunc(policy, np, newObj)
 			},
 		}, nil)
-	if err != nil {
-		klog.Errorf("Error watching local pods for policy %s in namespace %s: %v",
-			policy.Name, policy.Namespace, err)
-		return
-	}
 
 	np.podHandlerList = append(np.podHandlerList, h)
 }
@@ -804,8 +801,10 @@ func (oc *Controller) handlePeerPodSelector(
 	policy *knet.NetworkPolicy, podSelector *metav1.LabelSelector,
 	gp *gressPolicy, np *namespacePolicy) {
 
-	h, err := oc.watchFactory.AddFilteredPodHandler(policy.Namespace,
-		podSelector,
+	// NetworkPolicy is validated by the apiserver; this can't fail.
+	sel, _ := metav1.LabelSelectorAsSelector(podSelector)
+
+	h := oc.watchFactory.AddFilteredPodHandler(policy.Namespace, sel,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				oc.handlePeerPodSelectorAddUpdate(gp, obj)
@@ -817,12 +816,6 @@ func (oc *Controller) handlePeerPodSelector(
 				oc.handlePeerPodSelectorAddUpdate(gp, newObj)
 			},
 		}, nil)
-	if err != nil {
-		klog.Errorf("Error watching peer pods for policy %s in namespace %s: %v",
-			policy.Name, policy.Namespace, err)
-		return
-	}
-
 	np.podHandlerList = append(np.podHandlerList, h)
 }
 
@@ -832,8 +825,12 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 	podSelector *metav1.LabelSelector,
 	gp *gressPolicy,
 	np *namespacePolicy) {
-	namespaceHandler, err := oc.watchFactory.AddFilteredNamespaceHandler("",
-		namespaceSelector,
+
+	// NetworkPolicy is validated by the apiserver; this can't fail.
+	nsSel, _ := metav1.LabelSelectorAsSelector(namespaceSelector)
+	podSel, _ := metav1.LabelSelectorAsSelector(podSelector)
+
+	namespaceHandler := oc.watchFactory.AddFilteredNamespaceHandler("", nsSel,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				namespace := obj.(*kapi.Namespace)
@@ -846,8 +843,7 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 
 				// The AddFilteredPodHandler call might call handlePeerPodSelectorAddUpdate
 				// on existing pods so we can't be holding the lock at this point
-				podHandler, err := oc.watchFactory.AddFilteredPodHandler(namespace.Name,
-					podSelector,
+				podHandler := oc.watchFactory.AddFilteredPodHandler(namespace.Name, podSel,
 					cache.ResourceEventHandlerFuncs{
 						AddFunc: func(obj interface{}) {
 							oc.handlePeerPodSelectorAddUpdate(gp, obj)
@@ -859,10 +855,6 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 							oc.handlePeerPodSelectorAddUpdate(gp, newObj)
 						},
 					}, nil)
-				if err != nil {
-					klog.Errorf("Error watching pods in namespace %s for policy %s: %v", namespace.Name, policy.Name, err)
-					return
-				}
 				np.Lock()
 				defer np.Unlock()
 				if np.deleted {
@@ -876,11 +868,6 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 			},
 		}, nil)
-	if err != nil {
-		klog.Errorf("Error watching namespaces for policy %s: %v",
-			policy.Name, err)
-		return
-	}
 	np.nsHandlerList = append(np.nsHandlerList, namespaceHandler)
 }
 
@@ -889,8 +876,10 @@ func (oc *Controller) handlePeerNamespaceSelector(
 	namespaceSelector *metav1.LabelSelector,
 	gress *gressPolicy, np *namespacePolicy) {
 
-	h, err := oc.watchFactory.AddFilteredNamespaceHandler("",
-		namespaceSelector,
+	// NetworkPolicy is validated by the apiserver; this can't fail.
+	sel, _ := metav1.LabelSelectorAsSelector(namespaceSelector)
+
+	h := oc.watchFactory.AddFilteredNamespaceHandler("", sel,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				namespace := obj.(*kapi.Namespace)
@@ -911,12 +900,6 @@ func (oc *Controller) handlePeerNamespaceSelector(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 			},
 		}, nil)
-	if err != nil {
-		klog.Errorf("Error watching namespaces for policy %s: %v",
-			policy.Name, err)
-		return
-	}
-
 	np.nsHandlerList = append(np.nsHandlerList, h)
 }
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -866,7 +866,7 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 				np.Lock()
 				defer np.Unlock()
 				if np.deleted {
-					_ = oc.watchFactory.RemovePodHandler(podHandler)
+					oc.watchFactory.RemovePodHandler(podHandler)
 					return
 				}
 				np.podHandlerList = append(np.podHandlerList, podHandler)
@@ -922,9 +922,9 @@ func (oc *Controller) handlePeerNamespaceSelector(
 
 func (oc *Controller) shutdownHandlers(np *namespacePolicy) {
 	for _, handler := range np.podHandlerList {
-		_ = oc.watchFactory.RemovePodHandler(handler)
+		oc.watchFactory.RemovePodHandler(handler)
 	}
 	for _, handler := range np.nsHandlerList {
-		_ = oc.watchFactory.RemoveNamespaceHandler(handler)
+		oc.watchFactory.RemoveNamespaceHandler(handler)
 	}
 }


### PR DESCRIPTION
while reviewing #1567 I noticed it was checking for errors while removing handlers and was wondering why it needs to do that, and the answer is that it really doesn't