### PR TITLE
node: Run gateway after wait

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -220,9 +220,6 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 		return err
 	}
 
-	wg.Add(1)
-	go n.gateway.Run(n.stopChan)
-
 	if err := nodeAnnotator.Run(); err != nil {
 		return fmt.Errorf("failed to set node %s annotations: %v", n.name, err)
 	}
@@ -233,6 +230,8 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 	if err := waiter.Wait(); err != nil {
 		return err
 	}
+	wg.Add(1)
+	go n.gateway.Run(n.stopChan)
 	klog.Infof("Gateway and management port readiness took %v", time.Since(start))
 
 	if config.HybridOverlay.Enabled {


### PR DESCRIPTION
If we run the gateway beforehand, gw.initFunc will be nil and the
openflow manager thread will not be started.

Reported-by: Yun Zhou <yunz@nvidia.com>
Signed-off-by: Dave Tucker <dave@dtucker.co.uk>