### PR TITLE
Fix egress IP test SIGSEGV

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -651,7 +651,9 @@ func findReroutePolicyIDs(filterOption, egressIPName string, gatewayRouterIP net
 func (oc *Controller) addEgressNode(egressNode *kapi.Node) error {
 	klog.V(5).Infof("Egress node: %s about to be initialized", egressNode.Name)
 	oc.eIPAllocatorMutex.Lock()
-	oc.eIPAllocator[egressNode.Name].isEgressAssignable = true
+	if eNode, exists := oc.eIPAllocator[egressNode.Name]; exists {
+		eNode.isEgressAssignable = true
+	}
 	oc.eIPAllocatorMutex.Unlock()
 	oc.egressAssignmentRetry.Range(func(key, value interface{}) bool {
 		eIPName := key.(string)


### PR DESCRIPTION
The test `should skip populating egress node data for nodes that have incorrect IP address`
explicitly defines bad IP addresses for nodes as to make sure we don't use such nodes for
egress assignment, however: `addEgressNode` did not take into account that the node in question
might not exist in the map due to the previous condition. The test flakes as the checks it
performs do not change state and thus the Eventually calls might pass faster than the code
path is executed, i.e: it all depends on the CPU

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->