### PR TITLE
Make sure help message is always printed for kind.sh

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-
-# ensure j2 renderer installed
-pip freeze | grep j2cli || pip install j2cli[yaml] --user
-export PATH=~/.local/bin:$PATH
-
 run_kubectl() {
   local retries=0
   local attempts=10
@@ -148,6 +143,11 @@ print_params()
 }
 
 parse_args $*
+
+# ensure j2 renderer installed
+pip install wheel
+pip freeze | grep j2cli || pip install j2cli[yaml] --user
+export PATH=~/.local/bin:$PATH
 
 # Set default values
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}


### PR DESCRIPTION
Moved installation of j2cli via PIP after parsing the arguments.
Parsing command line arguments should be the first statement in the script so that if someone is just providing
the "-h" flag we print out the help  without doing any check. By moving the above statement as mentioned
we have ensured "-h" flag works even if say pip is not installed in the system.

Signed-off-by: Balaji Varadaraju <bvaradar@redhat.com>

