### PR TITLE
Use flood for shared gw

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -144,7 +144,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=50, in_port=7, ip, actions=ct(zone=64000, table=1)",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, table=1, ct_state=+trk+est, actions=output:5",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, table=1, ct_state=+trk+rel, actions=output:5",
-			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=1, actions=output:NORMAL",
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=1, actions=output:FLOOD",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=2, actions=output:7",
 		})
 		// nodePortWatcher()
@@ -161,7 +161,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd: "ovs-ofctl dump-flows breth0",
 			Output: `cookie=0x0, duration=8366.605s, table=0, n_packets=0, n_bytes=0, priority=100,ip,in_port="patch-breth0_no" actions=ct(commit,zone=64000),output:eth0
 cookie=0x0, duration=8366.603s, table=0, n_packets=10642, n_bytes=10370438, priority=50,ip,in_port=eth0 actions=ct(table=1,zone=64000)
-cookie=0x0, duration=8366.705s, table=0, n_packets=11549, n_bytes=1746901, priority=0 actions=NORMAL
+cookie=0x0, duration=8366.705s, table=0, n_packets=11549, n_bytes=1746901, priority=0 actions=FLOOD
 cookie=0x0, duration=8366.602s, table=1, n_packets=0, n_bytes=0, priority=100,ct_state=+est+trk actions=output:"patch-breth0_no"
 cookie=0x0, duration=8366.600s, table=1, n_packets=0, n_bytes=0, priority=100,ct_state=+rel+trk actions=output:"patch-breth0_no"
 cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, priority=0 actions=LOCAL

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -361,8 +361,8 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 			gwIntf, stderr, err)
 	}
 
-	// replace the left over OpenFlow flows with the NORMAL action flow
-	_, stderr, err = util.AddNormalActionOFFlow(gwBridge)
+	// replace the left over OpenFlow flows with the FLOOD action flow
+	_, stderr, err = util.AddFloodActionOFFlow(gwBridge)
 	if err != nil {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
 	}
@@ -412,7 +412,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 
 	// table 1, all other connections do normal processing
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
-		fmt.Sprintf("cookie=%s, priority=0, table=1, actions=output:NORMAL", defaultOpenFlowCookie))
+		fmt.Sprintf("cookie=%s, priority=0, table=1, actions=output:FLOOD", defaultOpenFlowCookie))
 	if err != nil {
 		return fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
 			"error: %v", gwBridge, stderr, err)
@@ -554,7 +554,7 @@ func cleanupSharedGateway() error {
 		return nil
 	}
 
-	_, stderr, err = util.AddNormalActionOFFlow(bridgeName)
+	_, stderr, err = util.AddFloodActionOFFlow(bridgeName)
 	if err != nil {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", bridgeName, stderr, err)
 	}

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -652,12 +652,12 @@ func RunRoute(args ...string) (string, string, error) {
 	return strings.TrimSpace(stdout.String()), stderr.String(), err
 }
 
-// AddNormalActionOFFlow replaces flows in the bridge with a NORMAL action flow
-func AddNormalActionOFFlow(bridgeName string) (string, string, error) {
+// AddFloodActionOFFlow replaces flows in the bridge with a FLOOD action flow
+func AddFloodActionOFFlow(bridgeName string) (string, string, error) {
 	args := []string{"-O", "OpenFlow13", "replace-flows", bridgeName, "-"}
 
 	stdin := &bytes.Buffer{}
-	stdin.Write([]byte("table=0,priority=0,actions=NORMAL\n"))
+	stdin.Write([]byte("table=0,priority=0,actions=FLOOD\n"))
 
 	cmd := runner.exec.Command(runner.ofctlPath, args...)
 	cmd.SetStdin(stdin)

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -2110,7 +2110,7 @@ func TestRunIP(t *testing.T) {
 	}
 }
 
-func TestAddNormalActionOFFlow(t *testing.T) {
+func TestAddFloodActionOFFlow(t *testing.T) {
 	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
 	mockCmd := new(mock_k8s_io_utils_exec.Cmd)
 	mockExecRunner := new(mocks.ExecRunner)
@@ -2169,7 +2169,7 @@ func TestAddNormalActionOFFlow(t *testing.T) {
 			}
 			mockCall.Once()
 
-			_, _, e := AddNormalActionOFFlow("somename")
+			_, _, e := AddFloodActionOFFlow("somename")
 
 			if tc.expectedErr != nil {
 				assert.Error(t, e)


### PR DESCRIPTION
Use action flood intead of normal for shared gw bridge

Today we use conntrack to make decisions on how to steer traffic between
the host and OVN on the shared gw bridge (breth0 in KIND cases). This
necessary because we share the same MAC/IP between OVN and the host.
However, some traffic cannot be conntracked (like IPv6 ND) so therefore
it will hit the default rule which currently is NORMAL action.

However, NORMAL action is not sufficient because that will end up
choosing whichever entry is in the FDB, and that is undeterministic
because both ports are sharing the same MAC. This patch changes the
behavior to use FLOOD so that unknown packets are sent to both the host
and OVN.