### PR TITLE
Fix race in informers_test

### DIFF
--- a/go-controller/pkg/informer/informer_test.go
+++ b/go-controller/pkg/informer/informer_test.go
@@ -261,6 +261,15 @@ var _ = Describe("Informer Event Handler Tests", func() {
 
 		_, err := k.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() (bool, error) {
+			pod, err := k.CoreV1().Pods(namespace).Get(context.TODO(), "foo", metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			return pod.ResourceVersion == "11", nil
+		}, 2).Should(BeTrue())
+
 		// no deletes
 		Consistently(func() int32 { return atomic.LoadInt32(&deletes) }).Should(Equal(int32(0)), "deletes")
 		// two updates, initial add from cache + update event


### PR DESCRIPTION
We are seeing flakes in informers_test only in CI. Probably a timing
issue with slow VMs in upstream. Using this PR to reproduce and fix
them.

Signed-off-by: Tim Rozet <trozet@redhat.com>

