### PR TITLE
Revert "Fix default allow mgmt ACL using conntrack"

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -189,10 +189,7 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		})
 	}
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + nodeMgmtPortIP.String() + " allow " +
-			"-- --may-exist acl-add " + nodeName + " to-lport 1001 ip4.dst==" + nodeMgmtPortIP.String() + " allow " +
-			"-- --may-exist acl-add " + nodeName + " from-lport 1001 ip4.src==" + nodeMgmtPortIP.String() + " allow " +
-			"-- --may-exist acl-add " + nodeName + " from-lport 1001 ip4.dst==" + nodeMgmtPortIP.String() + " allow",
+		"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + nodeMgmtPortIP.String() + " allow-related",
 		"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + util.K8sPrefix + nodeName + " -- lsp-set-addresses " + util.K8sPrefix + nodeName + " " + mgmtMAC + " " + nodeMgmtPortIP.String(),
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -614,10 +611,7 @@ subnet=%s
 				"ovn-nbctl --timeout=15 set logical_switch " + masterName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + masterName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + masterName + " load_balancer " + sctpLBUUID,
-				"ovn-nbctl --timeout=15 --may-exist acl-add " + masterName + " to-lport 1001 ip4.src==" + masterMgmtPortIP + " allow " +
-					"-- --may-exist acl-add " + masterName + " to-lport 1001 ip4.dst==" + masterMgmtPortIP + " allow " +
-					"-- --may-exist acl-add " + masterName + " from-lport 1001 ip4.src==" + masterMgmtPortIP + " allow " +
-					"-- --may-exist acl-add " + masterName + " from-lport 1001 ip4.dst==" + masterMgmtPortIP + " allow",
+				"ovn-nbctl --timeout=15 --may-exist acl-add " + masterName + " to-lport 1001 ip4.src==" + masterMgmtPortIP + " allow-related",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + masterName + " " + util.K8sPrefix + masterName + " -- lsp-set-addresses " + util.K8sPrefix + masterName + " " + masterMgmtPortMAC + " " + masterMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -830,10 +824,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
-				"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + masterMgmtPortIP + " allow " +
-					"-- --may-exist acl-add " + nodeName + " to-lport 1001 ip4.dst==" + masterMgmtPortIP + " allow " +
-					"-- --may-exist acl-add " + nodeName + " from-lport 1001 ip4.src==" + masterMgmtPortIP + " allow " +
-					"-- --may-exist acl-add " + nodeName + " from-lport 1001 ip4.dst==" + masterMgmtPortIP + " allow",
+				"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + masterMgmtPortIP + " allow-related",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + util.K8sPrefix + nodeName + " -- lsp-set-addresses " + util.K8sPrefix + nodeName + " " + brLocalnetMAC + " " + masterMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -1022,10 +1013,7 @@ var _ = Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
-				"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + nodeMgmtPortIP + " allow " +
-					"-- --may-exist acl-add " + nodeName + " to-lport 1001 ip4.dst==" + nodeMgmtPortIP + " allow " +
-					"-- --may-exist acl-add " + nodeName + " from-lport 1001 ip4.src==" + nodeMgmtPortIP + " allow " +
-					"-- --may-exist acl-add " + nodeName + " from-lport 1001 ip4.dst==" + nodeMgmtPortIP + " allow",
+				"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + nodeMgmtPortIP + " allow-related",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + util.K8sPrefix + nodeName + " -- lsp-set-addresses " + util.K8sPrefix + nodeName + " " + nodeMgmtPortMAC + " " + nodeMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -100,14 +100,9 @@ func addAllowACLFromNode(logicalSwitch string, mgmtPortIP net.IP) error {
 	if utilnet.IsIPv6(mgmtPortIP) {
 		ipFamily = "ip6"
 	}
-
-	matchSrc := fmt.Sprintf("%s.src==%s", ipFamily, mgmtPortIP.String())
-	matchDst := fmt.Sprintf("%s.dst==%s", ipFamily, mgmtPortIP.String())
-	_, stderr, err := util.RunOVNNbctl(
-		"--may-exist", "acl-add", logicalSwitch, "to-lport", defaultAllowPriority, matchSrc, "allow",
-		"--", "--may-exist", "acl-add", logicalSwitch, "to-lport", defaultAllowPriority, matchDst, "allow",
-		"--", "--may-exist", "acl-add", logicalSwitch, "from-lport", defaultAllowPriority, matchSrc, "allow",
-		"--", "--may-exist", "acl-add", logicalSwitch, "from-lport", defaultAllowPriority, matchDst, "allow")
+	match := fmt.Sprintf("%s.src==%s", ipFamily, mgmtPortIP.String())
+	_, stderr, err := util.RunOVNNbctl("--may-exist", "acl-add", logicalSwitch,
+		"to-lport", defaultAllowPriority, match, "allow-related")
 	if err != nil {
 		return fmt.Errorf("failed to create the node acl for "+
 			"logical_switch=%s, stderr: %q (%v)", logicalSwitch, stderr, err)


### PR DESCRIPTION
This reverts commit fd4758701cd61e0f69e21ef5a96ab5d91f704ef0.

We found that this causes problems with network policy ACLs when using
multi-node setups where the network policy ACL only targets a portgroup
of the destination, and in effect only places the ACL there with
allow-related. This causes return traffic destined to another node to be
dropped, because that node does not have any allow-related ACL, and thus
never able to determine via CT if this is reply traffic.

