### PR TITLE
ovn-controller should not delete ovn-remote field

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -835,10 +835,6 @@ ovn-controller() {
   echo "ovn_nbdb ${ovn_nbdb}   ovn_sbdb ${ovn_sbdb}"
   echo "ovn_nbdb_conn ${ovn_nbdb_conn}"
 
-  # cleanup any stale ovn-nb and ovn-remote keys in Open_vSwitch table
-  ovs-vsctl remove Open_vSwitch . external_ids ovn-remote
-  ovs-vsctl remove Open_vSwitch . external_ids ovn-nb
-
   echo "=============== ovn-controller  start_controller"
   rm -f /var/run/ovn-kubernetes/cni/*
   rm -f ${OVN_RUNDIR}/ovn-controller.*.ctl
@@ -906,7 +902,7 @@ ovn-node() {
   if [[ ${ovn_egressip_enable} == "true" ]]; then
       egressip_enabled_flag="--enable-egress-ip"
   fi
-  
+
   OVN_ENCAP_IP=""
   ovn_encap_ip=$(ovs-vsctl --if-exists get Open_vSwitch . external_ids:ovn-encap-ip)
   if [[ $? == 0 ]]; then


### PR DESCRIPTION
It may happen that the ovn-controller container restarts (a bug,
fatty fingers, ... )
If this happens, the container init script deletes the ovn-remote
in the external_ids field, causing that it never reconnects until
the ovnkube-node pod is recreated.
This causes that all the pods in that node can not get an interface,
failing with the error:

"failed to configure pod interface: timed out waiting for pod flows
 for pod"

Signed-off-by: Antonio Ojea <aojea@redhat.com>


Seen in this job 
https://github.com/ovn-org/ovn-kubernetes/runs/1059062544?check_suite_focus=true
caused by
https://bugzilla.redhat.com/show_bug.cgi?id=1871961

It can be easily reproduced in kind, deleting ONLY the ovn-controller container inside the ovnkube-node pod, after that no pod can be scheduled in that node