### PR TITLE
modify the periodic job to run dual-stack against k8s master

### DIFF
--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.15.1
-  K8S_VERSION: v1.19.0
+  GO_VERSION: 1.15.3
+  K8S_VERSION: master
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true
   KIND_ALLOW_SYSTEM_WRITES: true
@@ -35,14 +35,6 @@ jobs:
         export GOPATH=$(go env GOPATH)
         echo "GOPATH=$GOPATH" >> $GITHUB_ENV
         echo "$GOPATH/bin" >> $GITHUB_PATH
-
-    - name: Verify
-      run: |
-        pushd go-controller
-          make gofmt
-          make install.tools
-          make lint
-        popd
 
     - name: Build
       run: |
@@ -78,30 +70,45 @@ jobs:
         echo "GOPATH=$GOPATH" >> $GITHUB_ENV
         echo "$GOPATH/bin" >> $GITHUB_PATH
 
-    - name: Cache Kubernetes
-      id: cache-k8s
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.GOPATH }}/src/k8s.io/kubernetes/
-        key: kubernetes-${{ env.K8S_VERSION }}
-
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
         go-version: ${{ env.GO_VERSION }}
-      if: steps.cache-k8s.outputs.cache-hit != 'true'
+
+    - name: Install KIND
+      run: |
+        sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
+        sudo chmod +x /usr/local/bin/kind
+
+    - name: Clone Kubernetes
+      run: |
+        set -x
+        rm -rf $GOPATH/src/k8s.io/kubernetes
+        git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
+        cd $GOPATH/src/k8s.io/kubernetes
+        source hack/lib/version.sh
+        kube::version::get_version_vars
+        echo "KUBE_GIT_VERSION=$KUBE_GIT_VERSION" >> $GITHUB_ENV
+        
+    - name: Cache Kubernetes
+      id: cache-k8s
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.GOPATH }}/src/k8s.io/kubernetes
+        key: k8s-go-master-${{ env.KUBE_GIT_VERSION }}
+        restore-keys: |
+          k8s-go-master
 
     - name: Build and install Kubernetes
       if: steps.cache-k8s.outputs.cache-hit != 'true'
       run: |
         set -x
-        rm -rf $GOPATH/src/k8s.io/kubernetes
-        git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
         pushd $GOPATH/src/k8s.io/kubernetes/
           make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
-          rm -rf .git
+          /usr/local/bin/kind build node-image --image=kindest/node:master
+          docker save kindest/node:master > _output/kind-image.tar
         popd
-
+        
   e2e-dual:
     if: github.repository == 'ovn-org/ovn-kubernetes' || github.event_name == 'workflow_dispatch'
     name: e2e-dual
@@ -142,49 +149,37 @@ jobs:
         echo "GOPATH=$GOPATH" >> $GITHUB_ENV
         echo "$GOPATH/bin" >> $GITHUB_PATH
 
-    - name: Restore cache Kubernetes
-      id: cache-k8s
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.GOPATH }}/src/k8s.io/kubernetes/
-        key: kubernetes-${{ env.K8S_VERSION }}
-
-    # Re-build if kube wasn't in the cache due to
-    # https://github.com/actions/cache/issues/107#issuecomment-598188250
-    # https://github.com/actions/cache/issues/208#issuecomment-596664572
-    - name: Build and install Kubernetes
-      if: steps.cache-k8s.outputs.cache-hit != 'true'
+    - name: Install KIND
       run: |
-        set -x
-        rm -rf $GOPATH/src/k8s.io/kubernetes
-        git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
-        pushd $GOPATH/src/k8s.io/kubernetes/
-          make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
-          rm -rf .git
-        popd
+        sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
+        sudo chmod +x /usr/local/bin/kind
 
     - uses: actions/download-artifact@v2
       with:
         name: test-image
+   
     - name: Load docker image
       run: |
         docker load --input image.tar
 
+    - name: Restore Kubernetes from cache
+      id: cache-k8s
+      uses: actions/cache@v2
+      with:
+        path: "${{ env.GOPATH }}/src/k8s.io/kubernetes"
+        key: k8s-go-master
+
+    - name: Copy k8s artifacts
+      run: |
+        pushd $GOPATH/src/k8s.io/kubernetes/
+          docker load --input ./_output/kind-image.tar
+          sudo cp ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
+          sudo cp ./_output/local/go/bin/e2e.test /usr/local/bin/e2e.test
+        popd
+        
     - name: kind setup
       run: |
         export OVN_IMAGE="ovn-daemonset-f:dev"
-        # Copy the kubernetes binaries
-        pushd $GOPATH/src/k8s.io/kubernetes/
-          if [[ ! -f /usr/local/bin/kubectl ]]; then
-            sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
-          fi
-          if [[ ! -f /usr/local/bin/e2e.test ]]; then
-            sudo ln ./_output/local/go/bin/e2e.test /usr/local/bin/e2e.test
-          fi
-        popd
-        # Install KIND
-        sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
-        sudo chmod +x /usr/local/bin/kind
         # Run KIND
         pushd ./contrib
           ./kind.sh


### PR DESCRIPTION
We had a periodic job to test dual-stack, this job was added with
the intention of getting signal on dual-stack, so we could observe
the results.

After the job was stable, it was promoted to presubmit, so we can
gate on dual-stack.

New dual-stack features are being added upstream, so we should test
against those. In order to do that we modify current dual-stack job
to use master kubernetes.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

results here https://github.com/aojea/ovn-kubernetes/runs/1319914695?check_suite_focus=true