### PR TITLE
cni: cancel sandbox ADD when the pod is deleted

### DIFF
--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -4,6 +4,7 @@ package cni
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -15,7 +16,12 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/client-go/informers"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	utiltesting "k8s.io/client-go/util/testing"
@@ -61,6 +67,14 @@ func makeCNIArgs(namespace, name string) string {
 	return fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, name)
 }
 
+const (
+	sandboxID string = "adsfadsfasfdasdfasf"
+	namespace string = "awesome-namespace"
+	name      string = "awesome-name"
+	cniConfig string = "{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"
+	nodeName  string = "mynode"
+)
+
 func TestCNIServer(t *testing.T) {
 	tmpDir, err := utiltesting.MkTmpdir("cniserver")
 	if err != nil {
@@ -69,8 +83,14 @@ func TestCNIServer(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	socketPath := filepath.Join(tmpDir, serverSocketName)
 	fakeClient := fake.NewSimpleClientset()
-	f := informers.NewSharedInformerFactory(fakeClient, 0)
-	s := NewCNIServer(tmpDir, f.Core().V1().Pods().Lister())
+
+	fakeClientset := &util.OVNClientset{KubeClient: fakeClient}
+	wf, err := factory.NewNodeWatchFactory(fakeClientset, nodeName)
+	if err != nil {
+		t.Fatalf("failed to create watch factory: %v", err)
+	}
+
+	s := NewCNIServer(tmpDir, wf)
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
@@ -100,12 +120,6 @@ func TestCNIServer(t *testing.T) {
 		errorPrefix string
 	}
 
-	const (
-		sandboxID string = "adsfadsfasfdasdfasf"
-		namespace string = "awesome-namespace"
-		name      string = "awesome-name"
-		cniConfig string = "{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"
-	)
 	testcases := []testcase{
 		// Normal ADD request
 		{
@@ -216,5 +230,94 @@ func TestCNIServer(t *testing.T) {
 				t.Fatalf("[%s] unexpected error message '%v'", tc.name, string(body))
 			}
 		}
+	}
+}
+
+func newObjectMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		UID:       types.UID(name),
+		Namespace: namespace,
+	}
+}
+
+func TestCNIServerCancelAdd(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("cniserver")
+	if err != nil {
+		t.Fatalf("failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	socketPath := filepath.Join(tmpDir, serverSocketName)
+
+	fakeClient := fake.NewSimpleClientset(
+		&v1.NamespaceList{
+			Items: []v1.Namespace{{ObjectMeta: newObjectMeta(name, name)}},
+		},
+		&v1.PodList{
+			Items: []v1.Pod{
+				{
+					ObjectMeta: newObjectMeta(name, namespace),
+					Spec:       v1.PodSpec{NodeName: nodeName},
+				},
+			},
+		},
+	)
+
+	fakeClientset := &util.OVNClientset{KubeClient: fakeClient}
+	wf, err := factory.NewNodeWatchFactory(fakeClientset, nodeName)
+	if err != nil {
+		t.Fatalf("failed to create watch factory: %v", err)
+	}
+
+	started := make(chan bool)
+
+	s := NewCNIServer(tmpDir, wf)
+	if err := s.Start(func(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error) {
+		// Let the testcase know it can now delete the pod
+		close(started)
+		// Wait for the testcase to cancel us
+		<-request.ctx.Done()
+		return nil, fmt.Errorf("pod operation canceled")
+	}); err != nil {
+		t.Fatalf("error starting CNI server: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Dial: func(proto, addr string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+
+	request := &Request{
+		Env: map[string]string{
+			"CNI_COMMAND":     string(CNIAdd),
+			"CNI_CONTAINERID": sandboxID,
+			"CNI_NETNS":       "/some/path",
+			"CNI_ARGS":        makeCNIArgs(namespace, name),
+		},
+		Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"),
+	}
+
+	var code int
+	var body []byte
+	done := make(chan bool)
+	go func() {
+		body, code = clientDoCNI(t, client, request)
+		close(done)
+	}()
+	<-started
+	err = fakeClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, *metav1.NewDeleteOptions(0))
+	if err != nil {
+		t.Fatalf("[ADD] failed to delete pod: %v", err)
+	}
+	<-done
+
+	if code != http.StatusBadRequest {
+		t.Fatalf("[ADD] expected status %v but got %v", http.StatusBadRequest, code)
+	}
+	if !strings.Contains(string(body), "pod operation canceled") {
+		t.Fatalf("[ADD] unexpected error message '%v'", string(body))
 	}
 }

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -57,6 +57,10 @@ func serverHandleCNI(request *PodRequest, podLister corev1listers.PodLister) ([]
 	return nil, fmt.Errorf("unhandled CNI command %v", request.Command)
 }
 
+func makeCNIArgs(namespace, name string) string {
+	return fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, name)
+}
+
 func TestCNIServer(t *testing.T) {
 	tmpDir, err := utiltesting.MkTmpdir("cniserver")
 	if err != nil {
@@ -96,6 +100,12 @@ func TestCNIServer(t *testing.T) {
 		errorPrefix string
 	}
 
+	const (
+		sandboxID string = "adsfadsfasfdasdfasf"
+		namespace string = "awesome-namespace"
+		name      string = "awesome-name"
+		cniConfig string = "{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"
+	)
 	testcases := []testcase{
 		// Normal ADD request
 		{
@@ -103,11 +113,11 @@ func TestCNIServer(t *testing.T) {
 			request: &Request{
 				Env: map[string]string{
 					"CNI_COMMAND":     string(CNIAdd),
-					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
+					"CNI_CONTAINERID": sandboxID,
 					"CNI_NETNS":       "/path/to/something",
-					"CNI_ARGS":        "K8S_POD_NAMESPACE=awesome-namespace;K8S_POD_NAME=awesome-name",
+					"CNI_ARGS":        makeCNIArgs(namespace, name),
 				},
-				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"),
+				Config: []byte(cniConfig),
 			},
 			result: expectedResult,
 		},
@@ -117,11 +127,11 @@ func TestCNIServer(t *testing.T) {
 			request: &Request{
 				Env: map[string]string{
 					"CNI_COMMAND":     string(CNIDel),
-					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
+					"CNI_CONTAINERID": sandboxID,
 					"CNI_NETNS":       "/path/to/something",
-					"CNI_ARGS":        "K8S_POD_NAMESPACE=awesome-namespace;K8S_POD_NAME=awesome-name",
+					"CNI_ARGS":        makeCNIArgs(namespace, name),
 				},
-				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"),
+				Config: []byte(cniConfig),
 			},
 			result: nil,
 		},
@@ -131,11 +141,11 @@ func TestCNIServer(t *testing.T) {
 			request: &Request{
 				Env: map[string]string{
 					"CNI_COMMAND":     string(CNIUpdate),
-					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
+					"CNI_CONTAINERID": sandboxID,
 					"CNI_NETNS":       "/path/to/something",
-					"CNI_ARGS":        "K8S_POD_NAMESPACE=awesome-namespace;K8S_POD_NAME=awesome-name",
+					"CNI_ARGS":        makeCNIArgs(namespace, name),
 				},
-				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"),
+				Config: []byte(cniConfig),
 			},
 			result: nil,
 		},
@@ -145,10 +155,10 @@ func TestCNIServer(t *testing.T) {
 			request: &Request{
 				Env: map[string]string{
 					"CNI_COMMAND":     string(CNIAdd),
-					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
+					"CNI_CONTAINERID": sandboxID,
 					"CNI_NETNS":       "/path/to/something",
 				},
-				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"),
+				Config: []byte(cniConfig),
 			},
 			result:      nil,
 			errorPrefix: "missing CNI_ARGS",
@@ -159,10 +169,10 @@ func TestCNIServer(t *testing.T) {
 			request: &Request{
 				Env: map[string]string{
 					"CNI_COMMAND":     string(CNIAdd),
-					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
-					"CNI_ARGS":        "K8S_POD_NAMESPACE=awesome-namespace;K8S_POD_NAME=awesome-name",
+					"CNI_CONTAINERID": sandboxID,
+					"CNI_ARGS":        makeCNIArgs(namespace, name),
 				},
-				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"),
+				Config: []byte(cniConfig),
 			},
 			result:      nil,
 			errorPrefix: "missing CNI_NETNS",
@@ -172,11 +182,11 @@ func TestCNIServer(t *testing.T) {
 			name: "ARGS3",
 			request: &Request{
 				Env: map[string]string{
-					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
+					"CNI_CONTAINERID": sandboxID,
 					"CNI_NETNS":       "/path/to/something",
-					"CNI_ARGS":        "K8S_POD_NAMESPACE=awesome-namespace;K8S_POD_NAME=awesome-name",
+					"CNI_ARGS":        makeCNIArgs(namespace, name),
 				},
-				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"),
+				Config: []byte(cniConfig),
 			},
 			result:      nil,
 			errorPrefix: "unexpected or missing CNI_COMMAND",

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -373,7 +373,7 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 	}
 
 	if err = waitForPodFlows(ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID); err != nil {
-		return nil, fmt.Errorf("error while waiting on flows for pod: %s, error: %v", podName, err)
+		return nil, fmt.Errorf("error while waiting on flows for pod: %v", err)
 	}
 
 	return []*current.Interface{hostIface, contIface}, nil

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -372,7 +372,7 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 		klog.Warningf("Failed to settle addresses: %q", err)
 	}
 
-	if err = waitForPodFlows(ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID); err != nil {
+	if err = waitForPodFlows(pr.ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID); err != nil {
 		return nil, fmt.Errorf("error while waiting on flows for pod: %v", err)
 	}
 

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -1,6 +1,7 @@
 package cni
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"time"
@@ -78,6 +79,10 @@ type PodRequest struct {
 	CNIConf *types.NetConf
 	// Timestamp when the request was started
 	timestamp time.Time
+	// ctx is a context tracking this request's lifetime
+	ctx context.Context
+	// cancel should be called to cancel this request
+	cancel context.CancelFunc
 }
 
 type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error)

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -6,7 +6,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 // serverRunDir is the default directory for CNIServer runtime files
@@ -76,7 +76,7 @@ type PodRequest struct {
 	CNIConf *types.NetConf
 }
 
-type cniRequestFunc func(request *PodRequest, kclient kubernetes.Interface) ([]byte, error)
+type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error)
 
 // Server object that listens for JSON-marshaled Request objects
 // on a private root-only Unix domain socket.
@@ -84,5 +84,5 @@ type Server struct {
 	http.Server
 	requestFunc cniRequestFunc
 	rundir      string
-	kclient     kubernetes.Interface
+	podLister   corev1listers.PodLister
 }

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -2,6 +2,8 @@ package cni
 
 import (
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
@@ -74,6 +76,8 @@ type PodRequest struct {
 	IfName string
 	// CNI conf obtained from stdin conf
 	CNIConf *types.NetConf
+	// Timestamp when the request was started
+	timestamp time.Time
 }
 
 type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error)
@@ -85,4 +89,8 @@ type Server struct {
 	requestFunc cniRequestFunc
 	rundir      string
 	podLister   corev1listers.PodLister
+
+	// runningSandboxAdds is a map of sandbox ID to PodRequest for any CNIAdd operation
+	runningSandboxAddsLock sync.Mutex
+	runningSandboxAdds     map[string]*PodRequest
 }

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -35,6 +35,9 @@ type NodeWatchFactory interface {
 	AddFilteredEndpointsHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
 	RemoveEndpointsHandler(handler *Handler)
 
+	AddPodHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
+	RemovePodHandler(handler *Handler)
+
 	NodeInformer() cache.SharedIndexInformer
 	LocalPodInformer() cache.SharedIndexInformer
 }

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -22,7 +22,6 @@ import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
@@ -275,10 +274,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 
 	n.WatchEndpoints()
 
-	// start the cni server with a podLister
-	// so we get the Pod information from the local cache
-	podLister := listers.NewPodLister(n.watchFactory.LocalPodInformer().GetIndexer())
-	cniServer := cni.NewCNIServer("", podLister)
+	cniServer := cni.NewCNIServer("", n.watchFactory)
 	err = cniServer.Start(cni.HandleCNIRequest)
 
 	return err


### PR DESCRIPTION
Runtimes have no way to cancel an ongoing ADD request. So if a pod is added, then very quickly deleted, our CNI may be uselessly waiting up to 20 seconds for OVS flows that will never appear.

Track sandbox ADD requests in the CNI server and allow them to be canceled by a pod watch in the Node.

@trozet 