### PR TITLE
Fixes losing link local addresses for ipv6

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -50,7 +50,7 @@ func (n *OvnNode) initLocalnetGateway(hostSubnets []*net.IPNet, nodeAnnotator ku
 			", stderr:%s (%v)", localnetBridgeName, stderr, err)
 	}
 
-	ifaceID, macAddress, err := bridgedGatewayNodeSetup(n.name, localnetBridgeName, localnetBridgeName,
+	ifaceID, _, err := bridgedGatewayNodeSetup(n.name, localnetBridgeName, localnetBridgeName,
 		util.PhysicalNetworkName, true)
 	if err != nil {
 		return fmt.Errorf("failed to set up shared interface gateway: %v", err)
@@ -101,18 +101,6 @@ func (n *OvnNode) initLocalnetGateway(hostSubnets []*net.IPNet, nodeAnnotator ku
 
 		if err = util.LinkAddrAdd(link, gatewayNextHopIfAddr); err != nil {
 			return err
-		}
-		if utilnet.IsIPv6CIDR(hostSubnet) {
-			// TODO - IPv6 hack ... for some reason neighbor discovery isn't working here, so hard code a
-			// MAC binding for the gateway IP address for now - need to debug this further
-			if exists, _ := util.LinkNeighExists(link, gatewayIP, macAddress); !exists {
-				err = util.LinkNeighAdd(link, gatewayIP, macAddress)
-				if err == nil {
-					klog.Infof("Added MAC binding for %s on %s", gatewayIP, localnetGatewayNextHopPort)
-				} else {
-					klog.Errorf("Error in adding MAC binding for %s on %s: %v", gatewayIP, localnetGatewayNextHopPort, err)
-				}
-			}
 		}
 	}
 

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -54,7 +54,7 @@ func setupLocalNodeAccessBridge(nodeName string, subnets []*net.IPNet) error {
 		return err
 	}
 
-	// Flush all IP addresses on the nexthop port and add the new IP address(es)
+	// Flush all (non-LL) IP addresses on the nexthop port and add the new IP address(es)
 	if err = util.LinkAddrFlush(link); err != nil {
 		return err
 	}

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -127,7 +127,7 @@ func newManagementPortConfig(interfaceName string, hostSubnets []*net.IPNet) (*m
 
 func tearDownManagementPortConfig(mpcfg *managementPortConfig) error {
 	// for the initial setup we need to start from the clean slate, so flush
-	// all addresses on this link, routes through this link, and
+	// all (non-LL) addresses on this link, routes through this link, and
 	// finally any IPtable rules for this link.
 	if err := util.LinkAddrFlush(mpcfg.link); err != nil {
 		return err

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -144,13 +144,16 @@ func LinkSetUp(interfaceName string) (netlink.Link, error) {
 	return link, nil
 }
 
-// LinkAddrFlush flushes all the addresses on the given link
+// LinkAddrFlush flushes all the addresses on the given link, except IPv6 link-local addresses
 func LinkAddrFlush(link netlink.Link) error {
 	addrs, err := netLinkOps.AddrList(link, netlink.FAMILY_ALL)
 	if err != nil {
 		return fmt.Errorf("failed to list addresses for the link %s: %v", link.Attrs().Name, err)
 	}
 	for _, addr := range addrs {
+		if utilnet.IsIPv6(addr.IP) && addr.IP.IsLinkLocalUnicast() {
+			continue
+		}
 		err = netLinkOps.AddrDel(link, &addr)
 		if err != nil {
 			return fmt.Errorf("failed to delete address %s on link %s: %v",

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -170,6 +170,24 @@ func TestLinkAddrFlush(t *testing.T) {
 				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
 			},
 		},
+		{
+			desc:  "IPv6 link-local address is not flushed",
+			input: mockLink,
+			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+				{
+					"AddrList",
+					[]string{"*mocks.Link", "int"},
+					[]interface{}{
+						[]netlink.Addr{
+							{
+								IPNet: ovntest.MustParseIPNet("fe80::1234/64"),
+							},
+						},
+						nil,
+					},
+				},
+			},
+		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {


### PR DESCRIPTION
extracted from #1680 and rewritten a bit; rather than doing a separate LinkSetDown+LinkSetUp, just avoid removing the link-local address in the first place...
