### PR TITLE
don't compile k8s in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,42 +100,6 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: coverage.lcov
 
-  k8s:
-    name: Build k8s
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Set up environment
-      run: |
-        export GOPATH=$(go env GOPATH)
-        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
-        echo "$GOPATH/bin" >> $GITHUB_PATH
-
-    - name: Cache Kubernetes
-      id: cache-k8s
-      if: github.event_name == 'push' || github.event_name == 'pull_request'
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.GOPATH }}/src/k8s.io/kubernetes/
-        key: k8s-go-2-${{ env.K8S_VERSION }}
-
-    - name: Set up Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ env.GO_VERSION }}
-      id: go
-      if: steps.cache-k8s.outputs.cache-hit != 'true'
-
-    - name: Build and install Kubernetes
-      if: steps.cache-k8s.outputs.cache-hit != 'true'
-      run: |
-        set -x
-        rm -rf $GOPATH/src/k8s.io/kubernetes
-        git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
-        pushd $GOPATH/src/k8s.io/kubernetes/
-        make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
-        rm -rf .git
-
   e2e:
     name: e2e
     if: github.event_name != 'schedule'
@@ -193,7 +157,7 @@ jobs:
          - {"ipfamily": {"ip": ipv6}, "ha": {"enabled": "false"}, "gateway-mode": shared}
          - {"ipfamily": {"ip": dualstack}, "ha": {"enabled": "true"}, "gateway-mode": shared}
          - {"ipfamily": {"ip": dualstack}, "ha": {"enabled": "false"}}
-    needs: [build, k8s]
+    needs: [build]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
       OVN_HA: "${{ matrix.ha.enabled }}"
@@ -227,29 +191,10 @@ jobs:
       run: |
         sudo ufw disable
 
-    - name: Restore Kubernetes from cache
-      id: cache-k8s
-      uses: actions/cache@v2
-      with:
-        path: "${{ env.GOPATH }}/src/k8s.io/kubernetes/"
-        key: k8s-go-2-${{ env.K8S_VERSION }}
-
-    # Re-build if kube wasn't in the cache due to
-    # https://github.com/actions/cache/issues/107#issuecomment-598188250
-    # https://github.com/actions/cache/issues/208#issuecomment-596664572
-    - name: Build and install Kubernetes
-      if: steps.cache-k8s.outputs.cache-hit != 'true'
-      run: |
-        set -x
-        rm -rf $GOPATH/src/k8s.io/kubernetes/
-        git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
-        pushd $GOPATH/src/k8s.io/kubernetes/
-        make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
-        rm -rf .git
-
     - uses: actions/download-artifact@v2
       with:
         name: test-image
+
     - name: Load docker image
       run: |
         docker load --input image.tar
@@ -325,7 +270,7 @@ jobs:
             name: "Dualstack"
             ipv4: true
             ipv6: true
-    needs: [ build, k8s ]
+    needs: [ build ]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
       OVN_HA: "${{ matrix.ha.enabled }}"
@@ -358,26 +303,6 @@ jobs:
         # Not needed for KIND deployments, so just disable all the time.
         run: |
           sudo ufw disable
-
-      - name: Restore Kubernetes from cache
-        id: cache-k8s
-        uses: actions/cache@v2
-        with:
-          path: "${{ env.GOPATH }}/src/k8s.io/kubernetes/"
-          key: k8s-go-2-${{ env.K8S_VERSION }}
-
-      # Re-build if kube wasn't in the cache due to
-      # https://github.com/actions/cache/issues/107#issuecomment-598188250
-      # https://github.com/actions/cache/issues/208#issuecomment-596664572
-      - name: Build and install Kubernetes
-        if: steps.cache-k8s.outputs.cache-hit != 'true'
-        run: |
-          set -x
-          rm -rf $GOPATH/src/k8s.io/kubernetes/
-          git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
-          pushd $GOPATH/src/k8s.io/kubernetes/
-          make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
-          rm -rf .git
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -79,35 +79,6 @@ jobs:
       run: |
         sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
         sudo chmod +x /usr/local/bin/kind
-
-    - name: Clone Kubernetes
-      run: |
-        set -x
-        rm -rf $GOPATH/src/k8s.io/kubernetes
-        git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
-        cd $GOPATH/src/k8s.io/kubernetes
-        source hack/lib/version.sh
-        kube::version::get_version_vars
-        echo "KUBE_GIT_VERSION=$KUBE_GIT_VERSION" >> $GITHUB_ENV
-        
-    - name: Cache Kubernetes
-      id: cache-k8s
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.GOPATH }}/src/k8s.io/kubernetes
-        key: k8s-go-master-${{ env.KUBE_GIT_VERSION }}
-        restore-keys: |
-          k8s-go-master
-
-    - name: Build and install Kubernetes
-      if: steps.cache-k8s.outputs.cache-hit != 'true'
-      run: |
-        set -x
-        pushd $GOPATH/src/k8s.io/kubernetes/
-          make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
-          /usr/local/bin/kind build node-image --image=kindest/node:master
-          docker save kindest/node:master > _output/kind-image.tar
-        popd
         
   e2e-dual:
     if: github.repository == 'ovn-org/ovn-kubernetes' || github.event_name == 'workflow_dispatch'
@@ -161,29 +132,11 @@ jobs:
     - name: Load docker image
       run: |
         docker load --input image.tar
-
-    - name: Restore Kubernetes from cache
-      id: cache-k8s
-      uses: actions/cache@v2
-      with:
-        path: "${{ env.GOPATH }}/src/k8s.io/kubernetes"
-        key: k8s-go-master
-
-    - name: Copy k8s artifacts
-      run: |
-        pushd $GOPATH/src/k8s.io/kubernetes/
-          docker load --input ./_output/kind-image.tar
-          sudo cp ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
-          sudo cp ./_output/local/go/bin/e2e.test /usr/local/bin/e2e.test
-        popd
         
     - name: kind setup
       run: |
         export OVN_IMAGE="ovn-daemonset-f:dev"
-        # Run KIND
-        pushd ./contrib
-          ./kind.sh
-        popd
+        make -C test install-kind
 
     - name: Run Tests
       run: |

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -4,11 +4,6 @@ set -ex
 
 SHARD=$1
 
-pushd $GOPATH/src/k8s.io/kubernetes/
-export KUBECONFIG=${HOME}/admin.conf
-export MASTER_NAME=${KIND_CLUSTER_NAME}-control-plane
-export NODE_NAMES=${MASTER_NAME}
-
 groomTestList() {
 	echo $(echo "${1}" | sed -e '/^\($\|#\)/d' -e 's/ /\\s/g' | tr '\n' '|' | sed -e 's/|$//')
 }
@@ -129,10 +124,16 @@ export KUBE_CONTAINER_RUNTIME_NAME=containerd
 # FIXME we should not tolerate flakes
 # but until then, we retry the test in the same job
 # to stop PR retriggers for totally broken code
-export GINKGO_TOLERATE_FLAKES='y'
-export FLAKE_ATTEMPTS=2
-NUM_NODES=2
-./hack/ginkgo-e2e.sh \
-'--provider=skeleton' "--num-nodes=${NUM_NODES}" \
-"--ginkgo.focus=${FOCUS}" "--ginkgo.skip=${SKIPPED_TESTS}" \
-"--report-dir=${E2E_REPORT_DIR}" '--disable-log-dump=true'
+export FLAKE_ATTEMPTS=3
+export NUM_NODES=20
+ginkgo --nodes=${NUM_NODES} \
+	--focus=${FOCUS} \
+	--skip=${SKIPPED_TESTS} \
+	--flakeAttempts=${FLAKE_ATTEMPTS} \
+	/usr/local/bin/e2e.test \
+	-- \
+	--kubeconfig=${HOME}/admin.conf \
+	--provider=local \
+	--dump-logs-on-failure=false \
+	--report-dir=${E2E_REPORT_DIR}	\
+	--disable-log-dump=true

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -2,23 +2,30 @@
 
 set -ex
 
-export GO111MODULE="on"
+# Install latest stable kubectl
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
 
-pushd $GOPATH/src/k8s.io/kubernetes/
-if [[ ! -f /usr/local/bin/kubectl ]]; then
-  sudo ln ./_output/local/go/bin/kubectl /usr/local/bin/kubectl
-fi
-if [[ ! -f /usr/local/bin/e2e.test ]]; then
-  sudo ln ./_output/local/go/bin/e2e.test /usr/local/bin/e2e.test
-fi
-popd
+# Install latest e2e test binary
+# The e2e binaries are built from https://github.com/aojea/kubernetes-e2e-binaries
+# Current e2e binary versions is latest 1.19 tag v1.19.4
+curl -LO https://github.com/aojea/kubernetes-e2e-binaries/releases/download/d360454c/e2e.test
+chmod +x ./e2e.test
+sudo mv ./e2e.test /usr/local/bin/e2e.test
+
+# Install ginkgo
+go get github.com/onsi/ginkgo/ginkgo
+go get github.com/onsi/gomega/...
 
 # Install kind (dual-stack is not released upstream so we have to use our own version)
 if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
   sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
   sudo chmod +x /usr/local/bin/kind
 else
-  go get sigs.k8s.io/kind@v0.9.0
+  curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64
+  chmod +x ./kind
+  sudo mv ./kind /usr/local/bin/
 fi
 
 pushd ../contrib


### PR DESCRIPTION
We are compiling the e2e.test and kubect binaries from the
kubernetes repo to match the Kubernetes version used in kind.

However, this binaries doesn' t need to match the exact version
of the cluster under test, and we can use precompiled binaries
that are public available, saving more than 500Mb of storage and
5 minutes in the CI.

Signed-off-by: Antonio Ojea <aojea@redhat.com>