### PR TITLE
.github: Replace usage of set-env

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,9 +26,8 @@ jobs:
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
-        echo "::set-env name=GOPATH::$GOPATH"
-        export PATH=$GOPATH/bin:$PATH
-        echo "::add-path::$GOPATH/bin"
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
 
     - name: Build images
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,8 @@ jobs:
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
-        echo "::set-env name=GOPATH::$GOPATH"
-        export PATH=$GOPATH/bin:$PATH
-        echo "::add-path::$GOPATH/bin"
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
 
     - name: Verify
       run: |
@@ -108,9 +107,8 @@ jobs:
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
-        echo "::set-env name=GOPATH::$GOPATH"
-        export PATH=$GOPATH/bin:$PATH
-        echo "::add-path::$GOPATH/bin"
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
 
     - name: Cache Kubernetes
       id: cache-k8s
@@ -218,9 +216,8 @@ jobs:
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
-        echo "::set-env name=GOPATH::$GOPATH"
-        export PATH=$GOPATH/bin:$PATH
-        echo "::add-path::$GOPATH/bin"
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
 
     - name: Disable ufw
       # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -33,9 +33,8 @@ jobs:
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
-        echo "::set-env name=GOPATH::$GOPATH"
-        export PATH=$GOPATH/bin:$PATH
-        echo "::add-path::$GOPATH/bin"
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
 
     - name: Verify
       run: |
@@ -76,9 +75,8 @@ jobs:
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
-        echo "::set-env name=GOPATH::$GOPATH"
-        export PATH=$GOPATH/bin:$PATH
-        echo "::add-path::$GOPATH/bin"
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
 
     - name: Cache Kubernetes
       id: cache-k8s
@@ -141,9 +139,8 @@ jobs:
     - name: Set up environment
       run: |
         export GOPATH=$(go env GOPATH)
-        echo "::set-env name=GOPATH::$GOPATH"
-        export PATH=$GOPATH/bin:$PATH
-        echo "::add-path::$GOPATH/bin"
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
 
     - name: Restore cache Kubernetes
       id: cache-k8s


### PR DESCRIPTION
set-env is being deprecated due to security issues.
Appending to $GITHUB_PATH or $GITHUB_ENV should provide the same
functionality.