### PR TITLE
run OVS in its own daemonset

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo apt-get install openvswitch-datapath-dkms -y
 
 Create OVN StatefulSet, DaemonSet and Deployment yamls from templates by running the commands below:
 (The $MASTER_IP below is the IP address of the machine where kube-apiserver is
-running). 
+running).
 
 **Note:** when specifying the pod CIDR to the command below, daemonset.sh will
 generate a /24 subnet prefix to create per-node CIDRs. Ensure your pod subnet is has a
@@ -55,7 +55,7 @@ cd $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/images
     --k8s-apiserver=https://$MASTER_IP:6443
 ```
 
-To set specific logging level for OVN components, pass the related parameter from the below mentioned 
+To set specific logging level for OVN components, pass the related parameter from the below mentioned
 list to the above command. Set values are the default values.
 ```
     --master-loglevel="5" \\Log level for ovnkube (master)
@@ -67,13 +67,18 @@ list to the above command. Set values are the default values.
     --ovn-loglevel-nbctld="-vconsole:info" \\ Log config for nbctl daemon
 ```
 
+If you are not running OVS directly in the nodes, you must apply the OVS Daemonset yaml.
+```
+kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/ovs-node.yaml
+```
+
 Apply OVN DaemonSet and Deployment yamls.
 
 ```
 # Create OVN namespace, service accounts, ovnkube-db headless service, configmap, and policies
 kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/ovn-setup.yaml
 
-# Optionally, if you plan to use the Egress IPs or EgressFirewall features, create the corresponding CRDs: 
+# Optionally, if you plan to use the Egress IPs or EgressFirewall features, create the corresponding CRDs:
 # create egressips.k8s.ovn.org CRD
 kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/k8s.ovn.org_egressips.yaml
 # create egressfirewalls.k8s.ovn.org CRD

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -368,6 +368,7 @@ if [ "$KIND_HA" == true ]; then
 else
   run_kubectl apply -f ovnkube-db.yaml
 fi
+run_kubectl apply -f ovs-node.yaml
 run_kubectl apply -f ovnkube-master.yaml
 run_kubectl apply -f ovnkube-node.yaml
 popd

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -282,6 +282,11 @@ ovn_image=${image} \
   ovn_sb_raft_port=${ovn_sb_raft_port} \
   j2 ../templates/ovnkube-db-raft.yaml.j2 -o ../yaml/ovnkube-db-raft.yaml
 
+ovn_image=${image} \
+  ovn_image_pull_policy=${image_pull_policy} \
+  ovn_unprivileged_mode=${ovn_unprivileged_mode} \
+  j2 ../templates/ovs-node.yaml.j2 -o ../yaml/ovs-node.yaml
+
 # ovn-setup.yaml
 net_cidr=${OVN_NET_CIDR:-"10.128.0.0/14/23"}
 svc_cidr=${OVN_SVC_CIDR:-"172.30.0.0/16"}

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -1,7 +1,7 @@
 ---
 # ovnkube-node
 # daemonset version 3
-# starts node daemons for ovs and ovn, each in a separate container
+# starts node daemons for ovn, each in a separate container
 # it is run on all nodes
 kind: DaemonSet
 apiVersion: apps/v1
@@ -35,67 +35,6 @@ spec:
       hostNetwork: true
       {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}
       containers:
-
-      # ovsdb-server and ovs-switchd daemons
-      - name: ovs-daemons
-        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
-        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
-
-        command: ["/root/ovnkube.sh", "ovs-server"]
-
-        livenessProbe:
-          exec:
-            command:
-            - /usr/share/openvswitch/scripts/ovs-ctl
-            - status
-          initialDelaySeconds: 30
-          timeoutSeconds: 30
-          periodSeconds: 60
-        readinessProbe:
-          exec:
-            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovs-daemons"]
-          initialDelaySeconds: 30
-          timeoutSeconds: 30
-          periodSeconds: 60
-
-        securityContext:
-          runAsUser: 0
-          # Permission could be reduced by selecting an appropriate SELinux policy
-          privileged: true
-
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: host-modules
-          readOnly: true
-        - mountPath: /run/openvswitch
-          name: host-run-ovs
-        - mountPath: /var/run/openvswitch
-          name: host-var-run-ovs
-        - mountPath: /sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /etc/openvswitch
-          name: host-config-openvswitch
-        resources:
-          requests:
-            cpu: 100m
-            memory: 300Mi
-          limits:
-            cpu: 200m
-            memory: 400Mi
-        env:
-        - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/root/ovnkube.sh", "cleanup-ovs-server"]
 
       - name: ovn-controller
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
@@ -313,10 +252,6 @@ spec:
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
-      - name: host-modules
-        hostPath:
-          path: /lib/modules
-
       - name: host-var-run-dbus
         hostPath:
           path: /var/run/dbus
@@ -335,9 +270,6 @@ spec:
       - name: host-var-run-ovn-kubernetes
         hostPath:
           path: /var/run/ovn-kubernetes
-      - name: host-sys
-        hostPath:
-          path: /sys
       - name: host-opt-cni-bin
         hostPath:
           path: /opt/cni/bin
@@ -351,9 +283,6 @@ spec:
       - name: host-slash
         hostPath:
           path: /
-      - name: host-config-openvswitch
-        hostPath:
-          path: /etc/origin/openvswitch
       - name: host-var-lib-ovs
         hostPath:
           path: /var/lib/openvswitch

--- a/dist/templates/ovs-node.yaml.j2
+++ b/dist/templates/ovs-node.yaml.j2
@@ -1,0 +1,127 @@
+---
+# ovs-node
+# daemonset version 3
+# starts node daemons for ovs
+# it is run on all nodes
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovs-node
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovs networking components for all nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovs-node
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovs-node
+        name: ovs-node
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}
+      containers:
+
+      # ovsdb-server and ovs-switchd daemons
+      - name: ovs-daemons
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "ovs-server"]
+
+        livenessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovs-daemons"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: host-modules
+          readOnly: true
+        - mountPath: /run/openvswitch
+          name: host-run-ovs
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-ovs
+        - mountPath: /sys
+          name: host-sys
+        - mountPath: /etc/openvswitch
+          name: host-config-openvswitch
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 200m
+            memory: 400Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/root/ovnkube.sh", "cleanup-ovs-server"]
+
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      volumes:
+      - name: host-modules
+        hostPath:
+          path: /lib/modules
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-config-openvswitch
+        hostPath:
+          path: /etc/origin/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+
+      tolerations:
+      - operator: "Exists"


### PR DESCRIPTION
**- What this PR does and why is it needed**

Quoting from issue #1599, where this was discussed
"In production and serious deployments, the OVS is choice of
software for host networking. So, deployers will not run OVS in
containers."

We should try to test the same scenarios that we run in production,
hence we run openvswitch in its own daemonset instead of running it
in the ovnkube-node pod.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

Fixes: #1599 
**- Special notes for reviewers**


**- How to verify it**

**- Description for the changelog**
