### PR TITLE
remove requeing of hostnetwork pods causing spurious errors

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -95,6 +95,10 @@ func podIPToCookie(podIP net.IP) string {
 
 // AddPod handles the pod add event
 func (n *NodeController) AddPod(pod *kapi.Pod) error {
+	// nothing to do for hostnetworked pod
+	if !util.PodWantsNetwork(pod) {
+		return nil
+	}
 	podIPs, podMAC, err := getPodDetails(pod)
 	if err != nil {
 		klog.V(5).Infof("Cleaning up hybrid overlay pod %s/%s because %v", pod.Namespace, pod.Name, err)
@@ -225,6 +229,10 @@ func (n *NodeController) AddPod(pod *kapi.Pod) error {
 
 // DeletePod handles the pod delete event
 func (n *NodeController) DeletePod(pod *kapi.Pod) error {
+	// nothing to do for hostnetworked pods
+	if !util.PodWantsNetwork(pod) {
+		return nil
+	}
 	podIPs, _, err := getPodDetails(pod)
 	if err != nil {
 		return fmt.Errorf("error getting pod details: %v", err)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -33,7 +33,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 			continue
 		}
 		annotations, err := util.UnmarshalPodAnnotation(pod.Annotations)
-		if podScheduled(pod) && podWantsNetwork(pod) && err == nil {
+		if podScheduled(pod) && util.PodWantsNetwork(pod) && err == nil {
 			logicalPort := podLogicalPortName(pod)
 			expectedLogicalPorts[logicalPort] = true
 			if err = oc.lsManager.AllocateIPs(pod.Spec.NodeName, annotations.IPs); err != nil {

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -134,6 +134,12 @@ func GetNodePrimaryIP(node *kapi.Node) (string, error) {
 		kapi.NodeInternalIP, kapi.NodeExternalIP)
 }
 
+// PodWantsNetwork returns if the given pod is hostNetworked or not to determine if networking
+// needs to be setup
+func PodWantsNetwork(pod *kapi.Pod) bool {
+	return !pod.Spec.HostNetwork
+}
+
 const (
 	// DefNetworkAnnotation is the pod annotation for the cluster-wide default network
 	DefNetworkAnnotation = "v1.multus-cni.io/default-network"


### PR DESCRIPTION
When using hybrid networking hostnetwork pods will cause the error seen below

`E0925 14:57:10.497565 2878 informer.go:254] error syncing 'openshift-kube-apiserver/kube-apiserver-ci-op-3rmk5i8z-0e6bb-v7v6w-master-1': error getting pod details: could not find OVN pod annotation in map[kubectl.kubernetes.io/default-logs-container:kube-apiserver kubernetes.io/config.hash:356a1361733dbc5fb4922e8352293741 kubernetes.io/config.mirror:356a1361733dbc5fb4922e8352293741 kubernetes.io/config.seen:2020-09-25T14:57:10.167982155Z kubernetes.io/config.source:file], requeuing`

It is meaningless becuase the hostnetwork pods do not have an OVN pod annotation and requing the event just causes errrors until
the max retries is reached (at the time of making this patch that is 3)

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->