### PR TITLE
Enable shared gateway + ipv6 job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,19 +174,18 @@ jobs:
          # Not currently supported but needs to be.
          - {"ipfamily": {"ip": dualstack}}
          - {"ipfamily": {"ip": ipv6}, "target": {"shard": control-plane}}
-         - {"ipfamily": {"ip": ipv6}, "gateway-mode": shared}
          # Limit matrix combinations for CI. DISABLED items added to exclude list:
          #   DISABLED  v4  ha     local
          #   ENABLED   v4  ha     shared
          #   ENABLED   v4  noha   local
          #   DISABLED  v4  noha   shared
-         #   ENABLED   v6  ha     local
-         #   DISABLED  v6  ha     shared
+         #   DISABLED   v6  ha     local
+         #   ENABLED  v6  ha     shared
          #   DISABLED  v6  noha   local
          #   DISABLED  v6  noha   shared
          - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "true"}, "gateway-mode": local}
          - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "false"}, "gateway-mode": shared}
-         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "true"}, "gateway-mode": shared}
+         - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "true"}, "gateway-mode": local}
          - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": local}
          - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": shared}
     needs: [build, k8s]


### PR DESCRIPTION
Disable local gateway+ipv6 and enable shared instead.

Signed-off-by: Tim Rozet <trozet@redhat.com>

