### PR TITLE
Make pod delete also use go-ovn bindings

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -174,9 +174,6 @@ func (p pod) delCmds(fexec *ovntest.FakeExec) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID,
 	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists lsp-del " + p.portName,
-	})
 }
 
 func (p pod) addPodDenyMcast(fexec *ovntest.FakeExec) {


### PR DESCRIPTION
There's a race during pod and delete where a delete will go to ovn-nbctl
and update the NB DB, while an add will read from go-ovn cache. When a
pod is created/deleted fast enough, add_logical_port will not add the
new port (thinking it exists because it is in cache), when really it has
already been deleted. Use bindings to ensure we delete from cache first.

Issue discussed here:
https://github.com/eBay/go-ovn/issues/104

Signed-off-by: Tim Rozet <trozet@redhat.com>


**- How to verify it**
./hack/ginkgo-e2e.sh --provider=skeleton --num-nodes=6 "--ginkgo.focus=Should\srecreate\sevicted\sstatefulset" --report-dir=/home/trozet/e2e --disable-log-dump=true