### PR TITLE
Make sure to update the copy of egress firewall objects 

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -721,7 +721,7 @@ func (oc *Controller) WatchCRD() {
 func (oc *Controller) WatchEgressFirewall() *factory.Handler {
 	return oc.watchFactory.AddEgressFirewallHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			egressFirewall := obj.(*egressfirewall.EgressFirewall)
+			egressFirewall := obj.(*egressfirewall.EgressFirewall).DeepCopy()
 			errList := oc.addEgressFirewall(egressFirewall)
 			for _, err := range errList {
 				klog.Error(err)
@@ -737,7 +737,7 @@ func (oc *Controller) WatchEgressFirewall() *factory.Handler {
 			}
 		},
 		UpdateFunc: func(old, newer interface{}) {
-			newEgressFirewall := newer.(*egressfirewall.EgressFirewall)
+			newEgressFirewall := newer.(*egressfirewall.EgressFirewall).DeepCopy()
 			oldEgressFirewall := old.(*egressfirewall.EgressFirewall)
 			if !reflect.DeepEqual(oldEgressFirewall.Spec, newEgressFirewall.Spec) {
 				errList := oc.updateEgressFirewall(oldEgressFirewall, newEgressFirewall)


### PR DESCRIPTION
Egress firewall objects have an assigned status which needs to be
updated by OVN-Kubernetes. The update can however lead to a data race
with the API server object contained in memory in case the update is
not done on a copy. This is something that has been seen when testing PR:
https://github.com/ovn-org/ovn-kubernetes/pull/1640 which enables the
race detector

/cc @aojea @JacobTanenbaum 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->