### PR TITLE
Improve kind cleanup

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -278,6 +278,9 @@ ovn_apiServerAddress=${API_IP} \
 
 # Create KIND cluster. For additional debug, add '--verbosity <int>': 0 None .. 3 Debug
 export KUBECONFIG=${HOME}/admin.conf
+if kind get clusters | grep ovn; then
+  delete
+fi
 kind create cluster --name ${KIND_CLUSTER_NAME} --kubeconfig ${KUBECONFIG} --image kindest/node:${K8S_VERSION} --config=${KIND_CONFIG_LCL}
 cat ${KUBECONFIG}
 

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -24,7 +24,7 @@ run_kubectl() {
 # with Fedora32 Cloud, but it does not happen if we clean first the ovn-kubernetes resources.
 delete()
 {
-  kubectl --kubeconfig ${HOME}/admin.conf delete namespace ovn-kubernetes
+  timeout 5 kubectl --kubeconfig ${HOME}/admin.conf delete namespace ovn-kubernetes || true
   sleep 5
   kind delete cluster --name ${KIND_CLUSTER_NAME:-ovn}
 }


### PR DESCRIPTION
The kind.sh --delete command can hang because the ovn-kubernetes ns delete will cause a loss of connectivity to the network. This PR adds a sufficient timeout to avoid waiting too long, while also giving enough time for the OVN pods to be torn down. Additionally, allow for automatic cleanup of the previous kind deployment when launching a new one.