### PR TITLE
Guard against nil address set usage

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -110,6 +110,11 @@ func (oc *Controller) addEgressFirewall(egressFirewall *egressfirewallapi.Egress
 		return errList
 	}
 
+	if nsInfo.addressSet == nil {
+		// TODO(trozet): remove dependency on nsInfo object and just determine hash names to create Egress FW with
+		return []error{fmt.Errorf("unable to add egress firewall policy, namespace: %s has no address set", egressFirewall.Namespace)}
+	}
+
 	err = ef.addLogicalRouterPolicyToClusterRouter(nsInfo.addressSet.GetIPv4HashName(), nsInfo.addressSet.GetIPv6HashName(), egressFirewallStartPriorityInt)
 	if err != nil {
 		return []error{err}

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -100,6 +100,7 @@ func (gp *gressPolicy) addPeerPod(pod *v1.Pod) error {
 	if err != nil {
 		return err
 	}
+
 	return gp.peerAddressSet.AddIPs(ips)
 }
 


### PR DESCRIPTION
When an address set is created in the code, there is no guarantee that
the address set is created. Failure in ovn-nbctl can cause no address
set to be created for a namespace nsInfo struct, for example. In this
case other threads will assume there is an address set and this will
cause segfault. This patch adds some protection around calling address
set methods and ensuring the address set is created.

Found in:
https://bugzilla.redhat.com/show_bug.cgi?id=1888827

Signed-off-by: Tim Rozet <trozet@redhat.com>
