### PR TITLE
Changes local gateway flows to NORMAL action

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -464,7 +464,7 @@ func newSharedGatewayOpenFlowManager(nodeName, macAddress, gwBridge, gwIntf stri
 	}
 	nFlows++
 
-	// table 1, we check to see if this dest mac is the shared mac, if so flood to both ports
+	// table 1, we check to see if this dest mac is the shared mac, if so send to host
 	_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
 		fmt.Sprintf("cookie=%s, priority=10, table=1, dl_dst=%s, actions=output:LOCAL",
 			defaultOpenFlowCookie, macAddress))


### PR DESCRIPTION
Following the changes for shared gw mode from:
https://github.com/ovn-org/ovn-kubernetes/pull/1774

This behavior will allow NORMAL action for all packets not destined to
the shared gw mac, thus allowing an non-ovn port to be attached to the
shared gw bridge and function normally.

Signed-off-by: Tim Rozet <trozet@redhat.com>

