### PR TITLE
config: fix dual-stack config parsing

### DIFF
--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -21,7 +21,6 @@ type CIDRNetworkEntry struct {
 // addresses from.
 func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, error) {
 	var parsedClusterList []CIDRNetworkEntry
-	ipv6 := false
 	clusterEntriesList := strings.Split(clusterSubnetCmd, ",")
 
 	for _, clusterEntry := range clusterEntriesList {
@@ -39,10 +38,7 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 			return nil, err
 		}
 
-		if utilnet.IsIPv6(parsedClusterEntry.CIDR.IP) {
-			ipv6 = true
-		}
-
+		ipv6 := utilnet.IsIPv6(parsedClusterEntry.CIDR.IP)
 		entryMaskLength, _ := parsedClusterEntry.CIDR.Mask.Size()
 		if len(splitClusterEntry) == 3 {
 			tmp, err := strconv.Atoi(splitClusterEntry[2])


### PR DESCRIPTION
If you passed dual-stack cluster subnets with the IPv6 subnet first it would mistakenly apply the IPv6 validation rules to the IPv4 subnet too (which was guaranteed to fail).

eg
```
I1028 10:18:51.401400       1 config.go:1283] Parsed config: {... RawClusterSubnets:fd01::/48/64,10.128.0.0/14/23 ...}
F1028 10:18:51.401566       1 ovnkube.go:130] cluster subnet invalid: IPv6 only supports /64 host subnets
```
