### PR TITLE
check-cluster semantics don't support running the tool online

### DIFF
--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -65,7 +64,6 @@ func ensureOvnDBState(db string, kclient kube.Interface, stopCh <-chan struct{})
 			klog.V(5).Infof("Ensure routines for Raft db: %s kicked off by ticker", db)
 			ensureLocalRaftServerID(db)
 			ensureClusterRaftMembership(db, kclient)
-			ensureDBHealth(db)
 		case <-stopCh:
 			ticker.Stop()
 			return
@@ -210,42 +208,4 @@ func ensureClusterRaftMembership(db string, kclient kube.Interface) {
 			kickedMembersCount = kickedMembersCount + 1
 		}
 	}
-}
-
-// ensureDBHealth ensures that if the db is clustered, it is healthy by calling the cluster-check command
-// if the clustered db is corrupt, the db will be deleted and kube-master pod needs to be started again.
-func ensureDBHealth(db string) {
-	stdout, stderr, err := util.RunOVSDBTool("check-cluster", db)
-	if err != nil {
-		// backup the db by renaming it and then stop the nb/sb ovsdb process.
-		klog.Errorf("Error occured during checking of clustered db "+
-			"db: %s,stdout: %q, stderr: %q, err: %v",
-			db, stdout, stderr, err)
-		dbFile := filepath.Base(db)
-		backupFile := strings.TrimSuffix(dbFile, filepath.Ext(dbFile)) +
-			time.Now().UTC().Format("2006-01-02_150405") + "db_bak"
-		backupDB := filepath.Join(filepath.Dir(db), backupFile)
-		err := os.Rename(db, backupDB)
-		if err != nil {
-			klog.Warningf("Failed to back up the db to backupFile: %s", backupFile)
-		} else {
-			klog.Infof("Backed up the db to backupFile: %s", backupFile)
-			var dbName string
-			var appCtl func(args ...string) (string, string, error)
-			if strings.Contains(db, "ovnnb") {
-				dbName = "OVN_Northbound"
-				appCtl = util.RunOVNNBAppCtl
-			} else {
-				dbName = "OVN_Southbound"
-				appCtl = util.RunOVNSBAppCtl
-			}
-			_, stderr, err := appCtl("exit")
-			if err != nil {
-				klog.Warningf("Unable to restart the ovn db: %s ,"+
-					"stderr: %v, err: %v", dbName, stderr, err)
-			}
-			klog.Infof("Stopped %s db after backing up the db: %s", dbName, backupFile)
-		}
-	}
-	klog.Infof("check-cluster returned out: %q, stderr: %q", stdout, stderr)
 }


### PR DESCRIPTION
The check-cluster tool is not intended to be run online. The
OVN team is looking into providing an alternative for doing live
consistency checks of raft cluster. Meanwhile, this functionality
is causing red-herrings during scale tests. This PR disables the
DB Health checks for now.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>