### PR TITLE
disable informers factory resync period

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -441,7 +441,7 @@ type ObjectCacheInterface interface {
 var _ ObjectCacheInterface = &WatchFactory{}
 
 const (
-	resyncInterval        = 12 * time.Hour
+	resyncInterval        = 0
 	handlerAlive   uint32 = 0
 	handlerDead    uint32 = 1
 	numEventQueues int    = 15
@@ -461,11 +461,12 @@ var (
 
 // NewWatchFactory initializes a new watch factory
 func NewWatchFactory(c kubernetes.Interface, eip egressipclientset.Interface, ec egressfirewallclientset.Interface, crd apiextensionsclientset.Interface) (*WatchFactory, error) {
-	// resync time is 12 hours, none of the resources being watched in ovn-kubernetes have
+	// resync time is 0, none of the resources being watched in ovn-kubernetes have
 	// any race condition where a resync may be required e.g. cni executable on node watching for
 	// events on pods and assuming that an 'ADD' event will contain the annotations put in by
 	// ovnkube master (currently, it is just a 'get' loop)
 	// the downside of making it tight (like 10 minutes) is needless spinning on all resources
+	// However, AddEventHandlerWithResyncPeriod can specify a per handler resync period
 	wf := &WatchFactory{
 		iFactory:    informerfactory.NewSharedInformerFactory(c, resyncInterval),
 		eipFactory:  egressipinformerfactory.NewSharedInformerFactory(eip, resyncInterval),

--- a/go-controller/pkg/informer/const.go
+++ b/go-controller/pkg/informer/const.go
@@ -1,15 +1,14 @@
 package informer
 
-import "time"
-
 // These constants can be removed at some point
 // They are here to provide backwards-compatibility with the
 // pkg/factory code which provided defaults.
 // The package consumer should make these decisions instead.
 const (
 	// DefaultResyncInterval is the default interval that all caches should
-	// periodically resync
-	DefaultResyncInterval = time.Hour * 12
+	// periodically resync. AddEventHandlerWithResyncPeriod can specify a
+	// per handler resync period if necessary
+	DefaultResyncInterval = 0
 	// DefaultNodeInformerThreadiness is the number of worker routines spawned
 	// to services the Node event queue
 	DefaultNodeInformerThreadiness = 10


### PR DESCRIPTION
current resync period was set to 12 hours, instead of having
such large period with the risk of overwhelming ovn with events
every 12 hours, just disable the resync period.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
