### PR TITLE
Decouple OVN ACLs and LoadBalancer operations from OVN controller

### DIFF
--- a/go-controller/pkg/ovn/acl/acl.go
+++ b/go-controller/pkg/ovn/acl/acl.go
@@ -1,0 +1,128 @@
+package acl
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	"github.com/pkg/errors"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+)
+
+// GetACLByName returns the ACL UUID
+func GetACLByName(aclName string) (string, error) {
+	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
+		fmt.Sprintf("name=%s", aclName))
+	if err != nil {
+		return "", errors.Wrapf(err, "Error while querying ACLs by name: %s", stderr)
+	}
+	return aclUUID, nil
+}
+
+// GetRejectACLs returns a map with the ACLs with a reject action
+// the map uses the name of the ACL as key and the uuid as value
+func GetRejectACLs() (map[string]string, error) {
+	// Get OVN's current reject ACLs. Note, currently only services use reject ACLs.
+	result := make(map[string]string)
+	type ovnACLData struct {
+		Data [][]interface{}
+	}
+	data, stderr, err := util.RunOVNNbctl("--columns=name,_uuid", "--format=json", "find", "acl", "action=reject")
+	if err != nil {
+		return result, errors.Wrapf(err, "Error while querying ACLs with reject action: %s", stderr)
+	}
+	// Process the output
+	x := ovnACLData{}
+	if err := json.Unmarshal([]byte(data), &x); err != nil {
+		return result, errors.Wrapf(err, "Unable to get current OVN reject ACLs. Unable to sync reject ACLs")
+	}
+	for _, entry := range x.Data {
+		// ACL entry format is a slice: [<aclName>, ["_uuid", <uuid>]]
+		if len(entry) != 2 {
+			continue
+		}
+		name, ok := entry[0].(string)
+		if !ok {
+			continue
+		}
+		uuidData, ok := entry[1].([]interface{})
+		if !ok || len(uuidData) != 2 {
+			continue
+		}
+		uuid, ok := uuidData[1].(string)
+		if !ok {
+			continue
+		}
+		result[name] = uuid
+	}
+	return result, nil
+}
+
+// RemoveACLFromNodeSwitches removes the ACL uuid entry from Logical Switch acl's list.
+func RemoveACLFromNodeSwitches(switches []string, aclUUID string) error {
+	if len(switches) == 0 {
+		return nil
+	}
+	args := []string{}
+	for _, ls := range switches {
+		args = append(args, "--", "--if-exists", "remove", "logical_switch", ls, "acl", aclUUID)
+	}
+	_, _, err := util.RunOVNNbctl(args...)
+	if err != nil {
+		return errors.Wrapf(err, "Error while removing ACL: %s, from switches", aclUUID)
+	}
+	klog.Infof("ACL: %s, removed from switches: %s", aclUUID, switches)
+	return nil
+}
+
+// RemoveACLFromPortGroup removes the ACL from the port-group
+func RemoveACLFromPortGroup(aclUUID, clusterPortGroupUUID string) error {
+	_, stderr, err := util.RunOVNNbctl("--", "--if-exists", "remove", "port_group", clusterPortGroupUUID, "acls", aclUUID)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to remove reject ACL %s from port group %s: stderr: %q", aclUUID, clusterPortGroupUUID, stderr)
+	}
+	klog.Infof("ACL: %s, removed from the port group : %s", aclUUID, clusterPortGroupUUID)
+	return nil
+}
+
+// AddRejectACLToPortGroup adds a reject ACL to a PortGroup
+func AddRejectACLToPortGroup(clusterPortGroupUUID, aclName, sourceIP string, sourcePort int, proto v1.Protocol) (string, error) {
+	l3Prefix := "ip4"
+	if utilnet.IsIPv6String(sourceIP) {
+		l3Prefix = "ip6"
+	}
+
+	aclMatch := fmt.Sprintf("match=\"%s.dst==%s && %s && %s.dst==%d\"", l3Prefix, sourceIP,
+		strings.ToLower(string(proto)), strings.ToLower(string(proto)), sourcePort)
+	cmd := []string{"--id=@reject-acl", "create", "acl", "direction=from-lport", "priority=1000", aclMatch, "action=reject",
+		fmt.Sprintf("name=%s", aclName), "--", "add", "port_group", clusterPortGroupUUID, "acls", "@reject-acl"}
+	aclUUID, stderr, err := util.RunOVNNbctl(cmd...)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to add ACL: %s, %q, to cluster port group %s, stderr: %q", aclUUID, aclName, clusterPortGroupUUID, stderr)
+	}
+	return aclUUID, nil
+}
+
+// AddRejectACLToLogicalSwitch adds a reject ACL to a logical switch
+func AddRejectACLToLogicalSwitch(logicalSwitch, aclName, sourceIP string, sourcePort int, proto v1.Protocol) (string, error) {
+	l3Prefix := "ip4"
+	if utilnet.IsIPv6String(sourceIP) {
+		l3Prefix = "ip6"
+	}
+
+	aclMatch := fmt.Sprintf("match=\"%s.dst==%s && %s && %s.dst==%d\"", l3Prefix, sourceIP,
+		strings.ToLower(string(proto)), strings.ToLower(string(proto)), sourcePort)
+	cmd := []string{"--id=@reject-acl", "create", "acl", "direction=from-lport", "priority=1000", aclMatch, "action=reject",
+		fmt.Sprintf("name=%s", aclName), "--", "add", "logical_switch", logicalSwitch, "acls", "@reject-acl"}
+
+	aclUUID, stderr, err := util.RunOVNNbctl(cmd...)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to add ACL: %s, %q, to cluster switch %s, stderr: %q", aclUUID, aclName, logicalSwitch, stderr)
+	}
+	return aclUUID, nil
+}

--- a/go-controller/pkg/ovn/acl/acl_test.go
+++ b/go-controller/pkg/ovn/acl/acl_test.go
@@ -1,0 +1,318 @@
+package acl
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestGetACLByName(t *testing.T) {
+	tests := []struct {
+		name    string
+		aclName string
+		ovnCmd  ovntest.ExpectedCmd
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "existing acl",
+			aclName: "my-acl",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=my-acl",
+				Output: "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			},
+			want:    "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:    "non existing acl",
+			aclName: "my-acl",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=my-acl",
+				Output: "",
+			},
+			want:    "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := GetACLByName(tt.aclName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetACLByName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetACLByName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveACLFromNodeSwitches(t *testing.T) {
+	tests := []struct {
+		name     string
+		switches []string
+		aclUUID  string
+		ovnCmd   ovntest.ExpectedCmd
+		wantErr  bool
+	}{
+		{
+			name:     "remove acl on two switches",
+			switches: []string{"sw1", "sw2"},
+			aclUUID:  "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- --if-exists remove logical_switch sw1 acl a08ea426-2288-11eb-a30b-a8a1590cda29 -- --if-exists remove logical_switch sw2 acl a08ea426-2288-11eb-a30b-a8a1590cda29",
+				Output: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "remove acl on no switches",
+			switches: []string{},
+			aclUUID:  "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd:   ovntest.ExpectedCmd{},
+			wantErr:  false,
+		},
+		{
+			name:     "remove acl and OVN error on first switch",
+			switches: []string{"sw1", "sw2"},
+			aclUUID:  "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- --if-exists remove logical_switch sw1 acl a08ea426-2288-11eb-a30b-a8a1590cda29 -- --if-exists remove logical_switch sw2 acl a08ea426-2288-11eb-a30b-a8a1590cda29",
+				Output: "",
+				Err:    fmt.Errorf("error while removing ACL: sw1, from switches"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			err = RemoveACLFromNodeSwitches(tt.switches, tt.aclUUID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RemoveACLFromNodeSwitches() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestRemoveACLFromPortGroup(t *testing.T) {
+	tests := []struct {
+		name                 string
+		clusterPortGroupUUID string
+		aclUUID              string
+		ovnCmd               ovntest.ExpectedCmd
+		wantErr              bool
+	}{
+		{
+			name:                 "remove acl from portgroup",
+			clusterPortGroupUUID: "63c3e636-387d-11eb-ac78-a8a1590cda29",
+			aclUUID:              "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- --if-exists remove port_group 63c3e636-387d-11eb-ac78-a8a1590cda29 acls a08ea426-2288-11eb-a30b-a8a1590cda29",
+				Output: "",
+			},
+			wantErr: false,
+		},
+
+		// TODO: Add test cases for errors
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			err = RemoveACLFromPortGroup(tt.aclUUID, tt.clusterPortGroupUUID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RemoveACLFromPortGroup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestGetRejectACLs(t *testing.T) {
+	tests := []struct {
+		name    string
+		ovnCmd  ovntest.ExpectedCmd
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "no reject ACLs in OVN",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --columns=name,_uuid --format=json find acl action=reject",
+				Output: `{"data":[],"headings":["name","_uuid"]}`,
+			},
+			want:    make(map[string]string),
+			wantErr: false,
+		},
+
+		// TODO: Add test cases with some data
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetRejectACLs()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetRejectACLs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetRejectACLs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddRejectACLToLogicalSwitch(t *testing.T) {
+	tests := []struct {
+		name          string
+		logicalSwitch string
+		aclName       string
+		sourceIP      string
+		sourcePort    int
+		proto         v1.Protocol
+		ovnCmd        ovntest.ExpectedCmd
+		want          string
+		wantErr       bool
+	}{
+		{
+			name:          "add ipv4 acl",
+			logicalSwitch: "545dc436-387e-11eb-9f38-a8a1590cda29",
+			aclName:       "myacl",
+			sourceIP:      "192.168.2.2",
+			sourcePort:    80,
+			proto:         v1.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.2.2 && tcp && tcp.dst==80" action=reject name=myacl -- add logical_switch 545dc436-387e-11eb-9f38-a8a1590cda29 acls @reject-acl`,
+				Output: "97347886-387e-11eb-9fdf-a8a1590cda29",
+			},
+			want:    "97347886-387e-11eb-9fdf-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:          "add ipv6 acl",
+			logicalSwitch: "545dc436-387e-11eb-9f38-a8a1590cda29",
+			aclName:       "myacl",
+			sourceIP:      "2001:db2:1:2::23",
+			sourcePort:    80,
+			proto:         v1.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip6.dst==2001:db2:1:2::23 && tcp && tcp.dst==80" action=reject name=myacl -- add logical_switch 545dc436-387e-11eb-9f38-a8a1590cda29 acls @reject-acl`,
+				Output: "97347886-387e-11eb-9fdf-a8a1590cda29",
+			},
+			want:    "97347886-387e-11eb-9fdf-a8a1590cda29",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := AddRejectACLToLogicalSwitch(tt.logicalSwitch, tt.aclName, tt.sourceIP, tt.sourcePort, tt.proto)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddRejectACLToLogicalSwitch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("AddRejectACLToLogicalSwitch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddRejectACLToPortGroup(t *testing.T) {
+	tests := []struct {
+		name       string
+		portGroup  string
+		aclName    string
+		sourceIP   string
+		sourcePort int
+		proto      v1.Protocol
+		ovnCmd     ovntest.ExpectedCmd
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "add ipv4 acl",
+			portGroup:  "545dc436-387e-11eb-9f38-a8a1590cda29",
+			aclName:    "myacl",
+			sourceIP:   "192.168.2.2",
+			sourcePort: 80,
+			proto:      v1.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.2.2 && tcp && tcp.dst==80" action=reject name=myacl -- add port_group 545dc436-387e-11eb-9f38-a8a1590cda29 acls @reject-acl`,
+				Output: "97347886-387e-11eb-9fdf-a8a1590cda29",
+			},
+			want:    "97347886-387e-11eb-9fdf-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:       "add ipv6 acl",
+			portGroup:  "545dc436-387e-11eb-9f38-a8a1590cda29",
+			aclName:    "myacl",
+			sourceIP:   "2001:db2:1:2::23",
+			sourcePort: 80,
+			proto:      v1.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip6.dst==2001:db2:1:2::23 && tcp && tcp.dst==80" action=reject name=myacl -- add port_group 545dc436-387e-11eb-9f38-a8a1590cda29 acls @reject-acl`,
+				Output: "97347886-387e-11eb-9fdf-a8a1590cda29",
+			},
+			want:    "97347886-387e-11eb-9fdf-a8a1590cda29",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := AddRejectACLToPortGroup(tt.portGroup, tt.aclName, tt.sourceIP, tt.sourcePort, tt.proto)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddRejectACLToPortGroup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("AddRejectACLToPortGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -1,81 +1,44 @@
 package ovn
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
-	"strings"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/acl"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
 
+// getLoadBalancer is a convenience wrapper over GetOVNKubeLoadBalancer to use a cache
+// it will return an error if it can not find a load balancer
 func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string, error) {
+	ovn.loadbalancerClusterCacheMutex.Lock()
+	defer ovn.loadbalancerClusterCacheMutex.Unlock()
 	if outStr, ok := ovn.loadbalancerClusterCache[protocol]; ok {
 		return outStr, nil
 	}
 
-	var out string
-	var err error
-	if protocol == kapi.ProtocolTCP {
-		out, _, err = util.RunOVNNbctl("--data=bare",
-			"--no-heading", "--columns=_uuid", "find", "load_balancer",
-			"external_ids:k8s-cluster-lb-tcp=yes")
-	} else if protocol == kapi.ProtocolUDP {
-		out, _, err = util.RunOVNNbctl("--data=bare", "--no-heading",
-			"--columns=_uuid", "find", "load_balancer",
-			"external_ids:k8s-cluster-lb-udp=yes")
-	} else if protocol == kapi.ProtocolSCTP {
-		out, _, err = util.RunOVNNbctl("--data=bare", "--no-heading",
-			"--columns=_uuid", "find", "load_balancer",
-			"external_ids:k8s-cluster-lb-sctp=yes")
-	}
+	out, err := loadbalancer.GetOVNKubeLoadBalancer(protocol)
+	// GetOVNKubeLoadBalancer will return an err if out is empty
 	if err != nil {
 		return "", err
-	}
-	if out == "" {
-		return "", fmt.Errorf("no load balancer found in the database")
 	}
 	ovn.loadbalancerClusterCache[protocol] = out
 	return out, nil
 }
 
-// getLoadBalancerVIPs returns a map whose keys are VIPs (IP:port) on loadBalancer
-func (ovn *Controller) getLoadBalancerVIPs(loadBalancer string) (map[string]interface{}, error) {
-	outStr, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"get", "load_balancer", loadBalancer, "vips")
-	if err != nil {
-		return nil, err
-	}
-	if outStr == "" {
-		return nil, fmt.Errorf("load balancer vips in OVN DB is an empty string")
-	}
-	// sample outStr:
-	// - {"192.168.0.1:80"="10.1.1.1:80,10.2.2.2:80"}
-	// - {"[fd01::]:80"="[fd02::]:80,[fd03::]:80"}
-	outStrMap := strings.Replace(outStr, "=", ":", -1)
-
-	var raw map[string]interface{}
-	err = json.Unmarshal([]byte(outStrMap), &raw)
-	if err != nil {
-		return nil, err
-	}
-	return raw, nil
-}
-
 // deleteLoadBalancerVIP removes the VIP as well as any reject ACLs associated to the LB
 func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) error {
-	vipQuotes := fmt.Sprintf("\"%s\"", vip)
-	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove", "load_balancer", loadBalancer, "vips", vipQuotes)
+	err := loadbalancer.DeleteLoadBalancerVIP(loadBalancer, vip)
 	if err != nil {
 		// if we hit an error and fail to remove load balancer, we skip removing the rejectACL
-		return fmt.Errorf("error in deleting load balancer vip %s for %s"+
-			"stdout: %q, stderr: %q, error: %v",
-			vip, loadBalancer, stdout, stderr, err)
+		return err
 	}
 	ovn.removeServiceEndpoints(loadBalancer, vip)
 	ovn.deleteLoadBalancerRejectACL(loadBalancer, vip)
@@ -88,18 +51,13 @@ func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) error {
 func (ovn *Controller) configureLoadBalancer(lb, sourceIP string, sourcePort int32, targets []string) error {
 	ovn.serviceLBLock.Lock()
 	defer ovn.serviceLBLock.Unlock()
-
 	vip := util.JoinHostPortInt32(sourceIP, sourcePort)
-	lbTarget := fmt.Sprintf(`vips:"%s"="%s"`, vip, strings.Join(targets, ","))
-
-	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, lbTarget)
+	err := loadbalancer.UpdateLoadBalancer(lb, vip, targets)
 	if err != nil {
-		return fmt.Errorf("error in configuring load balancer: %s "+
-			"stdout: %q, stderr: %q, error: %v", lb, out, stderr, err)
+		return err
 	}
 	ovn.setServiceEndpointsToLB(lb, vip, targets)
-	klog.V(5).Infof("LB entry set for %s, %s, %v", lb, lbTarget,
-		ovn.serviceLBMap[lb][vip])
+	klog.V(5).Infof("LB entry set for %s, %v, %v", lb, targets, ovn.serviceLBMap[lb][vip])
 	return nil
 }
 
@@ -134,63 +92,20 @@ func (ovn *Controller) createLoadBalancerVIPs(lb string,
 }
 
 func (ovn *Controller) getLogicalSwitchesForLoadBalancer(lb string) ([]string, error) {
-	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=_uuid", "find",
-		"logical_switch", fmt.Sprintf("load_balancer{>=}%s", lb))
+	switches, err := loadbalancer.GetLogicalSwitchesForLoadBalancer(lb)
 	if err != nil {
 		return nil, err
 	}
-	if len(strings.Fields(out)) > 0 {
-		return strings.Fields(out), nil
-	}
-
-	return nil, nil
+	return switches, nil
 }
 
 // getGRLogicalSwitchForLoadBalancer returns the external switch name if the load balancer is on a GR
 func (ovn *Controller) getGRLogicalSwitchForLoadBalancer(lb string) (string, error) {
-	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=name", "find", "logical_router", fmt.Sprintf("load_balancer{>=}%s", lb))
+	externalSwitch, err := loadbalancer.GetGRLogicalSwitchForLoadBalancer(lb)
 	if err != nil {
 		return "", err
 	}
-	if len(out) == 0 {
-		return "", nil
-	}
-
-	// if this is a GR we know the corresponding external switch, otherwise this is an unhandled case
-	if strings.HasPrefix(out, types.GWRouterPrefix) {
-		routerName := strings.TrimPrefix(out, types.GWRouterPrefix)
-		return types.ExternalSwitchPrefix + routerName, nil
-	}
-	return "", fmt.Errorf("router detected with load balancer that is not a GR")
-}
-
-// TODO: Add unittest for function.
-func generateACLName(lb string, sourceIP string, sourcePort int32) string {
-	aclName := fmt.Sprintf("%s-%s:%d", lb, sourceIP, sourcePort)
-	// ACL names are limited to 63 characters
-	if len(aclName) > 63 {
-		var ipPortLen int
-		srcPortStr := fmt.Sprintf("%d", sourcePort)
-		// Add the length of the IP (max 15 with periods, max 39 with colons),
-		// plus length of sourcePort (max 5 char),
-		// plus 1 for additional ':' to separate,
-		// plus 1 for '-' between lb and IP.
-		// With full IPv6 address and 5 char port, max ipPortLen is 62
-		// With full IPv4 address and 5 char port, max ipPortLen is 24.
-		ipPortLen = len(sourceIP) + len(srcPortStr) + 1 + 1
-		lbTrim := 63 - ipPortLen
-		// Shorten the Load Balancer name to allow full IP:port
-		tmpLb := lb[:lbTrim]
-		klog.Infof("Limiting ACL Name from %s to %s-%s:%d to keep under 63 characters", aclName, tmpLb, sourceIP, sourcePort)
-		aclName = fmt.Sprintf("%s-%s:%d", tmpLb, sourceIP, sourcePort)
-	}
-	return aclName
-}
-
-func generateACLNameForOVNCommand(lb string, sourceIP string, sourcePort int32) string {
-	return strings.ReplaceAll(generateACLName(lb, sourceIP, sourcePort), ":", "\\:")
+	return externalSwitch, nil
 }
 
 func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePort int32, proto kapi.Protocol) (string, error) {
@@ -205,8 +120,7 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 	if len(switches) > 0 {
 		applyToPortGroup = true
 	} else {
-		klog.V(5).Infof("Ignoring creating reject ACL for port group with load balancer %s. It has no "+
-			"logical switches", lb)
+		klog.V(5).Infof("Ignoring creating reject ACL for port group with load balancer %s. It has no logical switches", lb)
 	}
 
 	// check if the load balancer is on a GR, if so we need to get the external switches
@@ -224,21 +138,15 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 	if ip == nil {
 		return "", fmt.Errorf("cannot create reject ACL, invalid source IP: %s", sourceIP)
 	}
-	var l3Prefix, aclMatch string
-	if utilnet.IsIPv6(ip) {
-		l3Prefix = "ip6"
-	} else {
-		l3Prefix = "ip4"
-	}
+
 	vip := util.JoinHostPortInt32(sourceIP, sourcePort)
 	// NOTE: doesn't use vip, to avoid having brackets in the name with IPv6
-	aclName := generateACLNameForOVNCommand(lb, sourceIP, sourcePort)
+	aclName := loadbalancer.GenerateACLNameForOVNCommand(lb, sourceIP, sourcePort)
 	// If ovn-k8s was restarted, we lost the cache, and an ACL may already exist in OVN. In that case we need to check
 	// using ACL name
-	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
-		fmt.Sprintf("name=%s", aclName))
+	aclUUID, err := acl.GetACLByName(aclName)
 	if err != nil {
-		klog.Errorf("Error while querying ACLs by name: %s, %v", stderr, err)
+		klog.Errorf("Error while querying ACLs by name: %v", err)
 	} else if len(aclUUID) > 0 {
 		klog.Infof("Existing Service Reject ACL found: %s for %s", aclUUID, aclName)
 		var cmd []string
@@ -251,8 +159,7 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 		if len(cmd) > 0 {
 			_, _, err = util.RunOVNNbctl(cmd...)
 			if err != nil {
-				klog.Errorf("Failed to add LB %s, ACL %s, %q, to cluster port group/switches, stderr: %q,"+
-					"error: %v", lb, aclUUID, aclName, stderr, err)
+				klog.Errorf("Failed to add LB %s, ACL %s, %q, to cluster port group/switches, error: %v", lb, aclUUID, aclName, err)
 			}
 		}
 
@@ -264,29 +171,27 @@ func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePo
 		ovn.removeACLFromNodeSwitches(switches, aclUUID)
 		return aclUUID, nil
 	}
-
-	aclMatch = fmt.Sprintf("match=\"%s.dst==%s && %s && %s.dst==%d\"", l3Prefix, sourceIP,
-		strings.ToLower(string(proto)), strings.ToLower(string(proto)), sourcePort)
-	cmd := []string{"--id=@reject-acl", "create", "acl", "direction=from-lport", "priority=1000", aclMatch, "action=reject",
-		fmt.Sprintf("name=%s", aclName)}
+	errList := []error{}
 	if applyToPortGroup {
-		cmd = append(cmd, "--", "add", "port_group", ovn.clusterPortGroupUUID, "acls", "@reject-acl")
+		aclUUID, err = acl.AddRejectACLToPortGroup(ovn.clusterPortGroupUUID, aclName, sourceIP, int(sourcePort), proto)
+		if err != nil {
+			klog.Errorf("Failed to add LB: %v", err)
+			errList = append(errList, err)
+		}
 	}
 	if len(gwRouterExtSwitch) > 0 {
-		cmd = append(cmd, "--", "add", "logical_switch", gwRouterExtSwitch, "acls", "@reject-acl")
-	}
-	aclUUID, stderr, err = util.RunOVNNbctl(cmd...)
-	if err != nil {
-		klog.Errorf("Failed to add LB: %s ACL: %s, %q, to cluster port group/switches, stderr: %q, error: %v",
-			lb, aclUUID, aclName, stderr, err)
-		return "", err
+		aclUUID, err = acl.AddRejectACLToLogicalSwitch(gwRouterExtSwitch, aclName, sourceIP, int(sourcePort), proto)
+		if err != nil {
+			klog.Errorf("Failed to add LB: %v", err)
+			errList = append(errList, err)
+		}
 	}
 
 	// Associate ACL UUID with load balancer and ip+port so we can remove this ACL if
 	// backends are re-added.
 	ovn.setServiceACLToLB(lb, vip, aclUUID)
 
-	return aclUUID, nil
+	return aclUUID, utilerrors.NewAggregate(errList)
 }
 
 func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
@@ -300,7 +205,8 @@ func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
 			klog.Errorf("Unable to parse vip for Reject ACL deletion: %v", err)
 			return
 		}
-		aclUUID, err = ovn.findStaleRejectACL(lb, ip, port)
+		aclName := loadbalancer.GenerateACLNameForOVNCommand(lb, ip, port)
+		aclUUID, err = acl.GetACLByName(aclName)
 		if err != nil {
 			klog.Infof("Unable to delete Reject ACL for load-balancer: %s, vip: %s. No entry in cache and "+
 				"error occurred while trying to find the ACL by name in OVN, error: %v", lb, vip, err)
@@ -326,42 +232,17 @@ func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
 	ovn.removeServiceACL(lb, vip)
 }
 
-func (ovn *Controller) findStaleRejectACL(lb, ip string, port int32) (string, error) {
-	aclName := generateACLNameForOVNCommand(lb, ip, port)
-	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
-		fmt.Sprintf("name=%s", aclName))
-	if err != nil {
-		klog.Errorf("Error while querying ACLs by name: %s, %v", stderr, err)
-		return "", err
-	} else if len(aclUUID) == 0 {
-		klog.Infof("Reject ACL not found to remove for name: %s", aclName)
-		return "", fmt.Errorf("reject ACL not found to remove for name: %s", aclName)
-	}
-	return aclUUID, nil
-}
-
 // Remove the ACL uuid entry from Logical Switch acl's list.
 func (ovn *Controller) removeACLFromNodeSwitches(switches []string, aclUUID string) {
-	args := []string{}
-	for _, ls := range switches {
-		args = append(args, "--", "--if-exists", "remove", "logical_switch", ls, "acl", aclUUID)
-	}
-
-	if len(args) > 0 {
-		_, _, err := util.RunOVNNbctl(args...)
-		if err != nil {
-			klog.Errorf("Error while removing ACL: %s, from switches, error: %v", aclUUID, err)
-		} else {
-			klog.Infof("ACL: %s, removed from switches: %s", aclUUID, switches)
-		}
+	err := acl.RemoveACLFromNodeSwitches(switches, aclUUID)
+	if err != nil {
+		klog.Errorf("Failed to remove ACL %s from switches %v, error: %v", aclUUID, switches, err)
 	}
 }
 
 func (ovn *Controller) removeACLFromPortGroup(lb, aclUUID string) {
-	_, stderr, err := util.RunOVNNbctl("--", "--if-exists", "remove", "port_group", ovn.clusterPortGroupUUID, "acls", aclUUID)
+	err := acl.RemoveACLFromPortGroup(aclUUID, ovn.clusterPortGroupUUID)
 	if err != nil {
-		klog.Errorf("Failed to remove reject ACL %s from LB %s: stderr: %q, error: %v", aclUUID, lb, stderr, err)
-	} else {
-		klog.Infof("ACL: %s, removed from the port group : %s", aclUUID, ovn.clusterPortGroupUUID)
+		klog.Errorf("Failed to remove reject ACL %s from LB %s: error: %v", aclUUID, lb, err)
 	}
 }

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -1,0 +1,153 @@
+package loadbalancer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// GetOVNKubeLoadBalancer returns the LoadBalancer matching the protocol
+// in the OVN database using the external_ids = k8s-cluster-lb-${protocol}
+func GetOVNKubeLoadBalancer(protocol kapi.Protocol) (string, error) {
+	id := fmt.Sprintf("external_ids:k8s-cluster-lb-%s=yes", strings.ToLower(string(protocol)))
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid",
+		"find", "load_balancer", id)
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		return "", fmt.Errorf("no load balancer found in the database")
+	}
+	return out, nil
+}
+
+// GetLoadBalancerVIPs returns a map whose keys are VIPs (IP:port) on loadBalancer
+func GetLoadBalancerVIPs(loadBalancer string) (map[string]string, error) {
+	var vips map[string]string
+	outStr, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"get", "load_balancer", loadBalancer, "vips")
+	if err != nil {
+		return nil, err
+	}
+	if outStr == "" {
+		return vips, nil
+	}
+	// sample outStr:
+	// - {"192.168.0.1:80"="10.1.1.1:80,10.2.2.2:80"}
+	// - {"[fd01::]:80"="[fd02::]:80,[fd03::]:80"}
+	outStrMap := strings.Replace(outStr, "=", ":", -1)
+	err = json.Unmarshal([]byte(outStrMap), &vips)
+	if err != nil {
+		return nil, err
+	}
+	return vips, nil
+}
+
+// DeleteLoadBalancerVIP removes the VIP as well as any reject ACLs associated to the LB
+func DeleteLoadBalancerVIP(loadBalancer, vip string) error {
+	vipQuotes := fmt.Sprintf("\"%s\"", vip)
+	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove", "load_balancer", loadBalancer, "vips", vipQuotes)
+	if err != nil {
+		// if we hit an error and fail to remove load balancer, we skip removing the rejectACL
+		return fmt.Errorf("error in deleting load balancer vip %s for %s"+
+			"stdout: %q, stderr: %q, error: %v",
+			vip, loadBalancer, stdout, stderr, err)
+	}
+	return nil
+}
+
+// UpdateLoadBalancer updates the VIP for sourceIP:sourcePort to point to targets (an
+// array of IP:port strings)
+func UpdateLoadBalancer(lb, vip string, targets []string) error {
+	lbTarget := fmt.Sprintf(`vips:"%s"="%s"`, vip, strings.Join(targets, ","))
+
+	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, lbTarget)
+	if err != nil {
+		return fmt.Errorf("error in configuring load balancer: %s "+
+			"stdout: %q, stderr: %q, error: %v", lb, out, stderr, err)
+	}
+
+	return nil
+}
+
+// GetLogicalSwitchesForLoadBalancer get the switches associated to a LoadBalancer
+func GetLogicalSwitchesForLoadBalancer(lb string) ([]string, error) {
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "find",
+		"logical_switch", fmt.Sprintf("load_balancer{>=}%s", lb))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(out), nil
+}
+
+// GetLogicalRoutersForLoadBalancer get the routers associated to a LoadBalancer
+func GetLogicalRoutersForLoadBalancer(lb string) ([]string, error) {
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=name", "find",
+		"logical_router", fmt.Sprintf("load_balancer{>=}%s", lb))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(out), nil
+}
+
+// GetGRLogicalSwitchForLoadBalancer returns the external switch name if the load balancer is on a GR
+func GetGRLogicalSwitchForLoadBalancer(lb string) (string, error) {
+	routers, err := GetLogicalRoutersForLoadBalancer(lb)
+	if err != nil {
+		return "", err
+	}
+	if len(routers) == 0 {
+		return "", nil
+	}
+
+	// if this is a GR we know the corresponding join and external switches, otherwise this is an unhandled
+	// case
+	for _, r := range routers {
+		if strings.HasPrefix(r, types.GWRouterPrefix) {
+			routerName := strings.TrimPrefix(r, types.GWRouterPrefix)
+			return types.ExternalSwitchPrefix + routerName, nil
+		}
+	}
+	return "", fmt.Errorf("router detected with load balancer that is not a GR")
+}
+
+// GenerateACLName generates a deterministic ACL name based on the load_balancer parameters
+func GenerateACLName(lb string, sourceIP string, sourcePort int32) string {
+	aclName := fmt.Sprintf("%s-%s:%d", lb, sourceIP, sourcePort)
+	// ACL names are limited to 63 characters
+	if len(aclName) > 63 {
+		var ipPortLen int
+		srcPortStr := fmt.Sprintf("%d", sourcePort)
+		// Add the length of the IP (max 15 with periods, max 39 with colons),
+		// plus length of sourcePort (max 5 char),
+		// plus 1 for additional ':' to separate,
+		// plus 1 for '-' between lb and IP.
+		// With full IPv6 address and 5 char port, max ipPortLen is 62
+		// With full IPv4 address and 5 char port, max ipPortLen is 24.
+		ipPortLen = len(sourceIP) + len(srcPortStr) + 1 + 1
+		lbTrim := 63 - ipPortLen
+		// Shorten the Load Balancer name to allow full IP:port
+		tmpLb := lb[:lbTrim]
+		klog.Infof("Limiting ACL Name from %s to %s-%s:%d to keep under 63 characters", aclName, tmpLb, sourceIP, sourcePort)
+		aclName = fmt.Sprintf("%s-%s:%d", tmpLb, sourceIP, sourcePort)
+	}
+	return aclName
+}
+
+// GenerateACLNameForOVNCommand sanitize the ACL name because the generateACLName
+// function was including backslash escapes for the ACL
+// name for use in OVN commands that have trouble with literal ":". That
+// was causing a mismatch when services were syncing because the name
+// actually returned from an OVN command does not include any backslashes
+// so the names would not match. #1749
+func GenerateACLNameForOVNCommand(lb string, sourceIP string, sourcePort int32) string {
+	return strings.ReplaceAll(GenerateACLName(lb, sourceIP, sourcePort), ":", "\\:")
+}

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,326 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+)
+
+func TestGetOVNKubeLoadBalancer(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol kapi.Protocol
+		ovnCmd   ovntest.ExpectedCmd
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "existing loadbalancer TCP",
+			protocol: kapi.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+				Output: "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			},
+			want:    "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:     "non existing loadbalancer UDP",
+			protocol: kapi.ProtocolUDP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+				Output: "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := GetOVNKubeLoadBalancer(tt.protocol)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetOVNKubeLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetOVNKubeLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLoadBalancerVIPs(t *testing.T) {
+	tests := []struct {
+		name         string
+		loadBalancer string
+		ovnCmd       ovntest.ExpectedCmd
+		want         map[string]string
+		wantErr      bool
+	}{
+		{
+			name:         "loadbalancer with VIPs",
+			loadBalancer: "my-lb",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer my-lb vips",
+				Output: `{"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53", "10.96.0.10:9153"="10.244.2.3:9153,10.244.2.5:9153", "10.96.0.1:443"="172.19.0.3:6443"}`,
+			},
+			want: map[string]string{
+				"10.96.0.10:53":   "10.244.2.3:53,10.244.2.5:53",
+				"10.96.0.10:9153": "10.244.2.3:9153,10.244.2.5:9153",
+				"10.96.0.1:443":   "172.19.0.3:6443",
+			},
+			wantErr: false,
+		},
+		{
+			name:         "empty load balancer",
+			loadBalancer: "my-lb",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer my-lb vips",
+				Output: "",
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetLoadBalancerVIPs(tt.loadBalancer)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLoadBalancerVIPs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLoadBalancerVIPs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteLoadBalancerVIP(t *testing.T) {
+	tests := []struct {
+		name         string
+		loadBalancer string
+		vip          string
+		ovnCmd       ovntest.ExpectedCmd
+		wantErr      bool
+	}{
+		{
+			name:         "loadbalancer with VIPs",
+			loadBalancer: "my-lb",
+			vip:          "10.96.0.10:53",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer my-lb vips "10.96.0.10:53"`,
+				Output: `{"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53", "10.96.0.10:9153"="10.244.2.3:9153,10.244.2.5:9153", "10.96.0.1:443"="172.19.0.3:6443"}`,
+			},
+			wantErr: false,
+		},
+		{
+			name:         "load balancer and OVN error",
+			loadBalancer: "my-lb",
+			vip:          "10.96.0.10:53",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer my-lb vips "10.96.0.10:53"`,
+				Output: "",
+				Err:    fmt.Errorf("error while removing ACL: sw1, from switches"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			err = DeleteLoadBalancerVIP(tt.loadBalancer, tt.vip)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteLoadBalancerVIP() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestUpdateLoadBalancer(t *testing.T) {
+	type args struct {
+		lb      string
+		vip     string
+		targets []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		ovnCmd  ovntest.ExpectedCmd
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			if err := UpdateLoadBalancer(tt.args.lb, tt.args.vip, tt.args.targets); (err != nil) != tt.wantErr {
+				t.Errorf("UpdateLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetLogicalSwitchesForLoadBalancer(t *testing.T) {
+	type args struct {
+		lb string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		ovnCmd  ovntest.ExpectedCmd
+		want    []string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetLogicalSwitchesForLoadBalancer(tt.args.lb)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLogicalSwitchesForLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLogicalSwitchesForLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLogicalRoutersForLoadBalancer(t *testing.T) {
+	type args struct {
+		lb string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		ovnCmd  ovntest.ExpectedCmd
+		want    []string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetLogicalRoutersForLoadBalancer(tt.args.lb)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLogicalRoutersForLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLogicalRoutersForLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateACLName(t *testing.T) {
+	type args struct {
+		lb         string
+		sourceIP   string
+		sourcePort int32
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateACLName(tt.args.lb, tt.args.sourceIP, tt.args.sourcePort); got != tt.want {
+				t.Errorf("GenerateACLName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateACLNameForOVNCommand(t *testing.T) {
+	type args struct {
+		lb         string
+		sourceIP   string
+		sourcePort int32
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateACLNameForOVNCommand(tt.args.lb, tt.args.sourceIP, tt.args.sourcePort); got != tt.want {
+				t.Errorf("GenerateACLNameForOVNCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetGRLogicalSwitchForLoadBalancer(t *testing.T) {
+	type args struct {
+		lb string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetGRLogicalSwitchForLoadBalancer(tt.args.lb)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetGRLogicalSwitchForLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetGRLogicalSwitchForLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -122,7 +122,8 @@ type Controller struct {
 
 	// For TCP, UDP, and SCTP type traffic, cache OVN load-balancers used for the
 	// cluster's east-west traffic.
-	loadbalancerClusterCache map[kapi.Protocol]string
+	loadbalancerClusterCache      map[kapi.Protocol]string
+	loadbalancerClusterCacheMutex sync.Mutex
 
 	// A cache of all logical switches seen by the watcher and their subnets
 	lsManager *logicalSwitchManager


### PR DESCRIPTION
We can move the OVN operations to deal with ACLs and LoadBalancers into its own package so we can unit test them and reuse it.