### PR TITLE
ovnkube-node use the cache to get the node information

### DIFF
--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -40,6 +40,7 @@ type NodeWatchFactory interface {
 
 	NodeInformer() cache.SharedIndexInformer
 	LocalPodInformer() cache.SharedIndexInformer
+	GetNode(name string) (*kapi.Node, error)
 }
 
 type Shutdownable interface {


### PR DESCRIPTION
we can save some API calls if we leverage the local cache of
the informer.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
