### PR TITLE
support for ACL logging

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -33,6 +33,7 @@ OVN_LOGLEVEL_NBCTLD=""
 OVNKUBE_LOGFILE_MAXSIZE=""
 OVNKUBE_LOGFILE_MAXBACKUPS=""
 OVNKUBE_LOGFILE_MAXAGE=""
+OVN_ACL_LOGGING_RATE_LIMIT=""
 OVN_MASTER_COUNT=""
 OVN_REMOTE_PROBE_INTERVAL=""
 OVN_HYBRID_OVERLAY_ENABLE=""
@@ -113,6 +114,9 @@ while [ "$1" != "" ]; do
     ;;
   --ovnkube-logfile-maxage)
     OVNKUBE_LOGFILE_MAXAGE=$VALUE
+    ;;
+  --acl-logging-rate-limit)
+    OVN_ACL_LOGGING_RATE_LIMIT=$VALUE
     ;;
   --ssl)
     OVN_SSL_ENABLE="yes"
@@ -208,6 +212,8 @@ ovnkube_logfile_maxbackups=${OVNKUBE_LOGFILE_MAXBACKUPS:-"5"}
 echo "ovnkube_logfile_maxbackups: ${ovnkube_logfile_maxbackups}"
 ovnkube_logfile_maxage=${OVNKUBE_LOGFILE_MAXAGE:-"5"}
 echo "ovnkube_logfile_maxage: ${ovnkube_logfile_maxage}"
+ovn_acl_logging_rate_limit=${OVN_ACL_LOGGING_RATE_LIMIT:-"20"}
+echo "ovn_acl_logging_rate_limit: ${ovn_acl_logging_rate_limit}"
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE}
 echo "ovn_hybrid_overlay_enable: ${ovn_hybrid_overlay_enable}"
 ovn_egress_ip_enable=${OVN_EGRESSIP_ENABLE}
@@ -275,6 +281,7 @@ ovn_image=${image} \
   ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
   ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
   ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
+  ovn_acl_logging_rate_limit=${ovn_acl_logging_rate_limit} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -58,6 +58,7 @@ fi
 # OVNKUBE_LOGFILE_MAXSIZE - log file max size in MB(default 100 MB)
 # OVNKUBE_LOGFILE_MAXBACKUPS - log file max backups (default 5)
 # OVNKUBE_LOGFILE_MAXAGE - log file max age in days (default 5 days)
+# OVN_ACL_LOGGING_RATE_LIMIT - specify default ACL logging rate limit in messages per second (default: 20)
 # OVN_NB_PORT - ovn north db port (default 6641)
 # OVN_SB_PORT - ovn south db port (default 6642)
 # OVN_NB_RAFT_PORT - ovn north db raft port (default 6643)
@@ -188,6 +189,7 @@ ovn_remote_probe_interval=${OVN_REMOTE_PROBE_INTERVAL:-100000}
 ovn_multicast_enable=${OVN_MULTICAST_ENABLE:-}
 #OVN_EGRESSIP_ENABLE - enable egress IP for ovn-kubernetes
 ovn_egressip_enable=${OVN_EGRESSIP_ENABLE:-false}
+ovn_acl_logging_rate_limit=${OVN_ACL_LOGGING_RATE_LIMIT:-"20"}
 
 # Determine the ovn rundir.
 if [[ -f /usr/bin/ovn-appctl ]]; then
@@ -861,6 +863,11 @@ ovn-master() {
       "
   }
 
+  ovn_acl_logging_rate_limit_flag=
+  if [[ -n ${ovn_acl_logging_rate_limit} ]]; then
+      ovn_acl_logging_rate_limit_flag="--acl-logging-rate-limit ${ovn_acl_logging_rate_limit}"
+  fi
+
   multicast_enabled_flag=
   if [[ ${ovn_multicast_enable} == "true" ]]; then
       multicast_enabled_flag="--enable-multicast"
@@ -893,6 +900,7 @@ ovn-master() {
     --logfile /var/log/ovn-kubernetes/ovnkube-master.log \
     ${ovn_master_ssl_opts} \
     ${multicast_enabled_flag} \
+    ${ovn_acl_logging_rate_limit_flag} \
     ${egressip_enabled_flag} \
     --metrics-bind-address ${ovnkube_master_metrics_bind_address} &
   echo "=============== ovn-master ========== running"

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -256,6 +256,8 @@ spec:
           value: "{{ ovn_gateway_mode }}"
         - name: OVN_MULTICAST_ENABLE
           value: "{{ ovn_multicast_enable }}"
+        - name: OVN_ACL_LOGGING_RATE_LIMIT
+          value: "{{ ovn_acl_logging_rate_limit }}"
       # end of container
 
       volumes:

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -67,12 +67,13 @@ var (
 
 	// Logging holds logging-related parsed config file parameters and command-line overrides
 	Logging = LoggingConfig{
-		File:              "", // do not log to a file by default
-		CNIFile:           "",
-		Level:             4,
-		LogFileMaxSize:    100, // Size in Megabytes
-		LogFileMaxBackups: 5,
-		LogFileMaxAge:     5, //days
+		File:                "", // do not log to a file by default
+		CNIFile:             "",
+		Level:               4,
+		LogFileMaxSize:      100, // Size in Megabytes
+		LogFileMaxBackups:   5,
+		LogFileMaxAge:       5, //days
+		ACLLoggingRateLimit: 20,
 	}
 
 	// CNI holds CNI-related parsed config file parameters and command-line overrides
@@ -183,6 +184,8 @@ type LoggingConfig struct {
 	LogFileMaxBackups int `gcfg:"logfile-maxbackups"`
 	// LogFileMaxAge represents the maximum number of days to retain old log files
 	LogFileMaxAge int `gcfg:"logfile-maxage"`
+	// Logging rate-limiting meter
+	ACLLoggingRateLimit int `gcfg:"acl-logging-rate-limit"`
 }
 
 // CNIConfig holds CNI-related parsed config file parameters and command-line overrides
@@ -584,6 +587,12 @@ var CommonFlags = []cli.Flag{
 		Usage:       "Maximum number of days to retain old log files",
 		Destination: &cliConfig.Logging.LogFileMaxAge,
 		Value:       Logging.LogFileMaxAge,
+	},
+	&cli.IntFlag{
+		Name:        "acl-logging-rate-limit",
+		Usage:       "The largest number of messages per second that gets logged before drop (default 20)",
+		Destination: &cliConfig.Logging.ACLLoggingRateLimit,
+		Value:       20,
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -474,6 +474,7 @@ var _ = Describe("Config Operations", func() {
 			Expect(Default.ConntrackZone).To(Equal(64321))
 			Expect(Logging.File).To(Equal("/var/log/ovnkube.log"))
 			Expect(Logging.Level).To(Equal(5))
+			Expect(Logging.ACLLoggingRateLimit).To(Equal(20))
 			Expect(CNI.ConfDir).To(Equal("/etc/cni/net.d22"))
 			Expect(CNI.Plugin).To(Equal("ovn-k8s-cni-overlay22"))
 			Expect(Kubernetes.Kubeconfig).To(Equal(kubeconfigFile))
@@ -540,6 +541,7 @@ var _ = Describe("Config Operations", func() {
 			Expect(Default.ConntrackZone).To(Equal(5555))
 			Expect(Logging.File).To(Equal("/some/logfile"))
 			Expect(Logging.Level).To(Equal(3))
+			Expect(Logging.ACLLoggingRateLimit).To(Equal(30))
 			Expect(CNI.ConfDir).To(Equal("/some/cni/dir"))
 			Expect(CNI.Plugin).To(Equal("a-plugin"))
 			Expect(Kubernetes.Kubeconfig).To(Equal(kubeconfigFile))
@@ -584,6 +586,7 @@ var _ = Describe("Config Operations", func() {
 			"-conntrack-zone=5555",
 			"-loglevel=3",
 			"-logfile=/some/logfile",
+			"-acl-logging-rate-limit=30",
 			"-cni-conf-dir=/some/cni/dir",
 			"-cni-plugin=a-plugin",
 			"-cluster-subnets=10.130.0.0/15/24",

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -239,8 +239,9 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 }
 
 func (ovn *Controller) clearVIPsAddRejectACL(svc *kapi.Service, lb, ip string, port int32, proto kapi.Protocol) {
+	aclLogging := ovn.GetNetworkPolicyACLLogging(svc.Namespace).Deny
 	if svcQualifiesForReject(svc) {
-		aclUUID, err := ovn.createLoadBalancerRejectACL(lb, ip, port, proto)
+		aclUUID, err := ovn.createLoadBalancerRejectACL(lb, ip, port, proto, aclLogging)
 		if err != nil {
 			klog.Errorf("Failed to create reject ACL for VIP: %s:%d, load balancer: %s, error: %v",
 				ip, port, lb, err)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -144,9 +144,9 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=clusterRtrPortGroup",
 		"ovn-nbctl --timeout=15 create port_group name=clusterRtrPortGroup external-ids:name=clusterRtrPortGroup",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Egress",
-		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=from-lport match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Egress -- add port_group  acls @acl",
+		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=from-lport log=false match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Egress -- add port_group  acls @acl",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Ingress",
-		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=to-lport match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Ingress -- add port_group  acls @acl",
+		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=to-lport log=false match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Ingress -- add port_group  acls @acl",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net"
 	"reflect"
@@ -65,6 +66,12 @@ type loadBalancerConf struct {
 	rejectACL string
 }
 
+// ACL logging severity levels
+type ACLLoggingLevels struct {
+	Allow string `json:"allow,omitempty"`
+	Deny  string `json:"deny,omitempty"`
+}
+
 // namespaceInfo contains information related to a Namespace. Use oc.getNamespaceLocked()
 // or oc.waitForNamespaceLocked() to get a locked namespaceInfo for a Namespace, and call
 // nsInfo.Unlock() on it when you are done with it. (No code outside of the code that
@@ -76,11 +83,11 @@ type namespaceInfo struct {
 	// of all pods in the namespace.
 	addressSet addressset.AddressSet
 
-	// map from NetworkPolicy name to namespacePolicy. You must hold the
+	// map from NetworkPolicy name to networkPolicy. You must hold the
 	// namespaceInfo's mutex to add/delete/lookup policies, but must hold the
-	// namespacePolicy's mutex (and not necessarily the namespaceInfo's) to work with
+	// networkPolicy's mutex (and not necessarily the namespaceInfo's) to work with
 	// the policy itself.
-	networkPolicies map[string]*namespacePolicy
+	networkPolicies map[string]*networkPolicy
 
 	// defines the namespaces egressFirewallPolicy
 	egressFirewallPolicy *egressFirewall
@@ -101,6 +108,13 @@ type namespaceInfo struct {
 	portGroupUUID string
 
 	multicastEnabled bool
+
+	// If not empty, then it has to be set to a logging a severity level, e.g. "notice", "alert", etc
+	aclLogging ACLLoggingLevels
+
+	// Per-namespace port group default deny UUIDs
+	portGroupIngressDenyUUID string // Port group for ingress deny rule
+	portGroupEgressDenyUUID  string // Port group for egress deny rule
 }
 
 // Controller structure is the object which holds the controls for starting
@@ -151,12 +165,6 @@ type Controller struct {
 	// logical router
 	clusterRtrPortGroupUUID string
 
-	// Port group for ingress deny rule
-	portGroupIngressDeny string
-
-	// Port group for egress deny rule
-	portGroupEgressDeny string
-
 	// For each logical port, the number of network policies that want
 	// to add a ingress deny rule.
 	lspIngressDenyCache map[string]int
@@ -175,6 +183,9 @@ type Controller struct {
 	eIPC egressIPController
 
 	egressFirewallDNS *EgressDNS
+
+	// Is ACL logging enabled while configuring meters?
+	aclLoggingEnabled bool
 
 	// Map of load balancers to service namespace
 	serviceVIPToName map[ServiceVIPKey]types.NamespacedName
@@ -275,6 +286,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory,
 		},
 		loadbalancerClusterCache: make(map[kapi.Protocol]string),
 		multicastSupport:         config.EnableMulticast,
+		aclLoggingEnabled:        true,
 		serviceVIPToName:         make(map[ServiceVIPKey]types.NamespacedName),
 		serviceVIPToNameLock:     sync.Mutex{},
 		serviceLBMap:             make(map[string]map[string]*loadBalancerConf),
@@ -1053,6 +1065,45 @@ func (oc *Controller) GetServiceVIPToName(vip string, protocol kapi.Protocol) (t
 	defer oc.serviceVIPToNameLock.Unlock()
 	namespace, ok := oc.serviceVIPToName[ServiceVIPKey{vip, protocol}]
 	return namespace, ok
+}
+
+// GetNetworkPolicyACLLogging retrieves ACL deny policy logging setting for the Namespace
+func (oc *Controller) GetNetworkPolicyACLLogging(ns string) *ACLLoggingLevels {
+	nsInfo := oc.getNamespaceLocked(ns)
+	if nsInfo == nil {
+		return &ACLLoggingLevels{
+			Allow: "",
+			Deny:  "",
+		}
+	}
+	defer nsInfo.Unlock()
+	return &nsInfo.aclLogging
+}
+
+// Verify if controller can support ACL logging and validate annotation
+func (oc *Controller) aclLoggingCanEnable(annotation string, nsInfo *namespaceInfo) bool {
+	if !oc.aclLoggingEnabled || annotation == "" {
+		nsInfo.aclLogging.Deny = ""
+		nsInfo.aclLogging.Allow = ""
+		return false
+	}
+	var aclLevels ACLLoggingLevels
+	err := json.Unmarshal([]byte(annotation), &aclLevels)
+	if err != nil {
+		return false
+	}
+	okCnt := 0
+	for _, s := range []string{"alert", "warning", "notice", "info", "debug"} {
+		if aclLevels.Deny != "" && s == aclLevels.Deny {
+			nsInfo.aclLogging.Deny = aclLevels.Deny
+			okCnt++
+		}
+		if aclLevels.Allow != "" && s == aclLevels.Allow {
+			nsInfo.aclLogging.Allow = aclLevels.Allow
+			okCnt++
+		}
+	}
+	return okCnt > 0
 }
 
 // setServiceLBToACL associates an empty load balancer with its associated ACL reject rule

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -137,7 +137,7 @@ func (s service) addCmds(fexec *ovntest.FakeExec, service v1.Service) {
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=%s-%s\\:%v",
 				k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
 			fmt.Sprintf("ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match=\"ip4.dst==%s && tcp "+
-				"&& tcp.dst==%v\" action=reject name=%s-%s\\:%v -- add port_group %s acls @reject-acl", service.Spec.ClusterIP, port.Port,
+				"&& tcp.dst==%v\" action=reject log=false severity=info meter=acl-logging name=%s-%s\\:%v -- add port_group %s acls @reject-acl", service.Spec.ClusterIP, port.Port,
 				k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port, ovnClusterPortGroupUUID),
 		})
 	}

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -55,4 +55,6 @@ const (
 	// OpenFlow and Networking constants
 	RouteAdvertisementICMPType    = 134
 	NeighborAdvertisementICMPType = 136
+
+	OvnACLLoggingMeter = "acl-logging"
 )


### PR DESCRIPTION
this feature enables ACL logging for all drop/reject/allow actions
if specified in metadata annotations for Namespace, example:

```
kind: Namespace
apiVersion: v1
metadata:
  name: tenantA
  annotations:
    k8s.ovn.org/acl-logging: '{ "deny": "alert", "allow": "notice" }'

kind: Namespace
apiVersion: v1
metadata:
  name: tenantB
  annotations:
    k8s.ovn.org/acl-logging: '{ "deny": "notice" }'
```

the logging events then can be viewed in OVN controller's log and
will be marked with selected ACL severity level and name set to
a namespace that generates the event.

to make per namespace deny logging configurable as well as to
somewhat make things a bit cleaner, we moved default deny port group
to be part of namespacePolicy. If anything, we expect things to
potentially scale even better, because of reduced scope of updates.

additionally configuration flag --acl-logging-rate-limit can
be passed to daemonset.sh.

Signed-off-by: Dmitry Yusupov <dyusupov@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->