### PR TITLE
kind.sh: ignore directories when copying executables

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -316,7 +316,9 @@ if [ "$OVN_IMAGE" == local ]; then
 
   # Build ovn kube image
   pushd ../dist/images
-  sudo cp -f ../../go-controller/_output/go/bin/* .
+  # Find all built executables, but ignore the 'windows' directory if it exists
+  BINS=$(find ../../go-controller/_output/go/bin/ -maxdepth 1 -type f | xargs)
+  sudo cp -f ${BINS} .
   echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
   docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
   OVN_IMAGE=ovn-daemonset-f:dev


### PR DESCRIPTION
Avoids the copy exiting with code 1 when it tries to copy the
'windows' directory if you ever ran 'make windows'.

```
+ pushd ../dist/images
~/Development/containers/ovn-kubernetes/dist/images ~/Development/containers/ovn-kubernetes/contrib
+ sudo cp -f ../../go-controller/_output/go/bin/hybrid-overlay-node ../../go-controller/_output/go/bin/ovn-k8s-cni-overlay ../../go-controller/_output/go/bin/ovnkube ../../go-controller/_output/go/bin/ovn-kube-util ../../go-controller/_output/go/bin/windows .
cp: -r not specified; omitting directory '../../go-controller/_output/go/bin/windows'
```

Signed-off-by: Dan Williams <dcbw@redhat.com>

@aojea 