### PR TITLE
Revert "run conformance tests in the CI"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - shard: shard-conformance
+          - shard: shard-network
             hybrid-overlay: false
           - shard: control-plane
             hybrid-overlay: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,7 +191,7 @@ jobs:
     needs: [build, k8s]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
-      OVN_HA: "${{ matrix.ha.enabled }}"
+      KIND_HA: "${{ matrix.ha.enabled }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily.ipv4 }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily.ipv6 }}"
       OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target.hybrid-overlay }}"

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -54,7 +54,7 @@ nodes:
          authorization-mode: "AlwaysAllow"
 {%- if ovn_ha is equalto "true" %}
 {%- for _ in range(1, ovn_num_master | int) %}
- - role: worker
+ - role: control-plane
 {%- endfor %}
 {%- endif %}
 {%- for _ in range(ovn_num_worker | int) %}

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -109,7 +109,7 @@ case "$SHARD" in
 		FOCUS="\\[sig-network\\]"
 		;;
 	shard-conformance)
-		FOCUS="\\[Conformance\\]|\\[sig-network\\]"
+		FOCUS="\\[Conformance\\]"
 		;;
 	shard-test)
 		FOCUS=$(echo ${@:2} | sed 's/ /\\s/g')

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -100,7 +100,7 @@ SKIPPED_TESTS="$(groomTestList "${SKIPPED_TESTS}")"
 # if we set PARALLEL=true, skip serial test
 if [ "${PARALLEL:-false}" = "true" ]; then
   export GINKGO_PARALLEL=y
-  export GINKGO_PARALLEL_NODES=20
+  export GINKGO_PARALLEL_NODES=4
   SKIPPED_TESTS="${SKIPPED_TESTS}|\\[Serial\\]"
 fi
 


### PR DESCRIPTION
Reverts ovn-org/ovn-kubernetes#1672

I don't think this actually does OVN HA, so we need to revert it until the correct fix that still allows HA is in.

Signed-off-by: Tim Rozet <trozet@redhat.com>