### PR TITLE
metrics: Add metrics for total and available subnets for nodes

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -83,6 +83,34 @@ var MetricMasterLeader = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help:      "Identifies whether the instance of ovnkube-master is a leader(1) or not(0).",
 })
 
+var metricV4HostSubnetCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "num_v4_host_subnets",
+	Help:      "The total number of v4 host subnets possible",
+})
+
+var metricV6HostSubnetCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "num_v6_host_subnets",
+	Help:      "The total number of v6 host subnets possible",
+})
+
+var metricV4AllocatedHostSubnetCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "allocated_v4_host_subnets",
+	Help:      "The total number of v4 host subnets currently allocated",
+})
+
+var metricV6AllocatedHostSubnetCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "allocated_v6_host_subnets",
+	Help:      "The total number of v6 host subnets currently allocated",
+})
+
 var registerMasterMetricsOnce sync.Once
 var startE2ETimeStampUpdaterOnce sync.Once
 
@@ -148,6 +176,10 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 			},
 			func() float64 { return 1 },
 		))
+		prometheus.MustRegister(metricV4HostSubnetCount)
+		prometheus.MustRegister(metricV6HostSubnetCount)
+		prometheus.MustRegister(metricV4AllocatedHostSubnetCount)
+		prometheus.MustRegister(metricV6AllocatedHostSubnetCount)
 	})
 }
 
@@ -203,4 +235,17 @@ func RecordPodCreated(pod *kapi.Pod) {
 		metricPodCreationLatency.Observe(creationLatency)
 		return
 	}
+}
+
+// RecordSubnetUsage records the number of subnets allocated for nodes
+func RecordSubnetUsage(v4SubnetsAllocated, v6SubnetsAllocated float64) {
+	metricV4AllocatedHostSubnetCount.Set(v4SubnetsAllocated)
+	metricV6AllocatedHostSubnetCount.Set(v6SubnetsAllocated)
+}
+
+// RecordSubnetCount records the number of available subnets per configuration
+// for ovn-kubernetes
+func RecordSubnetCount(v4SubnetCount, v6SubnetCount float64) {
+	metricV4HostSubnetCount.Set(v4SubnetCount)
+	metricV6HostSubnetCount.Set(v6SubnetCount)
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -251,11 +251,14 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		return err
 	}
 
+	var v4HostSubnetCount, v6HostSubnetCount float64
+
 	for _, clusterEntry := range config.Default.ClusterSubnets {
 		err := oc.masterSubnetAllocator.AddNetworkRange(clusterEntry.CIDR, clusterEntry.HostSubnetLength)
 		if err != nil {
 			return err
 		}
+		util.CalculateHostSubnetsForClusterEntry(clusterEntry, &v4HostSubnetCount, &v6HostSubnetCount)
 	}
 	for _, node := range existingNodes.Items {
 		hostSubnets, _ := util.ParseNodeHostSubnetAnnotation(&node)
@@ -264,6 +267,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 			if err != nil {
 				utilruntime.HandleError(err)
 			}
+			util.UpdateUsedHostSubnetsCount(hostSubnet, &oc.v4HostSubnetsUsed, &oc.v6HostSubnetsUsed, true)
 		}
 		nodeLocalNatIPs, _ := util.ParseNodeLocalNatIPAnnotation(&node)
 		for _, nodeLocalNatIP := range nodeLocalNatIPs {
@@ -278,6 +282,10 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 			}
 		}
 	}
+
+	// update metrics for host subnets
+	metrics.RecordSubnetCount(v4HostSubnetCount, v6HostSubnetCount)
+	metrics.RecordSubnetUsage(oc.v4HostSubnetsUsed, oc.v6HostSubnetsUsed)
 
 	if _, _, err := util.RunOVNNbctl("--columns=_uuid", "list", "port_group"); err != nil {
 		klog.Fatal("OVN version too old; does not support port groups")
@@ -812,6 +820,14 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 		return nil, err
 	}
 
+	// If node annotation succeeds, update the used subnet count
+	for _, hostSubnet := range hostSubnets {
+		util.UpdateUsedHostSubnetsCount(hostSubnet,
+			&oc.v4HostSubnetsUsed,
+			&oc.v6HostSubnetsUsed, true)
+	}
+	metrics.RecordSubnetUsage(oc.v4HostSubnetsUsed, oc.v6HostSubnetsUsed)
+
 	return hostSubnets, nil
 }
 
@@ -846,8 +862,13 @@ func (oc *Controller) deleteNode(nodeName string, hostSubnets []*net.IPNet,
 	for _, hostSubnet := range hostSubnets {
 		if err := oc.deleteNodeHostSubnet(nodeName, hostSubnet); err != nil {
 			klog.Errorf("Error deleting node %s HostSubnet %v: %v", nodeName, hostSubnet, err)
+		} else {
+			util.UpdateUsedHostSubnetsCount(hostSubnet, &oc.v4HostSubnetsUsed, &oc.v6HostSubnetsUsed, false)
 		}
 	}
+	// update metrics
+	metrics.RecordSubnetUsage(oc.v4HostSubnetsUsed, oc.v6HostSubnetsUsed)
+
 	for _, nodeLocalNatIP := range nodeLocalNatIPs {
 		var err error
 		if utilnet.IsIPv6(nodeLocalNatIP) {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -188,6 +188,12 @@ type Controller struct {
 
 	// go-ovn southbound client interface
 	ovnSBClient goovn.Client
+
+	// v4HostSubnetsUsed keeps track of number of v4 subnets currently assigned to nodes
+	v4HostSubnetsUsed float64
+
+	// v6HostSubnetsUsed keeps track of number of v6 subnets currently assigned to nodes
+	v6HostSubnetsUsed float64
 }
 
 const (

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -139,3 +139,37 @@ func IsAnnotationNotSetError(err error) bool {
 	_, ok := err.(annotationNotSetError)
 	return ok
 }
+
+// CalculateHostSubnetsForClusterEntry calculates the host subnets
+// available in a CIDR entry
+func CalculateHostSubnetsForClusterEntry(cidrEntry config.CIDRNetworkEntry,
+	v4HostSubnetCount, v6HostSubnetCount *float64) {
+	prefixLength, _ := cidrEntry.CIDR.Mask.Size()
+	var one uint64 = 1
+	if prefixLength > cidrEntry.HostSubnetLength {
+		klog.Warningf("Invalid cidr entry: %+v found while calculating subnet count",
+			cidrEntry)
+		return
+	}
+	if !utilnet.IsIPv6CIDR(cidrEntry.CIDR) {
+		*v4HostSubnetCount = *v4HostSubnetCount + float64(one<<(cidrEntry.HostSubnetLength-prefixLength))
+	} else {
+		*v6HostSubnetCount = *v6HostSubnetCount + float64(one<<(cidrEntry.HostSubnetLength-prefixLength))
+
+	}
+}
+
+// UpdateUsedHostSubnetsCount increments the v4/v6 host subnets count based on
+// the subnet being visited
+func UpdateUsedHostSubnetsCount(subnet *net.IPNet,
+	v4SubnetsAllocated, v6SubnetsAllocated *float64, isAdd bool) {
+	op := -1
+	if isAdd {
+		op = 1
+	}
+	if !utilnet.IsIPv6CIDR(subnet) {
+		*v4SubnetsAllocated = *v4SubnetsAllocated + float64(1*op)
+	} else {
+		*v6SubnetsAllocated = *v6SubnetsAllocated + float64(1*op)
+	}
+}


### PR DESCRIPTION
This commit adds support for collecting metrics related to subnet
allocation for the node. In particular, metrics for total number
of v4 and v6 subnets allowed in the cluster and metrics for
number of v4 subnets and v6 subnets allocated to nodes are collected.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>