### PR TITLE
Enable Debug Logging For All Tests That Support It

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				},
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -158,7 +158,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 		err := app.Run([]string{
 			app.Name,
-			"-loglevel=5",
 			"-no-hostsubnet-nodes=" + v1.LabelOSStable + "=windows",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
@@ -181,7 +180,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				},
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
@@ -233,7 +232,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 		err := app.Run([]string{
 			app.Name,
-			"-loglevel=5",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
 		})
@@ -255,7 +253,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				},
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
@@ -293,7 +291,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 		}
 		err := app.Run([]string{
 			app.Name,
-			"-loglevel=5",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
 		})
@@ -369,7 +366,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 		err := app.Run([]string{
 			app.Name,
-			"-loglevel=5",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
 		})
@@ -410,7 +406,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				&v1.NodeList{Items: []v1.Node{newTestNode(nodeName, "linux", nodeSubnet, "", nodeHOMAC)}},
 			}...)
 
-			_, err := config.InitConfig(ctx, nil, nil)
+			_, err := config.InitDebugConfig(ctx, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -456,7 +452,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 		err := app.Run([]string{
 			app.Name,
-			"-loglevel=5",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
 		})
@@ -500,7 +495,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			}...)
 
 			addLinuxNodeCommands(fexec, nodeHOMAC, nodeName, nodeHOIP)
-			_, err := config.InitConfig(ctx, nil, nil)
+			_, err := config.InitDebugConfig(ctx, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
@@ -553,7 +548,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 		err := app.Run([]string{
 			app.Name,
-			"-loglevel=5",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
 		})

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				Output: "",
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -294,7 +294,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				Output: "",
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
@@ -342,7 +342,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				Output: "",
 			})
 			config.HybridOverlay.RawClusterSubnets = "10.0.0.1/16/23"
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
@@ -390,7 +390,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				Output: "",
 			})
 			config.HybridOverlay.RawClusterSubnets = "10.0.0.1/16/23"
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -445,7 +445,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				"ovs-ofctl add-flow br-ext cookie=0xca12f31b,table=0,priority=100,ip,nw_dst=5.6.7.0/24,actions=load:4097->NXM_NX_TUN_ID[0..31],set_field:10.0.0.2->tun_dst,set_field:22:33:44:55:66:77->eth_dst,output:ext-vxlan",
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -498,7 +498,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				"ovs-ofctl del-flows br-ext cookie=0x1f40e27c/0xffffffff",
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
@@ -549,7 +549,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
@@ -622,7 +622,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1223,21 +1223,29 @@ func getConfigFilePath(ctx *cli.Context) (string, bool) {
 // constructs the global config object from them. It returns the config file
 // path (if explicitly specified) or an error
 func InitConfig(ctx *cli.Context, exec kexec.Interface, defaults *Defaults) (string, error) {
-	return initConfigWithPath(ctx, exec, kubeServiceAccountPath, defaults)
+	return initConfigWithPath(ctx, exec, kubeServiceAccountPath, defaults, false)
+}
+
+// InitDebugConfig reads the config file and common command-line options and
+// constructs the global config object from them.
+// It sets the log level to 5 for debug purposes
+// It returns the config file path (if explicitly specified) or an error
+func InitDebugConfig(ctx *cli.Context, exec kexec.Interface, defaults *Defaults) (string, error) {
+	return initConfigWithPath(ctx, exec, kubeServiceAccountPath, defaults, true)
 }
 
 // InitConfigSa reads the config file and common command-line options and
 // constructs the global config object from them. It passes the service account directory.
 // It returns the config file path (if explicitly specified) or an error
 func InitConfigSa(ctx *cli.Context, exec kexec.Interface, saPath string, defaults *Defaults) (string, error) {
-	return initConfigWithPath(ctx, exec, saPath, defaults)
+	return initConfigWithPath(ctx, exec, saPath, defaults, false)
 }
 
 // initConfigWithPath reads the given config file (or if empty, reads the config file
 // specified by command-line arguments, or empty, the default config file) and
 // common command-line options and constructs the global config object from
 // them. It returns the config file path (if explicitly specified) or an error
-func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, defaults *Defaults) (string, error) {
+func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, defaults *Defaults, debug bool) (string, error) {
 	var retConfigFile string
 	var configFile string
 	var configFileIsDefault bool
@@ -1296,6 +1304,9 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 	}
 
 	// Logging setup
+	if debug {
+		cfg.Logging.Level = 5
+	}
 	if err = overrideFields(&Logging, &cfg.Logging, &savedLogging); err != nil {
 		return "", err
 	}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -169,7 +169,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 		err := util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = config.InitConfig(ctx, fexec, nil)
+		_, err = config.InitDebugConfig(ctx, fexec, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -128,7 +128,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 		Items: []v1.Node{existingNode},
 	})
 
-	_, err = config.InitConfig(ctx, fexec, nil)
+	_, err = config.InitDebugConfig(ctx, fexec, nil)
 	Expect(err).NotTo(HaveOccurred())
 
 	nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient, egressipv1fake.NewSimpleClientset(), &egressfirewallfake.Clientset{}}, &existingNode)

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Node Operations", func() {
 			err := util.SetExec(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = config.InitConfig(ctx, fexec, nil)
+			_, err = config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = setupOVNNode(&node)
@@ -131,7 +131,7 @@ var _ = Describe("Node Operations", func() {
 			err := util.SetExec(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = config.InitConfig(ctx, fexec, nil)
+			_, err = config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			config.Default.EncapPort = encapPort
 

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -45,7 +45,7 @@ func (o *FakeOVNNode) start(ctx *cli.Context, objects ...runtime.Object) {
 	for _, object := range objects {
 		v1Objects = append(v1Objects, object)
 	}
-	_, err := config.InitConfig(ctx, o.fakeExec, nil)
+	_, err := config.InitDebugConfig(ctx, o.fakeExec, nil)
 	Expect(err).NotTo(HaveOccurred())
 
 	o.fakeCRDClient = apiextensionsfake.NewSimpleClientset()

--- a/go-controller/pkg/ovn/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set_test.go
@@ -49,7 +49,7 @@ var _ = Describe("OVN Address Set operations", func() {
 	Context("when iterating address sets", func() {
 		It("calls the iterator function for each address set with the given prefix", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				namespaces := []testAddressSetName{
@@ -112,7 +112,7 @@ var _ = Describe("OVN Address Set operations", func() {
 					addr2 string = "5.6.7.8"
 				)
 
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -135,7 +135,7 @@ var _ = Describe("OVN Address Set operations", func() {
 
 		It("clears an existing address set of IPs", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -163,7 +163,7 @@ var _ = Describe("OVN Address Set operations", func() {
 					addr2 string = "5.6.7.8"
 				)
 
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -187,7 +187,7 @@ var _ = Describe("OVN Address Set operations", func() {
 
 	It("destroys an address set", func() {
 		app.Action = func(ctx *cli.Context) error {
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -217,7 +217,7 @@ var _ = Describe("OVN Address Set operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				const addr1 string = "1.2.3.4"
 
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -250,7 +250,7 @@ var _ = Describe("OVN Address Set operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				const addr1 string = "1.2.3.4"
 
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -293,7 +293,7 @@ var _ = Describe("OVN Address Set operations", func() {
 					addr4 string = "2001:db8::2"
 				)
 
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				config.IPv6Mode = true
 
@@ -326,7 +326,7 @@ var _ = Describe("OVN Address Set operations", func() {
 
 		It("clears an existing address set of dual stack IPs", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				config.IPv6Mode = true
 
@@ -365,7 +365,7 @@ var _ = Describe("OVN Address Set operations", func() {
 					addr4 string = "2001:db8::2"
 				)
 
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				config.IPv6Mode = true
 
@@ -399,7 +399,7 @@ var _ = Describe("OVN Address Set operations", func() {
 
 	It("destroys an dual stack address set", func() {
 		app.Action = func(ctx *cli.Context) error {
-			_, err := config.InitConfig(ctx, fexec, nil)
+			_, err := config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			config.IPv6Mode = true
 
@@ -442,7 +442,7 @@ var _ = Describe("OVN Address Set operations", func() {
 				const addr1 string = "1.2.3.4"
 				const addr2 string = "2001:db8::1"
 
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				config.IPv6Mode = true
 
@@ -491,7 +491,7 @@ var _ = Describe("OVN Address Set operations", func() {
 				const addr1 string = "1.2.3.4"
 				const addr2 string = "2001:db8::1"
 
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				config.IPv6Mode = true
 

--- a/go-controller/pkg/ovn/logical_switch_manager_test.go
+++ b/go-controller/pkg/ovn/logical_switch_manager_test.go
@@ -36,7 +36,7 @@ var _ = Describe("OVN Logical Switch Manager operations", func() {
 	Context("when adding node", func() {
 		It("creates IPAM for each subnet and reserves IPs correctly", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				testNode := testNodeSubnetData{
@@ -85,7 +85,7 @@ var _ = Describe("OVN Logical Switch Manager operations", func() {
 
 		It("manages no host subnet nodes correctly", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				testNode := testNodeSubnetData{
 					nodeName: "testNode1",
@@ -104,7 +104,7 @@ var _ = Describe("OVN Logical Switch Manager operations", func() {
 
 		It("handles updates to the host subnets correctly", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				testNode := testNodeSubnetData{
 					nodeName: "testNode1",
@@ -144,7 +144,7 @@ var _ = Describe("OVN Logical Switch Manager operations", func() {
 	Context("when allocating IP addresses", func() {
 		It("IPAM for each subnet allocates IPs contiguously", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				testNode := testNodeSubnetData{
 					nodeName: "testNode1",
@@ -176,7 +176,7 @@ var _ = Describe("OVN Logical Switch Manager operations", func() {
 
 		It("IPAM allocates, releases, and reallocates IPs correctly", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				testNode := testNodeSubnetData{
 					nodeName: "testNode1",
@@ -211,7 +211,7 @@ var _ = Describe("OVN Logical Switch Manager operations", func() {
 
 		It("releases IPs for other host subnet nodes when any host subnets allocation fails", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				testNode := testNodeSubnetData{
 					nodeName: "testNode1",
@@ -249,7 +249,7 @@ var _ = Describe("OVN Logical Switch Manager operations", func() {
 
 		It("fails correctly when trying to block a previously allocated IP", func() {
 			app.Action = func(ctx *cli.Context) error {
-				_, err := config.InitConfig(ctx, fexec, nil)
+				_, err := config.InitDebugConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				testNode := testNodeSubnetData{
 					nodeName: "testNode1",

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -301,7 +301,7 @@ var _ = Describe("Master Operations", func() {
 			err := util.SetExec(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = config.InitConfig(ctx, fexec, nil)
+			_, err = config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
@@ -399,7 +399,7 @@ var _ = Describe("Master Operations", func() {
 			err := util.SetExec(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = config.InitConfig(ctx, fexec, nil)
+			_, err = config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
@@ -495,7 +495,7 @@ var _ = Describe("Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			cleanupGateway(fexec, nodeName, nodeSubnet, clusterCIDR, nextHop)
 
-			_, err = config.InitConfig(ctx, fexec, nil)
+			_, err = config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
 			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
@@ -645,7 +645,7 @@ subnet=%s
 			err := util.SetExec(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = config.InitConfig(ctx, fexec, nil)
+			_, err = config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient, egressIPFakeClient, egressFirewallFakeClient}, &masterNode)
@@ -779,7 +779,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			err := util.SetExec(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = config.InitConfig(ctx, fexec, nil)
+			_, err = config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient, egressIPFakeClient, egressFirewallFakeClient}, &testNode)
@@ -967,7 +967,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			err := util.SetExec(fexec)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = config.InitConfig(ctx, fexec, nil)
+			_, err = config.InitDebugConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient, egressIPFakeClient, egressFirewallFakeClient}, &testNode)

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -62,7 +62,7 @@ func (o *FakeOVN) start(ctx *cli.Context, objects ...runtime.Object) {
 			v1Objects = append(v1Objects, object)
 		}
 	}
-	_, err := config.InitConfig(ctx, o.fakeExec, nil)
+	_, err := config.InitDebugConfig(ctx, o.fakeExec, nil)
 	Expect(err).NotTo(HaveOccurred())
 
 	o.fakeCRDClient = apiextensionsfake.NewSimpleClientset()


### PR DESCRIPTION
This commit adds a new config function, `InitDebugConfig` that sets the log level to 5.
I then ran ` find . -type f -iname "*_test.go" -exec sed -i "s/InitConfig/InitDebugConfig/g" {} \;` to make this the default in tests.
All debug logs (i.e `klog.V(5).Infof`) will be emitted when this is set.
This allows for easier debugging of failing tests from the logs in CI.