### PR TITLE
Increase QPS and Burst setting

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -66,6 +66,8 @@ func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error
 	if err != nil {
 		return nil, err
 	}
+	kconfig.QPS = 25
+	kconfig.Burst = 25
 	return kconfig, nil
 }
 


### PR DESCRIPTION
Our client will under high load exceed the default QPS (query per second)
and Burst setting when communicating with the API server, which will cause
the client request to get throttled by the API server. These default
values are currently 5 and 10 respectively. Scalability testing has shown that
25 and 25 are values which lead to reasonable pod ready latency times
under high load.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>

/assign @trozet 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->