### PR TITLE
install: add CRD installation instructions to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Apply OVN DaemonSet and Deployment yamls.
 # Create OVN namespace, service accounts, ovnkube-db headless service, configmap, and policies
 kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/ovn-setup.yaml
 
+# Optionally, if you plan to use the Egress IPs or EgressFirewall features, create the corresponding CRDs: 
+# create egressips.k8s.ovn.org CRD
+kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/k8s.ovn.org_egressips.yaml
+# create egressfirewalls.k8s.ovn.org CRD
+kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/k8s.ovn.org_egressfirewalls.yaml
+
 # Run ovnkube-db deployment.
 kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/ovnkube-db.yaml
 


### PR DESCRIPTION
The current installation instructions did not include instructions to deploy/create CRDs

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

fixes "Missing CRD definitions" https://github.com/ovn-org/ovn-kubernetes/issues/1650 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Without instructions added by this fix, user will not deploy CRDs and as result `ovnkube-node` pods will not find the resources definitions 
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->