### PR TITLE
Correct egress IP assignment for egress node IPs

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -290,8 +290,7 @@ func (oc *Controller) assignEgressIPs(eIP *egressipv1.EgressIP) error {
 				Name: eIP.Name,
 			}
 			oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "InvalidEgressIP", "egress IP: %s for object EgressIP: %s is not a valid IP address", egressIP, eIP.Name)
-			klog.Errorf("Unable to parse provided EgressIP: %s, invalid", egressIP)
-			continue
+			return fmt.Errorf("unable to parse provided EgressIP: %s, invalid", egressIP)
 		}
 		if node := oc.isAnyClusterNodeIP(eIPC); node != nil {
 			eIPRef := kapi.ObjectReference{

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -1688,7 +1688,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				err := fakeOvn.controller.assignEgressIPs(&eIP)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("no matching host found"))
+				Expect(err.Error()).To(Equal(fmt.Sprintf("unable to parse provided EgressIP: %s, invalid", egressIPs[0])))
 				Expect(eIP.Status.Items).To(HaveLen(0))
 				return nil
 			}
@@ -2012,7 +2012,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				err := fakeOvn.controller.assignEgressIPs(&eIP)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("no matching host found"))
+				Expect(err.Error()).To(Equal(fmt.Sprintf("unable to parse provided EgressIP: %s, invalid", egressIPs[0])))
 				Expect(eIP.Status.Items).To(HaveLen(0))
 				return nil
 			}

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -54,13 +54,16 @@ var (
 )
 
 func setupNode(nodeName string, ipNets []string, mockAllocationIPs []string) eNode {
+	var v4IP, v6IP net.IP
 	var v4Subnet, v6Subnet *net.IPNet
 	for _, ipNet := range ipNets {
-		_, net, _ := net.ParseCIDR(ipNet)
+		ip, net, _ := net.ParseCIDR(ipNet)
 		if utilnet.IsIPv6CIDR(net) {
 			v6Subnet = net
+			v6IP = ip
 		} else {
 			v4Subnet = net
+			v4IP = ip
 		}
 	}
 
@@ -70,10 +73,13 @@ func setupNode(nodeName string, ipNets []string, mockAllocationIPs []string) eNo
 	}
 
 	node := eNode{
-		v4Subnet:    v4Subnet,
-		v6Subnet:    v6Subnet,
-		allocations: mockAllcations,
-		name:        nodeName,
+		v4IP:               v4IP,
+		v6IP:               v6IP,
+		v4Subnet:           v4Subnet,
+		v6Subnet:           v6Subnet,
+		allocations:        mockAllcations,
+		name:               nodeName,
+		isEgressAssignable: true,
 	}
 	return node
 }
@@ -103,6 +109,17 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 		tmp, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		return tmp.Status.Items
+	}
+
+	isEgressAssignableNode := func(nodeName string) func() bool {
+		return func() bool {
+			fakeOvn.controller.eIPAllocatorMutex.Lock()
+			defer fakeOvn.controller.eIPAllocatorMutex.Unlock()
+			if item, exists := fakeOvn.controller.eIPAllocator[nodeName]; exists {
+				return item.isEgressAssignable
+			}
+			return false
+		}
 	}
 
 	BeforeEach(func() {
@@ -185,8 +202,11 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 
 				fakeOvn.controller.WatchEgressNodes()
-				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(1))
+				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(2))
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
+				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node2.Name))
+				Eventually(isEgressAssignableNode(node1.Name)).Should(BeTrue())
+				Eventually(isEgressAssignableNode(node2.Name)).Should(BeFalse())
 
 				fakeOvn.controller.WatchEgressIP()
 				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
@@ -297,8 +317,11 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					},
 				)
 				fakeOvn.controller.WatchEgressNodes()
-				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(1))
+				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(2))
 				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
+				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node2.Name))
+				Eventually(isEgressAssignableNode(node1.Name)).Should(BeTrue())
+				Eventually(isEgressAssignableNode(node2.Name)).Should(BeFalse())
 
 				fakeOvn.controller.WatchEgressIP()
 				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
@@ -1217,7 +1240,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.controller.WatchEgressNodes()
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(0))
+				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(1))
+				Eventually(isEgressAssignableNode(node.Name)).Should(BeFalse())
 				Eventually(eIP.Status.Items).Should(HaveLen(0))
 
 				node.Labels = map[string]string{
@@ -1231,6 +1255,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
+				Eventually(isEgressAssignableNode(node.Name)).Should(BeTrue())
 				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node.Name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
@@ -1250,6 +1275,73 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				}
 
 				Eventually(getCacheCount).Should(Equal(0))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should result in error and event if specified egress IP is a cluster node IP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP := "192.168.126.51"
+				node1IPv4 := "192.168.128.202/24"
+				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
+				node2IPv4 := "192.168.126.51/24"
+
+				node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name: node1Name,
+					Labels: map[string]string{
+						"k8s.ovn.org/egress-assignable": "",
+					},
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+					},
+				}}
+				node2 := v1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name: node2Name,
+					Labels: map[string]string{
+						"k8s.ovn.org/egress-assignable": "",
+					},
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+					},
+				}}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				fakeOvn.start(ctx,
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1, node2},
+					})
+
+				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
+					[]string{
+						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 101 ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14 allow"),
+					},
+				)
+				fakeOvn.controller.WatchEgressNodes()
+				fakeOvn.controller.WatchEgressIP()
+
+				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(2))
+				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
+				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node2.Name))
+
+				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(0))
+				recordedEvent := <-fakeOvn.fakeRecorder.Events
+				Expect(recordedEvent).To(ContainSubstring("Egress IP: %v for object EgressIP: %s is the IP address of node: %s, this is unsupported", egressIP, eIP.Name, node2.Name))
 				return nil
 			}
 
@@ -1307,7 +1399,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.controller.WatchEgressNodes()
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(1))
+				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(2))
 				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
 
 				getCacheCount := func() int {
@@ -1386,25 +1478,29 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				fakeOvn.controller.WatchEgressNodes()
 				fakeOvn.controller.WatchEgressIP()
 
-				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(0))
+				_, ip1V4Sub, err := net.ParseCIDR(node1IPv4)
+				_, ip1V6Sub, err := net.ParseCIDR(node1IPv6)
+				_, ip2V4Sub, err := net.ParseCIDR(node2IPv4)
+
+				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(2))
+				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
+				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node2.Name))
+				Eventually(isEgressAssignableNode(node1.Name)).Should(BeFalse())
+				Eventually(isEgressAssignableNode(node2.Name)).Should(BeFalse())
+				Expect(fakeOvn.controller.eIPAllocator[node1.Name].v4Subnet).To(Equal(ip1V4Sub))
+				Expect(fakeOvn.controller.eIPAllocator[node1.Name].v6Subnet).To(Equal(ip1V6Sub))
+				Expect(fakeOvn.controller.eIPAllocator[node2.Name].v4Subnet).To(Equal(ip2V4Sub))
 				Eventually(eIP.Status.Items).Should(HaveLen(0))
 
 				node1.Labels = map[string]string{
 					"k8s.ovn.org/egress-assignable": "",
 				}
 
-				_, ip1V4Sub, err := net.ParseCIDR(node1IPv4)
-				_, ip1V6Sub, err := net.ParseCIDR(node1IPv6)
-				_, ip2V4Sub, err := net.ParseCIDR(node2IPv4)
-
 				_, err = fakeOvn.fakeClient.CoreV1().Nodes().Update(context.TODO(), &node1, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(0))
-				Eventually(getEgressIPAllocatorSizeSafely).Should(Equal(1))
-				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
-				Expect(fakeOvn.controller.eIPAllocator[node1.Name].v4Subnet).To(Equal(ip1V4Sub))
-				Expect(fakeOvn.controller.eIPAllocator[node1.Name].v6Subnet).To(Equal(ip1V6Sub))
+				Eventually(isEgressAssignableNode(node1.Name)).Should(BeTrue())
 
 				calculateCacheCount := func() int {
 					cacheCount := 0
@@ -1428,12 +1524,6 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				statuses := getEgressIPStatus(egressIPName)
 				Expect(statuses[0].Node).To(Equal(node2.Name))
 				Expect(statuses[0].EgressIP).To(Equal(egressIP))
-				Expect(fakeOvn.controller.eIPAllocator).To(HaveLen(2))
-				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node1.Name))
-				Expect(fakeOvn.controller.eIPAllocator).To(HaveKey(node2.Name))
-				Expect(fakeOvn.controller.eIPAllocator[node1.Name].v4Subnet).To(Equal(ip1V4Sub))
-				Expect(fakeOvn.controller.eIPAllocator[node1.Name].v6Subnet).To(Equal(ip1V6Sub))
-				Expect(fakeOvn.controller.eIPAllocator[node2.Name].v4Subnet).To(Equal(ip2V4Sub))
 				Eventually(calculateCacheCount).Should(Equal(0))
 				return nil
 			}
@@ -1742,7 +1832,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should be able to allocate node IP", func() {
+		It("should not be able to allocate node IP", func() {
 			app.Action = func(ctx *cli.Context) error {
 
 				fakeOvn.start(ctx)
@@ -1762,8 +1852,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 				err := fakeOvn.controller.assignEgressIPs(&eIP)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(eIP.Status.Items).To(HaveLen(1))
+				Expect(err).To(HaveOccurred())
+				Expect(eIP.Status.Items).To(HaveLen(0))
 
 				return nil
 			}
@@ -2477,46 +2567,6 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should create EgressIPs when request is node IP", func() {
-
-			app.Action = func(ctx *cli.Context) error {
-
-				egressIP := "192.168.126.12"
-
-				node1 := setupNode(node1Name, []string{egressIP + "/24"}, []string{"192.168.126.102", "192.168.126.111"})
-				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, []string{"192.168.126.68"})
-
-				eIP1 := egressipv1.EgressIP{
-					ObjectMeta: newEgressIPMeta(egressIPName),
-					Spec: egressipv1.EgressIPSpec{
-						EgressIPs: []string{egressIP},
-					},
-				}
-				fakeOvn.start(ctx)
-
-				fakeOvn.controller.eIPAllocator[node1.name] = &node1
-				fakeOvn.controller.eIPAllocator[node2.name] = &node2
-				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
-					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 lr-policy-add ovn_cluster_router 101 ip4.src == 10.128.0.0/14 && ip4.dst == 10.128.0.0/14 allow"),
-					},
-				)
-				fakeOvn.controller.WatchEgressIP()
-
-				_, err := fakeOvn.fakeEgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP1, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Eventually(getEgressIPStatusLen(egressIPName)).Should(Equal(1))
-				statuses := getEgressIPStatus(egressIPName)
-				Expect(statuses[0].Node).To(Equal(node2.name))
-				Expect(statuses[0].EgressIP).To(Equal(egressIP))
-
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			Expect(err).NotTo(HaveOccurred())
-		})
 	})
 
 	Context("UpdateEgressIP for IPv4", func() {
@@ -2527,7 +2577,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				egressIP := "192.168.126.101"
 				updateEgressIP := "192.168.126.10"
 
-				node1 := setupNode(node1Name, []string{egressIP + "/24"}, []string{"192.168.126.102", "192.168.126.111"})
+				node1 := setupNode(node1Name, []string{"192.168.126.41/24"}, []string{"192.168.126.102", "192.168.126.111"})
 				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, []string{"192.168.126.68"})
 
 				eIP1 := egressipv1.EgressIP{

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -104,11 +104,14 @@ type namespaceInfo struct {
 
 // eNode is a cache helper used for egress IP assignment
 type eNode struct {
-	v4Subnet    *net.IPNet
-	v6Subnet    *net.IPNet
-	allocations map[string]bool
-	tainted     bool
-	name        string
+	v4IP               net.IP
+	v6IP               net.IP
+	v4Subnet           *net.IPNet
+	v6Subnet           *net.IPNet
+	allocations        map[string]bool
+	isEgressAssignable bool
+	tainted            bool
+	name               string
 }
 
 // Controller structure is the object which holds the controls for starting


### PR DESCRIPTION
When writing e2e tests for Egress IP (upcoming PR soon), I realized a mistake made on my part in the assignment procedure, namely: when specifying an egress IP which is a cluster node X's IP address, we might assign it to another node Y in the assignment procedure. This patch thus fixes this by implementing a check and making sure that if the egress IP specified is a cluster node's, that it is also assigned to exactly that node. If that node does not have the egress label, then we do not perform an assignment and notify the user by triggering an event.  

Some of the tests in `egressip_test.go` were explicitly wrong and testing and verifying the complete opposite to what they should have....I obviously should have paid more attention to that and not let it slip by. 

/assign @danwinship 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->