### PR TITLE
[WIP] Bluefield split node

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"flag"
 	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -104,7 +105,9 @@ var (
 	OvnSouth OvnAuthConfig
 
 	// Gateway holds node gateway-related parsed config file parameters and command-line overrides
-	Gateway GatewayConfig
+	Gateway = GatewayConfig{
+		NodeType: types.NodeTypeFull,
+	}
 
 	// MasterHA holds master HA related config options.
 	MasterHA = MasterHAConfig{
@@ -246,6 +249,8 @@ type GatewayConfig struct {
 	NodeportEnable bool `gcfg:"nodeport"`
 	// DisableSNATMultipleGws sets whether to disable SNAT of egress traffic in namespaces annotated with routing-external-gws
 	DisableSNATMultipleGWs bool `gcfg:"disable-snat-multiple-gws"`
+	// NodeType determines which type of node to determine which gateway initialization is needed
+	NodeType string `gcfg:"node-type"`
 }
 
 // OvnAuthConfig holds client authentication and location details for
@@ -812,7 +817,12 @@ var OVNGatewayFlags = []cli.Flag{
 		Usage:       "Disable SNAT for egress traffic with multiple gateways.",
 		Destination: &cliConfig.Gateway.DisableSNATMultipleGWs,
 	},
-
+	&cli.StringFlag{
+		Name:        "gateway-node-type",
+		Usage:       "The type of gateway config needed for this node: bluefield, host-only, full (default)",
+		Destination: &cliConfig.Gateway.NodeType,
+		Value:       Gateway.NodeType,
+	},
 	// Deprecated CLI options
 	&cli.BoolFlag{
 		Name:        "init-gateways",

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -53,4 +53,9 @@ const (
 
 	V4JoinSubnetCIDR = "100.64.0.0/16"
 	V6JoinSubnetCIDR = "fd98::/64"
+
+	// Gateway Node Types
+	NodeTypeFull = "full"
+	NodeTypeBluefield = "bluefield"
+	NodeTypeHostOnly = "host-only"
 )


### PR DESCRIPTION
This breaks up what gets executed for bluefield or host-only type of
nodes. Really this boils down to what the node gateway setup does:

Bluefield Node:
 - port claim watcher (reserves ports on local host)
 - openflow manager
 - nodeport watcher (programs flows for openflow)

Host Node:
 - nodeport watcher (iptables rules only)
 - loadbalancer health checker
