### PR TITLE
Adds OFPort to CNI OVS check

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -150,8 +150,12 @@ func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister) ([]byte, error
 			return nil, fmt.Errorf("could not find host interface in the prevResult: %v", result)
 		}
 		ifaceID := fmt.Sprintf("%s_%s", namespace, podName)
+		ofPort, err := getIfaceOFPort(hostIfaceName)
+		if err != nil {
+			return nil, err
+		}
 		for _, ip := range result.IPs {
-			if err = waitForPodFlows(pr.ctx, result.Interfaces[*ip.Interface].Mac, []*net.IPNet{&ip.Address}, hostIfaceName, ifaceID); err != nil {
+			if err = waitForPodFlows(pr.ctx, result.Interfaces[*ip.Interface].Mac, []*net.IPNet{&ip.Address}, hostIfaceName, ifaceID, ofPort); err != nil {
 				return nil, fmt.Errorf("error while checkoing on flows for pod: %s ip: %v, error: %v", ifaceID, ip, err)
 			}
 		}

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -372,7 +372,12 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 		klog.Warningf("Failed to settle addresses: %q", err)
 	}
 
-	if err = waitForPodFlows(pr.ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID); err != nil {
+	ofPort, err := getIfaceOFPort(hostIface.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = waitForPodFlows(pr.ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID, ofPort); err != nil {
 		return nil, fmt.Errorf("error while waiting on flows for pod: %v", err)
 	}
 


### PR DESCRIPTION
We still see that at high scale, sometimes high latency will cause CNI
ADD to fail and then retry. During this time a subsequent CNI ADD may
succeed by accidentally checking the flows of the previous CNI
interface. This patch adds a check for the OpenFlow port in the OVS
flows to ensure that the flows we are checking are for the new port.

More context here:
https://bugzilla.redhat.com/show_bug.cgi?id=1885761

Signed-off-by: Tim Rozet <trozet@redhat.com>

Props to @dceara for thinking of this solution