### PR TITLE
Fix multicast allow ACLs after namespace AS name change.

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -238,9 +238,8 @@ func (oc *Controller) createDefaultDenyPortGroup(policyType knet.PolicyType) err
 
 // Creates the match string used for ACLs allowing incoming multicast into a
 // namespace, that is, from IPs that are in the namespace's address set.
-func getMulticastACLMatch(ns string) string {
-	nsAddressSet := hashedAddressSet(ns)
-	return "ip4.src == $" + nsAddressSet + " && ip4.mcast"
+func getMulticastACLMatch(nsInfo *namespaceInfo) string {
+	return "ip4.src == $" + nsInfo.addressSet.GetIPv4HashName() + " && ip4.mcast"
 }
 
 // Creates a policy to allow multicast traffic within 'ns':
@@ -265,7 +264,7 @@ func (oc *Controller) createMulticastAllowPolicy(ns string, nsInfo *namespaceInf
 	}
 
 	err = addACLPortGroup(nsInfo.portGroupUUID, hashedPortGroup(ns), toLport,
-		defaultMcastAllowPriority, getMulticastACLMatch(ns), "allow",
+		defaultMcastAllowPriority, getMulticastACLMatch(nsInfo), "allow",
 		knet.PolicyTypeIngress)
 	if err != nil {
 		return fmt.Errorf("failed to create allow ingress multicast ACL for %s (%v)",
@@ -289,7 +288,7 @@ func (oc *Controller) createMulticastAllowPolicy(ns string, nsInfo *namespaceInf
 	return nil
 }
 
-func deleteMulticastACLs(ns, portGroupHash string) error {
+func deleteMulticastACLs(ns, portGroupHash string, nsInfo *namespaceInfo) error {
 	err := deleteACLPortGroup(portGroupHash, fromLport,
 		defaultMcastAllowPriority, "ip4.mcast", "allow",
 		knet.PolicyTypeEgress)
@@ -299,7 +298,7 @@ func deleteMulticastACLs(ns, portGroupHash string) error {
 	}
 
 	err = deleteACLPortGroup(portGroupHash, toLport,
-		defaultMcastAllowPriority, getMulticastACLMatch(ns), "allow",
+		defaultMcastAllowPriority, getMulticastACLMatch(nsInfo), "allow",
 		knet.PolicyTypeIngress)
 	if err != nil {
 		return fmt.Errorf("failed to delete allow ingress multicast ACL for %s (%v)",
@@ -313,7 +312,7 @@ func deleteMulticastACLs(ns, portGroupHash string) error {
 func deleteMulticastAllowPolicy(ns string, nsInfo *namespaceInfo) error {
 	portGroupHash := hashedPortGroup(ns)
 
-	err := deleteMulticastACLs(ns, portGroupHash)
+	err := deleteMulticastACLs(ns, portGroupHash, nsInfo)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When multicast was enabled for a namespace, the allow ACL was trying to
refer the per namespace address set using the wrong name (changed after
commit 414599b7c631). The code now uses nsInfo.addressSet to get the
correct address set name.

Reported-at: https://bugzilla.redhat.com/1843695
Signed-off-by: Dumitru Ceara <dceara@redhat.com>

CC: @dcbw @abhat 