### PR TITLE
Ignore errors from "add pod" events for network policy

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -19,7 +19,7 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-// Builds the logical switch port name for a given pod.
+// podLogicalPortName builds the logical switch port name for a given pod.
 func podLogicalPortName(pod *kapi.Pod) string {
 	return pod.Namespace + "_" + pod.Name
 }


### PR DESCRIPTION
Currently policy code looks for add pod events, which can never be
successful. This is because the policy code relies on finding an IP in
the annotation or pod status, which is not set until after
addLogicalPort is complete and an update event comes.

This patch adds the behavior to check the logical port cache if nothing
is found in annotations or status fields. This way there is a chance
that while the add events are racing in the pod thread and policy thread
that the IPs may be available for the policy.

Additionally since we expect add pod to fail most of the time for a
policy, downgrade the error there to a warning, but keep the error for
update events, as we expect those to be successful.

Signed-off-by: Tim Rozet <trozet@redhat.com>
