### PR TITLE
On node deletion restore the NORMAL action and not FLOOD action

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -375,7 +375,7 @@ func addDefaultConntrackRulesLocal(nodeName, gwBridge, gwIntf string, stopChan c
 	}
 
 	// replace the left over OpenFlow flows with the FLOOD action flow
-	_, stderr, err = util.AddFloodActionOFFlow(gwBridge)
+	_, stderr, err = util.AddOFFlowWithSpecificAction(gwBridge, util.FloodAction)
 	if err != nil {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
 	}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -419,7 +419,7 @@ func addDefaultConntrackRules(nodeName, gwBridge, gwIntf string, stopChan chan s
 	}
 
 	// replace the left over OpenFlow flows with the FLOOD action flow
-	_, stderr, err = util.AddFloodActionOFFlow(gwBridge)
+	_, stderr, err = util.AddOFFlowWithSpecificAction(gwBridge, util.FloodAction)
 	if err != nil {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", gwBridge, stderr, err)
 	}
@@ -642,7 +642,7 @@ func cleanupSharedGateway() error {
 		return nil
 	}
 
-	_, stderr, err = util.AddFloodActionOFFlow(bridgeName)
+	_, stderr, err = util.AddOFFlowWithSpecificAction(bridgeName, util.NormalAction)
 	if err != nil {
 		return fmt.Errorf("failed to replace-flows on bridge %q stderr:%s (%v)", bridgeName, stderr, err)
 	}

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -51,6 +51,8 @@ const (
 	sbdbCtlSock     = "ovnsb_db.ctl"
 	OvnNbdbLocation = "/etc/ovn/ovnnb_db.db"
 	OvnSbdbLocation = "/etc/ovn/ovnsb_db.db"
+	FloodAction     = "FLOOD"
+	NormalAction    = "NORMAL"
 )
 
 var (
@@ -654,12 +656,12 @@ func RunRoute(args ...string) (string, string, error) {
 	return strings.TrimSpace(stdout.String()), stderr.String(), err
 }
 
-// AddFloodActionOFFlow replaces flows in the bridge with a FLOOD action flow
-func AddFloodActionOFFlow(bridgeName string) (string, string, error) {
+// AddOFFlowWithSpecificAction replaces flows in the bridge with a FLOOD action flow
+func AddOFFlowWithSpecificAction(bridgeName, action string) (string, string, error) {
 	args := []string{"-O", "OpenFlow13", "replace-flows", bridgeName, "-"}
 
 	stdin := &bytes.Buffer{}
-	stdin.Write([]byte("table=0,priority=0,actions=FLOOD\n"))
+	stdin.Write([]byte(fmt.Sprintf("table=0,priority=0,actions=%s\n", action)))
 
 	cmd := runner.exec.Command(runner.ofctlPath, args...)
 	cmd.SetStdin(stdin)

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -2110,7 +2110,7 @@ func TestRunIP(t *testing.T) {
 	}
 }
 
-func TestAddFloodActionOFFlow(t *testing.T) {
+func TestAddOFFlowWithSpecificAction(t *testing.T) {
 	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
 	mockCmd := new(mock_k8s_io_utils_exec.Cmd)
 	mockExecRunner := new(mocks.ExecRunner)
@@ -2169,7 +2169,7 @@ func TestAddFloodActionOFFlow(t *testing.T) {
 			}
 			mockCall.Once()
 
-			_, _, e := AddFloodActionOFFlow("somename")
+			_, _, e := AddOFFlowWithSpecificAction("somename", "someaction")
 
 			if tc.expectedErr != nil {
 				assert.Error(t, e)


### PR DESCRIPTION
when the node is deleted from the k8s cluster, we try to cleanup all the
ovn-k8s related configurations and one such cleanup is to repalce the
OF Flows on the host OVS bridge with a NORMAL action. however, we were
using FLOOD action and this commit fixes that.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@trozet @danwinship @dcbw PTAL