### PR TITLE
Fix Reject ACLs and improve logging

### DIFF
--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -183,8 +183,9 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 			aclUUID, err := ovn.createLoadBalancerRejectACL(lb, svc.Spec.ClusterIP, svcPort.Port, svcPort.Protocol)
 			if err != nil {
 				klog.Errorf("Failed to create reject ACL for load balancer: %s, error: %v", lb, err)
+			} else {
+				klog.Infof("Reject ACL created for load balancer: %s, %s", lb, aclUUID)
 			}
-			klog.Infof("Reject ACL created for load balancer: %s, %s", lb, aclUUID)
 		}
 
 		// clear endpoints from the LB

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -143,23 +143,27 @@ func (ovn *Controller) getLogicalSwitchesForLoadBalancer(lb string) ([]string, e
 	if len(strings.Fields(out)) > 0 {
 		return strings.Fields(out), nil
 	}
-	// if load balancer was not on a switch, then it may be on a router
-	out, _, err = util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=name", "find",
-		"logical_router", fmt.Sprintf("load_balancer{>=}%s", lb))
+
+	return nil, nil
+}
+
+// getGRLogicalSwitchForLoadBalancer returns the external switch name if the load balancer is on a GR
+func (ovn *Controller) getGRLogicalSwitchForLoadBalancer(lb string) (string, error) {
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=name", "find", "logical_router", fmt.Sprintf("load_balancer{>=}%s", lb))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	if len(out) == 0 {
-		return nil, nil
+		return "", nil
 	}
-	// if this is a GR we know the corresponding join and external switches, otherwise this is an unhandled
-	// case
+
+	// if this is a GR we know the corresponding external switch, otherwise this is an unhandled case
 	if strings.HasPrefix(out, types.GWRouterPrefix) {
 		routerName := strings.TrimPrefix(out, types.GWRouterPrefix)
-		return []string{types.OVNJoinSwitch, types.ExternalSwitchPrefix + routerName}, nil
+		return types.ExternalSwitchPrefix + routerName, nil
 	}
-	return nil, fmt.Errorf("router detected with load balancer that is not a GR")
+	return "", fmt.Errorf("router detected with load balancer that is not a GR")
 }
 
 // TODO: Add unittest for function.
@@ -190,6 +194,7 @@ func (ovn *Controller) generateACLNameForOVNCommand(lb string, sourceIP string, 
 }
 
 func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePort int32, proto kapi.Protocol) (string, error) {
+	applyToPortGroup := false
 	ovn.serviceLBLock.Lock()
 	defer ovn.serviceLBLock.Unlock()
 	switches, err := ovn.getLogicalSwitchesForLoadBalancer(lb)
@@ -197,9 +202,22 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 		return "", fmt.Errorf("error finding logical switch that contains load balancer %s: %v", lb, err)
 	}
 
-	if len(switches) == 0 {
-		klog.V(5).Infof("Ignoring creating reject ACL for load balancer %s. It has no logical switches", lb)
-		return "", nil
+	if len(switches) > 0 {
+		applyToPortGroup = true
+	} else {
+		klog.V(5).Infof("Ignoring creating reject ACL for port group with load balancer %s. It has no "+
+			"logical switches", lb)
+	}
+
+	// check if the load balancer is on a GR, if so we need to get the external switches
+	gwRouterExtSwitch, err := ovn.getGRLogicalSwitchForLoadBalancer(lb)
+	if err != nil {
+		return "", fmt.Errorf("unable to query logical switches for GR with load balancer: %s, error: %v", lb, err)
+	}
+
+	if len(switches) == 0 && gwRouterExtSwitch == "" {
+		return "", fmt.Errorf("load balancer %s does not apply to any switches in the cluster. Will not create "+
+			"Reject ACL", lb)
 	}
 
 	ip := net.ParseIP(sourceIP)
@@ -223,11 +241,19 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 		klog.Errorf("Error while querying ACLs by name: %s, %v", stderr, err)
 	} else if len(aclUUID) > 0 {
 		klog.Infof("Existing Service Reject ACL found: %s for %s", aclUUID, aclName)
-		_, stderr, err = util.RunOVNNbctl("--", "add", "port_group", ovn.clusterPortGroupUUID, "acls", aclUUID)
-		if err != nil {
-			klog.Errorf("Failed to add LB %s ACL %s %q to cluster port group: %q (%v)",
-				lb, aclUUID, aclName, stderr, err)
-			return "", err
+		var cmd []string
+		if applyToPortGroup {
+			cmd = append(cmd, "--", "add", "port_group", ovn.clusterPortGroupUUID, "acls", aclUUID)
+		}
+		if len(gwRouterExtSwitch) > 0 {
+			cmd = append(cmd, "--", "add", "logical_switch", gwRouterExtSwitch, "acls", aclUUID)
+		}
+		if len(cmd) > 0 {
+			_, _, err = util.RunOVNNbctl(cmd...)
+			if err != nil {
+				klog.Errorf("Failed to add LB %s, ACL %s, %q, to cluster port group/switches, stderr: %q,"+
+					"error: %v", lb, aclUUID, aclName, stderr, err)
+			}
 		}
 
 		ovn.setServiceACLToLB(lb, vip, aclUUID)
@@ -243,10 +269,15 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 		strings.ToLower(string(proto)), strings.ToLower(string(proto)), sourcePort)
 	cmd := []string{"--id=@reject-acl", "create", "acl", "direction=from-lport", "priority=1000", aclMatch, "action=reject",
 		fmt.Sprintf("name=%s", aclName)}
-	cmd = append(cmd, "--", "add", "port_group", ovn.clusterPortGroupUUID, "acls", "@reject-acl")
+	if applyToPortGroup {
+		cmd = append(cmd, "--", "add", "port_group", ovn.clusterPortGroupUUID, "acls", "@reject-acl")
+	}
+	if len(gwRouterExtSwitch) > 0 {
+		cmd = append(cmd, "--", "add", "logical_switch", gwRouterExtSwitch, "acls", "@reject-acl")
+	}
 	aclUUID, stderr, err = util.RunOVNNbctl(cmd...)
 	if err != nil {
-		klog.Errorf("Failed to add LB %s ACL %s %q to cluster port group: %q (%v)",
+		klog.Errorf("Failed to add LB: %s ACL: %s, %q, to cluster port group/switches, stderr: %q, error: %v",
 			lb, aclUUID, aclName, stderr, err)
 		return "", err
 	}
@@ -270,14 +301,26 @@ func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
 			return
 		}
 		aclUUID, err = ovn.findStaleRejectACL(lb, ip, port)
-		if err == nil {
-			ovn.removeACLFromPortGroup(lb, aclUUID)
+		if err != nil {
+			klog.Infof("Unable to delete Reject ACL for load-balancer: %s, vip: %s. No entry in cache and "+
+				"error occurred while trying to find the ACL by name in OVN, error: %v", lb, vip, err)
+			return
 		}
-		return
+		if aclUUID == "" {
+			klog.Infof("No reject ACL found in cache or in OVN to remove for load-balancer: %s, vip: %s", lb, vip)
+			return
+		}
 	} else if aclUUID == "" {
 		// Must have endpoints and no reject ACL to remove
 		klog.V(5).Infof("No reject ACL found to remove for load balancer: %s, vip: %s", lb, vip)
 		return
+	}
+	// check if the load balancer is on a GR, if so we need to get the join/external switches
+	gwRouterSwitch, err := ovn.getGRLogicalSwitchForLoadBalancer(lb)
+	if err != nil {
+		klog.Errorf("Unable to query logical switches for GR with load balancer: %s, error: %v", lb, err)
+	} else {
+		ovn.removeACLFromNodeSwitches([]string{gwRouterSwitch}, aclUUID)
 	}
 	ovn.removeACLFromPortGroup(lb, aclUUID)
 	ovn.removeServiceACL(lb, vip)
@@ -298,8 +341,6 @@ func (ovn *Controller) findStaleRejectACL(lb, ip string, port int32) (string, er
 }
 
 // Remove the ACL uuid entry from Logical Switch acl's list.
-// Deprecated:This method is not required once a release with this patch is out.
-// This logic is specifically added to address the ovn upgrade.
 func (ovn *Controller) removeACLFromNodeSwitches(switches []string, aclUUID string) {
 	args := []string{}
 	for _, ls := range switches {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -726,15 +726,6 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 		return err
 	}
 
-	// Add any service reject ACLs applicable for TCP LB
-	acls := oc.getAllACLsForServiceLB(oc.TCPLoadBalancerUUID)
-	if len(acls) > 0 {
-		_, _, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "acls", strings.Join(acls, ","))
-		if err != nil {
-			klog.Warningf("Unable to add TCP reject ACLs: %s for switch: %s, error: %v", acls, nodeName, err)
-		}
-	}
-
 	if oc.UDPLoadBalancerUUID == "" {
 		return fmt.Errorf("UDP cluster load balancer not created")
 	}
@@ -742,15 +733,6 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 	if err != nil {
 		klog.Errorf("Failed to add logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 		return err
-	}
-
-	// Add any service reject ACLs applicable for UDP LB
-	acls = oc.getAllACLsForServiceLB(oc.UDPLoadBalancerUUID)
-	if len(acls) > 0 {
-		_, _, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "acls", strings.Join(acls, ","))
-		if err != nil {
-			klog.Warningf("Unable to add UDP reject ACLs: %s for switch: %s, error %v", acls, nodeName, err)
-		}
 	}
 
 	if oc.SCTPSupport {
@@ -761,15 +743,6 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 		if err != nil {
 			klog.Errorf("Failed to add logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 			return err
-		}
-
-		// Add any service reject ACLs applicable for SCTP LB
-		acls = oc.getAllACLsForServiceLB(oc.SCTPLoadBalancerUUID)
-		if len(acls) > 0 {
-			_, _, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "acls", strings.Join(acls, ","))
-			if err != nil {
-				klog.Warningf("Unable to add SCTP reject ACLs: %s for switch: %s, error %v", acls, nodeName, err)
-			}
 		}
 	}
 	// Add the node to the logical switch cache

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -1035,23 +1035,6 @@ func (oc *Controller) getServiceLBInfo(lb, vip string) (string, bool) {
 	return conf.rejectACL, len(conf.endpoints) > 0
 }
 
-// getAllACLsForServiceLB retrieves all of the ACLs for a given load balancer
-func (oc *Controller) getAllACLsForServiceLB(lb string) []string {
-	oc.serviceLBLock.Lock()
-	defer oc.serviceLBLock.Unlock()
-	confMap, ok := oc.serviceLBMap[lb]
-	if !ok {
-		return nil
-	}
-	var acls []string
-	for _, v := range confMap {
-		if len(v.rejectACL) > 0 {
-			acls = append(acls, v.rejectACL)
-		}
-	}
-	return acls
-}
-
 // removeServiceLB removes the entire LB entry for a VIP
 func (oc *Controller) removeServiceLB(lb, vip string) {
 	oc.serviceLBLock.Lock()

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -21,11 +21,12 @@ import (
 )
 
 const (
-	k8sTCPLoadBalancerIP  = "k8s_tcp_load_balancer"
-	k8sUDPLoadBalancerIP  = "k8s_udp_load_balancer"
-	k8sSCTPLoadBalancerIP = "k8s_sctp_load_balancer"
-	fakeUUID              = "8a86f6d8-7972-4253-b0bd-ddbef66e9303"
-	fakeUUIDv6            = "8a86f6d8-7972-4253-b0bd-ddbef66e9304"
+	k8sTCPLoadBalancerIP    = "k8s_tcp_load_balancer"
+	k8sUDPLoadBalancerIP    = "k8s_udp_load_balancer"
+	k8sSCTPLoadBalancerIP   = "k8s_sctp_load_balancer"
+	fakeUUID                = "8a86f6d8-7972-4253-b0bd-ddbef66e9303"
+	fakeUUIDv6              = "8a86f6d8-7972-4253-b0bd-ddbef66e9304"
+	ovnClusterPortGroupUUID = "740515f3-7ece-4cd1-9be5-6fdb9066d198"
 )
 
 type FakeOVN struct {

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -332,7 +332,9 @@ func (ovn *Controller) createService(service *kapi.Service) error {
 						if err != nil {
 							return fmt.Errorf("failed to create service ACL: %v", err)
 						}
-						klog.Infof("Service Reject ACL created for gateway router: %s", aclUUID)
+						klog.Infof("Service Reject ACL created for NodePort service: %s, namespace: %s, via "+
+							"gateway router: %s:%s:%d, ACL UUID:%s", service.Name, service.Namespace,
+							svcPort.Protocol, physicalIP, port, aclUUID)
 					}
 				}
 			}
@@ -358,7 +360,9 @@ func (ovn *Controller) createService(service *kapi.Service) error {
 					if err != nil {
 						return fmt.Errorf("failed to create service ACL: %v", err)
 					}
-					klog.Infof("Service Reject ACL created for cluster IP: %s", aclUUID)
+					klog.Infof("Service Reject ACL created for ClusterIP service: %s, namespace: %s, via: "+
+						"%s:%s:%d, ACL UUID: %s", service.Name, service.Namespace, svcPort.Protocol,
+						service.Spec.ClusterIP, svcPort.Port, aclUUID)
 				}
 				if len(service.Spec.ExternalIPs) > 0 {
 					gateways, _, err := ovn.getOvnGateways()
@@ -381,7 +385,9 @@ func (ovn *Controller) createService(service *kapi.Service) error {
 								if err != nil {
 									return fmt.Errorf("failed to create service ACL for external IP")
 								}
-								klog.Infof("Service Reject ACL created for external IP: %s", aclUUID)
+								klog.Infof("Service Reject ACL created for ExternalIP service: %s, namespace: %s,"+
+									"via: %s:%s:%d, ACL UUID: %s", service.Name, service.Namespace, svcPort.Protocol,
+									extIP, svcPort.Port, aclUUID)
 							}
 						}
 					}

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -3,8 +3,10 @@ package ovn
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"net"
 	"reflect"
+	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -169,14 +171,34 @@ func (ovn *Controller) syncServices(services []interface{}) {
 						if hasEps {
 							klog.Infof("Service Sync: Removing OVN stale reject ACL: %s", name)
 							ovn.removeACLFromPortGroup(lb, uuid)
+							var foundSwitches []string
+							// For upgrade from a non-port group Reject ACL implementation
+							// Deprecated: remove in the future
 							switches, err := ovn.getLogicalSwitchesForLoadBalancer(lb)
 							if err != nil {
-								klog.Errorf("Error finding logical switch that contains load balancer %s: %v", lb, err)
-								continue
-							} else if len(switches) != 0 {
-								klog.V(5).Infof("Service Sync: If exist, Remove OVN stale reject ACL (%s) "+
-									"from logical switches that contains load balancer %s", name, lb)
-								ovn.removeACLFromNodeSwitches(switches, uuid)
+								klog.Errorf("Error finding node logical switches for load balancer "+
+									"%s: %v", lb, err)
+							} else {
+								foundSwitches = append(foundSwitches, switches...)
+							}
+							// Look for load balancer on join/external switches
+							grExtSwitch, err := ovn.getGRLogicalSwitchForLoadBalancer(lb)
+							if err != nil {
+								klog.Errorf("Error finding GR logical switches for load balancer "+
+									"%s: %v", lb, err)
+							} else {
+								// For upgrade from a previous implementation the ACL may also be on join switch
+								if grExtSwitch != "" {
+									routerName := strings.TrimPrefix(grExtSwitch, types.ExternalSwitchPrefix)
+									grJoinSwitch := types.JoinSwitchPrefix + routerName
+									foundSwitches = append(foundSwitches, grExtSwitch, grJoinSwitch)
+								}
+							}
+							if len(foundSwitches) > 0 {
+								klog.V(5).Infof("Service Sync: Removing OVN stale reject ACL (%s) "+
+									"from logical switches that contains load balancer %s, switches: %s", name, lb,
+									foundSwitches)
+								ovn.removeACLFromNodeSwitches(foundSwitches, uuid)
 							}
 						}
 					}

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -120,14 +120,26 @@ func (s service) baseCmds(fexec *ovntest.FakeExec, service v1.Service) {
 		"ovn-nbctl --timeout=15 --if-exists remove load_balancer sctp_load_balancer_id_1 vips \"172.30.0.10:53\"",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=sctp_load_balancer_id_1-172.30.0.10\\:53",
 	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}%s", k8sTCPLoadBalancerIP),
+		Output: "62c672a4-1132-44ab-9202-e47d18784138",
+	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}k8s_tcp_load_balancer"),
-		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router load_balancer{>=}k8s_tcp_load_balancer"),
+		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router load_balancer{>=}%s", k8sTCPLoadBalancerIP),
 	})
 }
 
 func (s service) addCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	s.baseCmds(fexec, service)
+	for _, port := range service.Spec.Ports {
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=%s-%s\\:%v",
+				k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
+			fmt.Sprintf("ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match=\"ip4.dst==%s && tcp "+
+				"&& tcp.dst==%v\" action=reject name=%s-%s\\:%v -- add port_group %s acls @reject-acl", service.Spec.ClusterIP, port.Port,
+				k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port, ovnClusterPortGroupUUID),
+		})
+	}
 }
 
 func (s service) delCmds(fexec *ovntest.FakeExec, service v1.Service) {
@@ -180,7 +192,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 					nil,
 				)
 
-				test.baseCmds(fExec, service)
+				test.addCmds(fExec, service)
 
 				fakeOvn.start(ctx,
 					&v1.ServiceList{
@@ -189,6 +201,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 						},
 					},
 				)
+				fakeOvn.controller.clusterPortGroupUUID = ovnClusterPortGroupUUID
 				fakeOvn.controller.WatchServices()
 
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Get(context.TODO(), service.Name, metav1.GetOptions{})
@@ -218,7 +231,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 					nil,
 				)
 
-				test.baseCmds(fExec, service)
+				test.addCmds(fExec, service)
 
 				fakeOvn.start(ctx,
 					&v1.ServiceList{
@@ -227,6 +240,7 @@ var _ = Describe("OVN Namespace Operations", func() {
 						},
 					},
 				)
+				fakeOvn.controller.clusterPortGroupUUID = ovnClusterPortGroupUUID
 				fakeOvn.controller.WatchServices()
 
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Services(service.Namespace).Get(context.TODO(), service.Name, metav1.GetOptions{})


### PR DESCRIPTION
    Fix Reject ACLs for NodePort and External IP, and node add
    
    The previous patch for moving Reject ACLs to port group only applies the
    ACLs to the port group with management ports, which means the ACL will
    only get applied to the node logical switch. For NodePort and External
    IP those ACLs need to be on the External switches of the GR where the
    load balancer is hosted.
    
    Also, the reject ACLs were not getting created/deleted correctly and
    some of the unit tests were missing the expected commands.

   During node add, we were still adding reject ACLs directly to switches,
   instead of letting them naturally take effect through the mgmt port
   being added to the port group.
    
    Signed-off-by: Tim Rozet <trozet@redhat.com>
