### PR TITLE
Fix ovn_cluster_router policy deletion

### DIFF
--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -128,15 +128,21 @@ func delPbrAndNatRules(nodeName string) {
 			"stdout: %s, stderr: %s, error: %v", matches, stderr, err)
 		matches = ""
 	}
-	nodeSubnetMatchSubStr := fmt.Sprintf("rtos-%s", nodeName)
+	// matches inport for a policy, must use ending quote to substring match to avoid matching other nodes accidentally
+	// i.e. rtos-ovn-worker would match rtos-ovn-worker2
+	nodeSubnetMatchSubStr := fmt.Sprintf("rtos-%s\"", nodeName)
+	// for inter node, match the comment in the policy, and include extra space to avoid accidental submatch
+	interNodeMatchSubStr := fmt.Sprintf("inter-%s ", nodeName)
+	// mgmt port policy matches node name in comment, use extra spaces to avoid accidental match of other nodes
+	mgmtPortPolicyMatchSubStr := fmt.Sprintf(" %s ", nodeName)
 	for _, match := range strings.Split(matches, "\n\n") {
 		var priority string
 		if strings.Contains(match, nodeSubnetMatchSubStr) {
 			priority = nodeSubnetPolicyPriority
-		} else if strings.Contains(match, nodeName) {
-			priority = mgmtPortPolicyPriority
-		} else if strings.Contains(match, "inter") {
+		} else if strings.Contains(match, interNodeMatchSubStr) {
 			priority = interNodePolicyPriority
+		} else if strings.Contains(match, mgmtPortPolicyMatchSubStr) {
+			priority = mgmtPortPolicyPriority
 		} else {
 			continue
 		}


### PR DESCRIPTION
When we delete a node we initiate gateway cleanup which deletes PBR on
ovn_cluster_router. In the current code we list all PBR rules and then
use string submatch to figure out what to delete. Inter node policy was
not including the node name, so it was accidentally deleting PBR rules
for other nodes.

Additionally, the match logic was flawed in the case where there are
node names that overlap. For example, ovn-worker and ovn-worker2. If
ovn-worker node was deleted, it may accidentally match and delete
policies for ovn-worker2.

Both of these issues are addressed by this patch.

Note: in the future we should totally get rid of this and use the go-ovn bindings.
