### PR TITLE
CNI: quit waiting for pod flows for obsoleted ADD

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -372,8 +372,8 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 		klog.Warningf("Failed to settle addresses: %q", err)
 	}
 
-	if err = waitForPodFlows(ifInfo.MAC.String(), ifInfo.IPs); err != nil {
-		return nil, fmt.Errorf("timed out waiting for pod flows for pod: %s, error: %v", podName, err)
+	if err = waitForPodFlows(ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID); err != nil {
+		return nil, fmt.Errorf("error while waiting on flows for pod: %s, error: %v", podName, err)
 	}
 
 	return []*current.Interface{hostIface, contIface}, nil


### PR DESCRIPTION
Given a scenario where we have:
1. pod A added
2. pod A deleted
3. kubelet has already started CNI ADD for first event
4. pod A added
5. kubelet starts 2nd sandbox CNI ADD

The current code will remove the original OVS interface for the first
event, however the cmdAdd for the first event will still be running
waiting for flows (up to 20 seconds). Really if hte pod loses its
interface, that cmdAdd iteration is now invalid and we should just
return out immediately with an error.

Signed-off-by: Tim Rozet <trozet@redhat.com>

