### PR TITLE
decouple OVN load balancer from OVN controller

### DIFF
--- a/go-controller/pkg/ovn/acl/acl.go
+++ b/go-controller/pkg/ovn/acl/acl.go
@@ -1,0 +1,48 @@
+package acl
+
+import (
+	"fmt"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
+	"k8s.io/klog"
+)
+
+// GetACLByName returns the ACL UUID
+func GetACLByName(aclName string) (string, error) {
+	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
+		fmt.Sprintf("name=%s", aclName))
+	if err != nil {
+		return "", errors.Wrapf(err, "Error while querying ACLs by name: %s", stderr)
+	} else if len(aclUUID) == 0 {
+		return "", fmt.Errorf("ACL not found: %s", aclName)
+	}
+	return aclUUID, nil
+}
+
+// RemoveACLFromNodeSwitches removes the ACL uuid entry from Logical Switch acl's list.
+func RemoveACLFromNodeSwitches(switches []string, aclUUID string) error {
+	if len(switches) > 0 {
+		args := []string{}
+		for _, ls := range switches {
+			args = append(args, "--", "--if-exists", "remove", "logical_switch", ls, "acl", aclUUID)
+		}
+		_, _, err := util.RunOVNNbctl(args...)
+		if err != nil {
+			return errors.Wrapf(err, "Error while removing ACL: %s, from switches", aclUUID)
+		} else {
+			klog.Infof("ACL: %s, removed from switches: %s", aclUUID, switches)
+		}
+	}
+	return nil
+}
+
+// RemoveACLFromPortGroup removes the ACL from the port-group
+func RemoveACLFromPortGroup(aclUUID, clusterPortGroupUUID string) error {
+	_, stderr, err := util.RunOVNNbctl("--", "--if-exists", "remove", "port_group", clusterPortGroupUUID, "acls", aclUUID)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to remove reject ACL %s from port group %s: stderr: %q", aclUUID, clusterPortGroupUUID, stderr)
+	}
+	klog.Infof("ACL: %s, removed from the port group : %s", aclUUID, clusterPortGroupUUID)
+	return nil
+}

--- a/go-controller/pkg/ovn/acl/acl_test.go
+++ b/go-controller/pkg/ovn/acl/acl_test.go
@@ -1,0 +1,115 @@
+package acl
+
+import (
+	"fmt"
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func TestGetACLByName(t *testing.T) {
+	tests := []struct {
+		name    string
+		aclName string
+		ovnCmd  ovntest.ExpectedCmd
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "existing acl",
+			aclName: "my-acl",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=my-acl",
+				Output: "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			},
+			want:    "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:    "non existing acl",
+			aclName: "my-acl",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=my-acl",
+				Output: "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := GetACLByName(tt.aclName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetACLByName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetACLByName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveACLFromNodeSwitches(t *testing.T) {
+	tests := []struct {
+		name     string
+		switches []string
+		aclUUID  string
+		ovnCmd   ovntest.ExpectedCmd
+		wantErr  bool
+	}{
+		{
+			name:     "remove acl on two switches",
+			switches: []string{"sw1", "sw2"},
+			aclUUID:  "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- --if-exists remove logical_switch sw1 acl a08ea426-2288-11eb-a30b-a8a1590cda29 -- --if-exists remove logical_switch sw2 acl a08ea426-2288-11eb-a30b-a8a1590cda29",
+				Output: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "remove acl on no switches",
+			switches: []string{},
+			aclUUID:  "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd:   ovntest.ExpectedCmd{},
+			wantErr:  false,
+		},
+		{
+			name:     "remove acl and OVN error on first switch",
+			switches: []string{"sw1", "sw2"},
+			aclUUID:  "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- --if-exists remove logical_switch sw1 acl a08ea426-2288-11eb-a30b-a8a1590cda29 -- --if-exists remove logical_switch sw2 acl a08ea426-2288-11eb-a30b-a8a1590cda29",
+				Output: "",
+				Err:    fmt.Errorf("error while removing ACL: sw1, from switches"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			err = RemoveACLFromNodeSwitches(tt.switches, tt.aclUUID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RemoveACLFromNodeSwitches() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+		})
+	}
+}

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -1,11 +1,12 @@
 package ovn
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/acl"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
@@ -14,68 +15,29 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
+// getLoadBalancer is a convenience wrapper over GetOVNKubeLoadBalancer to use a cache
+// it will return an error if it can not find a load balancer
 func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string, error) {
+	ovn.loadbalancerClusterCacheMutex.Lock()
+	defer ovn.loadbalancerClusterCacheMutex.Unlock()
 	if outStr, ok := ovn.loadbalancerClusterCache[protocol]; ok {
 		return outStr, nil
 	}
 
-	var out string
-	var err error
-	if protocol == kapi.ProtocolTCP {
-		out, _, err = util.RunOVNNbctl("--data=bare",
-			"--no-heading", "--columns=_uuid", "find", "load_balancer",
-			"external_ids:k8s-cluster-lb-tcp=yes")
-	} else if protocol == kapi.ProtocolUDP {
-		out, _, err = util.RunOVNNbctl("--data=bare", "--no-heading",
-			"--columns=_uuid", "find", "load_balancer",
-			"external_ids:k8s-cluster-lb-udp=yes")
-	} else if protocol == kapi.ProtocolSCTP {
-		out, _, err = util.RunOVNNbctl("--data=bare", "--no-heading",
-			"--columns=_uuid", "find", "load_balancer",
-			"external_ids:k8s-cluster-lb-sctp=yes")
-	}
+	out, err := loadbalancer.GetOVNKubeLoadBalancer(protocol)
+	// GetOVNKubeLoadBalancer will return an err if out is empty
 	if err != nil {
 		return "", err
-	}
-	if out == "" {
-		return "", fmt.Errorf("no load balancer found in the database")
 	}
 	ovn.loadbalancerClusterCache[protocol] = out
 	return out, nil
 }
 
-// getLoadBalancerVIPs returns a map whose keys are VIPs (IP:port) on loadBalancer
-func (ovn *Controller) getLoadBalancerVIPs(loadBalancer string) (map[string]interface{}, error) {
-	outStr, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"get", "load_balancer", loadBalancer, "vips")
-	if err != nil {
-		return nil, err
-	}
-	if outStr == "" {
-		return nil, fmt.Errorf("load balancer vips in OVN DB is an empty string")
-	}
-	// sample outStr:
-	// - {"192.168.0.1:80"="10.1.1.1:80,10.2.2.2:80"}
-	// - {"[fd01::]:80"="[fd02::]:80,[fd03::]:80"}
-	outStrMap := strings.Replace(outStr, "=", ":", -1)
-
-	var raw map[string]interface{}
-	err = json.Unmarshal([]byte(outStrMap), &raw)
-	if err != nil {
-		return nil, err
-	}
-	return raw, nil
-}
-
 // deleteLoadBalancerVIP removes the VIP as well as any reject ACLs associated to the LB
 func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) error {
-	vipQuotes := fmt.Sprintf("\"%s\"", vip)
-	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove", "load_balancer", loadBalancer, "vips", vipQuotes)
+	err := loadbalancer.DeleteLoadBalancerVIP(loadBalancer, vip)
 	if err != nil {
-		// if we hit an error and fail to remove load balancer, we skip removing the rejectACL
-		return fmt.Errorf("error in deleting load balancer vip %s for %s"+
-			"stdout: %q, stderr: %q, error: %v",
-			vip, loadBalancer, stdout, stderr, err)
+		return err
 	}
 	ovn.removeServiceEndpoints(loadBalancer, vip)
 	ovn.deleteLoadBalancerRejectACL(loadBalancer, vip)
@@ -88,18 +50,13 @@ func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) error {
 func (ovn *Controller) configureLoadBalancer(lb, sourceIP string, sourcePort int32, targets []string) error {
 	ovn.serviceLBLock.Lock()
 	defer ovn.serviceLBLock.Unlock()
-
 	vip := util.JoinHostPortInt32(sourceIP, sourcePort)
-	lbTarget := fmt.Sprintf(`vips:"%s"="%s"`, vip, strings.Join(targets, ","))
-
-	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, lbTarget)
+	err := loadbalancer.UpdateLoadBalancer(lb, vip, targets)
 	if err != nil {
-		return fmt.Errorf("error in configuring load balancer: %s "+
-			"stdout: %q, stderr: %q, error: %v", lb, out, stderr, err)
+		return err
 	}
 	ovn.setServiceEndpointsToLB(lb, vip, targets)
-	klog.V(5).Infof("LB entry set for %s, %s, %v", lb, lbTarget,
-		ovn.serviceLBMap[lb][vip])
+	klog.V(5).Infof("LB entry set for %s, %v, %v", lb, targets, ovn.serviceLBMap[lb][vip])
 	return nil
 }
 
@@ -134,63 +91,32 @@ func (ovn *Controller) createLoadBalancerVIPs(lb string,
 }
 
 func (ovn *Controller) getLogicalSwitchesForLoadBalancer(lb string) ([]string, error) {
-	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=_uuid", "find",
-		"logical_switch", fmt.Sprintf("load_balancer{>=}%s", lb))
+	switches, err := loadbalancer.GetLogicalSwitchesForLoadBalancer(lb)
 	if err != nil {
 		return nil, err
 	}
-	if len(strings.Fields(out)) > 0 {
-		return strings.Fields(out), nil
-	}
-
-	return nil, nil
+	return switches, nil
 }
 
 // getGRLogicalSwitchForLoadBalancer returns the external switch name if the load balancer is on a GR
 func (ovn *Controller) getGRLogicalSwitchForLoadBalancer(lb string) (string, error) {
-	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=name", "find", "logical_router", fmt.Sprintf("load_balancer{>=}%s", lb))
+	routers, err := loadbalancer.GetLogicalRoutersForLoadBalancer(lb)
 	if err != nil {
 		return "", err
 	}
-	if len(out) == 0 {
+	if len(routers) == 0 {
 		return "", nil
 	}
 
-	// if this is a GR we know the corresponding external switch, otherwise this is an unhandled case
-	if strings.HasPrefix(out, types.GWRouterPrefix) {
-		routerName := strings.TrimPrefix(out, types.GWRouterPrefix)
-		return types.ExternalSwitchPrefix + routerName, nil
+	// if this is a GR we know the corresponding join and external switches, otherwise this is an unhandled
+	// case
+	for _, r := range routers {
+		if strings.HasPrefix(r, types.GWRouterPrefix) {
+			routerName := strings.TrimPrefix(r, types.GWRouterPrefix)
+			return types.ExternalSwitchPrefix + routerName, nil
+		}
 	}
 	return "", fmt.Errorf("router detected with load balancer that is not a GR")
-}
-
-// TODO: Add unittest for function.
-func generateACLName(lb string, sourceIP string, sourcePort int32) string {
-	aclName := fmt.Sprintf("%s-%s:%d", lb, sourceIP, sourcePort)
-	// ACL names are limited to 63 characters
-	if len(aclName) > 63 {
-		var ipPortLen int
-		srcPortStr := fmt.Sprintf("%d", sourcePort)
-		// Add the length of the IP (max 15 with periods, max 39 with colons),
-		// plus length of sourcePort (max 5 char),
-		// plus 1 for additional ':' to separate,
-		// plus 1 for '-' between lb and IP.
-		// With full IPv6 address and 5 char port, max ipPortLen is 62
-		// With full IPv4 address and 5 char port, max ipPortLen is 24.
-		ipPortLen = len(sourceIP) + len(srcPortStr) + 1 + 1
-		lbTrim := 63 - ipPortLen
-		// Shorten the Load Balancer name to allow full IP:port
-		tmpLb := lb[:lbTrim]
-		klog.Infof("Limiting ACL Name from %s to %s-%s:%d to keep under 63 characters", aclName, tmpLb, sourceIP, sourcePort)
-		aclName = fmt.Sprintf("%s-%s:%d", tmpLb, sourceIP, sourcePort)
-	}
-	return aclName
-}
-
-func generateACLNameForOVNCommand(lb string, sourceIP string, sourcePort int32) string {
-	return strings.ReplaceAll(generateACLName(lb, sourceIP, sourcePort), ":", "\\:")
 }
 
 func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePort int32, proto kapi.Protocol) (string, error) {
@@ -205,8 +131,7 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 	if len(switches) > 0 {
 		applyToPortGroup = true
 	} else {
-		klog.V(5).Infof("Ignoring creating reject ACL for port group with load balancer %s. It has no "+
-			"logical switches", lb)
+		klog.V(5).Infof("Ignoring creating reject ACL for port group with load balancer %s. It has no logical switches", lb)
 	}
 
 	// check if the load balancer is on a GR, if so we need to get the external switches
@@ -232,13 +157,12 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 	}
 	vip := util.JoinHostPortInt32(sourceIP, sourcePort)
 	// NOTE: doesn't use vip, to avoid having brackets in the name with IPv6
-	aclName := generateACLNameForOVNCommand(lb, sourceIP, sourcePort)
+	aclName := loadbalancer.GenerateACLNameForOVNCommand(lb, sourceIP, sourcePort)
 	// If ovn-k8s was restarted, we lost the cache, and an ACL may already exist in OVN. In that case we need to check
 	// using ACL name
-	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
-		fmt.Sprintf("name=%s", aclName))
+	aclUUID, err := acl.GetACLByName(aclName)
 	if err != nil {
-		klog.Errorf("Error while querying ACLs by name: %s, %v", stderr, err)
+		klog.Errorf("Error while querying ACLs by name: %v", err)
 	} else if len(aclUUID) > 0 {
 		klog.Infof("Existing Service Reject ACL found: %s for %s", aclUUID, aclName)
 		var cmd []string
@@ -251,8 +175,7 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 		if len(cmd) > 0 {
 			_, _, err = util.RunOVNNbctl(cmd...)
 			if err != nil {
-				klog.Errorf("Failed to add LB %s, ACL %s, %q, to cluster port group/switches, stderr: %q,"+
-					"error: %v", lb, aclUUID, aclName, stderr, err)
+				klog.Errorf("Failed to add LB %s, ACL %s, %q, to cluster port group/switches, error: %v", lb, aclUUID, aclName, err)
 			}
 		}
 
@@ -275,9 +198,9 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 	if len(gwRouterExtSwitch) > 0 {
 		cmd = append(cmd, "--", "add", "logical_switch", gwRouterExtSwitch, "acls", "@reject-acl")
 	}
-	aclUUID, stderr, err = util.RunOVNNbctl(cmd...)
+	aclUUID, stderr, err := util.RunOVNNbctl(cmd...)
 	if err != nil {
-		klog.Errorf("Failed to add LB: %s ACL: %s, %q, to cluster port group/switches, stderr: %q, error: %v",
+		klog.Errorf("Failed to add LB: %s ACL: %s, %q, to cluster port group/switches, stderr: %s error: %v",
 			lb, aclUUID, aclName, stderr, err)
 		return "", err
 	}
@@ -300,7 +223,8 @@ func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
 			klog.Errorf("Unable to parse vip for Reject ACL deletion: %v", err)
 			return
 		}
-		aclUUID, err = ovn.findStaleRejectACL(lb, ip, port)
+		aclName := loadbalancer.GenerateACLNameForOVNCommand(lb, ip, port)
+		aclUUID, err = acl.GetACLByName(aclName)
 		if err != nil {
 			klog.Infof("Unable to delete Reject ACL for load-balancer: %s, vip: %s. No entry in cache and "+
 				"error occurred while trying to find the ACL by name in OVN, error: %v", lb, vip, err)
@@ -326,42 +250,17 @@ func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
 	ovn.removeServiceACL(lb, vip)
 }
 
-func (ovn *Controller) findStaleRejectACL(lb, ip string, port int32) (string, error) {
-	aclName := generateACLNameForOVNCommand(lb, ip, port)
-	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
-		fmt.Sprintf("name=%s", aclName))
-	if err != nil {
-		klog.Errorf("Error while querying ACLs by name: %s, %v", stderr, err)
-		return "", err
-	} else if len(aclUUID) == 0 {
-		klog.Infof("Reject ACL not found to remove for name: %s", aclName)
-		return "", fmt.Errorf("reject ACL not found to remove for name: %s", aclName)
-	}
-	return aclUUID, nil
-}
-
 // Remove the ACL uuid entry from Logical Switch acl's list.
 func (ovn *Controller) removeACLFromNodeSwitches(switches []string, aclUUID string) {
-	args := []string{}
-	for _, ls := range switches {
-		args = append(args, "--", "--if-exists", "remove", "logical_switch", ls, "acl", aclUUID)
-	}
-
-	if len(args) > 0 {
-		_, _, err := util.RunOVNNbctl(args...)
-		if err != nil {
-			klog.Errorf("Error while removing ACL: %s, from switches, error: %v", aclUUID, err)
-		} else {
-			klog.Infof("ACL: %s, removed from switches: %s", aclUUID, switches)
-		}
+	err := acl.RemoveACLFromNodeSwitches(switches, aclUUID)
+	if err != nil {
+		klog.Errorf("Failed to remove ACL %s from switches %v, error: %v", aclUUID, switches, err)
 	}
 }
 
 func (ovn *Controller) removeACLFromPortGroup(lb, aclUUID string) {
-	_, stderr, err := util.RunOVNNbctl("--", "--if-exists", "remove", "port_group", ovn.clusterPortGroupUUID, "acls", aclUUID)
+	err := acl.RemoveACLFromPortGroup(aclUUID, ovn.clusterPortGroupUUID)
 	if err != nil {
-		klog.Errorf("Failed to remove reject ACL %s from LB %s: stderr: %q, error: %v", aclUUID, lb, stderr, err)
-	} else {
-		klog.Infof("ACL: %s, removed from the port group : %s", aclUUID, ovn.clusterPortGroupUUID)
+		klog.Errorf("Failed to remove reject ACL %s from LB %s: error: %v", aclUUID, lb, err)
 	}
 }

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -1,0 +1,131 @@
+package loadbalancer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+// GetOVNKubeLoadBalancer returns the LoadBalancer matching the protocol
+// in the OVN database using the external_ids = k8s-cluster-lb-${protocol}
+func GetOVNKubeLoadBalancer(protocol kapi.Protocol) (string, error) {
+	id := fmt.Sprintf("external_ids:k8s-cluster-lb-%s=yes", strings.ToLower(string(protocol)))
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid",
+		"find", "load_balancer", id)
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		return "", fmt.Errorf("no load balancer found in the database")
+	}
+	return out, nil
+}
+
+// GetLoadBalancerVIPs returns a map whose keys are VIPs (IP:port) on loadBalancer
+func GetLoadBalancerVIPs(loadBalancer string) (map[string]string, error) {
+	var vips map[string]string
+	outStr, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"get", "load_balancer", loadBalancer, "vips")
+	if err != nil {
+		return nil, err
+	}
+	if outStr == "" {
+		return nil, fmt.Errorf("load balancer vips in OVN DB is an empty string")
+	}
+	// sample outStr:
+	// - {"192.168.0.1:80"="10.1.1.1:80,10.2.2.2:80"}
+	// - {"[fd01::]:80"="[fd02::]:80,[fd03::]:80"}
+	outStrMap := strings.Replace(outStr, "=", ":", -1)
+	err = json.Unmarshal([]byte(outStrMap), &vips)
+	if err != nil {
+		return nil, err
+	}
+	return vips, nil
+}
+
+// DeleteLoadBalancerVIP removes the VIP as well as any reject ACLs associated to the LB
+func DeleteLoadBalancerVIP(loadBalancer, vip string) error {
+	vipQuotes := fmt.Sprintf("\"%s\"", vip)
+	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove", "load_balancer", loadBalancer, "vips", vipQuotes)
+	if err != nil {
+		// if we hit an error and fail to remove load balancer, we skip removing the rejectACL
+		return fmt.Errorf("error in deleting load balancer vip %s for %s"+
+			"stdout: %q, stderr: %q, error: %v",
+			vip, loadBalancer, stdout, stderr, err)
+	}
+	return nil
+}
+
+// UpdateLoadBalancer updates the VIP for sourceIP:sourcePort to point to targets (an
+// array of IP:port strings)
+func UpdateLoadBalancer(lb, vip string, targets []string) error {
+	lbTarget := fmt.Sprintf(`vips:"%s"="%s"`, vip, strings.Join(targets, ","))
+
+	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, lbTarget)
+	if err != nil {
+		return fmt.Errorf("error in configuring load balancer: %s "+
+			"stdout: %q, stderr: %q, error: %v", lb, out, stderr, err)
+	}
+
+	return nil
+}
+
+// GetLogicalSwitchesForLoadBalancer get the switches associated to a LoadBalancer
+func GetLogicalSwitchesForLoadBalancer(lb string) ([]string, error) {
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "find",
+		"logical_switch", fmt.Sprintf("load_balancer{>=}%s", lb))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(out), nil
+}
+
+// GetLogicalRoutersForLoadBalancer get the routers associated to a LoadBalancer
+func GetLogicalRoutersForLoadBalancer(lb string) ([]string, error) {
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=name", "find",
+		"logical_router", fmt.Sprintf("load_balancer{>=}%s", lb))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(out), nil
+}
+
+// GenerateACLName generates a deterministic ACL name based on the load_balancer parameters
+func GenerateACLName(lb string, sourceIP string, sourcePort int32) string {
+	aclName := fmt.Sprintf("%s-%s:%d", lb, sourceIP, sourcePort)
+	// ACL names are limited to 63 characters
+	if len(aclName) > 63 {
+		var ipPortLen int
+		srcPortStr := fmt.Sprintf("%d", sourcePort)
+		// Add the length of the IP (max 15 with periods, max 39 with colons),
+		// plus length of sourcePort (max 5 char),
+		// plus 1 for additional ':' to separate,
+		// plus 1 for '-' between lb and IP.
+		// With full IPv6 address and 5 char port, max ipPortLen is 62
+		// With full IPv4 address and 5 char port, max ipPortLen is 24.
+		ipPortLen = len(sourceIP) + len(srcPortStr) + 1 + 1
+		lbTrim := 63 - ipPortLen
+		// Shorten the Load Balancer name to allow full IP:port
+		tmpLb := lb[:lbTrim]
+		klog.Infof("Limiting ACL Name from %s to %s-%s:%d to keep under 63 characters", aclName, tmpLb, sourceIP, sourcePort)
+		aclName = fmt.Sprintf("%s-%s:%d", tmpLb, sourceIP, sourcePort)
+	}
+	return aclName
+}
+
+// GenerateACLNameForOVNCommand sanitize the ACL name because the generateACLName
+// function was including backslash escapes for the ACL
+// name for use in OVN commands that have trouble with literal ":". That
+// was causing a mismatch when services were syncing because the name
+// actually returned from an OVN command does not include any backslashes
+// so the names would not match. #1749
+func GenerateACLNameForOVNCommand(lb string, sourceIP string, sourcePort int32) string {
+	return strings.ReplaceAll(GenerateACLName(lb, sourceIP, sourcePort), ":", "\\:")
+}

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,300 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+)
+
+func TestGetOVNKubeLoadBalancer(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol kapi.Protocol
+		ovnCmd   ovntest.ExpectedCmd
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "existing loadbalancer TCP",
+			protocol: kapi.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+				Output: "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			},
+			want:    "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:     "non existing loadbalancer UDP",
+			protocol: kapi.ProtocolUDP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+				Output: "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := GetOVNKubeLoadBalancer(tt.protocol)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetOVNKubeLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetOVNKubeLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLoadBalancerVIPs(t *testing.T) {
+	tests := []struct {
+		name         string
+		loadBalancer string
+		ovnCmd       ovntest.ExpectedCmd
+		want         map[string]string
+		wantErr      bool
+	}{
+		{
+			name:         "loadbalancer with VIPs",
+			loadBalancer: "my-lb",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer my-lb vips",
+				Output: `{"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53", "10.96.0.10:9153"="10.244.2.3:9153,10.244.2.5:9153", "10.96.0.1:443"="172.19.0.3:6443"}`,
+			},
+			want: map[string]string{
+				"10.96.0.10:53":   "10.244.2.3:53,10.244.2.5:53",
+				"10.96.0.10:9153": "10.244.2.3:9153,10.244.2.5:9153",
+				"10.96.0.1:443":   "172.19.0.3:6443",
+			},
+			wantErr: false,
+		},
+		{
+			name:         "empty load balancer",
+			loadBalancer: "my-lb",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer my-lb vips",
+				Output: "",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetLoadBalancerVIPs(tt.loadBalancer)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLoadBalancerVIPs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLoadBalancerVIPs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteLoadBalancerVIP(t *testing.T) {
+	tests := []struct {
+		name         string
+		loadBalancer string
+		vip          string
+		ovnCmd       ovntest.ExpectedCmd
+		wantErr      bool
+	}{
+		{
+			name:         "loadbalancer with VIPs",
+			loadBalancer: "my-lb",
+			vip:          "10.96.0.10:53",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer my-lb vips "10.96.0.10:53"`,
+				Output: `{"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53", "10.96.0.10:9153"="10.244.2.3:9153,10.244.2.5:9153", "10.96.0.1:443"="172.19.0.3:6443"}`,
+			},
+			wantErr: false,
+		},
+		{
+			name:         "load balancer and OVN error",
+			loadBalancer: "my-lb",
+			vip:          "10.96.0.10:53",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer my-lb vips "10.96.0.10:53"`,
+				Output: "",
+				Err:    fmt.Errorf("error while removing ACL: sw1, from switches"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			err = DeleteLoadBalancerVIP(tt.loadBalancer, tt.vip)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteLoadBalancerVIP() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestUpdateLoadBalancer(t *testing.T) {
+	type args struct {
+		lb      string
+		vip     string
+		targets []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		ovnCmd  ovntest.ExpectedCmd
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			if err := UpdateLoadBalancer(tt.args.lb, tt.args.vip, tt.args.targets); (err != nil) != tt.wantErr {
+				t.Errorf("UpdateLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetLogicalSwitchesForLoadBalancer(t *testing.T) {
+	type args struct {
+		lb string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		ovnCmd  ovntest.ExpectedCmd
+		want    []string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetLogicalSwitchesForLoadBalancer(tt.args.lb)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLogicalSwitchesForLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLogicalSwitchesForLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLogicalRoutersForLoadBalancer(t *testing.T) {
+	type args struct {
+		lb string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		ovnCmd  ovntest.ExpectedCmd
+		want    []string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetLogicalRoutersForLoadBalancer(tt.args.lb)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLogicalRoutersForLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLogicalRoutersForLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateACLName(t *testing.T) {
+	type args struct {
+		lb         string
+		sourceIP   string
+		sourcePort int32
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateACLName(tt.args.lb, tt.args.sourceIP, tt.args.sourcePort); got != tt.want {
+				t.Errorf("GenerateACLName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateACLNameForOVNCommand(t *testing.T) {
+	type args struct {
+		lb         string
+		sourceIP   string
+		sourcePort int32
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateACLNameForOVNCommand(tt.args.lb, tt.args.sourceIP, tt.args.sourcePort); got != tt.want {
+				t.Errorf("GenerateACLNameForOVNCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -122,8 +122,8 @@ type Controller struct {
 
 	// For TCP, UDP, and SCTP type traffic, cache OVN load-balancers used for the
 	// cluster's east-west traffic.
-	loadbalancerClusterCache map[kapi.Protocol]string
-
+	loadbalancerClusterCache      map[kapi.Protocol]string
+	loadbalancerClusterCacheMutex sync.Mutex
 	// A cache of all logical switches seen by the watcher and their subnets
 	lsManager *logicalSwitchManager
 

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -3,12 +3,14 @@ package ovn
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"net"
 	"reflect"
 	"strings"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -19,7 +21,7 @@ import (
 
 func addRejectACLs(rejectACLs map[string]map[string]bool, lb, ip string, port int32, hasEndpoints bool) {
 	if ip != "" {
-		name := generateACLName(lb, ip, port)
+		name := loadbalancer.GenerateACLName(lb, ip, port)
 		if _, ok := rejectACLs[name]; !ok {
 			rejectACLs[name] = make(map[string]bool)
 		}
@@ -219,7 +221,7 @@ func (ovn *Controller) syncServices(services []interface{}) {
 			continue
 		}
 
-		loadBalancerVIPs, err := ovn.getLoadBalancerVIPs(loadBalancer)
+		loadBalancerVIPs, err := loadbalancer.GetLoadBalancerVIPs(loadBalancer)
 		if err != nil {
 			klog.Errorf("Failed to get load balancer vips for %s (%v)", loadBalancer, err)
 			continue
@@ -249,7 +251,7 @@ func (ovn *Controller) syncServices(services []interface{}) {
 				klog.Errorf("Gateway router %s does not have load balancer (%v)", gateway, err)
 				continue
 			}
-			loadBalancerVIPs, err := ovn.getLoadBalancerVIPs(loadBalancer)
+			loadBalancerVIPs, err := loadbalancer.GetLoadBalancerVIPs(loadBalancer)
 			if err != nil {
 				klog.Errorf("Failed to get load balancer vips for %s (%v)", loadBalancer, err)
 				continue


### PR DESCRIPTION
The OVN controller was using methods to handle all the OVN operations
with load balancers.
This PR refactors the LB OVN methods, decoupling the OVN operations,
using functions in its own package so it can be reused by other components.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

