### PR TITLE
run periodic tests in parallel

### DIFF
--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -11,6 +11,9 @@ env:
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true
   KIND_ALLOW_SYSTEM_WRITES: true
+  # This skips tests tagged as Serial
+  # Current Serial tests are not relevant for OVN
+  PARALLEL: true
 
 jobs:
   build:


### PR DESCRIPTION
Considering the jobs takes about 25 mins to run, in average, we
have limited the CI jobs to timeout after 1 hour.

However, this implies that the test are running in parallel.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
