### PR TITLE
Custom VersionPrinter

### DIFF
--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -26,10 +26,10 @@ build_binaries() {
             -mod vendor \
             -gcflags "${GCFLAGS}" \
             -ldflags "-B ${BUILDID} \
-                -X ${OVN_KUBE_GO_PACKAGE}/pkg/metrics.Commit=${GIT_COMMIT} \
-                -X ${OVN_KUBE_GO_PACKAGE}/pkg/metrics.Branch=${GIT_BRANCH} \
-                -X ${OVN_KUBE_GO_PACKAGE}/pkg/metrics.BuildUser=${BUILD_USER} \
-                -X ${OVN_KUBE_GO_PACKAGE}/pkg/metrics.BuildDate=${BUILD_DATE}" \
+                -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.Commit=${GIT_COMMIT} \
+                -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.Branch=${GIT_BRANCH} \
+                -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.BuildUser=${BUILD_USER} \
+                -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.BuildDate=${BUILD_DATE}" \
             -o "${OVN_KUBE_OUTPUT_BINPATH}/${binbase}"\
             "./${bin}"
     done

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -39,8 +40,21 @@ const DefaultVXLANPort = 4789
 
 // The following are global config parameters that other modules may access directly
 var (
+	// Build information. Populated at build-time.
+	// commit ID used to build ovn-kubernetes
+	Commit = ""
+	// branch used to build ovn-kubernetes
+	Branch = ""
+	// ovn-kubernetes build user
+	BuildUser = ""
+	// ovn-kubernetes build date
+	BuildDate = ""
 	// ovn-kubernetes version, to be changed with every release
 	Version = "0.3.0"
+	// version of the go runtime used to compile ovn-kubernetes
+	GoVersion = runtime.Version()
+	// os and architecture used to build ovn-kubernetes
+	OSArch = fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH)
 
 	// ovn-kubernetes cni config file name
 	CNIConfFileName = "10-ovn-kubernetes.conf"
@@ -335,6 +349,14 @@ func init() {
 	savedGateway = Gateway
 	savedMasterHA = MasterHA
 	savedHybridOverlay = HybridOverlay
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("Version: %s\n", Version)
+		fmt.Printf("Git commit: %s\n", Commit)
+		fmt.Printf("Git branch: %s\n", Branch)
+		fmt.Printf("Go version: %s\n", GoVersion)
+		fmt.Printf("Build date: %s\n", BuildDate)
+		fmt.Printf("OS/Arch: %s\n", OSArch)
+	}
 	Flags = append(Flags, CommonFlags...)
 	Flags = append(Flags, CNIFlags...)
 	Flags = append(Flags, OVNK8sFeatureFlags...)

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	goovn "github.com/ebay/go-ovn"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -138,10 +139,10 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 					"and go version from which ovnkube was built and when and who built it",
 				ConstLabels: prometheus.Labels{
 					"version":    "0.0",
-					"revision":   Commit,
-					"branch":     Branch,
-					"build_user": BuildUser,
-					"build_date": BuildDate,
+					"revision":   config.Commit,
+					"branch":     config.Branch,
+					"build_user": config.BuildUser,
+					"build_date": config.BuildDate,
 					"goversion":  runtime.Version(),
 				},
 			},

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -36,14 +36,6 @@ const (
 	ovsVswitchd   = "ovs-vswitchd"
 )
 
-// Build information. Populated at build-time.
-var (
-	Commit    string
-	Branch    string
-	BuildUser string
-	BuildDate string
-)
-
 type metricDetails struct {
 	srcName       string
 	aggregateFrom []string

--- a/go-controller/pkg/metrics/node.go
+++ b/go-controller/pkg/metrics/node.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -50,10 +51,10 @@ func RegisterNodeMetrics() {
 					"and go version from which ovnkube was built and when and who built it.",
 				ConstLabels: prometheus.Labels{
 					"version":    "0.0",
-					"revision":   Commit,
-					"branch":     Branch,
-					"build_user": BuildUser,
-					"build_date": BuildDate,
+					"revision":   config.Commit,
+					"branch":     config.Branch,
+					"build_user": config.BuildUser,
+					"build_date": config.BuildDate,
 					"goversion":  runtime.Version(),
 				},
 			},


### PR DESCRIPTION
**- What this PR does and why is it needed**

This PR improves version information printed by ovn-kubernetes binaries to include useful information such as:
- Version
- Git commit
- Go version
- Build date
- OS/Architecture

This information is usually required in debugging tasks.

**- How to verify it**

To verify it just execute any binary with the -version flag
```
$ _output/go/bin/hybrid-overlay-node -version
Version: 0.3.0
Git commit: 952ef9424870563711a48d0f2f8b4afc787b5641
Git branch: print-version
Go version: go1.14.6
Build date: 2020-08-23
OS/Arch: linux amd64
```

**- Description for the changelog**

Improve binaries version information.

---

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>