### PR TITLE
egress_ip: Move functions to egressIPController

### DIFF
--- a/go-controller/cmd/ovndbchecker/ovndbchecker.go
+++ b/go-controller/cmd/ovndbchecker/ovndbchecker.go
@@ -186,7 +186,6 @@ func runOvnKubeDBChecker(ctx *cli.Context) error {
 	ovndbmanager.RunDBChecker(
 		&kube.Kube{
 			KClient:              ovnClientset.KubeClient,
-			EIPClient:            ovnClientset.EgressIPClient,
 			EgressFirewallClient: ovnClientset.EgressFirewallClient,
 		},
 		stopChan)

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -17,6 +17,8 @@ import (
 	egressipapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	egressipscheme "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/scheme"
 	egressipinformerfactory "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions"
+	egressiplister "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/listers/egressip/v1"
+
 	apiextensionsapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	apiextensionsinformerfactory "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
@@ -501,6 +503,13 @@ func (wf *WatchFactory) GetPods(namespace string) ([]*kapi.Pod, error) {
 	return podLister.Pods(namespace).List(labels.Everything())
 }
 
+// GetPodsWithSelector returns a list of pods matching the selector
+func (wf *WatchFactory) GetPodsWithSelector(namespace string, selector metav1.LabelSelector) ([]*kapi.Pod, error) {
+	labelSelector := labels.SelectorFromSet(selector.MatchLabels)
+	podLister := wf.informers[podType].lister.(listers.PodLister)
+	return podLister.Pods(namespace).List(labelSelector)
+}
+
 // GetNodes returns the node specs of all the nodes
 func (wf *WatchFactory) GetNodes() ([]*kapi.Node, error) {
 	nodeLister := wf.informers[nodeType].lister.(listers.NodeLister)
@@ -541,6 +550,25 @@ func (wf *WatchFactory) GetNamespace(name string) (*kapi.Namespace, error) {
 func (wf *WatchFactory) GetNamespaces() ([]*kapi.Namespace, error) {
 	namespaceLister := wf.informers[namespaceType].lister.(listers.NamespaceLister)
 	return namespaceLister.List(labels.Everything())
+}
+
+// GetNamespacesWithSelector returns a list of namespaces matching the selector
+func (wf *WatchFactory) GetNamespacesWithSelector(selector metav1.LabelSelector) ([]*kapi.Namespace, error) {
+	labelSelector := labels.SelectorFromSet(selector.MatchLabels)
+	namespaceLister := wf.informers[namespaceType].lister.(listers.NamespaceLister)
+	return namespaceLister.List(labelSelector)
+}
+
+// GetEgressIPs returns a list of egress IPs in the cluster
+func (wf *WatchFactory) GetEgressIPs() ([]*egressipapi.EgressIP, error) {
+	eIPLister := wf.informers[egressIPType].lister.(egressiplister.EgressIPLister)
+	return eIPLister.List(labels.Everything())
+}
+
+// GetEgressIP returns an egress IP by name
+func (wf *WatchFactory) GetEgressIP(name string) (*egressipapi.EgressIP, error) {
+	eIPLister := wf.informers[egressIPType].lister.(egressiplister.EgressIPLister)
+	return eIPLister.Get(name)
 }
 
 func (wf *WatchFactory) NodeInformer() cache.SharedIndexInformer {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -217,7 +217,7 @@ cookie=0x0, duration=8366.597s, table=1, n_packets=10641, n_bytes=10370087, prio
 			wf.Shutdown()
 		}()
 
-		k := &kube.Kube{fakeClient.KubeClient, egressIPFakeClient, egressFirewallFakeClient}
+		k := &kube.Kube{fakeClient.KubeClient, egressFirewallFakeClient}
 
 		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	egressipv1fake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -132,7 +131,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	_, err = config.InitConfig(ctx, fexec, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient, egressipv1fake.NewSimpleClientset(), &egressfirewallfake.Clientset{}}, &existingNode)
+	nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient, &egressfirewallfake.Clientset{}}, &existingNode)
 	waiter := newStartupWaiter()
 
 	err = testNS.Do(func(ns.NetNS) error {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -1935,7 +1935,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 						EgressIPs: []string{egressIP},
 					},
 				}
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(eIP.Status.Items).To(HaveLen(1))
 				Expect(eIP.Status.Items[0].Node).To(Equal(node2.name))
@@ -1972,7 +1972,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal(fmt.Sprintf("unable to parse provided EgressIP: %s, invalid", egressIPs[0])))
 				Expect(eIP.Status.Items).To(HaveLen(0))
@@ -2005,7 +2005,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 						EgressIPs: []string{egressIP},
 					},
 				}
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(eIP.Status.Items).To(HaveLen(1))
 				Expect(eIP.Status.Items[0].Node).To(Equal(node2.name))
@@ -2037,7 +2037,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 						EgressIPs: []string{egressIP1, egressIP2},
 					},
 				}
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(eIP.Status.Items).To(HaveLen(2))
 				Expect(eIP.Status.Items[0].Node).To(Equal(node2.name))
@@ -2072,7 +2072,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 						EgressIPs: []string{egressIP1, egressIP2, egressIP3},
 					},
 				}
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(eIP.Status.Items).To(HaveLen(2))
 				Expect(eIP.Status.Items[0].Node).To(Equal(node2.name))
@@ -2108,7 +2108,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("no matching host found"))
 				Expect(eIP.Status.Items).To(HaveLen(0))
@@ -2138,7 +2138,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 						EgressIPs: []string{egressIP},
 					},
 				}
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).To(HaveOccurred())
 				Expect(eIP.Status.Items).To(HaveLen(0))
 
@@ -2171,7 +2171,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("no matching host found"))
 				Expect(eIP.Status.Items).To(HaveLen(0))
@@ -2203,7 +2203,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("no matching host found"))
 				Expect(eIP.Status.Items).To(HaveLen(0))
@@ -2233,7 +2233,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 						EgressIPs: []string{egressIP},
 					},
 				}
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(eIP.Status.Items).To(HaveLen(1))
 				Expect(eIP.Status.Items[0].Node).To(Equal(node2.name))
@@ -2266,7 +2266,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("no matching host found"))
 				Expect(eIP.Status.Items).To(HaveLen(0))
@@ -2297,7 +2297,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				err := fakeOvn.controller.assignEgressIPs(&eIP)
+				err := fakeOvn.controller.eIPC.assignEgressIPs(&eIP)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal(fmt.Sprintf("unable to parse provided EgressIP: %s, invalid", egressIPs[0])))
 				Expect(eIP.Status.Items).To(HaveLen(0))

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1051,7 +1051,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			_, err = config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressIPFakeClient, egressFirewallFakeClient}, &testNode)
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{kubeFakeClient, egressFirewallFakeClient}, &testNode)
 			ifaceID := physicalBridgeName + "_" + nodeName
 			vlanID := uint(1024)
 			err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

This commit formalizes egressIPController as the place where all
egressIP related functions live.

It moves a number of egressIP related functions out of the OvnController
as they only require access to the WatchFactory - I'll be working on
factoring this out in future.

When moving these functions over I noticed that EgressIP was fetching from
the API Server and not from the cache. Once I'd fixed this to use the
informer cache there was only UpdateEgressIP left in the Kube interface.
As it's only used in the egress IP code, I went ahead and in-lined it in
egress_ip.go to save passing the Kube interface around everywhere.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->