### PR TITLE
Fix mistake in ovn-ci crontab

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ master ]
   schedule:
-    - cron: '* */12 * * *'
+    - cron: '0 */12 * * *'
 
 env:
   GO_VERSION: 1.15.1


### PR DESCRIPTION
Looks like '* */12 * * *' is what would run ovn-ci every
minute past the 12th hour instead of just every 12
hours. It's not actually running it that fast (probably
getting throttled). '0 */12 * * *' will run the job
every 00:00 and 12:00 which is what I'm looking for.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->