### PR TITLE
don't run etcd in memory

### DIFF
--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -21,9 +21,6 @@ kubeadmConfigPatches:
   kind: ClusterConfiguration
   metadata:
     name: config
-  etcd:
-    local:
-      dataDir: "/tmp/lib/etcd"
   apiServer:
     extraArgs:
       "v": "{{ cluster_log_level }}"


### PR DESCRIPTION
Previously, for HA deployements, we were running a 3 node etcd
cluster. This added a lot of pressure on the system, because
etcd is very IO intensive, so we sacrified our RAM to mount etcd
storage on a tmpfs.

However, this has the problem that if someone is using the script
to run clusters locally, the cluster will be wiped out if the
host reboots, because etct information was stored in ram.

We can run etcd with the local storage because we only use one node.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

