### PR TITLE
Possibility to run single control-plane test

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -26,4 +26,4 @@ control-plane:
 	E2E_REPORT_PREFIX=$(JOB_NAME)_ \
 	KIND_IPV4_SUPPORT=$(KIND_IPV4_SUPPORT) \
 	KIND_IPV6_SUPPORT=$(KIND_IPV6_SUPPORT) \
-	./scripts/e2e-cp.sh
+	./scripts/e2e-cp.sh $(WHAT)

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -18,11 +18,14 @@ export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
 export KUBE_CONTAINER_RUNTIME_NAME=containerd
 export NUM_NODES=2
 
+FOCUS=$(echo ${@:1} | sed 's/ /\\s/g')
+
 pushd e2e
 
 go mod download
 go test -timeout=0 -v . \
         -ginkgo.v \
+        -ginkgo.focus ${FOCUS:-.} \
         -ginkgo.flakeAttempts ${FLAKE_ATTEMPTS:-2} \
         -ginkgo.skip="${SKIPPED_TESTS}" \
         -provider skeleton \


### PR DESCRIPTION
PR: https://github.com/ovn-org/ovn-kubernetes/pull/1324 introduced
the possibility to run a single e2e tests. However, since then we've
split our own tests into "control-plane" tests, and this possibility
didn't exists for that. This PR introduces the same concept for the
control plane tests.

This will now allow us to run tests as:

```
$ make -C test control-plane WHAT="egress IP"
```

and thus run all egress IP tests only. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->