### PR TITLE
ci: don't run periodic jobs in forks

### DIFF
--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'ovn-org/ovn-kubernetes' || github.event_name == 'workflow_dispatch'
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -64,6 +65,7 @@ jobs:
         path: dist/images/_output/image.tar
 
   k8s:
+    if: github.repository == 'ovn-org/ovn-kubernetes' || github.event_name == 'workflow_dispatch'
     name: Build k8s
     runs-on: ubuntu-latest
     steps:
@@ -100,6 +102,7 @@ jobs:
         popd
 
   e2e-dual:
+    if: github.repository == 'ovn-org/ovn-kubernetes' || github.event_name == 'workflow_dispatch'
     name: e2e-dual
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
We shouldn't be running the periodic dual-stack CI job (or future periodic jobs) in people's local forks. (And in particular, we shouldn't be sending mail to them about it every day.)

I couldn't find any way to mark the whole file as "`if`" something; it seems like you have to specify it separate for each job...

@aojea @trozet 