### PR TITLE
Fix setting ovn-k8s-gw0 mac address for ipv6 single-stack

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -38,7 +38,13 @@ func setupLocalNodeAccessBridge(nodeName string, subnets []*net.IPNet) error {
 		return err
 	}
 
-	macAddress := util.IPAddrToHWAddr(net.ParseIP(util.V4NodeLocalNatSubnetNextHop)).String()
+	var macAddress string
+	if config.IPv4Mode {
+		macAddress = util.IPAddrToHWAddr(net.ParseIP(util.V4NodeLocalNatSubnetNextHop)).String()
+	} else {
+		macAddress = util.IPAddrToHWAddr(net.ParseIP(util.V6NodeLocalNatSubnetNextHop)).String()
+	}
+
 	_, stderr, err = util.RunOVSVsctl(
 		"--may-exist", "add-port", localBridgeName, localnetGatewayNextHopPort,
 		"--", "set", "interface", localnetGatewayNextHopPort, "type=internal",


### PR DESCRIPTION
We were setting it correctly in the mac_binding table for OVN, but the
mac did not match the address configured on the host. This caused host
destined packets from OVN to be dropped in IPv6.

Signed-off-by: Tim Rozet <trozet@redhat.com>
