### PR TITLE
Pod IPs could be leaked in some cases

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -81,6 +81,23 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	portInfo, err := oc.logicalPortCache.get(logicalPort)
 	if err != nil {
 		klog.Errorf(err.Error())
+		// If ovnkube-master restarts, it is also possible the Pod's logical switch port
+		// is not readded into the cache. Delete logical switch port anyway.
+		err = util.OvnNBLSPDel(oc.ovnNBClient, logicalPort)
+		if err != nil {
+			klog.Errorf(err.Error())
+		}
+
+		// Even if the port is not in the cache, IPs annotated in the Pod annotation may already be allocated,
+		// need to release them to avoid leakage.
+		logicalSwitch := pod.Spec.NodeName
+		if logicalSwitch != "" {
+			annotation, err := util.UnmarshalPodAnnotation(pod.Annotations)
+			if err == nil {
+				podIfAddrs := annotation.IPs
+				_ = oc.lsManager.ReleaseIPs(logicalSwitch, podIfAddrs)
+			}
+		}
 		return
 	}
 
@@ -97,12 +114,8 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		klog.Errorf(err.Error())
 	}
 
-	cmd, err := oc.ovnNBClient.LSPDel(logicalPort)
-	if err == nil {
-		if err = oc.ovnNBClient.Execute(cmd); err != nil {
-			klog.Errorf("Error while deleting logical port: %s, %v", logicalPort, err)
-		}
-	} else if err != goovn.ErrorNotFound {
+	err = util.OvnNBLSPDel(oc.ovnNBClient, logicalPort)
+	if err != nil {
 		klog.Errorf(err.Error())
 	}
 
@@ -370,6 +383,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 			}
 		}
 
+		releaseIPs = true
 		var networks []*types.NetworkSelectionElement
 
 		networks, err = util.GetPodNetSelAnnotation(pod, util.DefNetworkAnnotation)
@@ -414,9 +428,9 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		klog.V(5).Infof("Annotation values: ip=%v ; mac=%s ; gw=%s\nAnnotation=%s",
 			podIfAddrs, podMac, podAnnotation.Gateways, marshalledAnnotation)
 		if err = oc.kube.SetAnnotationsOnPod(pod, marshalledAnnotation); err != nil {
-			releaseIPs = true
 			return fmt.Errorf("failed to set annotation on pod %s: %v", pod.Name, err)
 		}
+		releaseIPs = false
 	}
 
 	// set addresses on the port

--- a/go-controller/pkg/util/go_ovn.go
+++ b/go-controller/pkg/util/go_ovn.go
@@ -122,3 +122,16 @@ func initGoOvnUnixClient(address, db string) (goovn.Client, error) {
 	klog.Infof("Created OVNDB UNIX client for db: %s", db)
 	return ovndbclient, nil
 }
+
+// OvnNBLSPDel deletes the given logical switch port using the go-ovn library
+func OvnNBLSPDel(nbClient goovn.Client, logicalPort string) error {
+	cmd, err := nbClient.LSPDel(logicalPort)
+	if err == nil {
+		if err = nbClient.Execute(cmd); err != nil {
+			return fmt.Errorf("error while deleting logical port: %s, %v", logicalPort, err)
+		}
+	} else if err != goovn.ErrorNotFound {
+		return fmt.Errorf(err.Error())
+	}
+	return nil
+}

--- a/go-controller/pkg/util/go_ovn_test.go
+++ b/go-controller/pkg/util/go_ovn_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"fmt"
+	goovn "github.com/ebay/go-ovn"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	go_ovn_mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/ebay/go-ovn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+func TestOvnNBLSPDel(t *testing.T) {
+	mockNbClient := new(go_ovn_mocks.Client)
+	inpLogicalPort := "blahPort"
+
+	tests := []struct {
+		desc            string
+		errMatch        error
+		errExp          bool
+		goovnMockHelper []ovntest.TestifyMockHelper
+	}{
+		{
+			desc:     "test path when 'nbClient.Execute(cmd)' returns error",
+			errMatch: fmt.Errorf("error while deleting logical port"),
+			goovnMockHelper: []ovntest.TestifyMockHelper{
+				{"LSPDel", []string{"string"}, []interface{}{&goovn.OvnCommand{}, nil}},
+				{"Execute", []string{"*goovn.OvnCommand"}, []interface{}{fmt.Errorf("mock error")}},
+			},
+		},
+		{
+			desc:   "test path when 'err != goovn.ErrorNotFound'",
+			errExp: true,
+			goovnMockHelper: []ovntest.TestifyMockHelper{
+				{"LSPDel", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+			},
+		},
+		{
+			desc:   "test path when 'err == goovn.ErrorNotFound'",
+			errExp: false,
+			goovnMockHelper: []ovntest.TestifyMockHelper{
+				{"LSPDel", []string{"string"}, []interface{}{nil, goovn.ErrorNotFound}},
+			},
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+
+			for _, item := range tc.goovnMockHelper {
+				call := mockNbClient.On(item.OnCallMethodName)
+				for _, arg := range item.OnCallMethodArgType {
+					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
+				}
+				for _, ret := range item.RetArgList {
+					call.ReturnArguments = append(call.ReturnArguments, ret)
+				}
+				call.Once()
+			}
+			err := OvnNBLSPDel(mockNbClient, inpLogicalPort)
+			t.Log(err)
+			if tc.errExp {
+				assert.Error(t, err)
+			} else if tc.errMatch != nil {
+				assert.Contains(t, err.Error(), tc.errMatch.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+
+			mockNbClient.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
This change fixes potential Pod IPs leakage. The general rule is that
Pod IPs need to be released in case of failure until they are
successfully annotated in the Pod annotation.

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->