### PR TITLE
use go-ovn bindings for Chassis related OVN SB transactions

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -331,7 +331,6 @@ var _ = Describe("OVN EgressFirewall Operations", func() {
 				defer close(stopChan)
 				fExec.AddFakeCmdsNoOutputNoError([]string{
 					//adding the original node commands
-					"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
 					"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch",
 					"ovn-nbctl --timeout=15 --if-exists lrp-del rtos-node1 -- lrp-add ovn_cluster_router rtos-node1 ",
 					"ovn-nbctl --timeout=15 --may-exist ls-add node1 -- set logical_switch node1",

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -2,7 +2,6 @@ package ovn
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -22,6 +21,7 @@ import (
 	"k8s.io/klog"
 	utilnet "k8s.io/utils/net"
 
+	goovn "github.com/ebay/go-ovn"
 	hocontroller "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
@@ -843,6 +843,27 @@ func (oc *Controller) clearInitialNodeNetworkUnavailableCondition(origNode, newN
 	}
 }
 
+// delete chassis of the given nodeName/chassisName map
+func deleteChassis(ovnSBClient goovn.Client, chassisMap map[string]string) {
+	cmds := make([]*goovn.OvnCommand, 0, len(chassisMap))
+	for _, chassisName := range chassisMap {
+		if chassisName != "" {
+			cmd, err := ovnSBClient.ChassisDel(chassisName)
+			if err != nil {
+				klog.Errorf("Unable to create the ChassisDel command for chassis: %s from the sbdb", chassisName)
+			} else {
+				cmds = append(cmds, cmd)
+			}
+		}
+	}
+
+	if len(cmds) != 0 {
+		if err := ovnSBClient.Execute(cmds...); err != nil {
+			klog.Errorf("Failed to delete chassis for node/chassis map %v: error: %v", chassisMap, err)
+		}
+	}
+}
+
 // this is the worker function that does the periodic sync of nodes from kube API
 // and sbdb and deletes chassis that are stale
 func (oc *Controller) syncNodesPeriodic() {
@@ -859,18 +880,15 @@ func (oc *Controller) syncNodesPeriodic() {
 		nodeNames = append(nodeNames, node.Name)
 	}
 
-	chassisData, stderr, err := util.RunOVNSbctl("--data=bare", "--no-heading",
-		"--columns=name,hostname", "--format=json", "list", "Chassis")
+	chassisList, err := oc.ovnSBClient.ChassisList()
 	if err != nil {
-		klog.Errorf("Failed to get chassis list: stderr: %s, error: %v",
-			stderr, err)
+		klog.Errorf("Failed to get chassis list: error: %v", err)
 		return
 	}
 
-	chassisMap, err := oc.unmarshalChassisDataIntoMap([]byte(chassisData))
-	if err != nil {
-		klog.Errorf("Failed to unmarshal chassis data into chassis map, error: %v: %s", err, chassisData)
-		return
+	chassisMap := map[string]string{}
+	for _, chassis := range chassisList {
+		chassisMap[chassis.Hostname] = chassis.Name
 	}
 
 	//delete existing nodes from the chassis map.
@@ -878,15 +896,7 @@ func (oc *Controller) syncNodesPeriodic() {
 		delete(chassisMap, nodeName)
 	}
 
-	for nodeName, chassisName := range chassisMap {
-		if chassisName != "" {
-			_, stderr, err = util.RunOVNSbctl("--if-exist", "chassis-del", chassisName)
-			if err != nil {
-				klog.Errorf("Failed to delete chassis with name %s for node %s: stderr: %s, error: %v",
-					chassisName, nodeName, stderr, err)
-			}
-		}
-	}
+	deleteChassis(oc.ovnSBClient, chassisMap)
 }
 
 func (oc *Controller) syncNodes(nodes []interface{}) {
@@ -904,19 +914,15 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 	// watchNodes() will be called for all existing nodes at startup anyway.
 	// Note that this list will include the 'join' cluster switch, which we
 	// do not want to delete.
-
-	chassisData, stderr, err := util.RunOVNSbctl("--data=bare", "--no-heading",
-		"--columns=name,hostname", "--format=json", "list", "Chassis")
+	chassisList, err := oc.ovnSBClient.ChassisList()
 	if err != nil {
-		klog.Errorf("Failed to get chassis list: stderr: %q, error: %v",
-			stderr, err)
+		klog.Errorf("Failed to get chassis list: error: %v", err)
 		return
 	}
 
-	chassisMap, err := oc.unmarshalChassisDataIntoMap([]byte(chassisData))
-	if err != nil {
-		klog.Errorf("Failed to unmarshal chassis data into chassis map, error: %v: %s", err, chassisData)
-		return
+	chassisMap := map[string]string{}
+	for _, chassis := range chassisList {
+		chassisMap[chassis.Hostname] = chassis.Name
 	}
 
 	//delete existing nodes from the chassis map.
@@ -994,65 +1000,38 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 		delete(chassisMap, nodeName)
 	}
 
-	for nodeName, chassisName := range chassisMap {
-		if chassisName != "" {
-			_, stderr, err = util.RunOVNSbctl("--if-exist", "chassis-del", chassisName)
-			if err != nil {
-				klog.Errorf("Failed to delete chassis with name %s for logical switch %s: stderr: %q, error: %v",
-					chassisName, nodeName, stderr, err)
-			}
-		}
-	}
-}
-
-func (oc *Controller) unmarshalChassisDataIntoMap(chData []byte) (map[string]string, error) {
-	//map of node name to chassis name
-	chassisMap := make(map[string]string)
-
-	type chassisList struct {
-		Data     [][]string
-		Headings []string
-	}
-	var mapUnmarshal chassisList
-
-	if len(chData) == 0 {
-		return chassisMap, nil
-	}
-
-	err := json.Unmarshal(chData, &mapUnmarshal)
-
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling the chassis data: %s", err)
-	}
-
-	for _, chassis := range mapUnmarshal.Data {
-		if len(chassis) < 2 || chassis[0] == "" || chassis[1] == "" {
-			continue
-		}
-		chassisMap[chassis[1]] = chassis[0]
-	}
-
-	return chassisMap, nil
+	deleteChassis(oc.ovnSBClient, chassisMap)
 }
 
 func (oc *Controller) deleteNodeChassis(nodeName string) error {
-	chassisName, stderr, err := util.RunOVNSbctl("--data=bare", "--no-heading",
-		"--columns=name", "find", "Chassis",
-		"hostname="+nodeName)
+	var chNames []string
+
+	chassisList, err := oc.ovnSBClient.ChassisGet(nodeName)
 	if err != nil {
-		return fmt.Errorf("failed to get chassis name for node %s: stderr: %q, error: %v",
-			nodeName, stderr, err)
+		return fmt.Errorf("failed to get chassis list for node %s: error: %v", nodeName, err)
 	}
 
-	if chassisName == "" {
-		klog.Warningf("Chassis name is empty for node: %s", nodeName)
-	} else {
-		_, stderr, err = util.RunOVNSbctl("--if-exist", "chassis-del", chassisName)
-		if err != nil {
-			return fmt.Errorf("failed to delete chassis with name %s for node %s: stderr: %q, error: %v",
-				chassisName, nodeName, stderr, err)
+	cmds := make([]*goovn.OvnCommand, 0, len(chassisList))
+	for _, chassis := range chassisList {
+		if chassis.Name == "" {
+			klog.Warningf("Chassis name is empty for node: %s", nodeName)
+			continue
 		}
+		cmd, err := oc.ovnSBClient.ChassisDel(chassis.Name)
+		if err != nil {
+			return fmt.Errorf("unable to create the ChassisDel command for chassis: %s", chassis.Name)
+		}
+		chNames = append(chNames, chassis.Name)
+		cmds = append(cmds, cmd)
 	}
 
+	if len(cmds) == 0 {
+		return fmt.Errorf("failed to find chassis for node %s", nodeName)
+	}
+
+	if err = oc.ovnSBClient.Execute(cmds...); err != nil {
+		return fmt.Errorf("failed to delete chassis %q for node %s: error: %v",
+			strings.Join(chNames, ","), nodeName, err)
+	}
 	return nil
 }

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -171,7 +171,6 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	hybridOverlayIP := util.NextIP(nodeMgmtPortIP)
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -580,9 +579,6 @@ var _ = Describe("Master Operations", func() {
 			)
 
 			fexec := ovntest.NewFakeExec()
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
-			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch",
 				// Return two nodes
@@ -600,9 +596,6 @@ subnet=%s
 				"ovn-nbctl --timeout=15 --if-exist lrp-del " + routerToSwitchPrefix + node1Name,
 			})
 			cleanupGateway(fexec, node1Name, node1Subnet, ovnClusterRouter, node1MgmtPortIP)
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name find Chassis hostname=" + node1Name,
-			})
 
 			// Expect the code to re-add the master (which still exists)
 			// when the factory watch begins and enumerates all existing
@@ -819,7 +812,6 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
 				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch",
 			})
 
@@ -1011,7 +1003,6 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
 				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch",
 			})
 

--- a/go-controller/pkg/testing/mock_chassis.go
+++ b/go-controller/pkg/testing/mock_chassis.go
@@ -1,0 +1,65 @@
+package testing
+
+import (
+	"fmt"
+
+	goovn "github.com/ebay/go-ovn"
+	"k8s.io/klog"
+)
+
+// Get logical switch port by name
+func (mock *MockOVNClient) ChassisList() ([]*goovn.Chassis, error) {
+	var chassisCache MockObjectCacheByName
+	var ok bool
+
+	chArray := []*goovn.Chassis{}
+	if chassisCache, ok = mock.cache[ChassisType]; !ok {
+		klog.V(5).Infof("Cache doesn't have any object of type %s", ChassisType)
+		return nil, goovn.ErrorSchema
+	}
+	var ch interface{}
+	for _, ch = range chassisCache {
+		chassis, ok := ch.(*goovn.Chassis)
+		if !ok {
+			return nil, fmt.Errorf("invalid object type assertion for %s", ChassisType)
+		}
+		chArray = append(chArray, chassis)
+	}
+	return chArray, nil
+}
+
+// Delete chassis with given name
+func (mock *MockOVNClient) ChassisDel(chName string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("Deleting chassis %s", chName)
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpDelete,
+			table:   ChassisType,
+			objName: chName,
+		},
+	}, nil
+}
+
+// Get chassis by hostname or name
+func (mock *MockOVNClient) ChassisGet(name string) ([]*goovn.Chassis, error) {
+	var chassisCache MockObjectCacheByName
+	var ok bool
+	if chassisCache, ok = mock.cache[ChassisType]; !ok {
+		klog.V(5).Infof("Cache doesn't have any object of type %s", ChassisType)
+		return nil, goovn.ErrorSchema
+	}
+
+	var ch interface{}
+	chArray := make([]*goovn.Chassis, 0, len(chassisCache))
+	for _, ch = range chassisCache {
+		chassis, ok := ch.(*goovn.Chassis)
+		if !ok {
+			return nil, fmt.Errorf("invalid object type assertion for %s", ChassisType)
+		}
+		if chassis.Name == name || chassis.Hostname == name {
+			chArray = append(chArray, chassis)
+		}
+	}
+	return chArray, nil
+}

--- a/go-controller/pkg/testing/mock_ovn.go
+++ b/go-controller/pkg/testing/mock_ovn.go
@@ -13,6 +13,7 @@ import (
 const (
 	LogicalSwitchType     string = "Logical_Switch"
 	LogicalSwitchPortType string = "Logical_Switch_Port"
+	ChassisType           string = "Chassis"
 )
 
 const (
@@ -62,12 +63,16 @@ var _ goovn.Execution = &MockExecution{}
 
 // return a new mock client to operate on db
 func NewMockOVNClient(db string) *MockOVNClient {
-	return &MockOVNClient{
+	mock := &MockOVNClient{
 		db:         db,
 		cache:      make(map[string]MockObjectCacheByName),
 		errorCache: make(map[string]error),
 		connected:  true,
 	}
+	mock.cache[LogicalSwitchPortType] = make(MockObjectCacheByName)
+	mock.cache[ChassisType] = make(MockObjectCacheByName)
+	mock.cache[LogicalSwitchType] = make(MockObjectCacheByName)
+	return mock
 }
 
 func functionName() string {

--- a/go-controller/pkg/testing/mock_stubs.go
+++ b/go-controller/pkg/testing/mock_stubs.go
@@ -268,21 +268,6 @@ func (mock *MockOVNClient) ChassisAdd(name string, hostname string, etype []stri
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
 }
 
-// Delete chassis with given name
-func (mock *MockOVNClient) ChassisDel(chName string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Get chassis by hostname or name
-func (mock *MockOVNClient) ChassisGet(chname string) ([]*goovn.Chassis, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// List chassis
-func (mock *MockOVNClient) ChassisList() ([]*goovn.Chassis, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
 // Get encaps by chassis name
 func (mock *MockOVNClient) EncapList(chname string) ([]*goovn.Encap, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())


### PR DESCRIPTION
This change replaces the ovn-sbctl calls with go-ovn bindings functions
for SB Chassis related OVN SB operations.

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->