### PR TITLE
Fix panic during upgrade

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -152,7 +152,7 @@ func (oc *Controller) upgradeToSingleSwitchOVNTopology(existingNodeList *kapi.No
 		if !strings.HasPrefix(switchName, "join_") {
 			continue
 		}
-		nodeName := strings.SplitN(switchName, "_", 1)[1]
+		nodeName := strings.TrimPrefix(switchName, "join_")
 		logicalNodes[nodeName] = true
 	}
 


### PR DESCRIPTION
This was causing:

panic: runtime error: index out of range [1] with length 1

goroutine 222 [running]:
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).upgradeToSingleSwitchOVNTopology(0xc001817b00, 0xc0018ff730, 0x1993b1f, 0x5c)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/master.go:155 +0x8a8

Signed-off-by: Tim Rozet <trozet@redhat.com>

