### PR TITLE
Fix Orphaned ACL race condition

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -331,6 +331,12 @@ func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
 		return
 	}
 	defer nsInfo.Unlock()
+
+	klog.V(5).Infof("Deleting Namespace's NetworkPolicy entities")
+	for _, np := range nsInfo.networkPolicies {
+		delete(nsInfo.networkPolicies, np.name)
+		oc.destroyNamespacePolicy(np)
+	}
 	oc.deleteGWRoutesForNamespace(nsInfo)
 	oc.multicastDeleteNamespace(ns, nsInfo)
 }


### PR DESCRIPTION
There is a race condition, described here
(https://bugzilla.redhat.com/show_bug.cgi?id=1859682)
that results in ACL's and their associated network
entities being orphaned upon the deletion of
a namespace

Specifically, if a namespace is deleted by OVN-K8's
prior to all the Network Policies being handled,
the ACLS, portgroups, address sets, and handlers
become orphaned in `nbdb` beacuse a namespace lock
can never be acquired in `policy.go`'s
`deleteNetworkPolicy()`

This fix ensures that all network entities involving
a namespace's NetworkPolicies are deleted prior to the
namespace's deletion

TODO: I think this is just a quick fix, ultimately
It would be nice to decouple the NetworkPolicy's
dependency on namespaces within OVN maybe by moving the
[`networkPolicies` map](https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/ovn/ovn.go#L79)
out of the `namespace` object to the
[`controller` object](https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/ovn/ovn.go#L79)? 

signed-off-by: Andrew Stoycos <astoycos@redhat.com>

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
To reproduce this race add a sleep for approximately 3 seconds [here](https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/ovn/policy.go#L749) 

Then bring up an `ovn-k8's` cluster locally using kind and your custom OVN build. 

Next make a new namespace titled `test1` and create 10 `NetworkPolicies` in that namespace 

Finally delete the namespace and look in the `nbdb` for any orphaned ACLs, port-groups, and address sets 

There will be orphaned ACLs attatched to a NS that doesn't exist as shown below 

```
[astoycos@localhost ovn-org]$ ./list-acls.sh 
Current ACLs
ovnkube-master-7888658d8-67nqz:
Defaulting container name to ovn-northd.
Use 'kubectl describe pod/ovnkube-master-7888658d8-67nqz -n ovn-kubernetes' to see all of the containers in this pod.
external_ids        : {Ingress_num="0", ipblock_cidr="false", l4Match=None, namespace=test2, policy=allow-from-blue-4, policy_type=Ingress}
external_ids        : {Ingress_num="0", ipblock_cidr="false", l4Match=None, namespace=test2, policy=allow-from-blue-2, policy_type=Ingress}
external_ids        : {Ingress_num="0", ipblock_cidr="false", l4Match=None, namespace=test2, policy=allow-from-blue-10, policy_type=Ingress}
external_ids        : {Ingress_num="0", ipblock_cidr="false", l4Match=None, namespace=test2, policy=allow-from-blue-1, policy_type=Ingress}
external_ids        : {Ingress_num="0", ipblock_cidr="false", l4Match=None, namespace=test2, policy=allow-from-blue-9, policy_type=Ingress}
external_ids        : {Ingress_num="0", ipblock_cidr="false", l4Match=None, namespace=test2, policy=allow-from-blue-3, policy_type=Ingress}
external_ids        : {Ingress_num="0", ipblock_cidr="false", l4Match=None, namespace=test2, policy=allow-from-blue-5, policy_type=Ingress}
external_ids        : {Ingress_num="0", ipblock_cidr="false", l4Match=None, namespace=test2, policy=allow-from-blue-6, policy_type=Ingress}
[astoycos@localhost ovn-org]$ oc get namespaces
NAME                 STATUS   AGE
default              Active   31m
kube-node-lease      Active   31m
kube-public          Active   31m
kube-system          Active   31m
local-path-storage   Active   31m
ovn-kubernetes       Active   27m
[astoycos@localhost ovn-org]$ 
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This duplicates the deletion of network entities found in `go-contoller/pkg/ovn/policy.go` to be included upon 
namespace deletion in a new `go-contoller/pkg/ovn/namespace.go` function `cleanNPentities` that is shared and called in both `namespace.go` and `policy.go`. Also I modified `localPodDelDafaultDeny` to take a `namespacePolicy` object rather than a `knet.NetworkPolicy` since in the case of this issue, we need to confirm that everything involving NP's can be cleaned up by both `policy.go` and `namespace.go`. 