### PR TITLE
Skip kube proxy connection reset test

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -46,6 +46,11 @@ ClusterDns \[Feature:Example\]
 should set default value on new IngressClass
 # RACE CONDITION IN TEST, SEE https://github.com/kubernetes/kubernetes/pull/90254
 should prevent Ingress creation if more than 1 IngressClass marked as default
+
+# shard-n Tests
+#  See: https://github.com/ovn-org/ovn-kubernetes/issues/1516
+#  IPV4 fails due to: https://bugzilla.redhat.com/show_bug.cgi?id=1870359
+Network.+should resolve connrection reset issue
 "
 
 IPV4_ONLY_TESTS="
@@ -55,10 +60,6 @@ IPV4_ONLY_TESTS="
 
 # The following tests currently fail for IPv6 only, but should be passing.
 # They will be removed as they are resolved.
-
-# shard-n Tests
-#  See: https://github.com/ovn-org/ovn-kubernetes/issues/1516
-Network.+should resolve connrection reset issue
 
 # shard-np Tests
 #  See: https://github.com/ovn-org/ovn-kubernetes/issues/1517


### PR DESCRIPTION
This test was already skipped in IPv6 and is now failing for us on IPv4
due to a bug in OVN:
https://bugzilla.redhat.com/show_bug.cgi?id=1870359

Signed-off-by: Tim Rozet <trozet@redhat.com>

