### PR TITLE
decouple ovn gateway commands from controller

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/satori/go.uuid v0.0.0-20181028125025-b2ce2384e17b // indirect
 	github.com/spf13/afero v1.2.2

--- a/go-controller/pkg/ovn/gateway/gateway.go
+++ b/go-controller/pkg/ovn/gateway/gateway.go
@@ -1,0 +1,95 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
+
+	kapi "k8s.io/api/core/v1"
+)
+
+// GetOvnGateways return all created gateways.
+func GetOvnGateways() ([]string, string, error) {
+	out, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=name", "find",
+		"logical_router",
+		"options:chassis!=null")
+	if err != nil {
+		return nil, stderr, err
+	}
+	return strings.Fields(out), stderr, err
+}
+
+// GetGatewayPhysicalIP return gateway physical IP
+func GetGatewayPhysicalIP(gatewayRouter string) (string, error) {
+	physicalIP, stderr, err := util.RunOVNNbctl("get", "logical_router",
+		gatewayRouter, "external_ids:physical_ip")
+	if err != nil {
+		return "", errors.Wrapf(err, "error to obtain physical IP on router %s, stderr: %v", gatewayRouter, stderr)
+	}
+	if physicalIP == "" {
+		return "", fmt.Errorf("not physical IP found for gateway %s", gatewayRouter)
+	}
+	return physicalIP, nil
+}
+
+// GetGatewayPhysicalIPs return gateway physical IPs
+func GetGatewayPhysicalIPs(gatewayRouter string) ([]string, error) {
+	physicalIPs, _, err := util.RunOVNNbctl("get", "logical_router",
+		gatewayRouter, "external_ids:physical_ips")
+	if err == nil && physicalIPs != "" {
+		return strings.Split(physicalIPs, ","), nil
+	}
+
+	physicalIP, err := GetGatewayPhysicalIP(gatewayRouter)
+	if err != nil {
+		return nil, err
+	}
+	return []string{physicalIP}, nil
+}
+
+// GetGatewayLoadBalancer return the gateway load balancer
+func GetGatewayLoadBalancer(gatewayRouter string, protocol kapi.Protocol) (string, error) {
+	externalIDKey := string(protocol) + "_lb_gateway_router"
+	loadBalancer, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "find", "load_balancer",
+		"external_ids:"+externalIDKey+"="+
+			gatewayRouter)
+	if err != nil {
+		return "", err
+	}
+	if loadBalancer == "" {
+		return "", fmt.Errorf("load balancer item in OVN DB is an empty string")
+	}
+	return loadBalancer, nil
+}
+
+// GetGatewayLoadBalancers find TCP, SCTP, UDP load-balancers from gateway router.
+func GetGatewayLoadBalancers(gatewayRouter string) (string, string, string, error) {
+	lbTCP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "find", "load_balancer",
+		"external_ids:TCP_lb_gateway_router="+gatewayRouter)
+	if err != nil {
+		return "", "", "", errors.Wrapf(err, "failed to get gateway router %q TCP "+
+			"load balancer, stderr: %q", gatewayRouter, stderr)
+	}
+
+	lbUDP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "find", "load_balancer",
+		"external_ids:UDP_lb_gateway_router="+gatewayRouter)
+	if err != nil {
+		return "", "", "", errors.Wrapf(err, "failed to get gateway router %q UDP "+
+			"load balancer, stderr: %q", gatewayRouter, stderr)
+	}
+
+	lbSCTP, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "find", "load_balancer",
+		"external_ids:SCTP_lb_gateway_router="+gatewayRouter)
+	if err != nil {
+		return "", "", "", errors.Wrapf(err, "failed to get gateway router %q SCTP "+
+			"load balancer, stderr: %q", gatewayRouter, stderr)
+	}
+	return lbTCP, lbUDP, lbSCTP, nil
+}

--- a/go-controller/pkg/ovn/gateway/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway/gateway_test.go
@@ -1,0 +1,152 @@
+package gateway
+
+import (
+	"reflect"
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+func TestGetOvnGateways(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		ovnCmd  ovntest.ExpectedCmd
+		want    []string
+		want1   string
+		wantErr bool
+	}{
+		{
+			name: "return multiple gateways",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd: "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+				Output: `GR_ovn-control-plane
+
+					GR_ovn-worker
+					
+					GR_ovn-worker2
+					`,
+			},
+			want:    []string{"GR_ovn-control-plane", "GR_ovn-worker", "GR_ovn-worker2"},
+			want1:   "",
+			wantErr: false,
+		},
+		{
+			name: "return one gateway",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+				Output: "GR_ovn-control-plane",
+			},
+			want:    []string{"GR_ovn-control-plane"},
+			want1:   "",
+			wantErr: false,
+		},
+		{
+			name: "return no gateway",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+				Output: "",
+			},
+			want:    []string{},
+			want1:   "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, got1, err := GetOvnGateways()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetOvnGateways() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetOvnGateways() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetOvnGateways() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestGetGatewayPhysicalIPs(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		ovnCmd  []ovntest.ExpectedCmd
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "multiple gateways",
+			ovnCmd: []ovntest.ExpectedCmd{
+				{
+					Cmd:    "ovn-nbctl --timeout=15 get logical_router GR_ovn-control-plane external_ids:physical_ips",
+					Output: "172.19.0.3,fc00:f853:ccd:e793::3",
+				},
+			},
+			want:    []string{"172.19.0.3", "fc00:f853:ccd:e793::3"},
+			wantErr: false,
+		},
+		{
+			name: "one gateway",
+			ovnCmd: []ovntest.ExpectedCmd{
+				{
+					Cmd:    "ovn-nbctl --timeout=15 get logical_router GR_ovn-control-plane external_ids:physical_ips",
+					Output: "",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 get logical_router GR_ovn-control-plane external_ids:physical_ip",
+					Output: "172.19.0.3",
+				},
+			},
+			want:    []string{"172.19.0.3"},
+			wantErr: false,
+		},
+		{
+			name: "no gateway",
+			ovnCmd: []ovntest.ExpectedCmd{
+				{
+					Cmd:    "ovn-nbctl --timeout=15 get logical_router GR_ovn-control-plane external_ids:physical_ips",
+					Output: "",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 get logical_router GR_ovn-control-plane external_ids:physical_ip",
+					Output: "",
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewFakeExec()
+			for _, cmd := range tt.ovnCmd {
+				cmd := cmd
+				fexec.AddFakeCmd(&cmd)
+			}
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := GetGatewayPhysicalIPs("GR_ovn-control-plane")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetGatewayPhysicalIPs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetGatewayPhysicalIPs() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Isolate the OVN Gateway commands in their own package, decoupling
them from the controller so they can be reused and tested separately.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
