### PR TITLE
add ovs-node.yaml to .gitignore

### DIFF
--- a/dist/yaml/.gitignore
+++ b/dist/yaml/.gitignore
@@ -6,3 +6,4 @@ ovnkube-db.yaml
 ovnkube-node.yaml
 ovnkube-monitor.yaml
 ovnkube-db-raft.yaml
+ovs-node.yaml


### PR DESCRIPTION
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
The `ovs-daemons` containers were separated into dedicates DaemonSet - `ovs-node`, with generated yaml file.
This PR adds `ovs-node.yaml` into the `dist/yaml/.gitignore` file.   

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->