### PR TITLE
make services backed by a hybrid-network more efficent

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -289,6 +290,64 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 		}
 	}
 
+	// create a reroute on the ovn_cluster_router
+	err = createLogicalRouterPolicyForNode(node, subnets)
+	if err != nil {
+		return fmt.Errorf("failed to create logical router policy: %v", err)
+	}
+
+	return nil
+}
+
+func createLogicalRouterPolicyForNode(node *kapi.Node, subnets []*net.IPNet) error {
+	// get all the windows subnets as the dest for lr-policy match
+	var dest string
+	var nextHop string
+	var src string
+	for _, hybridSubnet := range config.HybridOverlay.ClusterSubnets {
+		if !utilnet.IsIPv6CIDR(hybridSubnet.CIDR) {
+			if len(dest) > 0 {
+				dest = dest + " || "
+			}
+			dest = dest + fmt.Sprintf("ip4.dst == %s", hybridSubnet.CIDR.String())
+		}
+	}
+	// the src is the nodes subnet and the next hop is the third address (x.x.x.3) in the nodes subnet
+	for _, subnet := range subnets {
+		if !utilnet.IsIPv6CIDR(subnet) {
+			src = fmt.Sprintf("ip4.src == %s", subnet.String())
+			ip := util.GetNodeHybridOverlayIfAddr(subnet)
+			nextHop = ip.IP.String()
+			break
+		}
+	}
+	if len(nextHop) == 0 {
+		return fmt.Errorf("could not find an ipv4 Node subnet for node %s", node.Name)
+	}
+
+	_, stderr, err := util.RunOVNNbctl(
+		"--id=@lr-policy",
+		"create",
+		"logical_router_policy",
+		"priority="+config.HybridOverlayNodeReroutePriority,
+		"action=reroute",
+		fmt.Sprintf("external-ids:hybrid-overlay=%s", node.Name),
+		fmt.Sprintf("match=\"(%s) && %s\"", dest, src),
+		fmt.Sprintf("nexthop=%s", nextHop),
+		"--",
+		"add",
+		"logical_router",
+		config.OVNClusterRouter,
+		"policies",
+		"@lr-policy",
+	)
+	if err != nil {
+		// TODO: lr-policy-add doesn't support --may-exist, resort to this workaround for now.
+		// Have raised an issue against ovn repository (https://github.com/ovn-org/ovn/issues/49)
+		if !strings.Contains(stderr, "already existed") {
+			return fmt.Errorf("cannot add logical router policy for hybrid cluster network for node %s: %s", node.Name, stderr)
+		}
+	}
 	return nil
 }
 
@@ -296,6 +355,22 @@ func (m *MasterController) deleteOverlayPort(node *kapi.Node) {
 	klog.Infof("Removing node %s hybrid overlay port", node.Name)
 	portName := util.GetHybridOverlayPortName(node.Name)
 	_, _, _ = util.RunOVNNbctl("--", "--if-exists", "lsp-del", portName)
+
+	stdout, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "logical_router_policy", fmt.Sprintf("external-ids:hybrid-overlay=%s", node.Name))
+	if err != nil {
+		klog.Errorf("Error deleting hybrid logical router policy  for node %s, cannot get logical router policies from LR %s - %s:%s", node.Name, "ovn_cluster_router", err, stderr)
+		return
+	}
+	uuids := strings.Fields(stdout)
+	for _, uuid := range uuids {
+		_, stderr, err := util.RunOVNNbctl("lr-policy-del", "ovn_cluster_router", uuid)
+		if err != nil {
+			klog.Errorf("Failed to delete the hybrid logical-router-policy for "+
+				"node %s on logical switch %s, stderr: %q (%v)", node.Name, "ovn_cluster_router", stderr, err)
+			return
+		}
+	}
+
 }
 
 // AddNode handles node additions

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -571,7 +571,7 @@ func addLinuxNodeCommands(fexec *ovntest.FakeExec, nodeHOMAC, nodeName, nodeHOIP
 
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 lsp-list " + nodeName,
-		Output: "29df5ce5-2802-4ee5-891f-4fb27ca776e9 (" + util.K8sPrefix + nodeName + ")",
+		Output: "29df5ce5-2802-4ee5-891f-4fb27ca776e9 (" + config.K8sPrefix + nodeName + ")",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 -- --if-exists set logical_switch " + nodeName + " other-config:exclude_ips=" + nodeHOIP,

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -522,9 +522,9 @@ func (n *NodeController) EnsureHybridOverlayBridge(node *kapi.Node) error {
 	if len(config.HybridOverlay.ClusterSubnets) > 0 {
 		// Add a route via the hybrid overlay port IP through the management port
 		// interface for each hybrid overlay cluster subnet
-		mgmtPortLink, err := netlink.LinkByName(util.K8sMgmtIntfName)
+		mgmtPortLink, err := netlink.LinkByName(config.K8sMgmtIntfName)
 		if err != nil {
-			return fmt.Errorf("failed to lookup link %s: %v", util.K8sMgmtIntfName, err)
+			return fmt.Errorf("failed to lookup link %s: %v", config.K8sMgmtIntfName, err)
 		}
 		mgmtPortMAC := mgmtPortLink.Attrs().HardwareAddr
 		for _, clusterEntry := range config.HybridOverlay.ClusterSubnets {

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -129,7 +129,7 @@ func validateNetlinkState(nodeSubnet string) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(link.Attrs().Flags & net.FlagUp).To(Equal(net.FlagUp))
 
-	link, err = netlink.LinkByName(util.K8sMgmtIntfName)
+	link, err = netlink.LinkByName(config.K8sMgmtIntfName)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(link.Attrs().Flags & net.FlagUp).To(Equal(net.FlagUp))
 
@@ -208,7 +208,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			ovntest.AddLink(extBridgeName)
 
 			// Set up management interface with its address
-			link := ovntest.AddLink(util.K8sMgmtIntfName)
+			link := ovntest.AddLink(config.K8sMgmtIntfName)
 			_, thisNet, err := net.ParseCIDR(thisSubnet)
 			Expect(err).NotTo(HaveOccurred())
 			mgmtIfAddr := util.GetNodeManagementIfAddr(thisNet)

--- a/go-controller/pkg/config/const.go
+++ b/go-controller/pkg/config/const.go
@@ -35,6 +35,7 @@ const (
 	// priority of logical router policies on the OVNClusterRouter
 	EgressFirewallStartPriority           = "10000"
 	MinimumReservedEgressFirewallPriority = "2000"
+	HybridOverlayNodeReroutePriority      = "1006"
 	MGMTPortPolicyPriority                = "1005"
 	NodeSubnetPolicyPriority              = "1004"
 	InterNodePolicyPriority               = "1003"

--- a/go-controller/pkg/config/const.go
+++ b/go-controller/pkg/config/const.go
@@ -1,0 +1,56 @@
+package config
+
+const (
+	K8sPrefix = "k8s-"
+	// K8sMgmtIntfName name to be used as an OVS internal port on the node
+	K8sMgmtIntfName = "ovn-k8s-mp0"
+
+	// PhysicalNetworkName is the name that maps to an OVS bridge that provides
+	// access to physical/external network
+	PhysicalNetworkName = "physnet"
+
+	// LocalNetworkName is the name that maps to an OVS bridge that provides
+	// access to local service
+	LocalNetworkName = "locnet"
+
+	// config.OVNClusterRouter is the name of the distributed router
+	OVNClusterRouter = "ovn_cluster_router"
+	OVNJoinSwitch    = "join"
+
+	JoinSwitchPrefix             = "join_"
+	ExternalSwitchPrefix         = "ext_"
+	GWRouterPrefix               = "GR_"
+	RouterToSwitchPrefix         = "rtos-"
+	InterPrefix                  = "inter-"
+	SwitchToRouterPrefix         = "stor-"
+	JoinSwitchToGWRouterPrefix   = "jtor-"
+	GWRouterToJoinSwitchPrefix   = "rtoj-"
+	DistRouterToJoinSwitchPrefix = "dtoj-"
+	JoinSwitchToDistRouterPrefix = "jtod-"
+	EXTSwitchToGWRouterPrefix    = "etor-"
+	GWRouterToExtSwitchPrefix    = "rtoe-"
+
+	NodeLocalSwitch = "node_local_switch"
+
+	// priority of logical router policies on the OVNClusterRouter
+	EgressFirewallStartPriority           = "10000"
+	MinimumReservedEgressFirewallPriority = "2000"
+	MGMTPortPolicyPriority                = "1005"
+	NodeSubnetPolicyPriority              = "1004"
+	InterNodePolicyPriority               = "1003"
+	DefaultNoRereoutePriority             = "101"
+	EgressIPReroutePriority               = "100"
+
+	V6NodeLocalNATSubnet           = "fd99::/64"
+	V6NodeLocalNATSubnetPrefix     = 64
+	V6NodeLocalNATSubnetNextHop    = "fd99::1"
+	V6NodeLocalDistributedGWPortIP = "fd99::2"
+
+	V4NodeLocalNATSubnet           = "169.254.0.0/20"
+	V4NodeLocalNATSubnetPrefix     = 20
+	V4NodeLocalNATSubnetNextHop    = "169.254.0.1"
+	V4NodeLocalDistributedGWPortIP = "169.254.0.2"
+
+	V4JoinSubnetCIDR = "100.64.0.0/16"
+	V6JoinSubnetCIDR = "fd98::/64"
+)

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -206,7 +206,7 @@ func CleanupClusterNode(name string) error {
 
 	klog.V(5).Infof("Cleaning up gateway resources on node: %q", name)
 	if config.Gateway.Mode == config.GatewayModeLocal || config.Gateway.Mode == config.GatewayModeShared {
-		err = cleanupLocalnetGateway(util.LocalNetworkName)
+		err = cleanupLocalnetGateway(config.LocalNetworkName)
 		if err != nil {
 			klog.Errorf("Failed to cleanup Localnet Gateway, error: %v", err)
 		}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func setupNodeAccessBridgeTest(fexec *ovntest.FakeExec, nodeName, brLocalnetMAC, mtu string) {
-	gwPortMac := util.IPAddrToHWAddr(net.ParseIP(util.V4NodeLocalNatSubnetNextHop)).String()
+	gwPortMac := util.IPAddrToHWAddr(net.ParseIP(config.V4NodeLocalNATSubnetNextHop)).String()
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovs-vsctl --timeout=15 --may-exist add-br br-local",
@@ -47,10 +47,10 @@ func setupNodeAccessBridgeTest(fexec *ovntest.FakeExec, nodeName, brLocalnetMAC,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
-		Output: util.PhysicalNetworkName + ":breth0",
+		Output: config.PhysicalNetworkName + ":breth0",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + util.PhysicalNetworkName + ":breth0" + "," + util.LocalNetworkName + ":br-local",
+		"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + config.PhysicalNetworkName + ":breth0" + "," + config.LocalNetworkName + ":br-local",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovs-vsctl --timeout=15 --may-exist add-port br-local " + localnetGatewayNextHopPort +
@@ -65,13 +65,13 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 	app.Action = func(ctx *cli.Context) error {
 		const (
 			nodeName      string = "node1"
-			brNextHopIp   string = util.V4NodeLocalNatSubnetNextHop
+			brNextHopIp   string = config.V4NodeLocalNATSubnetNextHop
 			systemID      string = "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"
 			nodeSubnet    string = "10.1.1.0/24"
 			brLocalnetMAC string = "11:22:33:44:55:66"
 		)
 
-		brNextHopCIDR := fmt.Sprintf("%s/%d", brNextHopIp, util.V4NodeLocalNatSubnetPrefix)
+		brNextHopCIDR := fmt.Sprintf("%s/%d", brNextHopIp, config.V4NodeLocalNATSubnetPrefix)
 		fexec := ovntest.NewFakeExec()
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd: "ovs-vsctl --timeout=15 -- port-to-br eth0",
@@ -113,7 +113,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: "",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + util.PhysicalNetworkName + ":breth0",
+			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + config.PhysicalNetworkName + ":breth0",
 		})
 
 		setupNodeAccessBridgeTest(fexec, nodeName, brLocalnetMAC, mtu)
@@ -344,7 +344,7 @@ func localNetInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: "",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + util.PhysicalNetworkName + ":br-local",
+			"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-bridge-mappings=" + config.PhysicalNetworkName + ":br-local",
 			"ovs-vsctl --timeout=15 --if-exists del-port br-local " + legacyLocalnetGatewayNextHopPort +
 				" -- --may-exist add-port br-local " + localnetGatewayNextHopPort + " -- set interface " + localnetGatewayNextHopPort + " type=internal mtu_request=" + mtu + " mac=00\\:00\\:a9\\:fe\\:21\\:01",
 		})

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -146,7 +146,7 @@ func (npw *localPortWatcherData) addService(svc *kapi.Service) error {
 		}
 	}
 	for externalIP := range routeUsage {
-		if stdout, stderr, err := util.RunIP("route", "replace", externalIP, "via", gatewayIP, "dev", util.K8sMgmtIntfName, "table", localnetGatewayExternalIDTable); err != nil {
+		if stdout, stderr, err := util.RunIP("route", "replace", externalIP, "via", gatewayIP, "dev", config.K8sMgmtIntfName, "table", localnetGatewayExternalIDTable); err != nil {
 			klog.Errorf("Error adding routing table entry for ExternalIP %s, via gw: %s: stdout: %s, stderr: %s, err: %v", externalIP, gatewayIP, stdout, stderr, err)
 		} else {
 			klog.V(5).Infof("Successfully added route for ExternalIP: %s", externalIP)
@@ -195,7 +195,7 @@ func (npw *localPortWatcherData) deleteService(svc *kapi.Service) error {
 	}
 
 	for externalIP := range routeUsage {
-		if stdout, stderr, err := util.RunIP("route", "del", externalIP, "via", gatewayIP, "dev", util.K8sMgmtIntfName, "table", localnetGatewayExternalIDTable); err != nil {
+		if stdout, stderr, err := util.RunIP("route", "del", externalIP, "via", gatewayIP, "dev", config.K8sMgmtIntfName, "table", localnetGatewayExternalIDTable); err != nil {
 			klog.Errorf("Error delete routing table entry for ExternalIP %s: stdout: %s, stderr: %s, err: %v", externalIP, stdout, stderr, err)
 		} else {
 			klog.V(5).Infof("Successfully deleted route for ExternalIP: %s", externalIP)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -176,13 +176,13 @@ var _ = Describe("Node Operations", func() {
 				})
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ip route list table " + localnetGatewayExternalIDTable,
-					Output: fmt.Sprintf("%s via %s dev %s\n9.9.9.9 via %s dev %s\n", externalIP, v4localnetGatewayIP, util.K8sMgmtIntfName, v4localnetGatewayIP, util.K8sMgmtIntfName),
+					Output: fmt.Sprintf("%s via %s dev %s\n9.9.9.9 via %s dev %s\n", externalIP, v4localnetGatewayIP, config.K8sMgmtIntfName, v4localnetGatewayIP, config.K8sMgmtIntfName),
 				})
 				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route del 9.9.9.9 via %s dev %s table %s", v4localnetGatewayIP, util.K8sMgmtIntfName, localnetGatewayExternalIDTable),
+					fmt.Sprintf("ip route del 9.9.9.9 via %s dev %s table %s", v4localnetGatewayIP, config.K8sMgmtIntfName, localnetGatewayExternalIDTable),
 				})
 				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, util.K8sMgmtIntfName, localnetGatewayExternalIDTable),
+					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, config.K8sMgmtIntfName, localnetGatewayExternalIDTable),
 				})
 
 				service := *newService("service1", "namespace1", "10.129.0.2",
@@ -299,7 +299,7 @@ var _ = Describe("Node Operations", func() {
 				)
 
 				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, util.K8sMgmtIntfName, localnetGatewayExternalIDTable),
+					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, config.K8sMgmtIntfName, localnetGatewayExternalIDTable),
 				})
 
 				fNPW.addService(&service)
@@ -519,7 +519,7 @@ var _ = Describe("Node Operations", func() {
 				)
 
 				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route del %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, util.K8sMgmtIntfName, localnetGatewayExternalIDTable),
+					fmt.Sprintf("ip route del %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, config.K8sMgmtIntfName, localnetGatewayExternalIDTable),
 				})
 
 				fNPW.deleteService(&service)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -556,7 +556,7 @@ func (n *OvnNode) initSharedGateway(subnets []*net.IPNet, gwNextHops []net.IP, g
 			gwIntf, err)
 	}
 	ifaceID, macAddress, err := bridgedGatewayNodeSetup(n.name, bridgeName, gwIntf,
-		util.PhysicalNetworkName, brCreated)
+		config.PhysicalNetworkName, brCreated)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}
@@ -633,7 +633,7 @@ func cleanupSharedGateway() error {
 	bridgeMappings := strings.Split(stdout, ",")
 	for _, bridgeMapping := range bridgeMappings {
 		m := strings.Split(bridgeMapping, ":")
-		if network := m[0]; network == util.PhysicalNetworkName {
+		if network := m[0]; network == config.PhysicalNetworkName {
 			bridgeName = m[1]
 			break
 		}

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -28,7 +28,7 @@ func setupLocalNodeAccessBridge(nodeName string, subnets []*net.IPNet) error {
 	}
 
 	_, _, err = bridgedGatewayNodeSetup(nodeName, localBridgeName, localBridgeName,
-		util.LocalNetworkName, true)
+		config.LocalNetworkName, true)
 	if err != nil {
 		return fmt.Errorf("failed while setting up local node access bridge : %v", err)
 	}
@@ -40,9 +40,9 @@ func setupLocalNodeAccessBridge(nodeName string, subnets []*net.IPNet) error {
 
 	var macAddress string
 	if config.IPv4Mode {
-		macAddress = util.IPAddrToHWAddr(net.ParseIP(util.V4NodeLocalNatSubnetNextHop)).String()
+		macAddress = util.IPAddrToHWAddr(net.ParseIP(config.V4NodeLocalNATSubnetNextHop)).String()
 	} else {
-		macAddress = util.IPAddrToHWAddr(net.ParseIP(util.V6NodeLocalNatSubnetNextHop)).String()
+		macAddress = util.IPAddrToHWAddr(net.ParseIP(config.V6NodeLocalNATSubnetNextHop)).String()
 	}
 
 	_, stderr, err = util.RunOVSVsctl(
@@ -71,11 +71,11 @@ func setupLocalNodeAccessBridge(nodeName string, subnets []*net.IPNet) error {
 		var gatewaySubnetMask net.IPMask
 		isSubnetIPv6 := utilnet.IsIPv6CIDR(subnet)
 		if isSubnetIPv6 {
-			gatewayNextHop = net.ParseIP(util.V6NodeLocalNatSubnetNextHop)
-			gatewaySubnetMask = net.CIDRMask(util.V6NodeLocalNatSubnetPrefix, 128)
+			gatewayNextHop = net.ParseIP(config.V6NodeLocalNATSubnetNextHop)
+			gatewaySubnetMask = net.CIDRMask(config.V6NodeLocalNATSubnetPrefix, 128)
 		} else {
-			gatewayNextHop = net.ParseIP(util.V4NodeLocalNatSubnetNextHop)
-			gatewaySubnetMask = net.CIDRMask(util.V4NodeLocalNatSubnetPrefix, 32)
+			gatewayNextHop = net.ParseIP(config.V4NodeLocalNATSubnetNextHop)
+			gatewaySubnetMask = net.CIDRMask(config.V4NodeLocalNATSubnetPrefix, 32)
 		}
 		gatewayNextHopCIDR := &net.IPNet{IP: gatewayNextHop, Mask: gatewaySubnetMask}
 		if err = util.LinkAddrAdd(link, gatewayNextHopCIDR); err != nil {

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -196,7 +196,7 @@ func setupManagementPortIPFamilyConfig(mpcfg *managementPortConfig, cfg *managem
 	// source protocol address to be in the Logical Switch's subnet.
 	if exists, err = util.LinkNeighExists(mpcfg.link, cfg.gwIP, mpcfg.routerMAC); err == nil && !exists {
 		warnings = append(warnings, fmt.Sprintf("missing arp entry for MAC/IP binding (%s/%s) on link %s",
-			mpcfg.routerMAC.String(), cfg.gwIP, util.K8sMgmtIntfName))
+			mpcfg.routerMAC.String(), cfg.gwIP, config.K8sMgmtIntfName))
 		err = util.LinkNeighAdd(mpcfg.link, cfg.gwIP, mpcfg.routerMAC)
 	}
 	if err != nil {
@@ -288,7 +288,7 @@ func DelMgtPortIptRules() {
 	if err != nil {
 		return
 	}
-	rule := []string{"-o", util.K8sMgmtIntfName, "-j", iptableMgmPortChain}
+	rule := []string{"-o", config.K8sMgmtIntfName, "-j", iptableMgmPortChain}
 	_ = ipt.Delete("nat", "POSTROUTING", rule...)
 	_ = ipt6.Delete("nat", "POSTROUTING", rule...)
 	_ = ipt.ClearChain("nat", iptableMgmPortChain)

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -65,8 +65,8 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	const (
 		nodeName      string = "node1"
 		mgtPortMAC    string = "00:00:00:55:66:77"
-		mgtPort       string = util.K8sMgmtIntfName
-		legacyMgtPort string = util.K8sPrefix + nodeName
+		mgtPort       string = config.K8sMgmtIntfName
+		legacyMgtPort string = config.K8sPrefix + nodeName
 		mtu           string = "1400"
 	)
 
@@ -259,7 +259,7 @@ var _ = Describe("Management Port Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		err = testNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
-			ovntest.AddLink(util.K8sMgmtIntfName)
+			ovntest.AddLink(config.K8sMgmtIntfName)
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -82,11 +82,11 @@ func (oc *Controller) addEgressFirewall(egressFirewall *egressfirewallapi.Egress
 	ef := newEgressFirewall(egressFirewall)
 	nsInfo.egressFirewallPolicy = ef
 	var errList []error
-	egressFirewallStartPriorityInt, err := strconv.Atoi(egressFirewallStartPriority)
+	egressFirewallStartPriorityInt, err := strconv.Atoi(config.EgressFirewallStartPriority)
 	if err != nil {
 		return []error{fmt.Errorf("failed to convert egressFirewallStartPriority to Integer: cannot add egressFirewall for namespace %s", egressFirewall.Namespace)}
 	}
-	minimumReservedEgressFirewallPriorityInt, err := strconv.Atoi(minimumReservedEgressFirewallPriority)
+	minimumReservedEgressFirewallPriorityInt, err := strconv.Atoi(config.MinimumReservedEgressFirewallPriority)
 	if err != nil {
 		return []error{fmt.Errorf("failed to convert minumumReservedEgressFirewallPriority to Integer: cannot add egressFirewall for namespace %s", egressFirewall.Namespace)}
 	}
@@ -141,16 +141,16 @@ func (oc *Controller) deleteEgressFirewall(egressFirewall *egressfirewallapi.Egr
 	stdout, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "logical_router_policy", fmt.Sprintf("external-ids:egressFirewall=%s", egressFirewall.Namespace))
 	if err != nil {
 		return []error{fmt.Errorf("error deleting egressFirewall for namespace %s, cannot get logical router policies from LR %s - %s:%s",
-			egressFirewall.Namespace, util.OVNClusterRouter, err, stderr)}
+			egressFirewall.Namespace, config.OVNClusterRouter, err, stderr)}
 	}
 	var errList []error
 
 	uuids := strings.Fields(stdout)
 	for _, uuid := range uuids {
-		_, stderr, err := util.RunOVNNbctl("lr-policy-del", util.OVNClusterRouter, uuid)
+		_, stderr, err := util.RunOVNNbctl("lr-policy-del", config.OVNClusterRouter, uuid)
 		if err != nil {
 			errList = append(errList, fmt.Errorf("failed to delete the rules for "+
-				"egressFirewall in namespace %s on logical switch %s, stderr: %q (%v)", egressFirewall.Namespace, util.OVNClusterRouter, stderr, err))
+				"egressFirewall in namespace %s on logical switch %s, stderr: %q (%v)", egressFirewall.Namespace, config.OVNClusterRouter, stderr, err))
 		}
 	}
 	return errList
@@ -186,13 +186,13 @@ func (ef *egressFirewall) addLogicalRouterPolicyToClusterRouter(hashedAddressSet
 		_, stderr, err := util.RunOVNNbctl("--id=@logical_router_policy", "create", "logical_router_policy",
 			fmt.Sprintf("priority=%d", efStartPriority-rule.id),
 			match, "action="+action, fmt.Sprintf("external-ids:egressFirewall=%s", ef.namespace),
-			"--", "add", "logical_router", util.OVNClusterRouter, "policies", "@logical_router_policy")
+			"--", "add", "logical_router", config.OVNClusterRouter, "policies", "@logical_router_policy")
 		if err != nil {
 			// TODO: lr-policy-add doesn't support --may-exist, resort to this workaround for now.
 			// Have raised an issue against ovn repository (https://github.com/ovn-org/ovn/issues/49)
 			if !strings.Contains(stderr, "already existed") {
 				return fmt.Errorf("failed to add policy route '%s' to %s "+
-					"stderr: %s, error: %v", match, util.OVNClusterRouter, stderr, err)
+					"stderr: %s, error: %v", match, config.OVNClusterRouter, stderr, err)
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -341,9 +341,9 @@ func (oc *Controller) addHybridRoutePolicyForPod(podIP net.IP, node string) erro
 			l3Prefix = "ip4"
 		}
 		// get the GR to join switch ip address
-		grJoinIfAddrs, err := util.GetLRPAddrs(util.GwRouterToJoinSwitchPrefix + util.GwRouterPrefix + node)
+		grJoinIfAddrs, err := util.GetLRPAddrs(config.GWRouterToJoinSwitchPrefix + config.GWRouterPrefix + node)
 		if err != nil {
-			return fmt.Errorf("unable to find IP address for node: %s, %s port, err: %v", node, util.GwRouterToJoinSwitchPrefix, err)
+			return fmt.Errorf("unable to find IP address for node: %s, %s port, err: %v", node, config.GWRouterToJoinSwitchPrefix, err)
 		}
 		grJoinIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6(podIP), grJoinIfAddrs)
 		if err != nil {
@@ -364,16 +364,16 @@ func (oc *Controller) addHybridRoutePolicyForPod(podIP net.IP, node string) erro
 			matchDst += fmt.Sprintf(" && %s.dst != %s", clusterL3Prefix, clusterSubnet.CIDR)
 		}
 		// traffic destined outside of cluster subnet go to GR
-		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.src == %s`, util.RouterToSwitchPrefix, node, l3Prefix, podIP)
+		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.src == %s`, config.RouterToSwitchPrefix, node, l3Prefix, podIP)
 		matchStr += matchDst
-		_, stderr, err := util.RunOVNNbctl("lr-policy-add", util.OVNClusterRouter, "501", matchStr, "reroute",
+		_, stderr, err := util.RunOVNNbctl("lr-policy-add", config.OVNClusterRouter, "501", matchStr, "reroute",
 			grJoinIfAddr.IP.String())
 		if err != nil {
 			// TODO: lr-policy-add doesn't support --may-exist, resort to this workaround for now.
 			// Have raised an issue against ovn repository (https://github.com/ovn-org/ovn/issues/49)
 			if !strings.Contains(stderr, "already existed") {
 				return fmt.Errorf("failed to add policy route '%s' to %s "+
-					"stderr: %s, error: %v", matchStr, util.OVNClusterRouter, stderr, err)
+					"stderr: %s, error: %v", matchStr, config.OVNClusterRouter, stderr, err)
 			}
 		}
 	}
@@ -404,12 +404,12 @@ func (oc *Controller) delHybridRoutePolicyForPod(podIP net.IP, node string) erro
 			}
 			matchDst += fmt.Sprintf(" && %s.dst != %s", l3Prefix, clusterSubnet.CIDR)
 		}
-		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.src == %s`, util.RouterToSwitchPrefix, node, l3Prefix, podIP)
+		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.src == %s`, config.RouterToSwitchPrefix, node, l3Prefix, podIP)
 		matchStr += matchDst
-		_, stderr, err := util.RunOVNNbctl("lr-policy-del", util.OVNClusterRouter, "501", matchStr)
+		_, stderr, err := util.RunOVNNbctl("lr-policy-del", config.OVNClusterRouter, "501", matchStr)
 		if err != nil {
 			klog.Errorf("Failed to remove policy: %s, on: %s, stderr: %s, err: %v",
-				matchStr, util.OVNClusterRouter, stderr, err)
+				matchStr, config.OVNClusterRouter, stderr, err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -592,7 +592,7 @@ func (e *egressIPController) getGatewayRouterJoinIP(node string, wantsIPv6 bool)
 	} else {
 		err := utilwait.ExponentialBackoff(retry.DefaultRetry, func() (bool, error) {
 			var err error
-			gatewayIPs, err = util.GetLRPAddrs(util.GwRouterToJoinSwitchPrefix + util.GwRouterPrefix + node)
+			gatewayIPs, err = util.GetLRPAddrs(config.GWRouterToJoinSwitchPrefix + config.GWRouterPrefix + node)
 			if err != nil {
 				klog.Errorf("Attempt at finding node gateway router network information failed, err: %v", err)
 			}
@@ -655,13 +655,13 @@ func (e *egressIPController) createEgressReroutePolicy(podIps []net.IP, status e
 				"logical_router_policy",
 				"action=reroute",
 				fmt.Sprintf("match=\"%s\"", filterOption),
-				fmt.Sprintf("priority=%v", egressIPReroutePriority),
+				fmt.Sprintf("priority=%v", config.EgressIPReroutePriority),
 				fmt.Sprintf("nexthop=%s", gatewayRouterIP),
 				fmt.Sprintf("external_ids:name=%s", egressIPName),
 				"--",
 				"add",
 				"logical_router",
-				util.OVNClusterRouter,
+				config.OVNClusterRouter,
 				"policies",
 				"@lr-policy",
 			)
@@ -694,7 +694,7 @@ func (e *egressIPController) deleteEgressReroutePolicy(podIps []net.IP, status e
 			_, stderr, err := util.RunOVNNbctl(
 				"remove",
 				"logical_router",
-				util.OVNClusterRouter,
+				config.OVNClusterRouter,
 				"policies",
 				policyID,
 			)
@@ -715,7 +715,7 @@ func findReroutePolicyIDs(filterOption, egressIPName string, gatewayRouterIP net
 		"find",
 		"logical_router_policy",
 		fmt.Sprintf("match=\"%s\"", filterOption),
-		fmt.Sprintf("priority=%v", egressIPReroutePriority),
+		fmt.Sprintf("priority=%v", config.EgressIPReroutePriority),
 		fmt.Sprintf("external_ids:name=%s", egressIPName),
 		fmt.Sprintf("nexthop=%s", gatewayRouterIP),
 	)
@@ -759,14 +759,14 @@ func getNodeInternalAddrs(node *v1.Node) (net.IP, net.IP) {
 // i.e: ensuring that an egress pod can still communicate with a regular pod / service backed by regular pods
 func createDefaultNoReroutePodPolicies(v4ClusterSubnet, v6ClusterSubnet *net.IPNet) {
 	if v4ClusterSubnet != nil {
-		_, stderr, err := util.RunOVNNbctl("lr-policy-add", util.OVNClusterRouter, defaultNoRereoutePriority,
+		_, stderr, err := util.RunOVNNbctl("lr-policy-add", config.OVNClusterRouter, config.DefaultNoRereoutePriority,
 			fmt.Sprintf("ip4.src == %s && ip4.dst == %s", v4ClusterSubnet.String(), v4ClusterSubnet.String()), "allow")
 		if err != nil && !strings.Contains(stderr, policyAlreadyExistsMsg) {
 			klog.Errorf("Unable to create IPv4 default no-reroute logical router policy, stderr: %s, err: %v", stderr, err)
 		}
 	}
 	if v6ClusterSubnet != nil {
-		_, stderr, err := util.RunOVNNbctl("lr-policy-add", util.OVNClusterRouter, defaultNoRereoutePriority,
+		_, stderr, err := util.RunOVNNbctl("lr-policy-add", config.OVNClusterRouter, config.DefaultNoRereoutePriority,
 			fmt.Sprintf("ip6.src == %s && ip6.dst == %s", v6ClusterSubnet.String(), v6ClusterSubnet.String()), "allow")
 		if err != nil && !strings.Contains(stderr, policyAlreadyExistsMsg) {
 			klog.Errorf("Unable to create IPv6 default no-reroute logical router policy, stderr: %s, err: %v", stderr, err)
@@ -778,14 +778,14 @@ func createDefaultNoReroutePodPolicies(v4ClusterSubnet, v6ClusterSubnet *net.IPN
 // i.e: ensuring that an egress pod can still communicate with a hostNetwork pod / service backed by hostNetwork pods
 func createDefaultNoRerouteNodePolicies(v4NodeAddr, v6NodeAddr net.IP, v4ClusterSubnet, v6ClusterSubnet *net.IPNet) error {
 	if v4NodeAddr != nil && v4ClusterSubnet != nil {
-		_, stderr, err := util.RunOVNNbctl("lr-policy-add", util.OVNClusterRouter, defaultNoRereoutePriority,
+		_, stderr, err := util.RunOVNNbctl("lr-policy-add", config.OVNClusterRouter, config.DefaultNoRereoutePriority,
 			fmt.Sprintf("ip4.src == %s && ip4.dst == %s/32", v4ClusterSubnet.String(), v4NodeAddr.String()), "allow")
 		if err != nil && !strings.Contains(stderr, policyAlreadyExistsMsg) {
 			return fmt.Errorf("unable to create IPv4 default no-reroute logical router policy, stderr: %s, err: %v", stderr, err)
 		}
 	}
 	if v6NodeAddr != nil && v6ClusterSubnet != nil {
-		_, stderr, err := util.RunOVNNbctl("lr-policy-add", util.OVNClusterRouter, defaultNoRereoutePriority,
+		_, stderr, err := util.RunOVNNbctl("lr-policy-add", config.OVNClusterRouter, config.DefaultNoRereoutePriority,
 			fmt.Sprintf("ip6.src == %s && ip6.dst == %s/128", v6ClusterSubnet.String(), v6NodeAddr.String()), "allow")
 		if err != nil && !strings.Contains(stderr, policyAlreadyExistsMsg) {
 			return fmt.Errorf("unable to create IPv6 default no-reroute logical router policy, stderr: %s, err: %v", stderr, err)
@@ -796,14 +796,14 @@ func createDefaultNoRerouteNodePolicies(v4NodeAddr, v6NodeAddr net.IP, v4Cluster
 
 func deleteDefaultNoRerouteNodePolicies(v4NodeAddr, v6NodeAddr net.IP, v4ClusterSubnet, v6ClusterSubnet *net.IPNet) error {
 	if v4NodeAddr != nil && v4ClusterSubnet != nil {
-		_, stderr, err := util.RunOVNNbctl("lr-policy-del", util.OVNClusterRouter, defaultNoRereoutePriority,
+		_, stderr, err := util.RunOVNNbctl("lr-policy-del", config.OVNClusterRouter, config.DefaultNoRereoutePriority,
 			fmt.Sprintf("ip4.src == %s && ip4.dst == %s/32", v4ClusterSubnet.String(), v4NodeAddr.String()))
 		if err != nil && !strings.Contains(stderr, policyAlreadyExistsMsg) {
 			return fmt.Errorf("unable to create IPv4 default no-reroute logical router policy, stderr: %s, err: %v", stderr, err)
 		}
 	}
 	if v6NodeAddr != nil && v6ClusterSubnet != nil {
-		_, stderr, err := util.RunOVNNbctl("lr-policy-del", util.OVNClusterRouter, defaultNoRereoutePriority,
+		_, stderr, err := util.RunOVNNbctl("lr-policy-del", config.OVNClusterRouter, config.DefaultNoRereoutePriority,
 			fmt.Sprintf("ip6.src == %s && ip6.dst == %s/128", v6ClusterSubnet.String(), v6NodeAddr.String()))
 		if err != nil && !strings.Contains(stderr, policyAlreadyExistsMsg) {
 			return fmt.Errorf("unable to create IPv6 default no-reroute logical router policy, stderr: %s, err: %v", stderr, err)

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -243,8 +242,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv4),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv4, eIP.Name, util.OVNClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv4),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, nodeLogicalRouterIPv4, eIP.Name, config.OVNClusterRouter),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find nat external_ids:name=%s logical_ip=%s external_ip=%s", eIP.Name, egressPod.Status.PodIP, egressIP),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@nat create nat type=snat %s %s %s %s -- add logical_router GR_%s nat @nat", fmt.Sprintf("logical_port=k8s-%s", node2.Name), fmt.Sprintf("external_ip=%s", egressIP), fmt.Sprintf("logical_ip=%s", egressPod.Status.PodIP), fmt.Sprintf("external_ids:name=%s", eIP.Name), node2.Name),
 					},
@@ -358,8 +357,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv4),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv4, eIP.Name, util.OVNClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv4),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip4.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, nodeLogicalRouterIPv4, eIP.Name, config.OVNClusterRouter),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find nat external_ids:name=%s logical_ip=%s external_ip=%s", eIP.Name, egressPod.Status.PodIP, egressIP),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@nat create nat type=snat %s %s %s %s -- add logical_router GR_%s nat @nat", fmt.Sprintf("logical_port=k8s-%s", node2.Name), fmt.Sprintf("external_ip=%s", egressIP), fmt.Sprintf("logical_ip=%s", egressPod.Status.PodIP), fmt.Sprintf("external_ids:name=%s", eIP.Name), node2.Name),
 					},
@@ -430,8 +429,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, util.OVNClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, config.OVNClusterRouter),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find nat external_ids:name=%s logical_ip=%s external_ip=%s", eIP.Name, egressPod.Status.PodIP, egressIP),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@nat create nat type=snat %s %s %s %s -- add logical_router GR_%s nat @nat", fmt.Sprintf("logical_port=k8s-%s", node2.name), fmt.Sprintf("external_ip=%s", egressIP), fmt.Sprintf("logical_ip=%s", egressPod.Status.PodIP), fmt.Sprintf("external_ids:name=%s", eIP.Name), node2.name),
 					},
@@ -453,13 +452,13 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
 						Output: reroutePolicyID,
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 remove logical_router %s policies %s", util.OVNClusterRouter, reroutePolicyID),
+						fmt.Sprintf("ovn-nbctl --timeout=15 remove logical_router %s policies %s", config.OVNClusterRouter, reroutePolicyID),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmd(
@@ -531,8 +530,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, util.OVNClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, config.OVNClusterRouter),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find nat external_ids:name=%s logical_ip=%s external_ip=%s", eIP.Name, egressPod.Status.PodIP, egressIP),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@nat create nat type=snat %s %s %s %s -- add logical_router GR_%s nat @nat", fmt.Sprintf("logical_port=k8s-%s", node2.name), fmt.Sprintf("external_ip=%s", egressIP), fmt.Sprintf("logical_ip=%s", egressPod.Status.PodIP), fmt.Sprintf("external_ids:name=%s", eIP.Name), node2.name),
 					},
@@ -627,8 +626,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", podV6IP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", podV6IP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, util.OVNClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", podV6IP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", podV6IP), config.EgressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, config.OVNClusterRouter),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find nat external_ids:name=%s logical_ip=%s external_ip=%s", eIP.Name, podV6IP, egressIP),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@nat create nat type=snat %s %s %s %s -- add logical_router GR_%s nat @nat", fmt.Sprintf("logical_port=k8s-%s", node2.name), fmt.Sprintf("external_ip=%s", egressIP), fmt.Sprintf("logical_ip=%s", podV6IP), fmt.Sprintf("external_ids:name=%s", eIP.Name), node2.name),
 					},
@@ -753,8 +752,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, util.OVNClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, config.OVNClusterRouter),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find nat external_ids:name=%s logical_ip=%s external_ip=%s", eIP.Name, egressPod.Status.PodIP, egressIP),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@nat create nat type=snat %s %s %s %s -- add logical_router GR_%s nat @nat", fmt.Sprintf("logical_port=k8s-%s", node2.name), fmt.Sprintf("external_ip=%s", egressIP), fmt.Sprintf("logical_ip=%s", egressPod.Status.PodIP), fmt.Sprintf("external_ids:name=%s", eIP.Name), node2.name),
 					},
@@ -776,13 +775,13 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
 						Output: reroutePolicyID,
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 remove logical_router %s policies %s", util.OVNClusterRouter, reroutePolicyID),
+						fmt.Sprintf("ovn-nbctl --timeout=15 remove logical_router %s policies %s", config.OVNClusterRouter, reroutePolicyID),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmd(
@@ -918,8 +917,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, util.OVNClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, config.OVNClusterRouter),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find nat external_ids:name=%s logical_ip=%s external_ip=%s", eIP.Name, egressPod.Status.PodIP, egressIP),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@nat create nat type=snat %s %s %s %s -- add logical_router GR_%s nat @nat", fmt.Sprintf("logical_port=k8s-%s", node2.name), fmt.Sprintf("external_ip=%s", egressIP), fmt.Sprintf("logical_ip=%s", egressPod.Status.PodIP), fmt.Sprintf("external_ids:name=%s", eIP.Name), node2.name),
 					},
@@ -953,13 +952,13 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				}
 				fakeOvn.fakeExec.AddFakeCmd(
 					&ovntest.ExpectedCmd{
-						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
 						Output: reroutePolicyID,
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 remove logical_router %s policies %s", util.OVNClusterRouter, reroutePolicyID),
+						fmt.Sprintf("ovn-nbctl --timeout=15 remove logical_router %s policies %s", config.OVNClusterRouter, reroutePolicyID),
 					},
 				)
 				fakeOvn.fakeExec.AddFakeCmd(
@@ -975,8 +974,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, util.OVNClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, config.OVNClusterRouter),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find nat external_ids:name=%s logical_ip=%s external_ip=%s", eIP.Name, egressPod.Status.PodIP, updatedEgressIP.String()),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@nat create nat type=snat %s %s %s %s -- add logical_router GR_%s nat @nat", fmt.Sprintf("logical_port=k8s-%s", node2.name), fmt.Sprintf("external_ip=%s", updatedEgressIP.String()), fmt.Sprintf("logical_ip=%s", egressPod.Status.PodIP), fmt.Sprintf("external_ids:name=%s", eIP.Name), node2.name),
 					},
@@ -1042,8 +1041,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
-						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
-						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), egressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, util.OVNClusterRouter),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find logical_router_policy match=\"%s\" priority=%s external_ids:name=%s nexthop=%s", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, eIP.Name, nodeLogicalRouterIPv6),
+						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@lr-policy create logical_router_policy action=reroute match=\"%s\" priority=%s nexthop=%s external_ids:name=%s -- add logical_router %s policies @lr-policy", fmt.Sprintf("ip6.src == %s", egressPod.Status.PodIP), config.EgressIPReroutePriority, nodeLogicalRouterIPv6, eIP.Name, config.OVNClusterRouter),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find nat external_ids:name=%s logical_ip=%s external_ip=%s", eIP.Name, egressPod.Status.PodIP, egressIP.String()),
 						fmt.Sprintf("ovn-nbctl --timeout=15 --id=@nat create nat type=snat %s %s %s %s -- add logical_router GR_%s nat @nat", fmt.Sprintf("logical_port=k8s-%s", node2.name), fmt.Sprintf("external_ip=%s", egressIP.String()), fmt.Sprintf("logical_ip=%s", egressPod.Status.PodIP), fmt.Sprintf("external_ids:name=%s", eIP.Name), node2.name),
 					},

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"fmt"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -112,7 +113,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 }
 
 func (ovn *Controller) handleNodePortLB(node *kapi.Node) error {
-	gatewayRouter := util.GwRouterPrefix + node.Name
+	gatewayRouter := config.GWRouterPrefix + node.Name
 	var physicalIPs []string
 	if physicalIPs, _ = ovn.getGatewayPhysicalIPs(gatewayRouter); physicalIPs == nil {
 		return fmt.Errorf("gateway physical IP for node %q does not yet exist", node.Name)

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -5,21 +5,11 @@ import (
 	"net"
 	"strings"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog"
-)
-
-const (
-	// priority of logical router policies on the ovnClusterRouter
-	egressFirewallStartPriority           = "10000"
-	minimumReservedEgressFirewallPriority = "2000"
-	mgmtPortPolicyPriority                = "1005"
-	nodeSubnetPolicyPriority              = "1004"
-	interNodePolicyPriority               = "1003"
-	defaultNoRereoutePriority             = "101"
-	egressIPReroutePriority               = "100"
 )
 
 func (ovn *Controller) getOvnGateways() ([]string, string, error) {
@@ -182,7 +172,7 @@ func getGatewayLoadBalancers(gatewayRouter string) (string, string, string, erro
 func (oc *Controller) getJoinLRPAddresses(nodeName string) []*net.IPNet {
 	// try to get the IPs from the logical router port
 	gwLRPIPs := []*net.IPNet{}
-	gwLrpName := util.GwRouterToJoinSwitchPrefix + util.GwRouterPrefix + nodeName
+	gwLrpName := config.GWRouterToJoinSwitchPrefix + config.GWRouterPrefix + nodeName
 	joinSubnets := oc.joinSwIPManager.lsm.GetSwitchSubnets(nodeName)
 	ifAddrs, err := util.GetLRPAddrs(gwLrpName)
 	if err == nil {

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -13,12 +14,12 @@ import (
 
 // gatewayCleanup removes all the NB DB objects created for a node's gateway
 func gatewayCleanup(nodeName string) error {
-	gatewayRouter := util.GwRouterPrefix + nodeName
+	gatewayRouter := config.GWRouterPrefix + nodeName
 
 	// Get the gateway router port's IP address (connected to join switch)
 	var nextHops []net.IP
 
-	gwIPAddrs, err := util.GetLRPAddrs(util.GwRouterToJoinSwitchPrefix + gatewayRouter)
+	gwIPAddrs, err := util.GetLRPAddrs(config.GWRouterToJoinSwitchPrefix + gatewayRouter)
 	if err != nil {
 		return err
 	}
@@ -29,10 +30,10 @@ func gatewayCleanup(nodeName string) error {
 	staticRouteCleanup(nextHops)
 
 	// Remove the patch port that connects join switch to gateway router
-	_, stderr, err := util.RunOVNNbctl("--if-exist", "lsp-del", util.JoinSwitchToGwRouterPrefix+gatewayRouter)
+	_, stderr, err := util.RunOVNNbctl("--if-exist", "lsp-del", config.JoinSwitchToGWRouterPrefix+gatewayRouter)
 	if err != nil {
 		return fmt.Errorf("failed to delete logical switch port %s%s: "+
-			"stderr: %q, error: %v", util.JoinSwitchToGwRouterPrefix, gatewayRouter, stderr, err)
+			"stderr: %q, error: %v", config.JoinSwitchToGWRouterPrefix, gatewayRouter, stderr, err)
 	}
 
 	// Remove the gateway router associated with nodeName
@@ -44,7 +45,7 @@ func gatewayCleanup(nodeName string) error {
 	}
 
 	// Remove external switch
-	externalSwitch := util.ExternalSwitchPrefix + nodeName
+	externalSwitch := config.ExternalSwitchPrefix + nodeName
 	_, stderr, err = util.RunOVNNbctl("--if-exist", "ls-del",
 		externalSwitch)
 	if err != nil {
@@ -82,7 +83,7 @@ func delPbrAndNatRules(nodeName string) {
 	// delete the dnat_and_snat entry that we added for the management port IP
 	// Note: we don't need to delete any MAC bindings that are dynamically learned from OVN SB DB
 	// because there will be none since this NAT is only for outbound traffic and not for inbound
-	mgmtPortName := util.K8sPrefix + nodeName
+	mgmtPortName := config.K8sPrefix + nodeName
 	externalIP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
 		"--columns=external_ip", "find", "nat", fmt.Sprintf("logical_port=%s", mgmtPortName))
 	if err != nil {
@@ -91,7 +92,7 @@ func delPbrAndNatRules(nodeName string) {
 		externalIP = ""
 	}
 	if externalIP != "" {
-		_, stderr, err = util.RunOVNNbctl("--if-exists", "lr-nat-del", util.OVNClusterRouter, "dnat_and_snat", externalIP)
+		_, stderr, err = util.RunOVNNbctl("--if-exists", "lr-nat-del", config.OVNClusterRouter, "dnat_and_snat", externalIP)
 		if err != nil {
 			klog.Errorf("Failed to delete the dnat_and_snat ip %s associated with the management "+
 				"port %s: stderr: %s, error: %v", externalIP, mgmtPortName, stderr, err)
@@ -108,23 +109,23 @@ func delPbrAndNatRules(nodeName string) {
 	}
 	// matches inport for a policy, must use ending quote to substring match to avoid matching other nodes accidentally
 	// i.e. rtos-ovn-worker would match rtos-ovn-worker2
-	nodeSubnetMatchSubStr := fmt.Sprintf("%s%s\"", util.RouterToSwitchPrefix, nodeName)
+	nodeSubnetMatchSubStr := fmt.Sprintf("%s%s\"", config.RouterToSwitchPrefix, nodeName)
 	// for inter node, match the comment in the policy, and include extra space to avoid accidental submatch
-	interNodeMatchSubStr := fmt.Sprintf("%s%s ", util.InterPrefix, nodeName)
+	interNodeMatchSubStr := fmt.Sprintf("%s%s ", config.InterPrefix, nodeName)
 	// mgmt port policy matches node name in comment, use extra spaces to avoid accidental match of other nodes
 	mgmtPortPolicyMatchSubStr := fmt.Sprintf(" %s ", nodeName)
 	for _, match := range strings.Split(matches, "\n\n") {
 		var priority string
 		if strings.Contains(match, nodeSubnetMatchSubStr) {
-			priority = nodeSubnetPolicyPriority
+			priority = config.NodeSubnetPolicyPriority
 		} else if strings.Contains(match, interNodeMatchSubStr) {
-			priority = interNodePolicyPriority
+			priority = config.InterNodePolicyPriority
 		} else if strings.Contains(match, mgmtPortPolicyMatchSubStr) {
-			priority = mgmtPortPolicyPriority
+			priority = config.MGMTPortPolicyPriority
 		} else {
 			continue
 		}
-		_, stderr, err = util.RunOVNNbctl("lr-policy-del", util.OVNClusterRouter, priority, match)
+		_, stderr, err = util.RunOVNNbctl("lr-policy-del", config.OVNClusterRouter, priority, match)
 		if err != nil {
 			klog.Errorf("Failed to remove the policy routes (%s, %s) associated with the node %s: stderr: %s, error: %v",
 				priority, match, nodeName, stderr, err)
@@ -150,7 +151,7 @@ func staticRouteCleanup(nextHops []net.IP) {
 		routes := strings.Fields(uuids)
 		for _, route := range routes {
 			_, stderr, err = util.RunOVNNbctl("--if-exists", "remove",
-				"logical_router", util.OVNClusterRouter, "static_routes", route)
+				"logical_router", config.OVNClusterRouter, "static_routes", route)
 			if err != nil {
 				klog.Errorf("Failed to delete static route %s"+
 					", stderr: %q, err = %v", route, stderr, err)
@@ -172,12 +173,12 @@ func staticRouteCleanup(nextHops []net.IP) {
 // specified node if the node was deleted when the ovnkube-master pod was brought down
 // to do the version upgrade.
 func multiJoinSwitchGatewayCleanup(nodeName string, upgradeOnly bool) error {
-	gatewayRouter := util.GwRouterPrefix + nodeName
+	gatewayRouter := config.GWRouterPrefix + nodeName
 
 	// Get the gateway router port's IP address (connected to join switch)
 	var nextHops []net.IP
 
-	gwIPAddrs, err := util.GetLRPAddrs(util.GwRouterToJoinSwitchPrefix + gatewayRouter)
+	gwIPAddrs, err := util.GetLRPAddrs(config.GWRouterToJoinSwitchPrefix + gatewayRouter)
 	if err != nil {
 		return err
 	}
@@ -194,7 +195,7 @@ func multiJoinSwitchGatewayCleanup(nodeName string, upgradeOnly bool) error {
 		if stdout != "" {
 			policyIDs := strings.Fields(stdout)
 			for _, policyID := range policyIDs {
-				_, stderr, err = util.RunOVNNbctl("remove", "logical_router", util.OVNClusterRouter, "policies", policyID)
+				_, stderr, err = util.RunOVNNbctl("remove", "logical_router", config.OVNClusterRouter, "policies", policyID)
 				if err != nil {
 					klog.Errorf("Unable to remove LR policy: %s, stderr: %s, err: %v", policyID, stderr, err)
 				}
@@ -219,10 +220,10 @@ func multiJoinSwitchGatewayCleanup(nodeName string, upgradeOnly bool) error {
 	}
 
 	// Remove the logical router port on the gateway router that connects to the join switch
-	_, stderr, err = util.RunOVNNbctl("--if-exist", "lrp-del", util.GwRouterToJoinSwitchPrefix+gatewayRouter)
+	_, stderr, err = util.RunOVNNbctl("--if-exist", "lrp-del", config.GWRouterToJoinSwitchPrefix+gatewayRouter)
 	if err != nil {
 		return fmt.Errorf("failed to delete the port %s%s on gateway router "+
-			"stderr: %q, error: %v", util.GwRouterToJoinSwitchPrefix, gatewayRouter, stderr, err)
+			"stderr: %q, error: %v", config.GWRouterToJoinSwitchPrefix, gatewayRouter, stderr, err)
 	}
 
 	if upgradeOnly {
@@ -238,7 +239,7 @@ func multiJoinSwitchGatewayCleanup(nodeName string, upgradeOnly bool) error {
 	}
 
 	// Remove external switch
-	externalSwitch := util.ExternalSwitchPrefix + nodeName
+	externalSwitch := config.ExternalSwitchPrefix + nodeName
 	_, stderr, err = util.RunOVNNbctl("--if-exist", "ls-del",
 		externalSwitch)
 	if err != nil {

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -25,7 +25,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 	}
 
 	// Create a gateway router.
-	gatewayRouter := util.GwRouterPrefix + nodeName
+	gatewayRouter := config.GWRouterPrefix + nodeName
 	physicalIPs := make([]string, len(l3GatewayConfig.IPAddresses))
 	for i, ip := range l3GatewayConfig.IPAddresses {
 		physicalIPs[i] = ip.IP.String()
@@ -40,16 +40,16 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 			"stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
 	}
 
-	gwSwitchPort := util.JoinSwitchToGwRouterPrefix + gatewayRouter
-	gwRouterPort := util.GwRouterToJoinSwitchPrefix + gatewayRouter
+	gwSwitchPort := config.JoinSwitchToGWRouterPrefix + gatewayRouter
+	gwRouterPort := config.GWRouterToJoinSwitchPrefix + gatewayRouter
 
 	stdout, stderr, err = util.RunOVNNbctl(
-		"--", "--may-exist", "lsp-add", util.OVNJoinSwitch, gwSwitchPort,
+		"--", "--may-exist", "lsp-add", config.OVNJoinSwitch, gwSwitchPort,
 		"--", "set", "logical_switch_port", gwSwitchPort, "type=router", "options:router-port="+gwRouterPort,
 		"addresses=router")
 	if err != nil {
 		return fmt.Errorf("failed to add port %q to logical switch %q, "+
-			"stdout: %q, stderr: %q, error: %v", gwSwitchPort, util.OVNJoinSwitch, stdout, stderr, err)
+			"stdout: %q, stderr: %q, error: %v", gwSwitchPort, config.OVNJoinSwitch, stdout, stderr, err)
 	}
 
 	gwLRPMAC := util.IPAddrToHWAddr(gwLRPIPs[0])
@@ -181,7 +181,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 	}
 
 	// Create the external switch for the physical interface to connect to.
-	externalSwitch := util.ExternalSwitchPrefix + nodeName
+	externalSwitch := config.ExternalSwitchPrefix + nodeName
 	stdout, stderr, err = util.RunOVNNbctl("--may-exist", "ls-add",
 		externalSwitch)
 	if err != nil {
@@ -196,7 +196,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 		"--", "--may-exist", "lsp-add", externalSwitch, l3GatewayConfig.InterfaceID,
 		"--", "lsp-set-addresses", l3GatewayConfig.InterfaceID, "unknown",
 		"--", "lsp-set-type", l3GatewayConfig.InterfaceID, "localnet",
-		"--", "lsp-set-options", l3GatewayConfig.InterfaceID, "network_name=" + util.PhysicalNetworkName}
+		"--", "lsp-set-options", l3GatewayConfig.InterfaceID, "network_name=" + config.PhysicalNetworkName}
 
 	if l3GatewayConfig.VLANID != nil {
 		lspArgs := []string{
@@ -218,15 +218,15 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 	// direct addition of logical_router_port with --may-exists will not work since the MAC
 	// has changed. So, we need to delete that port, if it exists, and it back.
 	cmdArgs = []string{
-		"--", "--if-exists", "lrp-del", util.GwRouterToExtSwitchPrefix + gatewayRouter,
-		"--", "lrp-add", gatewayRouter, util.GwRouterToExtSwitchPrefix + gatewayRouter,
+		"--", "--if-exists", "lrp-del", config.GWRouterToExtSwitchPrefix + gatewayRouter,
+		"--", "lrp-add", gatewayRouter, config.GWRouterToExtSwitchPrefix + gatewayRouter,
 		l3GatewayConfig.MACAddress.String(),
 	}
 	for _, ip := range l3GatewayConfig.IPAddresses {
 		cmdArgs = append(cmdArgs, ip.String())
 	}
 	cmdArgs = append(cmdArgs,
-		"--", "set", "logical_router_port", util.GwRouterToExtSwitchPrefix+gatewayRouter,
+		"--", "set", "logical_router_port", config.GWRouterToExtSwitchPrefix+gatewayRouter,
 		"external-ids:gateway-physical-ip=yes")
 
 	stdout, stderr, err = util.RunOVNNbctl(cmdArgs...)
@@ -237,9 +237,9 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 
 	// Connect the external_switch to the router.
 	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add",
-		externalSwitch, util.ExtSwitchToGwRouterPrefix+gatewayRouter, "--", "set",
-		"logical_switch_port", util.ExtSwitchToGwRouterPrefix+gatewayRouter, "type=router",
-		"options:router-port="+util.GwRouterToExtSwitchPrefix+gatewayRouter,
+		externalSwitch, config.EXTSwitchToGWRouterPrefix+gatewayRouter, "--", "set",
+		"logical_switch_port", config.EXTSwitchToGWRouterPrefix+gatewayRouter, "type=router",
+		"options:router-port="+config.GWRouterToExtSwitchPrefix+gatewayRouter,
 		"addresses="+"\""+l3GatewayConfig.MACAddress.String()+"\"")
 	if err != nil {
 		return fmt.Errorf("failed to add logical port to router %s, stdout: %q, "+
@@ -256,7 +256,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 		}
 		stdout, stderr, err = util.RunOVNNbctl("--may-exist", "lr-route-add",
 			gatewayRouter, allIPs, nextHop.String(),
-			fmt.Sprintf("%s%s", util.GwRouterToExtSwitchPrefix, gatewayRouter))
+			fmt.Sprintf("%s%s", config.GWRouterToExtSwitchPrefix, gatewayRouter))
 		if err != nil {
 			return fmt.Errorf("failed to add a static route in GR %s with physical "+
 				"gateway as the default next hop, stdout: %q, "+
@@ -271,7 +271,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 	// This can be removed once https://bugzilla.redhat.com/show_bug.cgi?id=1891516 is fixed.
 	for _, gwLRPIP := range gwLRPIPs {
 		stdout, stderr, err = util.RunOVNNbctl("--may-exist", "lr-route-add",
-			util.OVNClusterRouter, gwLRPIP.String(), gwLRPIP.String())
+			config.OVNClusterRouter, gwLRPIP.String(), gwLRPIP.String())
 		if err != nil {
 			return fmt.Errorf("failed to add the route to Gateway router's IP of %q "+
 				"on the distributed router, stdout: %q, stderr: %q, error: %v",
@@ -286,17 +286,17 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 		if err != nil {
 			return fmt.Errorf("failed to add source IP address based "+
 				"routes in distributed router %s: %v",
-				util.OVNClusterRouter, err)
+				config.OVNClusterRouter, err)
 		}
 
 		if config.Gateway.Mode != config.GatewayModeLocal {
 			stdout, stderr, err = util.RunOVNNbctl("--may-exist",
-				"--policy=src-ip", "lr-route-add", util.OVNClusterRouter,
+				"--policy=src-ip", "lr-route-add", config.OVNClusterRouter,
 				hostSubnet.String(), gwLRPIP.String())
 			if err != nil {
 				return fmt.Errorf("failed to add source IP address based "+
 					"routes in distributed router %s, stdout: %q, "+
-					"stderr: %q, error: %v", util.OVNClusterRouter, stdout, stderr, err)
+					"stderr: %q, error: %v", config.OVNClusterRouter, stdout, stderr, err)
 			}
 		}
 	}
@@ -339,27 +339,27 @@ func addDistributedGWPort() error {
 	var dgpMac string
 	var nbctlArgs []string
 	// add a distributed gateway port to the distributed router
-	dgpName := util.RouterToSwitchPrefix + util.NodeLocalSwitch
+	dgpName := config.RouterToSwitchPrefix + config.NodeLocalSwitch
 	if config.IPv4Mode {
-		dgpMac = util.IPAddrToHWAddr(net.ParseIP(util.V4NodeLocalDistributedGwPortIP)).String()
+		dgpMac = util.IPAddrToHWAddr(net.ParseIP(config.V4NodeLocalDistributedGWPortIP)).String()
 	} else {
-		dgpMac = util.IPAddrToHWAddr(net.ParseIP(util.V6NodeLocalDistributedGwPortIP)).String()
+		dgpMac = util.IPAddrToHWAddr(net.ParseIP(config.V6NodeLocalDistributedGWPortIP)).String()
 	}
 	nbctlArgs = append(nbctlArgs,
-		"--may-exist", "lrp-add", util.OVNClusterRouter, dgpName, dgpMac,
+		"--may-exist", "lrp-add", config.OVNClusterRouter, dgpName, dgpMac,
 	)
 	if config.IPv4Mode && config.IPv6Mode {
 		nbctlArgs = append(nbctlArgs,
-			fmt.Sprintf("%s/%d", util.V4NodeLocalDistributedGwPortIP, util.V4NodeLocalNatSubnetPrefix),
-			fmt.Sprintf("%s/%d", util.V6NodeLocalDistributedGwPortIP, util.V6NodeLocalNatSubnetPrefix),
+			fmt.Sprintf("%s/%d", config.V4NodeLocalDistributedGWPortIP, config.V4NodeLocalNATSubnetPrefix),
+			fmt.Sprintf("%s/%d", config.V6NodeLocalDistributedGWPortIP, config.V6NodeLocalNATSubnetPrefix),
 		)
 	} else if config.IPv4Mode {
 		nbctlArgs = append(nbctlArgs,
-			fmt.Sprintf("%s/%d", util.V4NodeLocalDistributedGwPortIP, util.V4NodeLocalNatSubnetPrefix),
+			fmt.Sprintf("%s/%d", config.V4NodeLocalDistributedGWPortIP, config.V4NodeLocalNATSubnetPrefix),
 		)
 	} else if config.IPv6Mode {
 		nbctlArgs = append(nbctlArgs,
-			fmt.Sprintf("%s/%d", util.V6NodeLocalDistributedGwPortIP, util.V6NodeLocalNatSubnetPrefix),
+			fmt.Sprintf("%s/%d", config.V6NodeLocalDistributedGWPortIP, config.V6NodeLocalNATSubnetPrefix),
 		)
 	}
 	// set gateway chassis (the current master node) for distributed gateway port)
@@ -375,28 +375,28 @@ func addDistributedGWPort() error {
 
 	// connect the distributed gateway port to logical switch configured with localnet port
 	nbctlArgs = []string{
-		"--may-exist", "ls-add", util.NodeLocalSwitch,
+		"--may-exist", "ls-add", config.NodeLocalSwitch,
 	}
 	// add localnet port to the logical switch
-	lclNetPortname := "lnet-" + util.NodeLocalSwitch
+	lclNetPortname := "lnet-" + config.NodeLocalSwitch
 	nbctlArgs = append(nbctlArgs,
-		"--", "--may-exist", "lsp-add", util.NodeLocalSwitch, lclNetPortname,
+		"--", "--may-exist", "lsp-add", config.NodeLocalSwitch, lclNetPortname,
 		"--", "set", "logical_switch_port", lclNetPortname, "addresses=unknown", "type=localnet",
-		"options:network_name="+util.LocalNetworkName)
+		"options:network_name="+config.LocalNetworkName)
 	// connect the switch to the distributed router
-	lspName := util.SwitchToRouterPrefix + util.NodeLocalSwitch
+	lspName := config.SwitchToRouterPrefix + config.NodeLocalSwitch
 	nbctlArgs = append(nbctlArgs,
-		"--", "--may-exist", "lsp-add", util.NodeLocalSwitch, lspName,
+		"--", "--may-exist", "lsp-add", config.NodeLocalSwitch, lspName,
 		"--", "set", "logical_switch_port", lspName, "type=router", "addresses=router",
 		"options:nat-addresses=router", "options:router-port="+dgpName)
 	stdout, stderr, err = util.RunOVNNbctl(nbctlArgs...)
 	if err != nil {
 		return fmt.Errorf("failed creating logical switch %s and its ports (%s, %s) "+
-			"stdout: %q, stderr: %q, error: %v", util.NodeLocalSwitch, lclNetPortname, lspName, stdout, stderr, err)
+			"stdout: %q, stderr: %q, error: %v", config.NodeLocalSwitch, lclNetPortname, lspName, stdout, stderr, err)
 	}
 	// finally add an entry to the OVN SB MAC_Binding table, if not present, to capture the
-	// MAC-IP binding of util.V4NodeLocalNatSubnetNextHop address or
-	// util.V6NodeLocalNatSubnetNextHop address to its MAC. Normally, this will
+	// MAC-IP binding of config.V4NodeLocalNATSubnetNextHop address or
+	// config.V6NodeLocalNATSubnetNextHop address to its MAC. Normally, this will
 	// be learnt and added by the chassis to which the distributed gateway port (DGP) is
 	// bound. However, in our case we don't send any traffic out with the DGP port's IP
 	// as source IP, so that binding will never be learnt and we need to seed it.
@@ -404,14 +404,14 @@ func addDistributedGWPort() error {
 	// Only used for Error Strings
 	var nodeLocalNatSubnetNextHop string
 	if config.IPv4Mode && config.IPv6Mode {
-		dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(util.V4NodeLocalNatSubnetNextHop)).String()
-		nodeLocalNatSubnetNextHop = util.V4NodeLocalNatSubnetNextHop + " " + util.V6NodeLocalNatSubnetNextHop
+		dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(config.V4NodeLocalNATSubnetNextHop)).String()
+		nodeLocalNatSubnetNextHop = config.V4NodeLocalNATSubnetNextHop + " " + config.V6NodeLocalNATSubnetNextHop
 	} else if config.IPv4Mode {
-		dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(util.V4NodeLocalNatSubnetNextHop)).String()
-		nodeLocalNatSubnetNextHop = util.V4NodeLocalNatSubnetNextHop
+		dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(config.V4NodeLocalNATSubnetNextHop)).String()
+		nodeLocalNatSubnetNextHop = config.V4NodeLocalNATSubnetNextHop
 	} else if config.IPv6Mode {
-		dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(util.V6NodeLocalNatSubnetNextHop)).String()
-		nodeLocalNatSubnetNextHop = util.V6NodeLocalNatSubnetNextHop
+		dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(config.V6NodeLocalNATSubnetNextHop)).String()
+		nodeLocalNatSubnetNextHop = config.V6NodeLocalNATSubnetNextHop
 	}
 	stdout, stderr, err = util.RunOVNSbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "MAC_Binding",
 		"logical_port="+dgpName, fmt.Sprintf(`mac="%s"`, dnatSnatNextHopMac))
@@ -429,29 +429,29 @@ func addDistributedGWPort() error {
 	var datapath string
 	err = wait.PollImmediate(time.Second, 30*time.Second, func() (bool, error) {
 		datapath, stderr, err = util.RunOVNSbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "datapath",
-			"external_ids:name="+util.OVNClusterRouter)
+			"external_ids:name="+config.OVNClusterRouter)
 		// Ignore errors; can't easily detect which are transient or fatal
 		return datapath != "", nil
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get the datapatah UUID of %s from OVN SB "+
-			"stdout: %q, stderr: %q, error: %v", util.OVNClusterRouter, datapath, stderr, err)
+			"stdout: %q, stderr: %q, error: %v", config.OVNClusterRouter, datapath, stderr, err)
 	}
 
 	if config.IPv4Mode {
-		_, stderr, err = util.RunOVNSbctl("create", "mac_binding", "datapath="+datapath, "ip="+util.V4NodeLocalNatSubnetNextHop,
+		_, stderr, err = util.RunOVNSbctl("create", "mac_binding", "datapath="+datapath, "ip="+config.V4NodeLocalNATSubnetNextHop,
 			"logical_port="+dgpName, fmt.Sprintf(`mac="%s"`, dnatSnatNextHopMac))
 		if err != nil {
 			return fmt.Errorf("failed to create a MAC_Binding entry of (%s, %s) for distributed router port %s "+
-				"stderr: %q, error: %v", util.V4NodeLocalNatSubnetNextHop, dnatSnatNextHopMac, dgpName, stderr, err)
+				"stderr: %q, error: %v", config.V4NodeLocalNATSubnetNextHop, dnatSnatNextHopMac, dgpName, stderr, err)
 		}
 	}
 	if config.IPv6Mode {
-		_, stderr, err = util.RunOVNSbctl("create", "mac_binding", "datapath="+datapath, fmt.Sprintf(`ip="%s"`, util.V6NodeLocalNatSubnetNextHop),
+		_, stderr, err = util.RunOVNSbctl("create", "mac_binding", "datapath="+datapath, fmt.Sprintf(`ip="%s"`, config.V6NodeLocalNATSubnetNextHop),
 			"logical_port="+dgpName, fmt.Sprintf(`mac="%s"`, dnatSnatNextHopMac))
 		if err != nil {
 			return fmt.Errorf("failed to create a MAC_Binding entry of (%s, %s) for distributed router port %s "+
-				"stderr: %q, error: %v", util.V6NodeLocalNatSubnetNextHop, dnatSnatNextHopMac, dgpName, stderr, err)
+				"stderr: %q, error: %v", config.V6NodeLocalNATSubnetNextHop, dnatSnatNextHopMac, dgpName, stderr, err)
 		}
 	}
 	return nil
@@ -462,35 +462,35 @@ func addPolicyBasedRoutes(nodeName, mgmtPortIP string, hostIfAddr *net.IPNet) er
 	var natSubnetNextHop string
 	if utilnet.IsIPv6(hostIfAddr.IP) {
 		l3Prefix = "ip6"
-		natSubnetNextHop = util.V6NodeLocalNatSubnetNextHop
+		natSubnetNextHop = config.V6NodeLocalNATSubnetNextHop
 	} else {
 		l3Prefix = "ip4"
-		natSubnetNextHop = util.V4NodeLocalNatSubnetNextHop
+		natSubnetNextHop = config.V4NodeLocalNATSubnetNextHop
 	}
 	// embed nodeName as comment so that it is easier to delete these rules later on.
 	// logical router policy doesn't support external_ids to stash metadata
 	matchStr := fmt.Sprintf(`inport == "%s%s" && %s.dst == %s /* %s */`,
-		util.RouterToSwitchPrefix, nodeName, l3Prefix, hostIfAddr.IP.String(), nodeName)
-	_, stderr, err := util.RunOVNNbctl("lr-policy-add", util.OVNClusterRouter, nodeSubnetPolicyPriority, matchStr, "reroute",
+		config.RouterToSwitchPrefix, nodeName, l3Prefix, hostIfAddr.IP.String(), nodeName)
+	_, stderr, err := util.RunOVNNbctl("lr-policy-add", config.OVNClusterRouter, config.NodeSubnetPolicyPriority, matchStr, "reroute",
 		mgmtPortIP)
 	if err != nil {
 		// TODO: lr-policy-add doesn't support --may-exist, resort to this workaround for now.
 		// Have raised an issue against ovn repository (https://github.com/ovn-org/ovn/issues/49)
 		if !strings.Contains(stderr, "already existed") {
 			return fmt.Errorf("failed to add policy route '%s' for host %q on %s "+
-				"stderr: %s, error: %v", matchStr, nodeName, util.OVNClusterRouter, stderr, err)
+				"stderr: %s, error: %v", matchStr, nodeName, config.OVNClusterRouter, stderr, err)
 		}
 	}
 
 	// policy to allow host -> service -> hairpin back to host
 	matchStr = fmt.Sprintf("%s.src == %s && %s.dst == %s /* %s */",
 		l3Prefix, mgmtPortIP, l3Prefix, hostIfAddr.IP.String(), nodeName)
-	_, stderr, err = util.RunOVNNbctl("lr-policy-add", util.OVNClusterRouter, mgmtPortPolicyPriority, matchStr,
+	_, stderr, err = util.RunOVNNbctl("lr-policy-add", config.OVNClusterRouter, config.MGMTPortPolicyPriority, matchStr,
 		"reroute", natSubnetNextHop)
 	if err != nil {
 		if !strings.Contains(stderr, "already existed") {
 			return fmt.Errorf("failed to add policy route '%s' for host %q on %s "+
-				"stderr: %s, error: %v", matchStr, nodeName, util.OVNClusterRouter, stderr, err)
+				"stderr: %s, error: %v", matchStr, nodeName, config.OVNClusterRouter, stderr, err)
 		}
 	}
 
@@ -511,12 +511,12 @@ func addPolicyBasedRoutes(nodeName, mgmtPortIP string, hostIfAddr *net.IPNet) er
 		}
 		matchStr = fmt.Sprintf("%s.src == %s %s /* inter-%s */",
 			l3Prefix, mgmtPortIP, matchDst, nodeName)
-		_, stderr, err = util.RunOVNNbctl("lr-policy-add", util.OVNClusterRouter, interNodePolicyPriority, matchStr,
+		_, stderr, err = util.RunOVNNbctl("lr-policy-add", config.OVNClusterRouter, config.InterNodePolicyPriority, matchStr,
 			"reroute", natSubnetNextHop)
 		if err != nil {
 			if !strings.Contains(stderr, "already existed") {
 				return fmt.Errorf("failed to add policy route '%s' for host %q on %s "+
-					"stderr: %s, error: %v", matchStr, nodeName, util.OVNClusterRouter, stderr, err)
+					"stderr: %s, error: %v", matchStr, nodeName, config.OVNClusterRouter, stderr, err)
 			}
 		}
 	}
@@ -562,10 +562,10 @@ func (oc *Controller) addNodeLocalNatEntries(node *kapi.Node, mgmtPortMAC string
 		}()
 	}
 
-	mgmtPortName := util.K8sPrefix + node.Name
-	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "lr-nat-del", util.OVNClusterRouter,
+	mgmtPortName := config.K8sPrefix + node.Name
+	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "lr-nat-del", config.OVNClusterRouter,
 		"dnat_and_snat", externalIP.String(), "--",
-		"lr-nat-add", util.OVNClusterRouter, "dnat_and_snat",
+		"lr-nat-add", config.OVNClusterRouter, "dnat_and_snat",
 		externalIP.String(), mgmtPortIfAddr.IP.String(), mgmtPortName, mgmtPortMAC)
 	if err != nil {
 		return fmt.Errorf("failed to add dnat_and_snat entry for the management port on node %s, "+

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -70,7 +70,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add GR_test-node -- set logical_router GR_test-node options:chassis=SYSTEM-ID external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2",
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OVNJoinSwitch + " jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
+			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + config.OVNJoinSwitch + " jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:64:40:00:03 100.64.0.3/16",
 			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=100.64.0.3",
 			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:always_learn_from_arp_request=false",
@@ -142,7 +142,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		// 0a:58:5f:8a:48:8c generated from util.IPAddrToHWAddr(net.ParseIP("fd98::2")).String()
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add GR_test-node -- set logical_router GR_test-node options:chassis=SYSTEM-ID external_ids:physical_ip=fd99::2 external_ids:physical_ips=fd99::2",
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OVNJoinSwitch + " jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
+			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + config.OVNJoinSwitch + " jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:87:f0:33:ca fd98::3/64",
 			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=fd98::3",
 			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:always_learn_from_arp_request=false",
@@ -212,7 +212,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add GR_test-node -- set logical_router GR_test-node options:chassis=SYSTEM-ID external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2,fd99::2",
-			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + util.OVNJoinSwitch + " jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
+			"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + config.OVNJoinSwitch + " jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:64:40:00:03 100.64.0.3/16 fd98::3/64",
 			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:lb_force_snat_ip=100.64.0.3 fd98::3",
 			"ovn-nbctl --timeout=15 set logical_router GR_test-node options:always_learn_from_arp_request=false",

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -154,9 +155,9 @@ func (ovn *Controller) getLogicalSwitchesForLoadBalancer(lb string) ([]string, e
 	}
 	// if this is a GR we know the corresponding join and external switches, otherwise this is an unhandled
 	// case
-	if strings.HasPrefix(out, util.GwRouterPrefix) {
-		routerName := strings.TrimPrefix(out, util.GwRouterPrefix)
-		return []string{util.OVNJoinSwitch, util.ExternalSwitchPrefix + routerName}, nil
+	if strings.HasPrefix(out, config.GWRouterPrefix) {
+		routerName := strings.TrimPrefix(out, config.GWRouterPrefix)
+		return []string{config.OVNJoinSwitch, config.ExternalSwitchPrefix + routerName}, nil
 	}
 	return nil, fmt.Errorf("router detected with load balancer that is not a GR")
 }

--- a/go-controller/pkg/ovn/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager.go
@@ -314,14 +314,14 @@ func initJoinLogicalSwitchIPManager() (*joinSwitchIPManager, error) {
 		lrpIPCache: make(map[string][]*net.IPNet),
 	}
 	var joinSubnets []*net.IPNet
-	for _, joinSubnetString := range []string{util.V4JoinSubnetCidr, util.V6JoinSubnetCidr} {
+	for _, joinSubnetString := range []string{config.V4JoinSubnetCIDR, config.V6JoinSubnetCIDR} {
 		_, joinSubnet, err := net.ParseCIDR(joinSubnetString)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing join subnet string %s: %v", joinSubnetString, err)
 		}
 		joinSubnets = append(joinSubnets, joinSubnet)
 	}
-	err := j.lsm.AddNode(util.OVNJoinSwitch, joinSubnets)
+	err := j.lsm.AddNode(config.OVNJoinSwitch, joinSubnets)
 	if err != nil {
 		return nil, err
 	}
@@ -354,10 +354,10 @@ func (jsIPManager *joinSwitchIPManager) delJoinLRPCacheIPs(nodeName string) {
 // reserveJoinLRPIPs tries to add the LRP IPs to the joinSwitchIPManager, then they will be stored in the cache;
 func (jsIPManager *joinSwitchIPManager) reserveJoinLRPIPs(nodeName string, gwLRPIPs []*net.IPNet) (err error) {
 	// reserve the given IP in the allocator
-	if err = jsIPManager.lsm.AllocateIPs(util.OVNJoinSwitch, gwLRPIPs); err == nil {
+	if err = jsIPManager.lsm.AllocateIPs(config.OVNJoinSwitch, gwLRPIPs); err == nil {
 		defer func() {
 			if err != nil {
-				if relErr := jsIPManager.lsm.ReleaseIPs(util.OVNJoinSwitch, gwLRPIPs); relErr != nil {
+				if relErr := jsIPManager.lsm.ReleaseIPs(config.OVNJoinSwitch, gwLRPIPs); relErr != nil {
 					klog.Errorf("Failed to release logical router port IPs %v just reserved for node %s: %q",
 						util.JoinIPNetIPs(gwLRPIPs, " "), nodeName, relErr)
 				}
@@ -378,14 +378,14 @@ func (jsIPManager *joinSwitchIPManager) ensureJoinLRPIPs(nodeName string) (gwLRP
 	if ok {
 		return gwLRPIPs, nil
 	}
-	gwLRPIPs, err = jsIPManager.lsm.AllocateNextIPs(util.OVNJoinSwitch)
+	gwLRPIPs, err = jsIPManager.lsm.AllocateNextIPs(config.OVNJoinSwitch)
 	if err != nil {
 		return nil, err
 	}
 
 	defer func() {
 		if err != nil {
-			if relErr := jsIPManager.lsm.ReleaseIPs(util.OVNJoinSwitch, gwLRPIPs); relErr != nil {
+			if relErr := jsIPManager.lsm.ReleaseIPs(config.OVNJoinSwitch, gwLRPIPs); relErr != nil {
 				klog.Errorf("Failed to release logical router port IPs %v for node %s: %q",
 					util.JoinIPNetIPs(gwLRPIPs, " "), nodeName, relErr)
 			}
@@ -405,7 +405,7 @@ func (jsIPManager *joinSwitchIPManager) releaseJoinLRPIPs(nodeName string) error
 
 	gwLRPIPs, ok := jsIPManager.getJoinLRPCacheIPs(nodeName)
 	if ok {
-		err = jsIPManager.lsm.ReleaseIPs(util.OVNJoinSwitch, gwLRPIPs)
+		err = jsIPManager.lsm.ReleaseIPs(config.OVNJoinSwitch, gwLRPIPs)
 		jsIPManager.delJoinLRPCacheIPs(nodeName)
 	}
 	return err

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -213,19 +213,6 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 			gatewayIP = gatewayIPnet.IP
 		}
 
-		if len(config.HybridOverlay.ClusterSubnets) > 0 && !hasRoutingExternalGWs && !hasPodRoutingGWs {
-			// Add a route for each hybrid overlay subnet via the hybrid
-			// overlay port on the pod's logical switch.
-			nextHop := util.GetNodeHybridOverlayIfAddr(nodeSubnet).IP
-			for _, clusterSubnet := range config.HybridOverlay.ClusterSubnets {
-				if utilnet.IsIPv6CIDR(clusterSubnet.CIDR) == isIPv6 {
-					podAnnotation.Routes = append(podAnnotation.Routes, util.PodRoute{
-						Dest:    clusterSubnet.CIDR,
-						NextHop: nextHop,
-					})
-				}
-			}
-		}
 		if gatewayIP != nil {
 			podAnnotation.Gateways = append(podAnnotation.Gateways, gatewayIP)
 		}

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -14,52 +14,6 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
-const (
-	K8sPrefix = "k8s-"
-	// K8sMgmtIntfName name to be used as an OVS internal port on the node
-	K8sMgmtIntfName = "ovn-k8s-mp0"
-
-	// PhysicalNetworkName is the name that maps to an OVS bridge that provides
-	// access to physical/external network
-	PhysicalNetworkName = "physnet"
-
-	// LocalNetworkName is the name that maps to an OVS bridge that provides
-	// access to local service
-	LocalNetworkName = "locnet"
-
-	// OVNClusterRouter is the name of the distributed router
-	OVNClusterRouter = "ovn_cluster_router"
-
-	// OVNJoinSwitch is the name of the join switch
-	OVNJoinSwitch = "join"
-
-	JoinSwitchPrefix           = "join_"
-	ExternalSwitchPrefix       = "ext_"
-	GwRouterPrefix             = "GR_"
-	RouterToSwitchPrefix       = "rtos-"
-	InterPrefix                = "inter-"
-	SwitchToRouterPrefix       = "stor-"
-	JoinSwitchToGwRouterPrefix = "jtor-"
-	GwRouterToJoinSwitchPrefix = "rtoj-"
-	ExtSwitchToGwRouterPrefix  = "etor-"
-	GwRouterToExtSwitchPrefix  = "rtoe-"
-
-	NodeLocalSwitch = "node_local_switch"
-
-	V6NodeLocalNatSubnet           = "fd99::/64"
-	V6NodeLocalNatSubnetPrefix     = 64
-	V6NodeLocalNatSubnetNextHop    = "fd99::1"
-	V6NodeLocalDistributedGwPortIP = "fd99::2"
-
-	V4NodeLocalNatSubnet           = "169.254.0.0/20"
-	V4NodeLocalNatSubnetPrefix     = 20
-	V4NodeLocalNatSubnetNextHop    = "169.254.0.1"
-	V4NodeLocalDistributedGwPortIP = "169.254.0.2"
-
-	V4JoinSubnetCidr = "100.64.0.0/16"
-	V6JoinSubnetCidr = "fd98::/64"
-)
-
 // StringArg gets the named command-line argument or returns an error if it is empty
 func StringArg(context *cli.Context, name string) (string, error) {
 	val := context.String(name)
@@ -72,9 +26,9 @@ func StringArg(context *cli.Context, name string) (string, error) {
 // GetLegacyK8sMgmtIntfName returns legacy management ovs-port name
 func GetLegacyK8sMgmtIntfName(nodeName string) string {
 	if len(nodeName) > 11 {
-		return K8sPrefix + (nodeName[:11])
+		return config.K8sPrefix + (nodeName[:11])
 	}
-	return K8sPrefix + nodeName
+	return config.K8sPrefix + nodeName
 }
 
 // GetNodeChassisID returns the machine's OVN chassis ID
@@ -118,7 +72,7 @@ func UpdateNodeSwitchExcludeIPs(nodeName string, subnet *net.IPNet) error {
 	lines := strings.Split(stdout, "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		if strings.Contains(line, "("+K8sPrefix+nodeName+")") {
+		if strings.Contains(line, "("+config.K8sPrefix+nodeName+")") {
 			haveManagementPort = true
 		} else if strings.Contains(line, "("+GetHybridOverlayPortName(nodeName)+")") {
 			// we always need to set to false because we do not reserve the IP on the LSP for HO


### PR DESCRIPTION
instead of putting ovs rules for services backed by a pod on the hybrid network in every pod
put a logical router policy on the ovn_cluster_router that will put a logical_router_policy
to reeoute traffic as appropriate

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->