### PR TITLE
refactor boilerplate mock object processing code in UT into its own struct/function

### DIFF
--- a/go-controller/pkg/cni/bandwidth_test.go
+++ b/go-controller/pkg/cni/bandwidth_test.go
@@ -7,7 +7,6 @@ import (
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	mock_k8s_io_utils_exec "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	kexec "k8s.io/utils/exec"
 )
 
@@ -26,10 +25,10 @@ func TestClearPodBandwidth(t *testing.T) {
 			desc:        "Test error code path when ovsFind attempts to retrieve interfaces",
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("mock: failed to run ovsFind")}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsFind")}},
 			},
 			runnerInstance: mockKexecIface,
 		},
@@ -37,12 +36,12 @@ func TestClearPodBandwidth(t *testing.T) {
 			desc:        "Test code path when ovsClear returns an error",
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{[]byte{1}, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("mock: failed to run ovsClear")}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsClear")}},
 			},
 			runnerInstance: mockKexecIface,
 		},
@@ -50,12 +49,12 @@ func TestClearPodBandwidth(t *testing.T) {
 			desc:        "Test error code path when ovsFind attempts to retrieve qos instances",
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("mock: failed to run ovsFind")}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsFind")}},
 			},
 			runnerInstance: mockKexecIface,
 		},
@@ -63,32 +62,32 @@ func TestClearPodBandwidth(t *testing.T) {
 			desc:        "Test code path when ovsDestroy returns an error",
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{[]byte{1}, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{[]byte{1}, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("mock: failed to run ovsDestroy")}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsDestroy")}},
 			},
 			runnerInstance: mockKexecIface,
 		},
 		{
 			desc: "Positive test code path",
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{[]byte{1}, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{[]byte{1}, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			},
 			runnerInstance: mockKexecIface,
 		},
@@ -96,28 +95,10 @@ func TestClearPodBandwidth(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			if tc.onRetArgsKexecIface != nil {
-				for _, item := range tc.onRetArgsKexecIface {
-					ifaceCall := mockKexecIface.On(item.OnCallMethodName)
-					for _, arg := range item.OnCallMethodArgType {
-						ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-					}
-					for _, ret := range item.RetArgList {
-						ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-					}
-					ifaceCall.Once()
-				}
+				ovntest.ProcessMockFnList(&mockKexecIface.Mock, tc.onRetArgsKexecIface)
 			}
 			if tc.onRetArgsCmdList != nil {
-				for _, item := range tc.onRetArgsCmdList {
-					mockCall := mockCmd.On(item.OnCallMethodName)
-					for _, arg := range item.OnCallMethodArgType {
-						mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-					}
-					for _, ret := range item.RetArgList {
-						mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-					}
-					mockCall.Once()
-				}
+				ovntest.ProcessMockFnList(&mockCmd.Mock, tc.onRetArgsCmdList)
 			}
 			// note runner is defined in pkg/cni/ovs.go file
 			runner = tc.runnerInstance
@@ -152,9 +133,9 @@ func TestSetPodBandwidth(t *testing.T) {
 			desc:        "Test code path when both ingressBPS is greater than zero and ovsCreate returns an error",
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}}},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("mock: failed to run ovsCreate")}}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsCreate")}}},
 			runnerInstance: mockKexecIface,
 			egressBPS:      0,
 		},
@@ -162,12 +143,12 @@ func TestSetPodBandwidth(t *testing.T) {
 			desc:        "Test code path when inressBPS is greater than zero and ovsSet returns an error",
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
 			},
 			runnerInstance: mockKexecIface,
 			egressBPS:      0,
@@ -175,12 +156,12 @@ func TestSetPodBandwidth(t *testing.T) {
 		{
 			desc: "Positive test code path when ingressBPS is greater than zero",
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			},
 			runnerInstance: mockKexecIface,
 			egressBPS:      0,
@@ -189,14 +170,14 @@ func TestSetPodBandwidth(t *testing.T) {
 			desc:        "Negative test code path when setting ingress_policing_rate",
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
 			},
 			runnerInstance: mockKexecIface,
 			egressBPS:      3,
@@ -205,16 +186,16 @@ func TestSetPodBandwidth(t *testing.T) {
 			desc:        "Negative test code path when setting ingress_policing_burst",
 			expectedErr: true,
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
 			},
 			runnerInstance: mockKexecIface,
 			egressBPS:      3,
@@ -222,16 +203,16 @@ func TestSetPodBandwidth(t *testing.T) {
 		{
 			desc: "Positive test code path when both ingressBPS and egressBPS are greater than zero",
 			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
-				{"CombinedOutput", []string{}, []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			},
 			runnerInstance: mockKexecIface,
 			egressBPS:      3,
@@ -240,29 +221,11 @@ func TestSetPodBandwidth(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			if tc.onRetArgsKexecIface != nil {
-				for _, item := range tc.onRetArgsKexecIface {
-					ifaceCall := mockKexecIface.On(item.OnCallMethodName)
-					for _, arg := range item.OnCallMethodArgType {
-						ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-					}
-					for _, ret := range item.RetArgList {
-						ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-					}
-					ifaceCall.Once()
-				}
+				ovntest.ProcessMockFnList(&mockKexecIface.Mock, tc.onRetArgsKexecIface)
 			}
 
 			if tc.onRetArgsCmdList != nil {
-				for _, item := range tc.onRetArgsCmdList {
-					mockCall := mockCmd.On(item.OnCallMethodName)
-					for _, arg := range item.OnCallMethodArgType {
-						mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-					}
-					for _, ret := range item.RetArgList {
-						mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-					}
-					mockCall.Once()
-				}
+				ovntest.ProcessMockFnList(&mockCmd.Mock, tc.onRetArgsCmdList)
 			}
 			// note runner is defined in pkg/cni/ovs.go file
 			runner = tc.runnerInstance

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	util_mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
 )
 
@@ -42,7 +41,7 @@ func TestRenameLink(t *testing.T) {
 			inpNewName:  "testNewName",
 			errExp:      true,
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkByName", []string{"string", "string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -51,8 +50,8 @@ func TestRenameLink(t *testing.T) {
 			inpNewName:  "testNewName",
 			errExp:      true,
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -61,9 +60,9 @@ func TestRenameLink(t *testing.T) {
 			inpNewName:  "testNewName",
 			errExp:      true,
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetName", []string{"*mocks.Link", "string"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetName", OnCallMethodArgType: []string{"*mocks.Link", "string"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -72,10 +71,10 @@ func TestRenameLink(t *testing.T) {
 			inpNewName:  "testNewName",
 			errExp:      true,
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetName", []string{"*mocks.Link", "string"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetName", OnCallMethodArgType: []string{"*mocks.Link", "string"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -83,26 +82,16 @@ func TestRenameLink(t *testing.T) {
 			inpCurrName: "testCurrName",
 			inpNewName:  "testNewName",
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetName", []string{"*mocks.Link", "string"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetName", OnCallMethodArgType: []string{"*mocks.Link", "string"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-
-			for _, item := range tc.netLinkOpsMockHelper {
-				call := mockNetLinkOps.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.netLinkOpsMockHelper)
 			err := renameLink(tc.inpCurrName, tc.inpNewName)
 			t.Log(err)
 			if tc.errExp {
@@ -136,7 +125,7 @@ func TestMoveIfToNetns(t *testing.T) {
 			inpNetNs:     nil,
 			errMatch:     fmt.Errorf("failed to lookup vf device"),
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkByName", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -145,11 +134,11 @@ func TestMoveIfToNetns(t *testing.T) {
 			inpNetNs:     mockNetNS,
 			errMatch:     fmt.Errorf("failed to move device"),
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"LinkSetNsFd", []string{"*mocks.Link", "int"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetNsFd", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 			netNsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fd", []string{}, []interface{}{uintptr(123456)}},
+				{OnCallMethodName: "Fd", OnCallMethodArgType: []string{}, RetArgList: []interface{}{uintptr(123456)}},
 			},
 		},
 		{
@@ -157,36 +146,19 @@ func TestMoveIfToNetns(t *testing.T) {
 			inpIfaceName: "testIfaceName",
 			inpNetNs:     mockNetNS,
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"LinkSetNsFd", []string{"*mocks.Link", "int"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetNsFd", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
 			},
 			netNsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fd", []string{}, []interface{}{uintptr(123456)}},
+				{OnCallMethodName: "Fd", OnCallMethodArgType: []string{}, RetArgList: []interface{}{uintptr(123456)}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			for _, item := range tc.netLinkOpsMockHelper {
-				call := mockNetLinkOps.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.netNsOpsMockHelper {
-				call := mockNetNS.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.netLinkOpsMockHelper)
+			ovntest.ProcessMockFnList(&mockNetNS.Mock, tc.netNsOpsMockHelper)
+
 			err := moveIfToNetns(tc.inpIfaceName, tc.inpNetNs)
 			t.Log(err)
 			if tc.errMatch != nil {
@@ -228,11 +200,11 @@ func TestSetupNetwork(t *testing.T) {
 			},
 			errMatch: fmt.Errorf("failed to add mac address"),
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetHardwareAddr", []string{"*mocks.Link", "net.HardwareAddr"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetHardwareAddr", OnCallMethodArgType: []string{"*mocks.Link", "net.HardwareAddr"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 			linkMockHelper: []ovntest.TestifyMockHelper{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -246,13 +218,13 @@ func TestSetupNetwork(t *testing.T) {
 			},
 			errMatch: fmt.Errorf("failed to add IP addr"),
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetHardwareAddr", []string{"*mocks.Link", "net.HardwareAddr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetHardwareAddr", OnCallMethodArgType: []string{"*mocks.Link", "net.HardwareAddr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 			linkMockHelper: []ovntest.TestifyMockHelper{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -267,13 +239,13 @@ func TestSetupNetwork(t *testing.T) {
 			},
 			errMatch: fmt.Errorf("failed to add gateway route"),
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetHardwareAddr", []string{"*mocks.Link", "net.HardwareAddr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetHardwareAddr", OnCallMethodArgType: []string{"*mocks.Link", "net.HardwareAddr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
 			},
 			cniPluginMockHelper: []ovntest.TestifyMockHelper{
-				{"AddRoute", []string{"*net.IPNet", "net.IP", "*mocks.Link"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "AddRoute", OnCallMethodArgType: []string{"*net.IPNet", "net.IP", "*mocks.Link"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -294,14 +266,14 @@ func TestSetupNetwork(t *testing.T) {
 			},
 			errMatch: fmt.Errorf("failed to add pod route"),
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetHardwareAddr", []string{"*mocks.Link", "net.HardwareAddr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetHardwareAddr", OnCallMethodArgType: []string{"*mocks.Link", "net.HardwareAddr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
 			},
 			cniPluginMockHelper: []ovntest.TestifyMockHelper{
-				{"AddRoute", []string{"*net.IPNet", "net.IP", "*mocks.Link"}, []interface{}{nil}},
-				{"AddRoute", []string{"*net.IPNet", "net.IP", "*mocks.Link"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "AddRoute", OnCallMethodArgType: []string{"*net.IPNet", "net.IP", "*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddRoute", OnCallMethodArgType: []string{"*net.IPNet", "net.IP", "*mocks.Link"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -321,49 +293,23 @@ func TestSetupNetwork(t *testing.T) {
 				},
 			},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetHardwareAddr", []string{"*mocks.Link", "net.HardwareAddr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetHardwareAddr", OnCallMethodArgType: []string{"*mocks.Link", "net.HardwareAddr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
 			},
 			cniPluginMockHelper: []ovntest.TestifyMockHelper{
-				{"AddRoute", []string{"*net.IPNet", "net.IP", "*mocks.Link"}, []interface{}{nil}},
-				{"AddRoute", []string{"*net.IPNet", "net.IP", "*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "AddRoute", OnCallMethodArgType: []string{"*net.IPNet", "net.IP", "*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddRoute", OnCallMethodArgType: []string{"*net.IPNet", "net.IP", "*mocks.Link"}, RetArgList: []interface{}{nil}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			for _, item := range tc.netLinkOpsMockHelper {
-				call := mockNetLinkOps.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.linkMockHelper {
-				call := mockLink.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.cniPluginMockHelper {
-				call := mockCNIPlugin.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.netLinkOpsMockHelper)
+			ovntest.ProcessMockFnList(&mockLink.Mock, tc.linkMockHelper)
+			ovntest.ProcessMockFnList(&mockCNIPlugin.Mock, tc.cniPluginMockHelper)
+
 			err := setupNetwork(tc.inpLink, tc.inpPodIfaceInfo)
 			t.Log(err)
 			if tc.errMatch != nil {
@@ -417,7 +363,7 @@ func TestSetupInterface(t *testing.T) {
 			},
 			errExp: true,
 			nsMockHelper: []ovntest.TestifyMockHelper{
-				{"Do", []string{"func(ns.NetNS) error"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "Do", OnCallMethodArgType: []string{"func(ns.NetNS) error"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 		/* TODO: Running the below requires root, need to figure this out
@@ -447,45 +393,19 @@ func TestSetupInterface(t *testing.T) {
 			},
 			errMatch: fmt.Errorf("failed to rename"),
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"LinkByName", []string{"string", "string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 			nsMockHelper: []ovntest.TestifyMockHelper{
-				{"Do", []string{"func(ns.NetNS) error"}, []interface{}{nil}},
+				{OnCallMethodName: "Do", OnCallMethodArgType: []string{"func(ns.NetNS) error"}, RetArgList: []interface{}{nil}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			for _, item := range tc.netLinkOpsMockHelper {
-				call := mockNetLinkOps.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.cniPluginMockHelper {
-				call := mockCNIPlugin.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.nsMockHelper {
-				call := mockNS.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.netLinkOpsMockHelper)
+			ovntest.ProcessMockFnList(&mockCNIPlugin.Mock, tc.cniPluginMockHelper)
+			ovntest.ProcessMockFnList(&mockNS.Mock, tc.nsMockHelper)
+
 			hostIface, contIface, err := setupInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo)
 			t.Log(hostIface, contIface, err)
 			if tc.errExp {
@@ -551,7 +471,7 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -567,7 +487,7 @@ func TestSetupSriovInterface(t *testing.T) {
 			errMatch:    fmt.Errorf("failed to get one netdevice interface per"),
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
 				// e.g; `ls -l /sys/bus/pci/devices/0000:01:00.0/net/` is the equivalent command line to get devices info
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{[]string{"en01", "eno2"}, nil}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01", "eno2"}, nil}},
 			},
 		},
 		{
@@ -582,8 +502,8 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{[]string{"en01"}, nil}},
-				{"GetUplinkRepresentor", []string{"string"}, []interface{}{"", fmt.Errorf("mock error")}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -598,9 +518,9 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{[]string{"en01"}, nil}},
-				{"GetUplinkRepresentor", []string{"string"}, []interface{}{"testlinkrepresentor", nil}},
-				{"GetVfIndexByPciAddress", []string{"string"}, []interface{}{-1, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
+				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{-1, fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -615,10 +535,10 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{[]string{"en01"}, nil}},
-				{"GetUplinkRepresentor", []string{"string"}, []interface{}{"testlinkrepresentor", nil}},
-				{"GetVfIndexByPciAddress", []string{"string"}, []interface{}{0, nil}},
-				{"GetVfRepresentor", []string{"string", "int"}, []interface{}{"", fmt.Errorf("mock error")}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
+				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
+				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"", fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -633,14 +553,14 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs: "0000:03:00.1",
 			errMatch:    fmt.Errorf("failed to rename"),
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{[]string{"en01"}, nil}},
-				{"GetUplinkRepresentor", []string{"string"}, []interface{}{"testlinkrepresentor", nil}},
-				{"GetVfIndexByPciAddress", []string{"string"}, []interface{}{0, nil}},
-				{"GetVfRepresentor", []string{"string", "int"}, []interface{}{"VFRepresentor", nil}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
+				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
+				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
 			},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				// The below is mocked for the renameLink() method that internally invokes LinkByName
-				{"LinkByName", []string{"string", "string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -655,19 +575,19 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{[]string{"en01"}, nil}},
-				{"GetUplinkRepresentor", []string{"string"}, []interface{}{"testlinkrepresentor", nil}},
-				{"GetVfIndexByPciAddress", []string{"string"}, []interface{}{0, nil}},
-				{"GetVfRepresentor", []string{"string", "int"}, []interface{}{"VFRepresentor", nil}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
+				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
+				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
 			},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				// The below 4 calls are mocked for the renameLink() method that internally invokes the below 4 calls
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetName", []string{"*mocks.Link", "string"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetName", OnCallMethodArgType: []string{"*mocks.Link", "string"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// The below mock call is needed for the LinkByName() invocation right after the renameLink() method
-				{"LinkByName", []string{"string", "string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -682,25 +602,25 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs: "0000:03:00.1",
 			errMatch:    fmt.Errorf("failed to set MTU on"),
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{[]string{"en01"}, nil}},
-				{"GetUplinkRepresentor", []string{"string"}, []interface{}{"testlinkrepresentor", nil}},
-				{"GetVfIndexByPciAddress", []string{"string"}, []interface{}{0, nil}},
-				{"GetVfRepresentor", []string{"string", "int"}, []interface{}{"VFRepresentor", nil}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
+				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
+				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
 			},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				// The below 4 calls are mocked for the renameLink() method that internally invokes the below 4 calls
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetName", []string{"*mocks.Link", "string"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetName", OnCallMethodArgType: []string{"*mocks.Link", "string"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// The below mock call is needed for the LinkByName() invocation right after the renameLink() method
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
 				// The below mock call is self-explanatory and is for the LinkSetMTU() method
-				{"LinkSetMTU", []string{"*mocks.Link", "int"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 			linkMockHelper: []ovntest.TestifyMockHelper{
 				// The below mock call is to retrieve the MAC address of host interface right before LinkSetMTU() method
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -715,27 +635,27 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{[]string{"en01"}, nil}},
-				{"GetUplinkRepresentor", []string{"string"}, []interface{}{"testlinkrepresentor", nil}},
-				{"GetVfIndexByPciAddress", []string{"string"}, []interface{}{0, nil}},
-				{"GetVfRepresentor", []string{"string", "int"}, []interface{}{"VFRepresentor", nil}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
+				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
+				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
 			},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				// The below 4 calls are mocked for the renameLink() method that internally invokes the below 4 calls
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetName", []string{"*mocks.Link", "string"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetName", OnCallMethodArgType: []string{"*mocks.Link", "string"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// The below mock call is needed for the LinkByName() invocation right after the renameLink() method
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
 				// The below mock call is self-explanatory and is for the LinkSetMTU() method
-				{"LinkSetMTU", []string{"*mocks.Link", "int"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
 				// The below mock call is needed for the moveIfToNetns() call that internally invokes the LinkbyName()
-				{"LinkByName", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 			linkMockHelper: []ovntest.TestifyMockHelper{
 				// The below mock call is to retrieve the MAC address of host interface right before LinkSetMTU() method
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -750,88 +670,44 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"GetNetDevicesFromPci", []string{"string"}, []interface{}{[]string{"en01"}, nil}},
-				{"GetUplinkRepresentor", []string{"string"}, []interface{}{"testlinkrepresentor", nil}},
-				{"GetVfIndexByPciAddress", []string{"string"}, []interface{}{0, nil}},
-				{"GetVfRepresentor", []string{"string", "int"}, []interface{}{"VFRepresentor", nil}},
+				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
+				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
+				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
+				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
 			},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				// The below 4 calls are mocked for the renameLink() method that internally invokes the below 4 calls
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
-				{"LinkSetDown", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"LinkSetName", []string{"*mocks.Link", "string"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetDown", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetName", OnCallMethodArgType: []string{"*mocks.Link", "string"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// The below mock call is needed for the LinkByName() invocation right after the renameLink() method
-				{"LinkByName", []string{"string", "string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockLink, nil}},
 				// The below mock call is self-explanatory and is for the LinkSetMTU() method
-				{"LinkSetMTU", []string{"*mocks.Link", "int"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkSetMTU", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
 				// The below two mock calls are needed for the moveIfToNetns() call that internally invokes them
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"LinkSetNsFd", []string{"*mocks.Link", "int"}, []interface{}{nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetNsFd", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil}},
 			},
 			linkMockHelper: []ovntest.TestifyMockHelper{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 			nsMockHelper: []ovntest.TestifyMockHelper{
 				// The below mock call is needed when moveIfToNetns() is called
-				{"Fd", []string{}, []interface{}{uintptr(123456)}},
+				{OnCallMethodName: "Fd", OnCallMethodArgType: []string{}, RetArgList: []interface{}{uintptr(123456)}},
 				// The below mock call is for the netns.Do() invocation
-				{"Do", []string{"func(ns.NetNS) error"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "Do", OnCallMethodArgType: []string{"func(ns.NetNS) error"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			for _, item := range tc.netLinkOpsMockHelper {
-				call := mockNetLinkOps.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.cniPluginMockHelper {
-				call := mockCNIPlugin.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.nsMockHelper {
-				call := mockNS.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.sriovOpsMockHelper {
-				call := mockSriovNetLibOps.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.linkMockHelper {
-				call := mockLink.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.netLinkOpsMockHelper)
+			ovntest.ProcessMockFnList(&mockCNIPlugin.Mock, tc.cniPluginMockHelper)
+			ovntest.ProcessMockFnList(&mockNS.Mock, tc.nsMockHelper)
+			ovntest.ProcessMockFnList(&mockSriovNetLibOps.Mock, tc.sriovOpsMockHelper)
+			ovntest.ProcessMockFnList(&mockLink.Mock, tc.linkMockHelper)
+
 			hostIface, contIface, err := setupSriovInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo, tc.inpPCIAddrs)
 			t.Log(hostIface, contIface, err)
 			if tc.errExp {
@@ -882,7 +758,7 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 				},
 			},
 			resultMockHelper: []ovntest.TestifyMockHelper{
-				{"Version", []string{}, []interface{}{"0.0.0"}},
+				{OnCallMethodName: "Version", OnCallMethodArgType: []string{}, RetArgList: []interface{}{"0.0.0"}},
 			},
 		},
 		{
@@ -915,32 +791,15 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 				IPs:        []*current.IPConfig{{Version: "4", Interface: &[]int{0}[0], Address: *ovntest.MustParseIPNet("192.168.1.15/24"), Gateway: ovntest.MustParseIP("192.168.1.1")}},
 			},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ConntrackDeleteFilter", []string{"netlink.ConntrackTableType", "netlink.InetFamily", "*netlink.ConntrackFilter"}, []interface{}{uint(1), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "ConntrackDeleteFilter", OnCallMethodArgType: []string{"netlink.ConntrackTableType", "netlink.InetFamily", "*netlink.ConntrackFilter"}, RetArgList: []interface{}{uint(1), fmt.Errorf("mock error")}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			for _, item := range tc.resultMockHelper {
-				call := mockTypeResult.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.netLinkOpsMockHelper {
-				call := mockNetLinkOps.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockTypeResult.Mock, tc.resultMockHelper)
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.netLinkOpsMockHelper)
+
 			if tc.inpPrevResult != nil {
 				res, err := json.Marshal(tc.inpPrevResult)
 				if err != nil {

--- a/go-controller/pkg/cni/ovs_unit_test.go
+++ b/go-controller/pkg/cni/ovs_unit_test.go
@@ -7,7 +7,6 @@ import (
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	mock_k8s_io_utils_exec "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	kexec "k8s.io/utils/exec"
 )
 
@@ -21,20 +20,14 @@ func TestSetExec(t *testing.T) {
 		{
 			desc:        "positive, ovs-vsctl found",
 			expectedErr: nil,
-			onRetArgs:   &ovntest.TestifyMockHelper{"LookPath", []string{"string"}, []interface{}{"", nil}},
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", nil}},
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockKexecIface.On(tc.onRetArgs.OnCallMethodName)
-			for _, arg := range tc.onRetArgs.OnCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, elem := range tc.onRetArgs.RetArgList {
-				call.ReturnArguments = append(call.ReturnArguments, elem)
-			}
-			call.Once()
+
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgs)
 
 			e := setExec(mockKexecIface)
 			assert.Equal(t, e, tc.expectedErr)
@@ -62,39 +55,25 @@ func TestOvsExec(t *testing.T) {
 		{
 			desc:                "Test codepath when runner is non nil and returns error",
 			expectedErr:         fmt.Errorf("failed to run ovs-vsctl"),
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:    &ovntest.TestifyMockHelper{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("failed to run 'ovs-vsctl")}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:    &ovntest.TestifyMockHelper{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("failed to run 'ovs-vsctl")}},
 			runnerInstance:      mockKexecIface,
 		},
 		{
 			desc:                "Test codepath when runner is not nil and does not return an error",
 			expectedErr:         nil,
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:    &ovntest.TestifyMockHelper{"CombinedOutput", []string{}, []interface{}{nil, nil}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:    &ovntest.TestifyMockHelper{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			runnerInstance:      mockKexecIface,
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.OnCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.OnCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.RetArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
+				ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 			}
 			if tc.onRetArgsCmdList != nil {
-				mockCall := mockCmd.On(tc.onRetArgsCmdList.OnCallMethodName)
-				for _, arg := range tc.onRetArgsCmdList.OnCallMethodArgType {
-					mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsCmdList.RetArgList {
-					mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-				}
-				mockCall.Once()
+				ovntest.ProcessMockFn(&mockCmd.Mock, *tc.onRetArgsCmdList)
 			}
 
 			runner = tc.runnerInstance
@@ -127,33 +106,15 @@ func TestOvsCreate(t *testing.T) {
 		{
 			desc:                "Positive test codepath for ovsCreate",
 			expectedErr:         nil,
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:    &ovntest.TestifyMockHelper{"CombinedOutput", []string{}, []interface{}{nil, nil}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:    &ovntest.TestifyMockHelper{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			runnerInstance:      mockKexecIface,
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.OnCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.OnCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.RetArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
-			}
-			if tc.onRetArgsCmdList != nil {
-				mockCall := mockCmd.On(tc.onRetArgsCmdList.OnCallMethodName)
-				for _, arg := range tc.onRetArgsCmdList.OnCallMethodArgType {
-					mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsCmdList.RetArgList {
-					mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-				}
-				mockCall.Once()
-			}
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+			ovntest.ProcessMockFn(&mockCmd.Mock, *tc.onRetArgsCmdList)
 
 			runner = tc.runnerInstance
 
@@ -185,33 +146,15 @@ func TestOvsDestroy(t *testing.T) {
 		{
 			desc:                "Positive test codepath for ovsDestroy",
 			expectedErr:         nil,
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:    &ovntest.TestifyMockHelper{"CombinedOutput", []string{}, []interface{}{nil, nil}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:    &ovntest.TestifyMockHelper{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			runnerInstance:      mockKexecIface,
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.OnCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.OnCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.RetArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
-			}
-			if tc.onRetArgsCmdList != nil {
-				mockCall := mockCmd.On(tc.onRetArgsCmdList.OnCallMethodName)
-				for _, arg := range tc.onRetArgsCmdList.OnCallMethodArgType {
-					mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsCmdList.RetArgList {
-					mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-				}
-				mockCall.Once()
-			}
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+			ovntest.ProcessMockFn(&mockCmd.Mock, *tc.onRetArgsCmdList)
 
 			runner = tc.runnerInstance
 
@@ -243,33 +186,15 @@ func TestOvsSet(t *testing.T) {
 		{
 			desc:                "Positive test codepath for ovsSet",
 			expectedErr:         nil,
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:    &ovntest.TestifyMockHelper{"CombinedOutput", []string{}, []interface{}{nil, nil}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:    &ovntest.TestifyMockHelper{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			runnerInstance:      mockKexecIface,
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.OnCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.OnCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.RetArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
-			}
-			if tc.onRetArgsCmdList != nil {
-				mockCall := mockCmd.On(tc.onRetArgsCmdList.OnCallMethodName)
-				for _, arg := range tc.onRetArgsCmdList.OnCallMethodArgType {
-					mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsCmdList.RetArgList {
-					mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-				}
-				mockCall.Once()
-			}
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+			ovntest.ProcessMockFn(&mockCmd.Mock, *tc.onRetArgsCmdList)
 
 			runner = tc.runnerInstance
 
@@ -301,47 +226,29 @@ func TestOvsFind(t *testing.T) {
 		{
 			desc:                "Test codepath when ovsExec returns an error",
 			expectedErr:         fmt.Errorf("failed to run ovsFind"),
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:    &ovntest.TestifyMockHelper{"CombinedOutput", []string{}, []interface{}{nil, fmt.Errorf("failed to run ovsFind")}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:    &ovntest.TestifyMockHelper{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("failed to run ovsFind")}},
 			runnerInstance:      mockKexecIface,
 		},
 		{
 			desc:                "Test codepath when ovsExec output is nil",
 			expectedErr:         nil,
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:    &ovntest.TestifyMockHelper{"CombinedOutput", []string{}, []interface{}{nil, nil}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:    &ovntest.TestifyMockHelper{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			runnerInstance:      mockKexecIface,
 		},
 		{
 			desc:                "Positive test codepath for ovsFind; ovsExec output is not nil",
 			expectedErr:         nil,
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:    &ovntest.TestifyMockHelper{"CombinedOutput", []string{}, []interface{}{[]byte{}, nil}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:    &ovntest.TestifyMockHelper{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{}, nil}},
 			runnerInstance:      mockKexecIface,
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.OnCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.OnCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.RetArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
-			}
-			if tc.onRetArgsCmdList != nil {
-				mockCall := mockCmd.On(tc.onRetArgsCmdList.OnCallMethodName)
-				for _, arg := range tc.onRetArgsCmdList.OnCallMethodArgType {
-					mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsCmdList.RetArgList {
-					mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-				}
-				mockCall.Once()
-			}
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+			ovntest.ProcessMockFn(&mockCmd.Mock, *tc.onRetArgsCmdList)
 
 			runner = tc.runnerInstance
 
@@ -373,33 +280,15 @@ func TestOvsClear(t *testing.T) {
 		{
 			desc:                "Positive test codepath for ovsClear",
 			expectedErr:         nil,
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:    &ovntest.TestifyMockHelper{"CombinedOutput", []string{}, []interface{}{nil, nil}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:    &ovntest.TestifyMockHelper{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
 			runnerInstance:      mockKexecIface,
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.OnCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.OnCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.RetArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
-			}
-			if tc.onRetArgsCmdList != nil {
-				mockCall := mockCmd.On(tc.onRetArgsCmdList.OnCallMethodName)
-				for _, arg := range tc.onRetArgsCmdList.OnCallMethodArgType {
-					mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsCmdList.RetArgList {
-					mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-				}
-				mockCall.Once()
-			}
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+			ovntest.ProcessMockFn(&mockCmd.Mock, *tc.onRetArgsCmdList)
 
 			runner = tc.runnerInstance
 
@@ -431,50 +320,31 @@ func TestOfctlExec(t *testing.T) {
 		{
 			desc:                "Positive test codepath for ofctlExec",
 			expectedErr:         nil,
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"SetStdout", []string{"*bytes.Buffer"}, []interface{}{nil}},
-				{"SetStderr", []string{"*bytes.Buffer"}, []interface{}{nil}},
-				{"Run", []string{}, []interface{}{nil}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil}},
 			},
 			runnerInstance: mockKexecIface,
 		},
 		{
 			desc:                "Negative test codepath for ofctlExec",
 			expectedErr:         fmt.Errorf("failed to run ovs-ofctl"),
-			onRetArgsKexecIface: &ovntest.TestifyMockHelper{"Command", []string{"string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			onRetArgsCmdList: []ovntest.TestifyMockHelper{
-				{"SetStdout", []string{"*bytes.Buffer"}, []interface{}{nil}},
-				{"SetStderr", []string{"*bytes.Buffer"}, []interface{}{nil}},
-				{"Run", []string{}, []interface{}{fmt.Errorf("failed to run 'ovs-ofctl'")}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{fmt.Errorf("failed to run 'ovs-ofctl'")}},
 			},
 			runnerInstance: mockKexecIface,
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.OnCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.OnCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.RetArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
-			}
-			for _, item := range tc.onRetArgsCmdList {
-				if tc.onRetArgsCmdList != nil {
-					mockCall := mockCmd.On(item.OnCallMethodName)
-					for _, arg := range item.OnCallMethodArgType {
-						mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-					}
-					for _, ret := range item.RetArgList {
-						mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-					}
-					mockCall.Once()
-				}
-			}
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+			ovntest.ProcessMockFnList(&mockCmd.Mock, tc.onRetArgsCmdList)
+
 			runner = tc.runnerInstance
 
 			_, e := ofctlExec()

--- a/go-controller/pkg/kube/kube_test.go
+++ b/go-controller/pkg/kube/kube_test.go
@@ -12,7 +12,6 @@ import (
 	mock_clientgo_iface "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/kubernetes"
 	mock_core_v1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/kubernetes/typed/core/v1"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
@@ -35,16 +34,16 @@ func TestKube_SetAnnotationsOnPod(t *testing.T) {
 		{
 			desc:                   "Negative test code path",
 			expectedErr:            true,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Pods", []string{"string"}, []interface{}{mockPodIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"Patch", []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, []interface{}{nil, fmt.Errorf("mock Error: Failed to run SetAnnotationsOnPod")}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Pods", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockPodIface}},
+			onRetMockPodArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "Patch", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, RetArgList: []interface{}{nil, fmt.Errorf("mock Error: Failed to run SetAnnotationsOnPod")}},
 		},
 		{
 			desc:                   "Positive test code path",
 			expectedErr:            false,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Pods", []string{"string"}, []interface{}{mockPodIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"Patch", []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, []interface{}{nil, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Pods", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockPodIface}},
+			onRetMockPodArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "Patch", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, RetArgList: []interface{}{nil, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -52,36 +51,15 @@ func TestKube_SetAnnotationsOnPod(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockPodArgs != nil {
-				mockPodCall := mockPodIface.On(tc.onRetMockPodArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockPodArgs.OnCallMethodArgType {
-					mockPodCall.Arguments = append(mockPodCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockPodArgs.RetArgList {
-					mockPodCall.ReturnArguments = append(mockPodCall.ReturnArguments, ret)
-				}
-				mockPodCall.Once()
+				ovntest.ProcessMockFn(&mockPodIface.Mock, *tc.onRetMockPodArgs)
 			}
 
 			e := k.SetAnnotationsOnPod(pod, annotations)
@@ -112,21 +90,21 @@ func TestKube_SetAnnotationsOnNode(t *testing.T) {
 		expectedErr            bool
 		onRetMockInterfaceArgs *ovntest.TestifyMockHelper
 		onRetMockCoreArgs      *ovntest.TestifyMockHelper
-		onRetMockPodArgs       *ovntest.TestifyMockHelper
+		onRetMockNodeArgs      *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                   "Negative test code path",
 			expectedErr:            true,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Nodes", []string{"string"}, []interface{}{mockNodeIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"Patch", []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, []interface{}{nil, fmt.Errorf("mock Error: Failed to run SetAnnotationsOnNode")}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Nodes", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockNodeIface}},
+			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Patch", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, RetArgList: []interface{}{nil, fmt.Errorf("mock Error: Failed to run SetAnnotationsOnNode")}},
 		},
 		{
 			desc:                   "Positive test code path",
 			expectedErr:            false,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Nodes", []string{"string"}, []interface{}{mockNodeIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"Patch", []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, []interface{}{nil, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Nodes", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockNodeIface}},
+			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Patch", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, RetArgList: []interface{}{nil, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -134,36 +112,15 @@ func TestKube_SetAnnotationsOnNode(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
-			if tc.onRetMockPodArgs != nil {
-				mockPodCall := mockNodeIface.On(tc.onRetMockPodArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockPodArgs.OnCallMethodArgType {
-					mockPodCall.Arguments = append(mockPodCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockPodArgs.RetArgList {
-					mockPodCall.ReturnArguments = append(mockPodCall.ReturnArguments, ret)
-				}
-				mockPodCall.Once()
+			if tc.onRetMockNodeArgs != nil {
+				ovntest.ProcessMockFn(&mockNodeIface.Mock, *tc.onRetMockNodeArgs)
 			}
 
 			e := k.SetAnnotationsOnNode(node, annotations)
@@ -199,16 +156,16 @@ func TestKube_SetAnnotationsOnNamespace(t *testing.T) {
 		{
 			desc:                   "Negative test code path",
 			expectedErr:            true,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Namespaces", []string{"string"}, []interface{}{mockNameSpaceIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"Patch", []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, []interface{}{nil, fmt.Errorf("mock Error: Failed to run SetAnnotationsOnNamespacces")}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Namespaces", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockNameSpaceIface}},
+			onRetMockPodArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "Patch", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, RetArgList: []interface{}{nil, fmt.Errorf("mock Error: Failed to run SetAnnotationsOnNamespacces")}},
 		},
 		{
 			desc:                   "Positive test code path",
 			expectedErr:            false,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Namespaces", []string{"string"}, []interface{}{mockNameSpaceIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"Patch", []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, []interface{}{nil, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Namespaces", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockNameSpaceIface}},
+			onRetMockPodArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "Patch", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "types.PatchType", "[]uint8", "v1.PatchOptions"}, RetArgList: []interface{}{nil, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -216,36 +173,15 @@ func TestKube_SetAnnotationsOnNamespace(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockPodArgs != nil {
-				mockPodCall := mockNameSpaceIface.On(tc.onRetMockPodArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockPodArgs.OnCallMethodArgType {
-					mockPodCall.Arguments = append(mockPodCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockPodArgs.RetArgList {
-					mockPodCall.ReturnArguments = append(mockPodCall.ReturnArguments, ret)
-				}
-				mockPodCall.Once()
+				ovntest.ProcessMockFn(&mockNameSpaceIface.Mock, *tc.onRetMockPodArgs)
 			}
 
 			e := k.SetAnnotationsOnNamespace(namespace, annotations)
@@ -281,15 +217,15 @@ func TestKube_UpdateEgressFirewall(t *testing.T) {
 		{
 			desc:                        "Negative test code path",
 			errorMatch:                  fmt.Errorf("error in updating status on EgressFirewall"),
-			onRetMockInterfaceArgs:      &ovntest.TestifyMockHelper{"K8sV1", []string{}, []interface{}{mockK8sIface}},
-			onRetMockK8sArgs:            &ovntest.TestifyMockHelper{"EgressFirewalls", []string{"string"}, []interface{}{mockEgressfirewallIface}},
-			onRetMockEgressFirewallArgs: &ovntest.TestifyMockHelper{"Update", []string{"*context.emptyCtx", "*v1.EgressFirewall", "v1.UpdateOptions"}, []interface{}{nil, fmt.Errorf("error in updating status on EgressFirewall")}},
+			onRetMockInterfaceArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "K8sV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockK8sIface}},
+			onRetMockK8sArgs:            &ovntest.TestifyMockHelper{OnCallMethodName: "EgressFirewalls", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockEgressfirewallIface}},
+			onRetMockEgressFirewallArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "Update", OnCallMethodArgType: []string{"*context.emptyCtx", "*v1.EgressFirewall", "v1.UpdateOptions"}, RetArgList: []interface{}{nil, fmt.Errorf("error in updating status on EgressFirewall")}},
 		},
 		{
 			desc:                        "Positive test code path",
-			onRetMockInterfaceArgs:      &ovntest.TestifyMockHelper{"K8sV1", []string{}, []interface{}{mockK8sIface}},
-			onRetMockK8sArgs:            &ovntest.TestifyMockHelper{"EgressFirewalls", []string{"string"}, []interface{}{mockEgressfirewallIface}},
-			onRetMockEgressFirewallArgs: &ovntest.TestifyMockHelper{"Update", []string{"*context.emptyCtx", "*v1.EgressFirewall", "v1.UpdateOptions"}, []interface{}{nil, nil}},
+			onRetMockInterfaceArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "K8sV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockK8sIface}},
+			onRetMockK8sArgs:            &ovntest.TestifyMockHelper{OnCallMethodName: "EgressFirewalls", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockEgressfirewallIface}},
+			onRetMockEgressFirewallArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "Update", OnCallMethodArgType: []string{"*context.emptyCtx", "*v1.EgressFirewall", "v1.UpdateOptions"}, RetArgList: []interface{}{nil, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -297,36 +233,15 @@ func TestKube_UpdateEgressFirewall(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockK8sArgs != nil {
-				mockK8sCall := mockK8sIface.On(tc.onRetMockK8sArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockK8sArgs.OnCallMethodArgType {
-					mockK8sCall.Arguments = append(mockK8sCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockK8sArgs.RetArgList {
-					mockK8sCall.ReturnArguments = append(mockK8sCall.ReturnArguments, elem)
-				}
-				mockK8sCall.Once()
+				ovntest.ProcessMockFn(&mockK8sIface.Mock, *tc.onRetMockK8sArgs)
 			}
 
 			if tc.onRetMockEgressFirewallArgs != nil {
-				mockEgressFirewallCall := mockEgressfirewallIface.On(tc.onRetMockEgressFirewallArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockEgressFirewallArgs.OnCallMethodArgType {
-					mockEgressFirewallCall.Arguments = append(mockEgressFirewallCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockEgressFirewallArgs.RetArgList {
-					mockEgressFirewallCall.ReturnArguments = append(mockEgressFirewallCall.ReturnArguments, elem)
-				}
-				mockEgressFirewallCall.Once()
+				ovntest.ProcessMockFn(&mockEgressfirewallIface.Mock, *tc.onRetMockEgressFirewallArgs)
 			}
 
 			e := k.UpdateEgressFirewall(&egressfirewall.EgressFirewall{})
@@ -360,15 +275,15 @@ func TestKube_UpdateEgressIP(t *testing.T) {
 		{
 			desc:                   "Negative test code path",
 			errorMatch:             fmt.Errorf("error in updating status on EgressIP"),
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"K8sV1", []string{}, []interface{}{mockK8sIface}},
-			onRetMockK8sArgs:       &ovntest.TestifyMockHelper{"EgressIPs", []string{}, []interface{}{mockEgressIPIface}},
-			onRetMockEgressIPArgs:  &ovntest.TestifyMockHelper{"Update", []string{"*context.emptyCtx", "*v1.EgressIP", "v1.UpdateOptions"}, []interface{}{nil, fmt.Errorf("error in updating status on EgressIP")}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "K8sV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockK8sIface}},
+			onRetMockK8sArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "EgressIPs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockEgressIPIface}},
+			onRetMockEgressIPArgs:  &ovntest.TestifyMockHelper{OnCallMethodName: "Update", OnCallMethodArgType: []string{"*context.emptyCtx", "*v1.EgressIP", "v1.UpdateOptions"}, RetArgList: []interface{}{nil, fmt.Errorf("error in updating status on EgressIP")}},
 		},
 		{
 			desc:                   "Positive test code path",
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"K8sV1", []string{}, []interface{}{mockK8sIface}},
-			onRetMockK8sArgs:       &ovntest.TestifyMockHelper{"EgressIPs", []string{}, []interface{}{mockEgressIPIface}},
-			onRetMockEgressIPArgs:  &ovntest.TestifyMockHelper{"Update", []string{"*context.emptyCtx", "*v1.EgressIP", "v1.UpdateOptions"}, []interface{}{nil, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "K8sV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockK8sIface}},
+			onRetMockK8sArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "EgressIPs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockEgressIPIface}},
+			onRetMockEgressIPArgs:  &ovntest.TestifyMockHelper{OnCallMethodName: "Update", OnCallMethodArgType: []string{"*context.emptyCtx", "*v1.EgressIP", "v1.UpdateOptions"}, RetArgList: []interface{}{nil, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -376,36 +291,15 @@ func TestKube_UpdateEgressIP(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockK8sArgs != nil {
-				mockK8sCall := mockK8sIface.On(tc.onRetMockK8sArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockK8sArgs.OnCallMethodArgType {
-					mockK8sCall.Arguments = append(mockK8sCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockK8sArgs.RetArgList {
-					mockK8sCall.ReturnArguments = append(mockK8sCall.ReturnArguments, elem)
-				}
-				mockK8sCall.Once()
+				ovntest.ProcessMockFn(&mockK8sIface.Mock, *tc.onRetMockK8sArgs)
 			}
 
 			if tc.onRetMockEgressIPArgs != nil {
-				mockEgressIPCall := mockEgressIPIface.On(tc.onRetMockEgressIPArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockEgressIPArgs.OnCallMethodArgType {
-					mockEgressIPCall.Arguments = append(mockEgressIPCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockEgressIPArgs.RetArgList {
-					mockEgressIPCall.ReturnArguments = append(mockEgressIPCall.ReturnArguments, elem)
-				}
-				mockEgressIPCall.Once()
+				ovntest.ProcessMockFn(&mockEgressIPIface.Mock, *tc.onRetMockEgressIPArgs)
 			}
 
 			e := k.UpdateEgressIP(&egressv1.EgressIP{})
@@ -439,15 +333,15 @@ func TestKube_UpdateNodeStatus(t *testing.T) {
 		{
 			desc:                   "Negative test code path",
 			errorMatch:             fmt.Errorf("error in updating status on node"),
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Nodes", []string{"string"}, []interface{}{mockNodeIface}},
-			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{"UpdateStatus", []string{"*context.emptyCtx", "*v1.Node", "UpdateOptions"}, []interface{}{nil, fmt.Errorf("error in updating status on node")}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Nodes", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockNodeIface}},
+			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "UpdateStatus", OnCallMethodArgType: []string{"*context.emptyCtx", "*v1.Node", "UpdateOptions"}, RetArgList: []interface{}{nil, fmt.Errorf("error in updating status on node")}},
 		},
 		{
 			desc:                   "Positive test code path",
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Nodes", []string{}, []interface{}{mockNodeIface}},
-			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{"UpdateStatus", []string{"*context.emptyCtx", "*v1.Node", "UpdateOptions"}, []interface{}{&v1.Node{}, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Nodes", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockNodeIface}},
+			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "UpdateStatus", OnCallMethodArgType: []string{"*context.emptyCtx", "*v1.Node", "UpdateOptions"}, RetArgList: []interface{}{&v1.Node{}, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -455,36 +349,15 @@ func TestKube_UpdateNodeStatus(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockNodeArgs != nil {
-				mockPodCall := mockNodeIface.On(tc.onRetMockNodeArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockNodeArgs.OnCallMethodArgType {
-					mockPodCall.Arguments = append(mockPodCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockNodeArgs.RetArgList {
-					mockPodCall.ReturnArguments = append(mockPodCall.ReturnArguments, ret)
-				}
-				mockPodCall.Once()
+				ovntest.ProcessMockFn(&mockNodeIface.Mock, *tc.onRetMockNodeArgs)
 			}
 
 			e := k.UpdateNodeStatus(&v1.Node{})
@@ -518,16 +391,16 @@ func TestKube_GetAnnotationsOnPod(t *testing.T) {
 		{
 			desc:                   "Negative test code path",
 			expectedErr:            true,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Pods", []string{"string"}, []interface{}{mockPodIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"Get", []string{"*context.emptyCtx", "string", "v1.GetOptions"}, []interface{}{nil, fmt.Errorf("mock Error: Failed to run GetAnnotationsOnPod")}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Pods", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockPodIface}},
+			onRetMockPodArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "Get", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "v1.GetOptions"}, RetArgList: []interface{}{nil, fmt.Errorf("mock Error: Failed to run GetAnnotationsOnPod")}},
 		},
 		{
 			desc:                   "Positive test code path",
 			expectedErr:            false,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Pods", []string{"string"}, []interface{}{mockPodIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"Get", []string{"*context.emptyCtx", "string", "v1.GetOptions"}, []interface{}{&v1.Pod{}, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Pods", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockPodIface}},
+			onRetMockPodArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "Get", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "v1.GetOptions"}, RetArgList: []interface{}{&v1.Pod{}, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -535,36 +408,15 @@ func TestKube_GetAnnotationsOnPod(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockPodArgs != nil {
-				mockPodCall := mockPodIface.On(tc.onRetMockPodArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockPodArgs.OnCallMethodArgType {
-					mockPodCall.Arguments = append(mockPodCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockPodArgs.RetArgList {
-					mockPodCall.ReturnArguments = append(mockPodCall.ReturnArguments, ret)
-				}
-				mockPodCall.Once()
+				ovntest.ProcessMockFn(&mockPodIface.Mock, *tc.onRetMockPodArgs)
 			}
 
 			_, e := k.GetAnnotationsOnPod("namespace", "name")
@@ -596,9 +448,9 @@ func TestKube_GetNamespaces(t *testing.T) {
 	}{
 		{
 			desc:                   "Positive test code path",
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Namespaces", []string{"string"}, []interface{}{mockNamespaceIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"List", []string{"*context.emptyCtx", "ListOptions"}, []interface{}{&v1.NamespaceList{}, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Namespaces", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockNamespaceIface}},
+			onRetMockPodArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "List", OnCallMethodArgType: []string{"*context.emptyCtx", "ListOptions"}, RetArgList: []interface{}{&v1.NamespaceList{}, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -606,36 +458,15 @@ func TestKube_GetNamespaces(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockPodArgs != nil {
-				mockPodCall := mockNamespaceIface.On(tc.onRetMockPodArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockPodArgs.OnCallMethodArgType {
-					mockPodCall.Arguments = append(mockPodCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockPodArgs.RetArgList {
-					mockPodCall.ReturnArguments = append(mockPodCall.ReturnArguments, ret)
-				}
-				mockPodCall.Once()
+				ovntest.ProcessMockFn(&mockNamespaceIface.Mock, *tc.onRetMockPodArgs)
 			}
 
 			_, e := k.GetNamespaces(metav1.LabelSelector{})
@@ -663,9 +494,9 @@ func TestKube_GetPods(t *testing.T) {
 	}{
 		{
 			desc:                   "Positive test code path",
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Pods", []string{"string"}, []interface{}{mockPodIface}},
-			onRetMockPodArgs:       &ovntest.TestifyMockHelper{"List", []string{"*context.emptyCtx", "ListOptions"}, []interface{}{&v1.PodList{}, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Pods", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockPodIface}},
+			onRetMockPodArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "List", OnCallMethodArgType: []string{"*context.emptyCtx", "ListOptions"}, RetArgList: []interface{}{&v1.PodList{}, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -673,36 +504,15 @@ func TestKube_GetPods(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockPodArgs != nil {
-				mockPodCall := mockPodIface.On(tc.onRetMockPodArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockPodArgs.OnCallMethodArgType {
-					mockPodCall.Arguments = append(mockPodCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockPodArgs.RetArgList {
-					mockPodCall.ReturnArguments = append(mockPodCall.ReturnArguments, ret)
-				}
-				mockPodCall.Once()
+				ovntest.ProcessMockFn(&mockPodIface.Mock, *tc.onRetMockPodArgs)
 			}
 
 			_, e := k.GetPods("namespace", metav1.LabelSelector{})
@@ -733,9 +543,9 @@ func TestKube_GetNodes(t *testing.T) {
 		{
 			desc:                   "Positive test code path",
 			expectedErr:            false,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Nodes", []string{"string"}, []interface{}{mockNodeIface}},
-			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{"List", []string{"*context.emptyCtx", "v1.ListOptions"}, []interface{}{&v1.NodeList{}, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Nodes", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockNodeIface}},
+			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "List", OnCallMethodArgType: []string{"*context.emptyCtx", "v1.ListOptions"}, RetArgList: []interface{}{&v1.NodeList{}, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -743,36 +553,15 @@ func TestKube_GetNodes(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockNodeArgs != nil {
-				mockEndpointCall := mockNodeIface.On(tc.onRetMockNodeArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockNodeArgs.OnCallMethodArgType {
-					mockEndpointCall.Arguments = append(mockEndpointCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockNodeArgs.RetArgList {
-					mockEndpointCall.ReturnArguments = append(mockEndpointCall.ReturnArguments, elem)
-				}
-				mockEndpointCall.Once()
+				ovntest.ProcessMockFn(&mockNodeIface.Mock, *tc.onRetMockNodeArgs)
 			}
 
 			_, e := k.GetNodes()
@@ -802,9 +591,9 @@ func TestKube_GetNode(t *testing.T) {
 		{
 			desc:                   "Positive test code path",
 			expectedErr:            false,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Nodes", []string{"string"}, []interface{}{mockNodeIface}},
-			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{"Get", []string{"*context.emptyCtx", "string", "v1.GetOptions"}, []interface{}{&v1.Node{}, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Nodes", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockNodeIface}},
+			onRetMockNodeArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Get", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "v1.GetOptions"}, RetArgList: []interface{}{&v1.Node{}, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -812,36 +601,15 @@ func TestKube_GetNode(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockNodeArgs != nil {
-				mockEndpointCall := mockNodeIface.On(tc.onRetMockNodeArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockNodeArgs.OnCallMethodArgType {
-					mockEndpointCall.Arguments = append(mockEndpointCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockNodeArgs.RetArgList {
-					mockEndpointCall.ReturnArguments = append(mockEndpointCall.ReturnArguments, elem)
-				}
-				mockEndpointCall.Once()
+				ovntest.ProcessMockFn(&mockNodeIface.Mock, *tc.onRetMockNodeArgs)
 			}
 
 			_, e := k.GetNode("name")
@@ -871,9 +639,9 @@ func TestKube_GetEgressIP(t *testing.T) {
 		{
 			desc:                   "Positive test code path",
 			expectedErr:            false,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"K8sV1", []string{}, []interface{}{mockK8sIface}},
-			onRetMockK8sArgs:       &ovntest.TestifyMockHelper{"EgressIPs", []string{}, []interface{}{mockEgressIPIface}},
-			onRetMockEgressIPArgs:  &ovntest.TestifyMockHelper{"Get", []string{"*context.emptyCtx", "string", "v1.GetOptions"}, []interface{}{nil, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "K8sV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockK8sIface}},
+			onRetMockK8sArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "EgressIPs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockEgressIPIface}},
+			onRetMockEgressIPArgs:  &ovntest.TestifyMockHelper{OnCallMethodName: "Get", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "v1.GetOptions"}, RetArgList: []interface{}{nil, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -881,36 +649,15 @@ func TestKube_GetEgressIP(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockK8sArgs != nil {
-				mockK8sCall := mockK8sIface.On(tc.onRetMockK8sArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockK8sArgs.OnCallMethodArgType {
-					mockK8sCall.Arguments = append(mockK8sCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockK8sArgs.RetArgList {
-					mockK8sCall.ReturnArguments = append(mockK8sCall.ReturnArguments, elem)
-				}
-				mockK8sCall.Once()
+				ovntest.ProcessMockFn(&mockK8sIface.Mock, *tc.onRetMockK8sArgs)
 			}
 
 			if tc.onRetMockEgressIPArgs != nil {
-				mockEgressIPCall := mockEgressIPIface.On(tc.onRetMockEgressIPArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockEgressIPArgs.OnCallMethodArgType {
-					mockEgressIPCall.Arguments = append(mockEgressIPCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockEgressIPArgs.RetArgList {
-					mockEgressIPCall.ReturnArguments = append(mockEgressIPCall.ReturnArguments, elem)
-				}
-				mockEgressIPCall.Once()
+				ovntest.ProcessMockFn(&mockEgressIPIface.Mock, *tc.onRetMockEgressIPArgs)
 			}
 
 			_, e := k.GetEgressIP("string")
@@ -940,9 +687,9 @@ func TestKube_GetEgressIPs(t *testing.T) {
 		{
 			desc:                   "Positive test code path",
 			expectedErr:            false,
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"K8sV1", []string{}, []interface{}{mockK8sIface}},
-			onRetMockK8sArgs:       &ovntest.TestifyMockHelper{"EgressIPs", []string{}, []interface{}{mockEgressIPIface}},
-			onRetMockEgressIPArgs:  &ovntest.TestifyMockHelper{"List", []string{"*context.emptyCtx", "v1.ListOptions"}, []interface{}{nil, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "K8sV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockK8sIface}},
+			onRetMockK8sArgs:       &ovntest.TestifyMockHelper{OnCallMethodName: "EgressIPs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockEgressIPIface}},
+			onRetMockEgressIPArgs:  &ovntest.TestifyMockHelper{OnCallMethodName: "List", OnCallMethodArgType: []string{"*context.emptyCtx", "v1.ListOptions"}, RetArgList: []interface{}{nil, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -950,36 +697,15 @@ func TestKube_GetEgressIPs(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockK8sArgs != nil {
-				mockK8sCall := mockK8sIface.On(tc.onRetMockK8sArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockK8sArgs.OnCallMethodArgType {
-					mockK8sCall.Arguments = append(mockK8sCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockK8sArgs.RetArgList {
-					mockK8sCall.ReturnArguments = append(mockK8sCall.ReturnArguments, elem)
-				}
-				mockK8sCall.Once()
+				ovntest.ProcessMockFn(&mockK8sIface.Mock, *tc.onRetMockK8sArgs)
 			}
 
 			if tc.onRetMockEgressIPArgs != nil {
-				mockEgressIPCall := mockEgressIPIface.On(tc.onRetMockEgressIPArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockEgressIPArgs.OnCallMethodArgType {
-					mockEgressIPCall.Arguments = append(mockEgressIPCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockEgressIPArgs.RetArgList {
-					mockEgressIPCall.ReturnArguments = append(mockEgressIPCall.ReturnArguments, elem)
-				}
-				mockEgressIPCall.Once()
+				ovntest.ProcessMockFn(&mockEgressIPIface.Mock, *tc.onRetMockEgressIPArgs)
 			}
 
 			_, e := k.GetEgressIPs()
@@ -1006,9 +732,9 @@ func TestKube_GetEndpoint(t *testing.T) {
 	}{
 		{
 			desc:                   "Positive test code path",
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Endpoints", []string{"string"}, []interface{}{mockEndpointIface}},
-			onRetMockEndpointArgs:  &ovntest.TestifyMockHelper{"Get", []string{"*context.emptyCtx", "string", "v1.GetOptions"}, []interface{}{&v1.Endpoints{}, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Endpoints", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockEndpointIface}},
+			onRetMockEndpointArgs:  &ovntest.TestifyMockHelper{OnCallMethodName: "Get", OnCallMethodArgType: []string{"*context.emptyCtx", "string", "v1.GetOptions"}, RetArgList: []interface{}{&v1.Endpoints{}, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -1016,36 +742,15 @@ func TestKube_GetEndpoint(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockEndpointArgs != nil {
-				mockEndpointCall := mockEndpointIface.On(tc.onRetMockEndpointArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockEndpointArgs.OnCallMethodArgType {
-					mockEndpointCall.Arguments = append(mockEndpointCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockEndpointArgs.RetArgList {
-					mockEndpointCall.ReturnArguments = append(mockEndpointCall.ReturnArguments, elem)
-				}
-				mockEndpointCall.Once()
+				ovntest.ProcessMockFn(&mockEndpointIface.Mock, *tc.onRetMockEndpointArgs)
 			}
 
 			_, e := k.GetEndpoint("namespace", "name")
@@ -1072,9 +777,9 @@ func TestKube_CreateEndpoint(t *testing.T) {
 	}{
 		{
 			desc:                   "Positive test code path",
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Endpoints", []string{"string"}, []interface{}{mockEndpointIface}},
-			onRetMockEndpointArgs:  &ovntest.TestifyMockHelper{"Create", []string{"*context.emptyCtx", "*v1.Endpoints", "CreateOptions"}, []interface{}{&v1.Endpoints{}, nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Endpoints", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockEndpointIface}},
+			onRetMockEndpointArgs:  &ovntest.TestifyMockHelper{OnCallMethodName: "Create", OnCallMethodArgType: []string{"*context.emptyCtx", "*v1.Endpoints", "CreateOptions"}, RetArgList: []interface{}{&v1.Endpoints{}, nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -1082,36 +787,15 @@ func TestKube_CreateEndpoint(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			if tc.onRetMockEndpointArgs != nil {
-				mockEndpointCall := mockEndpointIface.On(tc.onRetMockEndpointArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockEndpointArgs.OnCallMethodArgType {
-					mockEndpointCall.Arguments = append(mockEndpointCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockEndpointArgs.RetArgList {
-					mockEndpointCall.ReturnArguments = append(mockEndpointCall.ReturnArguments, elem)
-				}
-				mockEndpointCall.Once()
+				ovntest.ProcessMockFn(&mockEndpointIface.Mock, *tc.onRetMockEndpointArgs)
 			}
 
 			_, e := k.CreateEndpoint("namespace", &v1.Endpoints{})
@@ -1136,8 +820,8 @@ func TestKube_Events(t *testing.T) {
 	}{
 		{
 			desc:                   "Positive test code path",
-			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{"CoreV1", []string{}, []interface{}{mockCoreIface}},
-			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{"Events", []string{"string"}, []interface{}{nil}},
+			onRetMockInterfaceArgs: &ovntest.TestifyMockHelper{OnCallMethodName: "CoreV1", OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCoreIface}},
+			onRetMockCoreArgs:      &ovntest.TestifyMockHelper{OnCallMethodName: "Events", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil}},
 		},
 	}
 	for i, tc := range tests {
@@ -1145,25 +829,11 @@ func TestKube_Events(t *testing.T) {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
 			if tc.onRetMockInterfaceArgs != nil {
-				mockiFaceCall := mockIface.On(tc.onRetMockInterfaceArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockInterfaceArgs.OnCallMethodArgType {
-					mockiFaceCall.Arguments = append(mockiFaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetMockInterfaceArgs.RetArgList {
-					mockiFaceCall.ReturnArguments = append(mockiFaceCall.ReturnArguments, ret)
-				}
-				mockiFaceCall.Once()
+				ovntest.ProcessMockFn(&mockIface.Mock, *tc.onRetMockInterfaceArgs)
 			}
 
 			if tc.onRetMockCoreArgs != nil {
-				mockCoreCall := mockCoreIface.On(tc.onRetMockCoreArgs.OnCallMethodName)
-				for _, arg := range tc.onRetMockCoreArgs.OnCallMethodArgType {
-					mockCoreCall.Arguments = append(mockCoreCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, elem := range tc.onRetMockCoreArgs.RetArgList {
-					mockCoreCall.ReturnArguments = append(mockCoreCall.ReturnArguments, elem)
-				}
-				mockCoreCall.Once()
+				ovntest.ProcessMockFn(&mockCoreIface.Mock, *tc.onRetMockCoreArgs)
 			}
 
 			e := k.Events()

--- a/go-controller/pkg/testing/testifymockhelper.go
+++ b/go-controller/pkg/testing/testifymockhelper.go
@@ -1,7 +1,60 @@
 package testing
 
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+// TestifyMockHelper captures the arguments needed for the `On` , `Return` and 'Times` method ( refer
+// https://godoc.org/github.com/stretchr/testify/mock#Call.On ,
+// https://godoc.org/github.com/stretchr/testify/mock#Call.Return and
+// https://godoc.org/github.com/stretchr/testify/mock#Call.Times )
 type TestifyMockHelper struct {
-	OnCallMethodName    string
+	// OnCallMethodName - mock method that will be called.
+	// Refer the `Method` field at https://godoc.org/github.com/stretchr/testify/mock#Call
+	OnCallMethodName string
+	// OnCallMethodArgType - argument types of the method that will be called.
+	// Refer the `Arguments` field at https://godoc.org/github.com/stretchr/testify/mock#Call
 	OnCallMethodArgType []string
-	RetArgList          []interface{}
+	// RetArgList - arguments returned by mock method when called.
+	// Refer the `ReturnArguments` field at https://godoc.org/github.com/stretchr/testify/mock#Call
+	RetArgList []interface{}
+	// OnCallMethodsArgsStrTypeAppendCount - number of times the `string` type argument is repeated at the end.
+	// NOTE: There are a couple of cases where the ovn related calls take upto 23 string arguments
+	OnCallMethodsArgsStrTypeAppendCount int
+	// CallTimes - number of times to return the return arguments when mock method is called
+	// Refer the `Repeatability` field at https://godoc.org/github.com/stretchr/testify/mock#Call
+	// NOTE: The zero value for an int is 0 in go, however, it the value for 'CallTimes' is not set, we interpret that
+	// it will need to be called once.
+	CallTimes int
+}
+
+// ProcessMockFnList allows for handling mocking of multiple/differnt method calls on a single mock object
+func ProcessMockFnList(mockObj *mock.Mock, mArgs []TestifyMockHelper) {
+	for _, item := range mArgs {
+		ProcessMockFn(mockObj, item)
+	}
+}
+
+// ProcessMockFn handles mocking of a single method call on a single mock object
+func ProcessMockFn(mockObj *mock.Mock, mArgs TestifyMockHelper) {
+	if mockObj == nil {
+		panic("mock object missing")
+	}
+	call := mockObj.On(mArgs.OnCallMethodName)
+	for _, arg := range mArgs.OnCallMethodArgType {
+		call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
+	}
+	// append the repetitive arg types of `string` at the end
+	for i := 0; i < mArgs.OnCallMethodsArgsStrTypeAppendCount; i++ {
+		call.Arguments = append(call.Arguments, mock.AnythingOfType("string"))
+	}
+	for _, ret := range mArgs.RetArgList {
+		call.ReturnArguments = append(call.ReturnArguments, ret)
+	}
+	// set the default to once if no input is provided.
+	if mArgs.CallTimes == 0 {
+		call.Once()
+	} else {
+		call.Times(mArgs.CallTimes)
+	}
 }

--- a/go-controller/pkg/util/go_ovn_test.go
+++ b/go-controller/pkg/util/go_ovn_test.go
@@ -2,13 +2,12 @@ package util
 
 import (
 	"fmt"
+	goovn "github.com/ebay/go-ovn"
 	"testing"
 
-	goovn "github.com/ebay/go-ovn"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	go_ovn_mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/ebay/go-ovn"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestOvnNBLSPDel(t *testing.T) {
@@ -25,38 +24,29 @@ func TestOvnNBLSPDel(t *testing.T) {
 			desc:     "test path when 'nbClient.Execute(cmd)' returns error",
 			errMatch: fmt.Errorf("error while deleting logical port"),
 			goovnMockHelper: []ovntest.TestifyMockHelper{
-				{"LSPDel", []string{"string"}, []interface{}{&goovn.OvnCommand{}, nil}},
-				{"Execute", []string{"*goovn.OvnCommand"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LSPDel", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil}},
+				{OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 		{
 			desc:   "test path when 'err != goovn.ErrorNotFound'",
 			errExp: true,
 			goovnMockHelper: []ovntest.TestifyMockHelper{
-				{"LSPDel", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LSPDel", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
 			desc:   "test path when 'err == goovn.ErrorNotFound'",
 			errExp: false,
 			goovnMockHelper: []ovntest.TestifyMockHelper{
-				{"LSPDel", []string{"string"}, []interface{}{nil, goovn.ErrorNotFound}},
+				{OnCallMethodName: "LSPDel", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, goovn.ErrorNotFound}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFnList(&mockNbClient.Mock, tc.goovnMockHelper)
 
-			for _, item := range tc.goovnMockHelper {
-				call := mockNbClient.On(item.OnCallMethodName)
-				for _, arg := range item.OnCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.RetArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
 			err := OvnNBLSPDel(mockNbClient, inpLogicalPort)
 			t.Log(err)
 			if tc.errExp {

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -12,7 +12,6 @@ import (
 	mock_k8s_io_utils_exec "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestNextIP(t *testing.T) {
@@ -69,68 +68,61 @@ func TestGetPortAddresses(t *testing.T) {
 		inpPort              string
 		errAssert            bool
 		errMatch             error
-		onRetArgsOvnNBClient *onCallReturnArgs
+		onRetArgsOvnNBClient *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                 "test path where LSPGet() returns goovn.ErrorSchema/goovn.ErrorNotFound",
 			inpPort:              "TEST_PORT",
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{nil, goovn.ErrorSchema}},
+			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, goovn.ErrorSchema}},
 		},
 		{
 			desc:                 "test path where LSPGet() returns an error other than goovn.ErrorSchema/goovn.ErrorNotFound",
 			inpPort:              "TEST_PORT",
 			errAssert:            true,
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{nil, goovn.ErrorOption}},
+			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, goovn.ErrorOption}},
 		},
 		{
 			desc:                 "test path where LSPGet() returns nil",
 			inpPort:              "TEST_PORT",
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{nil, nil}},
+			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, nil}},
 		},
 		{
 			desc:                 "test path where lsp.DynamicAddresses is a zero length string and len(addresses)==0",
 			inpPort:              "TEST_PORT",
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: ""}, nil}},
+			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: ""}, nil}},
 		},
 		{
 			desc:                 "test path where lsp.DynamicAddresses is non-zero length string and value of first address in addresses list is set to dynamic",
 			inpPort:              "TEST_PORT",
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: "06:c6:d4:fb:fb:ba 10.244.2.2"}, nil}},
+			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: "06:c6:d4:fb:fb:ba 10.244.2.2"}, nil}},
 		},
 		{
 			desc:                 "test code path where addresses list count is less than 2",
 			inpPort:              "TEST_PORT",
 			errMatch:             fmt.Errorf("error while obtaining addresses for"),
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: "06:c6:d4:fb:fb:ba"}, nil}},
+			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: "06:c6:d4:fb:fb:ba"}, nil}},
 		},
 		{
 			desc:                 "test the code path where ParseMAC fails",
 			inpPort:              "TEST_PORT",
 			errMatch:             fmt.Errorf("failed to parse logical switch port"),
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"192.168.1.3 0a:00:00:00:00:01"}}, nil}},
+			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"192.168.1.3 0a:00:00:00:00:01"}}, nil}},
 		},
 		{
 			desc:                 "test code path where IP address parsing fails",
 			inpPort:              "TEST_PORT",
 			errMatch:             fmt.Errorf("failed to parse logical switch port"),
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"192.168.1.3 0a:00:00:00:00:01"}}, nil}},
+			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"192.168.1.3 0a:00:00:00:00:01"}}, nil}},
 		},
 		{
 			desc:                 "test success path where MAC, IPs are returned",
 			inpPort:              "TEST_PORT",
-			onRetArgsOvnNBClient: &onCallReturnArgs{"LSPGet", []string{"string"}, []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"0a:00:00:00:00:01 192.168.1.3"}}, nil}},
+			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{Addresses: []string{"0a:00:00:00:00:01 192.168.1.3"}}, nil}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockOvnNBClient.On(tc.onRetArgsOvnNBClient.onCallMethodName)
-			for _, arg := range tc.onRetArgsOvnNBClient.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsOvnNBClient.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockOvnNBClient.Mock, *tc.onRetArgsOvnNBClient)
 
 			hwAddr, ipList, err := GetPortAddresses(tc.inpPort, mockOvnNBClient)
 			t.Log(hwAddr.String(), ipList, err)
@@ -156,49 +148,35 @@ func TestGetOVSPortMACAddress(t *testing.T) {
 		desc                    string
 		input                   string
 		errExpected             bool
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		// NOTE: May need a test to validate (e.g; zero length string ) portName parameter that is passed to function
 		{
 			desc:                    "tests code path when RunOVSVsctl returns error",
 			input:                   "TEST_PORT",
 			errExpected:             true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("executable file not found in $PATH")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("executable file not found in $PATH")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "tests code path when MAC address returned is []",
 			input:                   "TEST_PORT",
 			errExpected:             true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("[]")), nil, nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[]")), nil, nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "tests code path when Valid MAC address is returned",
 			input:                   "TEST_PORT",
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("00:00:a9:fe:21:01")), nil, nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("00:00:a9:fe:21:01")), nil, nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
 			res, err := GetOVSPortMACAddress(tc.input)
 			t.Log(res, err)

--- a/go-controller/pkg/util/nicstobridge_test.go
+++ b/go-controller/pkg/util/nicstobridge_test.go
@@ -11,7 +11,6 @@ import (
 
 	mock_k8s_io_utils_exec "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
-	"github.com/stretchr/testify/mock"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -29,19 +28,19 @@ func TestGetNicName(t *testing.T) {
 		errMatch            error
 		outputExp           string
 		inpBrName           string
-		onRetArgsExecIface  []onCallReturnArgs
-		onRetArgsKexecIface []onCallReturnArgs
+		onRetArgsExecIface  []ovntest.TestifyMockHelper
+		onRetArgsKexecIface []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:      "empty string as inputBrName",
 			errMatch:  fmt.Errorf("failed to get list of ports on bridge"),
 			outputExp: "",
 			inpBrName: "",
-			onRetArgsExecIface: []onCallReturnArgs{
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("test error")}},
+			onRetArgsExecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("test error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 		{
@@ -49,13 +48,13 @@ func TestGetNicName(t *testing.T) {
 			errMatch:  fmt.Errorf("failed to get port"),
 			outputExp: "",
 			inpBrName: "testPortName",
-			onRetArgsExecIface: []onCallReturnArgs{
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("port1\nport2")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+			onRetArgsExecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("port1\nport2")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 		{
@@ -63,30 +62,30 @@ func TestGetNicName(t *testing.T) {
 			errMatch:  fmt.Errorf("failed to get Interface"),
 			outputExp: "",
 			inpBrName: "testPortName",
-			onRetArgsExecIface: []onCallReturnArgs{
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+			onRetArgsExecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 		{
 			desc:      "test code path when `ovs-vsctl get Interface ifaceId Type` returns `system`",
 			outputExp: "port1",
 			inpBrName: "testPortName",
-			onRetArgsExecIface: []onCallReturnArgs{
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsExecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 		{
@@ -94,77 +93,58 @@ func TestGetNicName(t *testing.T) {
 			errMatch:  fmt.Errorf("failed to get the bridge-uplink for the bridge"),
 			outputExp: "",
 			inpBrName: "testPortName",
-			onRetArgsExecIface: []onCallReturnArgs{
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("internal")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+			onRetArgsExecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("internal")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 		{
 			desc:      "test code path when input bridge name has prefix `br` and stdout is empty",
 			outputExp: "Name",
 			inpBrName: "brName",
-			onRetArgsExecIface: []onCallReturnArgs{
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("internal")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsExecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("internal")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 		{
 			desc:      "test code path when input bridge name has NO prefix `br`",
 			outputExp: "someoutput",
 			inpBrName: "testName",
-			onRetArgsExecIface: []onCallReturnArgs{
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("internal")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("someoutput")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsExecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("port1")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("internal")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("someoutput")), bytes.NewBuffer([]byte("")), nil}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			for _, item := range tc.onRetArgsExecIface {
-				call := mockExecRunner.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-
-			for _, item := range tc.onRetArgsKexecIface {
-				call := mockKexecIface.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockExecRunner.Mock, tc.onRetArgsExecIface)
+			ovntest.ProcessMockFnList(&mockKexecIface.Mock, tc.onRetArgsKexecIface)
 
 			res, err := GetNicName(tc.inpBrName)
 
@@ -192,16 +172,16 @@ func TestSaveIPAddress(t *testing.T) {
 		inpNewLink               netlink.Link
 		inpAddrs                 []netlink.Addr
 		errExp                   bool
-		onRetArgsNetLinkLibOpers []onCallReturnArgs
-		onRetArgsLinkIfaceOpers  []onCallReturnArgs
+		onRetArgsNetLinkLibOpers []ovntest.TestifyMockHelper
+		onRetArgsLinkIfaceOpers  []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:       "empty address list, LinkSetup(newLink) succeeds",
 			inpOldLink: mockLink,
 			inpNewLink: mockLink,
 			inpAddrs:   []netlink.Addr{},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 			},
 		},
 		{
@@ -210,11 +190,11 @@ func TestSaveIPAddress(t *testing.T) {
 			inpOldLink: mockLink,
 			inpNewLink: mockLink,
 			inpAddrs:   []netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -223,12 +203,12 @@ func TestSaveIPAddress(t *testing.T) {
 			inpOldLink: mockLink,
 			inpNewLink: mockLink,
 			inpAddrs:   []netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -236,40 +216,20 @@ func TestSaveIPAddress(t *testing.T) {
 			inpOldLink: mockLink,
 			inpNewLink: mockLink,
 			inpAddrs:   []netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-
-			for _, item := range tc.onRetArgsNetLinkLibOpers {
-				call := mockNetLinkOps.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-
-			for _, item := range tc.onRetArgsLinkIfaceOpers {
-				call := mockLink.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
+			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 
 			err := saveIPAddress(tc.inpNewLink, tc.inpOldLink, tc.inpAddrs)
 			t.Log(err)
@@ -296,8 +256,8 @@ func TestDelAddRoute(t *testing.T) {
 		inpOldLink               netlink.Link
 		inpNewLink               netlink.Link
 		inpRoute                 netlink.Route
-		onRetArgsNetLinkLibOpers []onCallReturnArgs
-		onRetArgsLinkIfaceOpers  []onCallReturnArgs
+		onRetArgsNetLinkLibOpers []ovntest.TestifyMockHelper
+		onRetArgsLinkIfaceOpers  []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:       "test path where RouteDel() fails",
@@ -305,11 +265,11 @@ func TestDelAddRoute(t *testing.T) {
 			inpOldLink: mockLink,
 			inpNewLink: mockLink,
 			inpRoute:   netlink.Route{Dst: ovntest.MustParseIPNet("192.168.1.0/24")},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -318,13 +278,13 @@ func TestDelAddRoute(t *testing.T) {
 			inpOldLink: mockLink,
 			inpNewLink: mockLink,
 			inpRoute:   netlink.Route{Dst: ovntest.MustParseIPNet("192.168.1.0/24")},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Index: 1}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Index: 1}}},
 			},
 		},
 		{
@@ -332,39 +292,19 @@ func TestDelAddRoute(t *testing.T) {
 			inpOldLink: mockLink,
 			inpNewLink: mockLink,
 			inpRoute:   netlink.Route{Dst: ovntest.MustParseIPNet("192.168.1.0/24")},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Index: 1}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Index: 1}}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-
-			for _, item := range tc.onRetArgsNetLinkLibOpers {
-				call := mockNetLinkOps.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-
-			for _, item := range tc.onRetArgsLinkIfaceOpers {
-				call := mockLink.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
+			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 
 			err := delAddRoute(tc.inpOldLink, tc.inpNewLink, tc.inpRoute)
 			t.Log(err)
@@ -391,8 +331,8 @@ func TestSaveRoute(t *testing.T) {
 		inpOldLink               netlink.Link
 		inpNewLink               netlink.Link
 		inpRoutes                []netlink.Route
-		onRetArgsNetLinkLibOpers []onCallReturnArgs
-		onRetArgsLinkIfaceOpers  []onCallReturnArgs
+		onRetArgsNetLinkLibOpers []ovntest.TestifyMockHelper
+		onRetArgsLinkIfaceOpers  []ovntest.TestifyMockHelper
 	}{
 		{
 			desc: "providing empty routes should return no error",
@@ -406,11 +346,11 @@ func TestSaveRoute(t *testing.T) {
 				{Dst: ovntest.MustParseIPNet("192.168.1.0/24"), Gw: ovntest.MustParseIP("10.10.10.1")},
 				{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -421,11 +361,11 @@ func TestSaveRoute(t *testing.T) {
 			inpRoutes: []netlink.Route{
 				{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -435,39 +375,21 @@ func TestSaveRoute(t *testing.T) {
 			inpRoutes: []netlink.Route{
 				{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 
-			for _, item := range tc.onRetArgsNetLinkLibOpers {
-				call := mockNetLinkOps.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
+			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 
-			for _, item := range tc.onRetArgsLinkIfaceOpers {
-				call := mockLink.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
 			err := saveRoute(tc.inpOldLink, tc.inpNewLink, tc.inpRoutes)
 			t.Log(err)
 			if tc.errExp {
@@ -499,182 +421,139 @@ func TestNicToBridge(t *testing.T) {
 		inpIface                 string
 		outBridge                string
 		errExp                   bool
-		onRetArgsExecUtilsIface  *onCallReturnArgsRepetitive
-		onRetArgsKexecIface      *onCallReturnArgsRepetitive
-		onRetArgsNetLinkLibOpers []onCallReturnArgs
-		onRetArgsLinkIfaceOpers  []onCallReturnArgs
+		onRetArgsExecUtilsIface  *ovntest.TestifyMockHelper
+		onRetArgsKexecIface      *ovntest.TestifyMockHelper
+		onRetArgsNetLinkLibOpers []ovntest.TestifyMockHelper
+		onRetArgsLinkIfaceOpers  []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:     "invalid interface name fails to return a link",
 			inpIface: "",
 			errExp:   true,
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"LinkByName", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
 			desc:                    "RunOVSVsctl fails to create OVS bridge",
 			inpIface:                "eth0",
 			errExp:                  true,
-			onRetArgsExecUtilsIface: &onCallReturnArgsRepetitive{"RunCmd", 31, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("RunOVSVsctl error")}},
-			onRetArgsKexecIface:     &onCallReturnArgsRepetitive{"Command", 32, []string{}, []interface{}{mockCmd}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 31, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("RunOVSVsctl error")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 32, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:                    "IP address retrieval for link fails",
 			inpIface:                "eth0",
 			errExp:                  true,
-			onRetArgsExecUtilsIface: &onCallReturnArgsRepetitive{"RunCmd", 31, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgsRepetitive{"Command", 32, []string{}, []interface{}{mockCmd}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{nil, fmt.Errorf("mock error")}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 31, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 32, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:                    "Route retrieval for link fails",
 			inpIface:                "eth0",
 			errExp:                  true,
-			onRetArgsExecUtilsIface: &onCallReturnArgsRepetitive{"RunCmd", 31, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgsRepetitive{"Command", 32, []string{}, []interface{}{mockCmd}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{nil, fmt.Errorf("mock error")}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 31, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 32, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:                    "Retrieving link by bridge name fails",
 			errExp:                  true,
-			onRetArgsExecUtilsIface: &onCallReturnArgsRepetitive{"RunCmd", 31, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgsRepetitive{"Command", 32, []string{}, []interface{}{mockCmd}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Dst: ovntest.MustParseIPNet("10.168.1.0/24")}}, nil}},
-				{"LinkByName", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 31, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 32, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Dst: ovntest.MustParseIPNet("10.168.1.0/24")}}, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:                    "Saving IP address to bridge fails",
 			errExp:                  true,
-			onRetArgsExecUtilsIface: &onCallReturnArgsRepetitive{"RunCmd", 31, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgsRepetitive{"Command", 32, []string{}, []interface{}{mockCmd}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{}, nil}},
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{}, nil}},
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 31, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 32, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{}, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:                    "Saving routes to bridge fails",
 			errExp:                  true,
-			onRetArgsExecUtilsIface: &onCallReturnArgsRepetitive{"RunCmd", 31, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgsRepetitive{"Command", 32, []string{}, []interface{}{mockCmd}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{}, nil}},
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 31, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 32, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:                    "IP address and Routes of interface to OVS bridge succeeds",
-			onRetArgsExecUtilsIface: &onCallReturnArgsRepetitive{"RunCmd", 31, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgsRepetitive{"Command", 32, []string{}, []interface{}{mockCmd}},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{}, nil}},
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 31, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 32, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			if tc.onRetArgsExecUtilsIface != nil {
-				call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-				for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				// append the repetitive arg types of `string` at the end
-				for i := 0; i < tc.onRetArgsExecUtilsIface.onCallMethodsArgsStrTypeAppendCount; i++ {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType("string"))
-				}
-				for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
+				ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
 			}
-
 			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				// append the repetitive arg types of `string` at the end
-				for i := 0; i < tc.onRetArgsKexecIface.onCallMethodsArgsStrTypeAppendCount; i++ {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType("string"))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.retArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
+				ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 			}
-
-			for _, item := range tc.onRetArgsNetLinkLibOpers {
-				call := mockNetLinkOps.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-
-			for _, item := range tc.onRetArgsLinkIfaceOpers {
-				call := mockLink.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
+			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 
 			res, err := NicToBridge(tc.inpIface)
 			t.Log(res, err)
@@ -710,42 +589,42 @@ func TestBridgeToNic(t *testing.T) {
 		desc                     string
 		inpBridge                string
 		errExp                   bool
-		onRetArgsExecUtilsIface  []onCallReturnArgsRepetitive
-		onRetArgsKexecIface      []onCallReturnArgsRepetitive
-		onRetArgsNetLinkLibOpers []onCallReturnArgs
-		onRetArgsLinkIfaceOpers  []onCallReturnArgs
+		onRetArgsExecUtilsIface  []ovntest.TestifyMockHelper
+		onRetArgsKexecIface      []ovntest.TestifyMockHelper
+		onRetArgsNetLinkLibOpers []ovntest.TestifyMockHelper
+		onRetArgsLinkIfaceOpers  []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:      "invalid bridge name fails to return a link",
 			inpBridge: "brinvalid",
 			errExp:    true,
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
 			desc:      "IP address retrieval for link fails",
 			inpBridge: "breth0",
 			errExp:    true,
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
 			desc:      "Route retrieval for link fails",
 			inpBridge: "breth0",
 			errExp:    true,
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -753,51 +632,48 @@ func TestBridgeToNic(t *testing.T) {
 			inpBridge: "breth0",
 			errExp:    true,
 			// Below two entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below entry is for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below entry is for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{nil, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil, nil}},
 			},
 		},
 		{
 			desc:      "retrieving interface link using nic name fails",
 			inpBridge: "breth0",
 			errExp:    true,
-			// Below two entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-			//onRetArgsExecUtilsIface: &onCallReturnArgsRepetitive{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-			//onRetArgsKexecIface:     &onCallReturnArgsRepetitive{"Command", 5, []string{}, []interface{}{mockCmd}},
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{nil, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -805,34 +681,34 @@ func TestBridgeToNic(t *testing.T) {
 			inpBridge: "breth0",
 			errExp:    true,
 			// Below two entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}}},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{nil, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{nil, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below three rows are to invoke the save ip adddress function
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -840,42 +716,42 @@ func TestBridgeToNic(t *testing.T) {
 			inpBridge: "breth0",
 			errExp:    true,
 			// Below two entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below three row entries are for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path.
 				//The delAddRoute function is indirectly invoked and needs mocking of Attrs() function.
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
@@ -883,445 +759,399 @@ func TestBridgeToNic(t *testing.T) {
 			inpBridge: "breth0",
 			errExp:    true,
 			// Below two entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 				//Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"RunCmd", 3, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 3, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"Command", 4, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below three row entries are for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 				// Below entry is for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path.
 				//The delAddRoute function is indirectly invoked and needs mocking of Attrs() function.
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:      "determining iface type fails",
 			inpBridge: "breth0",
 			errExp:    true,
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"RunCmd", 3, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("9d2bc35689fa975")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 3, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("9d2bc35689fa975")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "type")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"Command", 4, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below rows are for mocking the three RunOVSVsctl executed inside the for loop that processes the interface list returned
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below three row entries are for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path.
 				//The delAddRoute function is indirectly invoked and needs mocking of Attrs() function.
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:      "test code path where the interface type IS NOT patch",
 			inpBridge: "breth0",
 			errExp:    true,
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"RunCmd", 3, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("9d2bc35689fa975")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 3, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("9d2bc35689fa975")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "type")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("internal")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("internal")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"Command", 4, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below rows are for mocking the three RunOVSVsctl executed inside the for loop that processes the interface list returned
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below three row entries are for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path.
 				//The delAddRoute function is indirectly invoked and needs mocking of Attrs() function.
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:      "fails to get peer port for patch interface",
 			inpBridge: "breth0",
 			errExp:    true,
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"RunCmd", 3, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("ovn-3e22f4-0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 3, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("ovn-3e22f4-0")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "type")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("patch")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("patch")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"Command", 4, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below rows are for mocking the three RunOVSVsctl executed inside the for loop that processes the interface list returned
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below three row entries are for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path.
 				//The delAddRoute function is indirectly invoked and needs mocking of Attrs() function.
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:      "failed to delete peer patch port on br-int",
 			inpBridge: "breth0",
 			errExp:    true,
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"RunCmd", 3, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("ovn-3e22f4-0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 3, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("ovn-3e22f4-0")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "type")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("patch")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("patch")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `_, stderr, err = RunOVSVsctl("--if-exists", "del-port", "br-int", peer)` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"Command", 4, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below rows are for mocking the three RunOVSVsctl executed inside the for loop that processes the interface list returned
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `_, stderr, err = RunOVSVsctl("--if-exists", "del-port", "br-int", peer)` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below three row entries are for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path.
 				//The delAddRoute function is indirectly invoked and needs mocking of Attrs() function.
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:      "deleting the bridge fails",
 			inpBridge: "breth0",
 			errExp:    true,
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"RunCmd", 3, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("ovn-3e22f4-0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 3, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("ovn-3e22f4-0")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "type")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("patch")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("patch")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `_, stderr, err = RunOVSVsctl("--if-exists", "del-port", "br-int", peer)` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("mock error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"Command", 4, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below rows are for mocking the three RunOVSVsctl executed inside the for loop that processes the interface list returned
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `_, stderr, err = RunOVSVsctl("--if-exists", "del-port", "br-int", peer)` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below three row entries are for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path.
 				//The delAddRoute function is indirectly invoked and needs mocking of Attrs() function.
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 		{
 			desc:      "delete bridge successfully",
 			inpBridge: "breth0",
-			onRetArgsExecUtilsIface: []onCallReturnArgsRepetitive{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"RunCmd", 4, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("eth0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("[080841d8-4e12-4003-b0ac-36fefd63bae1]")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("system")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"RunCmd", 3, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("ovn-3e22f4-0")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 3, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("ovn-3e22f4-0")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "type")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("patch")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("patch")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `_, stderr, err = RunOVSVsctl("--if-exists", "del-port", "br-int", peer)` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"RunCmd", 5, []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+				{OnCallMethodName: "RunCmd", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgsRepetitive{
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
 				//Below three entries are for mocking the `nicName, err := GetNicName(bridge)` code path
-				{"Command", 5, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 5, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err := RunOVSVsctl("list-ifaces", bridge)` code path
-				{"Command", 4, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 4, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below rows are for mocking the three RunOVSVsctl executed inside the for loop that processes the interface list returned
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("get", "interface", iface, "options:peer")` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `_, stderr, err = RunOVSVsctl("--if-exists", "del-port", "br-int", peer)` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 				// Below row is for mocking the `stdout, stderr, err = RunOVSVsctl("--", "--if-exists", "del-br", bridge)` code path
-				{"Command", 6, []string{}, []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodsArgsStrTypeAppendCount: 6, OnCallMethodArgType: []string{}, RetArgList: []interface{}{mockCmd}},
 			},
-			onRetArgsNetLinkLibOpers: []onCallReturnArgs{
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `bridgeLink, err := netlink.LinkByName(bridge)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below row entry is for mocking the `addrs, err := netlink.AddrList(bridgeLink, syscall.AF_INET)` code path
-				{"AddrList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
+				{OnCallMethodName: "AddrList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Addr{{IPNet: ovntest.MustParseIPNet("192.168.1.15/24")}}, nil}},
 				// Below row entry is for mocking the `routes, err := netlink.RouteList(bridgeLink, syscall.AF_INET)` code path
-				{"RouteList", []string{"*mocks.Link", "int"}, []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
+				{OnCallMethodName: "RouteList", OnCallMethodArgType: []string{"*mocks.Link", "int"}, RetArgList: []interface{}{[]netlink.Route{{Gw: ovntest.MustParseIP("10.10.10.1"), LinkIndex: 1}}, nil}},
 				// Below row entry is for mocking the `ifaceLink, err := netlink.LinkByName(nicName)` code path
-				{"LinkByName", []string{"string"}, []interface{}{mockLink, nil}},
+				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
 				// Below three row entries are for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"AddrDel", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"AddrAdd", []string{"*mocks.Link", "*netlink.Addr"}, []interface{}{nil}},
-				{"LinkSetUp", []string{"*mocks.Link"}, []interface{}{nil}},
+				{OnCallMethodName: "AddrDel", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "AddrAdd", OnCallMethodArgType: []string{"*mocks.Link", "*netlink.Addr"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "LinkSetUp", OnCallMethodArgType: []string{"*mocks.Link"}, RetArgList: []interface{}{nil}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path
-				{"RouteDel", []string{"*netlink.Route"}, []interface{}{nil}},
-				{"RouteAdd", []string{"*netlink.Route"}, []interface{}{nil}},
+				{OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "RouteAdd", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
 			},
-			onRetArgsLinkIfaceOpers: []onCallReturnArgs{
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
 				// Below row entry is for mocking the `if err = saveIPAddress(bridgeLink, ifaceLink, addrs); err != nil` code path
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 				// Below two row entries are for mocking the `if err = saveRoute(bridgeLink, ifaceLink, routes); err != nil` code path.
 				//The delAddRoute function is indirectly invoked and needs mocking of Attrs() function.
-				{"Attrs", []string{}, []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName"}}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			for _, item := range tc.onRetArgsExecUtilsIface {
-				call := mockExecRunner.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				// append the repetitive arg types of `string` at the end
-				for i := 0; i < item.onCallMethodsArgsStrTypeAppendCount; i++ {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType("string"))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-			for _, item := range tc.onRetArgsKexecIface {
-				ifaceCall := mockKexecIface.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				// append the repetitive arg types of `string` at the end
-				for i := 0; i < item.onCallMethodsArgsStrTypeAppendCount; i++ {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType("string"))
-				}
-				for _, ret := range item.retArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
-			}
-
-			for _, item := range tc.onRetArgsNetLinkLibOpers {
-				call := mockNetLinkOps.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
-
-			for _, item := range tc.onRetArgsLinkIfaceOpers {
-				call := mockLink.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range item.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
-			}
+			ovntest.ProcessMockFnList(&mockExecRunner.Mock, tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFnList(&mockKexecIface.Mock, tc.onRetArgsKexecIface)
+			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
+			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 
 			err := BridgeToNic(tc.inpBridge)
 			t.Log(err)

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -188,22 +188,22 @@ func TestSetL3GatewayConfig(t *testing.T) {
 		inpNodeAnnotator       kube.Annotator
 		inputL3GwCfg           L3GatewayConfig
 		errExpected            bool
-		onRetArgsAnnotatorList []onCallReturnArgs
+		onRetArgsAnnotatorList []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:             "success: empty L3GatewayConfig applied should pass",
 			inpNodeAnnotator: mockAnnotator,
 			inputL3GwCfg:     L3GatewayConfig{},
-			onRetArgsAnnotatorList: []onCallReturnArgs{
-				{"Set", []string{"string", "interface{}"}, []interface{}{nil}},
+			onRetArgsAnnotatorList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Set", OnCallMethodArgType: []string{"string", "interface{}"}, RetArgList: []interface{}{nil}},
 			},
 		},
 		{
 			desc:             "test error path when setting gateway annotation",
 			inpNodeAnnotator: mockAnnotator,
 			inputL3GwCfg:     L3GatewayConfig{},
-			onRetArgsAnnotatorList: []onCallReturnArgs{
-				{"Set", []string{"string", "interface{}"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsAnnotatorList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Set", OnCallMethodArgType: []string{"string", "interface{}"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 		{
@@ -212,9 +212,9 @@ func TestSetL3GatewayConfig(t *testing.T) {
 			inputL3GwCfg: L3GatewayConfig{
 				ChassisID: " ",
 			},
-			onRetArgsAnnotatorList: []onCallReturnArgs{
-				{"Set", []string{"string", "interface{}"}, []interface{}{nil}},
-				{"Set", []string{"string", "interface{}"}, []interface{}{nil}},
+			onRetArgsAnnotatorList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Set", OnCallMethodArgType: []string{"string", "interface{}"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "Set", OnCallMethodArgType: []string{"string", "interface{}"}, RetArgList: []interface{}{nil}},
 			},
 		},
 		{
@@ -223,21 +223,21 @@ func TestSetL3GatewayConfig(t *testing.T) {
 			inputL3GwCfg: L3GatewayConfig{
 				ChassisID: "testid",
 			},
-			onRetArgsAnnotatorList: []onCallReturnArgs{
-				{"Set", []string{"string", "interface{}"}, []interface{}{nil}},
-				{"Set", []string{"string", "interface{}"}, []interface{}{fmt.Errorf("mock error")}},
+			onRetArgsAnnotatorList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Set", OnCallMethodArgType: []string{"string", "interface{}"}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "Set", OnCallMethodArgType: []string{"string", "interface{}"}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
 			},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			for _, item := range tc.onRetArgsAnnotatorList {
-				call := mockAnnotator.On(item.onCallMethodName)
-				for range item.onCallMethodArgType {
+				call := mockAnnotator.On(item.OnCallMethodName)
+				for range item.OnCallMethodArgType {
 					call.Arguments = append(call.Arguments, mock.Anything)
 				}
 
-				for _, e := range item.retArgList {
+				for _, e := range item.RetArgList {
 					call.ReturnArguments = append(call.ReturnArguments, e)
 				}
 				call.Once()

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -13,22 +13,8 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	kexec "k8s.io/utils/exec"
 )
-
-type onCallReturnArgsRepetitive struct {
-	onCallMethodName                    string
-	onCallMethodsArgsStrTypeAppendCount int
-	onCallMethodArgType                 []string
-	retArgList                          []interface{}
-}
-
-type onCallReturnArgs struct {
-	onCallMethodName    string
-	onCallMethodArgType []string
-	retArgList          []interface{}
-}
 
 func TestRunningPlatform(t *testing.T) {
 	// Below is defined in ovs.go file
@@ -109,52 +95,38 @@ func TestRunOVNretry(t *testing.T) {
 		inpCmdPath              string
 		inpEnvVars              []string
 		errMatch                error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "test path when runWithEnvVars returns no error",
 			inpCmdPath:              runner.ovnctlPath,
 			inpEnvVars:              []string{},
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{nil, nil, nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{nil, nil, nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "test path when runWithEnvVars returns  \"Connection refused\" error",
 			inpCmdPath:              runner.ovnctlPath,
 			inpEnvVars:              []string{},
 			errMatch:                fmt.Errorf("connection refused"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{nil, bytes.NewBuffer([]byte("Connection refused")), fmt.Errorf("connection refused")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{nil, bytes.NewBuffer([]byte("Connection refused")), fmt.Errorf("connection refused")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "test path when runWithEnvVars returns an error OTHER THAN \"Connection refused\" ",
 			inpCmdPath:              runner.ovnctlPath,
 			inpEnvVars:              []string{},
 			errMatch:                fmt.Errorf("OVN command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{nil, nil, fmt.Errorf("mock error")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("mock error")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := runOVNretry(tc.inpCmdPath, tc.inpEnvVars)
 
 			if tc.errMatch != nil {
@@ -428,8 +400,8 @@ func TestRunOVNNorthAppCtl(t *testing.T) {
 		inpVarArgs              string
 		errMatch                error
 		dirFileMocks            []ovntest.AferoDirMockHelper
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:     "test path when ReadFile returns error",
@@ -446,32 +418,17 @@ func TestRunOVNNorthAppCtl(t *testing.T) {
 					},
 				},
 			},
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			if tc.onRetArgsExecUtilsIface != nil {
-				call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-				for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
+				ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
 			}
-
 			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.retArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
+				ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 			}
 
 			if len(tc.dirFileMocks) > 0 {
@@ -516,8 +473,8 @@ func TestRunOVNControllerAppCtl(t *testing.T) {
 		inpVarArgs              string
 		errMatch                error
 		dirFileMocks            []ovntest.AferoDirMockHelper
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:     "test path when ReadFile returns error",
@@ -534,32 +491,17 @@ func TestRunOVNControllerAppCtl(t *testing.T) {
 					},
 				},
 			},
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			if tc.onRetArgsExecUtilsIface != nil {
-				call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-				for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
+				ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
 			}
-
 			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.retArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
+				ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 			}
 
 			if len(tc.dirFileMocks) > 0 {
@@ -602,8 +544,8 @@ func TestRunOvsVswitchdAppCtl(t *testing.T) {
 		inpVarArgs              string
 		errMatch                error
 		dirFileMocks            []ovntest.AferoDirMockHelper
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:     "test path when ReadFile returns error",
@@ -620,32 +562,17 @@ func TestRunOvsVswitchdAppCtl(t *testing.T) {
 					},
 				},
 			},
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			if tc.onRetArgsExecUtilsIface != nil {
-				call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-				for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-					call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-					call.ReturnArguments = append(call.ReturnArguments, ret)
-				}
-				call.Once()
+				ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
 			}
-
 			if tc.onRetArgsKexecIface != nil {
-				ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-				for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-					ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-				}
-				for _, ret := range tc.onRetArgsKexecIface.retArgList {
-					ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-				}
-				ifaceCall.Once()
+				ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 			}
 
 			if len(tc.dirFileMocks) > 0 {
@@ -685,7 +612,7 @@ func TestDefaultExecRunner_RunCmd(t *testing.T) {
 		cmdPath          string
 		cmdArg           string
 		envVars          []string
-		onRetArgsCmdList []onCallReturnArgs
+		onRetArgsCmdList []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:        "negative: set cmd parameter to be nil",
@@ -697,21 +624,21 @@ func TestDefaultExecRunner_RunCmd(t *testing.T) {
 			expectedErr: nil,
 			cmd:         mockCmd,
 			envVars:     []string{"OVN_NB_DAEMON=/some/blah/path"},
-			onRetArgsCmdList: []onCallReturnArgs{
-				{"Run", []string{}, []interface{}{nil}},
-				{"SetStdout", []string{"*bytes.Buffer"}, nil},
-				{"SetStderr", []string{"*bytes.Buffer"}, nil},
-				{"SetEnv", []string{"[]string"}, nil},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetEnv", OnCallMethodArgType: []string{"[]string"}, RetArgList: nil},
 			},
 		},
 		{
 			desc:        "cmd.Run returns error test",
 			expectedErr: fmt.Errorf("mock error"),
 			cmd:         mockCmd,
-			onRetArgsCmdList: []onCallReturnArgs{
-				{"Run", []string{}, []interface{}{fmt.Errorf("mock error")}},
-				{"SetStdout", []string{"*bytes.Buffer"}, nil},
-				{"SetStderr", []string{"*bytes.Buffer"}, nil},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{fmt.Errorf("mock error")}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
 			},
 		},
 	}
@@ -719,17 +646,7 @@ func TestDefaultExecRunner_RunCmd(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
 			if tc.cmd != nil {
-				for _, item := range tc.onRetArgsCmdList {
-					cmdCall := tc.cmd.(*mock_k8s_io_utils_exec.Cmd).On(item.onCallMethodName)
-					for _, arg := range item.onCallMethodArgType {
-						cmdCall.Arguments = append(cmdCall.Arguments, mock.AnythingOfType(arg))
-					}
-
-					for _, e := range item.retArgList {
-						cmdCall.ReturnArguments = append(cmdCall.ReturnArguments, e)
-					}
-					cmdCall.Once()
-				}
+				ovntest.ProcessMockFnList(&tc.cmd.(*mock_k8s_io_utils_exec.Cmd).Mock, tc.onRetArgsCmdList)
 			}
 			_, _, e := runCmdExecRunner.RunCmd(tc.cmd, tc.cmdPath, tc.envVars, tc.cmdArg)
 
@@ -744,36 +661,26 @@ func TestSetExec(t *testing.T) {
 	tests := []struct {
 		desc         string
 		expectedErr  error
-		onRetArgs    *onCallReturnArgs
-		fnCallTimes  int
+		onRetArgs    *ovntest.TestifyMockHelper
 		setRunnerNil bool
 	}{
 		{
 			desc:         "positive, test when 'runner' is nil",
 			expectedErr:  nil,
-			onRetArgs:    &onCallReturnArgs{"LookPath", []string{"string"}, []interface{}{"ip", nil, "arping", nil}},
-			fnCallTimes:  11,
+			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil, "arping", nil}, CallTimes: 11},
 			setRunnerNil: true,
 		},
 		{
 			desc:         "positive, test when 'runner' is not nil",
 			expectedErr:  nil,
-			onRetArgs:    &onCallReturnArgs{"LookPath", []string{"string"}, []interface{}{"", nil, "", nil}},
-			fnCallTimes:  11,
+			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", nil, "", nil}, CallTimes: 11},
 			setRunnerNil: false,
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockKexecIface.On(tc.onRetArgs.onCallMethodName)
-			for _, arg := range tc.onRetArgs.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, elem := range tc.onRetArgs.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, elem)
-			}
-			call.Times(tc.fnCallTimes)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgs)
 			if tc.setRunnerNil == false {
 				// note runner is defined in ovs.go file
 				runner = &execHelper{exec: mockKexecIface}
@@ -790,33 +697,27 @@ func TestSetExecWithoutOVS(t *testing.T) {
 	tests := []struct {
 		desc        string
 		expectedErr error
-		onRetArgs   *onCallReturnArgs
+		onRetArgs   *ovntest.TestifyMockHelper
 		fnCallTimes int
 	}{
 		{
 			desc:        "positive, ip and arping path found",
 			expectedErr: nil,
 			fnCallTimes: 2,
-			onRetArgs:   &onCallReturnArgs{"LookPath", []string{"string"}, []interface{}{"ip", nil, "arping", nil}},
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil, "arping", nil}, CallTimes: 2},
 		},
 		{
 			desc:        "negative, ip path not found",
 			expectedErr: fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`),
 			fnCallTimes: 1,
-			onRetArgs:   &onCallReturnArgs{"LookPath", []string{"string"}, []interface{}{"", fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`), "arping", nil}},
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`), "arping", nil}},
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockKexecIface.On(tc.onRetArgs.onCallMethodName)
-			for _, arg := range tc.onRetArgs.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, elem := range tc.onRetArgs.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, elem)
-			}
-			call.Times(tc.fnCallTimes)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgs)
+
 			e := SetExecWithoutOVS(mockKexecIface)
 			assert.Equal(t, e, tc.expectedErr)
 			mockKexecIface.AssertExpectations(t)
@@ -830,42 +731,33 @@ func TestSetSpecificExec(t *testing.T) {
 		desc        string
 		expectedErr error
 		fnArg       string
-		onRetArgs   *onCallReturnArgs
-		fnCallTimes int
+		onRetArgs   *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:        "positive: ovs-vsctl path found",
 			expectedErr: nil,
 			fnArg:       "ovs-vsctl",
-			onRetArgs:   &onCallReturnArgs{"LookPath", []string{"string"}, []interface{}{"ovs-vsctl", nil}},
-			fnCallTimes: 1,
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ovs-vsctl", nil}},
 		},
 		{
 			desc:        "negative: ovs-vsctl path not found",
 			expectedErr: fmt.Errorf(`exec: \"ovs-vsctl:\" executable file not found in $PATH`),
 			fnArg:       "ovs-vsctl",
-			onRetArgs:   &onCallReturnArgs{"LookPath", []string{"string"}, []interface{}{"", fmt.Errorf(`exec: \"ovs-vsctl:\" executable file not found in $PATH`)}},
-			fnCallTimes: 1,
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf(`exec: \"ovs-vsctl:\" executable file not found in $PATH`)}},
 		},
 		{
 			desc:        "negative: unknown command",
 			expectedErr: fmt.Errorf(`unknown command: "ovs-appctl"`),
 			fnArg:       "ovs-appctl",
-			onRetArgs:   &onCallReturnArgs{"LookPath", []string{"string"}, []interface{}{"ovs-appctl", nil}},
-			fnCallTimes: 0,
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockKexecIface.On(tc.onRetArgs.onCallMethodName)
-			for _, arg := range tc.onRetArgs.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
+			if tc.onRetArgs != nil {
+				ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgs)
 			}
-			for _, elem := range tc.onRetArgs.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, elem)
-			}
-			call.Times(tc.fnCallTimes)
+
 			e := SetSpecificExec(mockKexecIface, tc.fnArg)
 			assert.Equal(t, e, tc.expectedErr)
 			mockKexecIface.AssertExpectations(t)
@@ -881,17 +773,17 @@ func TestRunCmd(t *testing.T) {
 		expectedErr      error
 		cmdPath          string
 		cmdArg           string
-		onRetArgsCmdList []onCallReturnArgs
+		onRetArgsCmdList []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:        "positive: run `ip addr` command",
 			expectedErr: nil,
 			cmdPath:     "ip",
 			cmdArg:      "a",
-			onRetArgsCmdList: []onCallReturnArgs{
-				{"Run", []string{}, []interface{}{nil}},
-				{"SetStdout", []string{"*bytes.Buffer"}, nil},
-				{"SetStderr", []string{"*bytes.Buffer"}, nil},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
 			},
 		},
 		{
@@ -899,28 +791,18 @@ func TestRunCmd(t *testing.T) {
 			expectedErr: fmt.Errorf("executable file not found in $PATH"),
 			cmdPath:     "ips",
 			cmdArg:      "addr",
-			onRetArgsCmdList: []onCallReturnArgs{
-				{"Run", []string{}, []interface{}{fmt.Errorf("executable file not found in $PATH")}},
-				{"SetStdout", []string{"*bytes.Buffer"}, nil},
-				{"SetStderr", []string{"*bytes.Buffer"}, nil},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{fmt.Errorf("executable file not found in $PATH")}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
 			},
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFnList(&mockCmd.Mock, tc.onRetArgsCmdList)
 
-			for _, item := range tc.onRetArgsCmdList {
-				cmdCall := mockCmd.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					cmdCall.Arguments = append(cmdCall.Arguments, mock.AnythingOfType(arg))
-				}
-
-				for _, e := range item.retArgList {
-					cmdCall.ReturnArguments = append(cmdCall.ReturnArguments, e)
-				}
-				cmdCall.Once()
-			}
 			_, _, e := runCmd(mockCmd, tc.cmdPath, tc.cmdArg)
 
 			assert.Equal(t, e, tc.expectedErr)
@@ -940,19 +822,19 @@ func TestRun(t *testing.T) {
 		expectedErr      error
 		cmdPath          string
 		cmdArg           string
-		onRetArgsIface   *onCallReturnArgs
-		onRetArgsCmdList []onCallReturnArgs
+		onRetArgsIface   *ovntest.TestifyMockHelper
+		onRetArgsCmdList []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:           "negative: run `ip addr` command",
 			expectedErr:    fmt.Errorf("executable file not found in $PATH"),
 			cmdPath:        "ips",
 			cmdArg:         "addr",
-			onRetArgsIface: &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList: []onCallReturnArgs{
-				{"Run", []string{}, []interface{}{fmt.Errorf("executable file not found in $PATH")}},
-				{"SetStdout", []string{"*bytes.Buffer"}, nil},
-				{"SetStderr", []string{"*bytes.Buffer"}, nil},
+			onRetArgsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{fmt.Errorf("executable file not found in $PATH")}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
 			},
 		},
 		{
@@ -960,38 +842,40 @@ func TestRun(t *testing.T) {
 			expectedErr:    nil,
 			cmdPath:        "ip",
 			cmdArg:         "a",
-			onRetArgsIface: &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList: []onCallReturnArgs{
-				{"Run", []string{}, []interface{}{nil}},
-				{"SetStdout", []string{"*bytes.Buffer"}, nil},
-				{"SetStderr", []string{"*bytes.Buffer"}, nil},
+			onRetArgsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
 			},
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFnList(&mockCmd.Mock, tc.onRetArgsCmdList)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsIface)
 
-			for _, item := range tc.onRetArgsCmdList {
-				cmdCall := mockCmd.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
+			/*for _, item := range tc.onRetArgsCmdList {
+				cmdCall := mockCmd.On(item.OnCallMethodName)
+				for _, arg := range item.OnCallMethodArgType {
 					cmdCall.Arguments = append(cmdCall.Arguments, mock.AnythingOfType(arg))
 				}
 
-				for _, e := range item.retArgList {
+				for _, e := range item.RetArgList {
 					cmdCall.ReturnArguments = append(cmdCall.ReturnArguments, e)
 				}
 				cmdCall.Once()
 			}
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsIface.onCallMethodName, mock.Anything)
-			for _, arg := range tc.onRetArgsIface.onCallMethodArgType {
+			ifaceCall := mockKexecIface.On(tc.onRetArgsIface.OnCallMethodName, mock.Anything)
+			for _, arg := range tc.onRetArgsIface.OnCallMethodArgType {
 				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
 			}
-			for _, item := range tc.onRetArgsIface.retArgList {
+			for _, item := range tc.onRetArgsIface.RetArgList {
 				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, item)
 			}
-			ifaceCall.Once()
+			ifaceCall.Once()*/
 
 			_, _, e := run(tc.cmdPath, tc.cmdArg)
 
@@ -1014,8 +898,8 @@ func TestRunWithEnvVars(t *testing.T) {
 		cmdPath          string
 		cmdArg           string
 		envArgs          []string
-		onRetArgsIface   *onCallReturnArgs
-		onRetArgsCmdList []onCallReturnArgs
+		onRetArgsIface   *ovntest.TestifyMockHelper
+		onRetArgsCmdList []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:           "positive: run `ip addr` command with empty envVars",
@@ -1023,11 +907,11 @@ func TestRunWithEnvVars(t *testing.T) {
 			cmdPath:        "ip",
 			cmdArg:         "a",
 			envArgs:        []string{},
-			onRetArgsIface: &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList: []onCallReturnArgs{
-				{"Run", []string{}, []interface{}{nil}},
-				{"SetStdout", []string{"*bytes.Buffer"}, nil},
-				{"SetStderr", []string{"*bytes.Buffer"}, nil},
+			onRetArgsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
 			},
 		},
 		{
@@ -1036,12 +920,12 @@ func TestRunWithEnvVars(t *testing.T) {
 			cmdPath:        "ip",
 			cmdArg:         "a",
 			envArgs:        []string{"OVN_NB_DAEMON=/some/blah/path"},
-			onRetArgsIface: &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList: []onCallReturnArgs{
-				{"Run", []string{}, []interface{}{nil}},
-				{"SetStdout", []string{"*bytes.Buffer"}, nil},
-				{"SetStderr", []string{"*bytes.Buffer"}, nil},
-				{"SetEnv", []string{"[]string"}, nil},
+			onRetArgsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetEnv", OnCallMethodArgType: []string{"[]string"}, RetArgList: nil},
 			},
 		},
 		{
@@ -1050,38 +934,19 @@ func TestRunWithEnvVars(t *testing.T) {
 			cmdPath:        "ips",
 			cmdArg:         "addr",
 			envArgs:        nil,
-			onRetArgsIface: &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList: []onCallReturnArgs{
-				{"Run", []string{}, []interface{}{fmt.Errorf("executable file not found in $PATH")}},
-				{"SetStdout", []string{"*bytes.Buffer"}, nil},
-				{"SetStderr", []string{"*bytes.Buffer"}, nil},
+			onRetArgsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Run", OnCallMethodArgType: []string{}, RetArgList: []interface{}{fmt.Errorf("executable file not found in $PATH")}},
+				{OnCallMethodName: "SetStdout", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
+				{OnCallMethodName: "SetStderr", OnCallMethodArgType: []string{"*bytes.Buffer"}, RetArgList: nil},
 			},
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-
-			for _, item := range tc.onRetArgsCmdList {
-				cmdCall := mockCmd.On(item.onCallMethodName)
-				for _, arg := range item.onCallMethodArgType {
-					cmdCall.Arguments = append(cmdCall.Arguments, mock.AnythingOfType(arg))
-				}
-
-				for _, e := range item.retArgList {
-					cmdCall.ReturnArguments = append(cmdCall.ReturnArguments, e)
-				}
-				cmdCall.Once()
-			}
-
-			ifaceCall := mockKexecIface.On(tc.onRetArgsIface.onCallMethodName, mock.Anything)
-			for _, arg := range tc.onRetArgsIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, item := range tc.onRetArgsIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, item)
-			}
-			ifaceCall.Once()
+			ovntest.ProcessMockFnList(&mockCmd.Mock, tc.onRetArgsCmdList)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsIface)
 
 			_, _, e := runWithEnvVars(tc.cmdPath, tc.envArgs, tc.cmdArg)
 
@@ -1103,41 +968,27 @@ func TestRunOVSOfctl(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovs-ofctl` command",
 			expectedErr:             fmt.Errorf("executable file not found in $PATH"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{nil, nil, fmt.Errorf("executable file not found in $PATH")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("executable file not found in $PATH")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovs-ofctl` ",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVSOfctl()
 
 			assert.Equal(t, e, tc.expectedErr)
@@ -1158,41 +1009,27 @@ func TestRunOVSDpctl(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovs-dpctl` command",
 			expectedErr:             fmt.Errorf("failed to execute ovs-dpctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-dpctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-dpctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovs-dpctl` ",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVSDpctl()
 
 			assert.Equal(t, e, tc.expectedErr)
@@ -1213,41 +1050,27 @@ func TestRunOVSVsctl(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovs-vsctl` command",
 			expectedErr:             fmt.Errorf("failed to execute ovs-vsctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-vsctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-vsctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovs-vsctl` ",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVSVsctl()
 
 			assert.Equal(t, e, tc.expectedErr)
@@ -1269,43 +1092,28 @@ func TestRunOVSAppctlWithTimeout(t *testing.T) {
 		desc                    string
 		expectedErr             error
 		timeout                 int
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovs-appctl` command with timeout",
 			expectedErr:             fmt.Errorf("failed to execute ovs-appctl command"),
 			timeout:                 5,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-appctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-appctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovs-appctl` command with timeout",
 			expectedErr:             nil,
 			timeout:                 5,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
 			_, _, e := RunOVSAppctlWithTimeout(tc.timeout)
 
@@ -1327,41 +1135,26 @@ func TestRunOVSAppctl(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovs-appctl` command",
 			expectedErr:             fmt.Errorf("failed to execute ovs-appctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-appctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-appctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovs-appctl` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
 			_, _, e := RunOVSAppctl()
 
@@ -1384,43 +1177,29 @@ func TestRunOVNAppctlWithTimeout(t *testing.T) {
 		desc                    string
 		expectedErr             error
 		timeout                 int
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-appctl` command with timeout",
 			expectedErr:             fmt.Errorf("failed to execute ovn-appctl command"),
 			timeout:                 5,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-appctl` command with timeout",
 			expectedErr:             nil,
 			timeout:                 15,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVNAppctlWithTimeout(tc.timeout)
 
 			assert.Equal(t, e, tc.expectedErr)
@@ -1441,41 +1220,27 @@ func TestRunOVNNbctlUnix(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-nbctl` command with no env vars generated",
 			expectedErr:             fmt.Errorf("failed to execute ovn-nbctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-nbctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-nbctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-nbctl` command with no env vars generated",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVNNbctlUnix()
 
 			if tc.expectedErr != nil {
@@ -1499,43 +1264,29 @@ func TestRunOVNNbctlWithTimeout(t *testing.T) {
 		desc                    string
 		expectedErr             error
 		timeout                 int
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-nbctl` command with timeout",
 			expectedErr:             fmt.Errorf("failed to execute ovn-nbctl command"),
 			timeout:                 5,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-nbctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-nbctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-nbctl` command with timeout",
 			expectedErr:             nil,
 			timeout:                 15,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVNNbctlWithTimeout(tc.timeout)
 
 			if tc.expectedErr != nil {
@@ -1558,40 +1309,27 @@ func TestRunOVNNbctl(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-nbctl` command",
 			expectedErr:             fmt.Errorf("failed to execute ovn-nbctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-nbctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-nbctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-nbctl` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+
 			_, _, e := RunOVNNbctl()
 
 			if tc.expectedErr != nil {
@@ -1614,40 +1352,27 @@ func TestRunOVNSbctlUnix(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-sbctl` command with no env vars generated",
 			expectedErr:             fmt.Errorf("failed to execute ovn-sbctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-sbctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-sbctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-sbctl` command with no env vars generated",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+
 			_, _, e := RunOVNSbctlUnix()
 
 			if tc.expectedErr != nil {
@@ -1671,43 +1396,29 @@ func TestRunOVNSbctlWithTimeout(t *testing.T) {
 		desc                    string
 		expectedErr             error
 		timeout                 int
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-sbctl` command with timeout",
 			expectedErr:             fmt.Errorf("failed to execute ovn-sbctl command"),
 			timeout:                 5,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-sbctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-sbctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-sbctl` command with timeout",
 			expectedErr:             nil,
 			timeout:                 15,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVNSbctlWithTimeout(tc.timeout)
 
 			if tc.expectedErr != nil {
@@ -1730,41 +1441,27 @@ func TestRunOVNSbctl(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-sbctl` command",
 			expectedErr:             fmt.Errorf("failed to execute ovn-sbctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-sbctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-sbctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-sbctl` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVNSbctl()
 
 			if tc.expectedErr != nil {
@@ -1787,41 +1484,27 @@ func TestRunOVSDBClient(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovsdb-client` command",
 			expectedErr:             fmt.Errorf("failed to execute ovsdb-client command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovsdb-client command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovsdb-client command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovsdb-client` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVSDBClient()
 
 			if tc.expectedErr != nil {
@@ -1844,41 +1527,27 @@ func TestRunOVSDBTool(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovsdb-tool` command",
 			expectedErr:             fmt.Errorf("failed to execute ovsdb-tool command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovsdb-tool command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovsdb-tool command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovsdb-tool` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVSDBTool()
 
 			if tc.expectedErr != nil {
@@ -1901,41 +1570,27 @@ func TestRunOVSDBClientOVNNB(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovsdb-client` command against OVN NB database",
 			expectedErr:             fmt.Errorf("failed to execute ovsdb-client command against OVN NB database"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovsdb-client command against OVN NB database")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovsdb-client command against OVN NB database")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovsdb-client` command against OVN NB database",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVSDBClientOVNNB("list-dbs")
 
 			if tc.expectedErr != nil {
@@ -1958,41 +1613,27 @@ func TestRunOVNCtl(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-ctl` command",
 			expectedErr:             fmt.Errorf("failed to execute ovn-ctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-ctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-ctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-ctl` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVNCtl()
 
 			if tc.expectedErr != nil {
@@ -2015,41 +1656,27 @@ func TestRunOVNNBAppCtl(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-appctl -t nbdbCtlSockPath` command",
 			expectedErr:             fmt.Errorf("failed to execute ovn-appctl -t nbdbCtlSockPath command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl -t nbdbCtlSockPath command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl -t nbdbCtlSockPath command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-appctl -t nbdbCtlSockPath` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVNNBAppCtl()
 
 			if tc.expectedErr != nil {
@@ -2072,41 +1699,27 @@ func TestRunOVNSBAppCtl(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovn-appctl -t sbdbCtlSockPath` command",
 			expectedErr:             fmt.Errorf("failed to execute ovn-appctl -t sbdbCtlSockPath command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl -t sbdbCtlSockPath command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovn-appctl -t sbdbCtlSockPath command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovn-appctl -t sbdbCtlSockPath` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunOVNSBAppCtl()
 
 			if tc.expectedErr != nil {
@@ -2129,35 +1742,21 @@ func TestRunIP(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "positive: run IP ",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
 			_, _, e := RunIP()
 
 			assert.Equal(t, e, tc.expectedErr)
@@ -2178,53 +1777,30 @@ func TestAddOFFlowWithSpecificAction(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
-		onRetArgsCmdList        *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
+		onRetArgsCmdList        *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovs-ofctl` command",
 			expectedErr:             fmt.Errorf("failed to execute ovs-ofctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-ofctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:        &onCallReturnArgs{"SetStdin", []string{"*bytes.Buffer"}, nil},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-ofctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:        &ovntest.TestifyMockHelper{OnCallMethodName: "SetStdin", OnCallMethodArgType: []string{"*bytes.Buffer"}},
 		},
 		{
 			desc:                    "positive: run `ovs-ofctl` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), fmt.Errorf("executable file not found in $PATH")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:        &onCallReturnArgs{"SetStdin", []string{"*bytes.Buffer"}, nil},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), fmt.Errorf("executable file not found in $PATH")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:        &ovntest.TestifyMockHelper{OnCallMethodName: "SetStdin", OnCallMethodArgType: []string{"*bytes.Buffer"}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
-
-			mockCall := mockCmd.On(tc.onRetArgsCmdList.onCallMethodName)
-			for _, arg := range tc.onRetArgsCmdList.onCallMethodArgType {
-				mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsCmdList.retArgList {
-				mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-			}
-			mockCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+			ovntest.ProcessMockFn(&mockCmd.Mock, *tc.onRetArgsCmdList)
 
 			_, _, e := AddOFFlowWithSpecificAction("somename", "someaction")
 
@@ -2248,53 +1824,30 @@ func TestReplaceOFFlows(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             error
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
-		onRetArgsCmdList        *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
+		onRetArgsCmdList        *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: run `ovs-ofctl` command",
 			expectedErr:             fmt.Errorf("failed to execute ovs-ofctl command"),
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-ofctl command")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:        &onCallReturnArgs{"SetStdin", []string{"*bytes.Buffer"}, nil},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("failed to execute ovs-ofctl command")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:        &ovntest.TestifyMockHelper{OnCallMethodName: "SetStdin", OnCallMethodArgType: []string{"*bytes.Buffer"}},
 		},
 		{
 			desc:                    "positive: run `ovs-ofctl` command",
 			expectedErr:             nil,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-			onRetArgsCmdList:        &onCallReturnArgs{"SetStdin", []string{"*bytes.Buffer"}, nil},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("testblah")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			onRetArgsCmdList:        &ovntest.TestifyMockHelper{OnCallMethodName: "SetStdin", OnCallMethodArgType: []string{"*bytes.Buffer"}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
-
-			mockCall := mockCmd.On(tc.onRetArgsCmdList.onCallMethodName)
-			for _, arg := range tc.onRetArgsCmdList.onCallMethodArgType {
-				mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsCmdList.retArgList {
-				mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
-			}
-			mockCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
+			ovntest.ProcessMockFn(&mockCmd.Mock, *tc.onRetArgsCmdList)
 
 			_, _, e := ReplaceOFFlows("somename", []string{})
 
@@ -2318,53 +1871,38 @@ func TestGetOVNDBServerInfo(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             bool
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: executable not found",
 			expectedErr:             true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("executable file not found in $PATH")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("executable file not found in $PATH")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "negative: malformed json output",
 			expectedErr:             true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte(`["rows":[{"connected":true,"index":["set",[]],"leader":true}]}]`)), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte(`["rows":[{"connected":true,"index":["set",[]],"leader":true}]}]`)), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "negative: zero rows returned",
 			expectedErr:             true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte(`[{"rows":[]}]`)), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte(`[{"rows":[]}]`)), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "positive: run `ovsdb-client` command successfully",
 			expectedErr:             false,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte(`[{"rows":[{"connected":true,"index":["set",[]],"leader":true}]}]`)), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte(`[{"rows":[{"connected":true,"index":["set",[]],"leader":true}]}]`)), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
 			_, e := GetOVNDBServerInfo(15, "nb", "OVN_Northbound")
 
@@ -2389,79 +1927,64 @@ func TestDetectSCTPSupport(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		expectedErr             bool
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "negative: fails to query OVN NB DB for SCTP support",
 			expectedErr:             true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{nil, nil, fmt.Errorf("fails to query OVN NB DB")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{nil, nil, fmt.Errorf("fails to query OVN NB DB")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:        "negative: json unmarshal error",
 			expectedErr: true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{
-				"RunCmd",
-				[]string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string"},
-				[]interface{}{ // below three rows are stdout, stderr and error respectively returned by runWithEnvVars method
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{
+				OnCallMethodName:    "RunCmd",
+				OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string"},
+				RetArgList: []interface{}{ // below three rows are stdout, stderr and error respectively returned by runWithEnvVars method
 					bytes.NewBuffer([]byte(`"data":"headings":["Column","Type"]}`)), //stdout value: mocks malformed json returned
 					bytes.NewBuffer([]byte("")),
 					nil,
 				},
 			},
-			onRetArgsKexecIface: &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:        "positive: SCTP present in protocol list",
 			expectedErr: false,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{
-				"RunCmd",
-				[]string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string"},
-				[]interface{}{ // below three rows are stdout, stderr and error respectively returned by runWithEnvVars method
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{
+				OnCallMethodName:    "RunCmd",
+				OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string"},
+				RetArgList: []interface{}{ // below three rows are stdout, stderr and error respectively returned by runWithEnvVars method
 					// below is snippet of valid stdout returned and is truncated for unit testing and readability
 					bytes.NewBuffer([]byte(`{"data":[["protocol",{"key":{"enum":["set",["sctp","tcp","udp"]],"type":"string"},"min":0}]],"headings":["Column","Type"]}`)),
 					bytes.NewBuffer([]byte("")),
 					nil,
 				},
 			},
-			onRetArgsKexecIface: &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:        "negative: SCTP not present in protocol list",
 			expectedErr: false,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{
-				"RunCmd",
-				[]string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string"},
-				[]interface{}{ // below three rows are stdout, stderr and error respectively returned by runWithEnvVars method
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{
+				OnCallMethodName:    "RunCmd",
+				OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string"},
+				RetArgList: []interface{}{ // below three rows are stdout, stderr and error respectively returned by runWithEnvVars method
 					// below is snippet of valid stdout returned and is truncated for unit testing and readability
 					bytes.NewBuffer([]byte(`{"data":[["protocol",{"key":{"enum":["set",["tcp","udp"]],"type":"string"},"min":0}]],"headings":["Column","Type"]}`)),
 					bytes.NewBuffer([]byte("")),
 					nil,
 				},
 			},
-			onRetArgsKexecIface: &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
 			_, e := DetectSCTPSupport()
 

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"net"
 	"testing"
 
 	mock_k8s_io_utils_exec "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/utils/exec"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestGetLegacyK8sMgmtIntfName(t *testing.T) {
@@ -52,55 +52,39 @@ func TestGetNodeChassisID(t *testing.T) {
 	tests := []struct {
 		desc                    string
 		errExpected             bool
-		onRetArgsExecUtilsIface *onCallReturnArgs
-		onRetArgsKexecIface     *onCallReturnArgs
+		onRetArgsExecUtilsIface *ovntest.TestifyMockHelper
+		onRetArgsKexecIface     *ovntest.TestifyMockHelper
 	}{
 		{
 			desc:                    "ovs-vsctl command returns error",
 			errExpected:             true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("test error")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("test error")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "ovs-vsctl command returns empty chassisID along with error",
 			errExpected:             true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("test error")}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("test error")}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "ovs-vsctl command returns empty chassisID with NO error",
 			errExpected:             true,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 		{
 			desc:                    "ovs-vsctl command returns valid chassisID",
 			errExpected:             false,
-			onRetArgsExecUtilsIface: &onCallReturnArgs{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("4e98c281-f12b-4601-ab5a-a3d759fcb493")), bytes.NewBuffer([]byte("")), nil}},
-			onRetArgsKexecIface:     &onCallReturnArgs{"Command", []string{"string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsExecUtilsIface: &ovntest.TestifyMockHelper{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("4e98c281-f12b-4601-ab5a-a3d759fcb493")), bytes.NewBuffer([]byte("")), nil}},
+			onRetArgsKexecIface:     &ovntest.TestifyMockHelper{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-
-			call := mockExecRunner.On(tc.onRetArgsExecUtilsIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsExecUtilsIface.onCallMethodArgType {
-				call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsExecUtilsIface.retArgList {
-				call.ReturnArguments = append(call.ReturnArguments, ret)
-			}
-			call.Once()
-
-			ifaceCall := mockKexecIface.On(tc.onRetArgsKexecIface.onCallMethodName)
-			for _, arg := range tc.onRetArgsKexecIface.onCallMethodArgType {
-				ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-			}
-			for _, ret := range tc.onRetArgsKexecIface.retArgList {
-				ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
-			}
-			ifaceCall.Once()
+			ovntest.ProcessMockFn(&mockExecRunner.Mock, *tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFn(&mockKexecIface.Mock, *tc.onRetArgsKexecIface)
 
 			ret, e := GetNodeChassisID()
 			if tc.errExpected {
@@ -129,19 +113,19 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 		inpSubnetStr            string
 		errExpected             bool
 		setCfgHybridOvlyEnabled bool
-		onRetArgsExecUtilsIface []onCallReturnArgs
-		onRetArgsKexecIface     []onCallReturnArgs
+		onRetArgsExecUtilsIface []ovntest.TestifyMockHelper
+		onRetArgsKexecIface     []ovntest.TestifyMockHelper
 	}{
 		{
 			desc:         "IPv4 CIDR, ovn-nbctl fails to list logical switch ports",
 			errExpected:  true,
 			inpNodeName:  "ovn-control-plane",
 			inpSubnetStr: "192.168.1.0/24",
-			onRetArgsExecUtilsIface: []onCallReturnArgs{
-				{"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("RunOVNNbctl error")}},
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("RunOVNNbctl error")}},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 		{
@@ -156,11 +140,11 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			inpNodeName:             "ovn-control-plane",
 			inpSubnetStr:            "192.168.1.0/24",
 			setCfgHybridOvlyEnabled: true,
-			onRetArgsExecUtilsIface: []onCallReturnArgs{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				{
-					"RunCmd",
-					[]string{"*mocks.Cmd", "string", "[]string", "string", "string", "string"},
-					[]interface{}{
+					OnCallMethodName:    "RunCmd",
+					OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string"},
+					RetArgList: []interface{}{
 						// below is output from command --> ovn-nbctl lsp-list ovn-control-plane
 						bytes.NewBuffer([]byte("7dc3d98a-660a-477b-a6bc-d42904ed59e7 (k8s-ovn-control-plane)\nd23162b4-87b1-4ff8-b5a5-5cb731d822ed (kube-system_coredns-6955765f44-l9jxq)\n1e8cd861-c584-4e38-8c50-7a71a6ae26bb (local-path-storage_local-path-provisioner-85445b74d4-w5ghw)\n8f1b3173-aa43-4014-adcb-36eae52f7502 (stor-ovn-control-plane)")),
 						bytes.NewBuffer([]byte("")),
@@ -168,12 +152,12 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 					},
 				},
 				{
-					"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil},
+					OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil},
 				},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 		{
@@ -182,11 +166,11 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			inpNodeName:             "ovn-control-plane",
 			inpSubnetStr:            "192.168.1.0/24",
 			setCfgHybridOvlyEnabled: true,
-			onRetArgsExecUtilsIface: []onCallReturnArgs{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				{
-					"RunCmd",
-					[]string{"*mocks.Cmd", "string", "[]string", "string", "string", "string"},
-					[]interface{}{
+					OnCallMethodName:    "RunCmd",
+					OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string"},
+					RetArgList: []interface{}{
 						// below is output from command --> ovn-nbctl lsp-list ovn-control-plane
 						bytes.NewBuffer([]byte("7dc3d98a-660a-477b-a6bc-d42904ed59e7 (int-ovn-control-plane)\nd23162b4-87b1-4ff8-b5a5-5cb731d822ed (kube-system_coredns-6955765f44-l9jxq)\n1e8cd861-c584-4e38-8c50-7a71a6ae26bb (local-path-storage_local-path-provisioner-85445b74d4-w5ghw)\n8f1b3173-aa43-4014-adcb-36eae52f7502 (stor-ovn-control-plane)")),
 						bytes.NewBuffer([]byte("")),
@@ -194,12 +178,12 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 					},
 				},
 				{
-					"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil},
+					OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), nil},
 				},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 		{
@@ -207,11 +191,11 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			errExpected:  false,
 			inpNodeName:  "ovn-control-plane",
 			inpSubnetStr: "192.168.1.0/24",
-			onRetArgsExecUtilsIface: []onCallReturnArgs{
+			onRetArgsExecUtilsIface: []ovntest.TestifyMockHelper{
 				{
-					"RunCmd",
-					[]string{"*mocks.Cmd", "string", "[]string", "string", "string", "string"},
-					[]interface{}{
+					OnCallMethodName:    "RunCmd",
+					OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string"},
+					RetArgList: []interface{}{
 						// below is output from command --> ovn-nbctl lsp-list ovn-control-plane
 						bytes.NewBuffer([]byte("d23162b4-87b1-4ff8-b5a5-5cb731d822ed (kube-system_coredns-6955765f44-l9jxq)\n1e8cd861-c584-4e38-8c50-7a71a6ae26bb (local-path-storage_local-path-provisioner-85445b74d4-w5ghw)\n8f1b3173-aa43-4014-adcb-36eae52f7502 (stor-ovn-control-plane)")),
 						bytes.NewBuffer([]byte("")),
@@ -219,43 +203,20 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 					},
 				},
 				{
-					"RunCmd", []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("test error")},
+					OnCallMethodName: "RunCmd", OnCallMethodArgType: []string{"*mocks.Cmd", "string", "[]string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{bytes.NewBuffer([]byte("")), bytes.NewBuffer([]byte("")), fmt.Errorf("test error")},
 				},
 			},
-			onRetArgsKexecIface: []onCallReturnArgs{
-				{"Command", []string{"string", "string", "string", "string"}, []interface{}{mockCmd}},
-				{"Command", []string{"string", "string", "string", "string", "string", "string", "string", "string"}, []interface{}{mockCmd}},
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
 			},
 		},
 	}
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			if tc.onRetArgsExecUtilsIface != nil {
-				for _, item := range tc.onRetArgsExecUtilsIface {
-					call := mockExecRunner.On(item.onCallMethodName)
-					for _, arg := range item.onCallMethodArgType {
-						call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-					}
-					for _, elem := range item.retArgList {
-						call.ReturnArguments = append(call.ReturnArguments, elem)
-					}
-					call.Once()
-				}
-			}
-
-			if tc.onRetArgsKexecIface != nil {
-				for _, item := range tc.onRetArgsKexecIface {
-					ifaceCall := mockKexecIface.On(item.onCallMethodName)
-					for _, arg := range item.onCallMethodArgType {
-						ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
-					}
-					for _, elem := range item.retArgList {
-						ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, elem)
-					}
-					ifaceCall.Once()
-				}
-			}
+			ovntest.ProcessMockFnList(&mockExecRunner.Mock, tc.onRetArgsExecUtilsIface)
+			ovntest.ProcessMockFnList(&mockKexecIface.Mock, tc.onRetArgsKexecIface)
 
 			_, ipnet, err := net.ParseCIDR(tc.inpSubnetStr)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Vishwanath Jayaraman <vjayaram@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR consolidates the mock setup code (repeated in multiple unit tests) run as part of unit test into its own separate struct/function for re-usability/maintainability in the pkg/testing/testifymockhelper.go file. 
 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
- There were multiple structs defined (https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/util/ovs_unit_test.go#L20-L25 https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/util/ovs_unit_test.go#L27-L31 and https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/testing/testifymockhelper.go#L3-L7) across files for modelling the mocks that would have been confusing and unmaintainable. This definition is now in one single place at pkg/testing/testifymockhelper.go
- The unit test code that was processing the mock object was repeated for multiple mock object across unit test functions & files have now been consolidated into a single function in the pkg/testing/testifymockhelper.go file.
- The 'keys' for the TestifyMockHelper struct field in the unit test functions are called out explicitly( had to do this as some of the additionally defined fields are optional and would cause compile error if the keys are not defined)
- Any other fine tuning or optimizations will be evaluated/considered in a different PR by opening github issues (to track those suggestions.)


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->