### PR TITLE
Fix egress IP test panic

### DIFF
--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -1532,6 +1532,9 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				getEgressIP := func() string {
 					statuses = getEgressIPStatusSafely(egressIPName)
+					if len(statuses) == 0 {
+						return "try again"
+					}
 					return statuses[0].EgressIP
 				}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

This is a spin-off from: https://github.com/ovn-org/ovn-kubernetes/pull/1598#issuecomment-671328286 and comments mentioned on slack: https://coreos.slack.com/archives/GQ0CU2623/p1596750386234500?thread_ts=1596734533.218000&cid=GQ0CU2623

The test `should perform re-assignment of EgressIPs` in `egressip_test.go` sometimes panics as `getEgressIP` (which is used to retrieve that the egress IP status during the asynchronous update)  can return an empty status. This is because `WatchEgressIP` on update resets the status field to an empty status before performing the re-assignment. `deleteEgressIP` and `addEgressIP` both use a mutex to insure correct handling during the delete / add, but during the update there is a small window where the status field can be empty, see here: https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/ovn/ovn.go#L846. This solution does a small work-around  in the test to avoid that panic, but does not cause the test to fail and subsequently continue trying. 

/assign @danwinship @trozet 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->