### PR TITLE
Avoid restarting ovn-dbchecker if the local db check-cluster fails

### DIFF
--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -218,7 +218,7 @@ func ensureDBHealth(db string) {
 	stdout, stderr, err := util.RunOVSDBTool("check-cluster", db)
 	if err != nil {
 		// backup the db by renaming it and then stop the nb/sb ovsdb process.
-		klog.Fatalf("Error occured during checking of clustered db "+
+		klog.Errorf("Error occured during checking of clustered db "+
 			"db: %s,stdout: %q, stderr: %q, err: %v",
 			db, stdout, stderr, err)
 		dbFile := filepath.Base(db)


### PR DESCRIPTION
`klog.Fatalf` will generate a stack trace and exit with code 255. we don't want that to be the case when check-cluster errors out.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>