### PR TITLE
Fixes ICMPv6 flooding behavior

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -552,14 +552,17 @@ func newLocalGatewayOpenflowManager(nodeName, macAddress, gwBridge, gwIntf strin
 
 	if config.IPv6Mode {
 		// REMOVEME(trozet) when https://bugzilla.kernel.org/show_bug.cgi?id=11797 is resolved
-		// must flood icmpv6 traffic as it fails to create a CT entry
-		_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
-			fmt.Sprintf("cookie=%s, priority=1, table=1,icmp6 actions=FLOOD", defaultOpenFlowCookie))
-		if err != nil {
-			return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
-				"error: %v", gwBridge, stderr, err)
+		// must flood icmpv6 Route Advertisement and Neighbor Advertisement traffic as it fails to create a CT entry
+		for _, icmpType := range []int{types.RouteAdvertisementICMPType, types.NeighborAdvertisementICMPType} {
+			_, stderr, err = util.RunOVSOfctl("add-flow", gwBridge,
+				fmt.Sprintf("cookie=%s, priority=14, table=1,icmp6,icmpv6_type=%d actions=FLOOD",
+					defaultOpenFlowCookie, icmpType))
+			if err != nil {
+				return nil, fmt.Errorf("failed to add openflow flow to %s, stderr: %q, "+
+					"error: %v", gwBridge, stderr, err)
+			}
+			nFlows++
 		}
-		nFlows++
 	}
 
 	// table 1, we check to see if this dest mac is the shared mac, if so send to host

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -53,4 +53,8 @@ const (
 
 	V4JoinSubnetCIDR = "100.64.0.0/16"
 	V6JoinSubnetCIDR = "fd98::/64"
+
+	// OpenFlow and Networking constants
+	RouteAdvertisementICMPType    = 134
+	NeighborAdvertisementICMPType = 136
 )


### PR DESCRIPTION
Our flows for flooding icmpv6 to both OVN and the host were too generic.
This caused ICMPv6 echo requests to be sent to both, resulting in a
duplicate ack and other issues. This patch changes the flows for icmpv6
to be more specific and target only flooding for Neighbor Advertisements
and Route Advertisements. This will allow OVN to receive only the
packets it needs for peering/discovery, while all other ICMPv6 will go to
the host only.

Signed-off-by: Tim Rozet <trozet@redhat.com>

**- How to verify it**
1. deploy kind (./kind.sh -wk 1 -n4 -i6)
2. docker run --network kind --privileged -it centos /bin/bash
3. In docker container ping -6 <node ipv6 ip> verify no dup replies
4. Add ip6 VIP address to one of the nodes breth0 interfaces
5. Ping the VIP from docker container  and ensure a single response