### PR TITLE
bump k8s CI version to 1.19.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ on:
     - cron: '0 */12 * * *'
 
 env:
-  GO_VERSION: 1.15.1
-  K8S_VERSION: v1.19.0
+  GO_VERSION: 1.15.5
+  K8S_VERSION: v1.19.4
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true
   KIND_ALLOW_SYSTEM_WRITES: true


### PR DESCRIPTION
Use 1.19.4 version in the CI, aslo bump the golang version to the latest