### PR TITLE
fix network policy when the namespace label changes

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -853,6 +853,15 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 				np.podHandlerList = append(np.podHandlerList, podHandler)
 			},
 			DeleteFunc: func(obj interface{}) {
+				// when the namespace labels no longer apply
+				// remove the namespaces pods from the address_set
+				namespace := obj.(*kapi.Namespace)
+				pods, _ := oc.watchFactory.GetPods(namespace.Name)
+
+				for _, pod := range pods {
+					oc.handlePeerPodSelectorDelete(gp, pod)
+				}
+
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 			},


### PR DESCRIPTION
Currently when using a namespaceSelector and podSelector in the same network
policy when changing the labels of the namespace nothing happens.
Correct the operation so that when updating the label removes a
namespace from a network policy the pods are correctly removed.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1752220

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->