### PR TITLE
Add a host route for mock external gateways in e2e

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1139,6 +1139,11 @@ var _ = Describe("e2e non-vxlan external gateway and update validation", func() 
 		if validIP == nil {
 			framework.Failf("Warning: Failed to get an IP for the source pod %s, test will fail", srcPingPodName)
 		}
+		// add a host route on the first mock gateway for return traffic to the pod
+		_, err = runCommand("docker", "exec", gwContainerNameAlt1, "ip", "route", "add", pingSrc, "via", nodeIP)
+		if err != nil {
+			framework.Failf("failed to add the pod host route on the test container: %v", err)
+		}
 		time.Sleep(time.Second * 15)
 		// Verify the gateway and remote address is reachable from the initial pod
 		By(fmt.Sprintf("Verifying connectivity without vxlan to the updated annotation and initial external gateway %s and remote address %s", exGWIpAlt1, exGWRemoteIpAlt1))
@@ -1175,6 +1180,11 @@ var _ = Describe("e2e non-vxlan external gateway and update validation", func() 
 		_, err = runCommand("docker", "exec", gwContainerNameAlt2, "ip", "address", "add", exGWRemoteCidrAlt2, "dev", "lo")
 		if err != nil {
 			framework.Failf("failed to add the loopback ip to dev lo on the test container: %v", err)
+		}
+		// add a host route on the second mock gateway for return traffic to the pod
+		_, err = runCommand("docker", "exec", gwContainerNameAlt2, "ip", "route", "add", pingSrc, "via", nodeIP)
+		if err != nil {
+			framework.Failf("failed to add the pod route on the test container: %v", err)
 		}
 		// Wait for the exGW pod networking to be almost, updated
 		wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {


### PR DESCRIPTION
- this commit adds a host route for the case where the
  test infra has snat disabled for return traffic from
  the mock container back to the pod sourcing the traffic

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>

**- What this PR does and why is it needed**

- commit adds a host route for mock external gateways in e2e

**- Special notes for reviewers**

- This is to fix a failing e2e test in PR #1680 by @trozet 

**- How to verify it**

PR can be verified with the following:
```
# Install kind v7
curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(uname)-amd64"
chmod +x ./kind
mv ./kind /some-dir-in-your-PATH/kind

# Install kind v8
curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.8.1/kind-$(uname)-amd64
chmod +x ./kind
mv ./kind /some-dir-in-your-PATH/kind

# Start ovn-kube kind with hybrid mode enabled and snat disabled
pushd $GOPATH/src/github.com/ovn-org/ovn-kubernetes/contrib
./kind.sh -gm hybrid -ds

# From the Kubernetes repo run 
pushd $GOPATH/src/k8s.io/kubernetes
kubetest --provider=local --deployment=kind --kind-cluster-name=ovn --test
```
