### PR TITLE
[BZ #1903651] Add clusterIP to ingress policy AS for SNAT-ed hairpin Traffic 

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -399,6 +399,11 @@ func (wf *WatchFactory) AddServiceHandler(handlerFuncs cache.ResourceEventHandle
 	return wf.addHandler(serviceType, "", nil, handlerFuncs, processExisting)
 }
 
+// AddFilteredServiceHandler adds a handler function that will be executed on all Service object changes for a specific namespace
+func (wf *WatchFactory) AddFilteredServiceHandler(namespace string, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler {
+	return wf.addHandler(serviceType, namespace, nil, handlerFuncs, processExisting)
+}
+
 // RemoveServiceHandler removes a Service object event handler function
 func (wf *WatchFactory) RemoveServiceHandler(handler *Handler) {
 	wf.removeHandler(serviceType, handler)

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -29,6 +29,7 @@ type NodeWatchFactory interface {
 	Shutdownable
 
 	AddServiceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
+	AddFilteredServiceHandler(namespace string, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
 	RemoveServiceHandler(handler *Handler)
 
 	AddEndpointsHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -303,6 +303,10 @@ func (as *ovnAddressSets) SetIPs(ips []net.IP) error {
 
 func (as *ovnAddressSets) AddIPs(ips []net.IP) error {
 	var err error
+
+	if len(ips) == 0 {
+		return fmt.Errorf("no IPs to add to addressSet: %s", as.name)
+	}
 	as.Lock()
 	defer as.Unlock()
 

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -97,6 +97,32 @@ func (gp *gressPolicy) ensurePeerAddressSet(factory addressset.AddressSetFactory
 	return nil
 }
 
+func (gp *gressPolicy) addPeerSvcVip(service *v1.Service) error {
+	if gp.peerAddressSet == nil {
+		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
+			service.ObjectMeta.Name, gp.policyName)
+	}
+
+	klog.V(5).Infof("Service %s is applied to same namespace as network Policy, finding Service VIPs", service.Name)
+	ips := getSvcVips(service)
+
+	klog.V(5).Infof("Adding SVC clusterIP to gressPolicy's Address Set: %v", ips)
+	return gp.peerAddressSet.AddIPs(ips)
+}
+
+func (gp *gressPolicy) deletePeerSvcVip(service *v1.Service) error {
+	if gp.peerAddressSet == nil {
+		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
+			service.ObjectMeta.Name, gp.policyName)
+	}
+
+	klog.V(5).Infof("Service %s is applied to same namespace as network Policy, finding cluster IPs", service.Name)
+	ips := getSvcVips(service)
+
+	klog.Infof("Deleting service %s, possible VIPs: %v from gressPolicy's %s Address Set", service.Name, ips, gp.policyName)
+	return gp.peerAddressSet.DeleteIPs(ips)
+}
+
 func (gp *gressPolicy) addPeerPod(pod *v1.Pod) error {
 	if gp.peerAddressSet == nil {
 		return fmt.Errorf("peer AddressSet is nil, cannot add peer pod: %s for gressPolicy: %s",

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"sync"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -23,6 +24,7 @@ type namespacePolicy struct {
 	ingressPolicies []*gressPolicy
 	egressPolicies  []*gressPolicy
 	podHandlerList  []*factory.Handler
+	svcHandlerList  []*factory.Handler
 	nsHandlerList   []*factory.Handler
 	localPods       map[string]*lpInfo //pods effected by this policy
 	portGroupUUID   string             //uuid for OVN port_group
@@ -38,6 +40,7 @@ func NewNamespacePolicy(policy *knet.NetworkPolicy) *namespacePolicy {
 		ingressPolicies: make([]*gressPolicy, 0),
 		egressPolicies:  make([]*gressPolicy, 0),
 		podHandlerList:  make([]*factory.Handler, 0),
+		svcHandlerList:  make([]*factory.Handler, 0),
 		nsHandlerList:   make([]*factory.Handler, 0),
 		localPods:       make(map[string]*lpInfo),
 	}
@@ -627,10 +630,13 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
 		}
 
 		if hasAnyLabelSelector(ingressJSON.From) {
+			klog.V(5).Infof("Network policy %s with ingress rule %s has a selector", policy.Name, ingress.policyName)
 			if err := ingress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
 				klog.Errorf(err.Error())
 				continue
 			}
+			// Start service handlers ONLY if there's an ingress Address Set
+			oc.handlePeerService(policy, ingress, np)
 		}
 
 		for _, fromJSON := range ingressJSON.From {
@@ -662,6 +668,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) {
 		}
 
 		if hasAnyLabelSelector(egressJSON.To) {
+			klog.V(5).Infof("Network policy %s with egress rule %s has a selector", policy.Name, egress.policyName)
 			if err := egress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
 				klog.Errorf(err.Error())
 				continue
@@ -963,5 +970,8 @@ func (oc *Controller) shutdownHandlers(np *namespacePolicy) {
 	}
 	for _, handler := range np.nsHandlerList {
 		oc.watchFactory.RemoveNamespaceHandler(handler)
+	}
+	for _, handler := range np.svcHandlerList {
+		oc.watchFactory.RemoveServiceHandler(handler)
 	}
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -787,6 +787,61 @@ func (oc *Controller) handlePeerPodSelectorDelete(gp *gressPolicy, obj interface
 	}
 }
 
+// handlePeerServiceSelectorAddUpdate adds the VIP of a service that selects
+// pods that are selected by the Network Policy
+func (oc *Controller) handlePeerServiceAdd(gp *gressPolicy, obj interface{}) {
+	service := obj.(*kapi.Service)
+	klog.V(5).Infof("A Service: %s matches the namespace as the gress policy: %s", service.Name, gp.policyName)
+	if err := gp.addPeerSvcVip(service); err != nil {
+		klog.Errorf(err.Error())
+	}
+}
+
+// handlePeerServiceDelete removes the VIP of a service that selects
+// pods that are selected by the Network Policy
+func (oc *Controller) handlePeerServiceDelete(gp *gressPolicy, obj interface{}) {
+	service := obj.(*kapi.Service)
+	if err := gp.deletePeerSvcVip(service); err != nil {
+		klog.Errorf(err.Error())
+	}
+}
+
+// Watch Services that are in the same Namespace as the NP
+// To account for hairpined traffic
+func (oc *Controller) handlePeerService(
+	policy *knet.NetworkPolicy, gp *gressPolicy, np *namespacePolicy) {
+
+	h := oc.watchFactory.AddFilteredServiceHandler(policy.Namespace,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				// Service is matched so add VIP to addressSet
+				oc.handlePeerServiceAdd(gp, obj)
+			},
+			DeleteFunc: func(obj interface{}) {
+				// If Service that has matched pods are deleted remove VIP
+				oc.handlePeerServiceDelete(gp, obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				// If Service Is updated make sure same pods are still matched
+				oldSvc := oldObj.(kapi.Service)
+				newSvc := newObj.(kapi.Service)
+				if reflect.DeepEqual(newSvc.Spec.ExternalIPs, oldSvc.Spec.ExternalIPs) &&
+					reflect.DeepEqual(newSvc.Spec.ClusterIP, oldSvc.Spec.ClusterIP) &&
+					reflect.DeepEqual(newSvc.Spec.Type, oldSvc.Spec.Type) &&
+					reflect.DeepEqual(newSvc.Status.LoadBalancer.Ingress, oldSvc.Status.LoadBalancer.Ingress) {
+
+					klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
+						".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", newSvc.Name)
+					return
+				}
+
+				oc.handlePeerServiceDelete(gp, oldObj)
+				oc.handlePeerServiceAdd(gp, newObj)
+			},
+		}, nil)
+	np.svcHandlerList = append(np.svcHandlerList, h)
+}
+
 func (oc *Controller) handlePeerPodSelector(
 	policy *knet.NetworkPolicy, podSelector *metav1.LabelSelector,
 	gp *gressPolicy, np *namespacePolicy) {

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -511,4 +512,72 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 func svcQualifiesForReject(service *kapi.Service) bool {
 	_, ok := service.Annotations[OvnServiceIdledAt]
 	return !(config.Kubernetes.OVNEmptyLbEvents && ok)
+}
+
+// SVC can be of types 1. clusterIP, 2. NodePort, 3. LoadBalancer,
+// or 4.ExternalIP
+// TODO adjust for upstream patch when it lands:
+// https://bugzilla.redhat.com/show_bug.cgi?id=1908540
+func getSvcVips(service *kapi.Service) []net.IP {
+	ips := make([]net.IP, 0)
+
+	if util.ServiceTypeHasNodePort(service) {
+		gatewayRouters, _, err := gateway.GetOvnGateways()
+		if err != nil {
+			klog.Errorf("Cannot get gateways: %s", err)
+		}
+		for _, gatewayRouter := range gatewayRouters {
+			// VIPs would be the physical IPS of the GRs(IPs of the node) in this case
+			physicalIPs, err := gateway.GetGatewayPhysicalIPs(gatewayRouter)
+			if err != nil {
+				klog.Errorf("Unable to get gateway router %s physical ip, error: %v", gatewayRouter, err)
+				continue
+			}
+
+			for _, physicalIP := range physicalIPs {
+				ip := net.ParseIP(physicalIP)
+				if ip == nil {
+					klog.Errorf("Failed to parse pod IP %q", physicalIP)
+					continue
+				}
+				ips = append(ips, ip)
+			}
+		}
+	}
+	if util.ServiceTypeHasClusterIP(service) {
+		if util.IsClusterIPSet(service) {
+			ip := net.ParseIP(service.Spec.ClusterIP)
+			if ip == nil {
+				klog.Errorf("Failed to parse pod IP %q", service.Spec.ClusterIP)
+			}
+			ips = append(ips, ip)
+		}
+
+		for _, ing := range service.Status.LoadBalancer.Ingress {
+			ip := net.ParseIP(ing.IP)
+			if ip == nil {
+				klog.Errorf("Failed to parse pod IP %q", ing)
+				continue
+			}
+			klog.V(5).Infof("Adding ingress IPs from Service: %s to VIP set", service.Name)
+			ips = append(ips, ip)
+		}
+
+		if len(service.Spec.ExternalIPs) > 0 {
+			for _, extIP := range service.Spec.ExternalIPs {
+				ip := net.ParseIP(extIP)
+				if ip == nil {
+					klog.Errorf("Failed to parse pod IP %q", extIP)
+					continue
+				}
+				klog.V(5).Infof("Adding external IPs from Service: %s to VIP set", service.Name)
+				ips = append(ips, ip)
+			}
+		}
+	}
+	if len(ips) == 0 {
+		klog.V(5).Infof("Service has no VIPs")
+		return nil
+	}
+	return ips
 }


### PR DESCRIPTION
Simplifies and Closes #1914
Background: 

This PR fixes the problem found here https://bugzilla.redhat.com/show_bug.cgi?id=1903651

When a POD sends traffic to a service it is loadbalanced(DNAT-ed) and sometimes the same pod is chosen as the backend to the service. To ensure this traffic travels through OVN-K8s rather than the POD2POD network since (srcIP==dstIP), the traffic is SNAT-ed to the VIP of the service's loadbalancer, which results in some packet loss with hairpinned traffic since this is not currently accounted for in the network Policy code

**Temporary solution:** 

In the long term, a feature is being created that will allow for us to specify the loadbalancer's SNAT IP in OVN see -> https://bugzilla.redhat.com/show_bug.cgi?id=1908540.  This will allow us to make a few rules to cover all the possible SNAT IPs, which is not possible now since the SNAT ip selection process for hairpin traffic [is automatic](https://patchwork.ozlabs.org/project/openvswitch/patch/1580302197-14276-1-git-send-email-dceara@redhat.com/) 

However for shorter term solution this PR will add the `ClusterIP, node IPS, external IPs and Ingress IPS` of any services that are applied in the same namespace as a NetworkPolicy to the policy's ingress rule's address set. 

This involves adding... 

- a new service handler that only looks at services for specific namespaces 
- a function in service.go to get the possible VIPs of the Service 
- some work in policy.go to add service handlers in the same namespace as the network policy whenever ingress rules with selectors are applied  

Thankfully this will not result in any security gaps since the only time a packet will have a `src.ip` of the SVC's cluster IP is in with the hairpin case. 