### PR TITLE
Fixes parsing quotes on OVS iface ID

### DIFF
--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -62,7 +62,8 @@ func ovsGet(table, record, column, key string) (string, error) {
 	} else {
 		args = append(args, column)
 	}
-	return ovsExec(args...)
+	output, err := ovsExec(args...)
+	return strings.Trim(strings.TrimSpace(string(output)), "\""), err
 }
 
 // Returns the given column of records that match the condition

--- a/go-controller/pkg/cni/ovs_test.go
+++ b/go-controller/pkg/cni/ovs_test.go
@@ -75,4 +75,16 @@ d9af11aa-37c3-4ea9-8ba3-a74843cc0f47
 		Expect(uuids[0]).To(Equal(`""`))
 		Expect(uuids[1]).To(Equal(`""`))
 	})
+
+	It("returns unquoted value if the elements themselves are quoted from ovsGet", func() {
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd: "ovs-vsctl --timeout=30 --if-exists get Interface blah external-ids:iface-id",
+			Output: `"1234"
+`,
+		})
+
+		ifaceID, err := ovsGet("Interface", "blah", "external-ids", "iface-id")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ifaceID).To(Equal(`1234`))
+	})
 })


### PR DESCRIPTION
Sometimes OVS decides to put quotes around external ids:
https://bugzilla.redhat.com/show_bug.cgi?id=1899746

Signed-off-by: Tim Rozet <trozet@redhat.com>
