### PR TITLE
Fix lb ingress shared gw and fixes endpoint deletion

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -162,7 +162,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=100, table=1, ct_state=+trk+rel, actions=output:5",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=10, table=1, dl_dst=" + eth0MAC + ", actions=output:LOCAL",
 			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=1, actions=output:NORMAL",
-			"ovs-ofctl add-flow breth0 cookie=0xdeff105, priority=0, table=2, actions=output:7",
 		})
 		// nodePortWatcher()
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -147,6 +147,7 @@ func (s service) delCmds(fexec *ovntest.FakeExec, service v1.Service) {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"%s:%v\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
 			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=%s-%s\\:%v", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
 		})
 	}
 }


### PR DESCRIPTION
Changes Include:

1. Removes assumption that Ingress LB service has to be Node Port.
2. Rather than doing DNAT on our shared gateway bridge to DNAT Ingress VIP -> node port, just configure the Ingress on the OVN gateway load balancer and steer traffic there
3. Fixes bugs in endpoint deletion where we were performing a service delete instead of clearing endpoints on the load balancer and creating reject ACLs for External IP and Node Port types

