### PR TITLE
shared-gateway: ignore empty Ingress IPs

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -232,6 +232,9 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 				ports[externalPortKey] = externalIP
 			}
 			for _, ing := range service.Status.LoadBalancer.Ingress {
+				if ing.IP == "" {
+					continue
+				}
 				ingIP := net.ParseIP(ing.IP)
 				if ingIP == nil {
 					klog.Errorf("Failed to parse ingress IP: %s", ing.IP)


### PR DESCRIPTION
@trozet 