### PR TITLE
[fixes BZ #1903651] Add VIP to gress policy when traffic can be SNAT-ed at hairpin 

### DIFF
--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -333,7 +333,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = wf.InitializeEgressFirewallWatchFactory()
 			Expect(err).NotTo(HaveOccurred())
-			h := wf.addHandler(objType, namespace, sel,
+			h := wf.addHandler(objType, namespace, sel, nil,
 				cache.ResourceEventHandlerFuncs{},
 				func(objs []interface{}) {
 					defer GinkgoRecover()
@@ -409,7 +409,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			err = wf.InitializeEgressFirewallWatchFactory()
 			Expect(err).NotTo(HaveOccurred())
 			var addCalls int32
-			h := wf.addHandler(objType, "", nil,
+			h := wf.addHandler(objType, "", nil, nil,
 				cache.ResourceEventHandlerFuncs{
 					AddFunc: func(obj interface{}) {
 						atomic.AddInt32(&addCalls, 1)
@@ -487,7 +487,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 	addFilteredHandler := func(wf *WatchFactory, objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandlerFuncs) (*Handler, *handlerCalls) {
 		calls := handlerCalls{}
-		h := wf.addHandler(objType, namespace, sel, cache.ResourceEventHandlerFuncs{
+		h := wf.addHandler(objType, namespace, sel, nil, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				defer GinkgoRecover()
 				atomic.AddInt32(&calls.added, 1)

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -29,6 +29,7 @@ type NodeWatchFactory interface {
 	Shutdownable
 
 	AddServiceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
+	AddFilteredServiceHandler(namespace string, matchSel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
 	RemoveServiceHandler(handler *Handler)
 
 	AddEndpointsHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -95,6 +95,36 @@ func (gp *gressPolicy) ensurePeerAddressSet(factory AddressSetFactory) error {
 	return nil
 }
 
+func (gp *gressPolicy) addPeerSvcVip(service *v1.Service) error {
+	if gp.peerAddressSet == nil {
+		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
+			service.ObjectMeta.Name, gp.policyName)
+	}
+
+	ips, err := getSvcVips(service)
+	if err != nil {
+		return err
+	}
+
+	klog.V(5).Infof("Adding VIPs to gressPolicy's Address Set")
+	return gp.peerAddressSet.AddIPs(ips)
+}
+
+func (gp *gressPolicy) deletePeerSvcVip(service *v1.Service) error {
+	if gp.peerAddressSet == nil {
+		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
+			service.ObjectMeta.Name, gp.policyName)
+	}
+
+	ips, err := getSvcVips(service)
+	if err != nil {
+		return err
+	}
+
+	klog.V(5).Infof("Adding VIPs to gressPolicy's Address Set")
+	return gp.peerAddressSet.DeleteIPs(ips)
+}
+
 func (gp *gressPolicy) addPeerPod(pod *v1.Pod) error {
 	if gp.peerAddressSet == nil {
 		return fmt.Errorf("peer AddressSet is nil, cannot add peer pod: %s for gressPolicy: %s",

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -100,13 +100,11 @@ func (gp *gressPolicy) addPeerSvcVip(service *v1.Service) error {
 		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
 			service.ObjectMeta.Name, gp.policyName)
 	}
-
 	ips, err := getSvcVips(service)
 	if err != nil {
 		return err
 	}
-
-	klog.V(5).Infof("Adding VIPs to gressPolicy's Address Set")
+	klog.V(5).Infof("Adding VIPs to gressPolicy's Address Set: %v", ips)
 	return gp.peerAddressSet.AddIPs(ips)
 }
 
@@ -115,13 +113,11 @@ func (gp *gressPolicy) deletePeerSvcVip(service *v1.Service) error {
 		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
 			service.ObjectMeta.Name, gp.policyName)
 	}
-
 	ips, err := getSvcVips(service)
 	if err != nil {
 		return err
 	}
-
-	klog.V(5).Infof("Adding VIPs to gressPolicy's Address Set")
+	klog.V(5).Infof("Deleting VIPs from gressPolicy's Address Set: %v", ips)
 	return gp.peerAddressSet.DeleteIPs(ips)
 }
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -832,6 +832,7 @@ func (oc *Controller) handlePeerPodSelector(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				// Service is matched so add VIP to addressSet
+				klog.V(5).Infof("A Service matches the same Pods as the policy %s", policy.Name)
 				oc.handlePeerServiceSelectorAddUpdate(gp, obj)
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -839,7 +840,7 @@ func (oc *Controller) handlePeerPodSelector(
 				oc.handlePeerServiceSelectorDelete(gp, obj)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				// If SVC Is updated make sure ame pods are still matched
+				// If SVC Is updated make sure same pods are still matched
 				oc.handlePeerServiceSelectorAddUpdate(gp, newObj)
 			},
 		}, nil)


### PR DESCRIPTION
This PR fixes the problem found here https://bugzilla.redhat.com/show_bug.cgi?id=1903651

When a POD sends traffic to a service it is loadbalanced(DNAT-ed) and sometimes the same pod is chosen as the backend to the service. To ensure this traffic travels through OVN-K8s rather than the POD2POD network since (srcIP==dstIP), the traffic is SNAT-ed to the VIP of the service's loadbalancer, which results in some packet loss with hairpinned traffic since this is not currently accounted for in the network Policy code 

This PR adds a new handler to policy.go which matches on the `spec.Selector` labels rather than the `meta.labels` labels as done previously.  This allows the handler to watch services which match on the same pods at the network policy.  Once a "Peer service" is found the possible VIPs are deduced with the function `getSvcVips(service *kapi.Service)`

This function grabs all the possible VIPs the service's loadbalancer/ers could use and add's them to the gress policy's address set, much like when a new `peer-pod` is added.  Specifically it looks for the Cluster IP, Ingress IPs, External IPs, and physical IPs on the gateway routers, all of which can be used as the VIP for a Service's loadbalancer in specific cases. 

This was tested on a local kind cluster with a basic `clusterIP` type service, however I would like to also verify with more complicated Service definitions and Types

**- How to verify it**
1. Make a deployment 
2. Make a service using the deployment as a backend
3. apply a `default-deny` network policy along with a `allow-from-same-namespace` network policy 
4. Make sure the VIP for the Service was added to the `allow-from-same-namespace` allow address-set
(Sample definitions can be found in the bug) 