### PR TITLE
dist images: Change the base image to fedora:32 in the fedora Docker …

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -9,7 +9,7 @@
 # are built locally and included in the image (instead of the rpm)
 #
 
-FROM fedora:31
+FROM fedora:32
 
 USER root
 
@@ -17,7 +17,7 @@ ENV PYTHONDONTWRITEBYTECODE yes
 
 # install needed rpms - openvswitch must be 2.10.4 or higher
 RUN INSTALL_PKGS=" \
-	PyYAML bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
+	python3-pyyaml bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
 	libpcap hostname kubernetes-client \
         ovn ovn-central ovn-host python3-openvswitch python3-pyOpenSSL \
 	iptables iproute iputils strace socat \
@@ -25,10 +25,10 @@ RUN INSTALL_PKGS=" \
 	dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
 	dnf clean all && rm -rf /var/cache/dnf/*
 
-# ensure we pick up ovn-20.09.0-1.fc31 for ovn-northd MLD fixes.
+# ensure we pick up ovn-20.09.0-1.fc32 for ovn-northd MLD fixes.
 # This should have no effect in the future once the RPM has propagated
 # to all stable mirrors and can be removed
-RUN dnf install -y --enablerepo=updates-testing --best --advisory=FEDORA-2020-cc142bbddb "ovn >= 20.09.0-1" || exit 1
+RUN dnf install -y --enablerepo=updates-testing --best --advisory=FEDORA-2020-6c71d0012d "ovn >= 20.09.0-1" || exit 1
 
 RUN mkdir -p /var/run/openvswitch
 

--- a/dist/images/Dockerfile.fedora.dev
+++ b/dist/images/Dockerfile.fedora.dev
@@ -23,7 +23,7 @@
 # this image in any production environment.
 #
 
-FROM fedora:31
+FROM fedora:32
 
 USER root
 
@@ -38,7 +38,7 @@ ARG OVS_BRANCH=master
 #Install tools that is required for building ovs/ovn
 
 RUN dnf upgrade -y && dnf install --best --refresh -y --setopt=tsflags=nodocs \
-	PyYAML bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
+	python3-pyyaml bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
         libpcap hostname kubernetes-client python3-openvswitch python3-pyOpenSSL  \
         iptables iproute iputils strace socat\
         "kernel-devel-uname-r == $KERNEL_VERSION" \


### PR DESCRIPTION
…files.

Fedora 33 is already out and I think we can switch over to using fedora
32 as base image. With this I don't have to update OVN packages for
fedora 31.

Signed-off-by: Numan Siddique <numans@ovn.org>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->