### PR TITLE
Ensure raft membership

### DIFF
--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -225,6 +225,7 @@ ovsdb_cleanup() {
 
 # v3 - create nb_ovsdb/sb_ovsdb cluster in a separate container
 ovsdb-raft() {
+  DB_CLUSTERED=true
   local db=${1}
   local port=${2}
   local raft_port=${3}

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -290,13 +290,14 @@ check_ovn_daemonset_version() {
 get_ovn_db_vars() {
   ovn_nbdb_str=""
   ovn_sbdb_str=""
-  for i in ${!ovn_db_hosts[@]}; do
-    if [[ ${i} -ne 0 ]]; then
+  for i in "${ovn_db_hosts[@]}"; do
+    if [ -n "$ovn_nbdb_str" ]; then
       ovn_nbdb_str=${ovn_nbdb_str}","
       ovn_sbdb_str=${ovn_sbdb_str}","
     fi
-    ovn_nbdb_str=${ovn_nbdb_str}${transport}://[${ovn_db_hosts[${i}]}]:${ovn_nb_port}
-    ovn_sbdb_str=${ovn_sbdb_str}${transport}://[${ovn_db_hosts[${i}]}]:${ovn_sb_port}
+    ip=$(bracketify $i)
+    ovn_nbdb_str=${ovn_nbdb_str}${transport}://${ip}:${ovn_nb_port}
+    ovn_sbdb_str=${ovn_sbdb_str}${transport}://${ip}:${ovn_sb_port}
   done
   # OVN_NORTH and OVN_SOUTH override derived host
   ovn_nbdb=${OVN_NORTH:-$ovn_nbdb_str}
@@ -651,7 +652,7 @@ nb-ovsdb() {
     ovn-nbctl set-ssl ${ovn_nb_pk} ${ovn_nb_cert} ${ovn_ca_cert}
     echo "=============== nb-ovsdb ========== reconfigured for SSL"
   }
-  ovn-nbctl --inactivity-probe=0 set-connection p${transport}:${ovn_nb_port}:[${ovn_db_host}]
+  ovn-nbctl --inactivity-probe=0 set-connection p${transport}:${ovn_nb_port}:$(bracketify ${ovn_db_host})
 
   tail --follow=name ${OVN_LOGDIR}/ovsdb-server-nb.log &
   ovn_tail_pid=$!
@@ -683,7 +684,7 @@ sb-ovsdb() {
     ovn-sbctl set-ssl ${ovn_sb_pk} ${ovn_sb_cert} ${ovn_ca_cert}
     echo "=============== sb-ovsdb ========== reconfigured for SSL"
   }
-  ovn-sbctl --inactivity-probe=0 set-connection p${transport}:${ovn_sb_port}:[${ovn_db_host}]
+  ovn-sbctl --inactivity-probe=0 set-connection p${transport}:${ovn_sb_port}:$(bracketify ${ovn_db_host})
 
   # create the ovnkube-db endpoints
   wait_for_event attempts=10 check_ovnkube_db_ep ${ovn_db_host} ${ovn_nb_port}

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -146,7 +146,7 @@ func coverageShowMetricsUpdater(component string) {
 
 // The `keepTrying` boolean when set to true will not return an error if we can't find pods with the given label.
 // This is so that the caller can re-try again to see if the pods have appeared in the k8s cluster.
-func checkPodRunsOnGivenNode(clientset *kubernetes.Clientset, label, k8sNodeName string,
+func CheckPodRunsOnGivenNode(clientset *kubernetes.Clientset, label, k8sNodeName string,
 	keepTrying bool) (bool, error) {
 	pods, err := clientset.CoreV1().Pods(config.Kubernetes.OVNConfigNamespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: label,

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -351,7 +351,7 @@ func getOvnDbVersionInfo() {
 
 func RegisterOvnDBMetrics(clientset *kubernetes.Clientset, k8sNodeName string) {
 	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
-		return checkPodRunsOnGivenNode(clientset, "name=ovnkube-db", k8sNodeName, false)
+		return CheckPodRunsOnGivenNode(clientset, "name=ovnkube-db", k8sNodeName, false)
 	})
 	if err != nil {
 		if err == wait.ErrWaitTimeout {

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -75,7 +75,7 @@ var ovnNorthdCoverageShowMetricsMap = map[string]*metricDetails{
 
 func RegisterOvnNorthdMetrics(clientset *kubernetes.Clientset, k8sNodeName string) {
 	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
-		return checkPodRunsOnGivenNode(clientset, "name=ovnkube-master", k8sNodeName, true)
+		return CheckPodRunsOnGivenNode(clientset, "name=ovnkube-master", k8sNodeName, true)
 	})
 	if err != nil {
 		if err == wait.ErrWaitTimeout {

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -178,6 +178,9 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 		}
 	}
 
+	go n.ensureOvnRaft(util.OvnNbdbLocation)
+	go n.ensureOvnRaft(util.OvnSbdbLocation)
+
 	if node, err = n.Kube.GetNode(n.name); err != nil {
 		return fmt.Errorf("error retrieving node %s: %v", n.name, err)
 	}

--- a/go-controller/pkg/node/ovn_db_mgmt.go
+++ b/go-controller/pkg/node/ovn_db_mgmt.go
@@ -1,0 +1,139 @@
+package node
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func (n *OvnNode) ensureOvnRaft(db string) {
+	ticker := time.NewTicker(60 * time.Second)
+	klog.Infof("Starting ensure routine for Raft db: %s", db)
+	kclient := n.Kube.(*kube.Kube)
+	for {
+		select {
+		case <-ticker.C:
+			if dbOnNode, _ := metrics.CheckPodRunsOnGivenNode(kclient.KClient.(*kubernetes.Clientset),
+				"name=ovnkube-db", n.name, false); dbOnNode {
+				klog.Infof("Node %s has a OVN DB pod, ensuring OVN Raft membership", n.name)
+				n.ensureLocalRaftServerID(db)
+				n.ensureClusterRaftMembership(db)
+			}
+		case <-n.stopChan:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// ensureLocalRaftServerID is used to ensure there is no stale member in the Raft cluster with our address
+func (n *OvnNode) ensureLocalRaftServerID(db string) {
+	var dbName string
+	var appCtl func(args ...string) (string, string, error)
+
+	if strings.Contains(db, "ovnnb") {
+		dbName = "OVN_Northbound"
+		appCtl = util.RunOVNNBAppCtl
+	} else {
+		dbName = "OVN_Southbound"
+		appCtl = util.RunOVNSBAppCtl
+	}
+
+	out, stderr, err := util.RunOVSDBTool("db-sid", db)
+	if err != nil {
+		klog.Warningf("Unable to get db server ID for: %s, stderr: %v, err: %v", db, stderr, err)
+		return
+	}
+	if len(out) < 4 {
+		klog.Errorf("Invalid db id found: %s for db: %s", out, db)
+		return
+	}
+	// server ID in raft membership is only first 4 char prefix
+	serverID := out[:4]
+	out, stderr, err = appCtl("cluster/status", dbName)
+	if err != nil {
+		klog.Warningf("Unable to get cluster status for: %s, stderr: %v, err: %v", db, stderr, err)
+		return
+	}
+	r, _ := regexp.Compile(`Address: *((ssl|tcp):[?[a-z0-9.:]+]?)`)
+	matches := r.FindStringSubmatch(out)
+	if len(matches) < 2 {
+		klog.Warningf("Unable to parse Address for db: %s, output: %s", db, out)
+		return
+	}
+	addr := matches[1]
+	// look for current servers in raft cluster with the same address
+	r, _ = regexp.Compile("([a-z0-9]{4}) at " + addr)
+	members := r.FindAllStringSubmatch(out, -1)
+	for _, member := range members {
+		if len(member) < 2 {
+			klog.Warningf("Unable to find server id submatch in %s", member)
+			return
+		}
+		if member[1] != serverID {
+			// stale entry found for this node with same adddress, need to kick
+			klog.Infof("Previous stale member found: %s...kicking", member[1])
+			_, stderr, err = appCtl("cluster/kick", dbName, member[1])
+			if err != nil {
+				klog.Errorf("Error while kicking old Raft member: %s, for address: %s in db: %s,"+
+					"stderr: %v, error: %v", member[1], addr, db, stderr, err)
+			}
+		}
+	}
+}
+
+// ensureClusterRaftMembership ensures there are no unknown members in the current Raft cluster
+func (n *OvnNode) ensureClusterRaftMembership(db string) {
+	var knownMembers []string
+	var dbName string
+	var appCtl func(args ...string) (string, string, error)
+
+	if strings.Contains(db, "ovnnb") {
+		dbName = "OVN_Northbound"
+		appCtl = util.RunOVNNBAppCtl
+		knownMembers = strings.Split(config.OvnNorth.Address, ",")
+	} else {
+		dbName = "OVN_Southbound"
+		appCtl = util.RunOVNSBAppCtl
+		knownMembers = strings.Split(config.OvnSouth.Address, ",")
+	}
+
+	out, stderr, err := appCtl("cluster/status", dbName)
+	if err != nil {
+		klog.Warningf("Unable to get cluster status for: %s, stderr: %v, err: %v", db, stderr, err)
+		return
+	}
+	r, _ := regexp.Compile(`([a-z0-9]{4}) at ((ssl|tcp):\[?[a-z0-9.:]+\]?)`)
+	members := r.FindAllStringSubmatch(out, -1)
+	for _, member := range members {
+		if len(member) < 3 {
+			klog.Warningf("Unable to find parse member: %s", member)
+			return
+		}
+		memberFound := false
+		for _, knownMember := range knownMembers {
+			if knownMember == member[2] {
+				memberFound = true
+				break
+			}
+		}
+		if !memberFound && len(knownMembers) > 3 {
+			// unknown member and we have enough members its safe to kick the unknown address
+			klog.Infof("Unknown Raft member found: %s, %s...kicking", member[1], member[2])
+			_, stderr, err = appCtl("cluster/kick", dbName, member[1])
+			if err != nil {
+				// warn only: we might fail to kick since other nodes will also be trying to kick the member
+				klog.Warningf("Error while kicking old Raft member: %s, for address: %s in db: %s,"+
+					"stderr: %v, err: %v", member[1], member[2], db, stderr, err)
+			}
+		}
+	}
+}

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -47,8 +47,10 @@ const (
 )
 
 const (
-	nbdbCtlSock = "ovnnb_db.ctl"
-	sbdbCtlSock = "ovnsb_db.ctl"
+	nbdbCtlSock     = "ovnnb_db.ctl"
+	sbdbCtlSock     = "ovnsb_db.ctl"
+	OvnNbdbLocation = "/etc/openvswitch/ovnnb_db.db"
+	OvnSbdbLocation = "/etc/openvswitch/ovnsb_db.db"
 )
 
 var (


### PR DESCRIPTION
   
    There are two scenarios where a stale member may be leftover in the Raft
    membership:
    
    1. OVN DB pod goes down, database is wiped, comes back up with same
    address but gets a new server ID in Raft
    
    2. DB node is removed from cluster and replaced with a new one with a
    different address
    
    For 1, each ovnkube-master can check its current ID and look for any
    leftover members with its same address.
    
    For 2, only ovnkube-master leader will compare the known addresses
    passed to it for other DB members, and kick out any stale members.
    
    Signed-off-by: Tim Rozet <trozet@redhat.com>
