### PR TITLE
Delete stale connections by Destination IP (Service IP) instead of Natted Destinaition IP (endpoints)

### DIFF
--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -28,6 +28,7 @@ type ObjectCacheInterface interface {
 type NodeWatchFactory interface {
 	Shutdownable
 
+	GetService(namespace, name string) (*kapi.Service, error)
 	AddServiceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
 	RemoveServiceHandler(handler *Handler)
 

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -21,6 +21,8 @@ type Gateway interface {
 	informer.ServiceAndEndpointsEventHandler
 	Init() error
 	Run(<-chan struct{})
+	// getter for NodeIPs
+	NodeIPs() []string
 }
 
 type gateway struct {
@@ -34,6 +36,11 @@ type gateway struct {
 	localPortWatcher informer.ServiceEventHandler
 	openflowManager  *openflowManager
 	initFunc         func() error
+	nodeIPs          []string
+}
+
+func (g *gateway) NodeIPs() []string {
+	return g.nodeIPs
 }
 
 func (g *gateway) AddService(svc *kapi.Service) {
@@ -127,7 +134,6 @@ func (g *gateway) Run(stopChan <-chan struct{}) {
 
 func gatewayInitInternal(nodeName, gwIntf string, subnets []*net.IPNet, gwNextHops []net.IP, nodeAnnotator kube.Annotator) (
 	string, string, net.HardwareAddr, []*net.IPNet, error) {
-
 	var bridgeName string
 	var uplinkName string
 	var brCreated bool

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -205,6 +205,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	if err != nil {
 		return err
 	}
+	gw.nodeIPs = []string{v4IfAddr.IP.String(), v6IfAddr.IP.String()}
 	gw.loadBalancerHealthChecker = loadBalancerHealthChecker
 	gw.portClaimWatcher = portClaimWatcher
 

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,7 +18,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -285,7 +286,7 @@ func (n *OvnNode) WatchEndpoints() {
 		UpdateFunc: func(old, new interface{}) {
 			epNew := new.(*kapi.Endpoints)
 			epOld := old.(*kapi.Endpoints)
-			if reflect.DeepEqual(epNew.Subsets, epOld.Subsets) {
+			if apiequality.Semantic.DeepEqual(epNew.Subsets, epOld.Subsets) {
 				return
 			}
 			newEpAddressMap := buildEndpointAddressMap(epNew.Subsets)

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -305,7 +305,7 @@ func DeleteConntrack(ip string, port int32, protocol kapi.Protocol) error {
 			return fmt.Errorf("could not add port %d to conntrack filter: %v", port, err)
 		}
 	}
-	if err := filter.AddIP(netlink.ConntrackReplyAnyIP, ipAddress); err != nil {
+	if err := filter.AddIP(netlink.ConntrackOrigDstIP, ipAddress); err != nil {
 		return fmt.Errorf("could not add IP: %s to conntrack filter: %v", ipAddress, err)
 	}
 	if ipAddress.To4() != nil {

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -32,9 +32,6 @@ Services.+session affinity
 # TO BE IMPLEMENTED: https://github.com/ovn-org/ovn-kubernetes/issues/1116
 EndpointSlices
 
-# TO BE IMPLEMENTED: https://github.com/ovn-org/ovn-kubernetes/issues/1664
-should be able to preserve UDP traffic when server pod cycles for a NodePort service
-
 # NOT IMPLEMENTED; SEE DISCUSSION IN https://github.com/ovn-org/ovn-kubernetes/pull/1225
 named port.+\[Feature:NetworkPolicy\]
 


### PR DESCRIPTION
We have to delete the stale conntrack entries on the nodes, because
they can blackhole traffic. It needs to happen in all nodes because
the OVN LoadBalancers DNAT in origin, so we never know who is the
origin.

Until now we were watching the endpoints, and deleting all the
conntrack entries when they changed or were deleted.
Since the DNAT will be ClusterIP -> Endpoint, it is more optimal
to delete by the destination IP, it also has the benefit that
save us to watch on endpoint slices in order to support dual-stack
services.

Signed-off-by: Antonio Ojea <aojea@redhat.com>