### PR TITLE
Expose Ovn db metrics  for Prometheus 

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -283,6 +283,11 @@ func runOvnKube(ctx *cli.Context) error {
 	// now that ovnkube master/node are running, lets expose the metrics HTTP endpoint if configured
 	// start the prometheus server to serve OVN K8s Metrics (default master port: 9409, node port: 9410)
 	if config.Kubernetes.MetricsBindAddress != "" {
+		if config.Kubernetes.OVNMetricsBindAddress == "" {
+			//Expose OVNRegistry Metrics on same mux as Metrics Server
+			metrics.MakeOvnRegistryPointToDefault()
+			metrics.RegisterOvnMetrics(ovnClientset.KubeClient, master)
+		}
 		metrics.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof)
 	}
 

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -166,6 +166,12 @@ func checkPodRunsOnGivenNode(clientset kubernetes.Interface, label, k8sNodeName 
 	return false, fmt.Errorf("the Pod matching the label %q doesn't exist on this node %s", label, k8sNodeName)
 }
 
+var ovnRegistry = prometheus.NewRegistry()
+
+func MakeOvnRegistryPointToDefault() {
+	ovnRegistry = prometheus.DefaultRegisterer.(*prometheus.Registry)
+}
+
 // StartMetricsServer runs the prometheus listener so that OVN K8s metrics can be collected
 func StartMetricsServer(bindAddress string, enablePprof bool) {
 	mux := http.NewServeMux()
@@ -186,8 +192,6 @@ func StartMetricsServer(bindAddress string, enablePprof bool) {
 		}
 	}, 5*time.Second, utilwait.NeverStop)
 }
-
-var ovnRegistry = prometheus.NewRegistry()
 
 // StartOVNMetricsServer runs the prometheus listener so that OVN metrics can be collected
 func StartOVNMetricsServer(bindAddress string) {

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -362,7 +362,7 @@ func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 		}
 		return
 	}
-	klog.Info("Found OVN DB Pod running on this node. Registering OVN DB Metrics")
+	klog.Info("Found OVN DB Pod running on this node. Registering OVN DB Metrics on Node.")
 
 	// get the ovsdb server version info
 	getOvnDbVersionInfo()


### PR DESCRIPTION
This PR exposes ovn db metrics to prometheus for OVN-Kubernetes deployments by CNO.

This PR modifies StartMetricsServer() in ovnkube.go to take in an additional boolean parameter to expose Ovn db metrics on path=/ovnmetrics on the same mux that exposes Node-exporter metrics.

Co-authored by : Sayandeep Sen sayandes@in.ibm.com

Signed-off-by: Palani Kodeswaran <palankod@in.ibm.com>

