### PR TITLE
Fix default deny port removal issue

### DIFF
--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -96,6 +96,11 @@ func (gp *gressPolicy) ensurePeerAddressSet(factory AddressSetFactory) error {
 }
 
 func (gp *gressPolicy) addPeerPod(pod *v1.Pod) error {
+	if gp.peerAddressSet == nil {
+		return fmt.Errorf("peer AddressSet is nil, cannot add peer pod: %s for gressPolicy: %s",
+			pod.ObjectMeta.Name, gp.policyName)
+	}
+
 	ips, err := util.GetAllPodIPs(pod)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #1782

With the code updates to fix problems with orphaned ACLs 
in PR #1665 the code for `localPodDelDefaultDeny` was 
changed in order to be able to clean up related 
resources from both `policy.go` and `namespace.go` 

In order to do so, the `knet.policy` object could no longer
be used in the function call since we didn't have access
to it in `namespace.go` 

Therefore the logic used to determined `PolicyType` was changed
to use only the existing `namespacePolicy` fields egressPolicies and 
ingresPolicies. However it had some issues and the number of egress/ingress
rules weren't enough to tell the `NetworkPolicyType` 

For example, if we had a `NetworkPolicy`
that blocked ALL traffic by default but did not contain any 
ingress/egress rules, the new logic would fail to delete the ports from the 
default deny port group 

FIX: 
Add a `policyType:      policy.Spec.PolicyTypes,`  ensure we can always determine 
the type of `NetworkPolicy` regardless of the number of ingress and egress rules