### PR TITLE
exec: use an exec helper object instead of a global

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
+++ b/go-controller/cmd/ovn-kube-util/app/nics-to-bridge.go
@@ -20,13 +20,14 @@ var NicsToBridgeCommand = cli.Command{
 			return fmt.Errorf("please specify list of nic interfaces")
 		}
 
-		if err := util.SetSpecificExec(kexec.New(), "ovs-vsctl"); err != nil {
+		exec, err := util.NewOVSVsctlExecHelper(kexec.New())
+		if err != nil {
 			return err
 		}
 
 		var errorList []error
 		for _, nic := range args.Slice() {
-			if _, err := util.NicToBridge(nic); err != nil {
+			if _, err := util.NicToBridge(exec, nic); err != nil {
 				errorList = append(errorList, err)
 			}
 		}
@@ -46,13 +47,14 @@ var BridgesToNicCommand = cli.Command{
 			return fmt.Errorf("please specify list of bridges")
 		}
 
-		if err := util.SetSpecificExec(kexec.New(), "ovs-vsctl"); err != nil {
+		exec, err := util.NewOVSVsctlExecHelper(kexec.New())
+		if err != nil {
 			return err
 		}
 
 		var errorList []error
 		for _, bridge := range args.Slice() {
-			if err := util.BridgeToNic(bridge); err != nil {
+			if err := util.BridgeToNic(exec, bridge); err != nil {
 				errorList = append(errorList, err)
 			}
 		}

--- a/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
@@ -26,7 +26,8 @@ var OvsExporterCommand = cli.Command{
 			bindAddress = "0.0.0.0:9310"
 		}
 
-		if err := util.SetExec(kexec.New()); err != nil {
+		exec, err := util.NewExecHelper(kexec.New())
+		if err != nil {
 			return err
 		}
 
@@ -34,10 +35,9 @@ var OvsExporterCommand = cli.Command{
 		mux.Handle("/metrics", promhttp.Handler())
 
 		// register ovs metrics that will be served off of /metrics path
-		metrics.RegisterOvsMetrics()
+		metrics.RegisterOvsMetrics(exec)
 
-		err := http.ListenAndServe(bindAddress, mux)
-		if err != nil {
+		if err := http.ListenAndServe(bindAddress, mux); err != nil {
 			klog.Exitf("Starting metrics server failed: %v", err)
 		}
 		return nil

--- a/go-controller/cmd/ovndbchecker/ovndbchecker.go
+++ b/go-controller/cmd/ovndbchecker/ovndbchecker.go
@@ -166,18 +166,19 @@ func runOvnKubeDBChecker(ctx *cli.Context) error {
 		}
 	}
 
-	exec := kexec.New()
-	_, err := config.InitConfig(ctx, exec, nil)
+	baseExec := kexec.New()
+	_, err := config.InitConfig(ctx, baseExec, nil)
 	if err != nil {
 		return err
 	}
 
-	if err = util.SetExec(exec); err != nil {
+	exec, err := util.NewExecHelper(baseExec)
+	if err != nil {
 		return fmt.Errorf("failed to initialize exec helper: %v", err)
 	}
 
 	stopChan := make(chan struct{})
-	ovndbmanager.RunDBChecker(stopChan)
+	ovndbmanager.RunDBChecker(exec, stopChan)
 	// run until cancelled
 	<-ctx.Context.Done()
 	close(stopChan)

--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"sync"
 	"syscall"
 
@@ -91,8 +92,10 @@ func runHybridOverlay(ctx *cli.Context) error {
 		return err
 	}
 
-	if err := util.SetExecWithoutOVS(exec); err != nil {
-		return err
+	if runtime.GOOS != "windows" {
+		if err := util.SetExec(exec); err != nil {
+			return err
+		}
 	}
 
 	if nodeName == "" {

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 		stopChan chan struct{}
 		wg       *sync.WaitGroup
 		fexec    *ovntest.FakeExec
+		exec     util.ExecHelper
 	)
 
 	BeforeEach(func() {
@@ -85,7 +86,9 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 		stopChan = make(chan struct{})
 		wg = &sync.WaitGroup{}
 		fexec = ovntest.NewFakeExec()
-		err := util.SetExec(fexec)
+
+		var err error
+		exec, err = util.NewExecHelper(fexec)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -117,6 +120,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			m, err := NewMaster(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -183,12 +187,14 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
+
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 			m, err := NewMaster(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -257,6 +263,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
+
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 
@@ -265,6 +272,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 			m, err := NewMaster(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -327,6 +335,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 			m, err := NewMaster(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -410,7 +419,10 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				&v1.NodeList{Items: []v1.Node{newTestNode(nodeName, "linux", nodeSubnet, "", nodeHOMAC)}},
 			}...)
 
-			_, err := config.InitConfig(ctx, nil, nil)
+			fexec := ovntest.NewFakeExec()
+			_, err := config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+			exec, err := util.NewExecHelper(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -418,6 +430,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 			m, err := NewMaster(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -502,6 +515,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			addLinuxNodeCommands(fexec, nodeHOMAC, nodeName, nodeHOIP)
 			_, err := config.InitConfig(ctx, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
+
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
 			k := &kube.Kube{KClient: fakeClient}
@@ -509,6 +523,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 			m, err := NewMaster(
 				k,
+				exec,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),

--- a/go-controller/hybrid-overlay/pkg/controller/node.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node.go
@@ -73,6 +73,7 @@ func podChanged(old, new interface{}) bool {
 // NewNode Returns a new Node
 func NewNode(
 	kube kube.Interface,
+	exec util.ExecHelper,
 	nodeName string,
 	nodeInformer cache.SharedIndexInformer,
 	podInformer cache.SharedIndexInformer,
@@ -82,7 +83,7 @@ func NewNode(
 	nodeLister := listers.NewNodeLister(nodeInformer.GetIndexer())
 	podLister := listers.NewPodLister(podInformer.GetIndexer())
 
-	controller, err := newNodeController(kube, nodeName, nodeLister, podLister)
+	controller, err := newNodeController(kube, exec, nodeName, nodeLister, podLister)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -175,6 +175,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 	var (
 		app      *cli.App
 		fexec    *ovntest.FakeExec
+		exec     util.ExecHelper
 		netns    ns.NetNS
 		stopChan chan struct{}
 		wg       *sync.WaitGroup
@@ -195,8 +196,9 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		stopChan = make(chan struct{})
 		wg = &sync.WaitGroup{}
 
+		var err error
 		fexec = ovntest.NewLooseCompareFakeExec()
-		err := util.SetExec(fexec)
+		exec, err = util.NewExecHelper(fexec)
 		Expect(err).NotTo(HaveOccurred())
 
 		netns, err = testutils.NewNS()
@@ -251,6 +253,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -300,6 +303,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -348,6 +352,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -397,6 +402,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -452,6 +458,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -504,6 +511,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -555,6 +563,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
@@ -628,6 +637,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
+				exec,
 				thisNode,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),

--- a/go-controller/hybrid-overlay/pkg/controller/node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_windows.go
@@ -36,6 +36,7 @@ type NodeController struct {
 // newNodeController returns a node handler that listens for node events
 // so that Add/Update/Delete events are appropriately handled.
 func newNodeController(kube kube.Interface,
+	exec util.ExecHelper,
 	nodeName string,
 	nodeLister listers.NodeLister,
 	podLister listers.PodLister,

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -88,7 +88,7 @@ var startE2ETimeStampUpdaterOnce sync.Once
 
 // RegisterMasterMetrics registers some ovnkube master metrics with the Prometheus
 // registry
-func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
+func RegisterMasterMetrics(exec util.ExecHelper, nbClient, sbClient goovn.Client) {
 	registerMasterMetricsOnce.Do(func() {
 		// ovnkube-master metrics
 		// the updater for this metric is activated
@@ -122,7 +122,7 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 				Name:      "skipped_nbctl_daemon_total",
 				Help:      "The number of times we skipped using ovn-nbctl daemon and directly interacted with OVN NB DB",
 			}, func() float64 {
-				return float64(util.SkippedNbctlDaemonCounter)
+				return float64(exec.GetSkippedNbctlDaemonCount())
 			}))
 		prometheus.MustRegister(MetricMasterReadyDuration)
 		prometheus.MustRegister(metricOvnCliLatency)

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -75,7 +75,7 @@ func registerCoverageShowMetrics(target string, metricNamespace string, metricSu
 }
 
 // getCoverageShowOutputMap obtains the coverage/show metric values for the specified component.
-func getCoverageShowOutputMap(component string) (map[string]string, error) {
+func getCoverageShowOutputMap(exec util.ExecHelper, component string) (map[string]string, error) {
 	var stdout, stderr string
 	var err error
 
@@ -87,11 +87,11 @@ func getCoverageShowOutputMap(component string) (map[string]string, error) {
 	}()
 
 	if component == ovnController {
-		stdout, stderr, err = util.RunOVNControllerAppCtl("coverage/show")
+		stdout, stderr, err = exec.RunOVNControllerAppCtl("coverage/show")
 	} else if component == ovnNorthd {
-		stdout, stderr, err = util.RunOVNNorthAppCtl("coverage/show")
+		stdout, stderr, err = exec.RunOVNNorthAppCtl("coverage/show")
 	} else if component == ovsVswitchd {
-		stdout, stderr, err = util.RunOvsVswitchdAppCtl("coverage/show")
+		stdout, stderr, err = exec.RunOvsVswitchdAppCtl("coverage/show")
 	} else {
 		return nil, fmt.Errorf("component is unknown, and it isn't %s, %s, or %s",
 			ovnNorthd, ovnController, ovsVswitchd)
@@ -114,10 +114,10 @@ func getCoverageShowOutputMap(component string) (map[string]string, error) {
 
 // coverageShowMetricsUpdater updates the metric
 // by obtaining values from getCoverageShowOutputMap for specified component.
-func coverageShowMetricsUpdater(component string) {
+func coverageShowMetricsUpdater(exec util.ExecHelper, component string) {
 	for {
 		time.Sleep(30 * time.Second)
-		coverageShowOutputMap, err := getCoverageShowOutputMap(component)
+		coverageShowOutputMap, err := getCoverageShowOutputMap(exec, component)
 		if err != nil {
 			klog.Errorf("%s", err.Error())
 			continue
@@ -204,8 +204,8 @@ func StartOVNMetricsServer(bindAddress string) {
 	}, 5*time.Second, utilwait.NeverStop)
 }
 
-func RegisterOvnMetrics(clientset *kubernetes.Clientset, k8sNodeName string) {
-	go RegisterOvnDBMetrics(clientset, k8sNodeName)
-	go RegisterOvnControllerMetrics()
-	go RegisterOvnNorthdMetrics(clientset, k8sNodeName)
+func RegisterOvnMetrics(exec util.ExecHelper, clientset *kubernetes.Clientset, k8sNodeName string) {
+	go RegisterOvnDBMetrics(exec, clientset, k8sNodeName)
+	go RegisterOvnControllerMetrics(exec)
+	go RegisterOvnNorthdMetrics(exec, clientset, k8sNodeName)
 }

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -166,10 +166,9 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 `,
 		})
 
-		err := util.SetExec(fexec)
+		_, err := config.InitConfig(ctx, fexec, nil)
 		Expect(err).NotTo(HaveOccurred())
-
-		_, err = config.InitConfig(ctx, fexec, nil)
+		exec, err := util.NewExecHelper(fexec)
 		Expect(err).NotTo(HaveOccurred())
 
 		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{
@@ -191,7 +190,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 			wf.Shutdown()
 		}()
 
-		n := NewNode(nil, wf, existingNode.Name, stop, record.NewFakeRecorder(0))
+		n := NewNode(nil, exec, wf, existingNode.Name, stop, record.NewFakeRecorder(0))
 
 		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -40,6 +40,7 @@ func initFakeNodePortWatcher(fakeOvnNode *FakeOVNNode, iptV4, iptV6 util.IPTable
 	Expect(err).NotTo(HaveOccurred())
 
 	fNPW := localPortWatcherData{
+		exec:         fakeOvnNode.exec,
 		recorder:     fakeOvnNode.recorder,
 		gatewayIPv4:  v4localnetGatewayIP,
 		localAddrSet: getFakeLocalAddrs(),

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -19,15 +19,15 @@ import (
 // appropriate IP and MAC address on it. All the traffic from this node's hostNetwork
 // Pod towards cluster service ip whose backend is the node itself is forwarded to the
 // ovn-k8s-gw0 port after SNATing by the OVN's distributed gateway port.
-func setupLocalNodeAccessBridge(nodeName string, subnets []*net.IPNet) error {
+func setupLocalNodeAccessBridge(exec util.ExecHelper, nodeName string, subnets []*net.IPNet) error {
 	localBridgeName := "br-local"
-	_, stderr, err := util.RunOVSVsctl("--may-exist", "add-br", localBridgeName)
+	_, stderr, err := exec.RunOVSVsctl("--may-exist", "add-br", localBridgeName)
 	if err != nil {
 		return fmt.Errorf("failed to create bridge %s, stderr:%s (%v)",
 			localBridgeName, stderr, err)
 	}
 
-	_, _, err = bridgedGatewayNodeSetup(nodeName, localBridgeName, localBridgeName,
+	_, _, err = bridgedGatewayNodeSetup(exec, nodeName, localBridgeName, localBridgeName,
 		util.LocalNetworkName, true)
 	if err != nil {
 		return fmt.Errorf("failed while setting up local node access bridge : %v", err)
@@ -45,7 +45,7 @@ func setupLocalNodeAccessBridge(nodeName string, subnets []*net.IPNet) error {
 		macAddress = util.IPAddrToHWAddr(net.ParseIP(util.V6NodeLocalNatSubnetNextHop)).String()
 	}
 
-	_, stderr, err = util.RunOVSVsctl(
+	_, stderr, err = exec.RunOVSVsctl(
 		"--may-exist", "add-port", localBridgeName, localnetGatewayNextHopPort,
 		"--", "set", "interface", localnetGatewayNextHopPort, "type=internal",
 		"mtu_request="+fmt.Sprintf("%d", config.Default.MTU),

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -83,16 +83,16 @@ func getDefaultIfAddr(defaultGatewayIntf string) (*net.IPNet, *net.IPNet, error)
 	return v4IfAddr, v6IfAddr, nil
 }
 
-func getIntfName(gatewayIntf string) (string, error) {
+func getIntfName(exec util.ExecHelper, gatewayIntf string) (string, error) {
 	// The given (or autodetected) interface is an OVS bridge and this could be
 	// created by us using util.NicToBridge() or it was pre-created by the user.
 
 	// Is intfName a port of gatewayIntf?
-	intfName, err := util.GetNicName(gatewayIntf)
+	intfName, err := util.GetNicName(exec, gatewayIntf)
 	if err != nil {
 		return "", err
 	}
-	_, stderr, err := util.RunOVSVsctl("get", "interface", intfName, "ofport")
+	_, stderr, err := exec.RunOVSVsctl("get", "interface", intfName, "ofport")
 	if err != nil {
 		return "", fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
 			intfName, stderr, err)

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -102,16 +101,8 @@ func setupOVNNode(node *kapi.Node) error {
 }
 
 func isOVNControllerReady(name string) (bool, error) {
-	runDir := util.GetOvnRunDir()
-
-	pid, err := ioutil.ReadFile(runDir + "ovn-controller.pid")
-	if err != nil {
-		return false, fmt.Errorf("unknown pid for ovn-controller process: %v", err)
-	}
-
-	err = wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		ctlFile := runDir + fmt.Sprintf("ovn-controller.%s.ctl", strings.TrimSuffix(string(pid), "\n"))
-		ret, _, err := util.RunOVSAppctl("-t", ctlFile, "connection-status")
+	err := wait.PollImmediate(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+		ret, _, err := util.RunOVNControllerAppCtl("connection-status")
 		if err == nil {
 			klog.Infof("Node %s connection status = %s", name, ret)
 			return ret == "connected", nil

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -61,13 +61,12 @@ var _ = Describe("Node Operations", func() {
 					nodeIP, interval, ofintval, nodeName),
 			})
 
-			err := util.SetExec(fexec)
+			_, err := config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+			exec, err := util.NewExecHelper(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = setupOVNNode(&node)
+			err = setupOVNNode(exec, &node)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
@@ -128,14 +127,13 @@ var _ = Describe("Node Operations", func() {
 					"%s options:dst_port=%d", encapUUID, encapPort),
 			})
 
-			err := util.SetExec(fexec)
-			Expect(err).NotTo(HaveOccurred())
-
-			_, err = config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			config.Default.EncapPort = encapPort
+			exec, err := util.NewExecHelper(fexec)
+			Expect(err).NotTo(HaveOccurred())
 
-			err = setupOVNNode(&node)
+			err = setupOVNNode(exec, &node)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -28,14 +28,16 @@ type FakeOVNNode struct {
 	fakeEgressClient   *egressfirewallfake.Clientset
 	fakeCRDClient      *apiextensionsfake.Clientset
 	fakeExec           *ovntest.FakeExec
+	exec               util.ExecHelper
 }
 
 func NewFakeOVNNode(fexec *ovntest.FakeExec) *FakeOVNNode {
-	err := util.SetExec(fexec)
+	exec, err := util.NewExecHelper(fexec)
 	Expect(err).NotTo(HaveOccurred())
 
 	return &FakeOVNNode{
 		fakeExec: fexec,
+		exec:     exec,
 		recorder: record.NewFakeRecorder(1),
 	}
 }
@@ -72,5 +74,5 @@ func (o *FakeOVNNode) init() {
 	o.watcher, err = factory.NewWatchFactory(o.fakeClient, o.fakeEgressIPClient, o.fakeEgressClient, o.fakeCRDClient)
 	Expect(err).NotTo(HaveOccurred())
 
-	o.node = NewNode(o.fakeClient, o.watcher, fakeNodeName, o.stopChan, o.recorder)
+	o.node = NewNode(o.fakeClient, o.exec, o.watcher, fakeNodeName, o.stopChan, o.recorder)
 }

--- a/go-controller/pkg/ovn/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set_test.go
@@ -40,10 +40,10 @@ var _ = Describe("OVN Address Set operations", func() {
 		app.Flags = config.Flags
 
 		fexec = ovntest.NewFakeExec()
-		err := util.SetExec(fexec)
+		exec, err := util.NewExecHelper(fexec)
 		Expect(err).NotTo(HaveOccurred())
 
-		asFactory = NewOvnAddressSetFactory()
+		asFactory = NewOvnAddressSetFactory(exec)
 	})
 
 	Context("when iterating address sets", func() {

--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -25,9 +25,9 @@ func hashedPortGroup(s string) string {
 	return hashForOVN(s)
 }
 
-func createPortGroup(name string, hashName string) (string, error) {
+func createPortGroup(exec util.ExecHelper, name string, hashName string) (string, error) {
 	klog.V(5).Infof("createPortGroup with %s", name)
-	portGroup, stderr, err := util.RunOVNNbctl("--data=bare",
+	portGroup, stderr, err := exec.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "port_group",
 		fmt.Sprintf("name=%s", hashName))
 	if err != nil {
@@ -39,7 +39,7 @@ func createPortGroup(name string, hashName string) (string, error) {
 		return portGroup, nil
 	}
 
-	portGroup, stderr, err = util.RunOVNNbctl("create", "port_group",
+	portGroup, stderr, err = exec.RunOVNNbctl("create", "port_group",
 		fmt.Sprintf("name=%s", hashName),
 		fmt.Sprintf("external-ids:name=%s", name))
 	if err != nil {
@@ -50,10 +50,10 @@ func createPortGroup(name string, hashName string) (string, error) {
 	return portGroup, nil
 }
 
-func deletePortGroup(hashName string) {
+func deletePortGroup(exec util.ExecHelper, hashName string) {
 	klog.V(5).Infof("deletePortGroup %s", hashName)
 
-	portGroup, stderr, err := util.RunOVNNbctl("--data=bare",
+	portGroup, stderr, err := exec.RunOVNNbctl("--data=bare",
 		"--no-heading", "--columns=_uuid", "find", "port_group",
 		fmt.Sprintf("name=%s", hashName))
 	if err != nil {
@@ -66,7 +66,7 @@ func deletePortGroup(hashName string) {
 		return
 	}
 
-	_, stderr, err = util.RunOVNNbctl("--if-exists", "destroy",
+	_, stderr, err = exec.RunOVNNbctl("--if-exists", "destroy",
 		"port_group", portGroup)
 	if err != nil {
 		klog.Errorf("Failed to destroy port_group %s, stderr: %q, (%v)",

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -40,7 +40,7 @@ const (
 
 func (ovn *Controller) getOvnGateways() ([]string, string, error) {
 	// Return all created gateways.
-	out, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+	out, stderr, err := ovn.exec.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=name", "find",
 		"logical_router",
 		"options:chassis!=null")
@@ -48,13 +48,13 @@ func (ovn *Controller) getOvnGateways() ([]string, string, error) {
 }
 
 func (ovn *Controller) getGatewayPhysicalIPs(gatewayRouter string) ([]string, error) {
-	physicalIPs, _, err := util.RunOVNNbctl("get", "logical_router",
+	physicalIPs, _, err := ovn.exec.RunOVNNbctl("get", "logical_router",
 		gatewayRouter, "external_ids:physical_ips")
 	if err == nil {
 		return strings.Split(physicalIPs, ","), nil
 	}
 
-	physicalIP, _, err := util.RunOVNNbctl("get", "logical_router",
+	physicalIP, _, err := ovn.exec.RunOVNNbctl("get", "logical_router",
 		gatewayRouter, "external_ids:physical_ip")
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (ovn *Controller) getGatewayPhysicalIPs(gatewayRouter string) ([]string, er
 
 func (ovn *Controller) getGatewayLoadBalancer(gatewayRouter string, protocol kapi.Protocol) (string, error) {
 	externalIDKey := string(protocol) + "_lb_gateway_router"
-	loadBalancer, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+	loadBalancer, _, err := ovn.exec.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "load_balancer",
 		"external_ids:"+externalIDKey+"="+
 			gatewayRouter)
@@ -167,8 +167,8 @@ func (ovn *Controller) deleteExternalVIPs(service *kapi.Service, svcPort kapi.Se
 }
 
 // getGatewayLoadBalancers find TCP, SCTP, UDP load-balancers from gateway router.
-func getGatewayLoadBalancers(gatewayRouter string) (string, string, string, error) {
-	lbTCP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+func getGatewayLoadBalancers(exec util.ExecHelper, gatewayRouter string) (string, string, string, error) {
+	lbTCP, stderr, err := exec.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "load_balancer",
 		"external_ids:TCP_lb_gateway_router="+gatewayRouter)
 	if err != nil {
@@ -176,7 +176,7 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, string, erro
 			"load balancer, stderr: %q, error: %v", gatewayRouter, stderr, err)
 	}
 
-	lbUDP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+	lbUDP, stderr, err := exec.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "load_balancer",
 		"external_ids:UDP_lb_gateway_router="+gatewayRouter)
 	if err != nil {
@@ -184,7 +184,7 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, string, erro
 			"load balancer, stderr: %q, error: %v", gatewayRouter, stderr, err)
 	}
 
-	lbSCTP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+	lbSCTP, stderr, err := exec.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=_uuid", "find", "load_balancer",
 		"external_ids:SCTP_lb_gateway_router="+gatewayRouter)
 	if err != nil {

--- a/go-controller/pkg/ovn/gress_policy_test.go
+++ b/go-controller/pkg/ovn/gress_policy_test.go
@@ -109,7 +109,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		gressPolicy := newGressPolicy(knet.PolicyTypeIngress, 5, "testing", "test")
+		gressPolicy := newGressPolicy(nil, knet.PolicyTypeIngress, 5, "testing", "test")
 		for _, ipBlock := range tc.ipBlocks {
 			gressPolicy.addIPBlock(ipBlock)
 		}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -975,10 +975,9 @@ var _ = Describe("Gateway Init Operations", func() {
 			egressIPFakeClient := &egressipfake.Clientset{}
 
 			fexec := ovntest.NewFakeExec()
-			err := util.SetExec(fexec)
+			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
-
-			_, err = config.InitConfig(ctx, fexec, nil)
+			exec, err := util.NewExecHelper(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient, egressIPFakeClient, egressFirewallFakeClient}, &testNode)
@@ -1099,7 +1098,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			f, err = factory.NewWatchFactory(fakeClient, egressIPFakeClient, egressFirewallFakeClient, crdFakeClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			clusterController := NewOvnController(fakeClient, egressIPFakeClient, egressFirewallFakeClient, f, stopChan,
+			clusterController := NewOvnController(fakeClient, exec, egressIPFakeClient, egressFirewallFakeClient, f, stopChan,
 				newFakeAddressSetFactory(), ovntest.NewMockOVNClient(goovn.DBNB),
 				ovntest.NewMockOVNClient(goovn.DBSB), record.NewFakeRecorder(0))
 			Expect(clusterController).NotTo(BeNil())

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -36,6 +36,7 @@ type FakeOVN struct {
 	controller         *Controller
 	stopChan           chan struct{}
 	fakeExec           *ovntest.FakeExec
+	exec               util.ExecHelper
 	asf                *fakeAddressSetFactory
 	fakeRecorder       *record.FakeRecorder
 	ovnNBClient        goovn.Client
@@ -43,10 +44,12 @@ type FakeOVN struct {
 }
 
 func NewFakeOVN(fexec *ovntest.FakeExec) *FakeOVN {
-	err := util.SetExec(fexec)
+	exec, err := util.NewExecHelper(fexec)
 	Expect(err).NotTo(HaveOccurred())
+
 	return &FakeOVN{
 		fakeExec:     fexec,
+		exec:         exec,
 		asf:          newFakeAddressSetFactory(),
 		fakeRecorder: record.NewFakeRecorder(10),
 	}
@@ -99,7 +102,7 @@ func (o *FakeOVN) init() {
 	Expect(err).NotTo(HaveOccurred())
 	o.ovnNBClient = ovntest.NewMockOVNClient(goovn.DBNB)
 	o.ovnSBClient = ovntest.NewMockOVNClient(goovn.DBSB)
-	o.controller = NewOvnController(o.fakeClient, o.fakeEgressIPClient, o.fakeEgressClient, o.watcher,
+	o.controller = NewOvnController(o.fakeClient, o.exec, o.fakeEgressIPClient, o.fakeEgressClient, o.watcher,
 		o.stopChan, o.asf, o.ovnNBClient,
 		o.ovnSBClient, o.fakeRecorder)
 	o.controller.multicastSupport = true

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -45,7 +45,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	}
 
 	// get the list of logical ports from OVN
-	output, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+	output, stderr, err := oc.exec.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=name", "find", "logical_switch_port", "external_ids:pod=true")
 	if err != nil {
 		klog.Errorf("Error in obtaining list of logical ports, "+
@@ -58,7 +58,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 		if _, ok := expectedLogicalPorts[existingPort]; !ok {
 			// not found, delete this logical port
 			klog.Infof("Stale logical port found: %s. This logical port will be deleted.", existingPort)
-			out, stderr, err := util.RunOVNNbctl("--if-exists", "lsp-del",
+			out, stderr, err := oc.exec.RunOVNNbctl("--if-exists", "lsp-del",
 				existingPort)
 			if err != nil {
 				klog.Errorf("Error in deleting pod's logical port "+
@@ -88,7 +88,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 
 	// Remove the port from the default deny multicast policy
 	if oc.multicastSupport {
-		if err := podDeleteDefaultDenyMulticastPolicy(portInfo); err != nil {
+		if err := oc.podDeleteDefaultDenyMulticastPolicy(portInfo); err != nil {
 			klog.Errorf(err.Error())
 		}
 	}
@@ -462,7 +462,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 
 	// Enforce the default deny multicast policy
 	if oc.multicastSupport {
-		if err = podAddDefaultDenyMulticastPolicy(portInfo); err != nil {
+		if err = oc.podAddDefaultDenyMulticastPolicy(portInfo); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1372,13 +1372,16 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 	var (
 		fExec     *ovntest.FakeExec
 		asFactory *fakeAddressSetFactory
+		exec      util.ExecHelper
 	)
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
+
+		var err error
 		fExec = ovntest.NewLooseCompareFakeExec()
-		err := util.SetExec(fExec)
+		exec, err = util.NewExecHelper(fExec)
 		Expect(err).NotTo(HaveOccurred())
 
 		asFactory = newFakeAddressSetFactory()
@@ -1400,7 +1403,7 @@ var _ = Describe("OVN NetworkPolicy Low-Level Operations", func() {
 			},
 		}
 
-		gp := newGressPolicy(knet.PolicyTypeIngress, 0, policy.Namespace, policy.Name)
+		gp := newGressPolicy(exec, knet.PolicyTypeIngress, 0, policy.Namespace, policy.Name)
 		err := gp.ensurePeerAddressSet(asFactory)
 		Expect(err).NotTo(HaveOccurred())
 		asName := getIPv4ASName(gp.peerAddressSet.GetName())

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -137,7 +137,7 @@ func (ovn *Controller) syncServices(services []interface{}) {
 	type ovnACLData struct {
 		Data [][]interface{}
 	}
-	data, stderr, err := util.RunOVNNbctl("--columns=name,_uuid", "--format=json", "find", "acl", "action=reject")
+	data, stderr, err := ovn.exec.RunOVNNbctl("--columns=name,_uuid", "--format=json", "find", "acl", "action=reject")
 	if err != nil {
 		klog.Errorf("Error while querying ACLs with reject action: %s, %v", stderr, err)
 	} else {

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -32,8 +32,8 @@ func intToIP(i *big.Int) net.IP {
 // GetNodeLogicalRouterNetworkInfo returns the IPs (IPv4 and/or IPv6) of the provided node's logical router
 // Expected output from the ovn-nbctl command, which will need to be parsed is:
 // `100.64.1.1/29 fd98:1::/125`
-func GetNodeGatewayRouterNetInfo(nodeName string) ([]net.IP, error) {
-	stdout, _, err := RunOVNNbctl(
+func GetNodeGatewayRouterNetInfo(exec ExecHelper, nodeName string) ([]net.IP, error) {
+	stdout, _, err := exec.RunOVNNbctl(
 		"--format=table",
 		"--data=bare",
 		"--no-heading",
@@ -101,8 +101,8 @@ func GetPortAddresses(portName string, ovnNBClient goovn.Client) (net.HardwareAd
 }
 
 // GetOVSPortMACAddress returns the MAC address of a given OVS port
-func GetOVSPortMACAddress(portName string) (net.HardwareAddr, error) {
-	macAddress, stderr, err := RunOVSVsctl("--if-exists", "get",
+func GetOVSPortMACAddress(exec ExecHelper, portName string) (net.HardwareAddr, error) {
+	macAddress, stderr, err := exec.RunOVSVsctl("--if-exists", "get",
 		"interface", portName, "mac_in_use")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get MAC address for %q, stderr: %q, error: %v",

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -150,7 +150,7 @@ func TestGetOVSPortMACAddress(t *testing.T) {
 	// below is defined in ovs.go
 	runCmdExecRunner = mockExecRunner
 	// note runner is defined in ovs.go file
-	runner = &execHelper{exec: mockKexecIface}
+	runner := &execHelper{exec: mockKexecIface}
 
 	tests := []struct {
 		desc                    string
@@ -200,7 +200,7 @@ func TestGetOVSPortMACAddress(t *testing.T) {
 			}
 			ifaceCall.Once()
 
-			res, err := GetOVSPortMACAddress(tc.input)
+			res, err := GetOVSPortMACAddress(runner, tc.input)
 			t.Log(res, err)
 			if tc.errExpected {
 				assert.Error(t, err)

--- a/go-controller/pkg/util/nicstobridge_test.go
+++ b/go-controller/pkg/util/nicstobridge_test.go
@@ -25,7 +25,7 @@ func TestGetNicName(t *testing.T) {
 	// below is defined in ovs.go
 	runCmdExecRunner = mockExecRunner
 	// note runner is defined in ovs.go file
-	runner = &execHelper{exec: mockKexecIface}
+	runner := &execHelper{exec: mockKexecIface}
 	tests := []struct {
 		desc                string
 		errMatch            error
@@ -168,7 +168,7 @@ func TestGetNicName(t *testing.T) {
 				call.Once()
 			}
 
-			res, err := GetNicName(tc.inpBrName)
+			res, err := GetNicName(runner, tc.inpBrName)
 
 			t.Log(res, err)
 
@@ -490,7 +490,7 @@ func TestNicToBridge(t *testing.T) {
 	// below is defined in ovs.go
 	runCmdExecRunner = mockExecRunner
 	// note runner is defined in ovs.go file
-	runner = &execHelper{exec: mockKexecIface}
+	runner := &execHelper{exec: mockKexecIface}
 
 	mockNetLinkOps := new(mocks.NetLinkOps)
 	mockLink := new(netlink_mocks.Link)
@@ -678,7 +678,7 @@ func TestNicToBridge(t *testing.T) {
 				call.Once()
 			}
 
-			res, err := NicToBridge(tc.inpIface)
+			res, err := NicToBridge(runner, tc.inpIface)
 			t.Log(res, err)
 			if tc.errExp {
 				assert.Error(t, err)
@@ -702,7 +702,7 @@ func TestBridgeToNic(t *testing.T) {
 	// below is defined in ovs.go
 	runCmdExecRunner = mockExecRunner
 	// note runner is defined in ovs.go file
-	runner = &execHelper{exec: mockKexecIface}
+	runner := &execHelper{exec: mockKexecIface}
 
 	mockNetLinkOps := new(mocks.NetLinkOps)
 	mockLink := new(netlink_mocks.Link)
@@ -1325,7 +1325,7 @@ func TestBridgeToNic(t *testing.T) {
 				call.Once()
 			}
 
-			err := BridgeToNic(tc.inpBridge)
+			err := BridgeToNic(runner, tc.inpBridge)
 			t.Log(err)
 			if tc.errExp {
 				assert.Error(t, err)

--- a/go-controller/pkg/util/nicstobridge_test.go
+++ b/go-controller/pkg/util/nicstobridge_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"testing"
 
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1334,6 +1336,69 @@ func TestBridgeToNic(t *testing.T) {
 			mockExecRunner.AssertExpectations(t)
 			mockNetLinkOps.AssertExpectations(t)
 			mockLink.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRunningPlatform(t *testing.T) {
+	// Below is defined in nicstobridge.go file
+	appFs := afero.NewMemMapFs()
+	appFs.MkdirAll("/etc", 0755)
+	tests := []struct {
+		desc            string
+		fileContent     []byte
+		filePermissions os.FileMode
+		expOut          string
+		expErr          error
+	}{
+		{
+			desc:   "ReadFile returns error",
+			expErr: fmt.Errorf("failed to parse file"),
+		},
+		{
+			desc:            "failed to find platform name",
+			expErr:          fmt.Errorf("failed to find the platform name"),
+			fileContent:     []byte("NAME="),
+			filePermissions: 0755,
+		},
+		{
+			desc:            "platform name returned is RHEL",
+			expOut:          "RHEL",
+			fileContent:     []byte("NAME=\"CentOS Linux\""),
+			filePermissions: 0755,
+		},
+		{
+			desc:            "platform name returned is Ubuntu",
+			expOut:          "Ubuntu",
+			fileContent:     []byte("NAME=\"Debian\""),
+			filePermissions: 0755,
+		},
+		{
+			desc:            "platform name returned is Photon",
+			expOut:          "Photon",
+			fileContent:     []byte("NAME=\"VMware\""),
+			filePermissions: 0755,
+		},
+		{
+			desc:            "unknown platform",
+			expErr:          fmt.Errorf("unknown platform"),
+			fileContent:     []byte("NAME=\"blah\""),
+			filePermissions: 0755,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			if tc.fileContent != nil && tc.filePermissions != 0 {
+				afero.WriteFile(appFs, "/etc/os-release", tc.fileContent, tc.filePermissions)
+				defer appFs.Remove("/etc/os-release")
+			}
+			res, err := runningPlatform(appFs)
+			t.Log(res, err)
+			if tc.expErr != nil {
+				assert.Contains(t, err.Error(), tc.expErr.Error())
+			} else {
+				assert.Equal(t, res, tc.expOut)
+			}
 		})
 	}
 }

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -51,26 +51,13 @@ const (
 	sbdbCtlSock     = "ovnsb_db.ctl"
 	OvnNbdbLocation = "/etc/ovn/ovnnb_db.db"
 	OvnSbdbLocation = "/etc/ovn/ovnsb_db.db"
-)
 
-var (
-	// These are variables (not constants) so that testcases can modify them
 	ovsRunDir string = "/var/run/openvswitch/"
 	ovnRunDir string = "/var/run/ovn/"
-
-	savedOVSRunDir = ovsRunDir
-	savedOVNRunDir = ovnRunDir
 )
 
 var ovnCmdRetryCount = 200
 var AppFs = afero.NewOsFs()
-
-// PrepareTestConfig restores default config values. Used by testcases to
-// provide a pristine environment between tests.
-func PrepareTestConfig() {
-	ovsRunDir = savedOVSRunDir
-	ovnRunDir = savedOVNRunDir
-}
 
 // this metric is set only for the ovnkube in master mode since 99.9% of
 // all the ovn-nbctl/ovn-sbctl calls occur on the master
@@ -604,13 +591,13 @@ func RunOVNControllerAppCtl(args ...string) (string, string, error) {
 // RunOvsVswitchdAppCtl runs an 'ovs-appctl -t /var/run/openvsiwthc/ovs-vswitchd.pid.ctl command'
 func RunOvsVswitchdAppCtl(args ...string) (string, string, error) {
 	var cmdArgs []string
-	pid, err := afero.ReadFile(AppFs, savedOVSRunDir+"ovs-vswitchd.pid")
+	pid, err := afero.ReadFile(AppFs, ovsRunDir+"ovs-vswitchd.pid")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get ovs-vswitch pid : %v", err)
 	}
 	cmdArgs = []string{
 		"-t",
-		savedOVSRunDir + fmt.Sprintf("ovs-vswitchd.%s.ctl", strings.TrimSpace(string(pid))),
+		ovsRunDir + fmt.Sprintf("ovs-vswitchd.%s.ctl", strings.TrimSpace(string(pid))),
 	}
 	cmdArgs = append(cmdArgs, args...)
 	stdout, stderr, err := runOVNretry(runner.appctlPath, nil, cmdArgs...)

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -520,7 +520,7 @@ func RunOVNNorthAppCtl(args ...string) (string, string, error) {
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
 }
 
-// RunOVNControllerAppCtl runs an 'ovs-appctl -t ovn-controller.pid.ctl command'.
+// RunOVNControllerAppCtl runs an 'ovn-appctl -t ovn-controller.pid.ctl command'.
 func RunOVNControllerAppCtl(args ...string) (string, string, error) {
 	var cmdArgs []string
 	pid, err := afero.ReadFile(AppFs, ovnRunDir+"ovn-controller.pid")
@@ -605,11 +605,6 @@ func ReplaceOFFlows(bridgeName string, flows []string) (string, string, error) {
 	cmd.SetStdin(stdin)
 	stdout, stderr, err := runCmd(cmd, runner.ofctlPath, args...)
 	return strings.Trim(stdout.String(), "\" \n"), stderr.String(), err
-}
-
-// GetOvnRunDir returns the OVN's rundir.
-func GetOvnRunDir() string {
-	return ovnRunDir
 }
 
 // ovsdb-server(5) says a clustered database is connected if the server

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -286,13 +286,6 @@ func SetSpecificExec(exec kexec.Interface, commands ...string) error {
 	return nil
 }
 
-// GetExec returns the exec interface which can be used for running commands directly.
-// Only use for passing an exec interface into pkg/config which cannot call this
-// function directly because this module imports pkg/config already.
-func GetExec() kexec.Interface {
-	return runner.exec
-}
-
 var runCounter uint64
 
 func runCmd(cmd kexec.Cmd, cmdPath string, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -40,10 +40,6 @@ const (
 	powershellCommand  = "powershell"
 	netshCommand       = "netsh"
 	routeCommand       = "route"
-	osRelease          = "/etc/os-release"
-	rhel               = "RHEL"
-	ubuntu             = "Ubuntu"
-	windowsOS          = "windows"
 )
 
 const (
@@ -62,43 +58,6 @@ var AppFs = afero.NewOsFs()
 // this metric is set only for the ovnkube in master mode since 99.9% of
 // all the ovn-nbctl/ovn-sbctl calls occur on the master
 var MetricOvnCliLatency *prometheus.HistogramVec
-
-func runningPlatform() (string, error) {
-	if runtime.GOOS == windowsOS {
-		return windowsOS, nil
-	}
-	fileContents, err := afero.ReadFile(AppFs, osRelease)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse file %s (%v)", osRelease, err)
-	}
-
-	var platform string
-	ss := strings.Split(string(fileContents), "\n")
-	for _, pair := range ss {
-		keyValue := strings.Split(pair, "=")
-		if len(keyValue) == 2 {
-			if keyValue[0] == "Name" || keyValue[0] == "NAME" {
-				platform = keyValue[1]
-				break
-			}
-		}
-	}
-
-	if platform == "" {
-		return "", fmt.Errorf("failed to find the platform name")
-	}
-
-	if strings.Contains(platform, "Fedora") ||
-		strings.Contains(platform, "Red Hat") || strings.Contains(platform, "CentOS") {
-		return rhel, nil
-	} else if strings.Contains(platform, "Debian") ||
-		strings.Contains(platform, ubuntu) {
-		return ubuntu, nil
-	} else if strings.Contains(platform, "VMware") {
-		return "Photon", nil
-	}
-	return "", fmt.Errorf("unknown platform")
-}
 
 // Exec runs various OVN and OVS utilities
 type execHelper struct {

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -357,8 +357,6 @@ func TestRunOVNNorthAppCtl(t *testing.T) {
 	runCmdExecRunner = mockExecRunner
 	// note runner is defined in ovs.go file
 	runner = &execHelper{exec: mockKexecIface}
-	// note runner.ovndir is defined in ovs.go file and so is ovnRunDir var with an initial value
-	runner.ovnRunDir = ovnRunDir
 
 	tests := []struct {
 		desc                    string
@@ -445,8 +443,6 @@ func TestRunOVNControllerAppCtl(t *testing.T) {
 	runCmdExecRunner = mockExecRunner
 	// note runner is defined in ovs.go file
 	runner = &execHelper{exec: mockKexecIface}
-	// note runner.ovndir is defined in ovs.go file and so is ovnRunDir var with an initial value
-	runner.ovnRunDir = ovnRunDir
 
 	tests := []struct {
 		desc                    string

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -30,69 +30,6 @@ type onCallReturnArgs struct {
 	retArgList          []interface{}
 }
 
-func TestRunningPlatform(t *testing.T) {
-	// Below is defined in ovs.go file
-	AppFs = afero.NewMemMapFs()
-	AppFs.MkdirAll("/etc", 0755)
-	tests := []struct {
-		desc            string
-		fileContent     []byte
-		filePermissions os.FileMode
-		expOut          string
-		expErr          error
-	}{
-		{
-			desc:   "ReadFile returns error",
-			expErr: fmt.Errorf("failed to parse file"),
-		},
-		{
-			desc:            "failed to find platform name",
-			expErr:          fmt.Errorf("failed to find the platform name"),
-			fileContent:     []byte("NAME="),
-			filePermissions: 0755,
-		},
-		{
-			desc:            "platform name returned is RHEL",
-			expOut:          "RHEL",
-			fileContent:     []byte("NAME=\"CentOS Linux\""),
-			filePermissions: 0755,
-		},
-		{
-			desc:            "platform name returned is Ubuntu",
-			expOut:          "Ubuntu",
-			fileContent:     []byte("NAME=\"Debian\""),
-			filePermissions: 0755,
-		},
-		{
-			desc:            "platform name returned is Photon",
-			expOut:          "Photon",
-			fileContent:     []byte("NAME=\"VMware\""),
-			filePermissions: 0755,
-		},
-		{
-			desc:            "unknown platform",
-			expErr:          fmt.Errorf("unknown platform"),
-			fileContent:     []byte("NAME=\"blah\""),
-			filePermissions: 0755,
-		},
-	}
-	for i, tc := range tests {
-		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			if tc.fileContent != nil && tc.filePermissions != 0 {
-				afero.WriteFile(AppFs, "/etc/os-release", tc.fileContent, tc.filePermissions)
-				defer AppFs.Remove("/etc/os-release")
-			}
-			res, err := runningPlatform()
-			t.Log(res, err)
-			if tc.expErr != nil {
-				assert.Contains(t, err.Error(), tc.expErr.Error())
-			} else {
-				assert.Equal(t, res, tc.expOut)
-			}
-		})
-	}
-}
-
 func TestRunOVNretry(t *testing.T) {
 	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
 	mockExecRunner := new(mocks.ExecRunner)

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -1812,64 +1812,7 @@ func TestRunOVSDBClientOVNNB(t *testing.T) {
 				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
 			}
 			ifaceCall.Once()
-			_, _, e := RunOVSDBClientOVNNB("list-dbs")
-
-			if tc.expectedErr != nil {
-				assert.Error(t, e)
-			}
-			mockExecRunner.AssertExpectations(t)
-			mockKexecIface.AssertExpectations(t)
-		})
-	}
-}
-
-func TestRunOVNCtl(t *testing.T) {
-	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
-	mockExecRunner := new(mocks.ExecRunner)
-	mockCmd := new(mock_k8s_io_utils_exec.Cmd)
-	// below is defined in ovs.go
-	runCmdExecRunner = mockExecRunner
-	// note runner is defined in ovs.go file
-	runner = &execHelper{exec: mockKexecIface}
-	tests := []struct {
-		desc                    string
-		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
-	}{
-		{
-			desc:                    "negative: run `ovn-ctl` command",
-			expectedErr:             fmt.Errorf("failed to execute ovn-ctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-ctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
-		},
-		{
-			desc:                    "positive: run `ovn-ctl` command",
-			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
-		},
-	}
-	for i, tc := range tests {
-		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
-			_, _, e := RunOVNCtl()
+			_, _, e := runOVSDBClientOVNNB("list-dbs")
 
 			if tc.expectedErr != nil {
 				assert.Error(t, e)

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -47,7 +47,7 @@ func TestGetNodeChassisID(t *testing.T) {
 	// below is defined in ovs.go
 	runCmdExecRunner = mockExecRunner
 	// note runner is defined in ovs.go file
-	runner = &execHelper{exec: mockKexecIface}
+	runner := &execHelper{exec: mockKexecIface}
 
 	tests := []struct {
 		desc                    string
@@ -102,7 +102,7 @@ func TestGetNodeChassisID(t *testing.T) {
 			}
 			ifaceCall.Once()
 
-			ret, e := GetNodeChassisID()
+			ret, e := GetNodeChassisID(runner)
 			if tc.errExpected {
 				assert.Error(t, e)
 			} else {
@@ -121,7 +121,7 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 	// below is defined in ovs.go
 	runCmdExecRunner = mockExecRunner
 	// note runner is defined in ovs.go file
-	runner = &execHelper{exec: mockKexecIface}
+	runner := &execHelper{exec: mockKexecIface}
 
 	tests := []struct {
 		desc                    string
@@ -264,10 +264,10 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			var e error
 			if tc.setCfgHybridOvlyEnabled {
 				config.HybridOverlay.Enabled = true
-				e = UpdateNodeSwitchExcludeIPs(tc.inpNodeName, ipnet)
+				e = UpdateNodeSwitchExcludeIPs(runner, tc.inpNodeName, ipnet)
 				config.HybridOverlay.Enabled = false
 			} else {
-				e = UpdateNodeSwitchExcludeIPs(tc.inpNodeName, ipnet)
+				e = UpdateNodeSwitchExcludeIPs(runner, tc.inpNodeName, ipnet)
 			}
 
 			if tc.errExpected {


### PR DESCRIPTION
Instead of using a global exec helper that allows testcase context to bleed between testcases, make it a context-type object that gets passed around where needed.

@girishmg 