### PR TITLE
Metrics : Service counts as prometheus metrics

### DIFF
--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -34,6 +34,8 @@ const (
 	ovnNorthd     = "ovn-northd"
 	ovnController = "ovn-controller"
 	ovsVswitchd   = "ovs-vswitchd"
+
+	delayInSeconds = 30
 )
 
 type metricDetails struct {

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -2,12 +2,18 @@ package metrics
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+	
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 // ovnController Configuration metrics
@@ -279,6 +285,144 @@ func ovnControllerConfigurationMetricsUpdater() {
 	}
 }
 
+func ovnControllerServiceSubnetMetricsPublisher() {
+	cidrV4, cidrV6, v4Size, v6Size := getSubnetDetails(config.Kubernetes.ServiceCIDRs)
+	var metricServiceSubnet = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricOvnkubeNamespace,
+		Subsystem: MetricOvnkubeSubsystemMaster,
+		Name:      "service_subnets",
+		Help: "A metric with a constant '1' value labeled by subnet that " +
+			"specifies the subnets used for service. subnet_v4 and subnet_v6 are " +
+			"used as labels for IPv4 and IPv6 subnets respectively. If any of the subnets " +
+			"is not configured, corresponding label will have a blank value.",
+	},
+		[]string{
+			"subnet_v4",
+			"subnet_v6",
+		},
+	)
+	ovnRegistry.MustRegister(metricServiceSubnet)
+	metricServiceSubnet.WithLabelValues(cidrV4, cidrV6).Set(1)
+
+	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: MetricOvnkubeNamespace,
+			Subsystem: MetricOvnkubeSubsystemMaster,
+			Name:      "service_subnet_size_ipv4",
+			Help:      "Size of IPv4 service subnet size. 0 for the value means IPv4 subnet is not configured.",
+		},
+		func() float64 {
+			// There will be only one v4 service subnet or a blank value. So we can do Atoi.
+			if subnetSize, err := strconv.Atoi(v4Size); err == nil {
+				return float64(subnetSize)
+			}
+			return 0
+		}))
+
+	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: MetricOvnkubeNamespace,
+			Subsystem: MetricOvnkubeSubsystemMaster,
+			Name:      "service_subnet_size_ipv6",
+			Help:      "Size of IPv6 service subnet size. 0 for the value means IPv6 subnet is not configured.",
+		},
+		func() float64 {
+			// There will be only one v6 service subnet or a blank value. So we can do Atoi.
+			if subnetSize, err := strconv.Atoi(v6Size); err == nil {
+				return float64(subnetSize)
+			}
+			return 0
+		}))
+}
+
+func ovnControllerClusterSubnetMetricsPublisher() {
+	var cidrs []*net.IPNet
+
+	for _, subnet := range config.Default.ClusterSubnets {
+		cidrs = append(cidrs, subnet.CIDR)
+	}
+	cidrV4, cidrV6, v4Size, v6Size := getSubnetDetails(cidrs)
+
+	var metricClusterSubnet = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricOvnkubeNamespace,
+		Subsystem: MetricOvnkubeSubsystemMaster,
+		Name:      "cluster_subnets",
+		Help: "A metric with a constant '1' value labeled by subnets that " +
+			"specifies the subnets used for cluster. subnets_v4 and subnets_v6 are " +
+			"used as labels for IPv4 and IPv6 subnets respectively. If any of the subnets " +
+			"is not configured, corresponding label will have a blank value. If there are multiple " +
+			"subnets configured per IP family, then label value will be comma separated.",
+	},
+		[]string{
+			"subnets_v4",
+			"subnets_v6",
+		},
+	)
+	ovnRegistry.MustRegister(metricClusterSubnet)
+	metricClusterSubnet.WithLabelValues(cidrV4, cidrV6).Set(1)
+
+	var metricClusterV4Prefix = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricOvnkubeNamespace,
+		Subsystem: MetricOvnkubeSubsystemMaster,
+		Name:      "cluster_subnets_size_ipv4",
+		Help: "A metric with a constant '1' value labeled by prefix-length" +
+			"Value of the lable is the size of IPv4 cluster subnets. If there are multiple IPv4 " +
+			"subnets configured then lable value will be comma separated. Empty value for the label " +
+			"means IPv4 subnet is not configured.",
+	},
+		[]string{
+			"prefix-length",
+		},
+	)
+	ovnRegistry.MustRegister(metricClusterV4Prefix)
+	metricClusterSubnet.WithLabelValues(v4Size).Set(1)
+
+	var metricClusterV6Prefix = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricOvnkubeNamespace,
+		Subsystem: MetricOvnkubeSubsystemMaster,
+		Name:      "cluster_subnets_size_ipv6",
+		Help: "A metric with a constant '1' value labeled by prefix-length" +
+			"Value of the lable is the size of IPv6 cluster subnets. If there are multiple IPv6 " +
+			"subnets configured then lable value will be comma separated. Empty value for the label " +
+			"means IPv6 subnet is not configured.",
+	},
+		[]string{
+			"prefix-length",
+		},
+	)
+	ovnRegistry.MustRegister(metricClusterV6Prefix)
+	metricClusterSubnet.WithLabelValues(v6Size).Set(1)
+}
+
+func getSubnetDetails(cidrs []*net.IPNet) (string, string, string, string) {
+	var cidrV4 = ""
+	var cidrV6 = ""
+	var v4Size = ""
+	var v6Size = ""
+
+	for _, cidr := range cidrs {
+		ones, _ := cidr.Mask.Size()
+		if utilnet.IsIPv6CIDR(cidr) {
+			if cidrV6 == "" {
+				cidrV6 = cidr.String()
+				v6Size = string(ones)
+			} else {
+				cidrV6 = cidrV6 + "," + cidr.String()
+				v6Size = v6Size + "," + string(ones)
+			}
+		} else {
+			if cidrV4 == "" {
+				cidrV4 = cidr.String()
+				v4Size = string(ones)
+			} else {
+				cidrV4 = cidrV4 + "," + cidr.String()
+				v4Size = v4Size + "," + string(ones)
+			}
+		}
+	}
+	return cidrV4, cidrV6, v4Size, v6Size
+}
+
 func getPortCount(portType string) float64 {
 	var portCount float64
 	stdout, stderr, err := util.RunOVSVsctl("--no-headings", "--data=bare", "--format=csv",
@@ -380,4 +524,7 @@ func RegisterOvnControllerMetrics() {
 	go ovnControllerConfigurationMetricsUpdater()
 	// ovn-controller coverage show metrics updater
 	go coverageShowMetricsUpdater(ovnController)
+	// ovn-controller subnet configuration metrics publisher
+	ovnControllerServiceSubnetMetricsPublisher()
+	ovnControllerClusterSubnetMetricsPublisher()
 }

--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -9,7 +9,7 @@ import (
 
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
-	
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -524,6 +524,8 @@ func RegisterOvnControllerMetrics() {
 	go ovnControllerConfigurationMetricsUpdater()
 	// ovn-controller coverage show metrics updater
 	go coverageShowMetricsUpdater(ovnController)
+	// Service metrics updater
+	go serviceMetricsUpdater()
 	// ovn-controller subnet configuration metrics publisher
 	ovnControllerServiceSubnetMetricsPublisher()
 	ovnControllerClusterSubnetMetricsPublisher()

--- a/go-controller/pkg/metrics/service.go
+++ b/go-controller/pkg/metrics/service.go
@@ -1,0 +1,81 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	kapi "k8s.io/api/core/v1"
+)
+
+var metricServiceCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: MetricOvnNamespace,
+	Subsystem: MetricOvnSubsystemController,
+	Name:      "service_count",
+	Help: "Metric that specifies the number of services by their type. " +
+		"Type of the service is specified with the label type.",
+},
+	[]string{
+		"type",
+	},
+)
+
+type ServiceMetrics interface {
+	Increment(service *kapi.Service)
+	Decrement(service *kapi.Service)
+	GetAll() map[kapi.ServiceType]uint64
+}
+
+type serviceMetricsData struct {
+	sync.RWMutex
+	metricsMap map[kapi.ServiceType]uint64
+}
+
+var serviceMetrics ServiceMetrics = &serviceMetricsData{metricsMap: make(map[kapi.ServiceType]uint64)}
+
+func GetServiceMetricsInstance() ServiceMetrics {
+	return serviceMetrics
+}
+
+func (s *serviceMetricsData) Increment(service *kapi.Service) {
+	s.Lock()
+	defer s.Unlock()
+	if s.metricsMap[service.Spec.Type] < ^uint64(0) {
+		s.metricsMap[service.Spec.Type]++
+	}
+}
+
+func (s *serviceMetricsData) Decrement(service *kapi.Service) {
+	s.Lock()
+	defer s.Unlock()
+	if s.metricsMap[service.Spec.Type] > 0 {
+		s.metricsMap[service.Spec.Type]--
+	}
+}
+
+func (s *serviceMetricsData) GetAll() map[kapi.ServiceType]uint64 {
+	localMetricsMap := make(map[kapi.ServiceType]uint64)
+	s.RLock()
+	defer s.RUnlock()
+	for key, value := range s.metricsMap {
+		localMetricsMap[key] = value
+	}
+	return localMetricsMap
+}
+
+func serviceMetricsUpdater() {
+	ovnRegistry.MustRegister(metricServiceCount)
+	for {
+		setServiceMetrics()
+		time.Sleep(delayInSeconds * time.Second)
+	}
+}
+
+func setServiceMetrics() {
+	metricsService := GetServiceMetricsInstance()
+	serviceMetrics := metricsService.GetAll()
+	for key, value := range serviceMetrics {
+		metricServiceCount.WithLabelValues(string(key)).Set(float64(value))
+	}
+}

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	metrics "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
@@ -277,6 +278,11 @@ func (ovn *Controller) syncServices(services []interface{}) {
 
 func (ovn *Controller) createService(service *kapi.Service) error {
 	klog.Infof("Creating service %s", service.Name)
+
+	//Obtain the service instance to update metrics
+	metricsService := metrics.GetServiceMetricsInstance()
+	metricsService.Increment(service)
+
 	if !util.IsClusterIPSet(service) {
 		klog.V(5).Infof("Skipping service create: No cluster IP for service %s found", service.Name)
 		return nil
@@ -464,6 +470,11 @@ func (ovn *Controller) updateService(oldSvc, newSvc *kapi.Service) error {
 
 func (ovn *Controller) deleteService(service *kapi.Service) {
 	klog.Infof("Deleting service %s", service.Name)
+
+	//Obtain the service instance to update metrics
+	metricsService := metrics.GetServiceMetricsInstance()
+	metricsService.Decrement(service)
+
 	if !util.IsClusterIPSet(service) {
 		return
 	}


### PR DESCRIPTION
Added service count by service type as Prometheus metrics. This is done on top of my previous PR for subnet metrics which is a separate  commit btw. I've used the existing call back functions for services to gather the metrics

https://github.com/ovn-org/ovn-kubernetes/pull/1783

NOTE : As per discussion below this metric can be derived from other metrics exposed by other components. If we decide that direct metric is not needed, I can close this PR