### PR TITLE
Add e2e test to simulate a reboot of the control plane node.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 #IDE (GoLand) specific 
 .idea/
+.DS_STORE


### PR DESCRIPTION
**- What this PR does and why is it needed**
PR adds e2e test to simulate reboot of the control plane node. 
In reality, this test does not really reboot the node, but it kills the control
plane pods. That's because in Kind based cluster, etcd stores data 
in-memory and it looses that data after the reboot. So this test simply 
kills the control plain pods to simulate the reboot scenario.

Old PR : https://github.com/ovn-org/ovn-kubernetes/pull/1341

Signed-off-by: Andrew Sun <asun@redhat.com>
Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>

