### PR TITLE
fix a bug on kind deployment

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -358,7 +358,7 @@ pushd ../dist/yaml
 run_kubectl apply -f k8s.ovn.org_egressfirewalls.yaml
 run_kubectl apply -f k8s.ovn.org_egressips.yaml
 run_kubectl apply -f ovn-setup.yaml
-MASTER_NODES=$(kind get nodes --name ${KIND_CLUSTER_NAME} | head -n ${KIND_NUM_MASTER})
+MASTER_NODES=$(kind get nodes --name ${KIND_CLUSTER_NAME} | sort | head -n ${KIND_NUM_MASTER})
 # We want OVN HA not Kubernetes HA
 # leverage the kubeadm well-known label node-role.kubernetes.io/master=
 # to choose the nodes where ovn master components will be placed


### PR DESCRIPTION
we have to untaint the master nodes so we can schedule pods on them, however, the kind
get nodes does not report the nodes in the right order.

This does not an impact HA deployments since we untaint the same number of nodes that we create,
hence the order does not matter.
For noHA deployments it means we only schedule pods in the worker. But our CI is mainly using HA

Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>

