### PR TITLE
Adds mount /var/run/openvswitch/ -> /var/run/openvswitch/ to ovnkube-db.yaml.j2

### DIFF
--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -94,6 +94,8 @@ spec:
           readOnly: true
         - mountPath: /var/run/ovn/
           name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
 
         resources:
           requests:
@@ -158,6 +160,8 @@ spec:
           name: host-ovn-cert
           readOnly: true
         - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
           name: host-var-run-ovs
 
         resources:


### PR DESCRIPTION
When ovnkube-db is deployed without raft support it has mounts of host /var/run/openvswitch/
to /var/run/ovn, and as result the sockets are created in the container local directories
/var/run/openvswitch/, and are not be accessible outside of the containers.
This commit adds mount /var/run/openvswitch/ to /var/run/openvswitch/.

P.S. `ovnkube-db-raft.yaml.j2` has these mounts.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->
fixes https://github.com/ovn-org/ovn-kubernetes/issues/1669

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->