### PR TITLE
Dualstack Services with Endpoint Slices

### DIFF
--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -57,6 +57,14 @@ rules:
   - statefulsets
   verbs: ["get", "list", "watch"]
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -68,6 +68,38 @@ var MetricResourceUpdateLatency = prometheus.NewHistogramVec(prometheus.Histogra
 	[]string{"name"},
 )
 
+// MetricRequeueServiceCount is the number of times a particular service has been requeued.
+var MetricRequeueServiceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "requeue_service_total",
+	Help:      "A metric that captures the number of times a service is requeued after failing to sync with OVN"},
+	[]string{
+		"name",
+	},
+)
+
+// MetricSyncServiceCount is the number of times a particular service has been synced.
+var MetricSyncServiceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "sync_service_total",
+	Help:      "A metric that captures the number of times a service is synced with OVN load balancers"},
+	[]string{
+		"name",
+	},
+)
+
+// MetricSyncServiceLatency is the time taken to sync a service with the OVN load balancers.
+var MetricSyncServiceLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "sync_service_latency_seconds",
+	Help:      "The latency of syncing a service with the OVN load balancers",
+	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
+	[]string{"name"},
+)
+
 var MetricMasterReadyDuration = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
@@ -130,6 +162,9 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 		util.MetricOvnCliLatency = metricOvnCliLatency
 		prometheus.MustRegister(MetricResourceUpdateCount)
 		prometheus.MustRegister(MetricResourceUpdateLatency)
+		prometheus.MustRegister(MetricRequeueServiceCount)
+		prometheus.MustRegister(MetricSyncServiceCount)
+		prometheus.MustRegister(MetricSyncServiceLatency)
 		prometheus.MustRegister(prometheus.NewGaugeFunc(
 			prometheus.GaugeOpts{
 				Namespace: MetricOvnkubeNamespace,

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,7 +18,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -283,7 +284,7 @@ func (n *OvnNode) WatchEndpoints() {
 		UpdateFunc: func(old, new interface{}) {
 			epNew := new.(*kapi.Endpoints)
 			epOld := old.(*kapi.Endpoints)
-			if reflect.DeepEqual(epNew.Subsets, epOld.Subsets) {
+			if apiequality.Semantic.DeepEqual(epNew.Subsets, epOld.Subsets) {
 				return
 			}
 			newEpAddressMap := buildEndpointAddressMap(epNew.Subsets)

--- a/go-controller/pkg/ovn/acl/acl.go
+++ b/go-controller/pkg/ovn/acl/acl.go
@@ -1,0 +1,128 @@
+package acl
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	"github.com/pkg/errors"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+)
+
+// GetACLByName returns the ACL UUID
+func GetACLByName(aclName string) (string, error) {
+	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
+		fmt.Sprintf("name=%s", aclName))
+	if err != nil {
+		return "", errors.Wrapf(err, "Error while querying ACLs by name: %s", stderr)
+	}
+	return aclUUID, nil
+}
+
+// GetRejectACLs returns a map with the ACLs with a reject action
+// the map uses the name of the ACL as key and the uuid as value
+func GetRejectACLs() (map[string]string, error) {
+	// Get OVN's current reject ACLs. Note, currently only services use reject ACLs.
+	result := make(map[string]string)
+	type ovnACLData struct {
+		Data [][]interface{}
+	}
+	data, stderr, err := util.RunOVNNbctl("--columns=name,_uuid", "--format=json", "find", "acl", "action=reject")
+	if err != nil {
+		return result, errors.Wrapf(err, "Error while querying ACLs with reject action: %s", stderr)
+	}
+	// Process the output
+	x := ovnACLData{}
+	if err := json.Unmarshal([]byte(data), &x); err != nil {
+		return result, errors.Wrapf(err, "Unable to get current OVN reject ACLs. Unable to sync reject ACLs")
+	}
+	for _, entry := range x.Data {
+		// ACL entry format is a slice: [<aclName>, ["_uuid", <uuid>]]
+		if len(entry) != 2 {
+			continue
+		}
+		name, ok := entry[0].(string)
+		if !ok {
+			continue
+		}
+		uuidData, ok := entry[1].([]interface{})
+		if !ok || len(uuidData) != 2 {
+			continue
+		}
+		uuid, ok := uuidData[1].(string)
+		if !ok {
+			continue
+		}
+		result[name] = uuid
+	}
+	return result, nil
+}
+
+// RemoveACLFromNodeSwitches removes the ACL uuid entry from Logical Switch acl's list.
+func RemoveACLFromNodeSwitches(switches []string, aclUUID string) error {
+	if len(switches) == 0 {
+		return nil
+	}
+	args := []string{}
+	for _, ls := range switches {
+		args = append(args, "--", "--if-exists", "remove", "logical_switch", ls, "acl", aclUUID)
+	}
+	_, _, err := util.RunOVNNbctl(args...)
+	if err != nil {
+		return errors.Wrapf(err, "Error while removing ACL: %s, from switches", aclUUID)
+	}
+	klog.Infof("ACL: %s, removed from switches: %s", aclUUID, switches)
+	return nil
+}
+
+// RemoveACLFromPortGroup removes the ACL from the port-group
+func RemoveACLFromPortGroup(aclUUID, clusterPortGroupUUID string) error {
+	_, stderr, err := util.RunOVNNbctl("--", "--if-exists", "remove", "port_group", clusterPortGroupUUID, "acls", aclUUID)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to remove reject ACL %s from port group %s: stderr: %q", aclUUID, clusterPortGroupUUID, stderr)
+	}
+	klog.Infof("ACL: %s, removed from the port group : %s", aclUUID, clusterPortGroupUUID)
+	return nil
+}
+
+// AddRejectACLToPortGroup adds a reject ACL to a PortGroup
+func AddRejectACLToPortGroup(clusterPortGroupUUID, aclName, sourceIP string, sourcePort int, proto v1.Protocol) (string, error) {
+	l3Prefix := "ip4"
+	if utilnet.IsIPv6String(sourceIP) {
+		l3Prefix = "ip6"
+	}
+
+	aclMatch := fmt.Sprintf("match=\"%s.dst==%s && %s && %s.dst==%d\"", l3Prefix, sourceIP,
+		strings.ToLower(string(proto)), strings.ToLower(string(proto)), sourcePort)
+	cmd := []string{"--id=@reject-acl", "create", "acl", "direction=from-lport", "priority=1000", aclMatch, "action=reject",
+		fmt.Sprintf("name=%s", aclName), "--", "add", "port_group", clusterPortGroupUUID, "acls", "@reject-acl"}
+	aclUUID, stderr, err := util.RunOVNNbctl(cmd...)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to add ACL: %s, %q, to cluster port group %s, stderr: %q", aclUUID, aclName, clusterPortGroupUUID, stderr)
+	}
+	return aclUUID, nil
+}
+
+// AddRejectACLToLogicalSwitch adds a reject ACL to a logical switch
+func AddRejectACLToLogicalSwitch(logicalSwitch, aclName, sourceIP string, sourcePort int, proto v1.Protocol) (string, error) {
+	l3Prefix := "ip4"
+	if utilnet.IsIPv6String(sourceIP) {
+		l3Prefix = "ip6"
+	}
+
+	aclMatch := fmt.Sprintf("match=\"%s.dst==%s && %s && %s.dst==%d\"", l3Prefix, sourceIP,
+		strings.ToLower(string(proto)), strings.ToLower(string(proto)), sourcePort)
+	cmd := []string{"--id=@reject-acl", "create", "acl", "direction=from-lport", "priority=1000", aclMatch, "action=reject",
+		fmt.Sprintf("name=%s", aclName), "--", "add", "logical_switch", logicalSwitch, "acls", "@reject-acl"}
+
+	aclUUID, stderr, err := util.RunOVNNbctl(cmd...)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to add ACL: %s, %q, to cluster switch %s, stderr: %q", aclUUID, aclName, logicalSwitch, stderr)
+	}
+	return aclUUID, nil
+}

--- a/go-controller/pkg/ovn/acl/acl_test.go
+++ b/go-controller/pkg/ovn/acl/acl_test.go
@@ -1,0 +1,318 @@
+package acl
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestGetACLByName(t *testing.T) {
+	tests := []struct {
+		name    string
+		aclName string
+		ovnCmd  ovntest.ExpectedCmd
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "existing acl",
+			aclName: "my-acl",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=my-acl",
+				Output: "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			},
+			want:    "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:    "non existing acl",
+			aclName: "my-acl",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=my-acl",
+				Output: "",
+			},
+			want:    "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := GetACLByName(tt.aclName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetACLByName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetACLByName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveACLFromNodeSwitches(t *testing.T) {
+	tests := []struct {
+		name     string
+		switches []string
+		aclUUID  string
+		ovnCmd   ovntest.ExpectedCmd
+		wantErr  bool
+	}{
+		{
+			name:     "remove acl on two switches",
+			switches: []string{"sw1", "sw2"},
+			aclUUID:  "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- --if-exists remove logical_switch sw1 acl a08ea426-2288-11eb-a30b-a8a1590cda29 -- --if-exists remove logical_switch sw2 acl a08ea426-2288-11eb-a30b-a8a1590cda29",
+				Output: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "remove acl on no switches",
+			switches: []string{},
+			aclUUID:  "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd:   ovntest.ExpectedCmd{},
+			wantErr:  false,
+		},
+		{
+			name:     "remove acl and OVN error on first switch",
+			switches: []string{"sw1", "sw2"},
+			aclUUID:  "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- --if-exists remove logical_switch sw1 acl a08ea426-2288-11eb-a30b-a8a1590cda29 -- --if-exists remove logical_switch sw2 acl a08ea426-2288-11eb-a30b-a8a1590cda29",
+				Output: "",
+				Err:    fmt.Errorf("error while removing ACL: sw1, from switches"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			err = RemoveACLFromNodeSwitches(tt.switches, tt.aclUUID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RemoveACLFromNodeSwitches() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestRemoveACLFromPortGroup(t *testing.T) {
+	tests := []struct {
+		name                 string
+		clusterPortGroupUUID string
+		aclUUID              string
+		ovnCmd               ovntest.ExpectedCmd
+		wantErr              bool
+	}{
+		{
+			name:                 "remove acl from portgroup",
+			clusterPortGroupUUID: "63c3e636-387d-11eb-ac78-a8a1590cda29",
+			aclUUID:              "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 -- --if-exists remove port_group 63c3e636-387d-11eb-ac78-a8a1590cda29 acls a08ea426-2288-11eb-a30b-a8a1590cda29",
+				Output: "",
+			},
+			wantErr: false,
+		},
+
+		// TODO: Add test cases for errors
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			err = RemoveACLFromPortGroup(tt.aclUUID, tt.clusterPortGroupUUID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RemoveACLFromPortGroup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestGetRejectACLs(t *testing.T) {
+	tests := []struct {
+		name    string
+		ovnCmd  ovntest.ExpectedCmd
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "no reject ACLs in OVN",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --columns=name,_uuid --format=json find acl action=reject",
+				Output: `{"data":[],"headings":["name","_uuid"]}`,
+			},
+			want:    make(map[string]string),
+			wantErr: false,
+		},
+
+		// TODO: Add test cases with some data
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetRejectACLs()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetRejectACLs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetRejectACLs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddRejectACLToLogicalSwitch(t *testing.T) {
+	tests := []struct {
+		name          string
+		logicalSwitch string
+		aclName       string
+		sourceIP      string
+		sourcePort    int
+		proto         v1.Protocol
+		ovnCmd        ovntest.ExpectedCmd
+		want          string
+		wantErr       bool
+	}{
+		{
+			name:          "add ipv4 acl",
+			logicalSwitch: "545dc436-387e-11eb-9f38-a8a1590cda29",
+			aclName:       "myacl",
+			sourceIP:      "192.168.2.2",
+			sourcePort:    80,
+			proto:         v1.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.2.2 && tcp && tcp.dst==80" action=reject name=myacl -- add logical_switch 545dc436-387e-11eb-9f38-a8a1590cda29 acls @reject-acl`,
+				Output: "97347886-387e-11eb-9fdf-a8a1590cda29",
+			},
+			want:    "97347886-387e-11eb-9fdf-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:          "add ipv6 acl",
+			logicalSwitch: "545dc436-387e-11eb-9f38-a8a1590cda29",
+			aclName:       "myacl",
+			sourceIP:      "2001:db2:1:2::23",
+			sourcePort:    80,
+			proto:         v1.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip6.dst==2001:db2:1:2::23 && tcp && tcp.dst==80" action=reject name=myacl -- add logical_switch 545dc436-387e-11eb-9f38-a8a1590cda29 acls @reject-acl`,
+				Output: "97347886-387e-11eb-9fdf-a8a1590cda29",
+			},
+			want:    "97347886-387e-11eb-9fdf-a8a1590cda29",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := AddRejectACLToLogicalSwitch(tt.logicalSwitch, tt.aclName, tt.sourceIP, tt.sourcePort, tt.proto)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddRejectACLToLogicalSwitch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("AddRejectACLToLogicalSwitch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddRejectACLToPortGroup(t *testing.T) {
+	tests := []struct {
+		name       string
+		portGroup  string
+		aclName    string
+		sourceIP   string
+		sourcePort int
+		proto      v1.Protocol
+		ovnCmd     ovntest.ExpectedCmd
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "add ipv4 acl",
+			portGroup:  "545dc436-387e-11eb-9f38-a8a1590cda29",
+			aclName:    "myacl",
+			sourceIP:   "192.168.2.2",
+			sourcePort: 80,
+			proto:      v1.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.2.2 && tcp && tcp.dst==80" action=reject name=myacl -- add port_group 545dc436-387e-11eb-9f38-a8a1590cda29 acls @reject-acl`,
+				Output: "97347886-387e-11eb-9fdf-a8a1590cda29",
+			},
+			want:    "97347886-387e-11eb-9fdf-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:       "add ipv6 acl",
+			portGroup:  "545dc436-387e-11eb-9f38-a8a1590cda29",
+			aclName:    "myacl",
+			sourceIP:   "2001:db2:1:2::23",
+			sourcePort: 80,
+			proto:      v1.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip6.dst==2001:db2:1:2::23 && tcp && tcp.dst==80" action=reject name=myacl -- add port_group 545dc436-387e-11eb-9f38-a8a1590cda29 acls @reject-acl`,
+				Output: "97347886-387e-11eb-9fdf-a8a1590cda29",
+			},
+			want:    "97347886-387e-11eb-9fdf-a8a1590cda29",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := AddRejectACLToPortGroup(tt.portGroup, tt.aclName, tt.sourceIP, tt.sourcePort, tt.proto)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddRejectACLToPortGroup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("AddRejectACLToPortGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -1,0 +1,115 @@
+package services
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+// Repair is a controller loop that can work as in one-shot or periodic mode
+// it checks the OVN Load Balancers and delete the ones that doesn't exist in
+// the Kubernetes serviceTracker.
+// Based on:
+// https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.19/pkg/registry/core/service/ipallocator/controller/repair.go
+type Repair struct {
+	interval time.Duration
+	// serviceTracker tracks services and maps them to OVN LoadBalancers
+	serviceTracker *serviceTracker
+}
+
+// NewRepair creates a controller that periodically ensures that there is no stale data in OVN
+func NewRepair(interval time.Duration,
+	serviceTracker *serviceTracker,
+) *Repair {
+	return &Repair{
+		interval:       interval,
+		serviceTracker: serviceTracker,
+	}
+}
+
+// RunUntil starts the controller until the provided ch is closed.
+func (r *Repair) RunUntil(stopCh <-chan struct{}) {
+	wait.Until(func() {
+		if err := r.RunOnce(); err != nil {
+			klog.Errorf("Error repairing services: %v")
+		}
+	}, r.interval, stopCh)
+}
+
+// RunOnce verifies the state of Services and OVN LBs and returns an error if an unrecoverable problem occurs.
+func (r *Repair) RunOnce() error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, r.runOnce)
+}
+
+// runOnce verifies the state of the cluster OVN LB VIP allocations and returns an error if an unrecoverable problem occurs.
+func (r *Repair) runOnce() error {
+	startTime := time.Now()
+	klog.V(4).Infof("Starting repairing loop for services")
+	defer func() {
+		klog.V(4).Infof("Finished repairing loop for services: %v", time.Since(startTime))
+		metrics.MetricSyncServiceLatency.WithLabelValues("repair-loop").Observe(time.Since(startTime).Seconds())
+	}()
+
+	// Obtain all the load balancers UUID
+	ovnLBCache := make(map[v1.Protocol][]string)
+	// We have different loadbalancers per protocol
+	protocols := []v1.Protocol{v1.ProtocolSCTP, v1.ProtocolTCP, v1.ProtocolUDP}
+	// ClusterIP OVN load balancers
+	for _, p := range protocols {
+		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to get OVN load balancer for protocol %s", p)
+		}
+		ovnLBCache[p] = append(ovnLBCache[p], lbUUID)
+	}
+	// NodePort, ExternalIPs and Ingress OVN load balancers
+	gatewayRouters, _, err := gateway.GetOvnGateways()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get gateway router")
+	}
+	for _, p := range protocols {
+		for _, gatewayRouter := range gatewayRouters {
+			lbUUID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, p)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to get OVN GR load balancer for protocol %s", p)
+			}
+			ovnLBCache[p] = append(ovnLBCache[p], lbUUID)
+		}
+	}
+
+	// Get Kubernetes Service state
+	svcVIPsProtocolMap := r.serviceTracker.getServiceVipsMap()
+
+	// Reconcile with OVN state
+	// Obtain all the VIPs present in the OVN LoadBalancers
+	// and delete the ones that are not present in the service tracker
+	for _, p := range protocols {
+		for _, lb := range ovnLBCache[p] {
+			vips, err := loadbalancer.GetLoadBalancerVIPs(lb)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to get load balancer vips for %s", ovnLBCache[p])
+			}
+			for vip := range vips {
+				key := virtualIPKey(vip, p)
+				// Virtual IP and protocol doesn't belong to a Kubernetes service
+				if !svcVIPsProtocolMap.Has(key) {
+					klog.Infof("Deleting non-existing Kubernetes vip %s from OVN load balancer %s", vip, ovnLBCache[p])
+					if err := loadbalancer.DeleteLoadBalancerVIP(lb, vip); err != nil {
+						return errors.Wrapf(err, "Failed to delete load balancer vips %s for %s", vip, ovnLBCache[p])
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/go-controller/pkg/ovn/controller/services/repair_test.go
+++ b/go-controller/pkg/ovn/controller/services/repair_test.go
@@ -1,0 +1,249 @@
+package services
+
+import (
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	tcpLBUUID    string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
+	udpLBUUID    string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
+	sctpLBUUID   string = "0514c521-a120-4756-aec6-883fe5db7139"
+	grTcpLBUUID  string = "001c2ec6-2f32-11eb-9bc2-a8a1590cda29"
+	grUdpLBUUID  string = "05c55ae6-2f32-11eb-822e-a8a1590cda29"
+	grSctpLBUUID string = "0ac92874-2f32-11eb-8ca0-a8a1590cda29"
+)
+
+func TestRepair_Empty(t *testing.T) {
+	st := newServiceTracker()
+	r := &Repair{
+		interval:       0,
+		serviceTracker: st,
+	} // Expected OVN commands
+	fexec := ovntest.NewFakeExec()
+	initializeClusterIPLBs(fexec)
+	// OVN is empty
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + sctpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grSctpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + tcpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grTcpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + udpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
+		Output: "",
+	})
+
+	err := util.SetExec(fexec)
+	if err != nil {
+		t.Errorf("fexec error: %v", err)
+	}
+
+	if err := r.runOnce(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestRepair_OVNStaleData(t *testing.T) {
+	st := newServiceTracker()
+	r := &Repair{
+		interval:       0,
+		serviceTracker: st,
+	} // Expected OVN commands
+	fexec := ovntest.NewLooseCompareFakeExec()
+	initializeClusterIPLBs(fexec)
+	// There are remaining OVN LB that doesn't exist in Kubernetes
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + sctpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grSctpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + tcpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grTcpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + udpLBUUID + " vips",
+		Output: `{"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53", "10.96.0.10:9153"="10.244.2.3:9153,10.244.2.5:9153", "10.96.0.1:443"="172.19.0.3:6443"}`,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
+		Output: "",
+	})
+	// The repair loop must delete the remaining entries in OVN
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.10:53\"",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.10:9153\"",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.1:443\"",
+		Output: "",
+	})
+	// The repair loop must delete them
+	err := util.SetExec(fexec)
+	if err != nil {
+		t.Errorf("fexec error: %v", err)
+	}
+
+	if err := r.runOnce(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestRepair_OVNSynced(t *testing.T) {
+	st := newServiceTracker()
+	r := &Repair{
+		interval:       0,
+		serviceTracker: st,
+	}
+	// Expected OVN commands
+	fexec := ovntest.NewLooseCompareFakeExec()
+	initializeClusterIPLBs(fexec)
+
+	st.updateService("svcname", "nsname", "10.96.0.10:80", v1.ProtocolTCP)
+	st.updateService("svcname", "nsname", "[fd00:10:96::1]:80", v1.ProtocolTCP)
+
+	// OVN database is in Sync no operation expected
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + sctpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grSctpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + tcpLBUUID + " vips",
+		Output: `{"10.96.0.10:80"="10.0.0.2:3456,10.0.0.3:3456", "[fd00:10:96::1]:80"="[2001:db8::1]:3456,[2001:db8::2]:3456"}`,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grTcpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + udpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
+		Output: "",
+	})
+
+	err := util.SetExec(fexec)
+	if err != nil {
+		t.Errorf("fexec error: %v", err)
+	}
+
+	if err := r.runOnce(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestRepair_OVNMissingService(t *testing.T) {
+	st := newServiceTracker()
+	r := &Repair{
+		interval:       0,
+		serviceTracker: st,
+	} // Expected OVN commands
+	fexec := ovntest.NewFakeExec()
+	initializeClusterIPLBs(fexec)
+
+	r.serviceTracker.updateService("svcname", "nsname", "10.96.0.10:80", v1.ProtocolTCP)
+	r.serviceTracker.updateService("svcname", "nsname", "[fd00:10:96::1]:80", v1.ProtocolTCP)
+
+	// OVN database is in Sync no operation expected
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + sctpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grSctpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + tcpLBUUID + " vips",
+		Output: `{"10.96.0.10:80"="10.0.0.2:3456,10.0.0.3:3456"}`,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grTcpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + udpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
+		Output: "",
+	})
+
+	// The repair loop must do nothing, the controller will add the new service
+	err := util.SetExec(fexec)
+	if err != nil {
+		t.Errorf("fexec error: %v", err)
+	}
+
+	if err := r.runOnce(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func initializeClusterIPLBs(fexec *ovntest.FakeExec) {
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-sctp=yes",
+		Output: sctpLBUUID,
+	})
+
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: tcpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+		Output: udpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+		Output: "gateway1",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=gateway1",
+		Output: grSctpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=gateway1",
+		Output: grTcpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=gateway1",
+		Output: grUdpLBUUID,
+	})
+}

--- a/go-controller/pkg/ovn/controller/services/service_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/service_tracker.go
@@ -1,0 +1,148 @@
+package services
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+)
+
+// serviceTrackerKey returns a string used for the tracker index.
+func serviceTrackerKey(name, namespace string) string { return name + "/" + namespace }
+
+// virtualIPKey returns a string used for the virtual IPs index.
+func virtualIPKey(virtualIP string, protocol v1.Protocol) string {
+	return virtualIP + "/" + string(protocol)
+}
+
+// splitVirtualIPKey splits the VirtualIPKey from the service tracker in virtual ip and protocol
+func splitVirtualIPKey(key string) (string, v1.Protocol) {
+	parts := strings.Split(key, "/")
+	return parts[0], v1.Protocol(parts[1])
+}
+
+// serviceTracker tracks the services VIPs using the service name and namespace as key
+// one service can have multiple VIPs, they are stored in the format IP:Port/Protocol
+// The services allows to map Kubernetes Services and OVN LoadBalancer
+type serviceTracker struct {
+	sync.Mutex
+	virtualIPByService map[string]sets.String
+}
+
+// newServiceTracker creates and initializes a new serviceTracker.
+func newServiceTracker() *serviceTracker {
+	return &serviceTracker{
+		virtualIPByService: map[string]sets.String{},
+	}
+}
+
+// updateService adds or updates the virtualIPs and endpoints of the Service
+func (st *serviceTracker) updateService(name, namespace, virtualIP string, proto v1.Protocol) {
+	st.Lock()
+	defer st.Unlock()
+
+	serviceNN := serviceTrackerKey(name, namespace)
+	key := virtualIPKey(virtualIP, proto)
+
+	// check if the service already exists and create a new entry if it does not
+	vips, ok := st.virtualIPByService[serviceNN]
+	if !ok {
+		klog.V(5).Infof("Created service %s VIP %s %s on Service Tracker", serviceNN, virtualIP, proto)
+		st.virtualIPByService[serviceNN] = sets.NewString(key)
+		return
+	}
+	// Update the service VIP with the new endpoints
+	vips.Insert(key)
+	klog.V(5).Infof("Updated service %s VIP %s %s on Service Tracker", serviceNN, virtualIP, proto)
+}
+
+// deleteService removes the set of virtual IPs tracked for the Service.
+func (st *serviceTracker) deleteService(name, namespace string) {
+	st.Lock()
+	defer st.Unlock()
+
+	serviceNN := serviceTrackerKey(name, namespace)
+	delete(st.virtualIPByService, serviceNN)
+	klog.V(5).Infof("Deleted service %s from Service Tracker", serviceNN)
+}
+
+// deleteServiceVIP removes the virtual IP tracked for the Service.
+func (st *serviceTracker) deleteServiceVIP(name, namespace, virtualIP string, proto v1.Protocol) {
+	st.Lock()
+	defer st.Unlock()
+
+	serviceNN := serviceTrackerKey(name, namespace)
+	key := virtualIPKey(virtualIP, proto)
+	vips, ok := st.virtualIPByService[serviceNN]
+	if ok {
+		vips.Delete(key)
+		klog.V(5).Infof("Deleted service %s VIP %s %s from Service Tracker", serviceNN, virtualIP, proto)
+	}
+}
+
+// hasService return true if the service is being tracked
+func (st *serviceTracker) hasService(name, namespace string) bool {
+	st.Lock()
+	defer st.Unlock()
+
+	serviceNN := serviceTrackerKey(name, namespace)
+	_, ok := st.virtualIPByService[serviceNN]
+	return ok
+}
+
+// hasServiceVIP return true if the VIP is being tracked for that service
+func (st *serviceTracker) hasServiceVIP(name, namespace, virtualIP string, proto v1.Protocol) bool {
+	st.Lock()
+	defer st.Unlock()
+
+	serviceNN := serviceTrackerKey(name, namespace)
+	key := virtualIPKey(virtualIP, proto)
+
+	// check if the service already exists
+	vips, ok := st.virtualIPByService[serviceNN]
+	if !ok {
+		return false
+	}
+	return vips.Has(key)
+}
+
+// getService return the service VIPs associated to the service
+func (st *serviceTracker) getService(name, namespace string) sets.String {
+	st.Lock()
+	defer st.Unlock()
+
+	serviceNN := serviceTrackerKey(name, namespace)
+	if vips, ok := st.virtualIPByService[serviceNN]; ok {
+		klog.V(5).Infof("Obtained service %s on Service Tracker: %v", serviceNN, vips)
+		return vips
+	}
+	return sets.NewString()
+}
+
+// getServiceVipsMap return a set with all the service VIPs in the format IP:Port/Protocol
+func (st *serviceTracker) getServiceVipsMap() sets.String {
+	st.Lock()
+	defer st.Unlock()
+
+	result := sets.NewString()
+	for _, vips := range st.virtualIPByService {
+		for key := range vips {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// updateKubernetesService adds or updates the tracker from a Kubernetes service
+// added for testing purposes
+func (st *serviceTracker) updateKubernetesService(service *v1.Service) {
+	for _, ip := range service.Spec.ClusterIPs {
+		for _, svcPort := range service.Spec.Ports {
+			vip := util.JoinHostPortInt32(ip, svcPort.Port)
+			st.updateService(service.Name, service.Namespace, vip, svcPort.Protocol)
+		}
+	}
+}

--- a/go-controller/pkg/ovn/controller/services/service_tracker_test.go
+++ b/go-controller/pkg/ovn/controller/services/service_tracker_test.go
@@ -1,0 +1,74 @@
+package services
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func Test_serviceTracker_updateService(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		proto     v1.Protocol
+		vip       string
+	}{
+		// Create a new service
+		{
+			name:      "svc1",
+			namespace: "ns1",
+			proto:     v1.ProtocolTCP,
+			vip:       "10.0.0.0:80",
+		},
+		// Update the service endpoint
+		{
+			name:      "svc1",
+			namespace: "ns1",
+			proto:     v1.ProtocolTCP,
+			vip:       "10.0.0.0:80",
+		},
+		// Add a new VIP to the service
+		{
+			name:      "svc1",
+			namespace: "ns1",
+			proto:     v1.ProtocolTCP,
+			vip:       "10.0.0.0:890",
+		},
+		// Create another service
+		{
+			name:      "svc2",
+			namespace: "ns1",
+			proto:     v1.ProtocolUDP,
+			vip:       "10.0.0.0:80",
+		},
+	}
+
+	st := newServiceTracker()
+	for _, tt := range tests {
+		st.updateService(tt.name, tt.namespace, tt.vip, tt.proto)
+		if !st.hasService(tt.name, tt.namespace) {
+			t.Fatalf("Error: service %s %s not updated", tt.name, tt.namespace)
+		}
+		if !st.hasServiceVIP(tt.name, tt.namespace, tt.vip, tt.proto) {
+			t.Fatalf("Error: service %s %s vip %s-%v not updated", tt.name, tt.namespace, tt.vip, tt.proto)
+		}
+	}
+
+	// Delete a non existent service
+	st.deleteService("svc-fake", "ns1")
+	if st.hasService("svc-fake", "ns1") {
+		t.Fatalf("Service ns1 svc-fake should not exist")
+	}
+	// Delete service svc2
+	st.deleteService("svc2", "ns1")
+	if st.hasService("svc2", "ns1") {
+		t.Fatalf("Service ns1 svc2 should not exist")
+	}
+	// Delete a non existent VIP (is a noop)
+	st.deleteServiceVIP("svc3", "ns1", "10.0.0.0:890", v1.ProtocolTCP)
+	// Delete vip 10.0.0.0:890-TCP on service svc1
+	st.deleteServiceVIP("svc1", "ns1", "10.0.0.0:890", v1.ProtocolTCP)
+	if st.hasServiceVIP("svc1", "ns1", "10.0.0.0:890", v1.ProtocolTCP) {
+		t.Fatalf("Service ns1 svc2 should not exist")
+	}
+}

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -1,0 +1,543 @@
+package services
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/acl"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
+
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	discoveryinformers "k8s.io/client-go/informers/discovery/v1beta1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	discoverylisters "k8s.io/client-go/listers/discovery/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+)
+
+const (
+	// maxRetries is the number of times a object will be retried before it is dropped out of the queue.
+	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the
+	// sequence of delays between successive queuings of an object.
+	//
+	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
+	maxRetries = 15
+
+	controllerName = "ovn-lb-controller"
+)
+
+// NewController returns a new *Controller.
+func NewController(client clientset.Interface,
+	serviceInformer coreinformers.ServiceInformer,
+	endpointSliceInformer discoveryinformers.EndpointSliceInformer,
+	clusterPortGroupUUID string,
+) *Controller {
+	klog.V(4).Info("Creating event broadcaster")
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartStructuredLogging(0)
+	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: client.CoreV1().Events("")})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerName})
+
+	st := newServiceTracker()
+
+	c := &Controller{
+		client:               client,
+		serviceTracker:       st,
+		queue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+		workerLoopPeriod:     time.Second,
+		clusterPortGroupUUID: clusterPortGroupUUID,
+	}
+
+	// services
+	klog.Info("Setting up event handlers for services")
+	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onServiceAdd,
+		UpdateFunc: c.onServiceUpdate,
+		DeleteFunc: c.onServiceDelete,
+	})
+	c.serviceLister = serviceInformer.Lister()
+	c.servicesSynced = serviceInformer.Informer().HasSynced
+
+	// endpoints slices
+	klog.Info("Setting up event handlers for endpoint slices")
+	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onEndpointSliceAdd,
+		UpdateFunc: c.onEndpointSliceUpdate,
+		DeleteFunc: c.onEndpointSliceDelete,
+	})
+
+	c.endpointSliceLister = endpointSliceInformer.Lister()
+	c.endpointSlicesSynced = endpointSliceInformer.Informer().HasSynced
+
+	c.eventBroadcaster = broadcaster
+	c.eventRecorder = recorder
+
+	// repair controller
+	c.repair = NewRepair(0, st)
+
+	return c
+}
+
+// Controller manages selector-based service endpoints.
+type Controller struct {
+	client           clientset.Interface
+	eventBroadcaster record.EventBroadcaster
+	eventRecorder    record.EventRecorder
+
+	// serviceTrack tracks services and map them to OVN LoadBalancers
+	serviceTracker *serviceTracker
+
+	// serviceLister is able to list/get services and is populated by the shared informer passed to
+	serviceLister corelisters.ServiceLister
+	// servicesSynced returns true if the service shared informer has been synced at least once.
+	servicesSynced cache.InformerSynced
+
+	// endpointSliceLister is able to list/get endpoint slices and is populated
+	// by the shared informer passed to NewController
+	endpointSliceLister discoverylisters.EndpointSliceLister
+	// endpointSlicesSynced returns true if the endpoint slice shared informer
+	// has been synced at least once. Added as a member to the struct to allow
+	// injection for testing.
+	endpointSlicesSynced cache.InformerSynced
+
+	// Services that need to be updated. A channel is inappropriate here,
+	// because it allows services with lots of pods to be serviced much
+	// more often than services with few pods; it also would cause a
+	// service that's inserted multiple times to be processed more than
+	// necessary.
+	queue workqueue.RateLimitingInterface
+
+	// workerLoopPeriod is the time between worker runs. The workers process the queue of service and pod changes.
+	workerLoopPeriod time.Duration
+
+	// repair contains a controller that keeps in sync OVN and Kubernetes services
+	repair *Repair
+
+	// clusterPortGroupUUID contains the UUID of the port groups used for the services rejects ACLs
+	clusterPortGroupUUID string
+}
+
+// Run will not return until stopCh is closed. workers determines how many
+// endpoints will be handled in parallel.
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting controller %s", controllerName)
+	defer klog.Infof("Shutting down controller %s", controllerName)
+
+	// Wait for the caches to be synced before starting workers
+	klog.Info("Waiting for informer caches to sync")
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.servicesSynced, c.endpointSlicesSynced) {
+		return fmt.Errorf("error syncing cache")
+	}
+
+	klog.Info("Starting workers")
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.worker, c.workerLoopPeriod, stopCh)
+	}
+
+	// Run only once the repair controller to keep in sync Kubernetes and OVN
+	klog.Info("Remove stale OVN services")
+	if err := c.repair.RunOnce(); err != nil {
+		klog.Errorf("Error repairing services: %v")
+	}
+	<-stopCh
+	return nil
+}
+
+// worker runs a worker thread that just dequeues items, processes them, and
+// marks them done. You may run as many of these in parallel as you wish; the
+// workqueue guarantees that they will not end up processing the same service
+// at the same time.
+func (c *Controller) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) processNextWorkItem() bool {
+	eKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(eKey)
+
+	err := c.syncServices(eKey.(string))
+	c.handleErr(err, eKey)
+
+	return true
+}
+
+func (c *Controller) handleErr(err error, key interface{}) {
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+
+	ns, name, keyErr := cache.SplitMetaNamespaceKey(key.(string))
+	if keyErr != nil {
+		klog.ErrorS(err, "Failed to split meta namespace cache key", "key", key)
+	}
+	metrics.MetricRequeueServiceCount.WithLabelValues(key.(string)).Inc()
+
+	if c.queue.NumRequeues(key) < maxRetries {
+		klog.V(2).InfoS("Error syncing service, retrying", "service", klog.KRef(ns, name), "err", err)
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	klog.Warningf("Dropping service %q out of the queue: %v", key, err)
+	c.queue.Forget(key)
+	utilruntime.HandleError(err)
+}
+
+func (c *Controller) syncServices(key string) error {
+	startTime := time.Now()
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	klog.Infof("Processing sync for service %s on namespace %s ", name, namespace)
+	metrics.MetricSyncServiceCount.WithLabelValues(key).Inc()
+
+	defer func() {
+		klog.V(4).Infof("Finished syncing service %s on namespace %s : %v", name, namespace, time.Since(startTime))
+		metrics.MetricSyncServiceLatency.WithLabelValues(key).Observe(time.Since(startTime).Seconds())
+	}()
+
+	// Get current Service from the cache
+	service, err := c.serviceLister.Services(namespace).Get(name)
+	// It´s unlikely that we have an error different that "Not Found Object"
+	// because we are getting the object from the informer´s cache
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	// Get current state of the Service from the Service tracker
+	// These are the VIPs (ClusterIP:Port) that we have seen so far
+	// If the Service has updated the VIPs (has changed the Ports)
+	// and some were removed we have to delete those
+	// We need to create a NewString set to not mutate the service tracker VIPs
+	vipsTracked := sets.NewString().Union(c.serviceTracker.getService(name, namespace))
+
+	// Delete the Service VIPs from OVN if:
+	// - the Service was deleted from the cache (doesn't exist in Kubernetes anymore)
+	// - the Service mutated to a new service Type that we don't handle (ExternalName, Headless)
+	if err != nil || !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
+		err = deleteVIPsFromOVN(vipsTracked, c.serviceTracker, name, namespace, c.clusterPortGroupUUID)
+		if err != nil {
+			c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToDeleteOVNLoadBalancer",
+				"Error trying to delete the OVN LoadBalancer for Service %s/%s: %v", name, namespace, err)
+			return err
+		}
+		// Delete the Service form the Service Tracker
+		c.serviceTracker.deleteService(name, namespace)
+		return nil
+	}
+	klog.Infof("Creating service %s on namespace %s on OVN", name, namespace)
+	// The Service exists in the cache: update it in OVN
+	// Get the endpoint slices associated to the Service
+	esLabelSelector := labels.Set(map[string]string{
+		discovery.LabelServiceName: name,
+	}).AsSelectorPreValidated()
+	endpointSlices, err := c.endpointSliceLister.EndpointSlices(namespace).List(esLabelSelector)
+	if err != nil {
+		// Since we're getting stuff from a local cache, it is basically impossible to get this error.
+		c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToListEndpointSlices",
+			"Error listing Endpoint Slices for Service %s/%s: %v", namespace, name, err)
+		return err
+	}
+	// Iterate over the ClusterIPs and Ports fields to create the corresponding OVN loadbalancers
+	for _, ip := range service.Spec.ClusterIPs {
+		family := v1.IPv4Protocol
+		if utilnet.IsIPv6String(ip) {
+			family = v1.IPv6Protocol
+		}
+		for _, svcPort := range service.Spec.Ports {
+			// ClusterIP
+			lbID, err := loadbalancer.GetOVNKubeLoadBalancer(svcPort.Protocol)
+			if err != nil {
+				c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToGetOVNLoadBalancer",
+					"Error trying to obtain the OVN LoadBalancer for Service %s/%s: %v", name, namespace, err)
+				return err
+			}
+			// create the vip = ClusterIP:Port
+			vip := util.JoinHostPortInt32(ip, svcPort.Port)
+			klog.V(4).Infof("Updating service %s/%s with VIP %s %s", name, namespace, vip, svcPort.Protocol)
+			// get the endpoints associated to the vip
+			eps := getLbEndpoints(endpointSlices, svcPort, family)
+			// Reconcile OVN, update the load balancer with current endpoints
+			if err := loadbalancer.UpdateLoadBalancer(lbID, vip, eps); err != nil {
+				c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToUpdateOVNLoadBalancer",
+					"Error trying to update OVN LoadBalancer for Service %s/%s: %v", name, namespace, err)
+				return err
+			}
+			// update the tracker with the VIP
+			c.serviceTracker.updateService(name, namespace, vip, svcPort.Protocol)
+			// mark the vip as processed
+			vipsTracked = vipsTracked.Delete(virtualIPKey(vip, svcPort.Protocol))
+
+			// handle reject ACLs for services without endpoints
+			// eventually we have to remove this because it will
+			// be implemented by OVN
+			// https://github.com/ovn-org/ovn-kubernetes/pull/1887
+			rejectACLName := loadbalancer.GenerateACLNameForOVNCommand(lbID, ip, svcPort.Port)
+			aclID, err := acl.GetACLByName(rejectACLName)
+			if err != nil {
+				klog.Errorf("Error trying to get ACL for Service %s/%s: %v", name, namespace, err)
+			}
+			// if there is no ACL and there is no endpoints we add a new ACL
+			// if there is an ACL and we have endpoints we have to remove the ACL
+			// if there is no ACL and we have endpoints we don´t need to do anything
+			if len(eps) == 0 && len(aclID) == 0 {
+				klog.V(4).Infof("Service %s/%s without endpoints", name, namespace)
+				_, err = acl.AddRejectACLToPortGroup(c.clusterPortGroupUUID, rejectACLName, ip, int(svcPort.Port), svcPort.Protocol)
+				if err != nil {
+					klog.Errorf("Error trying to add ACL for Service %s/%s: %v", name, namespace, err)
+				}
+			} else if len(aclID) > 0 {
+				// remove acl
+				err = acl.RemoveACLFromPortGroup(aclID, c.clusterPortGroupUUID)
+				if err != nil {
+					klog.Errorf("Error trying to remove ACL for Service %s/%s: %v", name, namespace, err)
+				}
+			}
+			// end of reject ACL code
+
+			// Node Port
+			if svcPort.NodePort != 0 {
+				gatewayRouters, _, err := gateway.GetOvnGateways()
+				if err != nil {
+					return errors.Wrapf(err, "failed to retrieve OVN gateway routers")
+				}
+				// Configure the NodePort in each Node Gateway Router
+				for _, gatewayRouter := range gatewayRouters {
+					lbID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, svcPort.Protocol)
+					if err != nil {
+						klog.Warningf("Service Sync: Gateway router %s does not have load balancer (%v)",
+							gatewayRouter, err)
+						// TODO: why continue? should we error and requeue and retry?
+						continue
+					}
+					physicalIPs, err := gateway.GetGatewayPhysicalIPs(gatewayRouter)
+					if err != nil {
+						klog.Warningf("Service Sync: Gateway router %s does not have physical ips: %v",
+							gatewayRouter, err)
+						// TODO: why continue? should we error and requeue and retry?
+						continue
+					}
+					// With the physical_ip:port as the VIP, add an entry in 'load balancer'.
+					for _, physicalIP := range physicalIPs {
+						// only use the IPs of the same ClusterIP family
+						if utilnet.IsIPv6String(physicalIP) != utilnet.IsIPv6String(ip) {
+							continue
+						}
+						// VIP = NodeExternalIP:NodePort
+						vip := util.JoinHostPortInt32(physicalIP, svcPort.NodePort)
+						klog.V(4).Infof("Updating NodePort service %s/%s with VIP %s %s", name, namespace, vip, svcPort.Protocol)
+						// Reconcile OVN, update the load balancer with current endpoints
+						if err := loadbalancer.UpdateLoadBalancer(lbID, vip, eps); err != nil {
+							c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToUpdateOVNLoadBalancer",
+								"Error trying to update OVN LoadBalancer for Service %s/%s: %v", name, namespace, err)
+							return err
+						}
+						c.serviceTracker.updateService(name, namespace, vip, svcPort.Protocol)
+						// mark the vip as processed
+						vipsTracked = vipsTracked.Delete(virtualIPKey(vip, svcPort.Protocol))
+					}
+				}
+			}
+			// Services ExternalIPs and LoadBalancer.IngressIPs have the same behavior in OVN
+			// so they are aggregated in a slice and processed together.
+			var externalIPs []string
+			// ExternalIP
+			for _, extIP := range service.Spec.ExternalIPs {
+				// only use the IPs of the same ClusterIP family
+				if utilnet.IsIPv6String(extIP) == utilnet.IsIPv6String(ip) {
+					externalIPs = append(externalIPs, extIP)
+				}
+			}
+			// LoadBalancer
+			for _, ingress := range service.Status.LoadBalancer.Ingress {
+				// only use the IPs of the same ClusterIP family
+				if ingress.IP != "" && utilnet.IsIPv6String(ingress.IP) == utilnet.IsIPv6String(ip) {
+					externalIPs = append(externalIPs, ingress.IP)
+				}
+			}
+
+			// reconcile external IPs
+			if len(externalIPs) > 0 {
+				gatewayRouters, _, err := gateway.GetOvnGateways()
+				if err != nil {
+					return err
+				}
+				for _, extIP := range externalIPs {
+					// only use the IPs of the same ClusterIP family
+					if utilnet.IsIPv6String(extIP) != utilnet.IsIPv6String(ip) {
+						continue
+					}
+					for _, gatewayRouter := range gatewayRouters {
+						lbID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, svcPort.Protocol)
+						if err != nil {
+							klog.Warningf("Service Sync: Gateway router %s does not have load balancer (%v)",
+								gatewayRouter, err)
+							// TODO: why continue? should we error and requeue and retry?
+							continue
+						}
+						vip := util.JoinHostPortInt32(extIP, svcPort.Port)
+						// Reconcile OVN
+						klog.V(4).Infof("Updating ExternalIP service %s/%s with VIP %s %s", name, namespace, vip, svcPort.Protocol)
+						if err := loadbalancer.UpdateLoadBalancer(lbID, vip, eps); err != nil {
+							c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToUpdateOVNLoadBalancer",
+								"Error trying to update OVN LoadBalancer for Service %s/%s: %v", name, namespace, err)
+							return err
+						}
+						c.serviceTracker.updateService(name, namespace, vip, svcPort.Protocol)
+						// mark the vip as processed
+						vipsTracked = vipsTracked.Delete(virtualIPKey(vip, svcPort.Protocol))
+					}
+				}
+			}
+		}
+	}
+
+	// at this point we have processed all vips we've found in the service
+	// so the remaining ones that we had in the vipsTracked variable should be deleted
+	err = deleteVIPsFromOVN(vipsTracked, c.serviceTracker, name, namespace, c.clusterPortGroupUUID)
+	if err != nil {
+		c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToDeleteOVNLoadBalancer",
+			"Error trying to delete the OVN LoadBalancer for Service %s/%s: %v", name, namespace, err)
+		return err
+	}
+	return nil
+}
+
+// handlers
+
+// onServiceUpdate queues the Service for processing.
+func (c *Controller) onServiceAdd(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		return
+	}
+	klog.V(4).Infof("Adding service %s", key)
+	c.queue.Add(key)
+}
+
+// onServiceUpdate updates the Service Selector in the cache and queues the Service for processing.
+func (c *Controller) onServiceUpdate(oldObj, newObj interface{}) {
+	oldService := oldObj.(*v1.Service)
+	newService := newObj.(*v1.Service)
+
+	// don't process resync or objects that are marked for deletion
+	if oldService.ResourceVersion == newService.ResourceVersion ||
+		!newService.GetDeletionTimestamp().IsZero() {
+		return
+	}
+
+	key, err := cache.MetaNamespaceKeyFunc(newObj)
+	if err == nil {
+		c.queue.Add(key)
+	}
+}
+
+// onServiceDelete queues the Service for processing.
+func (c *Controller) onServiceDelete(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		return
+	}
+	klog.V(4).Infof("Deleting service %s", key)
+	c.queue.Add(key)
+}
+
+// onEndpointSliceAdd queues a sync for the relevant Service for a sync
+func (c *Controller) onEndpointSliceAdd(obj interface{}) {
+	endpointSlice := obj.(*discovery.EndpointSlice)
+	if endpointSlice == nil {
+		utilruntime.HandleError(fmt.Errorf("invalid EndpointSlice provided to onEndpointSliceAdd()"))
+		return
+	}
+	c.queueServiceForEndpointSlice(endpointSlice)
+}
+
+// onEndpointSliceUpdate queues a sync for the relevant Service for a sync
+func (c *Controller) onEndpointSliceUpdate(prevObj, obj interface{}) {
+	prevEndpointSlice := prevObj.(*discovery.EndpointSlice)
+	endpointSlice := obj.(*discovery.EndpointSlice)
+
+	// don't process resync or objects that are marked for deletion
+	if prevEndpointSlice.ResourceVersion == endpointSlice.ResourceVersion ||
+		!endpointSlice.GetDeletionTimestamp().IsZero() {
+		return
+	}
+	c.queueServiceForEndpointSlice(endpointSlice)
+}
+
+// onEndpointSliceDelete queues a sync for the relevant Service for a sync if the
+// EndpointSlice resource version does not match the expected version in the
+// endpointSliceTracker.
+func (c *Controller) onEndpointSliceDelete(obj interface{}) {
+	endpointSlice, ok := obj.(*discovery.EndpointSlice)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		endpointSlice, ok = tombstone.Obj.(*discovery.EndpointSlice)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a EndpointSlice: %#v", obj))
+			return
+		}
+	}
+
+	if endpointSlice != nil {
+		c.queueServiceForEndpointSlice(endpointSlice)
+	}
+}
+
+// queueServiceForEndpointSlice attempts to queue the corresponding Service for
+// the provided EndpointSlice.
+func (c *Controller) queueServiceForEndpointSlice(endpointSlice *discovery.EndpointSlice) {
+	key, err := serviceControllerKey(endpointSlice)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for EndpointSlice %+v: %v", endpointSlice, err))
+		return
+	}
+
+	c.queue.Add(key)
+}
+
+// serviceControllerKey returns a controller key for a Service but derived from
+// an EndpointSlice.
+func serviceControllerKey(endpointSlice *discovery.EndpointSlice) (string, error) {
+	if endpointSlice == nil {
+		return "", fmt.Errorf("nil EndpointSlice passed to serviceControllerKey()")
+	}
+	serviceName, ok := endpointSlice.Labels[discovery.LabelServiceName]
+	if !ok || serviceName == "" {
+		return "", fmt.Errorf("endpointSlice missing %s label", discovery.LabelServiceName)
+	}
+	return fmt.Sprintf("%s/%s", endpointSlice.Namespace, serviceName), nil
+}

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -1,0 +1,456 @@
+package services
+
+import (
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+const (
+	loadbalancerTCP = "a08ea426-2288-11eb-a30b-a8a1590cda29"
+	portGroupUUID   = "58a1ef18-3649-11eb-bd94-a8a1590cda29"
+	gatewayRouter1  = "2e290f10-3652-11eb-839b-a8a1590cda29"
+	logicalSwitch1  = "17bde5e8-3652-11eb-b53b-a8a1590cda29"
+)
+
+var alwaysReady = func() bool { return true }
+
+type serviceController struct {
+	*Controller
+	serviceStore       cache.Store
+	endpointSliceStore cache.Store
+}
+
+func newController() *serviceController {
+	client := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	controller := NewController(client,
+		informerFactory.Core().V1().Services(),
+		informerFactory.Discovery().V1beta1().EndpointSlices(),
+		portGroupUUID,
+	)
+	controller.servicesSynced = alwaysReady
+	controller.endpointSlicesSynced = alwaysReady
+	return &serviceController{
+		controller,
+		informerFactory.Core().V1().Services().Informer().GetStore(),
+		informerFactory.Discovery().V1beta1().EndpointSlices().Informer().GetStore(),
+	}
+}
+
+func TestSyncServices(t *testing.T) {
+	ns := "testns"
+	serviceName := "foo"
+
+	tests := []struct {
+		name          string
+		slice         *discovery.EndpointSlice
+		service       *v1.Service
+		updateTracker bool
+		ovnCmd        []ovntest.ExpectedCmd
+	}{
+		{
+			name: "delete OVN LoadBalancer from deleted Single Stack Service",
+			slice: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName + "ab23",
+					Namespace: ns,
+					Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+				},
+				Ports:       []discovery.EndpointPort{},
+				AddressType: discovery.AddressTypeIPv4,
+				Endpoints:   []discovery.Endpoint{},
+			},
+			service:       &v1.Service{},
+			updateTracker: true,
+			ovnCmd: []ovntest.ExpectedCmd{
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+					Output: loadbalancerTCP,
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + loadbalancerTCP + " vips \"192.168.1.1:80\"",
+					Output: "",
+				},
+			},
+		},
+		{
+			name: "create OVN LoadBalancer from Single Stack Service without endpoints",
+			slice: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName + "ab23",
+					Namespace: ns,
+					Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+				},
+				Ports:       []discovery.EndpointPort{},
+				AddressType: discovery.AddressTypeIPv4,
+				Endpoints:   []discovery.Endpoint{},
+			},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+				Spec: v1.ServiceSpec{
+					Type:       v1.ServiceTypeClusterIP,
+					ClusterIP:  "192.168.1.1",
+					ClusterIPs: []string{"192.168.1.1"},
+					Selector:   map[string]string{"foo": "bar"},
+					Ports: []v1.ServicePort{{
+						Port:       80,
+						Protocol:   v1.ProtocolTCP,
+						TargetPort: intstr.FromInt(3456),
+					}},
+				},
+			},
+			updateTracker: true,
+			ovnCmd: []ovntest.ExpectedCmd{
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+					Output: loadbalancerTCP,
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 set load_balancer ` + loadbalancerTCP + ` vips:"192.168.1.1:80"=""`,
+					Output: "",
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+					Output: "",
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls @reject-acl`,
+					Output: "",
+				},
+			},
+		},
+		{
+			name: "create OVN LoadBalancer from Single Stack NodePort Service without endpoints",
+			slice: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName + "ab23",
+					Namespace: ns,
+					Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+				},
+				Ports:       []discovery.EndpointPort{},
+				AddressType: discovery.AddressTypeIPv4,
+				Endpoints:   []discovery.Endpoint{},
+			},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+				Spec: v1.ServiceSpec{
+					Type:       v1.ServiceTypeClusterIP,
+					ClusterIP:  "192.168.1.1",
+					ClusterIPs: []string{"192.168.1.1"},
+					Selector:   map[string]string{"foo": "bar"},
+					Ports: []v1.ServicePort{{
+						Port:       80,
+						Protocol:   v1.ProtocolTCP,
+						TargetPort: intstr.FromInt(3456),
+						NodePort:   32766,
+					}},
+				},
+			},
+			updateTracker: true,
+			ovnCmd: []ovntest.ExpectedCmd{
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+					Output: loadbalancerTCP,
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 set load_balancer ` + loadbalancerTCP + ` vips:"192.168.1.1:80"=""`,
+					Output: "",
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+					Output: "",
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls @reject-acl`,
+					Output: "",
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null`,
+					Output: gatewayRouter1,
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=` + gatewayRouter1,
+					Output: "",
+				},
+
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}a08ea426-2288-11eb-a30b-a8a1590cda29`,
+					Output: logicalSwitch1,
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add logical_switch 17bde5e8-3652-11eb-b53b-a8a1590cda29 acls @reject-acl`,
+					Output: "",
+				},
+			},
+		},
+		{
+			name: "create OVN LoadBalancer from Single Stack Service with endpoints",
+			slice: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName + "ab23",
+					Namespace: ns,
+					Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+				},
+				Ports: []discovery.EndpointPort{
+					{
+						Name:     utilpointer.StringPtr("tcp-example"),
+						Protocol: protoPtr(v1.ProtocolTCP),
+						Port:     utilpointer.Int32Ptr(int32(3456)),
+					},
+				},
+				AddressType: discovery.AddressTypeIPv4,
+				Endpoints: []discovery.Endpoint{
+					{
+						Conditions: discovery.EndpointConditions{
+							Ready: utilpointer.BoolPtr(true),
+						},
+						Addresses: []string{"10.0.0.2"},
+						Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					},
+				},
+			},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+				Spec: v1.ServiceSpec{
+					Type:       v1.ServiceTypeClusterIP,
+					ClusterIP:  "192.168.1.1",
+					ClusterIPs: []string{"192.168.1.1"},
+					Selector:   map[string]string{"foo": "bar"},
+					Ports: []v1.ServicePort{{
+						Port:       80,
+						Protocol:   v1.ProtocolTCP,
+						TargetPort: intstr.FromInt(3456),
+					}},
+				},
+			},
+			updateTracker: false,
+			ovnCmd: []ovntest.ExpectedCmd{
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+					Output: loadbalancerTCP,
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 set load_balancer ` + loadbalancerTCP + ` vips:"192.168.1.1:80"="10.0.0.2:3456"`,
+					Output: "",
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+					Output: "",
+				},
+			},
+		},
+		{
+			name: "create OVN LoadBalancer from Dual Stack Service with dual stack endpoints",
+			slice: &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName + "ab23",
+					Namespace: ns,
+					Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+				},
+				Ports: []discovery.EndpointPort{
+					{
+						Name:     utilpointer.StringPtr("tcp-example"),
+						Protocol: protoPtr(v1.ProtocolTCP),
+						Port:     utilpointer.Int32Ptr(int32(3456)),
+					},
+				},
+				AddressType: discovery.AddressTypeIPv4,
+				Endpoints: []discovery.Endpoint{
+					{
+						Conditions: discovery.EndpointConditions{
+							Ready: utilpointer.BoolPtr(true),
+						},
+						Addresses: []string{"10.0.0.2"},
+						Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+					},
+				},
+			},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+				Spec: v1.ServiceSpec{
+					Type:       v1.ServiceTypeClusterIP,
+					ClusterIP:  "192.168.1.1",
+					ClusterIPs: []string{"192.168.1.1"},
+					Selector:   map[string]string{"foo": "bar"},
+					Ports: []v1.ServicePort{{
+						Port:       80,
+						Protocol:   v1.ProtocolTCP,
+						TargetPort: intstr.FromInt(3456),
+					}},
+				},
+			},
+			updateTracker: false,
+			ovnCmd: []ovntest.ExpectedCmd{
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+					Output: loadbalancerTCP,
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 set load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips:"192.168.1.1:80"="10.0.0.2:3456"`,
+					Output: "",
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+					Output: "",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := newController()
+			// Add objects to the Store
+			controller.endpointSliceStore.Add(tt.slice)
+			controller.serviceStore.Add(tt.service)
+			if tt.updateTracker {
+				controller.serviceTracker.updateKubernetesService(tt.service)
+			}
+
+			// Expected OVN commands
+			fexec := ovntest.NewFakeExec()
+			for _, cmd := range tt.ovnCmd {
+				cmd := cmd
+				fexec.AddFakeCmd(&cmd)
+			}
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			controller.syncServices(ns + "/" + serviceName)
+		})
+	}
+}
+
+// A service can mutate its ports, we need to be sure we don´t left dangling ports
+func TestUpdateServicePorts(t *testing.T) {
+	// Expected OVN commands
+	fexec := ovntest.NewFakeExec()
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: loadbalancerTCP,
+	})
+	// Add a new loadbalancer with the Service Port 80
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 set load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips:"192.168.1.1:80"="10.0.0.2:3456"`,
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: loadbalancerTCP,
+	})
+	// Add a new loadbalancer with the new Service Port 8888
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 set load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips:"192.168.1.1:8888"="10.0.0.2:3456"`,
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:8888`,
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: loadbalancerTCP,
+	})
+	// Remove the old ServicePort
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "192.168.1.1:80"`,
+		Output: "",
+	})
+	// Remove the ACL if exist
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+		Output: "",
+	})
+	// Check if there are NodePort LoadBalancers
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null`,
+		Output: "",
+	})
+
+	err := util.SetExec(fexec)
+	if err != nil {
+		t.Errorf("fexec error: %v", err)
+	}
+
+	ns := "testns"
+	serviceName := "foo"
+	slice := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName + "ab23",
+			Namespace: ns,
+			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
+		},
+		Ports: []discovery.EndpointPort{
+			{
+				Name:     utilpointer.StringPtr("tcp-example"),
+				Protocol: protoPtr(v1.ProtocolTCP),
+				Port:     utilpointer.Int32Ptr(int32(3456)),
+			},
+		},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints: []discovery.Endpoint{
+			{
+				Conditions: discovery.EndpointConditions{
+					Ready: utilpointer.BoolPtr(true),
+				},
+				Addresses: []string{"10.0.0.2"},
+				Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
+			},
+		},
+	}
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
+		Spec: v1.ServiceSpec{
+			Type:       v1.ServiceTypeClusterIP,
+			ClusterIP:  "192.168.1.1",
+			ClusterIPs: []string{"192.168.1.1"},
+			Selector:   map[string]string{"foo": "bar"},
+			Ports: []v1.ServicePort{{
+				Port:       80,
+				Protocol:   v1.ProtocolTCP,
+				TargetPort: intstr.FromInt(3456),
+			}},
+		},
+	}
+	controller := newController()
+	// Process the first service
+	controller.endpointSliceStore.Add(slice)
+	controller.serviceStore.Add(service)
+	controller.syncServices(ns + "/" + serviceName)
+
+	// Update the service with a different Port
+	serviceNew := service.DeepCopy()
+	serviceNew.Spec.Ports[0].Port = 8888
+	controller.serviceStore.Delete(service)
+	controller.serviceStore.Add(serviceNew)
+	// sync service
+	controller.syncServices(ns + "/" + serviceName)
+	if controller.serviceTracker.hasServiceVIP(serviceName, ns, "192.168.1.1:80", v1.ProtocolTCP) {
+		t.Fatalf("Service with port 80 should not exist")
+	}
+	if !controller.serviceTracker.hasServiceVIP(serviceName, ns, "192.168.1.1:8888", v1.ProtocolTCP) {
+		t.Fatalf("Service with port 8888 should exist")
+	}
+}
+
+// protoPtr takes a Protocol and returns a pointer to it.
+func protoPtr(proto v1.Protocol) *v1.Protocol {
+	return &proto
+}

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -1,0 +1,150 @@
+package services
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/acl"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
+
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/klog/v2"
+)
+
+// return the endpoints that belong to the IPFamily as a slice of IP:Port
+func getLbEndpoints(slices []*discovery.EndpointSlice, svcPort v1.ServicePort, family v1.IPFamily) []string {
+	// return an empty object so the caller don't have to check for nil and can use it as an iterator
+	if len(slices) == 0 {
+		return []string{}
+	}
+	// Endpoint Slices are allowed to have duplicate endpoints
+	// we use a set to deduplicate endpoints
+	lbEndpoints := sets.NewString()
+	for _, slice := range slices {
+		klog.V(4).Infof("Getting endpoints for slice %s", slice.Name)
+		// Only return addresses that belong to the requested IP family
+		if slice.AddressType != discovery.AddressType(family) {
+			klog.V(4).Infof("Slice %s with different IP Family endpoints, requested: %s received: %s",
+				slice.Name, slice.AddressType, family)
+			continue
+		}
+
+		// build the list of endpoints in the slice
+		for _, port := range slice.Ports {
+			// If Service port name set it must match the name field in the endpoint
+			if svcPort.Name != "" && svcPort.Name != *port.Name {
+				klog.V(5).Infof("Slice %s with different Port name, requested: %s received: %s",
+					slice.Name, svcPort.Name, *port.Name)
+				continue
+			}
+
+			// Get the targeted port
+			tgtPort := int32(svcPort.TargetPort.IntValue())
+			// If this is a string, it will return 0
+			// it has to match the port name
+			// otherwise, it has to match the port number
+			if (tgtPort == 0 && svcPort.TargetPort.String() != *port.Name) ||
+				(tgtPort > 0 && tgtPort != *port.Port) {
+				continue
+			}
+
+			// Skip ports that doesn't match the protocol
+			if *port.Protocol != svcPort.Protocol {
+				klog.V(5).Infof("Slice %s with different Port protocol, requested: %s received: %s",
+					slice.Name, svcPort.Protocol, *port.Protocol)
+				continue
+			}
+
+			for _, endpoint := range slice.Endpoints {
+				// Skip endpoints that are not ready
+				if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
+					klog.V(4).Infof("Slice endpoints Not Ready")
+					continue
+				}
+				for _, ip := range endpoint.Addresses {
+					klog.V(4).Infof("Adding slice %s endpoints: %s %d", slice.Name, ip, *port.Port)
+					lbEndpoints.Insert(util.JoinHostPortInt32(ip, *port.Port))
+				}
+			}
+		}
+	}
+
+	klog.V(4).Infof("LB Endpoints for %s are: %v", slices[0].Labels[discovery.LabelServiceName], lbEndpoints.List())
+	return lbEndpoints.List()
+}
+
+func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace, clusterPortGroupUUID string) error {
+	// Obtain the VIPs associated to the Service from the Service Tracker
+	for vipKey := range vips {
+		// the VIP is stored with the format IP:Port/Protocol
+		vip, proto := splitVirtualIPKey(vipKey)
+		// ClusterIP use a global load balancer per protocol
+		lbID, err := loadbalancer.GetOVNKubeLoadBalancer(proto)
+		if err != nil {
+			klog.Errorf("Error getting OVN LoadBalancer for protocol %s", proto)
+			return err
+		}
+		// Delete the Service VIP from OVN
+		klog.Infof("Deleting service %s on namespace %s from OVN", name, namespace)
+		if err := loadbalancer.DeleteLoadBalancerVIP(lbID, vip); err != nil {
+			klog.Errorf("Error deleting VIP %s on OVN LoadBalancer %s", vip, lbID)
+			return err
+		}
+		// handle reject ACLs for services without endpoints
+		// eventually we have to remove this because it will
+		// be implemented by OVN
+		// https://github.com/ovn-org/ovn-kubernetes/pull/1887
+		ip, portString, err := net.SplitHostPort(vip)
+		if err != nil {
+			return err
+		}
+		port, err := strconv.Atoi(portString)
+		if err != nil {
+			return err
+		}
+		rejectACLName := loadbalancer.GenerateACLNameForOVNCommand(lbID, ip, int32(port))
+		aclID, err := acl.GetACLByName(rejectACLName)
+		if err != nil {
+			klog.Errorf("Error trying to get ACL for Service %s/%s: %v", name, namespace, err)
+		}
+		// delete the ACL if exist
+		if len(aclID) > 0 {
+			// remove acl
+			err = acl.RemoveACLFromPortGroup(aclID, clusterPortGroupUUID)
+			if err != nil {
+				klog.Errorf("Error trying to remove ACL for Service %s/%s: %v", name, namespace, err)
+			}
+		}
+		// end of reject ACL code
+		// NodePort and ExternalIPs use loadbalancers in each node
+		gatewayRouters, _, err := gateway.GetOvnGateways()
+		if err != nil {
+			return errors.Wrapf(err, "failed to retrieve OVN gateway routers")
+		}
+		// Configure the NodePort in each Node Gateway Router
+		for _, gatewayRouter := range gatewayRouters {
+			lbID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, proto)
+			if err != nil {
+				klog.Warningf("Service Sync: Gateway router %s does not have load balancer (%v)",
+					gatewayRouter, err)
+				// TODO: why continue? should we error and requeue and retry?
+				continue
+			}
+			// Delete the Service VIP from OVN
+			klog.Infof("Deleting service %s on namespace %s from OVN", name, namespace)
+			if err := loadbalancer.DeleteLoadBalancerVIP(lbID, vip); err != nil {
+				klog.Errorf("Error deleting VIP %s on OVN LoadBalancer %s", vip, lbID)
+				return err
+			}
+		}
+		// Delete the Service VIP from the Service Tracker
+		st.deleteServiceVIP(name, namespace, vip, proto)
+	}
+	return nil
+}

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -1,0 +1,310 @@
+package services
+
+import (
+	"reflect"
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+func Test_getLbEndpoints(t *testing.T) {
+	type args struct {
+		slices  []*discovery.EndpointSlice
+		svcPort v1.ServicePort
+		family  v1.IPFamily
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "empty slices",
+			args: args{
+				slices: []*discovery.EndpointSlice{},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				family: v1.IPv4Protocol,
+			},
+			want: []string{},
+		},
+		{
+			name: "slices with endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.BoolPtr(true),
+								},
+								Addresses: []string{"10.0.0.2"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				family: v1.IPv4Protocol,
+			},
+			want: []string{"10.0.0.2:80"},
+		},
+		{
+			name: "slices with different ports",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(8080)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.BoolPtr(true),
+								},
+								Addresses: []string{"10.0.0.2"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				family: v1.IPv4Protocol,
+			},
+			want: []string{},
+		},
+		{
+			name: "slices with different IP family",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv6,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.BoolPtr(true),
+								},
+								Addresses: []string{"2001:db2::2"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				family: v1.IPv4Protocol,
+			},
+			want: []string{},
+		},
+		{
+			name: "multiples slices with duplicate endpoints",
+			args: args{
+				slices: []*discovery.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.BoolPtr(true),
+								},
+								Addresses: []string{"10.0.0.2", "10.1.1.2"},
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "svc-ab23",
+							Namespace: "ns",
+							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
+						},
+						Ports: []discovery.EndpointPort{
+							{
+								Name:     utilpointer.StringPtr("tcp-example"),
+								Protocol: protoPtr(v1.ProtocolTCP),
+								Port:     utilpointer.Int32Ptr(int32(80)),
+							},
+						},
+						AddressType: discovery.AddressTypeIPv4,
+						Endpoints: []discovery.Endpoint{
+							{
+								Conditions: discovery.EndpointConditions{
+									Ready: utilpointer.BoolPtr(true),
+								},
+								Addresses: []string{"10.0.0.2", "10.2.2.2"},
+							},
+						},
+					},
+				},
+				svcPort: v1.ServicePort{
+					Name:       "tcp-example",
+					TargetPort: intstr.FromInt(80),
+					Protocol:   v1.ProtocolTCP,
+				},
+				family: v1.IPv4Protocol,
+			},
+			want: []string{"10.0.0.2:80", "10.1.1.2:80", "10.2.2.2:80"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getLbEndpoints(tt.args.slices, tt.args.svcPort, tt.args.family); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getLbEndpoints() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_deleteVIPsFromOVN(t *testing.T) {
+	const clusterPortGroupUUID = "c62dd6d4-38b3-11eb-b663-a8a1590cda29"
+	type args struct {
+		vips   sets.String
+		svc    *v1.Service
+		ovnCmd []ovntest.ExpectedCmd
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			args: args{
+				vips: sets.NewString(),
+				svc:  &v1.Service{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "delete existing vip",
+			args: args{
+				vips: sets.NewString("10.0.0.1:80/TCP"),
+				svc: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+					Spec: v1.ServiceSpec{
+						Type:       v1.ServiceTypeClusterIP,
+						ClusterIP:  "10.0.0.1",
+						ClusterIPs: []string{"10.0.0.1"},
+						Selector:   map[string]string{"foo": "bar"},
+						Ports: []v1.ServicePort{{
+							Port:       80,
+							Protocol:   v1.ProtocolTCP,
+							TargetPort: intstr.FromInt(3456),
+						}},
+					},
+				},
+				ovnCmd: []ovntest.ExpectedCmd{
+					{
+						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+						Output: loadbalancerTCP,
+					},
+					{
+						Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "10.0.0.1:80"`,
+						Output: "",
+					},
+					{
+						Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-10.0.0.1\:80`,
+						Output: "",
+					},
+					{
+						Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null`,
+						Output: "",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := newServiceTracker()
+			if len(tt.args.svc.Spec.ClusterIP) > 0 {
+				st.updateKubernetesService(tt.args.svc)
+			}
+			// Expected OVN commands
+			fexec := ovntest.NewFakeExec()
+			for _, cmd := range tt.args.ovnCmd {
+				cmd := cmd
+				fexec.AddFakeCmd(&cmd)
+			}
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			if err := deleteVIPsFromOVN(tt.args.vips, st, tt.args.svc.Name, tt.args.svc.Namespace, clusterPortGroupUUID); (err != nil) != tt.wantErr {
+				t.Errorf("deleteVIPsFromOVN() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if len(tt.args.svc.Spec.ClusterIP) > 0 {
+				vip := util.JoinHostPortInt32(tt.args.svc.Spec.ClusterIP, tt.args.svc.Spec.Ports[0].Port)
+				if st.hasServiceVIP(tt.args.svc.Name, tt.args.svc.Namespace, vip, tt.args.svc.Spec.Ports[0].Protocol) {
+					t.Fatalf("Error: VIP not deleted from Service Tracker")
+				}
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -1,0 +1,153 @@
+package loadbalancer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	kapi "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// GetOVNKubeLoadBalancer returns the LoadBalancer matching the protocol
+// in the OVN database using the external_ids = k8s-cluster-lb-${protocol}
+func GetOVNKubeLoadBalancer(protocol kapi.Protocol) (string, error) {
+	id := fmt.Sprintf("external_ids:k8s-cluster-lb-%s=yes", strings.ToLower(string(protocol)))
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid",
+		"find", "load_balancer", id)
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		return "", fmt.Errorf("no load balancer found in the database")
+	}
+	return out, nil
+}
+
+// GetLoadBalancerVIPs returns a map whose keys are VIPs (IP:port) on loadBalancer
+func GetLoadBalancerVIPs(loadBalancer string) (map[string]string, error) {
+	var vips map[string]string
+	outStr, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"get", "load_balancer", loadBalancer, "vips")
+	if err != nil {
+		return nil, err
+	}
+	if outStr == "" {
+		return vips, nil
+	}
+	// sample outStr:
+	// - {"192.168.0.1:80"="10.1.1.1:80,10.2.2.2:80"}
+	// - {"[fd01::]:80"="[fd02::]:80,[fd03::]:80"}
+	outStrMap := strings.Replace(outStr, "=", ":", -1)
+	err = json.Unmarshal([]byte(outStrMap), &vips)
+	if err != nil {
+		return nil, err
+	}
+	return vips, nil
+}
+
+// DeleteLoadBalancerVIP removes the VIP as well as any reject ACLs associated to the LB
+func DeleteLoadBalancerVIP(loadBalancer, vip string) error {
+	vipQuotes := fmt.Sprintf("\"%s\"", vip)
+	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove", "load_balancer", loadBalancer, "vips", vipQuotes)
+	if err != nil {
+		// if we hit an error and fail to remove load balancer, we skip removing the rejectACL
+		return fmt.Errorf("error in deleting load balancer vip %s for %s"+
+			"stdout: %q, stderr: %q, error: %v",
+			vip, loadBalancer, stdout, stderr, err)
+	}
+	return nil
+}
+
+// UpdateLoadBalancer updates the VIP for sourceIP:sourcePort to point to targets (an
+// array of IP:port strings)
+func UpdateLoadBalancer(lb, vip string, targets []string) error {
+	lbTarget := fmt.Sprintf(`vips:"%s"="%s"`, vip, strings.Join(targets, ","))
+
+	out, stderr, err := util.RunOVNNbctl("set", "load_balancer", lb, lbTarget)
+	if err != nil {
+		return fmt.Errorf("error in configuring load balancer: %s "+
+			"stdout: %q, stderr: %q, error: %v", lb, out, stderr, err)
+	}
+
+	return nil
+}
+
+// GetLogicalSwitchesForLoadBalancer get the switches associated to a LoadBalancer
+func GetLogicalSwitchesForLoadBalancer(lb string) ([]string, error) {
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "find",
+		"logical_switch", fmt.Sprintf("load_balancer{>=}%s", lb))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(out), nil
+}
+
+// GetLogicalRoutersForLoadBalancer get the routers associated to a LoadBalancer
+func GetLogicalRoutersForLoadBalancer(lb string) ([]string, error) {
+	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=name", "find",
+		"logical_router", fmt.Sprintf("load_balancer{>=}%s", lb))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(out), nil
+}
+
+// GetGRLogicalSwitchForLoadBalancer returns the external switch name if the load balancer is on a GR
+func GetGRLogicalSwitchForLoadBalancer(lb string) (string, error) {
+	routers, err := GetLogicalRoutersForLoadBalancer(lb)
+	if err != nil {
+		return "", err
+	}
+	if len(routers) == 0 {
+		return "", nil
+	}
+
+	// if this is a GR we know the corresponding join and external switches, otherwise this is an unhandled
+	// case
+	for _, r := range routers {
+		if strings.HasPrefix(r, types.GWRouterPrefix) {
+			routerName := strings.TrimPrefix(r, types.GWRouterPrefix)
+			return types.ExternalSwitchPrefix + routerName, nil
+		}
+	}
+	return "", fmt.Errorf("router detected with load balancer that is not a GR")
+}
+
+// GenerateACLName generates a deterministic ACL name based on the load_balancer parameters
+func GenerateACLName(lb string, sourceIP string, sourcePort int32) string {
+	aclName := fmt.Sprintf("%s-%s:%d", lb, sourceIP, sourcePort)
+	// ACL names are limited to 63 characters
+	if len(aclName) > 63 {
+		var ipPortLen int
+		srcPortStr := fmt.Sprintf("%d", sourcePort)
+		// Add the length of the IP (max 15 with periods, max 39 with colons),
+		// plus length of sourcePort (max 5 char),
+		// plus 1 for additional ':' to separate,
+		// plus 1 for '-' between lb and IP.
+		// With full IPv6 address and 5 char port, max ipPortLen is 62
+		// With full IPv4 address and 5 char port, max ipPortLen is 24.
+		ipPortLen = len(sourceIP) + len(srcPortStr) + 1 + 1
+		lbTrim := 63 - ipPortLen
+		// Shorten the Load Balancer name to allow full IP:port
+		tmpLb := lb[:lbTrim]
+		klog.Infof("Limiting ACL Name from %s to %s-%s:%d to keep under 63 characters", aclName, tmpLb, sourceIP, sourcePort)
+		aclName = fmt.Sprintf("%s-%s:%d", tmpLb, sourceIP, sourcePort)
+	}
+	return aclName
+}
+
+// GenerateACLNameForOVNCommand sanitize the ACL name because the generateACLName
+// function was including backslash escapes for the ACL
+// name for use in OVN commands that have trouble with literal ":". That
+// was causing a mismatch when services were syncing because the name
+// actually returned from an OVN command does not include any backslashes
+// so the names would not match. #1749
+func GenerateACLNameForOVNCommand(lb string, sourceIP string, sourcePort int32) string {
+	return strings.ReplaceAll(GenerateACLName(lb, sourceIP, sourcePort), ":", "\\:")
+}

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,326 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+)
+
+func TestGetOVNKubeLoadBalancer(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol kapi.Protocol
+		ovnCmd   ovntest.ExpectedCmd
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "existing loadbalancer TCP",
+			protocol: kapi.ProtocolTCP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+				Output: "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			},
+			want:    "a08ea426-2288-11eb-a30b-a8a1590cda29",
+			wantErr: false,
+		},
+		{
+			name:     "non existing loadbalancer UDP",
+			protocol: kapi.ProtocolUDP,
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+				Output: "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+
+			got, err := GetOVNKubeLoadBalancer(tt.protocol)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetOVNKubeLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetOVNKubeLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLoadBalancerVIPs(t *testing.T) {
+	tests := []struct {
+		name         string
+		loadBalancer string
+		ovnCmd       ovntest.ExpectedCmd
+		want         map[string]string
+		wantErr      bool
+	}{
+		{
+			name:         "loadbalancer with VIPs",
+			loadBalancer: "my-lb",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer my-lb vips",
+				Output: `{"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53", "10.96.0.10:9153"="10.244.2.3:9153,10.244.2.5:9153", "10.96.0.1:443"="172.19.0.3:6443"}`,
+			},
+			want: map[string]string{
+				"10.96.0.10:53":   "10.244.2.3:53,10.244.2.5:53",
+				"10.96.0.10:9153": "10.244.2.3:9153,10.244.2.5:9153",
+				"10.96.0.1:443":   "172.19.0.3:6443",
+			},
+			wantErr: false,
+		},
+		{
+			name:         "empty load balancer",
+			loadBalancer: "my-lb",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer my-lb vips",
+				Output: "",
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetLoadBalancerVIPs(tt.loadBalancer)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLoadBalancerVIPs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLoadBalancerVIPs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteLoadBalancerVIP(t *testing.T) {
+	tests := []struct {
+		name         string
+		loadBalancer string
+		vip          string
+		ovnCmd       ovntest.ExpectedCmd
+		wantErr      bool
+	}{
+		{
+			name:         "loadbalancer with VIPs",
+			loadBalancer: "my-lb",
+			vip:          "10.96.0.10:53",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer my-lb vips "10.96.0.10:53"`,
+				Output: `{"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53", "10.96.0.10:9153"="10.244.2.3:9153,10.244.2.5:9153", "10.96.0.1:443"="172.19.0.3:6443"}`,
+			},
+			wantErr: false,
+		},
+		{
+			name:         "load balancer and OVN error",
+			loadBalancer: "my-lb",
+			vip:          "10.96.0.10:53",
+			ovnCmd: ovntest.ExpectedCmd{
+				Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer my-lb vips "10.96.0.10:53"`,
+				Output: "",
+				Err:    fmt.Errorf("error while removing ACL: sw1, from switches"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			err = DeleteLoadBalancerVIP(tt.loadBalancer, tt.vip)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteLoadBalancerVIP() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestUpdateLoadBalancer(t *testing.T) {
+	type args struct {
+		lb      string
+		vip     string
+		targets []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		ovnCmd  ovntest.ExpectedCmd
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			if err := UpdateLoadBalancer(tt.args.lb, tt.args.vip, tt.args.targets); (err != nil) != tt.wantErr {
+				t.Errorf("UpdateLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetLogicalSwitchesForLoadBalancer(t *testing.T) {
+	type args struct {
+		lb string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		ovnCmd  ovntest.ExpectedCmd
+		want    []string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetLogicalSwitchesForLoadBalancer(tt.args.lb)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLogicalSwitchesForLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLogicalSwitchesForLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLogicalRoutersForLoadBalancer(t *testing.T) {
+	type args struct {
+		lb string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		ovnCmd  ovntest.ExpectedCmd
+		want    []string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fexec := ovntest.NewLooseCompareFakeExec()
+			fexec.AddFakeCmd(&tt.ovnCmd)
+			err := util.SetExec(fexec)
+			if err != nil {
+				t.Errorf("fexec error: %v", err)
+			}
+			got, err := GetLogicalRoutersForLoadBalancer(tt.args.lb)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLogicalRoutersForLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetLogicalRoutersForLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateACLName(t *testing.T) {
+	type args struct {
+		lb         string
+		sourceIP   string
+		sourcePort int32
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateACLName(tt.args.lb, tt.args.sourceIP, tt.args.sourcePort); got != tt.want {
+				t.Errorf("GenerateACLName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateACLNameForOVNCommand(t *testing.T) {
+	type args struct {
+		lb         string
+		sourceIP   string
+		sourcePort int32
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateACLNameForOVNCommand(tt.args.lb, tt.args.sourceIP, tt.args.sourcePort); got != tt.want {
+				t.Errorf("GenerateACLNameForOVNCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetGRLogicalSwitchForLoadBalancer(t *testing.T) {
+	type args struct {
+		lb string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetGRLogicalSwitchForLoadBalancer(tt.args.lb)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetGRLogicalSwitchForLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetGRLogicalSwitchForLoadBalancer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -16,6 +16,7 @@ import (
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	svccontroller "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/subnetallocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -29,7 +30,9 @@ import (
 	kapisnetworking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
@@ -279,8 +282,58 @@ func (oc *Controller) Run(wg *sync.WaitGroup) error {
 	oc.WatchNodes()
 
 	oc.WatchPods()
-	oc.WatchServices()
-	oc.WatchEndpoints()
+
+	// Services are handled differently depending on the Kubernetes API versions
+	// and the OVN configuration.
+	// We use a level triggered controller to handle services if k8s > 1.19,
+	// using endpoint slices instead endpoints if OVN is configured for dual stack.
+	if util.UseEndpointSlices(oc.client) && config.IPv4Mode && config.IPv6Mode {
+		// Services are handled differently depending on the Kubernetes API versions
+		klog.Infof("Dual Stack enabled: using EndpointSlices instead of Endpoints in k8s versions > 1.19")
+		// Create our own informers to start compartamentalizing the code
+		// filter server side the things we don't care about
+		noProxyName, err := labels.NewRequirement("service.kubernetes.io/service-proxy-name", selection.DoesNotExist, nil)
+		if err != nil {
+			return err
+		}
+
+		noHeadlessEndpoints, err := labels.NewRequirement(kapi.IsHeadlessService, selection.DoesNotExist, nil)
+		if err != nil {
+			return err
+		}
+
+		labelSelector := labels.NewSelector()
+		labelSelector = labelSelector.Add(*noProxyName, *noHeadlessEndpoints)
+
+		informerFactory := informers.NewSharedInformerFactoryWithOptions(oc.client, 0,
+			informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+				options.LabelSelector = labelSelector.String()
+			}))
+
+		servicesController := svccontroller.NewController(
+			oc.client,
+			informerFactory.Core().V1().Services(),
+			informerFactory.Discovery().V1beta1().EndpointSlices(),
+			oc.clusterPortGroupUUID,
+		)
+		informerFactory.Start(oc.stopChan)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// use 5 workers like most of the kubernetes controllers in the
+			// kubernetes controller-manager
+			err := servicesController.Run(5, oc.stopChan)
+			if err != nil {
+				klog.Errorf("Error running OVN Kubernetes Services controller: %v", err)
+			}
+		}()
+
+	} else {
+		klog.Infof("OVN Controller using Endpoints instead of EndpointSlices")
+		oc.WatchServices()
+		oc.WatchEndpoints()
+	}
+
 	oc.WatchNetworkPolicy()
 	oc.WatchCRD()
 

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	kapi "k8s.io/api/core/v1"
@@ -17,6 +18,7 @@ import (
 
 	egressfirewallclientset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned"
 	egressipclientset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned"
+	discovery "k8s.io/api/discovery/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
@@ -210,16 +212,37 @@ func GetPodNetSelAnnotation(pod *kapi.Pod, netAttachAnnot string) ([]*types.Netw
 	return networks, nil
 }
 
-// eventRecorder returns an EventRecorder type that can be
+// EventRecorder returns an EventRecorder type that can be
 // used to post Events to different object's lifecycles.
 func EventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.Infof)
 	eventBroadcaster.StartRecordingToSink(
 		&typedcorev1.EventSinkImpl{
-			Interface: kubeClient.CoreV1().Events("")})
+			Interface: kubeClient.CoreV1().Events(""),
+		})
 	recorder := eventBroadcaster.NewRecorder(
 		scheme.Scheme,
 		kapi.EventSource{Component: "controlplane"})
 	return recorder
+}
+
+// UseEndpointSlices if the EndpointSlice API is available
+// and if the kubernetes versions supports DualStack (Kubernetes >= 1.20)
+func UseEndpointSlices(kubeClient kubernetes.Interface) bool {
+	endpointSlicesEnabled := false
+	if _, err := kubeClient.Discovery().ServerResourcesForGroupVersion(discovery.SchemeGroupVersion.String()); err == nil {
+		// The EndpointSlice API is enabled check if is running in a supported version
+		klog.V(2).Infof("Kubernetes Endpoint Slices enabled on the cluster: %s", discovery.SchemeGroupVersion.String())
+		endpointSlicesEnabled = true
+	}
+	// We only use Slices if > 1.19 since we only need them for Dual Stack
+	sv, _ := kubeClient.Discovery().ServerVersion()
+	major, _ := strconv.Atoi(sv.Major)
+	minor, _ := strconv.Atoi(sv.Minor)
+	klog.Infof("Kubernetes running with version %d.%d", major, minor)
+	if major <= 1 && minor < 20 || !endpointSlicesEnabled {
+		return false
+	}
+	return true
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -123,6 +123,19 @@ func IsClusterIPSet(service *kapi.Service) bool {
 	return service.Spec.ClusterIP != kapi.ClusterIPNone && service.Spec.ClusterIP != ""
 }
 
+// GetClusterIPs return an array with the ClusterIPs present in the service
+// for backward compatibility with versions < 1.20
+// we need to handle the case where only ClusterIP exist
+func GetClusterIPs(service *kapi.Service) []string {
+	if len(service.Spec.ClusterIPs) > 0 {
+		return service.Spec.ClusterIPs
+	}
+	if len(service.Spec.ClusterIP) > 0 && service.Spec.ClusterIP != kapi.ClusterIPNone {
+		return []string{service.Spec.ClusterIP}
+	}
+	return []string{}
+}
+
 // ValidatePort checks if the port is non-zero and port protocol is valid
 func ValidatePort(proto kapi.Protocol, port int32) error {
 	if port <= 0 || port > 65535 {


### PR DESCRIPTION
Endpoint Slices

Kubernetes EndpointSlices is the evolution of the Endpoint object, this doesn't mean that Endpoints are going to be deprecated, but they will not receive any new feature.

As an example, only EndpointSlices will support DualStack endpoints, the new Topology aware features, ...

Since we only need to manage one or other object, and we want to implement the latest Kubernetes features, we need to be able to consume Endpoint Slices without breaking previous deployments. In order to do that, OVN will check the Kubernetes API version, and will use Endpoint or EndpointSlices for Kubernetes versions > 1.19.

Since EndpointSlices can have duplicate multiple objects for the same Service and addresses are not guaranteed to be unique, we need to use a Level based approach for its implimentation, using and independ controller. This controller doesn't require additional resources because it is created from current shared informers, however, doesn't use the factory module, to break the dependency on it so we consume directly the client-go package and reduce the code we have to maintain.

xref: https://docs.google.com/document/d/1OMsp57dnbyI32VXX60EE6w_peYTM_7e0bPlFlIIV25U/edit


Followup from https://github.com/ovn-org/ovn-kubernetes/pull/1857 because the CI is not working for that PR, however it is working on my fork CI https://github.com/aojea/ovn-kubernetes/runs/1512794782?check_suite_focus=true