### PR TITLE
[WIP] Deploy ovn db-metrics-exporter for nbdb

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -282,23 +282,22 @@ func runOvnKube(ctx *cli.Context) error {
 
 	// now that ovnkube master/node are running, lets expose the metrics HTTP endpoint if configured
 	// start the prometheus server to serve OVN K8s Metrics (default master port: 9409, node port: 9410)
-	if config.Kubernetes.MetricsBindAddress != ""  {
-		if(config.Kubernetes.OVNMetricsBindAddress==""){
+	if config.Kubernetes.MetricsBindAddress != "" {
+		if config.Kubernetes.OVNMetricsBindAddress == "" {
 			metrics.RegisterOvnMetrics(ovnClientset.KubeClient, node)
-			metrics.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof,true)
-		} else{
-			metrics.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof,false)
+			metrics.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof, true)
+		} else {
+			metrics.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof, false)
 		}
-		
+
 	}
 
-	
 	// start the prometheus server to serve OVN Metrics (default port: 9476)
 	if config.Kubernetes.OVNMetricsBindAddress != "" {
 		klog.Infof("IRL: OVNMetricsBindAddress is NOT NULL")
 		metrics.RegisterOvnMetrics(ovnClientset.KubeClient, node)
 		metrics.StartOVNMetricsServer(config.Kubernetes.OVNMetricsBindAddress)
-	} 
+	}
 
 	// run until cancelled
 	<-ctx.Context.Done()

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -284,6 +284,10 @@ func runOvnKube(ctx *cli.Context) error {
 	// start the prometheus server to serve OVN K8s Metrics (default master port: 9409, node port: 9410)
 	if config.Kubernetes.MetricsBindAddress != "" {
 		metrics.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof)
+		
+		//Include OVN Metrics 
+		metrics.RegisterOvnMetrics(ovnClientset.KubeClient, node)
+		metrics.StartOVNMetricsServer(config.Kubernetes.MetricsBindAddress)	
 	}
 
 	// start the prometheus server to serve OVN Metrics (default port: 9476)

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -168,7 +168,6 @@ func checkPodRunsOnGivenNode(clientset kubernetes.Interface, label, k8sNodeName 
 
 var ovnRegistry = prometheus.NewRegistry()
 
-
 // StartMetricsServer runs the prometheus listener so that OVN K8s metrics can be collected
 func StartMetricsServer(bindAddress string, enablePprof bool, enableOvnDBMetrics bool) {
 	mux := http.NewServeMux()
@@ -181,14 +180,14 @@ func StartMetricsServer(bindAddress string, enablePprof bool, enableOvnDBMetrics
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
-	
-	if(enableOvnDBMetrics){
+
+	if enableOvnDBMetrics {
 		ovnHandler := promhttp.InstrumentMetricHandler(ovnRegistry,
-		promhttp.HandlerFor(ovnRegistry, promhttp.HandlerOpts{}))
+			promhttp.HandlerFor(ovnRegistry, promhttp.HandlerOpts{}))
 		//mux := http.NewServeMux()
 		mux.Handle("/ovnmetrics", ovnHandler)
 	}
-	
+
 	go utilwait.Until(func() {
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {
@@ -196,7 +195,6 @@ func StartMetricsServer(bindAddress string, enablePprof bool, enableOvnDBMetrics
 		}
 	}, 5*time.Second, utilwait.NeverStop)
 }
-
 
 // StartOVNMetricsServer runs the prometheus listener so that OVN metrics can be collected
 func StartOVNMetricsServer(bindAddress string) {
@@ -219,7 +217,7 @@ func StartOVNMetricsServerOnDifferentPath(bindAddress string) {
 		promhttp.HandlerFor(ovnRegistry, promhttp.HandlerOpts{}))
 	mux := http.NewServeMux()
 	mux.Handle("/ovnmetrics", handler)
-	
+
 	go utilwait.Until(func() {
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/apimachinery/pkg/util/wait"
+	//"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
@@ -350,6 +350,7 @@ func getOvnDbVersionInfo() {
 }
 
 func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
+	/*
 	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
 		return checkPodRunsOnGivenNode(clientset, "ovn-db-pod=true", k8sNodeName, false)
 	})
@@ -361,7 +362,7 @@ func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 			klog.Infof("Not registering OVN DB Metrics on this Node since OVN DBs are not running on this node.")
 		}
 		return
-	}
+	}*/
 	klog.Info("Found OVN DB Pod running on this node. Registering OVN DB Metrics")
 
 	// get the ovsdb server version info
@@ -387,7 +388,7 @@ func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 	))
 	// check if DB is clustered or not
 	dbIsClustered := true
-	_, _, err = util.RunOVSDBTool("db-is-standalone", "/etc/openvswitch/ovnsb_db.db")
+	_, _, err := util.RunOVSDBTool("db-is-standalone", "/etc/openvswitch/ovnsb_db.db")
 	if err == nil {
 		dbIsClustered = false
 	}

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -351,18 +351,18 @@ func getOvnDbVersionInfo() {
 
 func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 	/*
-	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
-		return checkPodRunsOnGivenNode(clientset, "ovn-db-pod=true", k8sNodeName, false)
-	})
-	if err != nil {
-		if err == wait.ErrWaitTimeout {
-			klog.Errorf("Timed out while checking if OVN DB Pod runs on this %q K8s Node: %v. "+
-				"Not registering OVN DB Metrics on this Node.", k8sNodeName, err)
-		} else {
-			klog.Infof("Not registering OVN DB Metrics on this Node since OVN DBs are not running on this node.")
-		}
-		return
-	}*/
+		err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
+			return checkPodRunsOnGivenNode(clientset, "ovn-db-pod=true", k8sNodeName, false)
+		})
+		if err != nil {
+			if err == wait.ErrWaitTimeout {
+				klog.Errorf("Timed out while checking if OVN DB Pod runs on this %q K8s Node: %v. "+
+					"Not registering OVN DB Metrics on this Node.", k8sNodeName, err)
+			} else {
+				klog.Infof("Not registering OVN DB Metrics on this Node since OVN DBs are not running on this node.")
+			}
+			return
+		}*/
 	klog.Info("Found OVN DB Pod running on this node. Registering OVN DB Metrics")
 
 	// get the ovsdb server version info


### PR DESCRIPTION

This PR exposes ovn db metrics for nbdb to prometheus for OVN-Kubernetes deployments by CNO.

This PR modifies StartMetricsServer() in ovnkube.go to take in an additional boolean parameter to expose Ovn db metrics on path=/ovnmetrics on the same mux that exposes Node-exporter metrics. 
