### PR TITLE
Added e2e for egress firewall

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1535,6 +1535,142 @@ var _ = Describe("e2e non-vxlan external gateway and update validation", func() 
 	})
 })
 
+// Validate the egress firewall policies by applying a policy and verify
+// that both explicitly allowed traffic and implicitly denied traffic
+// is properly handled as defined in the crd configuration in the test.
+var _ = ginkgo.Describe("e2e egress firewall policy validation", func() {
+	const (
+		svcname                string = "egress-firewall-policy"
+		exFWPermitTcpDnsDest   string = "8.8.8.8"
+		exFWDenyTcpDnsDest     string = "8.8.4.4"
+		exFWPermitTcpWwwDest   string = "1.1.1.1"
+		ovnContainer           string = "ovnkube-node"
+		egressFirewallYamlFile string = "egress-fw.yml"
+		testTimeout            string = "5"
+		retryInterval                 = 1 * time.Second
+		retryTimeout                  = 30 * time.Second
+	)
+
+	type nodeInfo struct {
+		name   string
+		nodeIP string
+	}
+
+	var (
+		serverNodeInfo nodeInfo
+	)
+
+	f := framework.NewDefaultFramework(svcname)
+
+	// Determine what mode the CI is running in and get relevant endpoint information for the tests
+	ginkgo.BeforeEach(func() {
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 2)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			framework.Failf(
+				"Test requires >= 2 Ready nodes, but there are only %v nodes",
+				len(nodes.Items))
+		}
+
+		ips := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
+
+		serverNodeInfo = nodeInfo{
+			name:   nodes.Items[1].Name,
+			nodeIP: ips[1],
+		}
+	})
+
+	ginkgo.AfterEach(func() {})
+
+	It("Should validate the egress firewall policy functionality against remote hosts", func() {
+		srcPodName := "e2e-egress-fw-src-pod"
+		command := []string{"bash", "-c", "sleep 20000"}
+		frameworkNsFlag := fmt.Sprintf("--namespace=%s", f.Namespace.Name)
+		testContainer := fmt.Sprintf("%s-container", srcPodName)
+		testContainerFlag := fmt.Sprintf("--container=%s", testContainer)
+		// egress firewall crd yaml configuration
+		var egressFirewallConfig = fmt.Sprintf(`kind: EgressFirewall
+apiVersion: k8s.ovn.org/v1
+metadata:
+  name: default
+  namespace: %s
+spec:
+  egress:
+  - type: Allow
+    to:
+      cidrSelector: 8.8.8.8/32
+  - type: Allow
+    to:
+      cidrSelector: 1.1.1.0/24
+    ports:
+      - protocol: TCP
+        port: 80
+  - type: Deny
+    to:
+      cidrSelector: 0.0.0.0/0
+`, f.Namespace.Name)
+		// write the config to a file for application and defer the removal
+		if err := ioutil.WriteFile(egressFirewallYamlFile, []byte(egressFirewallConfig), 0644); err != nil {
+			framework.Failf("Unable to write CRD config to disk: %v", err)
+		}
+		defer func() {
+			if err := os.Remove(egressFirewallYamlFile); err != nil {
+				framework.Logf("Unable to remove the CRD config from disk: %v", err)
+			}
+		}()
+		// create the CRD config parameters
+		applyArgs := []string{
+			"apply",
+			frameworkNsFlag,
+			"-f",
+			egressFirewallYamlFile,
+		}
+		framework.Logf("Applying EgressFirewall configuration: %s ", applyArgs)
+		// apply the egress firewall configuration
+		framework.RunKubectlOrDie(applyArgs...)
+		// create the pod that will be used as the source for the connectivity test
+		createGenericPod(f, srcPodName, serverNodeInfo.name, command)
+
+		// Wait for pod exgw setup to be almost ready
+		err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+			kubectlOut := getPodAddress(srcPodName, f.Namespace.Name)
+			validIP := net.ParseIP(kubectlOut)
+			if validIP == nil {
+				return false, nil
+			}
+			return true, nil
+		})
+		// Fail the test if no address is ever retrieved
+		if err != nil {
+			framework.Failf("Error trying to get the pod IP address %v", err)
+		}
+		// Verify the remote host/port as explicitly allowed by the firewall policy is reachable
+		By(fmt.Sprintf("Verifying connectivity to an explicitly allowed host %s is permitted as defined by the external firewall policy", exFWPermitTcpDnsDest))
+		_, err = framework.RunKubectl("exec", srcPodName, frameworkNsFlag, testContainerFlag, "--", "nc", "-vz", "-w", testTimeout, exFWPermitTcpDnsDest, "53")
+		if err != nil {
+			framework.Failf("Failed to connect to the remote host %s from container %s on node %s: %v", exFWPermitTcpDnsDest, ovnContainer, serverNodeInfo.name, err)
+		}
+		// Verify the remote host/port as implicitly denied by the firewall policy is not reachable
+		By(fmt.Sprintf("Verifying connectivity to an implicitly denied host %s is not permitted as defined by the external firewall policy", exFWDenyTcpDnsDest))
+		_, err = framework.RunKubectl("exec", srcPodName, frameworkNsFlag, testContainerFlag, "--", "nc", "-vz", "-w", testTimeout, exFWDenyTcpDnsDest, "53")
+		if err == nil {
+			framework.Failf("Succeeded in connecting the implicitly denied remote host %s from container %s on node %s", exFWDenyTcpDnsDest, ovnContainer, serverNodeInfo.name)
+		}
+		// Verify the the explicitly allowed host/port tcp port 80 rule is functional
+		By(fmt.Sprintf("Verifying connectivity to an explicitly allowed host %s is permitted as defined by the external firewall policy", exFWPermitTcpWwwDest))
+		_, err = framework.RunKubectl("exec", srcPodName, frameworkNsFlag, testContainerFlag, "--", "nc", "-vz", "-w", testTimeout, exFWPermitTcpWwwDest, "80")
+		if err != nil {
+			framework.Failf("Failed to curl the remote host %s from container %s on node %s: %v", exFWPermitTcpWwwDest, ovnContainer, serverNodeInfo.name, err)
+		}
+		// Verify the remote host/port 443 as implicitly denied by the firewall policy is not reachable
+		By(fmt.Sprintf("Verifying connectivity to an implicitly denied port on host %s is not permitted as defined by the external firewall policy", exFWPermitTcpWwwDest))
+		_, err = framework.RunKubectl("exec", srcPodName, frameworkNsFlag, testContainerFlag, "--", "nc", "-vz", "-w", testTimeout, exFWPermitTcpWwwDest, "443")
+		if err == nil {
+			framework.Failf("Failed to curl the remote host %s from container %s on node %s: %v", exFWPermitTcpWwwDest, ovnContainer, serverNodeInfo.name, err)
+		}
+	})
+})
+
 func getNodePodCIDR(nodeName string) (string, error) {
 	// retrieve the pod cidr for the worker node
 	jsonFlag := "jsonpath='{.metadata.annotations.k8s\\.ovn\\.org/node-subnets}'"


### PR DESCRIPTION
- this commit adds some e2e testing for egress firewall tests
- tests include traffic explicitly allowed by the firewall
  crd config as well as traffic implicitly denied by the policy
- changed the wait.PollImmediate to look for a pods ip annotation

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>

**- What this PR does and why is it needed**

- commit adds e2e tests for the egress firewall feature

**- Special notes for reviewers**

- I used some external sites for the testing. Before I got too deep into more tests I wanted to get consensus on the basics. I will add more scenarios such as:
- more acl protocol combinations 
- testing updates/deletes to the policy
- fixed the `wait.PollImmediate` function to work. Will patch the other tests once this gets reviewed.

This tests only one policy per namespace as that is what is currently supported. Ty.

**- How to verify it**

PR can be verified with the following:
```
# Install kind v7
curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(uname)-amd64"
chmod +x ./kind
mv ./kind /some-dir-in-your-PATH/kind

# Install kind v8
curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.8.1/kind-$(uname)-amd64
chmod +x ./kind
mv ./kind /some-dir-in-your-PATH/kind

# Start ovn-kube kind
pushd $GOPATH/src/github.com/ovn-org/ovn-kubernetes/contrib
./kind.sh
# From the Kubernetes repo run 
pushd $GOPATH/src/k8s.io/kubernetes
kubetest --provider=local --deployment=kind --kind-cluster-name=ovn --test
```



