### PR TITLE
Update lb_force_snat_ip code for dual-stack

### DIFF
--- a/go-controller/pkg/ovn/egressip_local_test.go
+++ b/go-controller/pkg/ovn/egressip_local_test.go
@@ -101,8 +101,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -192,8 +192,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -289,8 +289,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -418,8 +418,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -572,8 +572,8 @@ var _ = Describe("Local gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(

--- a/go-controller/pkg/ovn/egressip_shared_test.go
+++ b/go-controller/pkg/ovn/egressip_shared_test.go
@@ -160,8 +160,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.Name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv4),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.Name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv4),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -272,8 +272,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.Name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv4),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.Name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv4),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -344,8 +344,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -445,8 +445,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -541,8 +541,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -667,8 +667,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -832,8 +832,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
@@ -955,8 +955,8 @@ var _ = Describe("Shared gateway mode EgressIP Operations with", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
-						Output: fmt.Sprintf("lb_force_snat_ip=%s", nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=table --no-heading --columns=options find logical_router name=GR_%s options:lb_force_snat_ip!=-", node2.name),
+						Output: fmt.Sprintf(`{ lb_force_snat_ip="%s" }`, nodeLogicalRouterIPv6),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -272,8 +272,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					"k8s.ovn.org/egress-assignable": "",
 				}
 
-				_, ipV4Sub, err := net.ParseCIDR(nodeIPv4)
-				_, ipV6Sub, err := net.ParseCIDR(nodeIPv6)
+				_, ipv4Sub, err := net.ParseCIDR(nodeIPv4)
+				_, ipv6Sub, err := net.ParseCIDR(nodeIPv6)
 
 				_, err = fakeOvn.fakeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -285,8 +285,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveLen(1))
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node.Name))
-				Expect(fakeOvn.controller.eIPAllocator[node.Name].v4Subnet).To(Equal(ipV4Sub))
-				Expect(fakeOvn.controller.eIPAllocator[node.Name].v6Subnet).To(Equal(ipV6Sub))
+				Expect(fakeOvn.controller.eIPAllocator[node.Name].v4Subnet).To(Equal(ipv4Sub))
+				Expect(fakeOvn.controller.eIPAllocator[node.Name].v6Subnet).To(Equal(ipv6Sub))
 
 				getCacheCount := func() int {
 					cacheCount := 0

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -109,11 +109,8 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 	// default for any sane deployment), we need to SNAT traffic
 	// heading to the logical space with the Gateway router's IP so that
 	// return traffic comes back to the same gateway router.
-
-	// FIXME DUAL-STACK: There doesn't seem to be any way to configure multiple
-	// lb_force_snat_ip values. (https://bugzilla.redhat.com/show_bug.cgi?id=1823003)
 	stdout, stderr, err = util.RunOVNNbctl("set", "logical_router",
-		gatewayRouter, "options:lb_force_snat_ip="+gwLRPIPs[0].String())
+		gatewayRouter, "options:lb_force_snat_ip="+util.JoinIPs(gwLRPIPs, " "))
 	if err != nil {
 		return fmt.Errorf("failed to set logical router %s's lb_force_snat_ip option, "+
 			"stdout: %q, stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -207,7 +207,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:64:40:00:01 100.64.0.1/29 fd98::1/125",
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtod-test-node -- set logical_switch_port jtod-test-node type=router options:router-port=dtoj-test-node addresses=router",
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del dtoj-test-node -- lrp-add ovn_cluster_router dtoj-test-node 0a:58:64:40:00:02 100.64.0.2/29 fd98::2/125",
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=100.64.0.1",
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=100.64.0.1 fd98::1",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node 10.128.0.0/14 100.64.0.2",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node fd01::/48 fd98::2",
 		})

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -460,7 +460,7 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 		}
 		for _, subnet := range subnets {
 			hostIfAddr := util.GetNodeManagementIfAddr(subnet)
-			l3GatewayConfigIP, err := util.MatchIPFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
+			l3GatewayConfigIP, err := util.MatchIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
 			if err != nil {
 				return err
 			}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -161,7 +161,7 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 
 	for _, podIfAddr := range podAnnotation.IPs {
 		isIPv6 := utilnet.IsIPv6CIDR(podIfAddr)
-		nodeSubnet, err := util.MatchIPFamily(isIPv6, nodeSubnets)
+		nodeSubnet, err := util.MatchIPNetFamily(isIPv6, nodeSubnets)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -223,13 +223,24 @@ func IPFamilyName(isIPv6 bool) string {
 	}
 }
 
-// MatchIPFamily loops through the array of *net.IPNet and returns the
+// MatchIPFamily loops through the array of net.IP and returns the
 // first entry in the list in the same IP Family, based on input flag isIPv6.
-func MatchIPFamily(isIPv6 bool, subnets []*net.IPNet) (*net.IPNet, error) {
-	for _, subnet := range subnets {
-		if utilnet.IsIPv6CIDR(subnet) == isIPv6 {
-			return subnet, nil
+func MatchIPFamily(isIPv6 bool, ips []net.IP) (net.IP, error) {
+	for _, ip := range ips {
+		if utilnet.IsIPv6(ip) == isIPv6 {
+			return ip, nil
 		}
 	}
-	return nil, fmt.Errorf("no %s subnet available", IPFamilyName(isIPv6))
+	return nil, fmt.Errorf("no %s IP available", IPFamilyName(isIPv6))
+}
+
+// MatchIPNetFamily loops through the array of *net.IPNet and returns the
+// first entry in the list in the same IP Family, based on input flag isIPv6.
+func MatchIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) (*net.IPNet, error) {
+	for _, ipnet := range ipnets {
+		if utilnet.IsIPv6CIDR(ipnet) == isIPv6 {
+			return ipnet, nil
+		}
+	}
+	return nil, fmt.Errorf("no %s value available", IPFamilyName(isIPv6))
 }


### PR DESCRIPTION
I thought this was going to be a one-liner but it was tricker because apparently the egress IP code now parses `lb_force_snat_ip` to find the gateway IP for a node... I'm not sure that's the right way to find that information, but I didn't change it for now, other than to rewrite it a bit to be more like other dual-stack code.

cc @alexanderConstantinescu 