### PR TITLE
xunit reports don't fail the job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,6 +274,7 @@ jobs:
       uses: AutoModality/action-xunit-viewer@v1
       with:
         results: ./test/_artifacts/
+        fail: false
 
     - name: Upload Test Report
       if: always()

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -202,6 +202,7 @@ jobs:
       uses: AutoModality/action-xunit-viewer@v1
       with:
         results: ./test/_artifacts/
+        fail: false
 
     - name: Upload Test Report
       if: always()


### PR DESCRIPTION
The AutoModality/action-xunit-viewer@v1 action was failing the job and showing an error if one of the test of the report failed.
We are currently failing in the step that runs the tests, so no need to fail twice