### PR TITLE
prevent segfault in addIPs from address_sets

### DIFF
--- a/go-controller/pkg/ovn/address_set.go
+++ b/go-controller/pkg/ovn/address_set.go
@@ -278,10 +278,14 @@ func (as *ovnAddressSets) AddIPs(ips []net.IP) error {
 	defer as.Unlock()
 
 	for _, ip := range ips {
-		if utilnet.IsIPv6(ip) {
+		switch {
+		case utilnet.IsIPv6(ip) && as.ipv6 != nil:
 			err = as.ipv6.addIP(ip)
-		} else {
+		case !utilnet.IsIPv6(ip) && as.ipv4 != nil:
 			err = as.ipv4.addIP(ip)
+		default:
+			err = fmt.Errorf("cluster is not configured for this type of ip address (%s)", ip)
+
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
When a cluster is in single stack configuration and an IP for the
version not configured gets into the cluster and tries to be added
to an address_set ovn_kubernetes will segfault.

instead of segfaulting return an error

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->