### PR TITLE
[WIP] Enable IPsec

### DIFF
--- a/contrib/ipsec/.gitignore
+++ b/contrib/ipsec/.gitignore
@@ -1,0 +1,2 @@
+certs
+kindca

--- a/contrib/ipsec/ipsec-ca.cnf
+++ b/contrib/ipsec/ipsec-ca.cnf
@@ -1,0 +1,40 @@
+[ req ]
+prompt = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+C = US
+O = ovnkubernetes
+OU = kind
+CN = kindca
+[ ca ]
+default_ca = the_ca
+[ the_ca ]
+dir            = kindca                     # top dir
+database       = $dir/index.txt        # index file.
+new_certs_dir  = $dir/newcerts         # new certs dir
+certificate    = $dir/cacert.pem       # The CA cert
+serial         = $dir/serial           # serial no file
+private_key    = $dir/private/cakey.pem# CA private key
+RANDFILE       = $dir/private/.rand    # random number file
+default_days   = 3650                  # how long to certify for
+default_crl_days= 30                   # how long before next CRL
+default_md     = sha512                # message digest to use
+policy         = policy                # default policy
+email_in_dn    = no                    # Don't add the email into cert DN
+name_opt       = ca_default            # Subject name display option
+cert_opt       = ca_default            # Certificate display option
+copy_extensions = copy                 # Copy extensions from request
+unique_subject = no                    # Allow certs with duplicate subjects
+# For the CA policy
+[ policy ]
+countryName             = optional
+stateOrProvinceName     = optional
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+# For the x509v3 extension
+[ ca_cert ]
+basicConstraints=CA:true
+[ usr_cert ]
+basicConstraints=CA:false

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -45,6 +45,10 @@ kubeadmConfigPatches:
       "v": "{{ cluster_log_level }}"
 nodes:
  - role: control-plane
+   extraMounts:
+   - containerPath: /ipsec-certs
+     hostPath: ./ipsec/certs
+     readOnly: true
    kubeadmConfigPatches:
    - |
      kind: InitConfiguration
@@ -55,8 +59,16 @@ nodes:
 {%- if ovn_ha is equalto "true" %}
 {%- for _ in range(1, ovn_num_master | int) %}
  - role: worker
+   extraMounts:
+   - containerPath: /ipsec_certs
+     hostPath: ./ipsec/certs
+     readOnly: true
 {%- endfor %}
 {%- endif %}
 {%- for _ in range(ovn_num_worker | int) %}
  - role: worker
+   extraMounts:
+   - containerPath: /ipsec-certs
+     hostPath: ./ipsec/certs
+     readOnly: true
 {%- endfor %}

--- a/dist/images/Dockerfile
+++ b/dist/images/Dockerfile
@@ -24,7 +24,7 @@ COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 RUN INSTALL_PKGS=" \
 	PyYAML bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
 	libpcap kubectl \
-	iproute iputils strace socat \
+	iproute iputils strace socat libreswan \
 	unbound-libs \
         " && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS

--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -20,7 +20,7 @@ RUN INSTALL_PKGS=" \
 	PyYAML bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
 	libpcap hostname kubernetes-client \
         ovn ovn-central ovn-host python3-openvswitch python3-pyOpenSSL \
-	iptables iproute iputils strace socat \
+	iptables iproute iputils strace socat openvswitch-ipsec libreswan  \
         " && \
 	dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
 	dnf clean all && rm -rf /var/cache/dnf/*
@@ -31,6 +31,7 @@ RUN INSTALL_PKGS=" \
 RUN dnf install -y --enablerepo=updates-testing --best --advisory=FEDORA-2020-cc142bbddb "ovn >= 20.09.0-1" || exit 1
 
 RUN mkdir -p /var/run/openvswitch
+RUN mkdir -p /etc/keys
 
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the pkg
@@ -42,6 +43,7 @@ COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
 # variables to direct operation and configure ovn
 COPY ovnkube.sh /root/
 COPY ovndb-raft-functions.sh /root/
+COPY ovn-ipsec-functions.sh /root/
 
 # copy git commit number into image
 COPY git_info /root

--- a/dist/images/Dockerfile.fedora.dev
+++ b/dist/images/Dockerfile.fedora.dev
@@ -36,11 +36,11 @@ ARG OVS_REPO=https://github.com/openvswitch/ovs.git
 ARG OVS_BRANCH=master
 
 #Install tools that is required for building ovs/ovn
-
+#Install libreswan for IPsec
 RUN dnf upgrade -y && dnf install --best --refresh -y --setopt=tsflags=nodocs \
 	PyYAML bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
         libpcap hostname kubernetes-client python3-openvswitch python3-pyOpenSSL  \
-        iptables iproute iputils strace socat\
+        iptables iproute iputils strace socat libreswan\
         "kernel-devel-uname-r == $KERNEL_VERSION" \
 	@'Development Tools' rpm-build dnf-plugins-core kmod && \
 	dnf clean all && rm -rf /var/cache/dnf/*
@@ -61,6 +61,7 @@ RUN echo "Building OVS with kernel version : " $KERNEL_VERSION
 RUN ./boot.sh
 RUN ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --enable-ssl --with-linux=/usr/src/kernels/$KERNEL_VERSION/
 RUN make && make install
+RUN pip -qq install python/
 RUN ovs-vsctl --version && ovs-ofctl --version
 
 #Clone OVN Source Code
@@ -96,6 +97,7 @@ COPY ./iptables-scripts/ip6tables-restore /usr/sbin/
 # ovnkube.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
 COPY ovnkube.sh ovndb-raft-functions.sh /root/
+COPY ovn-ipsec-functions.sh /root/
 
 RUN getent group openvswitch >/dev/null || groupadd -r openvswitch
 RUN getent passwd openvswitch >/dev/null || useradd -r -g openvswitch -d / -s /sbin/nologin -c "Open vSwitch Daemons" openvswitch

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -144,6 +144,9 @@ while [ "$1" != "" ]; do
   --multicast-enabled)
     OVN_MULTICAST_ENABLE=$VALUE
     ;;
+  --ipsec-enabled)
+    OVN_IPSEC_ENABLE=$VALUE
+    ;;
   --egress-ip-enable)
     OVN_EGRESSIP_ENABLE=$VALUE
     ;;
@@ -226,6 +229,8 @@ ovn_sb_raft_port=${OVN_SB_RAFT_PORT:-6644}
 echo "ovn_sb_raft_port: ${ovn_sb_raft_port}"
 ovn_multicast_enable=${OVN_MULTICAST_ENABLE}
 echo "ovn_multicast_enable: ${ovn_multicast_enable}"
+ovn_ipsec_enable=${OVN_IPSEC_ENABLE}
+echo "ovn_ipsec_enable: ${ovn_ipsec_enable}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -295,7 +300,13 @@ ovn_image=${image} \
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
   ovn_unprivileged_mode=${ovn_unprivileged_mode} \
+  ovn_ipsec_enable=${ovn_ipsec_enable} \
   j2 ../templates/ovs-node.yaml.j2 -o ../yaml/ovs-node.yaml
+
+ovn_image=${image} \
+  ovn_image_pull_policy=${image_pull_policy} \
+  ovn_unprivileged_mode=${ovn_unprivileged_mode} \
+  j2 ../templates/ovn-ipsec.yaml.j2 -o ../yaml/ovn-ipsec.yaml
 
 # ovn-setup.yaml
 net_cidr=${OVN_NET_CIDR:-"10.128.0.0/14/23"}

--- a/dist/images/ovn-ipsec-functions.sh
+++ b/dist/images/ovn-ipsec-functions.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#set -euo pipefail
+
+# Stops IPsec daemons.
+cleanup-ovn-ipsec() {
+  # Stop ovn-monitor-ipsec
+  /usr/share/openvswitch/scripts/ovs-ctl stop-ovs-ipsec
+  # Stop libreswan
+  /usr/libexec/ipsec/whack --shutdown
+  /sbin/ip xfrm policy flush
+  /sbin/ip xfrm state flush
+  /usr/sbin/ipsec --stopnflog
+  echo "=============== ovs-ipsec terminated ========== "
+  exit 0
+}
+
+# v3 - Runs IPsec daemons.
+ovn-ipsec() {
+  check_ovn_daemonset_version "3"
+
+  trap cleanup-ovn-ipsec SIGTERM
+
+  echo "=============== ovn-ipsec ====================="
+
+  # Workaround for https://github.com/libreswan/libreswan/issues/373
+  ulimit -n 1024
+
+  /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
+  # Check for kernel modules
+  /usr/libexec/ipsec/_stackmanager start
+  # Check for nss database status and migration
+  /usr/sbin/ipsec --checknss
+  # Check for nflog setup
+  /usr/sbin/ipsec --checknflog
+  # Start the actual IKE daemon
+  /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --logfile /var/log/libreswan.log
+
+  # Workarounf for https://mail.openvswitch.org/pipermail/ovs-dev/2020-October/375734.html
+  OVS_LOGDIR=/var/log/openvswitch OVS_RUNDIR=/var/run/openvswitch OVS_PKGDATADIR=/usr/share/openvswitch /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=libreswan start-ovs-ipsec
+
+  # Wait for things to settle
+  sleep 10
+
+  # Only the control-plane node will be able to set this but we only need one
+  # node to set it and if it fails on the others, we do not care.
+  ovn-nbctl set nb_global . ipsec=true
+
+  while true; do
+    sleep 10
+  done
+
+  echo "=============== ovs-ipsec terminated ========== "
+}

--- a/dist/templates/ovn-ipsec.yaml.j2
+++ b/dist/templates/ovn-ipsec.yaml.j2
@@ -1,44 +1,45 @@
 ---
-# ovs-node
+# ovn-ipsec
 # daemonset version 3
-# starts node daemons for ovs
+# starts ipsec daemons for ovs
 # it is run on all nodes
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: ovs-node
+  name: ovn-ipsec
   # namespace set up by install
   namespace: ovn-kubernetes
   annotations:
     kubernetes.io/description: |
-      This DaemonSet launches the ovs networking components for all nodes.
+      This DaemonSet launches the ovs ipsec networking components for all nodes.
 spec:
   selector:
     matchLabels:
-      app: ovs-node
+      app: ovn-ipsec
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app: ovs-node
-        name: ovs-node
+        app: ovn-ipsec
+        name: ovn-ipsec
         component: network
         type: infra
         kubernetes.io/os: "linux"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      serviceAccountName: ovn
       hostNetwork: true
       {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}
       containers:
 
-      # ovsdb-server and ovs-switchd daemons
-      - name: ovs-daemons
+      # ovs-monitor-ipsec and libreswan daemons
+      - name: ovn-ipsec
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
 
-        command: ["/root/ovnkube.sh", "ovs-server"]
+        command: ["/root/ovnkube.sh", "ovn-ipsec"]
 
         livenessProbe:
           exec:
@@ -50,7 +51,7 @@ spec:
           periodSeconds: 60
         readinessProbe:
           exec:
-            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovs-daemons"]
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-ipsec"]
           initialDelaySeconds: 30
           timeoutSeconds: 30
           periodSeconds: 60
@@ -62,27 +63,19 @@ spec:
 
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /lib/modules
-          name: host-modules
-          readOnly: true
-        - mountPath: /run/openvswitch
-          name: host-run-ovs
         - mountPath: /var/run/openvswitch
           name: host-var-run-ovs
-        - mountPath: /sys
-          name: host-sys
         - mountPath: /etc/openvswitch
           name: host-config-openvswitch
-        - mountPath: /var/run/dbus/
-          name: host-var-run-dbus
         - mountPath: /var/log/openvswitch/
           name: host-var-log-ovs
-        - mountPath: /var/lib/openvswitch/
-          name: host-var-lib-ovs
-        - mountPath: /etc/keys
+        - mountPath: /etc/keys/
           name: host-ipsec-certs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
 
         resources:
+        # TODO what is reasonable here?
           requests:
             cpu: 100m
             memory: 300Mi
@@ -92,22 +85,14 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_IPSEC_ENABLE
-          value: "{{ ovn_ipsec_enable }}"
         lifecycle:
           preStop:
             exec:
-              command: ["/root/ovnkube.sh", "cleanup-ovs-server"]
+              command: ["/root/ovnkube.sh", "cleanup-ovn-ipsec"]
 
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:
-      - name: host-modules
-        hostPath:
-          path: /lib/modules
-      - name: host-var-run-dbus
-        hostPath:
-          path: /var/run/dbus
       - name: host-var-log-ovs
         hostPath:
           path: /var/log/openvswitch
@@ -117,18 +102,13 @@ spec:
       - name: host-var-run-ovs
         hostPath:
           path: /var/run/openvswitch
-      - name: host-sys
-        hostPath:
-          path: /sys
       - name: host-config-openvswitch
         hostPath:
           path: /etc/origin/openvswitch
-      - name: host-var-lib-ovs
-        hostPath:
-          path: /var/lib/openvswitch
       - name: host-ipsec-certs
         hostPath:
           path: /ipsec-certs
 
       tolerations:
       - operator: "Exists"
+


### PR DESCRIPTION
The OVN Kubernetes network plugin uses OVN to instantiate
virtual networks for Kubernetes. These virtual networks use Geneve, a network
virtualization overlay encapsulation protocol, to tunnel traffic across the
underlay network between Kubernetes Nodes.

IPsec is a protocol suite that enables secure network communications between
IP endpoints by providing the following services:
- Confidentiality
- Authentication
- Data Integrity

OVN tunnel traffic is transported by physical routers and switches. These
physical devices could be untrusted (devices in public network) or might be
compromised. Enabling IPsec encryption for this tunnel traffic can prevent the
traffic data from being monitored and manipulated.

The scope of this work is to encrypt all traffic between pods on the cluster
network when that traffic leaves the node (and correspondingly decrypt traffic
that enters the node) using IPsec.

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

The OVN Kubernetes network plugin uses OVN to instantiate
virtual networks for Kubernetes. These virtual networks use Geneve, a network
virtualization overlay encapsulation protocol, to tunnel traffic across the
underlay network between Kubernetes Nodes.

IPsec is a protocol suite that enables secure network communications between
IP endpoints by providing the following services:
- Confidentiality
- Authentication
- Data Integrity

OVN tunnel traffic is transported by physical routers and switches. These
physical devices could be untrusted (devices in public network) or might be
compromised. Enabling IPsec encryption for this tunnel traffic can prevent the
traffic data from being monitored and manipulated.

The scope of this work is to encrypt all traffic between pods on the cluster
network when that traffic leaves the node (and correspondingly decrypt traffic
that enters the node) using IPsec.

Encryption services are recommended when traffic is traversing an untrusted
network. Encryption services may also be required for regulatory or compliance
reasons (e.g. FIPS compliance).

**- Special notes for reviewers**

I am looking for a general review but some specific things to look at:

* Currently all IPsec services are instantiated in their own Pod. This has some advantages and disadvantages. Is this the best model?
* How can I determine resources for the OVN IPsec container in the yaml file?
* This will require a recent version of the Linux kernel. How can we get the CI to use this. Should I build a custom kernel in the CI?
* Each node will have its own private key, signed certificate and CA certificate in order to encrypt and decrypt traffic to and from other nodes in the cluster respectively. These keys are generated and signed as part of the `kind.sh` script and distributed through the `kind.yaml` kind configuration. They are currently shared through a "hostPath" mount into the container. This could also be changed to use secrets. However, as it currently stands, the ovn-ipsec containers which form part of the ovn-ipsec pods have access to all keys in the cluster. This is not ideal and will need to be modified to share the specific host keys with only that host.
* The OVS system-id has been modified from being "randomly" generated to being generated using the "hosthame" of the underlying kind worker. This is needed for OVN IPsec as it needs to relate the cert CN, hostname and system-id. I don't see an issue with this but I am just highlighting.
* As a note, this passes all control-plane and shard-conformance tests (with noHA, local, IPv4) when running locally against a patched kernel

**- How to verify it**

* This requires a kernel which has the following commit: <https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.9.2&id=34beb21594519ce64a55a498c2fe7d567bc1ca20.> This is currently not available in Fedora, RHEL - but this is being worked on.
* This also requires a recent version of OVS that has the following commit: <https://github.com/openvswitch/ovs/commit/8a09c2590ef2ea0edc250ec46e3d41bd5874b4ab>

If the host on which you are running the cluster on has the kernel patch. The following commands will enable an IPsec cluster:

```
pushd $OVN_K8S/dist/images;
make fedora-dev;
popd;
pushd $OVN_K8S/contrib;
./kind.sh -ie -ov ovn-kube-f-dev:latest;
popd

```

**- Description for the changelog**