### PR TITLE
Add support to the CNI CHECK command

### DIFF
--- a/go-controller/pkg/cni/bandwidth_test.go
+++ b/go-controller/pkg/cni/bandwidth_test.go
@@ -2,6 +2,7 @@ package cni
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/mock"
 	"testing"
 
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -238,6 +239,222 @@ func TestSetPodBandwidth(t *testing.T) {
 				assert.Nil(t, e)
 			}
 
+			mockCmd.AssertExpectations(t)
+			mockKexecIface.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetPodBandwidth(t *testing.T) {
+	mockKexecIface := new(mock_k8s_io_utils_exec.Interface)
+	mockCmd := new(mock_k8s_io_utils_exec.Cmd)
+
+	tests := []struct {
+		desc                string
+		expectedErr         bool
+		onRetArgsKexecIface []ovntest.TestifyMockHelper
+		onRetArgsCmdList    []ovntest.TestifyMockHelper
+		runnerInstance      kexec.Interface
+		egressBPS           int64
+		igressBPS           int64
+	}{
+		{
+			desc: "Positive test code path when ingressBPS and egressBPS are correctly set",
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("10000"), nil}},
+			},
+			runnerInstance: mockKexecIface,
+			igressBPS:      10000000,
+			egressBPS:      10000000,
+		},
+		{
+			desc: "Positive test code path when ingressBPS and egressBPS are not set",
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("0"), nil}},
+			},
+			runnerInstance: mockKexecIface,
+			igressBPS:      -1,
+			egressBPS:      0,
+		},
+		{
+			desc: "Positive test code path when ingressBPS is not set (no port) and egressBPS is set",
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("10000"), nil}},
+			},
+			runnerInstance: mockKexecIface,
+			igressBPS:      -1,
+			egressBPS:      10000000,
+		},
+		{
+			desc: "Positive test code path when ingressBPS is not set (no max-rate) and egressBPS is set",
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("10000"), nil}},
+			},
+			runnerInstance: mockKexecIface,
+			igressBPS:      -1,
+			egressBPS:      10000000,
+		},
+		{
+			desc: "Positive test code path when ingressBPS is set but egressBPS isn't",
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, nil}},
+			},
+			runnerInstance: mockKexecIface,
+			igressBPS:      10000000,
+			egressBPS:      -1,
+		},
+		{
+			desc:        "Negative test code path when ovsGet 'port' returns error",
+			expectedErr: true,
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
+			},
+			runnerInstance: mockKexecIface,
+		},
+		{
+			desc:        "Negative test code path when ovsGet 'qos' returns error",
+			expectedErr: true,
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
+			},
+			runnerInstance: mockKexecIface,
+		},
+		{
+			desc:        "Negative test code path when max-rate value cannot be transfer to integer",
+			expectedErr: true,
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("test"), nil}},
+			},
+			runnerInstance: mockKexecIface,
+		},
+		{
+			desc:        "Negative test code path when ovsGet 'interface' returns error",
+			expectedErr: true,
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
+			},
+			runnerInstance: mockKexecIface,
+		},
+		{
+			desc:        "Negative test code path when ovsGet 'interface' returns error",
+			expectedErr: true,
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{nil, fmt.Errorf("mock: failed to run ovsSet")}},
+			},
+			runnerInstance: mockKexecIface,
+		},
+		{ // cannot happen
+			desc:        "Negative test code path when ingress_policing_rate cannot be transfer to integer ",
+			expectedErr: true,
+			onRetArgsKexecIface: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+				{OnCallMethodName: "Command", OnCallMethodArgType: []string{"string", "string", "string", "string", "string", "string", "string", "string", "string"}, RetArgList: []interface{}{mockCmd}},
+			},
+			onRetArgsCmdList: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte{1}, nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("\"10000000\""), nil}},
+				{OnCallMethodName: "CombinedOutput", OnCallMethodArgType: []string{}, RetArgList: []interface{}{[]byte("test"), nil}},
+			},
+			runnerInstance: mockKexecIface,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			if tc.onRetArgsKexecIface != nil {
+				for _, item := range tc.onRetArgsKexecIface {
+					ifaceCall := mockKexecIface.On(item.OnCallMethodName)
+					for _, arg := range item.OnCallMethodArgType {
+						ifaceCall.Arguments = append(ifaceCall.Arguments, mock.AnythingOfType(arg))
+					}
+					for _, ret := range item.RetArgList {
+						ifaceCall.ReturnArguments = append(ifaceCall.ReturnArguments, ret)
+					}
+					ifaceCall.Once()
+				}
+			}
+
+			if tc.onRetArgsCmdList != nil {
+				for _, item := range tc.onRetArgsCmdList {
+					mockCall := mockCmd.On(item.OnCallMethodName)
+					for _, arg := range item.OnCallMethodArgType {
+						mockCall.Arguments = append(mockCall.Arguments, mock.AnythingOfType(arg))
+					}
+					for _, ret := range item.RetArgList {
+						mockCall.ReturnArguments = append(mockCall.ReturnArguments, ret)
+					}
+					mockCall.Once()
+				}
+			}
+			// note runner is defined in pkg/cni/ovs.go file
+			runner = tc.runnerInstance
+			igress, egress, e := getPodBandwidth("ifname")
+
+			if tc.expectedErr {
+				assert.Error(t, e)
+			} else {
+				assert.Nil(t, e)
+				assert.Equal(t, igress, tc.igressBPS)
+				assert.Equal(t, egress, tc.egressBPS)
+			}
 			mockCmd.AssertExpectations(t)
 			mockKexecIface.AssertExpectations(t)
 		})

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -116,6 +116,11 @@ func (pr *PodRequest) cmdDel() ([]byte, error) {
 	return []byte{}, nil
 }
 
+func (pr *PodRequest) cmdCheck() ([]byte, error) {
+	// TODO add implementation
+	return []byte{}, nil
+}
+
 // HandleCNIRequest is the callback for all the requests
 // coming to the cniserver after being procesed into PodRequest objects
 // Argument '*PodRequest' encapsulates all the necessary information
@@ -131,6 +136,8 @@ func HandleCNIRequest(request *PodRequest, podLister corev1listers.PodLister) ([
 		result, err = request.cmdAdd(podLister)
 	case CNIDel:
 		result, err = request.cmdDel()
+	case CNICheck:
+		result, err = request.cmdCheck()
 	default:
 	}
 	klog.Infof("%s %s finished CNI request %+v, result %q, err %v", request, request.Command, request, string(result), err)

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/klog/v2"
 	"net"
 	"net/http"
 	"os"
@@ -20,7 +19,12 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
+	"k8s.io/klog/v2"
 
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -196,7 +200,118 @@ func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
 }
 
 // CmdCheck is the callback for 'checking' container's networking is as expected.
-// Currently not implemented, so returns `nil`.
 func (p *Plugin) CmdCheck(args *skel.CmdArgs) error {
+	var err error
+
+	startTime := time.Now()
+	defer func() {
+		p.postMetrics(startTime, CNICheck, err)
+	}()
+
+	// read the config stdin args
+	// Note: in order to validate that RawPrevResult is not nil, we don't use config.ReadCNIConfig(args.StdinData)
+	conf := &ovntypes.NetConf{}
+	if err = json.Unmarshal(args.StdinData, conf); err != nil {
+		return err
+	}
+	// Parse previous result.
+	if conf.RawPrevResult == nil {
+		return fmt.Errorf("required prevResult missing")
+	}
+	if err = version.ParsePrevResult(&conf.NetConf); err != nil {
+		return err
+	}
+	setupLogging(conf)
+	defer func() {
+		if err != nil {
+			klog.Errorf(err.Error())
+		}
+	}()
+
+	gtet := false
+	if gtet, err = version.GreaterThanOrEqualTo(conf.CNIVersion, "0.4.0"); err != nil {
+		return types.NewError(types.ErrDecodingFailure, err.Error(), "")
+	} else if !gtet {
+		err = types.NewError(types.ErrIncompatibleCNIVersion, "config version does not allow CHECK", "")
+		return err
+	}
+
+	result, errR := current.NewResultFromResult(conf.PrevResult)
+	if errR != nil {
+		err = errR
+		return err
+	}
+	klog.Infof("PrevResult is %+v", result)
+
+	var intf current.Interface
+	for _, inf := range result.Interfaces {
+		if args.IfName == inf.Name {
+			if args.Netns == inf.Sandbox {
+				intf = *inf
+				break
+			}
+		}
+	}
+	// The namespace must be the same as what was configured
+	if args.Netns != intf.Sandbox {
+		err = fmt.Errorf("sandbox in prevResult %s doesn't match configured netns: %s",
+			intf.Sandbox, args.Netns)
+		return err
+	}
+
+	netns, errNs := ns.GetNS(args.Netns)
+	if errNs != nil {
+		err = fmt.Errorf("failed to open netns %q: %v", args.Netns, errNs)
+		return err
+	}
+	defer netns.Close()
+
+	// Check prevResults for ips, routes and dns against values found in the container
+	if err = netns.Do(func(_ ns.NetNS) error {
+
+		// Check interface against values found in the container
+		err = validateCniContainerInterface(intf)
+		if err != nil {
+			return err
+		}
+
+		err = ip.ValidateExpectedInterfaceIPs(args.IfName, result.IPs)
+		if err != nil {
+			return err
+		}
+
+		err = ip.ValidateExpectedRoute(result.Routes)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	_, err = p.doCNI("http://dummy/", newCNIRequest(args))
+	return err
+}
+
+func validateCniContainerInterface(intf current.Interface) error {
+	var link netlink.Link
+	var err error
+
+	if intf.Name == "" {
+		return fmt.Errorf("container interface name missing in prevResult: %v", intf.Name)
+	}
+	link, err = netlink.LinkByName(intf.Name)
+	if err != nil {
+		return fmt.Errorf("container Interface name in prevResult: %s not found", intf.Name)
+	}
+	if intf.Sandbox == "" {
+		return fmt.Errorf("Error: Container interface %s should not be in host namespace", link.Attrs().Name)
+	}
+
+	if intf.Mac != "" {
+		if intf.Mac != link.Attrs().HardwareAddr.String() {
+			return fmt.Errorf("interface %s Mac %s doesn't match container Mac: %s", intf.Name, intf.Mac, link.Attrs().HardwareAddr)
+		}
+	}
 	return nil
 }

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -39,6 +39,9 @@ const CNIUpdate command = "UPDATE"
 // CNIDel is the command representing delete operation on a pod that is to be torn down
 const CNIDel command = "DEL"
 
+// CNICheck is the command representing check operation on a pod
+const CNICheck command = "CHECK"
+
 // Request sent to the Server by the OVN CNI plugin
 type Request struct {
 	// CNI environment variables, like CNI_COMMAND and CNI_NETNS


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
This Pull Request extends ovn-kuberets to implement the CNI CHECK command, from the [SPEC](https://github.com/containernetworking/cni/blob/master/SPEC.md).

As result of this command, the OVN-kubernetes cni plugin will check that container's networking is as expected. 

- The plugin consults the `prevResult` from the ADD command to determine the expected interfaces and addresses.
- The plugin will return an error if a resource listed in `prevResult` (interface, address or route), but is missing or in an invalid state.
- The plugin validates traffic shaping controls (ingress-bandwidth and egress-bandwidth) and will return error if there is a difference between traffic shaping controls defined in the Pod anotations and real settings.
- If a deployment includes IPAM plugins, the plugin delegates the CHECK to them and passes any errors on to its caller.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
Currently CRI-O doesn't calls CHECK automatically. Therefore I verified its behavior by using the [ocicnitool](https://github.com/cri-o/ocicni/tree/master/tools/ocicnitool).

- build and copy ocicnitool to one of the cluster nodes.
- deploy a test Pod, I used the following one:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hello-kubernetes
spec:
  replicas: 3
  selector:
    matchLabels:
      app: hello-kubernetes
  template:
    metadata:
      labels:
        app: hello-kubernetes
      annotations: {
       "kubernetes.io/ingress-bandwidth": "10M",
       "kubernetes.io/egress-bandwidth": "10M"
      }

    spec:
      containers:
      - name: hello-kubernetes
        image: paulbouwer/hello-kubernetes:1.8
        ports:
        - containerPort: 8080
```

- Run ocicnitool, and check its output and log messages in `/var/log/ovn-kubernetes/ovnkube.log`
In order to simplify running of ocicnitool, I created the following script:
```bash
#!/usr/bin/bash

POD_ID=`crictl pods  --name hello-kubernetes* -q`
NET_ID=`crictl inspectp $(crictl pods  --name hello-kubernetes* -q) |  grep /var/run/netns/ | grep path | awk '{print $2}' | tr -d \"`
POD_NAME=`crictl inspectp $(crictl pods  --name hello-kubernetes* -q) |  grep hello-kubernetes | grep name | sed -n 1p |  awk '{print $2}' | tr -d \" | tr -d ,`
ocicnitool status default $POD_NAME $POD_ID $NET_ID
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->