### PR TITLE
Fix egress IP re-assignment for network failing node + minor fixes 

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -473,13 +473,14 @@ func (oc *Controller) reassignEgressIP(eIP *egressipv1.EgressIP) error {
 	eIP.Status = egressipv1.EgressIPStatus{
 		Items: []egressipv1.EgressIPStatusItem{},
 	}
+	var reassignError error
 	if err := oc.addEgressIP(eIP); err != nil {
-		return fmt.Errorf("new egress IP assignment failed, err: %v", err)
+		reassignError = fmt.Errorf("new egress IP assignment failed, err: %v", err)
 	}
 	if err := oc.updateEgressIPWithRetry(eIP); err != nil {
 		return fmt.Errorf("update of new egress IP failed, err: %v", err)
 	}
-	return nil
+	return reassignError
 }
 
 func (oc *Controller) initEgressIPAllocator(node *kapi.Node) (err error) {

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -598,6 +598,9 @@ type egressIPController struct {
 }
 
 func (e *egressIPController) addPodEgressIP(eIP *egressipv1.EgressIP, pod *kapi.Pod) error {
+	if pod.Spec.HostNetwork {
+		return nil
+	}
 	podIPs := e.getPodIPs(pod)
 	if podIPs == nil {
 		e.podRetry.Store(getPodKey(pod), true)
@@ -618,6 +621,9 @@ func (e *egressIPController) addPodEgressIP(eIP *egressipv1.EgressIP, pod *kapi.
 }
 
 func (e *egressIPController) deletePodEgressIP(eIP *egressipv1.EgressIP, pod *kapi.Pod) error {
+	if pod.Spec.HostNetwork {
+		return nil
+	}
 	podIPs := e.getPodIPs(pod)
 	if podIPs == nil {
 		return nil

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -80,6 +80,7 @@ func setupNode(nodeName string, ipNets []string, mockAllocationIPs []string) egr
 		v6Subnet:           v6Subnet,
 		allocations:        mockAllcations,
 		name:               nodeName,
+		isReady:            true,
 		isEgressAssignable: true,
 	}
 	return node
@@ -151,21 +152,41 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
 				egressNamespace := newNamespace(namespace)
 
-				node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node1Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, ""),
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, ""),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
 					},
-					Labels: map[string]string{
-						"k8s.ovn.org/egress-assignable": "",
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
 					},
-				}}
-				node2 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node2Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+						},
 					},
-				}}
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
 
 				eIP := egressipv1.EgressIP{
 					ObjectMeta: newEgressIPMeta(egressIPName),
@@ -270,21 +291,41 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				egressPod := *newPodWithLabels(namespace, podName, node1Name, podV4IP, egressPodLabel)
 				egressNamespace := newNamespace(namespace)
 
-				node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node1Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, ""),
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, ""),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
 					},
-					Labels: map[string]string{
-						"k8s.ovn.org/egress-assignable": "",
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
 					},
-				}}
-				node2 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node2Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+						},
 					},
-				}}
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
 
 				eIP := egressipv1.EgressIP{
 					ObjectMeta: newEgressIPMeta(egressIPName),
@@ -1102,18 +1143,38 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
 				node2IPv4 := "192.168.126.51/24"
 
-				node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: "node1",
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+						},
 					},
-				}}
-				node2 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: "node2",
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
 					},
-				}}
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
 				fakeOvn.start(ctx)
 				fakeOvn.fakeExec.AddFakeCmdsNoOutputNoError(
 					[]string{
@@ -1161,12 +1222,22 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 				nodeIPv4 := "192.168.126.510/24"
 				nodeIPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
-				node := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: "myNode",
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", nodeIPv4, nodeIPv6),
+				node := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "myNode",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", nodeIPv4, nodeIPv6),
+						},
 					},
-				}}
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
 				fakeOvn.start(ctx, &v1.NodeList{
 					Items: []v1.Node{node},
 				})
@@ -1209,12 +1280,22 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				nodeIPv4 := "192.168.126.51/24"
 				nodeIPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
 
-				node := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node1Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", nodeIPv4, nodeIPv6),
+				node := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", nodeIPv4, nodeIPv6),
+						},
 					},
-				}}
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
 
 				eIP := egressipv1.EgressIP{
 					ObjectMeta: newEgressIPMeta(egressIPName),
@@ -1292,24 +1373,44 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
 				node2IPv4 := "192.168.126.51/24"
 
-				node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node1Name,
-					Labels: map[string]string{
-						"k8s.ovn.org/egress-assignable": "",
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+						},
 					},
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
 					},
-				}}
-				node2 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node2Name,
-					Labels: map[string]string{
-						"k8s.ovn.org/egress-assignable": "",
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+						},
 					},
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
 					},
-				}}
+				}
 
 				eIP := egressipv1.EgressIP{
 					ObjectMeta: newEgressIPMeta(egressIPName),
@@ -1359,21 +1460,41 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				node1IPv4 := "192.168.126.51/24"
 				node2IPv4 := "192.168.126.101/24"
 
-				node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node1Name,
-					Labels: map[string]string{
-						"k8s.ovn.org/egress-assignable": "",
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4),
+						},
 					},
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4),
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
 					},
-				}}
-				node2 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node2Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node2IPv4),
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node2IPv4),
+						},
 					},
-				}}
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
 
 				eIP := egressipv1.EgressIP{
 					ObjectMeta: newEgressIPMeta(egressIPName),
@@ -1441,18 +1562,38 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
 				node2IPv4 := "192.168.126.51/24"
 
-				node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node1Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+						},
 					},
-				}}
-				node2 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node2Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
 					},
-				}}
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
 
 				eIP := egressipv1.EgressIP{
 					ObjectMeta: newEgressIPMeta(egressIPName),
@@ -1542,24 +1683,44 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
 				node2IPv4 := "192.168.126.51/24"
 
-				node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node1Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
 					},
-					Labels: map[string]string{
-						"k8s.ovn.org/egress-assignable": "",
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
 					},
-				}}
-				node2 := v1.Node{ObjectMeta: metav1.ObjectMeta{
-					Name: node2Name,
-					Annotations: map[string]string{
-						"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
 					},
-					Labels: map[string]string{
-						"k8s.ovn.org/egress-assignable": "",
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
 					},
-				}}
+				}
 
 				eIP := egressipv1.EgressIP{
 					ObjectMeta: newEgressIPMeta(egressIPName),

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -18,6 +18,12 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
+type fakeEgressIPDialer struct{}
+
+func (f fakeEgressIPDialer) dial(ip net.IP) bool {
+	return true
+}
+
 var (
 	reroutePolicyID           = "reroute_policy_id"
 	natID                     = "nat_id"
@@ -81,6 +87,7 @@ func setupNode(nodeName string, ipNets []string, mockAllocationIPs []string) egr
 		allocations:        mockAllcations,
 		name:               nodeName,
 		isReady:            true,
+		isReachable:        true,
 		isEgressAssignable: true,
 	}
 	return node
@@ -92,6 +99,8 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 		fakeOvn *FakeOVN
 		tExec   *ovntest.FakeExec
 	)
+
+	dialer = fakeEgressIPDialer{}
 
 	getEgressIPAllocatorSizeSafely := func() int {
 		fakeOvn.controller.eIPC.allocatorMutex.Lock()
@@ -134,6 +143,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 
 		tExec = ovntest.NewFakeExec()
 		fakeOvn = NewFakeOVN(tExec)
+
 	})
 
 	AfterEach(func() {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -737,9 +737,10 @@ func (oc *Controller) WatchEgressNodes() {
 				klog.Error(err)
 			}
 			nodeLabels := node.GetLabels()
-			if _, hasEgressLabel := nodeLabels[nodeEgressLabel]; hasEgressLabel && oc.isEgressNodeReady(node) {
+			if _, hasEgressLabel := nodeLabels[nodeEgressLabel]; hasEgressLabel && oc.isEgressNodeReady(node) && oc.isEgressNodeReachable(node) {
 				oc.setNodeEgressAssignable(node.Name, true)
 				oc.setNodeEgressReady(node.Name, true)
+				oc.setNodeEgressReachable(node.Name, true)
 				if err := oc.addEgressNode(node); err != nil {
 					klog.Error(err)
 				}
@@ -768,16 +769,18 @@ func (oc *Controller) WatchEgressNodes() {
 			}
 			isOldReady := oc.isEgressNodeReady(oldNode)
 			isNewReady := oc.isEgressNodeReady(newNode)
+			isNewReachable := oc.isEgressNodeReachable(newNode)
 			oc.setNodeEgressReady(newNode.Name, isNewReady)
+			oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 			if !oldHadEgressLabel && newHasEgressLabel {
 				klog.Infof("Node: %s has been labelled, adding it for egress assignment", newNode.Name)
 				oc.setNodeEgressAssignable(newNode.Name, true)
-				if isNewReady {
+				if isNewReady && isNewReachable {
 					if err := oc.addEgressNode(newNode); err != nil {
 						klog.Error(err)
 					}
 				} else {
-					klog.Warningf("Node: %s has been labelled, but node is not ready, cannot use it for egress assignment", newNode.Name)
+					klog.Warningf("Node: %s has been labelled, but node is not ready and reachable, cannot use it for egress assignment", newNode.Name)
 				}
 				return
 			}
@@ -789,8 +792,8 @@ func (oc *Controller) WatchEgressNodes() {
 				if err := oc.deleteEgressNode(newNode); err != nil {
 					klog.Error(err)
 				}
-			} else if isNewReady {
-				klog.Infof("Node: %s is ready, adding it for egress assignment", newNode.Name)
+			} else if isNewReady && isNewReachable {
+				klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
 				if err := oc.addEgressNode(newNode); err != nil {
 					klog.Error(err)
 				}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

This PR adds a temporary functionality for egress IP until both RFEs 

- https://bugzilla.redhat.com/show_bug.cgi?id=1881826 
- https://bugzilla.redhat.com/show_bug.cgi?id=1847570 

are implemented

Essentially we need to be checking if all the egress nodes are up, i.e: that the `.node.status.conditions` does not contain a `NotReady` status or that we cannot reach any of the nodes which are in use for egress assignment. In any of these events we need to re-assign the egress IPs which have previously been assigned to any of these egress nodes. The re-assignment procedure should today be correct, i.e: distributing the load (read: egress IPs) across the nodes available and updating the status of the `EgressIP` object accordingly. We are missing the higher level logic ensuring a continuous network validation for all egress nodes. 

I decided to split the commits: `Re-assign once kubelet starts posting NotReady status for node`  and `Add recurring dial to egress nodes` with the goal of easing the review. Once the PR is approved I will squash those commits however, as to ease the the revert once the RFEs have been implemented. 

I am planning on adding an e2e test for this tomorrow as well, but that can go in separately. For now this PR passes unit tests with the race detector set to on and I have tested the functionality locally with a kind cluster, simulating node failure by doing `iptables -I INPUT -p tcp --dport 9 -j REJECT --reject-with icmp-host-unreachable`

EDIT: this patch also contains minor fixes for issues seen during the work done. 

/assign @danwinship @trozet   

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->