### PR TITLE
Fix shadowed error variable

### DIFF
--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -139,16 +139,18 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 	}()
 
 	// read the config stdin args to obtain cniVersion
-	conf, err := config.ReadCNIConfig(args.StdinData)
-	if err != nil {
-		return fmt.Errorf("invalid stdin args")
+	conf, errC := config.ReadCNIConfig(args.StdinData)
+	if errC != nil {
+		err = fmt.Errorf("invalid stdin args %v", errC)
+		return err
 	}
 	setupLogging(conf)
 
 	req := newCNIRequest(args)
 
-	body, err := p.doCNI("http://dummy/", req)
-	if err != nil {
+	body, errB := p.doCNI("http://dummy/", req)
+	if errB != nil {
+		err = errB
 		klog.Error(err.Error())
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Implementation of the ADD CNI command in  cnishim.go has the following statements:
```golang
func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
	var err error

	startTime := time.Now()
	defer func() {
		p.postMetrics(startTime, CNIAdd, err)
	}()
``` 
but the very next statement shadowed the `err` variables:
```golang
conf, err := config.ReadCNIConfig(args.StdinData)
	if err != nil {
		return fmt.Errorf("invalid stdin")
	}
```  
This PR fixes it.
