### PR TITLE
Fixes requiring host-network for exgw pods in update

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -558,24 +558,25 @@ func (oc *Controller) WatchPods() {
 		UpdateFunc: func(old, newer interface{}) {
 			oldPod := old.(*kapi.Pod)
 			pod := newer.(*kapi.Pod)
-			if !podWantsNetwork(pod) {
+
+			_, retry := retryPods.Load(pod.UID)
+			if podScheduled(pod) && retry && podWantsNetwork(pod) {
+				if err := oc.addLogicalPort(pod); err != nil {
+					klog.Errorf(err.Error())
+					oc.recordPodEvent(err, pod)
+				} else {
+					retryPods.Delete(pod.UID)
+				}
+			} else {
+				// No matter if a pod is ovn networked, or host networked, we still need to check for exgw
+				// annotations. If the pod is ovn networked and is in update reschedule, addLogicalPort will take
+				// care of updating the exgw updates
 				if oldPod.Annotations[routingNamespaceAnnotation] != pod.Annotations[routingNamespaceAnnotation] ||
 					oldPod.Annotations[routingNetworkAnnotation] != pod.Annotations[routingNetworkAnnotation] {
 					oc.deletePodExternalGW(oldPod)
 					if err := oc.addPodExternalGW(pod); err != nil {
 						klog.Errorf(err.Error())
 					}
-				}
-				return
-			}
-
-			_, retry := retryPods.Load(pod.UID)
-			if podScheduled(pod) && retry {
-				if err := oc.addLogicalPort(pod); err != nil {
-					klog.Errorf(err.Error())
-					oc.recordPodEvent(err, pod)
-				} else {
-					retryPods.Delete(pod.UID)
 				}
 			}
 		},
@@ -585,6 +586,7 @@ func (oc *Controller) WatchPods() {
 				oc.deletePodExternalGW(pod)
 				return
 			}
+			// deleteLogicalPort will take care of removing exgw for ovn networked pods
 			oc.deleteLogicalPort(pod)
 			retryPods.Delete(pod.UID)
 		},


### PR DESCRIPTION
If an ovn network pod was updated with exgw annotations, we were
ignoring it because it was not rescheduled and was not a host networked
pod. We should always be updating the exgw for an ovn networked pod
because the pod may be using multus annotations and not rely on being
host networked.

Signed-off-by: Tim Rozet <trozet@redhat.com>


**- How to verify it**
We have no way in our CI/KIND to create a multus host network attachment, so we can trick it and still exercise the same code path:
1. Deploy kind with at least 1 worker node
2. Create a pod in a namespace that will be used for exgw (i.e. create any basic pod in "exgw" namespace)
3. Create another basic pod in default namespace
4. Create an external docker container on the kind network. Add an IP local to that container on lo like 9.0.0.1
5. Add a route on the external docker container for the ip of pod in exgw via the IP of the node that exgw pod resides on
6. Attempt to ping from exgw pod to 9.0.0.1. This should fail.
7. Edit the basic pod in default namespace with these annotations:
```
k8s.v1.cni.cncf.io/network-status: "[{\"name\":\"blah\",\"interface\":\"net1\",\"ips\":[\"172.18.0.4\"],\"mac\":\"62:ff:69:f0:83:03\",\"dns\":{}}]"
k8s.ovn.org/routing-namespaces: exgw
k8s.ovn.org/routing-network: blah

```
Replace 172.18.0.4 above with the IP of your external docker container.

8. Verify you can now ping from exgw pod to 9.0.0.1.

Note this tricks ovn-k8s into thinking the basic pod has a multus attachment on the external network at 172.18.0.4, even though it doesn't. However since we have our external docker container as 172.18.0.4, the functional behavior is the same for ovn-kubernetes...aka accessing something external via a pod gw annotation.
