### PR TITLE
Use the ovn-db-pod label to identify db pods running on the node

### DIFF
--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -351,7 +351,7 @@ func getOvnDbVersionInfo() {
 
 func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
-		return checkPodRunsOnGivenNode(clientset, "name=ovnkube-db", k8sNodeName, false)
+		return checkPodRunsOnGivenNode(clientset, "ovn-db-pod=true", k8sNodeName, false)
 	})
 	if err != nil {
 		if err == wait.ErrWaitTimeout {


### PR DESCRIPTION
The name label used so far in upstream ovn-k breaks openshift which
doesn't add the name=ovnkube-db label on the pods. The ovn-db-pod=true
is a more consistent label to use instead for metrics collection.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>