### PR TITLE
refactor: using goovn bindings for adding ACL in addAllowACLFromNode()

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -546,7 +546,7 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 		mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
 		addresses += " " + mgmtIfAddr.IP.String()
 
-		if err := addAllowACLFromNode(node.Name, mgmtIfAddr.IP); err != nil {
+		if err := addAllowACLFromNode(node.Name, mgmtIfAddr.IP, oc.ovnNBClient); err != nil {
 			return err
 		}
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -224,7 +224,6 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		})
 	}
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + nodeMgmtPortIP.String() + " allow-related",
 		"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.K8sPrefix + nodeName + " -- lsp-set-type " + types.K8sPrefix + nodeName + "  -- lsp-set-options " + types.K8sPrefix + nodeName + "  -- lsp-set-addresses " + types.K8sPrefix + nodeName + " " + mgmtMAC + " " + nodeMgmtPortIP.String(),
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -669,7 +668,6 @@ subnet=%s
 				"ovn-nbctl --timeout=15 set logical_switch " + masterName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + masterName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + masterName + " load_balancer " + sctpLBUUID,
-				"ovn-nbctl --timeout=15 --may-exist acl-add " + masterName + " to-lport 1001 ip4.src==" + masterMgmtPortIP + " allow-related",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + masterName + " " + types.K8sPrefix + masterName + " -- lsp-set-addresses " + types.K8sPrefix + masterName + " " + masterMgmtPortMAC + " " + masterMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -902,7 +900,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
-				"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + masterMgmtPortIP + " allow-related",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.K8sPrefix + nodeName + " -- lsp-set-addresses " + types.K8sPrefix + nodeName + " " + brLocalnetMAC + " " + masterMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -1110,7 +1107,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
-				"ovn-nbctl --timeout=15 --may-exist acl-add " + nodeName + " to-lport 1001 ip4.src==" + nodeMgmtPortIP + " allow-related",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.K8sPrefix + nodeName + " -- lsp-set-type " + types.K8sPrefix + nodeName + "  -- lsp-set-options " + types.K8sPrefix + nodeName + "  -- lsp-set-addresses " + types.K8sPrefix + nodeName + " " + nodeMgmtPortMAC + " " + nodeMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/ovn/policy_unit_test.go
+++ b/go-controller/pkg/ovn/policy_unit_test.go
@@ -1,0 +1,103 @@
+package ovn
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	goovn "github.com/ebay/go-ovn"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	goovn_mock "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/ebay/go-ovn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddAllowACLFromNode(t *testing.T) {
+	mockGoOvnNBClient := new(goovn_mock.Client)
+
+	tests := []struct {
+		desc                      string
+		inpSwName                 string
+		inpMgmtIp                 net.IP
+		errExp                    bool
+		errMatch                  error
+		onRetArgMockGoOvnNBClient []ovntest.TestifyMockHelper
+	}{
+		{
+			desc:      "test error when ovnNBClient.ACLAdd() fails",
+			inpSwName: "testSW",
+			inpMgmtIp: ovntest.MustParseIP("192.168.10.10"),
+			errMatch:  fmt.Errorf("ACLAdd() error when creating node acl for logical switch"),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "ACLAdd", OnCallMethodArgType: []string{"string", "string", "string", "string", "int", "map[string]string", "bool", "string", "string"}, RetArgList: []interface{}{nil, goovn.ErrorSchema},
+				},
+			},
+		},
+		{
+			desc:      "test when ACL already exists and confirm no error returned",
+			inpSwName: "testSW",
+			inpMgmtIp: ovntest.MustParseIP("192.168.10.10"),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "ACLAdd", OnCallMethodArgType: []string{"string", "string", "string", "string", "int", "map[string]string", "bool", "string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, goovn.ErrorExist},
+				},
+			},
+		},
+		{
+			desc:      "test when ovnNBClient.Execute() fails",
+			inpSwName: "testSW",
+			inpMgmtIp: ovntest.MustParseIP("192.168.10.10"),
+			errMatch:  fmt.Errorf("failed to create the node acl for logical_switch"),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "ACLAdd", OnCallMethodArgType: []string{"string", "string", "string", "string", "int", "map[string]string", "bool", "string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{goovn.ErrorOption},
+				},
+			},
+		},
+		{
+			desc:      "positive: test ip4 managment ip",
+			inpSwName: "testSW",
+			inpMgmtIp: ovntest.MustParseIP("192.168.10.10"),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "ACLAdd", OnCallMethodArgType: []string{"string", "string", "string", "string", "int", "map[string]string", "bool", "string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{nil},
+				},
+			},
+		},
+		{
+			desc:      "positive: test ip6 management ip",
+			inpSwName: "testSW",
+			inpMgmtIp: ovntest.MustParseIP("fd01::1234"),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "ACLAdd", OnCallMethodArgType: []string{"string", "string", "string", "string", "int", "map[string]string", "bool", "string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{nil},
+				},
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFnList(&mockGoOvnNBClient.Mock, tc.onRetArgMockGoOvnNBClient)
+
+			err := addAllowACLFromNode(tc.inpSwName, tc.inpMgmtIp, mockGoOvnNBClient)
+			if tc.errExp {
+				assert.Error(t, err)
+			} else if tc.errMatch != nil {
+				assert.Contains(t, err.Error(), tc.errMatch.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+			mockGoOvnNBClient.AssertExpectations(t)
+		})
+	}
+}

--- a/go-controller/pkg/testing/mock_acl.go
+++ b/go-controller/pkg/testing/mock_acl.go
@@ -1,0 +1,36 @@
+package testing
+
+import (
+	goovn "github.com/ebay/go-ovn"
+	"k8s.io/klog/v2"
+)
+
+// Add ACL
+func (mock *MockOVNClient) ACLAdd(ls, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("Adding ACL %s to switch %s", ls, ls)
+
+	ext_ids := make(map[interface{}]interface{})
+	for k, v := range external_ids {
+		ext_ids[k] = v
+	}
+
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpAdd,
+			table:   ACLType,
+			objName: ls,
+			obj: &goovn.ACL{
+				UUID:       FakeUUID,
+				Action:     action,
+				Direction:  direct,
+				Match:      match,
+				Priority:   priority,
+				Log:        logflag,
+				Meter:      []string{meter},
+				Severity:   severity,
+				ExternalID: ext_ids,
+			},
+		},
+	}, nil
+}

--- a/go-controller/pkg/testing/mock_ovn.go
+++ b/go-controller/pkg/testing/mock_ovn.go
@@ -15,6 +15,7 @@ const (
 	LogicalSwitchType     string = "Logical_Switch"
 	LogicalSwitchPortType string = "Logical_Switch_Port"
 	ChassisType           string = "Chassis"
+	ACLType               string = "ACL"
 )
 
 const (

--- a/go-controller/pkg/testing/mock_stubs.go
+++ b/go-controller/pkg/testing/mock_stubs.go
@@ -57,11 +57,6 @@ func (mock *MockOVNClient) LSLBList(ls string) ([]*goovn.LoadBalancer, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
 }
 
-// Add ACL
-func (mock *MockOVNClient) ACLAdd(ls, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
 // Delete acl
 func (mock *MockOVNClient) ACLDel(ls, direct, match string, priority int, external_ids map[string]string) (*goovn.OvnCommand, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())


### PR DESCRIPTION
Signed-off-by: Vishwanath Jayaraman <vjayaram@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR replaces the usage of `util.RunOVNNbctl()` function with the goovn bindings `ACLAdd` API for creating ACL rules.
Unit tests for the impacted function `addAllowACLFromNode()` has been added

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
Note1. There are no instances of `acl-del` being invoked in the codebase
Note2. References to `acl-add` in the test code are removed as well per suggestion from @abhat .  

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->