### PR TITLE
config: Make v4 and v6 join subnets configurable

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -174,7 +174,8 @@ NET_CIDR_IPV4=${NET_CIDR_IPV4:-10.244.0.0/16}
 SVC_CIDR_IPV4=${SVC_CIDR_IPV4:-10.96.0.0/16}
 NET_CIDR_IPV6=${NET_CIDR_IPV6:-fd00:10:244::/48}
 SVC_CIDR_IPV6=${SVC_CIDR_IPV6:-fd00:10:96::/112}
-
+JOIN_SUBNET_IPV4=${JOIN_SUBNET_IPV4:-100.64.0.0/16}
+JOIN_SUBNET_IPV6=${JOIN_SUBNET_IPV6:-fd98::/64}
 KIND_NUM_MASTER=1
 if [ "$OVN_HA" == true ]; then
   KIND_NUM_MASTER=3
@@ -353,7 +354,9 @@ pushd ../dist/images
   --ovn-unprivileged-mode=no \
   --master-loglevel=5 \
   --dbchecker-loglevel=5\
-  --egress-ip-enable=true
+  --egress-ip-enable=true\
+  --v4-join-subnet=${JOIN_SUBNET_IPV4}\
+  --v6-join-subnet=${JOIN_SUBNET_IPV6}
 popd
 
 kind load docker-image ${OVN_IMAGE} --name ${KIND_CLUSTER_NAME}

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -39,6 +39,8 @@ OVN_HYBRID_OVERLAY_ENABLE=""
 OVN_DISABLE_SNAT_MULTIPLE_GWS=""
 OVN_MULTICAST_ENABLE=""
 OVN_EGRESSIP_ENABLE=
+OVN_V4_JOIN_SUBNET=""
+OVN_V6_JOIN_SUBNET=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -147,6 +149,12 @@ while [ "$1" != "" ]; do
   --egress-ip-enable)
     OVN_EGRESSIP_ENABLE=$VALUE
     ;;
+  --v4-join-subnet)
+    OVN_V4_JOIN_SUBNET=$VALUE
+    ;;
+  --v6-join-subnet)
+    OVN_V6_JOIN_SUBNET=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -226,6 +234,10 @@ ovn_sb_raft_port=${OVN_SB_RAFT_PORT:-6644}
 echo "ovn_sb_raft_port: ${ovn_sb_raft_port}"
 ovn_multicast_enable=${OVN_MULTICAST_ENABLE}
 echo "ovn_multicast_enable: ${ovn_multicast_enable}"
+ovn_v4_join_subnet=${OVN_V4_JOIN_SUBNET}
+echo "ovn_v4_join_subnet: ${ovn_v4_join_subnet}"
+ovn_v6_join_subnet=${OVN_V6_JOIN_SUBNET}
+echo "ovn_v6_join_subnet: ${ovn_v6_join_subnet}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -241,6 +253,8 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_v4_join_subnet=${ovn_v4_join_subnet} \
+  ovn_v6_join_subnet=${ovn_v6_join_subnet} \
   ovn_multicast_enable=${ovn_multicast_enable} \
   ovn_egress_ip_enable=${ovn_egress_ip_enable} \
   ovn_ssl_en=${ovn_ssl_en} \
@@ -258,6 +272,8 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_v4_join_subnet=${ovn_v4_join_subnet} \
+  ovn_v6_join_subnet=${ovn_v6_join_subnet} \
   ovn_multicast_enable=${ovn_multicast_enable} \
   ovn_egress_ip_enable=${ovn_egress_ip_enable} \
   ovn_ssl_en=${ovn_ssl_en} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -178,6 +178,10 @@ ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE:-}
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR:-}
 ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-}
+# OVN_V4_JOIN_SUBNET - v4 join subnet
+ovn_v4_join_subnet=${OVN_V4_JOIN_SUBNET:-}
+# OVN_V6_JOIN_SUBNET - v6 join subnet
+ovn_v6_join_subnet=${OVN_V6_JOIN_SUBNET:-}
 #OVN_REMOTE_PROBE_INTERVAL - ovn remote probe interval in ms (default 100000)
 ovn_remote_probe_interval=${OVN_REMOTE_PROBE_INTERVAL:-100000}
 ovn_multicast_enable=${OVN_MULTICAST_ENABLE:-}
@@ -826,6 +830,17 @@ ovn-master() {
   if [[ ${ovn_disable_snat_multiple_gws} == "true" ]]; then
       disable_snat_multiple_gws_flag="--disable-snat-multiple-gws"
   fi
+
+  ovn_v4_join_subnet_opt=
+  if [[ -n ${ovn_v4_join_subnet} ]]; then
+      ovn_v4_join_subnet_opt="--gateway-v4-join-subnet=${ovn_v4_join_subnet}"
+  fi
+  
+  ovn_v6_join_subnet_opt=
+  if [[ -n ${ovn_v6_join_subnet} ]]; then
+      ovn_v6_join_subnet_opt="--gateway-v6-join-subnet=${ovn_v6_join_subnet}"
+  fi
+
   local ovn_master_ssl_opts=""
   [[ "yes" == ${OVN_SSL_ENABLE} ]] && {
     ovn_master_ssl_opts="
@@ -865,6 +880,8 @@ ovn-master() {
     --logfile-maxage=${ovnkube_logfile_maxage} \
     ${hybrid_overlay_flags} \
     ${disable_snat_multiple_gws_flag} \
+    ${ovn_v4_join_subnet_opt} \
+    ${ovn_v6_join_subnet_opt} \
     --pidfile ${OVN_RUNDIR}/ovnkube-master.pid \
     --logfile /var/log/ovn-kubernetes/ovnkube-master.log \
     ${ovn_master_ssl_opts} \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -244,6 +244,10 @@ spec:
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
           value: "{{ ovn_disable_snat_multiple_gws }}"
+        - name: OVN_V4_JOIN_SUBNET
+          value: "{{ ovn_v4_join_subnet }}"
+        - name: OVN_V6_JOIN_SUBNET
+          value: "{{ ovn_v6_join_subnet }}"
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
         - name: OVN_GATEWAY_MODE

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -201,6 +201,10 @@ spec:
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
           value: "{{ ovn_disable_snat_multiple_gws }}"
+        - name: OVN_V4_JOIN_SUBNET
+          value: "{{ ovn_v4_join_subnet }}"
+        - name: OVN_V6_JOIN_SUBNET
+          value: "{{ ovn_v6_join_subnet }}"
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
         - name: OVN_REMOTE_PROBE_INTERVAL

--- a/docs/ovnkube.1
+++ b/docs/ovnkube.1
@@ -60,6 +60,12 @@ DEPRECATED; use \fB\--gateway-mode\fR instead.
 Setup nodeport based entries in OVN gateways for ingress into the k8s cluster.
 By default, it is disabled.
 .TP
+\fB\--gateway-v4-join-subnet\fR string
+The v4 join subnet to use for assigning join switch IPv4 addresses\fR.
+.TP
+\fB\--gateway-v6-join-subnet\fR string
+The v6 join subnet to use for assigning join switch IPv6 addresses\fR.
+.TP
 \fB\--config-file\fR string
 Configuration file path.
 .TP

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -29,12 +29,6 @@ const DefaultEncapPort = 6081
 
 const DefaultAPIServer = "http://localhost:8443"
 
-// IP address range from which subnet is allocated for per-node join switch
-const (
-	V4JoinSubnet = "100.64.0.0/16"
-	V6JoinSubnet = "fd98::/48"
-)
-
 // Default IANA-assigned UDP port number for VXLAN
 const DefaultVXLANPort = 4789
 
@@ -106,7 +100,10 @@ var (
 	OvnSouth OvnAuthConfig
 
 	// Gateway holds node gateway-related parsed config file parameters and command-line overrides
-	Gateway GatewayConfig
+	Gateway = GatewayConfig{
+		V4JoinSubnet: "100.64.0.0/16",
+		V6JoinSubnet: "fd98::/64",
+	}
 
 	// MasterHA holds master HA related config options.
 	MasterHA = MasterHAConfig{
@@ -248,6 +245,10 @@ type GatewayConfig struct {
 	NodeportEnable bool `gcfg:"nodeport"`
 	// DisableSNATMultipleGws sets whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws
 	DisableSNATMultipleGWs bool `gcfg:"disable-snat-multiple-gws"`
+	// V4JoinSubnet to be used in the cluster
+	V4JoinSubnet string `gcfg:"v4-join-subnet"`
+	// V6JoinSubnet to be used in the cluster
+	V6JoinSubnet string `gcfg:"v6-join-subnet"`
 }
 
 // OvnAuthConfig holds client authentication and location details for
@@ -810,7 +811,18 @@ var OVNGatewayFlags = []cli.Flag{
 		Usage:       "Disable SNAT for egress traffic with multiple gateways.",
 		Destination: &cliConfig.Gateway.DisableSNATMultipleGWs,
 	},
-
+	&cli.StringFlag{
+		Name:        "gateway-v4-join-subnet",
+		Usage:       "The v4 join subnet used for assigning join switch IPv4 addresses",
+		Destination: &cliConfig.Gateway.V4JoinSubnet,
+		Value:       Gateway.V4JoinSubnet,
+	},
+	&cli.StringFlag{
+		Name:        "gateway-v6-join-subnet",
+		Usage:       "The v6 join subnet used for assigning join switch IPv6 addresses",
+		Destination: &cliConfig.Gateway.V6JoinSubnet,
+		Value:       Gateway.V6JoinSubnet,
+	},
 	// Deprecated CLI options
 	&cli.BoolFlag{
 		Name:        "init-gateways",
@@ -1061,7 +1073,7 @@ func buildKubernetesConfig(exec kexec.Interface, cli, file *config, saPath strin
 	return nil
 }
 
-func buildGatewayConfig(ctx *cli.Context, cli, file *config) error {
+func buildGatewayConfig(ctx *cli.Context, cli, file *config, allSubnets *configSubnets) error {
 	// Copy config file values over default values
 	if err := overrideFields(&Gateway, &file.Gateway, &savedGateway); err != nil {
 		return err
@@ -1109,6 +1121,21 @@ func buildGatewayConfig(ctx *cli.Context, cli, file *config) error {
 	if Gateway.Mode != GatewayModeShared && Gateway.VLANID != 0 {
 		return fmt.Errorf("gateway VLAN ID option: %d is supported only in shared gateway mode", Gateway.VLANID)
 	}
+
+	// Validate v4 and v6 join subnets
+	v4IP, v4JoinCIDR, err := net.ParseCIDR(Gateway.V4JoinSubnet)
+	if err != nil || utilnet.IsIPv6(v4IP) {
+		return fmt.Errorf("invalid gateway v4 join subnet specified, subnet: %s: error: %v", Gateway.V4JoinSubnet, err)
+	}
+
+	v6IP, v6JoinCIDR, err := net.ParseCIDR(Gateway.V6JoinSubnet)
+	if err != nil || !utilnet.IsIPv6(v6IP) {
+		return fmt.Errorf("invalid gateway v6 join subnet specified, subnet: %s: error: %v", Gateway.V6JoinSubnet, err)
+	}
+
+	allSubnets.append(configSubnetJoin, v4JoinCIDR)
+	allSubnets.append(configSubnetJoin, v6JoinCIDR)
+
 	return nil
 }
 
@@ -1257,8 +1284,6 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 	}
 
 	allSubnets := newConfigSubnets()
-	allSubnets.appendConst(configSubnetJoin, V4JoinSubnet)
-	allSubnets.appendConst(configSubnetJoin, V6JoinSubnet)
 
 	configFile, configFileIsDefault = getConfigFilePath(ctx)
 
@@ -1337,7 +1362,7 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 		return "", err
 	}
 
-	if err = buildGatewayConfig(ctx, &cliConfig, &cfg); err != nil {
+	if err = buildGatewayConfig(ctx, &cliConfig, &cfg, allSubnets); err != nil {
 		return "", err
 	}
 

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -115,16 +115,6 @@ func (cs *configSubnets) append(subnetType configSubnetType, subnet *net.IPNet) 
 	}
 }
 
-// appendConst adds a single subnet to cs; it will panic if subnetStr is not a valid CIDR
-// string
-func (cs *configSubnets) appendConst(subnetType configSubnetType, subnetStr string) {
-	_, subnet, err := net.ParseCIDR(subnetStr)
-	if err != nil {
-		panic(fmt.Sprintf("could not parse constant value %q: %v", subnetStr, err))
-	}
-	cs.append(subnetType, subnet)
-}
-
 // checkForOverlaps checks if any of the subnets in cs overlap
 func (cs *configSubnets) checkForOverlaps() error {
 	for i, si := range cs.subnets {

--- a/go-controller/pkg/ovn/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager.go
@@ -315,7 +315,7 @@ func initJoinLogicalSwitchIPManager() (*joinSwitchIPManager, error) {
 		lrpIPCache: make(map[string][]*net.IPNet),
 	}
 	var joinSubnets []*net.IPNet
-	for _, joinSubnetString := range []string{types.V4JoinSubnetCIDR, types.V6JoinSubnetCIDR} {
+	for _, joinSubnetString := range []string{config.Gateway.V4JoinSubnet, config.Gateway.V6JoinSubnet} {
 		_, joinSubnet, err := net.ParseCIDR(joinSubnetString)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing join subnet string %s: %v", joinSubnetString, err)

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -51,9 +51,6 @@ const (
 	V4NodeLocalNATSubnetNextHop    = "169.254.0.1"
 	V4NodeLocalDistributedGWPortIP = "169.254.0.2"
 
-	V4JoinSubnetCIDR = "100.64.0.0/16"
-	V6JoinSubnetCIDR = "fd98::/64"
-
 	// OpenFlow and Networking constants
 	RouteAdvertisementICMPType    = 134
 	NeighborAdvertisementICMPType = 136


### PR DESCRIPTION
This PR adds support for making v4 and v6 join subnets used
by the single join switch to be configurable. This is important
because some users may have the 100.64.0.0/16 or fd98::/64 block
routable in their private network and possibly even assigned for
cluster CIDR or service CIDR.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>