### PR TITLE
Fix shared gateway flood/normal behavior

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -155,11 +155,13 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovs-ofctl -O OpenFlow13 replace-flows breth0 -",
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=10, table=0, in_port=7, dl_dst=" + eth0MAC + ", actions=output:5,output:LOCAL",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, in_port=5, ip, actions=ct(commit, zone=64000), output:7",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=50, in_port=7, ip, actions=ct(zone=64000, table=1)",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, table=1, ct_state=+trk+est, actions=output:5",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, table=1, ct_state=+trk+rel, actions=output:5",
-			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=1, actions=output:FLOOD",
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=10, table=1, dl_dst=" + eth0MAC + ", actions=output:LOCAL",
+			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=1, actions=output:NORMAL",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=2, actions=output:7",
 		})
 		// nodePortWatcher()

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -51,7 +51,7 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 		}
 	}
 
-	bridgeName, uplinkName, _, err := gatewayInitInternal(
+	bridgeName, uplinkName, _, _, err := gatewayInitInternal(
 		nodeName, gwIntf, hostSubnets, gwNextHops, nodeAnnotator)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We desire the shared gateway bridge to have a NORMAL action behavior
when there is an unknown packet that enters the bridge. This is to
support cases where there may be other ports connected to the shared
bridge. However, NORMAL action will not work for the MAC that is shared
between OVN and the host, due to MAC table swapping when a packet hits
the normal action.

This patch adds a higher priority flow to match on destination packets
the shared MAC, and send the packet to the two possible destinations
(OVN and the host). The lower priority flow after it will allow all
other traffic to be NORMAL switched.

Signed-off-by: Tim Rozet <trozet@redhat.com>

