### PR TITLE
don't replace physical OVS bridge flows with a normal flow on startup

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -151,6 +151,10 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
 		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovs-ofctl dump-aggregate breth0 cookie=0xdeff105/-1",
+			Output: "",
+		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovs-ofctl -O OpenFlow13 replace-flows breth0 -",
 		})

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -134,21 +133,12 @@ type openflowManager struct {
 // checkDefaultOpenFlow checks for the existence of default OpenFlow rules and
 // exits if the output is not as expected
 func (c *openflowManager) Run(stopChan <-chan struct{}) {
-	flowCount := fmt.Sprintf("flow_count=%d", c.nFlows)
 	for {
 		select {
 		case <-time.After(15 * time.Second):
-			out, _, err := util.RunOVSOfctl("dump-aggregate", c.gwBridge,
-				fmt.Sprintf("cookie=%s/-1", defaultOpenFlowCookie))
+			err := validateDefaultOpenFlowCnt(c.gwBridge, c.nFlows)
 			if err != nil {
-				klog.Errorf("Failed to dump aggregate statistics of the default OpenFlow rules: %v", err)
-				continue
-			}
-
-			if !strings.Contains(out, flowCount) {
-				klog.Errorf("Fatal error: unexpected default OpenFlows count, expect %d output: %v\n",
-					c.nFlows, out)
-				os.Exit(1)
+				klog.Fatal(err)
 			}
 
 			// it could be that the ovn-controller recreated the patch between the host OVS bridge and


### PR DESCRIPTION
In order not to interrupt on-going network traffic during rolling
update, ovnkube-node will validate default OpenFlows when it starts and
only recreates default OpenFlows if the validation fails.

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->