### PR TITLE
Directly load balance traffic to cloud load balancers

### DIFF
--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -107,6 +107,15 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 					}
 				}
 			}
+			// Cloud load balancers: directly load balance that traffic from pods
+			for _, ing := range svc.Status.LoadBalancer.Ingress {
+				if ing.IP == "" {
+					continue
+				}
+				if err = ovn.createLoadBalancerVIPs(loadBalancer, []string{ing.IP}, svcPort.Port, lbEps.IPs, lbEps.Port); err != nil {
+					klog.Errorf("Error in creating Ingress LB IP for svc %s, target port: %d - %v\n", svc.Name, lbEps.Port, err)
+				}
+			}
 		}
 	}
 	return nil
@@ -193,6 +202,27 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		if err != nil {
 			klog.Errorf("Error in deleting endpoints for lb %s: %v", lb, err)
 		}
+
+		// Cloud load balancers: directly reject traffic from pods
+		for _, ing := range svc.Status.LoadBalancer.Ingress {
+			if ing.IP == "" {
+				continue
+			}
+			if ovn.svcQualifiesForReject(svc) {
+				aclUUID, err := ovn.createLoadBalancerRejectACL(lb, ing.IP, svcPort.Port, svcPort.Protocol)
+				if err != nil {
+					klog.Errorf("Failed to create reject ACL for Ingress IP: %s, load balancer: %s, error: %v",
+						ing.IP, lb, err)
+				} else {
+					klog.Infof("Reject ACL created for Ingress IP: %s, load balancer: %s, %s", ing.IP, lb, aclUUID)
+				}
+			}
+			err := ovn.configureLoadBalancer(lb, ing.IP, svcPort.Port, nil)
+			if err != nil {
+				klog.Errorf("Error in deleting endpoints for lb %s: %v", lb, err)
+			}
+		}
+
 		vip := util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port)
 		ovn.removeServiceEndpoints(lb, vip)
 

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -167,7 +167,7 @@ func (ovn *Controller) getGRLogicalSwitchForLoadBalancer(lb string) (string, err
 }
 
 // TODO: Add unittest for function.
-func (ovn *Controller) generateACLName(lb string, sourceIP string, sourcePort int32) string {
+func generateACLName(lb string, sourceIP string, sourcePort int32) string {
 	aclName := fmt.Sprintf("%s-%s:%d", lb, sourceIP, sourcePort)
 	// ACL names are limited to 63 characters
 	if len(aclName) > 63 {
@@ -189,8 +189,8 @@ func (ovn *Controller) generateACLName(lb string, sourceIP string, sourcePort in
 	return aclName
 }
 
-func (ovn *Controller) generateACLNameForOVNCommand(lb string, sourceIP string, sourcePort int32) string {
-	return strings.ReplaceAll(ovn.generateACLName(lb, sourceIP, sourcePort), ":", "\\:")
+func generateACLNameForOVNCommand(lb string, sourceIP string, sourcePort int32) string {
+	return strings.ReplaceAll(generateACLName(lb, sourceIP, sourcePort), ":", "\\:")
 }
 
 func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePort int32, proto kapi.Protocol) (string, error) {
@@ -232,7 +232,7 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 	}
 	vip := util.JoinHostPortInt32(sourceIP, sourcePort)
 	// NOTE: doesn't use vip, to avoid having brackets in the name with IPv6
-	aclName := ovn.generateACLNameForOVNCommand(lb, sourceIP, sourcePort)
+	aclName := generateACLNameForOVNCommand(lb, sourceIP, sourcePort)
 	// If ovn-k8s was restarted, we lost the cache, and an ACL may already exist in OVN. In that case we need to check
 	// using ACL name
 	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
@@ -327,7 +327,7 @@ func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
 }
 
 func (ovn *Controller) findStaleRejectACL(lb, ip string, port int32) (string, error) {
-	aclName := ovn.generateACLNameForOVNCommand(lb, ip, port)
+	aclName := generateACLNameForOVNCommand(lb, ip, port)
 	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
 		fmt.Sprintf("name=%s", aclName))
 	if err != nil {


### PR DESCRIPTION
Cloud load balancers like Azure and GCP deliver external packets
directly to the hosts without changing the destination IP address.
Therefore we have special iptables rules for handling those packets.
However for traffic sourced from within the cluster (an ovn networked
pod), the current behavior sends the packet out of OVN externally
(either via mp0 in local gw mode, or br-ex in shared gw mode) only to be
circulated back into OVN to be load balanced.

Rather than doing this unnecessary traffic forwarding, make OVN handle
the load balancing directly for the egress pod traffic destined to the
load balancer service.

Signed-off-by: Tim Rozet <trozet@redhat.com>

