### PR TITLE
Fixes External IP with local gateway mode

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -19,10 +19,8 @@ import (
 )
 
 const (
-	v4localnetGatewayIP = "169.254.33.2"
-
 	// localnetGatewayNextHopPort is the name of the gateway port on the host to which all
-	// the packets leaving the OVN logical topology will be forwarded
+	// the packets leaving/entering the OVN logical topology to the host will egress for shared gw mode
 	localnetGatewayNextHopPort = "ovn-k8s-gw0"
 
 	// Routing table for ExternalIP communication
@@ -137,8 +135,8 @@ func (npw *localPortWatcherData) addService(svc *kapi.Service) error {
 				klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip setup", externalIP)
 			} else {
 				if gatewayIP != "" {
-					if stdout, stderr, err := util.RunIP("route", "replace", externalIP, "via", gatewayIP, "dev", localnetGatewayNextHopPort, "table", localnetGatewayExternalIDTable); err != nil {
-						klog.Errorf("Error adding routing table entry for ExternalIP %s: stdout: %s, stderr: %s, err: %v", externalIP, stdout, stderr, err)
+					if stdout, stderr, err := util.RunIP("route", "replace", externalIP, "via", gatewayIP, "dev", util.K8sMgmtIntfName, "table", localnetGatewayExternalIDTable); err != nil {
+						klog.Errorf("Error adding routing table entry for ExternalIP %s, via gw: %s: stdout: %s, stderr: %s, err: %v", externalIP, gatewayIP, stdout, stderr, err)
 					} else {
 						klog.V(5).Infof("Successfully added route for ExternalIP: %s", externalIP)
 					}
@@ -183,7 +181,7 @@ func (npw *localPortWatcherData) deleteService(svc *kapi.Service) error {
 				klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip cleanup", externalIP)
 			} else {
 				if gatewayIP != "" {
-					if stdout, stderr, err := util.RunIP("route", "del", externalIP, "via", gatewayIP, "dev", localnetGatewayNextHopPort, "table", localnetGatewayExternalIDTable); err != nil {
+					if stdout, stderr, err := util.RunIP("route", "del", externalIP, "via", gatewayIP, "dev", util.K8sMgmtIntfName, "table", localnetGatewayExternalIDTable); err != nil {
 						klog.Errorf("Error delete routing table entry for ExternalIP %s: stdout: %s, stderr: %s, err: %v", externalIP, stdout, stderr, err)
 					} else {
 						klog.V(5).Infof("Successfully deleted route for ExternalIP: %s", externalIP)

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -210,7 +210,8 @@ func (npw *localPortWatcherData) syncServices(serviceInterface []interface{}) {
 	removeStaleRoutes := func(keepRoutes []string) {
 		stdout, stderr, err := util.RunIP("route", "list", "table", localnetGatewayExternalIDTable)
 		if err != nil || stdout == "" {
-			klog.Infof("No routing table entries for ExternalIP table %s: stdout: %s, stderr: %s, err: %v", localnetGatewayExternalIDTable, stdout, stderr, err)
+			klog.Infof("No routing table entries for ExternalIP table %s: stdout: %s, stderr: %s, err: %v",
+				localnetGatewayExternalIDTable, stdout, strings.Replace(stderr, "\n", "", -1), err)
 			return
 		}
 		for _, existingRoute := range strings.Split(stdout, "\n") {

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -15,6 +15,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	v4localnetGatewayIP = "10.244.0.1"
+)
+
 func getFakeLocalAddrs() map[string]net.IPNet {
 	localAddrSet := make(map[string]net.IPNet)
 	for _, network := range []string{"127.0.0.1/32", "10.10.10.1/24"} {
@@ -172,13 +176,13 @@ var _ = Describe("Node Operations", func() {
 				})
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ip route list table " + localnetGatewayExternalIDTable,
-					Output: fmt.Sprintf("%s via %s dev %s\n9.9.9.9 via %s dev %s\n", externalIP, v4localnetGatewayIP, localnetGatewayNextHopPort, v4localnetGatewayIP, localnetGatewayNextHopPort),
+					Output: fmt.Sprintf("%s via %s dev %s\n9.9.9.9 via %s dev %s\n", externalIP, v4localnetGatewayIP, util.K8sMgmtIntfName, v4localnetGatewayIP, util.K8sMgmtIntfName),
 				})
 				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route del 9.9.9.9 via %s dev %s table %s", v4localnetGatewayIP, localnetGatewayNextHopPort, localnetGatewayExternalIDTable),
+					fmt.Sprintf("ip route del 9.9.9.9 via %s dev %s table %s", v4localnetGatewayIP, util.K8sMgmtIntfName, localnetGatewayExternalIDTable),
 				})
 				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, localnetGatewayNextHopPort, localnetGatewayExternalIDTable),
+					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, util.K8sMgmtIntfName, localnetGatewayExternalIDTable),
 				})
 
 				service := *newService("service1", "namespace1", "10.129.0.2",
@@ -295,7 +299,7 @@ var _ = Describe("Node Operations", func() {
 				)
 
 				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, localnetGatewayNextHopPort, localnetGatewayExternalIDTable),
+					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, util.K8sMgmtIntfName, localnetGatewayExternalIDTable),
 				})
 
 				fNPW.addService(&service)
@@ -515,7 +519,7 @@ var _ = Describe("Node Operations", func() {
 				)
 
 				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route del %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, localnetGatewayNextHopPort, localnetGatewayExternalIDTable),
+					fmt.Sprintf("ip route del %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, util.K8sMgmtIntfName, localnetGatewayExternalIDTable),
 				})
 
 				fNPW.deleteService(&service)

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -70,7 +70,8 @@ func (n *OvnNode) createManagementPort(hostSubnets []*net.IPNet, nodeAnnotator k
 			} else {
 				nextHop = cfg.ipv4.ifAddr
 			}
-			gatewayIfAddrs = append(gatewayIfAddrs, nextHop)
+			// gatewayIfAddrs are the OVN next hops via mp0
+			gatewayIfAddrs = append(gatewayIfAddrs, util.GetNodeGatewayIfAddr(hostSubnet))
 
 			// add iptables masquerading for mp0 to exit the host for egress
 			cidr := nextHop.IP.Mask(nextHop.Mask)


### PR DESCRIPTION
For external IP usage where the IP does not exist on the host, we create
a route to get the packet into OVN where the load balancer will DNAT it.
However after the changes to new local gateway mode this packet needs be
routed to ovn_cluster_router via the mp0 interface.

Signed-off-by: Tim Rozet <trozet@redhat.com>


**- How to verify it**

1. Create a service with an external IP like:
```
[trozet@trozet go-controller]$ cat ~/service.yaml 
apiVersion: v1
kind: Service
metadata:
  name: my-service
spec:
  selector:
   pod-name: server2
  ports:
    - name: server-80
      protocol: TCP
      port: 80
      targetPort: 80
    - name: server-81
      port: 81
      protocol: TCP
      targetPort: 81
  externalIPs:
    - 80.11.12.10

```
2. Create a pod behind it and start a python simple http server on 80.
3. create another pod outside of the cluster: docker run --privileged --network kind -it centos /bin/bash
4. add a route in the new pod for 80.11.12.10 to one of the master/worker nodes
5. curl the external ip address at port 80