### PR TITLE
Enable DB memory trimming on compaction

### DIFF
--- a/go-controller/cmd/ovndbchecker/ovndbchecker.go
+++ b/go-controller/cmd/ovndbchecker/ovndbchecker.go
@@ -182,6 +182,10 @@ func runOvnKubeDBChecker(ctx *cli.Context) error {
 		return err
 	}
 
+	if err = ovndbmanager.EnableDBMemTrimming(); err != nil {
+		return err
+	}
+
 	stopChan := make(chan struct{})
 	ovndbmanager.RunDBChecker(
 		&kube.Kube{


### PR DESCRIPTION
Will periodically release memory back to the OS.

Signed-off-by: Tim Rozet <trozet@redhat.com>

