### PR TITLE
Add IPv6 multicast support.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,8 +111,10 @@ jobs:
         target:
           - shard: shard-conformance
             hybrid-overlay: false
+            multicast-enable: false
           - shard: control-plane
             hybrid-overlay: true
+            multicast-enable: true
         ha:
          - enabled: "true"
            name: "HA"
@@ -157,6 +159,10 @@ jobs:
          - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": shared}
          - {"ipfamily": {"ip": dualstack}, "ha": {"enabled": "true"}, "gateway-mode": shared}
          - {"ipfamily": {"ip": dualstack}, "ha": {"enabled": "false"}}
+         # IPv6 multicast is supported but tests fail due to old iperf version
+         # in agnhost images. Disable them for now.
+         - {"ipfamily": {"ip": dualstack}, "target": {"shard": {"multicast-enable": "true"}}}
+         - {"ipfamily": {"ip": ipv6}, "target": {"shard": {"multicast-enable": "true"}}}
     needs: [build]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
@@ -165,6 +171,7 @@ jobs:
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily.ipv6 }}"
       OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target.hybrid-overlay }}"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
+      OVN_MULTICAST_ENABLE:  "${{ matrix.target.multicast-enable }}"
     steps:
 
     - name: Free up disk space

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -297,10 +297,6 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 				"Disabling Multicast Support")
 			oc.multicastSupport = false
 		}
-		if !config.IPv4Mode {
-			klog.Warningf("Multicast support enabled, but can not be used with single-stack IPv6. Disabling Multicast Support")
-			oc.multicastSupport = false
-		}
 	}
 
 	if err := oc.SetupMaster(masterNodeName); err != nil {
@@ -664,12 +660,14 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 		"--", "set", "logical_switch", nodeName,
 	}
 
-	var v4Gateway net.IP
+	var v4Gateway, v6Gateway net.IP
 	for _, hostSubnet := range hostSubnets {
 		gwIfAddr := util.GetNodeGatewayIfAddr(hostSubnet)
 		lrpArgs = append(lrpArgs, gwIfAddr.String())
 
 		if utilnet.IsIPv6CIDR(hostSubnet) {
+			v6Gateway = gwIfAddr.IP
+
 			lsArgs = append(lsArgs,
 				"other-config:ipv6_prefix="+hostSubnet.IP.String(),
 			)
@@ -703,7 +701,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 		return err
 	}
 
-	// If supported, enable IGMP snooping and querier on the node.
+	// If supported, enable IGMP/MLD snooping and querier on the node.
 	if oc.multicastSupport {
 		stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
 			nodeName, "other-config:mcast_snoop=\"true\"")
@@ -713,27 +711,40 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 			return err
 		}
 
-		// Configure querier only if we have an IPv4 address, otherwise
-		// disable querier.
-		if v4Gateway != nil {
-			stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
-				nodeName, "other-config:mcast_querier=\"true\"",
-				"other-config:mcast_eth_src=\""+nodeLRPMAC.String()+"\"",
-				"other-config:mcast_ip4_src=\""+v4Gateway.String()+"\"")
-			if err != nil {
-				klog.Errorf("Failed to enable IGMP Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
-					nodeName, stdout, stderr, err)
-				return err
+		// Configure IGMP/MLD querier if the gateway IP address is known.
+		// Otherwise disable it.
+		if v4Gateway != nil || v6Gateway != nil {
+			if v4Gateway != nil {
+				stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
+					nodeName, "other-config:mcast_querier=\"true\"",
+					"other-config:mcast_eth_src=\""+nodeLRPMAC.String()+"\"",
+					"other-config:mcast_ip4_src=\""+v4Gateway.String()+"\"")
+				if err != nil {
+					klog.Errorf("Failed to enable IGMP Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
+						nodeName, stdout, stderr, err)
+					return err
+				}
+			}
+			if v6Gateway != nil {
+				stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
+					nodeName, "other-config:mcast_querier=\"true\"",
+					"other-config:mcast_eth_src=\""+nodeLRPMAC.String()+"\"",
+					"other-config:mcast_ip6_src=\""+v6Gateway.String()+"\"")
+				if err != nil {
+					klog.Errorf("Failed to enable MLD Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
+						nodeName, stdout, stderr, err)
+					return err
+				}
 			}
 		} else {
 			stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
 				nodeName, "other-config:mcast_querier=\"false\"")
 			if err != nil {
-				klog.Errorf("Failed to disable IGMP Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
+				klog.Errorf("Failed to disable IGMP/MLD Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
 					nodeName, stdout, stderr, err)
 				return err
 			}
-			klog.Infof("Disabled IGMP Querier on logical switch %v (No IPv4 Source IP available)",
+			klog.Infof("Disabled IGMP/MLD Querier on logical switch %v (No IPv4/IPv6 Source IP available)",
 				nodeName)
 		}
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -471,6 +471,31 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 	return nil
 }
 
+func addNodeLogicalSwitchPort(logicalSwitch, portName, portType, addresses, options string) (string, error) {
+	stdout, stderr, err := util.RunOVNNbctl("--", "--may-exist", "lsp-add", logicalSwitch, portName,
+		"--", "lsp-set-type", portName, portType,
+		"--", "lsp-set-options", portName, options,
+		"--", "lsp-set-addresses", portName, addresses)
+	if err != nil {
+		klog.Errorf("Failed to add logical port %s to switch %s, stdout: %q, stderr: %q, error: %v", portName, logicalSwitch, stdout, stderr, err)
+		return "", err
+	}
+
+	// UUID must be retrieved separately from the lsp-add transaction since
+	// (as of OVN 2.12) a bogus UUID is returned if they are part of the same
+	// transaction.
+	uuid, stderr, err := util.RunOVNNbctl("get", "logical_switch_port", portName, "_uuid")
+	if err != nil {
+		klog.Errorf("Error getting UUID for logical port %s "+
+			"stdout: %q, stderr: %q (%v)", portName, uuid, stderr, err)
+		return "", err
+	}
+	if uuid == "" {
+		return uuid, fmt.Errorf("invalid logical port %s uuid", portName)
+	}
+	return uuid, nil
+}
+
 func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net.IPNet) error {
 	macAddress, err := util.ParseNodeManagementPortMACAddress(node)
 	if err != nil {
@@ -512,26 +537,9 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 
 	// Create this node's management logical port on the node switch
 	portName := types.K8sPrefix + node.Name
-	stdout, stderr, err := util.RunOVNNbctl(
-		"--", "--may-exist", "lsp-add", node.Name, portName,
-		"--", "lsp-set-addresses", portName, addresses)
+	uuid, err := addNodeLogicalSwitchPort(node.Name, portName, "", addresses, "")
 	if err != nil {
-		klog.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v",
-			stdout, stderr, err)
 		return err
-	}
-
-	// UUID must be retrieved separately from the lsp-add transaction since
-	// (as of OVN 2.12) a bogus UUID is returned if they are part of the same
-	// transaction.
-	uuid, stderr, err := util.RunOVNNbctl("get", "logical_switch_port", portName, "_uuid")
-	if err != nil {
-		klog.Errorf("Error getting UUID for logical port %s "+
-			"stdout: %q, stderr: %q (%v)", portName, uuid, stderr, err)
-		return err
-	}
-	if uuid == "" {
-		return fmt.Errorf("invalid logical port %s uuid %q", portName, uuid)
 	}
 
 	if err := addToPortGroup(clusterPortGroupName, &lpInfo{
@@ -715,9 +723,8 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 	}
 
 	// Connect the switch to the router.
-	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", nodeName, types.SwitchToRouterPrefix+nodeName,
-		"--", "set", "logical_switch_port", types.SwitchToRouterPrefix+nodeName, "type=router",
-		"options:router-port="+types.RouterToSwitchPrefix+nodeName, "addresses="+"\""+nodeLRPMAC.String()+"\"")
+	_, err = addNodeLogicalSwitchPort(nodeName, types.SwitchToRouterPrefix+nodeName,
+		"router", nodeLRPMAC.String(), "router-port="+types.RouterToSwitchPrefix+nodeName)
 	if err != nil {
 		klog.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -360,6 +360,15 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 		return err
 	}
 
+	// Create a cluster-wide port group with all node-to-cluster router
+	// logical switch ports.  Currently the only user is multicast but it might
+	// be used for other features in the future.
+	oc.clusterRtrPortGroupUUID, err = createPortGroup(clusterRtrPortGroupName, clusterRtrPortGroupName)
+	if err != nil {
+		klog.Errorf("Failed to create cluster port group: %v", err)
+		return err
+	}
+
 	// If supported, enable IGMP relay on the router to forward multicast
 	// traffic between nodes.
 	if oc.multicastSupport {
@@ -374,6 +383,13 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 		// Drop IP multicast globally. Multicast is allowed only if explicitly
 		// enabled in a namespace.
 		if err := oc.createDefaultDenyMulticastPolicy(); err != nil {
+			klog.Errorf("Failed to create default deny multicast policy, error: %v", err)
+			return err
+		}
+
+		// Allow IP multicast from node switch to cluster router and from
+		// cluster router to node switch.
+		if err := oc.createDefaultAllowMulticastPolicy(); err != nil {
 			klog.Errorf("Failed to create default deny multicast policy, error: %v", err)
 			return err
 		}
@@ -723,10 +739,18 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 	}
 
 	// Connect the switch to the router.
-	_, err = addNodeLogicalSwitchPort(nodeName, types.SwitchToRouterPrefix+nodeName,
+	nodeSwToRtrUUID, err := addNodeLogicalSwitchPort(nodeName, types.SwitchToRouterPrefix+nodeName,
 		"router", nodeLRPMAC.String(), "router-port="+types.RouterToSwitchPrefix+nodeName)
 	if err != nil {
 		klog.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+		return err
+	}
+
+	if err = addToPortGroup(clusterRtrPortGroupName, &lpInfo{
+		uuid: nodeSwToRtrUUID,
+		name: types.SwitchToRouterPrefix + nodeName,
+	}); err != nil {
+		klog.Errorf(err.Error())
 		return err
 	}
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -204,7 +204,14 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		"ovn-nbctl --timeout=15 --may-exist ls-add " + nodeName + " -- set logical_switch " + nodeName + " other-config:subnet=" + nodeSubnet + " other-config:exclude_ips=" + nodeMgmtPortIP.String() + ".." + hybridOverlayIP.String(),
 		"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " other-config:mcast_snoop=\"true\"",
 		"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " other-config:mcast_querier=\"true\" other-config:mcast_eth_src=\"" + lrpMAC + "\" other-config:mcast_ip4_src=\"" + gwIP + "\"",
-		"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.SwitchToRouterPrefix + nodeName + " -- set logical_switch_port " + types.SwitchToRouterPrefix + nodeName + " type=router options:router-port=" + types.RouterToSwitchPrefix + nodeName + " addresses=\"" + lrpMAC + "\"",
+		"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.SwitchToRouterPrefix + nodeName + " -- lsp-set-type " + types.SwitchToRouterPrefix + nodeName + " router -- lsp-set-options " + types.SwitchToRouterPrefix + nodeName + " router-port=" + types.RouterToSwitchPrefix + nodeName + " -- lsp-set-addresses " + types.SwitchToRouterPrefix + nodeName + " " + lrpMAC,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + types.SwitchToRouterPrefix + nodeName + " _uuid",
+		Output: fakeUUID + "\n",
+	})
+
+	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 		"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 	})
@@ -215,7 +222,7 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	}
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + nodeMgmtPortIP.String() + " allow-related",
-		"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.K8sPrefix + nodeName + " -- lsp-set-addresses " + types.K8sPrefix + nodeName + " " + mgmtMAC + " " + nodeMgmtPortIP.String(),
+		"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.K8sPrefix + nodeName + " -- lsp-set-type " + types.K8sPrefix + nodeName + "  -- lsp-set-options " + types.K8sPrefix + nodeName + "  -- lsp-set-addresses " + types.K8sPrefix + nodeName + " " + mgmtMAC + " " + nodeMgmtPortIP.String(),
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + types.K8sPrefix + nodeName + " _uuid",
@@ -1087,12 +1094,20 @@ var _ = Describe("Gateway Init Operations", func() {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 --if-exists lrp-del " + types.RouterToSwitchPrefix + nodeName + " -- lrp-add ovn_cluster_router " + types.RouterToSwitchPrefix + nodeName + " " + nodeLRPMAC + " " + nodeGWIP,
 				"ovn-nbctl --timeout=15 --may-exist ls-add " + nodeName + " -- set logical_switch " + nodeName + " other-config:subnet=" + nodeSubnet + " other-config:exclude_ips=" + nodeMgmtPortIP,
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.SwitchToRouterPrefix + nodeName + " -- set logical_switch_port " + types.SwitchToRouterPrefix + nodeName + " type=router options:router-port=" + types.RouterToSwitchPrefix + nodeName + " addresses=\"" + nodeLRPMAC + "\"",
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.SwitchToRouterPrefix + nodeName + " -- lsp-set-type " + types.SwitchToRouterPrefix + nodeName + " router -- lsp-set-options " + types.SwitchToRouterPrefix + nodeName + " router-port=" + types.RouterToSwitchPrefix + nodeName + " -- lsp-set-addresses " + types.SwitchToRouterPrefix + nodeName + " " + nodeLRPMAC,
+			})
+
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + types.SwitchToRouterPrefix + nodeName + " _uuid",
+				Output: fakeUUID + "\n",
+			})
+
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
 				"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + nodeMgmtPortIP + " allow-related",
-				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.K8sPrefix + nodeName + " -- lsp-set-addresses " + types.K8sPrefix + nodeName + " " + nodeMgmtPortMAC + " " + nodeMgmtPortIP,
+				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.K8sPrefix + nodeName + " -- lsp-set-type " + types.K8sPrefix + nodeName + "  -- lsp-set-options " + types.K8sPrefix + nodeName + "  -- lsp-set-addresses " + types.K8sPrefix + nodeName + " " + nodeMgmtPortMAC + " " + nodeMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + types.K8sPrefix + nodeName + " _uuid",

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -143,10 +143,10 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		"ovn-nbctl --timeout=15 create port_group name=clusterPortGroup external-ids:name=clusterPortGroup",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=clusterRtrPortGroup",
 		"ovn-nbctl --timeout=15 create port_group name=clusterRtrPortGroup external-ids:name=clusterRtrPortGroup",
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.mcast\" action=drop external-ids:default-deny-policy-type=Egress",
-		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=from-lport match=\"ip4.mcast\" action=drop external-ids:default-deny-policy-type=Egress -- add port_group  acls @acl",
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.mcast\" action=drop external-ids:default-deny-policy-type=Ingress",
-		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=to-lport match=\"ip4.mcast\" action=drop external-ids:default-deny-policy-type=Ingress -- add port_group  acls @acl",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Egress",
+		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=from-lport match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Egress -- add port_group  acls @acl",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Ingress",
+		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=to-lport match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Ingress -- add port_group  acls @acl",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -141,6 +141,8 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		"ovn-nbctl --timeout=15 -- set logical_router ovn_cluster_router options:mcast_relay=\"true\"",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=clusterPortGroup",
 		"ovn-nbctl --timeout=15 create port_group name=clusterPortGroup external-ids:name=clusterPortGroup",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=clusterRtrPortGroup",
+		"ovn-nbctl --timeout=15 create port_group name=clusterRtrPortGroup external-ids:name=clusterRtrPortGroup",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.mcast\" action=drop external-ids:default-deny-policy-type=Egress",
 		"ovn-nbctl --timeout=15 --id=@acl create acl priority=1011 direction=from-lport match=\"ip4.mcast\" action=drop external-ids:default-deny-policy-type=Egress -- add port_group  acls @acl",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"ip4.mcast\" action=drop external-ids:default-deny-policy-type=Ingress",
@@ -212,6 +214,7 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	})
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --if-exists remove port_group clusterRtrPortGroup ports " + fakeUUID + " -- add port_group clusterRtrPortGroup ports " + fakeUUID,
 		"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 		"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 	})
@@ -1103,6 +1106,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --if-exists remove port_group clusterRtrPortGroup ports " + fakeUUID + " -- add port_group clusterRtrPortGroup ports " + fakeUUID,
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -46,6 +46,7 @@ import (
 const (
 	egressfirewallCRD                string        = "egressfirewalls.k8s.ovn.org"
 	clusterPortGroupName             string        = "clusterPortGroup"
+	clusterRtrPortGroupName          string        = "clusterRtrPortGroup"
 	egressFirewallDNSDefaultDuration time.Duration = 30 * time.Minute
 )
 
@@ -147,6 +148,10 @@ type Controller struct {
 
 	// Port group for all cluster logical switch ports
 	clusterPortGroupUUID string
+
+	// Port group for all node logical switch ports connected to the cluster
+	// logical router
+	clusterRtrPortGroupUUID string
 
 	// Port group for ingress deny rule
 	portGroupIngressDeny string

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -56,6 +56,8 @@ const (
 	defaultMcastDenyPriority = "1011"
 	// Default multicast allow acl rule priority
 	defaultMcastAllowPriority = "1012"
+	// Default routed multicast allow acl rule priority
+	defaultRoutedMcastAllowPriority = "1013"
 )
 
 func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
@@ -351,6 +353,27 @@ func (oc *Controller) createDefaultDenyMulticastPolicy() error {
 	// Remove old multicastDefaultDeny port group now that all ports
 	// have been added to the clusterPortGroup by WatchPods()
 	deletePortGroup("mcastPortGroupDeny")
+	return nil
+}
+
+// Creates a global default allow multicast policy:
+// - one ACL allowing multicast traffic from cluster router ports
+// - one ACL allowing multicast traffic to cluster router ports.
+// Caller must hold the namespace's namespaceInfo object lock.
+func (oc *Controller) createDefaultAllowMulticastPolicy() error {
+	match := getACLMatch(clusterRtrPortGroupName, "ip4.mcast", knet.PolicyTypeEgress)
+	err := addACLPortGroup(oc.clusterRtrPortGroupUUID, fromLport,
+		defaultRoutedMcastAllowPriority, match, "allow", knet.PolicyTypeEgress)
+	if err != nil {
+		return fmt.Errorf("failed to create default deny multicast egress ACL: %v", err)
+	}
+
+	match = getACLMatch(clusterRtrPortGroupName, "ip4.mcast", knet.PolicyTypeIngress)
+	err = addACLPortGroup(oc.clusterRtrPortGroupUUID, toLport,
+		defaultRoutedMcastAllowPriority, match, "allow", knet.PolicyTypeIngress)
+	if err != nil {
+		return fmt.Errorf("failed to create default deny multicast ingress ACL: %v", err)
+	}
 	return nil
 }
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
 
 	v1 "k8s.io/api/core/v1"
@@ -21,6 +21,31 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+type ipMode struct {
+	IPv4Mode bool
+	IPv6Mode bool
+}
+
+// FIXME DUAL-STACK: FakeOVN doesn't really support adding more than one
+// pod to the namespace. All logical ports would share the same fakeUUID.
+// When this is addressed we can add an entry for
+// IPv4Mode = true, IPv6Mode = true.
+func getIpModes() []ipMode {
+	return []ipMode{
+		{true, false},
+		{false, true},
+	}
+}
+
+func ipModeStr(m ipMode) string {
+	return fmt.Sprintf("(IPv4 %t IPv6 %t)", m.IPv4Mode, m.IPv6Mode)
+}
+
+func setIpMode(m ipMode) {
+	config.IPv4Mode = m.IPv4Mode
+	config.IPv6Mode = m.IPv6Mode
+}
 
 type networkPolicy struct{}
 
@@ -213,7 +238,7 @@ func (p multicastPolicy) enableCmds(fExec *ovntest.FakeExec, ns string) {
 		Output: "fake_uuid",
 	})
 
-	match := getACLMatch(pg_hash, "ip4.mcast", knet.PolicyTypeEgress)
+	match := getACLMatch(pg_hash, getMulticastACLEgrMatch(), knet.PolicyTypeEgress)
 	fExec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL " +
 			match + " action=allow external-ids:default-deny-policy-type=Egress",
@@ -224,9 +249,10 @@ func (p multicastPolicy) enableCmds(fExec *ovntest.FakeExec, ns string) {
 			"-- add port_group fake_uuid acls @acl",
 	})
 
-	ip4AddressSet, _ := addressset.MakeAddressSetHashNames(ns)
-	match = "ip4.src == $" + ip4AddressSet + " && ip4.mcast"
-	match = getACLMatch(pg_hash, match, knet.PolicyTypeIngress)
+	ip4AddressSet, ip6AddressSet := addressset.MakeAddressSetHashNames(ns)
+	mcastMatch := getACLMatchAF(getMulticastACLIgrMatchV4(ip4AddressSet),
+		getMulticastACLIgrMatchV6(ip6AddressSet))
+	match = getACLMatch(pg_hash, mcastMatch, knet.PolicyTypeIngress)
 	fExec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL " +
 			match + " action=allow external-ids:default-deny-policy-type=Ingress",
@@ -241,7 +267,7 @@ func (p multicastPolicy) enableCmds(fExec *ovntest.FakeExec, ns string) {
 func (p multicastPolicy) disableCmds(fExec *ovntest.FakeExec, ns string) {
 	pg_hash := hashedPortGroup(ns)
 
-	match := getACLMatch(pg_hash, "ip4.mcast", knet.PolicyTypeEgress)
+	match := getACLMatch(pg_hash, getMulticastACLEgrMatch(), knet.PolicyTypeEgress)
 	fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd: "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL " +
 			match + " " + "action=allow external-ids:default-deny-policy-type=Egress",
@@ -251,9 +277,10 @@ func (p multicastPolicy) disableCmds(fExec *ovntest.FakeExec, ns string) {
 		"ovn-nbctl --timeout=15 remove port_group " + pg_hash + " acls fake_uuid",
 	})
 
-	ip4AddressSet, _ := addressset.MakeAddressSetHashNames(ns)
-	match = "ip4.src == $" + ip4AddressSet + " && ip4.mcast"
-	match = getACLMatch(pg_hash, match, knet.PolicyTypeIngress)
+	ip4AddressSet, ip6AddressSet := addressset.MakeAddressSetHashNames(ns)
+	mcastMatch := getACLMatchAF(getMulticastACLIgrMatchV4(ip4AddressSet),
+		getMulticastACLIgrMatchV6(ip6AddressSet))
+	match = getACLMatch(pg_hash, mcastMatch, knet.PolicyTypeIngress)
 	fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd: "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL " +
 			match + " " + "action=allow external-ids:default-deny-policy-type=Ingress",
@@ -288,6 +315,258 @@ func (p multicastPolicy) delPodCmds(fExec *ovntest.FakeExec, ns string) {
 			"--if-exists remove port_group " + pg_hash + " ports " + fakeUUID,
 	})
 }
+
+var _ = Describe("OVN NetworkPolicy Operations with IP Address Family", func() {
+	const (
+		namespaceName1 = "namespace1"
+		namespaceName2 = "namespace2"
+	)
+	var (
+		app     *cli.App
+		fakeOvn *FakeOVN
+		fExec   *ovntest.FakeExec
+	)
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.PrepareTestConfig()
+		config.IPv4Mode = true
+		config.IPv6Mode = false
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		fExec = ovntest.NewLooseCompareFakeExec()
+		fakeOvn = NewFakeOVN(fExec)
+	})
+
+	AfterEach(func() {
+		fakeOvn.shutdown()
+	})
+
+	Context("during execution", func() {
+		for _, m := range getIpModes() {
+			m := m
+			It("tests enabling/disabling multicast in a namespace "+ipModeStr(m), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace(namespaceName1)
+
+					fakeOvn.start(ctx,
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						},
+					)
+					setIpMode(m)
+
+					fakeOvn.controller.WatchNamespaces()
+					ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(
+						context.TODO(), namespace1.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ns).NotTo(BeNil())
+
+					// Multicast is denied by default.
+					_, ok := ns.Annotations[nsMulticastAnnotation]
+					Expect(ok).To(BeFalse())
+
+					// Enable multicast in the namespace.
+					mcastPolicy := multicastPolicy{}
+					mcastPolicy.enableCmds(fExec, namespace1.Name)
+					ns.Annotations[nsMulticastAnnotation] = "true"
+					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
+
+					// Disable multicast in the namespace.
+					mcastPolicy.disableCmds(fExec, namespace1.Name)
+					ns.Annotations[nsMulticastAnnotation] = "false"
+					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
+					return nil
+				}
+
+				err := app.Run([]string{app.Name})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("tests enabling multicast in a namespace with a pod "+ipModeStr(m), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace(namespaceName1)
+					nPodTestV4 := newTPod(
+						"node1",
+						"10.128.1.0/24",
+						"10.128.1.2",
+						"10.128.1.1",
+						"myPod1",
+						"10.128.1.3",
+						"0a:58:0a:80:01:03",
+						namespace1.Name,
+					)
+					nPodTestV6 := newTPod(
+						"node1",
+						"fd00:10:244::/64",
+						"fd00:10:244::2",
+						"fd00:10:244::1",
+						"myPod2",
+						"fd00:10:244::3",
+						"0a:58:0a:80:02:03",
+						namespace1.Name,
+					)
+					var tPods []pod
+					var tPodIPs []string
+					if m.IPv4Mode {
+						tPods = append(tPods, nPodTestV4)
+						tPodIPs = append(tPodIPs, nPodTestV4.podIP)
+					}
+					if m.IPv6Mode {
+						tPods = append(tPods, nPodTestV6)
+						tPodIPs = append(tPodIPs, nPodTestV6.podIP)
+					}
+
+					var pods []v1.Pod
+					for _, tPod := range tPods {
+						pods = append(pods,
+							*newPod(tPod.namespace, tPod.podName, tPod.nodeName, tPod.podIP))
+						tPod.baseCmds(fExec)
+					}
+
+					fakeOvn.start(ctx,
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						},
+						&v1.PodList{
+							Items: pods,
+						},
+					)
+					setIpMode(m)
+
+					for _, tPod := range tPods {
+						tPod.populateLogicalSwitchCache(fakeOvn)
+					}
+					fakeOvn.controller.WatchNamespaces()
+					fakeOvn.controller.WatchPods()
+					ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(
+						context.TODO(), namespace1.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ns).NotTo(BeNil())
+					Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
+					// Enable multicast in the namespace
+					mcastPolicy := multicastPolicy{}
+					mcastPolicy.enableCmds(fExec, namespace1.Name)
+					// The pod should be added to the multicast allow port group.
+					mcastPolicy.addPodCmds(fExec, namespace1.Name)
+					ns.Annotations[nsMulticastAnnotation] = "true"
+					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
+					fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, tPodIPs)
+					return nil
+				}
+
+				err := app.Run([]string{app.Name})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("tests adding a pod to a multicast enabled namespace "+ipModeStr(m), func() {
+				app.Action = func(ctx *cli.Context) error {
+					namespace1 := *newNamespace(namespaceName1)
+					nPodTestV4 := newTPod(
+						"node1",
+						"10.128.1.0/24",
+						"10.128.1.2",
+						"10.128.1.1",
+						"myPod1",
+						"10.128.1.3",
+						"0a:58:0a:80:01:03",
+						namespace1.Name,
+					)
+					nPodTestV6 := newTPod(
+						"node1",
+						"fd00:10:244::/64",
+						"fd00:10:244::2",
+						"fd00:10:244::1",
+						"myPod2",
+						"fd00:10:244::3",
+						"0a:58:0a:80:02:03",
+						namespace1.Name,
+					)
+					var tPods []pod
+					var tPodIPs []string
+					if m.IPv4Mode {
+						tPods = append(tPods, nPodTestV4)
+						tPodIPs = append(tPodIPs, nPodTestV4.podIP)
+					}
+					if m.IPv6Mode {
+						tPods = append(tPods, nPodTestV6)
+						tPodIPs = append(tPodIPs, nPodTestV6.podIP)
+					}
+
+					fakeOvn.start(ctx,
+						&v1.NamespaceList{
+							Items: []v1.Namespace{
+								namespace1,
+							},
+						},
+					)
+					setIpMode(m)
+
+					for _, tPod := range tPods {
+						tPod.baseCmds(fExec)
+					}
+					fakeOvn.controller.WatchNamespaces()
+					fakeOvn.controller.WatchPods()
+					ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(
+						context.TODO(), namespace1.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ns).NotTo(BeNil())
+
+					// Enable multicast in the namespace.
+					mcastPolicy := multicastPolicy{}
+					mcastPolicy.enableCmds(fExec, namespace1.Name)
+					ns.Annotations[nsMulticastAnnotation] = "true"
+					_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
+
+					for _, tPod := range tPods {
+						tPod.populateLogicalSwitchCache(fakeOvn)
+
+						// The pod should be added to the multicast allow group.
+						mcastPolicy.addPodCmds(fExec, namespace1.Name)
+						_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(tPod.namespace).Create(context.TODO(), newPod(
+							tPod.namespace, tPod.podName, tPod.nodeName, tPod.podIP), metav1.CreateOptions{})
+						Expect(err).NotTo(HaveOccurred())
+
+					}
+
+					Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
+					fakeOvn.asf.ExpectAddressSetWithIPs(namespace1.Name, tPodIPs)
+
+					for _, tPod := range tPods {
+						// Delete the pod from the namespace.
+						mcastPolicy.delPodCmds(fExec, namespace1.Name)
+
+						err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(tPod.namespace).Delete(context.TODO(),
+							tPod.podName, *metav1.NewDeleteOptions(0))
+						Expect(err).NotTo(HaveOccurred())
+					}
+
+					Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
+					fakeOvn.asf.ExpectEmptyAddressSet(namespace1.Name)
+					return nil
+				}
+
+				err := app.Run([]string{app.Name})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		}
+	})
+})
 
 var _ = Describe("OVN NetworkPolicy Operations", func() {
 	const (
@@ -1236,167 +1515,6 @@ var _ = Describe("OVN NetworkPolicy Operations", func() {
 				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
 				eventuallyExpectNoAddressSets(fakeOvn, networkPolicy)
 
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("tests enabling/disabling multicast in a namespace", func() {
-			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace(namespaceName1)
-
-				fakeOvn.start(ctx,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespace1,
-						},
-					},
-				)
-
-				fakeOvn.controller.WatchNamespaces()
-				ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(
-					context.TODO(), namespace1.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ns).NotTo(BeNil())
-
-				// Multicast is denied by default.
-				_, ok := ns.Annotations[nsMulticastAnnotation]
-				Expect(ok).To(BeFalse())
-
-				// Enable multicast in the namespace.
-				mcastPolicy := multicastPolicy{}
-				mcastPolicy.enableCmds(fExec, namespace1.Name)
-				ns.Annotations[nsMulticastAnnotation] = "true"
-				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-
-				// Disable multicast in the namespace.
-				mcastPolicy.disableCmds(fExec, namespace1.Name)
-				ns.Annotations[nsMulticastAnnotation] = "false"
-				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("tests enabling multicast in a namespace with a pod", func() {
-			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace(namespaceName1)
-
-				nPodTest := newTPod(
-					"node1",
-					"10.128.1.0/24",
-					"10.128.1.2",
-					"10.128.1.1",
-					"myPod",
-					"10.128.1.3",
-					"0a:58:0a:80:01:03",
-					namespace1.Name,
-				)
-
-				nPodTest.baseCmds(fExec)
-				fakeOvn.start(ctx,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespace1,
-						},
-					},
-					&v1.PodList{
-						Items: []v1.Pod{
-							*newPod(nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP),
-						},
-					},
-				)
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
-				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
-				ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(
-					context.TODO(), namespace1.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ns).NotTo(BeNil())
-				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				// Enable multicast in the namespace
-				mcastPolicy := multicastPolicy{}
-				mcastPolicy.enableCmds(fExec, namespace1.Name)
-				// The pod should be added to the multicast allow port group.
-				mcastPolicy.addPodCmds(fExec, namespace1.Name)
-				ns.Annotations[nsMulticastAnnotation] = "true"
-				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
-				return nil
-			}
-
-			err := app.Run([]string{app.Name})
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("tests adding a pod to a multicast enabled namespace", func() {
-			app.Action = func(ctx *cli.Context) error {
-				namespace1 := *newNamespace(namespaceName1)
-
-				nPodTest := newTPod(
-					"node1",
-					"10.128.1.0/24",
-					"10.128.1.2",
-					"10.128.1.1",
-					"myPod",
-					"10.128.1.3",
-					"0a:58:0a:80:01:03",
-					namespace1.Name,
-				)
-
-				fakeOvn.start(ctx,
-					&v1.NamespaceList{
-						Items: []v1.Namespace{
-							namespace1,
-						},
-					},
-				)
-
-				nPodTest.baseCmds(fExec)
-				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
-				ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(
-					context.TODO(), namespace1.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ns).NotTo(BeNil())
-
-				// Enable multicast in the namespace.
-				mcastPolicy := multicastPolicy{}
-				mcastPolicy.enableCmds(fExec, namespace1.Name)
-				ns.Annotations[nsMulticastAnnotation] = "true"
-				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
-
-				// The pod should be added to the multicast allow group.
-				mcastPolicy.addPodCmds(fExec, namespace1.Name)
-
-				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(nPodTest.namespace).Create(context.TODO(), newPod(
-					nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP), metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
-
-				// Delete the pod from the namespace.
-				mcastPolicy.delPodCmds(fExec, namespace1.Name)
-
-				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(nPodTest.namespace).Delete(context.TODO(),
-					nPodTest.podName, *metav1.NewDeleteOptions(0))
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(fExec.CalledMatchesExpected).Should(BeTrue(), fExec.ErrorDesc)
-				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
 				return nil
 			}
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,4 +1,4 @@
-package e2e_test
+package e2e
 
 import (
 	"flag"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,4 +1,4 @@
-package e2e_test
+package e2e
 
 import (
 	"encoding/json"

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/onsi/gomega v1.9.0
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
+	k8s.io/client-go v0.17.4
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.0.0
 	k8s.io/kubernetes v1.17.2

--- a/test/e2e/multicast.go
+++ b/test/e2e/multicast.go
@@ -1,0 +1,130 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+const (
+	mcastSource  = "pod-client"
+	mcastServer1 = "pod-server1"
+	mcastServer2 = "pod-server2"
+)
+
+var _ = ginkgo.Describe("Multicast", func() {
+
+	fr := framework.NewDefaultFramework("multicast")
+
+	type nodeInfo struct {
+		name   string
+		nodeIP string
+	}
+
+	var (
+		cs                             clientset.Interface
+		ns                             string
+		clientNodeInfo, serverNodeInfo nodeInfo
+	)
+
+	ginkgo.BeforeEach(func() {
+		cs = fr.ClientSet
+		ns = fr.Namespace.Name
+
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			framework.Skipf(
+				"Test requires >= 2 Ready nodes, but there are only %v nodes",
+				len(nodes.Items))
+		}
+
+		ips := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
+
+		clientNodeInfo = nodeInfo{
+			name:   nodes.Items[0].Name,
+			nodeIP: ips[0],
+		}
+
+		serverNodeInfo = nodeInfo{
+			name:   nodes.Items[1].Name,
+			nodeIP: ips[1],
+		}
+
+		// annotate namespace to enable multicast
+		namespace, err := fr.ClientSet.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
+		framework.ExpectNoError(err, "Error getting Namespace %v: %v", fr.Namespace.Name, err)
+		if namespace.ObjectMeta.Annotations == nil {
+			namespace.ObjectMeta.Annotations = map[string]string{}
+		}
+		namespace.ObjectMeta.Annotations["k8s.ovn.org/multicast-enabled"] = "true"
+		_, err = fr.ClientSet.CoreV1().Namespaces().Update(namespace)
+		framework.ExpectNoError(err, "Error updating Namespace %v: %v", ns, err)
+	})
+
+	ginkgo.It("should be able to send multicast UDP traffic between nodes", func() {
+		mcastGroup := "224.3.3.3"
+		mcastGroupBad := "224.5.5.5"
+		if IsIPv6Cluster(cs) {
+			mcastGroup = "ff3e::4321:1234"
+			mcastGroupBad = "ff3e::4321:1235"
+		}
+
+		// Start the multicast source (iperf client is the sender in multicast)
+		ginkgo.By("creating a pod as a multicast source in node " + clientNodeInfo.name)
+		// multicast group (-c 224.3.3.3), UDP (-u), TTL (-T 2), during (-t 3000) seconds, report every (-i 5) seconds
+		iperf := fmt.Sprintf("iperf -c %s -u -T 2 -t 3000 -i 5", mcastGroup)
+		if IsIPv6Cluster(cs) {
+			iperf = iperf + " -V"
+		}
+		cmd := []string{"/bin/sh", "-c", iperf}
+		clientPod := newAgnhostPod(mcastSource, cmd...)
+		clientPod.Spec.NodeName = clientNodeInfo.name
+		fr.PodClient().CreateSync(clientPod)
+
+		// Start a multicast listener on the same groups and verify it received the traffic (iperf server is the multicast listener)
+		// join multicast group (-B 224.3.3.3), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
+		ginkgo.By("creating first multicast listener pod in node " + serverNodeInfo.name)
+		iperf = fmt.Sprintf("iperf -s -B %s -u -t 30 -i 5", mcastGroup)
+		if IsIPv6Cluster(cs) {
+			iperf = iperf + " -V"
+		}
+		cmd = []string{"/bin/sh", "-c", iperf}
+		mcastServerPod1 := newAgnhostPod(mcastServer1, cmd...)
+		mcastServerPod1.Spec.NodeName = serverNodeInfo.name
+		fr.PodClient().CreateSync(mcastServerPod1)
+
+		// Start a multicast listener on on other group and verify it does not receive the traffic (iperf server is the multicast listener)
+		// join multicast group (-B 224.4.4.4), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
+		ginkgo.By("creating second multicast listener pod in node " + serverNodeInfo.name)
+		iperf = fmt.Sprintf("iperf -s -B %s -u -t 30 -i 5", mcastGroupBad)
+		if IsIPv6Cluster(cs) {
+			iperf = iperf + " -V"
+		}
+		cmd = []string{"/bin/sh", "-c", iperf}
+		mcastServerPod2 := newAgnhostPod(mcastServer2, cmd...)
+		mcastServerPod2.Spec.NodeName = serverNodeInfo.name
+		fr.PodClient().CreateSync(mcastServerPod2)
+
+		ginkgo.By("checking if pod server1 received multicast traffic")
+		gomega.Eventually(func() (string, error) {
+			return e2epod.GetPodLogs(cs, ns, mcastServer1, mcastServer1)
+		},
+			30*time.Second, 1*time.Second).Should(gomega.ContainSubstring("connected"))
+
+		ginkgo.By("checking if pod server2 does not received multicast traffic")
+		gomega.Eventually(func() (string, error) {
+			return e2epod.GetPodLogs(cs, ns, mcastServer2, mcastServer2)
+		},
+			30*time.Second, 1*time.Second).ShouldNot(gomega.ContainSubstring("connected"))
+	})
+
+})


### PR DESCRIPTION
Enable MLD Snoop and MLD relay to allow multicast connectivity across
nodes. Extend the IPv4 multicast network policies to make them
applicable to IPv6.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>