### PR TITLE
Ubdate Ubuntu to 20.04

### DIFF
--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -8,11 +8,11 @@
 #
 # So this file will change over time.
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 USER root
 
-RUN apt-get update && apt-get install -y arping iproute2 curl software-properties-common setpriv
+RUN apt-get update && apt-get install -y arping iproute2 curl software-properties-common util-linux
 
 RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
 RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -


### PR DESCRIPTION
Ubuntu 18.04 repository contains old OVS/OVN packages, (2.9.5-0), which are not compatable with current implementation.
With Ubuntu 20.04 `apt-get` installs OVS 2.13 and OVN 20.03

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->
fixes https://github.com/ovn-org/ovn-kubernetes/issues/1695

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
With Ubuntu 18.04 the ovn-kubernetes image, contains OVN/OVS packages v2.9.5.
and as result there are the following errors:
```
ovn-nbctl: unrecognized option '--inactivity-probe=0'  (from the nb-ovsdb log)
ovn-sbctl: unrecognized option '--inactivity-probe=0   (from the sb-ovsdb log)
/usr/bin/ovn-nbctl: unrecognized option '--pidfile'      (from the nbctl-daemon  log)
```
**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->