### PR TITLE
Add address family checks to the external gateway feature

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -293,7 +293,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 		if config.Gateway.Mode != config.GatewayModeLocal {
 			stdout, stderr, err = util.RunOVNNbctl("--may-exist",
 				"--policy=src-ip", "lr-route-add", types.OVNClusterRouter,
-				hostSubnet.String(), gwLRPIP.String())
+				hostSubnet.String(), gwLRPIP[0].String())
 			if err != nil {
 				return fmt.Errorf("failed to add source IP address based "+
 					"routes in distributed router %s, stdout: %q, "+
@@ -321,7 +321,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 			// if the external ip has changed, but the logical ip has stayed the same
 			stdout, stderr, err := util.RunOVNNbctl("--if-exists", "lr-nat-del",
 				gatewayRouter, "snat", entry.String(), "--", "lr-nat-add",
-				gatewayRouter, "snat", externalIP.String(), entry.String())
+				gatewayRouter, "snat", externalIP[0].String(), entry.String())
 			if err != nil {
 				return fmt.Errorf("failed to create default SNAT rules for gateway router %s, "+
 					"stdout: %q, stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -214,11 +214,15 @@ func IPFamilyName(isIPv6 bool) string {
 
 // MatchIPFamily loops through the array of net.IP and returns the
 // first entry in the list in the same IP Family, based on input flag isIPv6.
-func MatchIPFamily(isIPv6 bool, ips []net.IP) (net.IP, error) {
+func MatchIPFamily(isIPv6 bool, ips []net.IP) ([]net.IP, error) {
+	var ipAddrs []net.IP
 	for _, ip := range ips {
 		if utilnet.IsIPv6(ip) == isIPv6 {
-			return ip, nil
+			ipAddrs = append(ipAddrs, ip)
 		}
+	}
+	if len(ipAddrs) > 0 {
+		return ipAddrs, nil
 	}
 	return nil, fmt.Errorf("no %s IP available", IPFamilyName(isIPv6))
 }

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -282,7 +282,7 @@ func TestMatchIPFamily(t *testing.T) {
 			if tc.expected == "" {
 				assert.Error(t, err)
 			} else {
-				assert.Equal(t, res, ovntest.MustParseIP(tc.expected))
+				assert.Equal(t, res[0], ovntest.MustParseIP(tc.expected))
 			}
 		})
 	}


### PR DESCRIPTION
- this commit adds adress family checks to addGWRoutesForPod(.)
  to avoid a condition where mismatched address families could
  be provided and result in an ovn-nbctl error

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>

**- What this PR does and why is it needed**

Add address family checks to the external gateway feature

**- How to verify it**

Verify by creating a v4 pod in a namespace with an external gateway of v6
and check the ovnkube-master logs for the error thrown

**- Special notes for reviewers**

I will followup in separate PRs for the delete method and another with e2e cases added
