### PR TITLE
Add EgressIP informer only if egress IP is enabled

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -514,10 +514,6 @@ func NewWatchFactory(c kubernetes.Interface, eip egressipclientset.Interface, ec
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[egressIPType], err = newInformer(egressIPType, wf.eipFactory.K8s().V1().EgressIPs().Informer())
-	if err != nil {
-		return nil, err
-	}
 
 	wf.crdFactory.Start(wf.stopChan)
 	for oType, synced := range wf.crdFactory.WaitForCacheSync(wf.stopChan) {
@@ -532,6 +528,10 @@ func NewWatchFactory(c kubernetes.Interface, eip egressipclientset.Interface, ec
 		}
 	}
 	if config.OVNKubernetesFeature.EnableEgressIP {
+		wf.informers[egressIPType], err = newInformer(egressIPType, wf.eipFactory.K8s().V1().EgressIPs().Informer())
+		if err != nil {
+			return nil, err
+		}
 		wf.eipFactory.Start(wf.stopChan)
 		for oType, synced := range wf.eipFactory.WaitForCacheSync(wf.stopChan) {
 			if !synced {

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -467,24 +467,10 @@ var _ = Describe("Watch Factory Operations", func() {
 		testExisting := func(objType reflect.Type) {
 			wf, err = NewWatchFactory(fakeClient, egressIPFakeClient, egressFirewallFakeClient, crdFakeClient)
 			Expect(err).NotTo(HaveOccurred())
-			var addCalls int32
-			h := wf.addHandler(objType, "", nil,
-				cache.ResourceEventHandlerFuncs{
-					AddFunc: func(obj interface{}) {
-						atomic.AddInt32(&addCalls, 1)
-					},
-					UpdateFunc: func(old, new interface{}) {},
-					DeleteFunc: func(obj interface{}) {},
-				}, func(existing []interface{}) {
-					atomic.AddInt32(&addCalls, int32(len(existing)))
-				})
-			Expect(int(addCalls)).To(Equal(0))
-			wf.removeHandler(objType, h)
+			Expect(wf.informers).NotTo(HaveKey(objType))
 		}
-		It("does not call ADD for each existing egressIP", func() {
+		It("does not contain Egress IP informer", func() {
 			config.OVNKubernetesFeature.EnableEgressIP = false
-			egressIPs = append(egressIPs, newEgressIP("myEgressIP", "default"))
-			egressIPs = append(egressIPs, newEgressIP("myEgressIP1", "default"))
 			testExisting(egressIPType)
 		})
 	})


### PR DESCRIPTION
When running ovn-kubernetes without `--enable-egress-ip`, ovnkube-master was experiencing errors as we still created the informers (though not starting it). This patch changes that to not instantiate the informer at all should we not be running with `--enable-egress-ip`

/assign @danwinship 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->