### PR TITLE
have to use the kube interface during windows initialization

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_windows.go
@@ -53,7 +53,7 @@ func newNodeController(kube kube.Interface,
 			"UDP port. Please make sure you install all the KB updates on your system.")
 	}
 
-	node, err := nodeLister.Get(nodeName)
+	node, err := kube.GetNode(nodeName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
commit https://github.com/openshift/ovn-kubernetes/commit/99e7c6a14e0a81bcc2ad6724ca693251218b5e00#diff-42fa75bc291c6795ed4125c85836441c2ada0c61d6808773c4bbfeb4d116905bL57 attempted to change the call to the kube.Interface
for the node object to a call to a nodeLister but the cache is not
populated at that point during initialization so the call to the
kube.Interface is required

The SharedInformer Start() is called after NewNode() completes

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1902894

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->