### PR TITLE
[WIP] testing for PR 1744

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -245,6 +246,8 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 			ip := util.GetNodeHybridOverlayIfAddr(subnet).IP
 			portMAC = util.IPAddrToHWAddr(ip)
 			annotationMAC = portMAC
+			//the src is the nodes subnet
+
 			if !utilnet.IsIPv6(ip) {
 				break
 			}
@@ -289,6 +292,61 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 		}
 	}
 
+	// create a reroute on the ovn_cluster_router
+	err = createLogicalRouterPolicyForNode(node, subnets)
+	if err != nil {
+		return fmt.Errorf("failed to create logical router policy: %v", err)
+	}
+
+	return nil
+}
+
+func createLogicalRouterPolicyForNode(node *kapi.Node, subnets []*net.IPNet) error {
+	// get all the windows subnets as the dest for lr-policy match
+	var dest string
+	var nextHop string
+	var src string
+	for _, hybridSubnet := range config.HybridOverlay.ClusterSubnets {
+		if !utilnet.IsIPv6CIDR(hybridSubnet.CIDR) {
+			dest = dest + fmt.Sprintf("|| ip4.dst == %s", hybridSubnet.CIDR.String())
+		}
+	}
+	//the src is the nodes subnet and the next hop is the third address (x.x.x.3) in the nodes subnet
+	for _, subnet := range subnets {
+		if !utilnet.IsIPv6CIDR(subnet) {
+			src = fmt.Sprintf("ip4.src == %s", subnet.String())
+			ip := util.GetNodeHybridOverlayIfAddr(subnet)
+			nextHop = ip.IP.String()
+			break
+		}
+	}
+	if len(nextHop) == 0 {
+		return fmt.Errorf("could not find an ipv4 Node subnet for node %s", node.Name)
+	}
+
+	_, stderr, err := util.RunOVNNbctl(
+		"--id=@lr-policy",
+		"create",
+		"logical_router_policy",
+		"priority=1006",
+		"action=reroute",
+		fmt.Sprintf("external-ids:hybrid-overlay:%s", node.Name),
+		fmt.Sprintf("match=\"(%s) && %s\"", dest[3:], src),
+		fmt.Sprintf("nexthop=%s", nextHop),
+		"--",
+		"add",
+		"logical_router",
+		"ovn_cluster_router",
+		"policies",
+		"@lr-policy",
+	)
+	if err != nil {
+		// TODO: lr-policy-add doesn't support --may-exist, resort to this workaround for now.
+		// Have raised an issue against ovn repository (https://github.com/ovn-org/ovn/issues/49)
+		if !strings.Contains(stderr, "already existed") {
+			return fmt.Errorf("cannot add logical router policy for hybrid cluster network for node %s: %s", node.Name, stderr)
+		}
+	}
 	return nil
 }
 
@@ -296,6 +354,22 @@ func (m *MasterController) deleteOverlayPort(node *kapi.Node) {
 	klog.Infof("Removing node %s hybrid overlay port", node.Name)
 	portName := util.GetHybridOverlayPortName(node.Name)
 	_, _, _ = util.RunOVNNbctl("--", "--if-exists", "lsp-del", portName)
+
+	stdout, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "logical_router_policy", fmt.Sprintf("external-ids:hybrid-overlay=%s", node.Name))
+	if err != nil {
+		klog.Errorf("Error deleting hybrid logical router policy  for node %s, cannot get logical router policies from LR %s - %s:%s", node.Name, "ovn_cluster_router", err, stderr)
+		return
+	}
+	uuids := strings.Fields(stdout)
+	for _, uuid := range uuids {
+		_, stderr, err := util.RunOVNNbctl("lr-policy-del", "ovn_cluster_router", uuid)
+		if err != nil {
+			klog.Errorf("Failed to delete the hybrid logical-router-policy for "+
+				"node %s on logical switch %s, stderr: %q (%v)", node.Name, "ovn_cluster_router", stderr, err)
+			return
+		}
+	}
+
 }
 
 // AddNode handles node additions

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -173,6 +173,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				nodeSubnet string = "10.1.2.0/24"
 				nodeHOIP   string = "10.1.2.3"
 				nodeHOMAC  string = "0a:58:0a:01:02:03"
+				uuid       string = "12345"
 			)
 
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
@@ -223,6 +224,13 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --if-exists lsp-del int-node1",
 			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_policy external-ids:hybrid-overlay=" + nodeName,
+				Output: uuid,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 lr-policy-del ovn_cluster_router " + uuid,
+			})
 
 			err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), nodeName, *metav1.NewDeleteOptions(0))
 			Expect(err).NotTo(HaveOccurred())
@@ -255,6 +263,22 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				},
 			})
 
+			// #1 node add
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --id=@lr-policy create " +
+					"logical_router_policy priority=1006 action=reroute " +
+					"external-ids:hybrid-overlay:node1 match=\"(ip4.dst == 11.1.0.0/16) " +
+					"&& ip4.src == 10.1.2.0/24\" nexthop=10.1.2.3 -- add logical_router " +
+					"ovn_cluster_router policies @lr-policy",
+			})
+			// #2 comes because we set the ho dr gw mac annotation in #1
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --id=@lr-policy create " +
+					"logical_router_policy priority=1006 action=reroute " +
+					"external-ids:hybrid-overlay:node1 match=\"(ip4.dst == 11.1.0.0/16) " +
+					"&& ip4.src == 10.1.2.0/24\" nexthop=10.1.2.3 -- add logical_router " +
+					"ovn_cluster_router policies @lr-policy",
+			})
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
@@ -307,6 +331,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				nodeSubnet string = "10.1.2.0/24"
 				nodeHOIP   string = "10.1.2.3"
 				nodeHOMAC  string = "00:00:00:52:19:d2"
+				uuid       string = "5678"
 			)
 
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
@@ -314,9 +339,23 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 					newTestNode(nodeName, "linux", nodeSubnet, "", nodeHOMAC),
 				},
 			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --id=@lr-policy create " +
+					"logical_router_policy priority=1006 action=reroute " +
+					"external-ids:hybrid-overlay:node1 match=\"(ip4.dst == 11.1.0.0/16) " +
+					"&& ip4.src == 10.1.2.0/24\" nexthop=10.1.2.3 -- add logical_router " +
+					"ovn_cluster_router policies @lr-policy",
+			})
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --if-exists lsp-del int-node1",
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_router_policy external-ids:hybrid-overlay=" + nodeName,
+				Output: uuid,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 lr-policy-del ovn_cluster_router " + uuid,
 			})
 
 			_, err := config.InitConfig(ctx, fexec, nil)
@@ -410,7 +449,14 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				&v1.NodeList{Items: []v1.Node{newTestNode(nodeName, "linux", nodeSubnet, "", nodeHOMAC)}},
 			}...)
 
-			_, err := config.InitConfig(ctx, nil, nil)
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovn-nbctl --timeout=15 --id=@lr-policy create " +
+					"logical_router_policy priority=1006 action=reroute " +
+					"external-ids:hybrid-overlay:node1 match=\"(ip4.dst == 11.1.0.0/16) " +
+					"&& ip4.src == 10.1.2.0/24\" nexthop=10.1.2.3 -- add logical_router " +
+					"ovn_cluster_router policies @lr-policy",
+			})
+			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -575,5 +621,10 @@ func addLinuxNodeCommands(fexec *ovntest.FakeExec, nodeHOMAC, nodeName, nodeHOIP
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 -- --if-exists set logical_switch " + nodeName + " other-config:exclude_ips=" + nodeHOIP,
+		"ovn-nbctl --timeout=15 --id=@lr-policy create " +
+			"logical_router_policy priority=1006 action=reroute " +
+			"external-ids:hybrid-overlay:node1 match=\"(ip4.dst == 11.1.0.0/16) " +
+			"&& ip4.src == 10.1.2.0/24\" nexthop=10.1.2.3 -- add logical_router " +
+			"ovn_cluster_router policies @lr-policy",
 	})
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -207,19 +207,6 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 			gatewayIP = gatewayIPnet.IP
 		}
 
-		if len(config.HybridOverlay.ClusterSubnets) > 0 && !hasRoutingExternalGWs && !hasPodRoutingGWs {
-			// Add a route for each hybrid overlay subnet via the hybrid
-			// overlay port on the pod's logical switch.
-			nextHop := util.GetNodeHybridOverlayIfAddr(nodeSubnet).IP
-			for _, clusterSubnet := range config.HybridOverlay.ClusterSubnets {
-				if utilnet.IsIPv6CIDR(clusterSubnet.CIDR) == isIPv6 {
-					podAnnotation.Routes = append(podAnnotation.Routes, util.PodRoute{
-						Dest:    clusterSubnet.CIDR,
-						NextHop: nextHop,
-					})
-				}
-			}
-		}
 		if gatewayIP != nil {
 			podAnnotation.Gateways = append(podAnnotation.Gateways, gatewayIP)
 		}


### PR DESCRIPTION
instead of putting ovs rules for services backed by a pod on the hybrid network in every pod
put a logical router policy on the ovn_cluster_router that will put a logical_router_policy
to reeoute traffic as appropriate

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->