### PR TITLE
test: Set GOMAXPROCS to 1

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -37,7 +37,11 @@ function testrun {
         args=""
         go_test="sudo ${testfile}"
     fi
-
+    # set gomaxprocs to 1 in CI, because actions are run in containers and we don't know what cpu
+    # limits are being imposed
+    if [ -n "${CI}" ]; then
+        args="${args}-test.cpu 1 "
+    fi
     if [[ -n "$gingko_focus" ]]; then
         local ginkgoargs=${ginkgo_focus:-}
     fi


### PR DESCRIPTION
GOMAXPROCS will default to whatever is offered by the host CPU.
As we are running in a container, we should respect whatever
CPU limits are imposed on the container. While we could use
automaxprocs to do this, it is simpler for our test cases
to set GOMAXPROCS to 1.

I hope this will solve a number of timing issues that have recently
plagued our unit tests.

Fixes: #1825 #1780