### PR TITLE
egressIP defaulting to true causes the wrong behavior.

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -95,9 +95,7 @@ var (
 	}
 
 	// OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
-	OVNKubernetesFeature = OVNKubernetesFeatureConfig{
-		EnableEgressIP: true,
-	}
+	OVNKubernetesFeature OVNKubernetesFeatureConfig
 
 	// OvnNorth holds northbound OVN database client and server authentication and location details
 	OvnNorth OvnAuthConfig

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -224,6 +224,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
+		config.OVNKubernetesFeature.EnableEgressIP = true
 
 		fakeClient = &fake.Clientset{}
 		egressFirewallFakeClient = &egressfirewallfake.Clientset{}

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -136,6 +136,7 @@ var _ = Describe("OVN master EgressIP Operations", func() {
 	BeforeEach(func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
+		config.OVNKubernetesFeature.EnableEgressIP = true
 
 		app = cli.NewApp()
 		app.Name = "test"


### PR DESCRIPTION
since the egressIP cli is depended on the existance of the flag if you
default to true egressIP will always been enabled because in the
absence of the `--enable-egress-ip` flag the value will default to true
and when the flag is present it correctly reads as true.

Remove the defaulting true on EnableEgressIP so that egressIP is disabled in the
absense of the `--enable-egress-ip` flag

fixes: https://github.com/ovn-org/ovn-kubernetes/issues/1848

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->