### PR TITLE
Enable debug logging for unit test runs

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -373,6 +373,7 @@ func init() {
 func PrepareTestConfig() {
 	Default = savedDefault
 	Logging = savedLogging
+	Logging.Level = 5
 	CNI = savedCNI
 	OVNKubernetesFeature = savedOVNKubernetesFeature
 	Kubernetes = savedKubernetes

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -231,7 +231,7 @@ var _ = Describe("Config Operations", func() {
 			Expect(Default.MTU).To(Equal(1400))
 			Expect(Default.ConntrackZone).To(Equal(64000))
 			Expect(Logging.File).To(Equal(""))
-			Expect(Logging.Level).To(Equal(4))
+			Expect(Logging.Level).To(Equal(5))
 			Expect(CNI.ConfDir).To(Equal("/etc/cni/net.d"))
 			Expect(CNI.Plugin).To(Equal("ovn-k8s-cni-overlay"))
 			Expect(Kubernetes.Kubeconfig).To(Equal(""))


### PR DESCRIPTION
Some unit test debugging could be made easier by enabling
debug log level. This PR changes the log level in `PrepareTestConfig`
which is used from the tests, as opposed to the `LoggingConfig` object.
This was done as to not impact users of OVN-Kubernetes deploying a
cluster without specifying `--loglevel` and modifying the default setting

The idea came from debugging runs such as: https://github.com/ovn-org/ovn-kubernetes/pull/1815/checks?check_run_id=1381157345 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->