### PR TITLE
fixing typos in CIDR in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ running).
 **Note:** when specifying the pod CIDR to the command below, daemonset.sh will
 generate a /24 subnet prefix to create per-node CIDRs. Ensure your pod subnet is has a
 prefix less than 24, or edit the generated ovn-setup.yaml and specify a host subnet
-prefix. For example, providing a net-cidr of "129.168.1.0/24" would require modifying
+prefix. For example, providing a net-cidr of "192.168.1.0/24" would require modifying
 ovn-setup.yaml with a host subnet prefix as follows:
 
 ```
 data:
-  net_cidr:      "192.168.1.0/24/25"
+  net_cidr:      "192.168.1.0/25"
 ```
 
 Where "/25" is just chosen for this example, but may be any legitimate prefix value greater


### PR DESCRIPTION
Signed-off-by: Vladislav Walek <22072258+vwalek@users.noreply.github.com>

just fixing the typo in CIDR in README.md during reading