### PR TITLE
Fix minor issues with metrics for OVS, OVN, and OVN-kubernetes

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -108,8 +108,8 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 			}
 			return 0
 		}
-		prometheus.MustRegister(prometheus.NewCounterFunc(
-			prometheus.CounterOpts{
+		prometheus.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
 				Namespace: MetricOvnkubeNamespace,
 				Subsystem: MetricOvnkubeSubsystemMaster,
 				Name:      "sb_e2e_timestamp",

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -101,9 +101,9 @@ func getOvnControllerVersionInfo() {
 	// ovn-controller 20.06.0.86f64fc1
 	// Open vSwitch Library 2.13.0.f945b5c5
 	for _, line := range strings.Split(stdout, "\n") {
-		if strings.HasPrefix("ovn-controller ", line) {
+		if strings.HasPrefix(line, "ovn-controller ") {
 			ovnControllerVersion = strings.Fields(line)[1]
-		} else if strings.HasPrefix("Open vSwitch Library ", line) {
+		} else if strings.HasPrefix(line, "Open vSwitch Library ") {
 			ovnControllerOvsLibVersion = strings.Fields(line)[3]
 		}
 	}

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -252,7 +252,7 @@ var metricDBE2eTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 )
 
 func ovnDBSizeMetricsUpdater(direction, database string) {
-	dbFile := fmt.Sprintf("/etc/openvswitch/ovn%s_db.db", direction)
+	dbFile := fmt.Sprintf("/etc/ovn/ovn%s_db.db", direction)
 	fileInfo, err := os.Stat(dbFile)
 	if err != nil {
 		klog.Errorf("Failed to get the DB size for database %s: %v", database, err)

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -26,9 +26,9 @@ func getOvnNorthdVersionInfo() {
 	// ovn-northd 20.06.0.86f64fc1
 	// Open vSwitch Library 2.13.0.f945b5c5
 	for _, line := range strings.Split(stdout, "\n") {
-		if strings.HasPrefix("ovn-northd ", line) {
+		if strings.HasPrefix(line, "ovn-northd ") {
 			ovnNorthdVersion = strings.Fields(line)[1]
-		} else if strings.HasPrefix("Open vSwitch Library ", line) {
+		} else if strings.HasPrefix(line, "Open vSwitch Library ") {
 			ovnNorthdOvsLibVersion = strings.Fields(line)[3]
 		}
 	}

--- a/go-controller/pkg/metrics/ovs.go
+++ b/go-controller/pkg/metrics/ovs.go
@@ -226,7 +226,7 @@ var metricOvsTcPolicy = prometheus.NewGauge(prometheus.GaugeOpts{
 var metricInterafceDriverName = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvsNamespace,
 	Subsystem: MetricOvsSubsystemVswitchd,
-	Name:      "interafce_driver_name",
+	Name:      "interface_driver_name",
 	Help: "A metric with a constant '1' value labeled by driver name that " +
 		"specifies the name of the device driver controlling the network interface"},
 	[]string{


### PR DESCRIPTION
OVN Kubernetes metrics:
1. sb_e2e_timestamp should be gauge type to match nb_e2e_timestamp

OVN metrics:
1. swap HasPrefix() arguments that were incorrectly used
2. use /etc/ovn path for the OVN DBs

OVS metrics:
1. fix typo in OVS metric name
