### PR TITLE
expose Kubernetes clientset in the OVN controller

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -248,7 +248,7 @@ func runOvnKube(ctx *cli.Context) error {
 		metrics.RegisterMasterMetrics(ovnNBClient, ovnSBClient)
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil, ovnNBClient, ovnSBClient, util.EventRecorder(ovnClientset.KubeClient))
-		if err := ovnController.Start(ovnClientset.KubeClient, master, wg); err != nil {
+		if err := ovnController.Start(master, wg); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/util/retry"
@@ -59,13 +58,13 @@ func (_ ovnkubeMasterLeaderMetricsProvider) NewLeaderMetric() leaderelection.Swi
 }
 
 // Start waits until this process is the leader before starting master functions
-func (oc *Controller) Start(kClient kubernetes.Interface, nodeName string, wg *sync.WaitGroup) error {
+func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup) error {
 	// Set up leader election process first
 	rl, err := resourcelock.New(
 		resourcelock.ConfigMapsResourceLock,
 		config.Kubernetes.OVNConfigNamespace,
 		"ovn-kubernetes-master",
-		kClient.CoreV1(),
+		oc.client.CoreV1(),
 		nil,
 		resourcelock.ResourceLockConfig{Identity: nodeName},
 	)


### PR DESCRIPTION
The OVN controller was embedding the Kubernetes clientset
under an Interface, thus other methods couldn't use it.

We add a new field in the controller with the Clientset,
so we don't have to modify the kube.Interface each time
that we need a new functionality, that the Kubernetes
clientset provide us for free.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
