### PR TITLE
Fix lb ingress service iptables rules for local gw

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -175,18 +175,20 @@ func (l *localPortWatcher) addService(svc *kapi.Service) error {
 	// holds map of external ips and if they are currently using routes
 	routeUsage := make(map[string]bool)
 	for _, port := range svc.Spec.Ports {
+		if util.ServiceTypeHasClusterIP(svc) {
+			// Fix Azure/GCP LoadBalancers. They will forward traffic directly to the node with the
+			// dest address as the load-balancer ingress IP and port
+			iptRules = append(iptRules, getLoadBalancerIPTRules(svc, port, svc.Spec.ClusterIP, port.Port)...)
+		}
+
 		if util.ServiceTypeHasNodePort(svc) {
 			if err := util.ValidatePort(port.Protocol, port.NodePort); err != nil {
 				klog.Warningf("Invalid service node port %s, err: %v", port.Name, err)
 				continue
 			}
-
 			if gatewayIP != "" {
-				// Fix Azure/GCP LoadBalancers. They will forward traffic directly to the node with the
-				// dest address as the load-balancer ingress IP and port
-				iptRules = append(iptRules, getLoadBalancerIPTRules(svc, port, svc.Spec.ClusterIP, port.Port)...)
 				iptRules = append(iptRules, getNodePortIPTRules(port, nil, svc.Spec.ClusterIP, port.Port)...)
-				klog.V(5).Infof("Will add iptables rule for NodePort and Cloud load balancers: %v and "+
+				klog.V(5).Infof("Will add iptables rule for NodePort: %v and "+
 					"protocol: %v", port.NodePort, port.Protocol)
 			} else {
 				klog.Warningf("No gateway of appropriate IP family for NodePort Service %s/%s %s",
@@ -250,13 +252,15 @@ func (l *localPortWatcher) deleteService(svc *kapi.Service) error {
 	routeUsage := make(map[string]bool)
 	// Note that unlike with addService we just silently ignore IPv4/IPv6 mismatches here
 	for _, port := range svc.Spec.Ports {
+		if util.ServiceTypeHasClusterIP(svc) {
+			// Fix Azure/GCP LoadBalancers. They will forward traffic directly to the node with the
+			// dest address as the load-balancer ingress IP and port
+			iptRules = append(iptRules, getLoadBalancerIPTRules(svc, port, svc.Spec.ClusterIP, port.Port)...)
+		}
 		if util.ServiceTypeHasNodePort(svc) {
 			if gatewayIP != "" {
-				// Fix Azure/GCP LoadBalancers. They will forward traffic directly to the node with the
-				// dest address as the load-balancer ingress IP and port
-				iptRules = append(iptRules, getLoadBalancerIPTRules(svc, port, svc.Spec.ClusterIP, port.Port)...)
 				iptRules = append(iptRules, getNodePortIPTRules(port, nil, svc.Spec.ClusterIP, port.Port)...)
-				klog.V(5).Infof("Will delete iptables rule for NodePort and cloud load balancers: %v and "+
+				klog.V(5).Infof("Will delete iptables rule for NodePort: %v and "+
 					"protocol: %v", port.NodePort, port.Protocol)
 			}
 		}


### PR DESCRIPTION
The code was assuming the lb ingress needed to be on a node port
service, which is not required. The lb ingress just needs to DNAT to a
cluster IP service to get to the right place.

Shared gw will be fixed in a separate commit.

Signed-off-by: Tim Rozet <trozet@redhat.com>

