### PR TITLE
Add support for OVN DB Health Check and Raft Membership changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ list to the above command. Set values are the default values.
 ```
     --master-loglevel="5" \\Log level for ovnkube (master)
     --node-loglevel="5" \\ Log level for ovnkube (node)
+    --dbchecker-loglevel="5" \\Log level for ovn-dbchecker (ovnkube-db)
     --ovn-loglevel-northd="-vconsole:info -vfile:info" \\ Log config for ovn northd
     --ovn-loglevel-nb="-vconsole:info -vfile:info" \\ Log config for northbound db
     --ovn-loglevel-sb="-vconsole:info -vfile:info" \\ Log config for southboudn db

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -349,6 +349,7 @@ pushd ../dist/images
   --kind \
   --ovn-unprivileged-mode=no \
   --master-loglevel=5 \
+  --dbchecker-loglevel=5\
   --egress-ip-enable=true
 popd
 

--- a/dist/images/.gitignore
+++ b/dist/images/.gitignore
@@ -1,5 +1,6 @@
 ovn-k8s-cni-overlay
 ovn-kube-util
 ovnkube
+ovndbchecker
 hybrid-overlay-node
 git_info

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -55,7 +55,7 @@ RUN mkdir -p /var/run/openvswitch
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the rpm
 RUN mkdir -p /usr/libexec/cni/
-COPY ovnkube ovn-kube-util /usr/bin/
+COPY ovnkube ovn-kube-util ovndbchecker /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 
 # ovnkube.sh is the entry point. This script examines environment

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -35,7 +35,7 @@ RUN mkdir -p /var/run/openvswitch
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the pkg
 RUN mkdir -p /usr/libexec/cni/
-COPY ovnkube ovn-kube-util /usr/bin/
+COPY ovnkube ovn-kube-util ovndbchecker /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 
 # ovnkube.sh is the entry point. This script examines environment

--- a/dist/images/Dockerfile.fedora.dev
+++ b/dist/images/Dockerfile.fedora.dev
@@ -78,7 +78,7 @@ RUN ovn-nbctl --version && ovn-sbctl --version
 RUN mkdir -p /var/run/openvswitch && \
     mkdir -p /usr/libexec/cni/
 
-COPY ovnkube ovn-kube-util /usr/bin/
+COPY ovnkube ovn-kube-util ovndbchecker /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 
 # copy git commit number into image

--- a/dist/images/Dockerfile.ubuntu
+++ b/dist/images/Dockerfile.ubuntu
@@ -25,7 +25,7 @@ RUN mkdir -p /var/run/openvswitch
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the pkg
 RUN mkdir -p /usr/libexec/cni/
-COPY ovnkube ovn-kube-util /usr/bin/
+COPY ovnkube ovn-kube-util ovndbchecker /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 
 # ovnkube.sh is the entry point. This script examines environment

--- a/dist/images/Dockerfile.ubuntu.arm64
+++ b/dist/images/Dockerfile.ubuntu.arm64
@@ -25,7 +25,7 @@ RUN mkdir -p /var/run/openvswitch
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the pkg
 RUN mkdir -p /usr/libexec/cni/
-COPY ovnkube ovn-kube-util /usr/bin/
+COPY ovnkube ovn-kube-util ovndbchecker /usr/bin/
 COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 
 # ovnkube.sh is the entry point. This script examines environment

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -24,6 +24,7 @@ KIND=""
 OVN_UNPRIVILEGED_MODE=""
 MASTER_LOGLEVEL=""
 NODE_LOGLEVEL=""
+DBCHECKER_LOGLEVEL=""
 OVN_LOGLEVEL_NORTHD=""
 OVN_LOGLEVEL_NB=""
 OVN_LOGLEVEL_SB=""
@@ -82,6 +83,9 @@ while [ "$1" != "" ]; do
     ;;
   --node-loglevel)
     NODE_LOGLEVEL=$VALUE
+    ;;
+  --dbchecker-loglevel)
+    DBCHECKER_LOGLEVEL=$VALUE
     ;;
   --ovn-loglevel-northd)
     OVN_LOGLEVEL_NORTHD=$VALUE
@@ -174,6 +178,8 @@ master_loglevel=${MASTER_LOGLEVEL:-"4"}
 echo "master_loglevel: ${master_loglevel}"
 node_loglevel=${NODE_LOGLEVEL:-"4"}
 echo "node_loglevel: ${node_loglevel}"
+db_checker_loglevel=${DBCHECKER_LOGLEVEL:-"4"}
+echo "db_checker_loglevel: ${db_checker_loglevel}"
 ovn_loglevel_northd=${OVN_LOGLEVEL_NORTHD:-"-vconsole:info -vfile:info"}
 echo "ovn_loglevel_northd: ${ovn_loglevel_northd}"
 ovn_loglevel_nb=${OVN_LOGLEVEL_NB:-"-vconsole:info -vfile:info"}
@@ -273,6 +279,10 @@ ovn_image=${image} \
   ovn_db_replicas=${ovn_db_replicas} \
   ovn_db_minAvailable=${ovn_db_minAvailable} \
   ovn_loglevel_nb=${ovn_loglevel_nb} ovn_loglevel_sb=${ovn_loglevel_sb} \
+  ovn_dbchecker_loglevel=${db_checker_loglevel} \
+  ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
+  ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
+  ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_nb_raft_election_timer=${ovn_nb_raft_election_timer} \
   ovn_sb_raft_election_timer=${ovn_sb_raft_election_timer} \

--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -17,24 +17,59 @@ verify-ovsdb-raft() {
   fi
 }
 
-# OVN DB must be up in the first DB node
-# This waits for ovnkube-db-0 POD to come up
-ready_to_join_cluster() {
+bracketify() { case "$1" in *:*) echo "[$1]" ;; *) echo "$1" ;; esac }
+
+# checks if a db pod is part of a current cluster
+db_part_of_cluster() {
+  local pod=${1}
+  local db=${2}
+  local port=${3}
+  echo "Checking if ${pod} is part of cluster"
+  init_ip=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+    get pod -n ${ovn_kubernetes_namespace} ${pod} -o=jsonpath='{.status.podIP}')
+  if [[ $? != 0 ]]; then
+    echo "Unable to get ${pod} ip "
+    return 1
+  fi
+  echo "Found ${pod} ip: $init_ip"
+  init_ip=$(bracketify $init_ip)
+  target=$(ovn-${db}ctl --timeout=5 --db=${transport}:${init_ip}:${port} ${ovndb_ctl_ssl_opts} \
+               --data=bare --no-headings --columns=target list connection)
+  if [[ "${target}" != "p${transport}:${port}${ovn_raft_conn_ip_url_suffix}" ]]; then
+    echo "Unable to check correct target ${target} "
+    return 1
+  fi
+
+  echo "${pod} is part of cluster"
+  return 0
+}
+
+# Checks if cluster has already been initialized.
+# If not it returns false and sets init_ip to ovnkube-db-0
+cluster_exists() {
   # See if ep is available ...
   local db=${1}
   local port=${2}
 
+  db_pods=$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
+    get pod -n ${ovn_kubernetes_namespace} -o=jsonpath='{.items[*].metadata.name}' | egrep -o 'ovnkube-db[^ ]+')
+
+  for db_pod in $db_pods; do
+    if db_part_of_cluster $db_pod $db $port; then
+      echo "${db_pod} is part of current cluster with ip: ${init_ip}!"
+      return 0
+    fi
+  done
+
+  # if we get here  there is no cluster, set init_ip and get out
   init_ip="$(kubectl --server=${K8S_APISERVER} --token=${k8s_token} --certificate-authority=${K8S_CACERT} \
     get pod -n ${ovn_kubernetes_namespace} ovnkube-db-0 -o=jsonpath='{.status.podIP}')"
   if [[ $? != 0 ]]; then
     return 1
   fi
-  target=$(ovn-${db}ctl --db=${transport}:[${init_ip}]:${port} ${ovndb_ctl_ssl_opts} --data=bare --no-headings \
-    --columns=target list connection)
-  if [[ "${target}" != "p${transport}:${port}${ovn_raft_conn_ip_url_suffix}" ]]; then
-    return 1
-  fi
-  return 0
+
+  init_ip=$(bracketify $init_ip)
+  return 1
 }
 
 check_ovnkube_db_ep() {
@@ -238,27 +273,68 @@ ovsdb-raft() {
     ovn_raft_conn_ip_url_suffix=":[::]"
   fi
 
-  if [[ "${POD_NAME}" == "ovnkube-db-0" ]]; then
-    run_as_ovs_user_if_needed \
+  initial_raft_create=true
+  if [[ "${initialize}" == "true" ]]; then
+    # check to see if a cluster already exists. If it does, just join it.
+    counter=0
+    cluster_found=false
+    while [ $counter -lt 5 ]; do
+      if cluster_exists ${db} ${port}; then
+        cluster_found=true
+        break
+      fi
+      sleep 1
+      counter=$((counter+1))
+    done
+
+    if ${cluster_found}; then
+      echo "Cluster already exists for DB: ${db}"
+      initial_raft_create=false
+      run_as_ovs_user_if_needed \
       ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
-      --db-${db}-cluster-local-addr=[${ovn_db_host}] \
-      --db-${db}-cluster-local-port=${raft_port} \
-      --db-${db}-cluster-local-proto=${transport} \
-      ${db_ssl_opts} \
-      --ovn-${db}-log="${ovn_loglevel_db}" &
-  else
-    # join the remote cluster node if the DB is not created
-    if [[ "${initialize}" == "true" ]]; then
-      wait_for_event ready_to_join_cluster ${db} ${port}
-    fi
-    run_as_ovs_user_if_needed \
-      ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
-      --db-${db}-cluster-local-addr=[${ovn_db_host}] --db-${db}-cluster-remote-addr=[${init_ip}] \
+      --db-${db}-cluster-local-addr=$(bracketify ${ovn_db_host}) --db-${db}-cluster-remote-addr=${init_ip} \
       --db-${db}-cluster-local-port=${raft_port} --db-${db}-cluster-remote-port=${raft_port} \
       --db-${db}-cluster-local-proto=${transport} --db-${db}-cluster-remote-proto=${transport} \
       ${db_ssl_opts} \
       --ovn-${db}-log="${ovn_loglevel_db}" &
+    else
+      # either we need to initialize a new cluster or wait for db-0 to create it
+      if [[ "${POD_NAME}" == "ovnkube-db-0" ]]; then
+        echo "Cluster does not exist for DB: ${db}, creating new raft cluster"
+        run_as_ovs_user_if_needed \
+        ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
+        --db-${db}-cluster-local-addr=$(bracketify ${ovn_db_host}) \
+        --db-${db}-cluster-local-port=${raft_port} \
+        --db-${db}-cluster-local-proto=${transport} \
+        ${db_ssl_opts} \
+        --ovn-${db}-log="${ovn_loglevel_db}" &
+      else
+        echo "Cluster does not exist for DB: ${db}, waiting for ovnkube-db-0 pod to create it"
+        wait_for_event cluster_exists ${db} ${port}
+        run_as_ovs_user_if_needed \
+        ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
+        --db-${db}-cluster-local-addr=$(bracketify ${ovn_db_host}) --db-${db}-cluster-remote-addr=${init_ip} \
+        --db-${db}-cluster-local-port=${raft_port} --db-${db}-cluster-remote-port=${raft_port} \
+        --db-${db}-cluster-local-proto=${transport} --db-${db}-cluster-remote-proto=${transport} \
+        ${db_ssl_opts} \
+        --ovn-${db}-log="${ovn_loglevel_db}" &
+      fi
+    fi
+  else
+    # in this case the cluster was already previously joined
+    # so we simply start without specifying the remote addr because
+    #  a) we can't reliably know who the raft leader is
+    #  b) we don't need to pass that information since it's already
+    #     in the db
+    run_as_ovs_user_if_needed \
+    ${OVNCTL_PATH} run_${db}_ovsdb --no-monitor \
+    --db-${db}-cluster-local-addr=[${ovn_db_host}] \
+    --db-${db}-cluster-local-port=${raft_port} \
+    --db-${db}-cluster-local-proto=${transport} \
+    ${db_ssl_opts} \
+    --ovn-${db}-log="${ovn_loglevel_db}" &
   fi
+
 
   # Following command waits for the database on server to enter a `connected` state
   # -- Waits until a database with the given name has been added to server. Then, if database
@@ -272,15 +348,17 @@ ovsdb-raft() {
   echo "=============== ${db}-ovsdb-raft ========== RUNNING"
 
   if [[ "${POD_NAME}" == "ovnkube-db-0" ]]; then
-    # set the election timer value before other servers join the cluster and it can
-    # only be set on the leader so we must do this in ovnkube-db-0 when it is still
-    # a single-node cluster
-    set_election_timer ${db} ${election_timer}
-    if [[ ${db} == "nb" ]]; then
-      set_northd_probe_interval
+    if ${initial_raft_create}; then
+      # set the election timer value before other servers join the cluster and it can
+      # only be set on the leader so we must do this in ovnkube-db-0 when it is still
+      # a single-node cluster
+      set_election_timer ${db} ${election_timer}
+      if [[ ${db} == "nb" ]]; then
+        set_northd_probe_interval
+      fi
+      # set the connection and disable inactivity probe, this deletes the old connection if any
+      set_connection ${db} ${port}
     fi
-    # set the connection and disable inactivity probe, this deletes the old connection if any
-    set_connection ${db} ${port}
   fi
 
   last_node_index=$(expr ${replicas} - 1)

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -243,6 +243,79 @@ spec:
           value: "{{ ovn_sb_raft_port }}"
       # end of container
 
+
+      # ovn-dbchecker - v3
+      - name: ovn-dbchecker
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+        command: ["/root/ovnkube.sh", "ovn-dbchecker"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: "{{ ovn_dbchecker_loglevel }}"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "{{ ovnkube_logfile_maxsize }}"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "{{ ovnkube_logfile_maxbackups }}"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "{{ ovnkube_logfile_maxage }}"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+        - name: OVN_NB_RAFT_ELECTION_TIMER
+          value: "{{ ovn_nb_raft_election_timer }}"
+        - name: OVN_NB_PORT
+          value: "{{ ovn_nb_port }}"
+        - name: OVN_NB_RAFT_PORT
+          value: "{{ ovn_nb_raft_port }}"
+      # end of container
+
       volumes:
       - name: host-var-log-ovs
         hostPath:

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -21,7 +21,7 @@ export TEST_REPORT_DIR
 
 
 all build:
-	hack/build-go.sh cmd/ovnkube cmd/ovn-k8s-cni-overlay cmd/ovn-kube-util hybrid-overlay/cmd/hybrid-overlay-node
+	hack/build-go.sh cmd/ovnkube cmd/ovn-k8s-cni-overlay cmd/ovn-kube-util hybrid-overlay/cmd/hybrid-overlay-node cmd/ovndbchecker
 
 windows:
 	WINDOWS_BUILD="yes" hack/build-go.sh hybrid-overlay/cmd/hybrid-overlay-node
@@ -36,6 +36,7 @@ install:
 	install -D -m 755 ${OUT_DIR}/go/bin/ovnkube ${BINDIR}/
 	install -D -m 755 ${OUT_DIR}/go/bin/ovn-kube-util ${BINDIR}/
 	install -D -m 755 ${OUT_DIR}/go/bin/ovn-k8s-cni-overlay -t ${CNIBINDIR}/
+	install -D -m 755 ${OUT_DIR}/go/bin/ovndbchecker ${BINDIR}/
 
 clean:
 	rm -rf ${OUT_DIR}

--- a/go-controller/cmd/ovndbchecker/ovndbchecker.go
+++ b/go-controller/cmd/ovndbchecker/ovndbchecker.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+	"text/template"
+
+	"k8s.io/klog"
+	kexec "k8s.io/utils/exec"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovndbmanager"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+const (
+	// CustomAppHelpTemplate helps in grouping options to ovnkube
+	CustomDBCheckAppHelpTemplate = `NAME:
+   {{.Name}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} [global options]
+
+VERSION:
+   {{.Version}}{{if .Description}}
+
+DESCRIPTION:
+   {{.Description}}{{end}}
+
+COMMANDS:{{range .VisibleCategories}}{{if .Name}}
+
+   {{.Name}}:{{end}}{{range .VisibleCommands}}
+     {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}
+
+GLOBAL OPTIONS:{{range $title, $category := getFlagsByCategory}}
+   {{upper $title}}
+   {{range $index, $option := $category}}{{if $index}}
+   {{end}}{{$option}}{{end}}
+   {{end}}`
+)
+
+func getFlagsByCategory() map[string][]cli.Flag {
+	m := map[string][]cli.Flag{}
+	m["Generic Options"] = config.CommonFlags
+	m["K8s-related Options"] = config.K8sFlags
+	m["OVN Northbound DB Options"] = config.OvnNBFlags
+	m["OVN Southbound DB Options"] = config.OvnSBFlags
+	return m
+}
+
+// borrowed from cli packages' printHelpCustom()
+func printOvnDBCheckHelp(out io.Writer, templ string, data interface{}, customFunc map[string]interface{}) {
+	funcMap := template.FuncMap{
+		"join":               strings.Join,
+		"upper":              strings.ToUpper,
+		"getFlagsByCategory": getFlagsByCategory,
+	}
+	for key, value := range customFunc {
+		funcMap[key] = value
+	}
+
+	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)
+	t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
+	err := t.Execute(w, data)
+	if err == nil {
+		_ = w.Flush()
+	}
+}
+
+func main() {
+	cli.HelpPrinterCustom = printOvnDBCheckHelp
+	c := cli.NewApp()
+	c.Name = "ovndbchecker"
+	c.Usage = "run ovn db checker to ensure raft membership and db health"
+	c.Version = config.Version
+	c.CustomAppHelpTemplate = CustomDBCheckAppHelpTemplate
+	c.Flags = config.GetFlags(nil)
+
+	c.Action = func(c *cli.Context) error {
+		return runOvnKubeDBChecker(c)
+	}
+
+	ctx := context.Background()
+
+	// trap SIGHUP, SIGINT, SIGTERM, SIGQUIT and
+	// cancel the context
+	ctx, cancel := context.WithCancel(ctx)
+	exitCh := make(chan os.Signal, 1)
+	signal.Notify(exitCh,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
+	defer func() {
+		signal.Stop(exitCh)
+		cancel()
+	}()
+	go func() {
+		select {
+		case s := <-exitCh:
+			klog.Infof("Received signal %s. Shutting down", s)
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	if err := c.RunContext(ctx, os.Args); err != nil {
+		klog.Exit(err)
+	}
+}
+
+func delPidfile(pidfile string) {
+	if pidfile != "" {
+		if _, err := os.Stat(pidfile); err == nil {
+			if err := os.Remove(pidfile); err != nil {
+				klog.Errorf("%s delete failed: %v", pidfile, err)
+			}
+		}
+	}
+}
+
+func setupPIDFile(pidfile string) error {
+	// need to test if already there
+	_, err := os.Stat(pidfile)
+
+	// Create if it doesn't exist, else exit with error
+	if os.IsNotExist(err) {
+		if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+			klog.Errorf("Failed to write pidfile %s (%v). Ignoring..", pidfile, err)
+		}
+	} else {
+		// get the pid and see if it exists
+		pid, err := ioutil.ReadFile(pidfile)
+		if err != nil {
+			return fmt.Errorf("pidfile %s exists but can't be read: %v", pidfile, err)
+		}
+		_, err1 := os.Stat("/proc/" + string(pid[:]) + "/cmdline")
+		if os.IsNotExist(err1) {
+			// Left over pid from dead process
+			if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+				klog.Errorf("Failed to write pidfile %s (%v). Ignoring..", pidfile, err)
+			}
+		} else {
+			return fmt.Errorf("pidfile %s exists and ovnkube is running", pidfile)
+		}
+	}
+
+	return nil
+}
+
+func runOvnKubeDBChecker(ctx *cli.Context) error {
+	pidfile := ctx.String("pidfile")
+	if pidfile != "" {
+		defer delPidfile(pidfile)
+		if err := setupPIDFile(pidfile); err != nil {
+			return err
+		}
+	}
+
+	exec := kexec.New()
+	_, err := config.InitConfig(ctx, exec, nil)
+	if err != nil {
+		return err
+	}
+
+	if err = util.SetExec(exec); err != nil {
+		return fmt.Errorf("failed to initialize exec helper: %v", err)
+	}
+
+	stopChan := make(chan struct{})
+	ovndbmanager.RunDBChecker(stopChan)
+	// run until cancelled
+	<-ctx.Context.Done()
+	close(stopChan)
+	return nil
+}

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -1,0 +1,230 @@
+package ovndbmanager
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func RunDBChecker(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	klog.Info("Starting DB Checker to ensure cluster membership and DB consistency")
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ensureOvnDBState(util.OvnNbdbLocation, stopCh)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ensureOvnDBState(util.OvnSbdbLocation, stopCh)
+	}()
+	<-stopCh
+	klog.Info("Shutting down db checker")
+	wg.Wait()
+	klog.Info("Shut down db checker")
+}
+
+func ensureOvnDBState(db string, stopCh <-chan struct{}) {
+	ticker := time.NewTicker(60 * time.Second)
+	klog.Infof("Starting ensure routine for Raft db: %s", db)
+	_, _, err := util.RunOVSDBTool("db-is-standalone", db)
+	if err == nil {
+		klog.Info("The db is running in standalone mode")
+		return
+	} else {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			klog.Infof("Exit code for the db-is-standalone: %v", ee.ExitCode())
+			if ee.ExitCode() != 2 {
+				klog.Fatalf("Can't determine if the db is clustered/stand-alone" +
+					" restarting the checker")
+				os.Exit(1)
+			}
+		}
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			klog.V(5).Infof("Ensure routines for Raft db: %s kicked off by ticker", db)
+			ensureLocalRaftServerID(db)
+			ensureClusterRaftMembership(db)
+			ensureDBHealth(db)
+		case <-stopCh:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// ensureLocalRaftServerID is used to ensure there is no stale member in the Raft cluster with our address
+func ensureLocalRaftServerID(db string) {
+	var dbName string
+	var appCtl func(args ...string) (string, string, error)
+
+	if strings.Contains(db, "ovnnb") {
+		dbName = "OVN_Northbound"
+		appCtl = util.RunOVNNBAppCtl
+	} else {
+		dbName = "OVN_Southbound"
+		appCtl = util.RunOVNSBAppCtl
+	}
+
+	out, stderr, err := util.RunOVSDBTool("db-sid", db)
+	if err != nil {
+		klog.Warningf("Unable to get db server ID for: %s, stderr: %v, err: %v", db, stderr, err)
+		return
+	}
+	if len(out) < 4 {
+		klog.Errorf("Invalid db id found: %s for db: %s", out, db)
+		return
+	}
+	// server ID in raft membership is only first 4 char prefix
+	serverID := out[:4]
+	out, stderr, err = appCtl("cluster/status", dbName)
+	if err != nil {
+		klog.Warningf("Unable to get cluster status for: %s, stderr: %v, err: %v", db, stderr, err)
+		return
+	}
+	r, _ := regexp.Compile(`Address: *((ssl|tcp):[?[a-z0-9.:]+]?)`)
+	matches := r.FindStringSubmatch(out)
+	if len(matches) < 2 {
+		klog.Warningf("Unable to parse Address for db: %s, output: %s", db, out)
+		return
+	}
+	addr := matches[1]
+	// look for current servers in raft cluster with the same address
+	r, _ = regexp.Compile("([a-z0-9]{4}) at " + addr)
+	members := r.FindAllStringSubmatch(out, -1)
+	for _, member := range members {
+		if len(member) < 2 {
+			klog.Warningf("Unable to find server id submatch in %s", member)
+			return
+		}
+		if member[1] != serverID {
+			// stale entry found for this node with same adddress, need to kick
+			klog.Infof("Previous stale member found: %s...kicking", member[1])
+			_, stderr, err = appCtl("cluster/kick", dbName, member[1])
+			if err != nil {
+				klog.Errorf("Error while kicking old Raft member: %s, for address: %s in db: %s,"+
+					"stderr: %v, error: %v", member[1], addr, db, stderr, err)
+			}
+		}
+	}
+}
+
+// ensureClusterRaftMembership ensures there are no unknown members in the current Raft cluster
+func ensureClusterRaftMembership(db string) {
+	var knownMembers, knownServers []string
+
+	var dbName string
+	var appCtl func(args ...string) (string, string, error)
+
+	if strings.Contains(db, "ovnnb") {
+		dbName = "OVN_Northbound"
+		appCtl = util.RunOVNNBAppCtl
+		knownMembers = strings.Split(config.OvnNorth.Address, ",")
+	} else {
+		dbName = "OVN_Southbound"
+		appCtl = util.RunOVNSBAppCtl
+		knownMembers = strings.Split(config.OvnSouth.Address, ",")
+	}
+	for _, knownMember := range knownMembers {
+		server := strings.Split(knownMember, ":")
+		if len(server) < 3 {
+			klog.Warningf("Failed to parse known member: %s", knownMember)
+			continue
+		}
+		knownServers = append(knownServers, server[1])
+	}
+	out, stderr, err := appCtl("cluster/status", dbName)
+	if err != nil {
+		klog.Warningf("Unable to get cluster status for: %s, stderr: %v, err: %v", db, stderr, err)
+		return
+	}
+	r, _ := regexp.Compile(`([a-z0-9]{4}) at ((ssl|tcp):\[?[a-z0-9.:]+\]?)`)
+	members := r.FindAllStringSubmatch(out, -1)
+	kickedMembersCount := 0
+	for _, member := range members {
+		if len(member) < 3 {
+			klog.Warningf("Unable to find parse member: %s", member)
+			return
+		}
+		matchedServer := strings.Split(member[2], ":")
+		if len(matchedServer) < 3 {
+			klog.Warningf("Unable to parse address portion of the member entry: %s", matchedServer)
+			return
+		}
+		memberFound := false
+		for _, knownServer := range knownServers {
+			if knownServer == matchedServer[1] {
+				memberFound = true
+				break
+			}
+		}
+		if !memberFound && (len(members)-kickedMembersCount) > 3 {
+			// unknown member and we have enough members its safe to kick the unknown address
+			klog.Infof("Unknown Raft member found: %s, %s...kicking", member[1], member[2])
+			_, stderr, err = appCtl("cluster/kick", dbName, member[1])
+			if err != nil {
+				// warn only: we might fail to kick since other nodes will also be trying to kick the member
+				klog.Warningf("Error while kicking old Raft member: %s, for address: %s in db: %s,"+
+					"stderr: %v, err: %v", member[1], member[2], db, stderr, err)
+				continue
+			}
+			kickedMembersCount = kickedMembersCount + 1
+		}
+	}
+}
+
+// ensureDBHealth ensures that if the db is clustered, it is healthy by calling the cluster-check command
+// if the clustered db is corrupt, the db will be deleted and kube-master pod needs to be started again.
+func ensureDBHealth(db string) {
+	stdout, stderr, err := util.RunOVSDBTool("check-cluster", db)
+	if err != nil {
+		// backup the db by renaming it and then stop the nb/sb ovsdb process.
+		klog.Fatalf("Error occured during checking of clustered db "+
+			"db: %s,stdout: %q, stderr: %q, err: %v",
+			db, stdout, stderr, err)
+		dbFile := filepath.Base(db)
+		backupFile := strings.TrimSuffix(dbFile, filepath.Ext(dbFile)) +
+			time.Now().UTC().Format("2006-01-02_150405") + "db_bak"
+		backupDB := filepath.Join(filepath.Dir(db), backupFile)
+		err := os.Rename(db, backupDB)
+		if err != nil {
+			klog.Warningf("Failed to back up the db to backupFile: %s", backupFile)
+		} else {
+			klog.Infof("Backed up the db to backupFile: %s", backupFile)
+			var dbName string
+			var appCtl func(args ...string) (string, string, error)
+			if strings.Contains(db, "ovnnb") {
+				dbName = "OVN_Northbound"
+				appCtl = util.RunOVNNBAppCtl
+			} else {
+				dbName = "OVN_Southbound"
+				appCtl = util.RunOVNSBAppCtl
+			}
+			_, stderr, err := appCtl("exit")
+			if err != nil {
+				klog.Warningf("Unable to restart the ovn db: %s ,"+
+					"stderr: %v, err: %v", dbName, stderr, err)
+			}
+			klog.Infof("Stopped %s db after backing up the db: %s", dbName, backupFile)
+		}
+	}
+	klog.Infof("check-cluster returned out: %q, stderr: %q", stdout, stderr)
+}

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -47,8 +47,10 @@ const (
 )
 
 const (
-	nbdbCtlSock = "ovnnb_db.ctl"
-	sbdbCtlSock = "ovnsb_db.ctl"
+	nbdbCtlSock     = "ovnnb_db.ctl"
+	sbdbCtlSock     = "ovnsb_db.ctl"
+	OvnNbdbLocation = "/etc/ovn/ovnnb_db.db"
+	OvnSbdbLocation = "/etc/ovn/ovnsb_db.db"
 )
 
 var (


### PR DESCRIPTION
This commit adds support for auditing the raft membership for NB
and SB databases as well as a health-check to recover from a corrupted
cluster.

Following use-cases are supposed to be solved:

- When ovnkube-db pods are restarted in a raft (HA)
mode, they will have a new server id with which they will join the cluster. 
This will cause the members list in the db to have two entries for the same node.

- When any of the existing master nodes is replaced, the cluster will end up
showing the old master's sid in the members list. The replaced node needs to
be evicted. This commit adds support to detect an orphan raft member and kick
it out of the cluster.

- Finally, when any one local instance of the raft db is corrupted, 
today there is no mechanism for the db to recover itself automatically. 
With this commit, we add a mechanism (via the ovn-dbchecker container) to monitor 
individual raft dbs for cluster-status and in case the db is reported as inconsistent/corrupt,
we backup the db files on that node and restart the corresponding ovsdb-server
container. This will force the db to get initialized.

**This does not handle the case when the entire raft db gets corrupted. That will need a manual intervention akin to performing the following steps:**  

1. Stop ovsdb-server (nb/sb) instances on all nodes.
2. Backup and delete all the db files while the server instances are down.
3. Bring up the ovsdb-server instances to start with a fresh raft cluster id
4. Reset ovn-northd instances in case of nbdb corruption by calling nb-cluster-state-reset
5. Reset ovn-controller instances in case of sbdb corruption by calling sb-cluster-state-reset
6. Restart the source of truth (ovn-k-master) to force sync the dbs in case nbdb got corrupted. 
7. If it's purely sbdb corruption, then the ovn-northd will propagate the changes to the sbdb, 
    so there is no need to restart the ovn-k-master in that case.

Co-authored-by: Tim Rozet <trozet@redhat.com>
Signed-off-by: Aniket Bhat <anbhat@redhat.com>