### PR TITLE
Gate on dual stack job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,7 +172,7 @@ jobs:
         # - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "false"}, "gateway-mode": shared, "target": {"shard": shard-n-other}}
         exclude:
          # Not currently supported but needs to be.
-         - {"ipfamily": {"ip": dualstack}}
+         - {"ipfamily": {"ip": dualstack}, "target": {"shard": control-plane}}
          - {"ipfamily": {"ip": ipv6}, "target": {"shard": control-plane}}
          # Limit matrix combinations for CI. DISABLED items added to exclude list:
          #   DISABLED  v4  ha     local
@@ -183,10 +183,16 @@ jobs:
          #   ENABLED   v6  ha     shared
          #   DISABLED  v6  noha   local
          #   DISABLED  v6  noha   shared
+         #   ENABLED   ds  ha     local
+         #   DISABLED  ds  ha     shared
+         #   DISABLED  ds  noha   local
+         #   DISABLED  ds  noha   shared
          - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "true"}, "gateway-mode": local}
          - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "false"}, "gateway-mode": shared}
          - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": local}
          - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": shared}
+         - {"ipfamily": {"ip": dualstack}, "ha": {"enabled": "true"}, "gateway-mode": shared}
+         - {"ipfamily": {"ip": dualstack}, "ha": {"enabled": "false"}}
     needs: [build, k8s]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,6 +8,8 @@ KIND_IPV6_SUPPORT?=false
 
 .PHONY: install-kind
 install-kind:
+	KIND_IPV4_SUPPORT=$(KIND_IPV4_SUPPORT) \
+	KIND_IPV6_SUPPORT=$(KIND_IPV6_SUPPORT) \
 	./scripts/install-kind.sh
 
 .PHONY: shard-%

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -13,7 +13,14 @@ if [[ ! -f /usr/local/bin/e2e.test ]]; then
 fi
 popd
 
-go get sigs.k8s.io/kind@v0.9.0
+# Install kind (dual-stack is not released upstream so we have to use our own version)
+if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
+  sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
+  sudo chmod +x /usr/local/bin/kind
+else
+  go get sigs.k8s.io/kind@v0.9.0
+fi
+
 pushd ../contrib
 ./kind.sh
 popd


### PR DESCRIPTION
We were running a dual-stack job periodically to get signal on the dual-stack status.
https://github.com/ovn-org/ovn-kubernetes/actions/runs/281808838

It seems that now is stable enough so we should gate on it to avoid regressions