### PR TITLE
Making VLAN ID option to be supported only in shared gateway mode

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1082,9 +1082,10 @@ func buildGatewayConfig(ctx *cli.Context, cli, file *config) error {
 		if Gateway.NextHop != "" {
 			return fmt.Errorf("gateway next-hop option %q not allowed when gateway is disabled", Gateway.NextHop)
 		}
-		if Gateway.VLANID != 0 {
-			return fmt.Errorf("gateway VLAN ID option '%d' not allowed when gateway is disabled", Gateway.VLANID)
-		}
+	}
+
+	if Gateway.Mode != GatewayModeShared && Gateway.VLANID != 0 {
+		return fmt.Errorf("gateway VLAN ID option: %d is supported only in shared gateway mode", Gateway.VLANID)
 	}
 	return nil
 }

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -562,7 +562,7 @@ var _ = Describe("Config Operations", func() {
 			Expect(OvnSouth.Address).To(Equal("ssl:6.5.4.1:6652"))
 			Expect(OvnSouth.CertCommonName).To(Equal("testsbcommonname"))
 
-			Expect(Gateway.Mode).To(Equal(GatewayModeLocal))
+			Expect(Gateway.Mode).To(Equal(GatewayModeShared))
 			Expect(Gateway.NodeportEnable).To(BeTrue())
 
 			Expect(HybridOverlay.Enabled).To(BeTrue())
@@ -597,7 +597,7 @@ var _ = Describe("Config Operations", func() {
 			"-sb-client-cert=/client/cert2",
 			"-sb-client-cacert=/client/cacert2",
 			"-sb-cert-common-name=testsbcommonname",
-			"-gateway-mode=local",
+			"-gateway-mode=shared",
 			"-nodeport",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=11.132.0.0/14/23",
@@ -777,6 +777,21 @@ mode=shared
 		cliArgs := []string{
 			app.Name,
 			"-gateway-mode=adsfasdfaf",
+		}
+		err := app.Run(cliArgs)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns an error when the vlan-id is specified for mode other than shared gateway mode", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := InitConfig(ctx, kexec.New(), nil)
+			Expect(err).To(MatchError("gateway VLAN ID option: 30 is supported only in shared gateway mode"))
+			return nil
+		}
+		cliArgs := []string{
+			app.Name,
+			"-gateway-mode=local",
+			"-gateway-vlanid=30",
 		}
 		err := app.Run(cliArgs)
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -135,6 +135,9 @@ func (cfg *L3GatewayConfig) UnmarshalJSON(bytes []byte) error {
 		if err != nil {
 			return fmt.Errorf("bad 'vlan-id' value %q: %v", cfgjson.VLANID, err)
 		}
+		if cfg.Mode != config.GatewayModeShared && uint(vlanID64) != 0 {
+			return fmt.Errorf("vlan-id is supported only in shared gateway mode")
+		}
 		vlanID := uint(vlanID64)
 		cfg.VLANID = &vlanID
 	}

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -110,8 +110,12 @@ func TestL3GatewayConfig_UnmarshalJSON(t *testing.T) {
 		},
 		{
 			desc:       "error: test bad VLANID input",
-			inputParam: []byte(`{"mode":"local","vlan-id":"A"}`),
+			inputParam: []byte(`{"mode":"shared","vlan-id":"A"}`),
 			errMatch:   fmt.Errorf("bad 'vlan-id' value"),
+		},
+		{desc: "error: test VLANID is supported only in shared gateway mode",
+			inputParam: []byte(`{"mode":"local","vlan-id":"223"}`),
+			errMatch:   fmt.Errorf("vlan-id is supported only in shared gateway mode"),
 		},
 		{
 			desc:       "success: test valid VLANID input",


### PR DESCRIPTION
Fixes: #1478

Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>
