### PR TITLE
node: Fix gateway start ordering

### DIFF
--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -37,6 +37,7 @@ type gateway struct {
 	localPortWatcher informer.ServiceEventHandler
 	openflowManager  *openflowManager
 	initFunc         func() error
+	readyFunc        func() (bool, error)
 }
 
 func (g *gateway) AddService(svc *kapi.Service) {
@@ -231,4 +232,14 @@ func gatewayInitInternal(nodeName, gwIntf string, subnets []*net.IPNet, gwNextHo
 		VLANID:         &config.Gateway.VLANID,
 	})
 	return bridgeName, uplinkName, macAddress, ips, err
+}
+
+func gatewayReady(patchPort string) (bool, error) {
+	// Get ofport of patchPort
+	ofportPatch, _, err := util.RunOVSVsctl("--if-exists", "get", "interface", patchPort, "ofport")
+	if err != nil || len(ofportPatch) == 0 {
+		return false, nil
+	}
+	klog.Info("Gateway is ready")
+	return true, nil
 }

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -6,11 +6,13 @@ import (
 	"sync"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	kapi "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
@@ -20,7 +22,7 @@ import (
 // are kept in sync
 type Gateway interface {
 	informer.ServiceAndEndpointsEventHandler
-	Init() error
+	Init(factory.NodeWatchFactory) error
 	Run(<-chan struct{}, *sync.WaitGroup)
 }
 
@@ -115,8 +117,43 @@ func (g *gateway) DeleteEndpoints(ep *kapi.Endpoints) {
 	}
 }
 
-func (g *gateway) Init() error {
-	return g.initFunc()
+func (g *gateway) Init(wf factory.NodeWatchFactory) error {
+	err := g.initFunc()
+	if err != nil {
+		return err
+	}
+	wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			svc := obj.(*kapi.Service)
+			g.AddService(svc)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			oldSvc := old.(*kapi.Service)
+			newSvc := new.(*kapi.Service)
+			g.UpdateService(oldSvc, newSvc)
+		},
+		DeleteFunc: func(obj interface{}) {
+			svc := obj.(*kapi.Service)
+			g.DeleteService(svc)
+		},
+	}, g.SyncServices)
+
+	wf.AddEndpointsHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			ep := obj.(*kapi.Endpoints)
+			g.AddEndpoints(ep)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			oldEp := old.(*kapi.Endpoints)
+			newEp := new.(*kapi.Endpoints)
+			g.UpdateEndpoints(oldEp, newEp)
+		},
+		DeleteFunc: func(obj interface{}) {
+			ep := obj.(*kapi.Endpoints)
+			g.DeleteEndpoints(ep)
+		},
+	}, nil)
+	return nil
 }
 
 func (g *gateway) Run(stopChan <-chan struct{}, wg *sync.WaitGroup) {

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -195,7 +195,10 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator)
 	case config.GatewayModeDisabled:
 		klog.Info("Gateway Mode is disabled")
-		gw = &gateway{}
+		gw = &gateway{
+			initFunc:  func() error { return nil },
+			readyFunc: func() (bool, error) { return true, nil },
+		}
 		err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
 			Mode: config.GatewayModeDisabled,
 		})
@@ -209,14 +212,8 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	initGw := func() error {
 		return gw.Init(n.watchFactory)
 	}
-	// Wait for gateway resources to be created by the master if DisableSNATMultipleGWs is not set,
-	// as that option does not add default SNAT rules on the GR and the gatewayReady function checks
-	// those default NAT rules are present
-	if !config.Gateway.DisableSNATMultipleGWs && config.Gateway.Mode != config.GatewayModeLocal {
-		waiter.AddWait(gatewayReady, initGw)
-	} else {
-		waiter.AddWait(func() (bool, error) { return true, nil }, initGw)
-	}
+
+	waiter.AddWait(gw.readyFunc, initGw)
 	n.gateway = gw
 	return err
 }
@@ -248,29 +245,4 @@ func CleanupClusterNode(name string) error {
 	DelMgtPortIptRules()
 
 	return nil
-}
-
-// GatewayReady will check to see if we have successfully added SNAT OpenFlow rules in the L3Gateway Routers
-func gatewayReady() (bool, error) {
-	// OpenFlow table 41 performs SNATing of packets that are heading to physical network from
-	// logical network.
-	for _, clusterSubnet := range config.Default.ClusterSubnets {
-		var cidr, match string
-		cidr = clusterSubnet.CIDR.String()
-		if strings.Contains(cidr, ":") {
-			match = "ipv6,ipv6_src=" + cidr
-		} else {
-			match = "ip,nw_src=" + cidr
-		}
-		stdout, _, err := util.RunOVSOfctl("--no-stats", "--no-names", "dump-flows", "br-int",
-			"table=41,"+match)
-		if err != nil {
-			return false, nil
-		}
-		if !strings.Contains(stdout, cidr) {
-			return false, nil
-		}
-	}
-	klog.Info("Gateway is ready")
-	return true, nil
 }

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -125,7 +125,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: systemID,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-vsctl --timeout=15 wait-until Interface patch-breth0_node1-to-br-int ofport>0 -- get Interface patch-breth0_node1-to-br-int ofport",
+			Cmd:    "ovs-vsctl --timeout=15 get Interface patch-breth0_node1-to-br-int ofport",
 			Output: "5",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -332,15 +332,9 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 // -- to also connection track the outbound north-south traffic through l3 gateway so that
 //    the return traffic can be steered back to OVN logical topology
 // -- to also handle unDNAT return traffic back out of the host
-func newSharedGatewayOpenFlowManager(nodeName, macAddress, gwBridge, gwIntf string) (*openflowManager, error) {
-	// the name of the patch port created by ovn-controller is of the form
-	// patch-<logical_port_name_of_localnet_port>-to-br-int
-	localnetLpName := gwBridge + "_" + nodeName
-	patchPort := "patch-" + localnetLpName + "-to-br-int"
-	// Get ofport of patchPort, but before that make sure ovn-controller created
-	// one for us (waits for about ovsCommandTimeout seconds)
-	ofportPatch, stderr, err := util.RunOVSVsctl("wait-until", "Interface", patchPort, "ofport>0",
-		"--", "get", "Interface", patchPort, "ofport")
+func newSharedGatewayOpenFlowManager(patchPort, macAddress, gwBridge, gwIntf string) (*openflowManager, error) {
+	// Get ofport of patchPort
+	ofportPatch, stderr, err := util.RunOVSVsctl("get", "Interface", patchPort, "ofport")
 	if err != nil {
 		return nil, fmt.Errorf("failed while waiting on patch port %q to be created by ovn-controller and "+
 			"while getting ofport. stderr: %q, error: %v", patchPort, stderr, err)
@@ -507,20 +501,28 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		return nil, err
 	}
 
+	// the name of the patch port created by ovn-controller is of the form
+	// patch-<logical_port_name_of_localnet_port>-to-br-int
+	patchPort := "patch-" + bridgeName + "_" + nodeName + "-to-br-int"
+
+	gw.readyFunc = func() (bool, error) {
+		return gatewayReady(patchPort)
+	}
+
 	gw.initFunc = func() error {
 		// Program cluster.GatewayIntf to let non-pod traffic to go to host
 		// stack
 		klog.Info("Creating Shared Gateway Openflow Manager")
 		var err error
 
-		gw.openflowManager, err = newSharedGatewayOpenFlowManager(nodeName, macAddress.String(), bridgeName, uplinkName)
+		gw.openflowManager, err = newSharedGatewayOpenFlowManager(patchPort, macAddress.String(), bridgeName, uplinkName)
 		if err != nil {
 			return err
 		}
 
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Shared Gateway Node Port Watcher")
-			gw.nodePortWatcher, err = newNodePortWatcher(nodeName, bridgeName, uplinkName, ips[0])
+			gw.nodePortWatcher, err = newNodePortWatcher(patchPort, bridgeName, uplinkName, ips[0])
 			if err != nil {
 				return err
 			}
@@ -532,10 +534,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 	return gw, nil
 }
 
-func newNodePortWatcher(nodeName, gwBridge, gwIntf string, nodeIP *net.IPNet) (*nodePortWatcher, error) {
-	// the name of the patch port created by ovn-controller is of the form
-	// patch-<logical_port_name_of_localnet_port>-to-br-int
-	patchPort := "patch-" + gwBridge + "_" + nodeName + "-to-br-int"
+func newNodePortWatcher(patchPort, gwBridge, gwIntf string, nodeIP *net.IPNet) (*nodePortWatcher, error) {
 	// Get ofport of patchPort
 	ofportPatch, stderr, err := util.RunOVSVsctl("--if-exists", "get",
 		"interface", patchPort, "ofport")


### PR DESCRIPTION
Make sure that the handlers aren't added to the watchFactory until
after the gateway is fully initialized. This stops us dropping
any events.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->