### PR TITLE
run conformance tests in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - shard: shard-network
+          - shard: shard-conformance
             hybrid-overlay: false
           - shard: control-plane
             hybrid-overlay: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,7 +191,7 @@ jobs:
     needs: [build, k8s]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
-      KIND_HA: "${{ matrix.ha.enabled }}"
+      OVN_HA: "${{ matrix.ha.enabled }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily.ipv4 }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily.ipv6 }}"
       OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target.hybrid-overlay }}"

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -74,7 +74,7 @@ parse_args()
                                                 ;;
             -ii | --install-ingress )           KIND_INSTALL_INGRESS=true
                                                 ;;
-            -ha | --ha-enabled )                KIND_HA=true
+            -ha | --ha-enabled )                OVN_HA=true
                                                 ;;
             -me | --multicast-enabled)          OVN_MULTICAST_ENABLE=true
                                                 ;;
@@ -127,7 +127,7 @@ print_params()
      echo "Using these parameters to install KIND"
      echo ""
      echo "KIND_INSTALL_INGRESS = $KIND_INSTALL_INGRESS"
-     echo "KIND_HA = $KIND_HA"
+     echo "OVN_HA = $OVN_HA"
      echo "KIND_CONFIG_FILE = $KIND_CONFIG"
      echo "KIND_REMOVE_TAINT = $KIND_REMOVE_TAINT"
      echo "KIND_IPV4_SUPPORT = $KIND_IPV4_SUPPORT"
@@ -154,7 +154,7 @@ KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
 K8S_VERSION=${K8S_VERSION:-v1.19.0}
 OVN_GATEWAY_MODE=${OVN_GATEWAY_MODE:-local}
 KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS:-false}
-KIND_HA=${KIND_HA:-false}
+OVN_HA=${OVN_HA:-false}
 KIND_CONFIG=${KIND_CONFIG:-./kind.yaml.j2}
 KIND_REMOVE_TAINT=${KIND_REMOVE_TAINT:-true}
 KIND_IPV4_SUPPORT=${KIND_IPV4_SUPPORT:-true}
@@ -176,7 +176,7 @@ NET_CIDR_IPV6=${NET_CIDR_IPV6:-fd00:10:244::/48}
 SVC_CIDR_IPV6=${SVC_CIDR_IPV6:-fd00:10:96::/112}
 
 KIND_NUM_MASTER=1
-if [ "$KIND_HA" == true ]; then
+if [ "$OVN_HA" == true ]; then
   KIND_NUM_MASTER=3
   KIND_NUM_WORKER=${KIND_NUM_WORKER:-0}
 else
@@ -268,7 +268,7 @@ KIND_CONFIG_LCL=./kind.yaml
 
 ovn_apiServerAddress=${API_IP} \
   ovn_ip_family=${IP_FAMILY} \
-  ovn_ha=${KIND_HA} \
+  ovn_ha=${OVN_HA} \
   net_cidr=${NET_CIDR} \
   svc_cidr=${SVC_CIDR} \
   ovn_num_master=${KIND_NUM_MASTER} \
@@ -356,14 +356,18 @@ pushd ../dist/yaml
 run_kubectl apply -f k8s.ovn.org_egressfirewalls.yaml
 run_kubectl apply -f k8s.ovn.org_egressips.yaml
 run_kubectl apply -f ovn-setup.yaml
-CONTROL_NODES=$(docker ps -f name=ovn-control | grep -v NAMES | awk '{ print $NF }')
-for n in $CONTROL_NODES; do
-  run_kubectl label node $n k8s.ovn.org/ovnkube-db=true
+MASTER_NODES=$(kind get nodes --name ${KIND_CLUSTER_NAME} | head -n ${KIND_NUM_MASTER})
+# We want OVN HA not Kubernetes HA
+# leverage the kubeadm well-known label node-role.kubernetes.io/master=
+# to choose the nodes where ovn master components will be placed
+for n in $MASTER_NODES; do
+  kubectl label node $n k8s.ovn.org/ovnkube-db=true node-role.kubernetes.io/master="" --overwrite
   if [ "$KIND_REMOVE_TAINT" == true ]; then
-    run_kubectl taint node $n node-role.kubernetes.io/master:NoSchedule-
+    # do not error if it fails to remove the taint
+    kubectl taint node $n node-role.kubernetes.io/master:NoSchedule- || true
   fi
 done
-if [ "$KIND_HA" == true ]; then
+if [ "$OVN_HA" == true ]; then
   run_kubectl apply -f ovnkube-db-raft.yaml
 else
   run_kubectl apply -f ovnkube-db.yaml

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -54,7 +54,7 @@ nodes:
          authorization-mode: "AlwaysAllow"
 {%- if ovn_ha is equalto "true" %}
 {%- for _ in range(1, ovn_num_master | int) %}
- - role: control-plane
+ - role: worker
 {%- endfor %}
 {%- endif %}
 {%- for _ in range(ovn_num_worker | int) %}

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -100,7 +100,7 @@ SKIPPED_TESTS="$(groomTestList "${SKIPPED_TESTS}")"
 # if we set PARALLEL=true, skip serial test
 if [ "${PARALLEL:-false}" = "true" ]; then
   export GINKGO_PARALLEL=y
-  export GINKGO_PARALLEL_NODES=4
+  export GINKGO_PARALLEL_NODES=20
   SKIPPED_TESTS="${SKIPPED_TESTS}|\\[Serial\\]"
 fi
 

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -109,7 +109,7 @@ case "$SHARD" in
 		FOCUS="\\[sig-network\\]"
 		;;
 	shard-conformance)
-		FOCUS="\\[Conformance\\]"
+		FOCUS="\\[Conformance\\]|\\[sig-network\\]"
 		;;
 	shard-test)
 		FOCUS=$(echo ${@:2} | sed 's/ /\\s/g')


### PR DESCRIPTION
the sig-network tests in the e2e framework only are not fully exercising
the cluster networking, also they are not stressing the cluster enough to
cover more all the races.
Running the whole conformance + sig-network test, and increasing the
parallelism we can emulate more real workloads.

Also, when running in HA mode, only run OVN in HA to avoid the excessive
resources requirements of a 3 nodes etcd cluster, that is overwhelming for the
current CI resources.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
