### PR TITLE
Use OVN reject logic instead ACLs for services without endpoints. Fix unidling logic

### DIFF
--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -70,7 +70,7 @@ func (r *Repair) runOnce() error {
 	protocols := []v1.Protocol{v1.ProtocolSCTP, v1.ProtocolTCP, v1.ProtocolUDP}
 	// ClusterIP OVN load balancers
 	for _, p := range protocols {
-		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p)
+		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p, loadbalancer.OvnLoadBalancerClusterIds)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to get OVN load balancer for protocol %s", p)
 		}

--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -83,7 +83,7 @@ func (r *Repair) runOnce() error {
 	}
 	for _, p := range protocols {
 		for _, gatewayRouter := range gatewayRouters {
-			lbUUID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, p)
+			lbUUID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, p, gateway.OvnGatewayLoadBalancerIds)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to get OVN GR load balancer for protocol %s", p)
 			}

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -271,7 +271,7 @@ func (c *Controller) syncServices(key string) error {
 		}
 		for _, svcPort := range service.Spec.Ports {
 			// ClusterIP
-			lbID, err := loadbalancer.GetOVNKubeLoadBalancer(svcPort.Protocol)
+			lbID, err := loadbalancer.GetOVNKubeLoadBalancer(svcPort.Protocol, loadbalancer.OvnLoadBalancerClusterIds)
 			if err != nil {
 				c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToGetOVNLoadBalancer",
 					"Error trying to obtain the OVN LoadBalancer for Service %s/%s: %v", name, namespace, err)

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -325,7 +325,7 @@ func (c *Controller) syncServices(key string) error {
 				}
 				// Configure the NodePort in each Node Gateway Router
 				for _, gatewayRouter := range gatewayRouters {
-					lbID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, svcPort.Protocol)
+					lbID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, svcPort.Protocol, gateway.OvnGatewayLoadBalancerIds)
 					if err != nil {
 						klog.Warningf("Service Sync: Gateway router %s does not have load balancer (%v)",
 							gatewayRouter, err)
@@ -395,7 +395,7 @@ func (c *Controller) syncServices(key string) error {
 						continue
 					}
 					for _, gatewayRouter := range gatewayRouters {
-						lbID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, svcPort.Protocol)
+						lbID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, svcPort.Protocol, gateway.OvnGatewayLoadBalancerIds)
 						if err != nil {
 							klog.Warningf("Service Sync: Gateway router %s does not have load balancer (%v)",
 								gatewayRouter, err)

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -37,7 +37,6 @@ func newController() *serviceController {
 	controller := NewController(client,
 		informerFactory.Core().V1().Services(),
 		informerFactory.Discovery().V1beta1().EndpointSlices(),
-		portGroupUUID,
 	)
 	controller.servicesSynced = alwaysReady
 	controller.endpointSlicesSynced = alwaysReady
@@ -117,11 +116,7 @@ func TestSyncServices(t *testing.T) {
 					Output: loadbalancerTCP,
 				},
 				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-					Output: "",
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls @reject-acl`,
+					Cmd:    `ovn-nbctl --timeout=15 set load_balancer ` + loadbalancerTCP + ` vips:"192.168.1.1:80"=""`,
 					Output: "",
 				},
 			},
@@ -160,14 +155,6 @@ func TestSyncServices(t *testing.T) {
 					Output: loadbalancerTCP,
 				},
 				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-					Output: "",
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls @reject-acl`,
-					Output: "",
-				},
-				{
 					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null`,
 					Output: gatewayRouter1,
 				},
@@ -175,14 +162,9 @@ func TestSyncServices(t *testing.T) {
 					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=` + gatewayRouter1,
 					Output: "",
 				},
-
 				{
 					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}a08ea426-2288-11eb-a30b-a8a1590cda29`,
 					Output: logicalSwitch1,
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add logical_switch 17bde5e8-3652-11eb-b53b-a8a1590cda29 acls @reject-acl`,
-					Output: "",
 				},
 			},
 		},
@@ -234,10 +216,6 @@ func TestSyncServices(t *testing.T) {
 				},
 				{
 					Cmd:    `ovn-nbctl --timeout=15 set load_balancer ` + loadbalancerTCP + ` vips:"192.168.1.1:80"="10.0.0.2:3456"`,
-					Output: "",
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
 					Output: "",
 				},
 			},
@@ -292,10 +270,6 @@ func TestSyncServices(t *testing.T) {
 					Cmd:    `ovn-nbctl --timeout=15 set load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips:"192.168.1.1:80"="10.0.0.2:3456"`,
 					Output: "",
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-					Output: "",
-				},
 			},
 		},
 	}
@@ -340,10 +314,6 @@ func TestUpdateServicePorts(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 		Output: loadbalancerTCP,
 	})
@@ -353,21 +323,12 @@ func TestUpdateServicePorts(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:8888`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 		Output: loadbalancerTCP,
 	})
 	// Remove the old ServicePort
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "192.168.1.1:80"`,
-		Output: "",
-	})
-	// Remove the ACL if exist
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
 		Output: "",
 	})
 	// Check if there are NodePort LoadBalancers
@@ -440,99 +401,6 @@ func TestUpdateServicePorts(t *testing.T) {
 	if !controller.serviceTracker.hasServiceVIP(serviceName, ns, "192.168.1.1:8888", v1.ProtocolTCP) {
 		t.Fatalf("Service with port 8888 should exist")
 	}
-}
-
-// A service created has no VIP entry and reject acl is created
-func TestServiceCreateReject(t *testing.T) {
-	// Expected OVN commands
-	fexec := ovntest.NewFakeExec()
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
-		Output: loadbalancerTCP,
-	})
-	// Find if ACL exists
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-		Output: "",
-	})
-	// Create ACL
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=from-lport priority=1000 match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls @reject-acl`,
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
-		Output: loadbalancerTCP,
-	})
-	// Endpoints got added, create LB entry
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 set load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips:"192.168.1.1:80"="10.0.0.2:3456"`,
-		Output: loadbalancerTCP,
-	})
-	// Find existing ACL
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-		Output: "1234",
-	})
-	// Remove ACL
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 -- --if-exists remove port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls 1234`,
-		Output: "",
-	})
-
-	err := util.SetExec(fexec)
-	if err != nil {
-		t.Errorf("fexec error: %v", err)
-	}
-
-	ns := "testns"
-	serviceName := "foo"
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
-		Spec: v1.ServiceSpec{
-			Type:       v1.ServiceTypeClusterIP,
-			ClusterIP:  "192.168.1.1",
-			ClusterIPs: []string{"192.168.1.1"},
-			Selector:   map[string]string{"foo": "bar"},
-			Ports: []v1.ServicePort{{
-				Port:       80,
-				Protocol:   v1.ProtocolTCP,
-				TargetPort: intstr.FromInt(3456),
-			}},
-		},
-	}
-	slice := &discovery.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName + "ab23",
-			Namespace: ns,
-			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
-		},
-		Ports: []discovery.EndpointPort{
-			{
-				Name:     utilpointer.StringPtr("tcp-example"),
-				Protocol: protoPtr(v1.ProtocolTCP),
-				Port:     utilpointer.Int32Ptr(int32(3456)),
-			},
-		},
-		AddressType: discovery.AddressTypeIPv4,
-		Endpoints: []discovery.Endpoint{
-			{
-				Conditions: discovery.EndpointConditions{
-					Ready: utilpointer.BoolPtr(true),
-				},
-				Addresses: []string{"10.0.0.2"},
-				Topology:  map[string]string{"kubernetes.io/hostname": "node-1"},
-			},
-		},
-	}
-	controller := newController()
-	// Process the first service, should not create VIP in LB and create reject ACL instead
-	controller.serviceStore.Add(service)
-	controller.syncServices(ns + "/" + serviceName)
-
-	// Now add endpoints and ensure ACL is removed and LB VIP gets created
-	controller.endpointSliceStore.Add(slice)
-	controller.syncServices(ns + "/" + serviceName)
 }
 
 // protoPtr takes a Protocol and returns a pointer to it.

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -100,7 +100,7 @@ func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace str
 		}
 		// Configure the NodePort in each Node Gateway Router
 		for _, gatewayRouter := range gatewayRouters {
-			lbID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, proto)
+			lbID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, proto, gateway.OvnGatewayLoadBalancerIds)
 			if err != nil {
 				klog.Warningf("Service Sync: Gateway router %s does not have load balancer (%v)",
 					gatewayRouter, err)

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -117,4 +118,15 @@ func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace str
 		st.deleteServiceVIP(name, namespace, vip, proto)
 	}
 	return nil
+}
+
+const OvnServiceIdledAt = "k8s.ovn.org/idled-at"
+
+// When idling or empty LB events are enabled, we want to ensure we receive these packets and not reject them.
+func svcNeedsIdling(annotations map[string]string) bool {
+	if !config.Kubernetes.OVNEmptyLbEvents {
+		return false
+	}
+	_, ok := annotations[OvnServiceIdledAt]
+	return ok
 }

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -81,7 +81,7 @@ func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace str
 		// the VIP is stored with the format IP:Port/Protocol
 		vip, proto := splitVirtualIPKey(vipKey)
 		// ClusterIP use a global load balancer per protocol
-		lbID, err := loadbalancer.GetOVNKubeLoadBalancer(proto)
+		lbID, err := loadbalancer.GetOVNKubeLoadBalancer(proto, loadbalancer.OvnLoadBalancerClusterIds)
 		if err != nil {
 			klog.Errorf("Error getting OVN LoadBalancer for protocol %s", proto)
 			return err

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -1,10 +1,6 @@
 package services
 
 import (
-	"net"
-	"strconv"
-
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/acl"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -79,7 +75,7 @@ func getLbEndpoints(slices []*discovery.EndpointSlice, svcPort v1.ServicePort, f
 	return lbEndpoints.List()
 }
 
-func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace, clusterPortGroupUUID string) error {
+func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace string) error {
 	// Obtain the VIPs associated to the Service from the Service Tracker
 	for vipKey := range vips {
 		// the VIP is stored with the format IP:Port/Protocol
@@ -96,32 +92,6 @@ func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace, cl
 			klog.Errorf("Error deleting VIP %s on OVN LoadBalancer %s", vip, lbID)
 			return err
 		}
-		// handle reject ACLs for services without endpoints
-		// eventually we have to remove this because it will
-		// be implemented by OVN
-		// https://github.com/ovn-org/ovn-kubernetes/pull/1887
-		ip, portString, err := net.SplitHostPort(vip)
-		if err != nil {
-			return err
-		}
-		port, err := strconv.Atoi(portString)
-		if err != nil {
-			return err
-		}
-		rejectACLName := loadbalancer.GenerateACLNameForOVNCommand(lbID, ip, int32(port))
-		aclID, err := acl.GetACLByName(rejectACLName)
-		if err != nil {
-			klog.Errorf("Error trying to get ACL for Service %s/%s: %v", name, namespace, err)
-		}
-		// delete the ACL if exist
-		if len(aclID) > 0 {
-			// remove acl
-			err = acl.RemoveACLFromPortGroup(aclID, clusterPortGroupUUID)
-			if err != nil {
-				klog.Errorf("Error trying to remove ACL for Service %s/%s: %v", name, namespace, err)
-			}
-		}
-		// end of reject ACL code
 		// NodePort and ExternalIPs use loadbalancers in each node
 		gatewayRouters, _, err := gateway.GetOvnGateways()
 		if err != nil {

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -267,10 +267,6 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 						Output: "",
 					},
 					{
-						Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-10.0.0.1\:80`,
-						Output: "",
-					},
-					{
 						Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null`,
 						Output: "",
 					},
@@ -295,7 +291,7 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 			if err != nil {
 				t.Errorf("fexec error: %v", err)
 			}
-			if err := deleteVIPsFromOVN(tt.args.vips, st, tt.args.svc.Name, tt.args.svc.Namespace, clusterPortGroupUUID); (err != nil) != tt.wantErr {
+			if err := deleteVIPsFromOVN(tt.args.vips, st, tt.args.svc.Name, tt.args.svc.Namespace); (err != nil) != tt.wantErr {
 				t.Errorf("deleteVIPsFromOVN() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -21,7 +21,7 @@ func (ovn *Controller) getGatewayPhysicalIPs(gatewayRouter string) ([]string, er
 }
 
 func (ovn *Controller) getGatewayLoadBalancer(gatewayRouter string, protocol kapi.Protocol) (string, error) {
-	return gateway.GetGatewayLoadBalancer(gatewayRouter, protocol)
+	return gateway.GetGatewayLoadBalancer(gatewayRouter, protocol, gateway.OvnGatewayLoadBalancerIds)
 }
 
 // getGatewayLoadBalancers find TCP, SCTP, UDP load-balancers from gateway router.

--- a/go-controller/pkg/ovn/gateway/gateway.go
+++ b/go-controller/pkg/ovn/gateway/gateway.go
@@ -11,7 +11,9 @@ import (
 )
 
 const (
-	// OvnGatewayLoadBalancerIds represent the OVN loadbalancers used on nodes
+	// OvnLoadBalancerIdlingIds represent the OVN loadbalancers
+	// used for services that has been idled.
+	// Default behaviour to send an event and drop the packet for VIPs without backends
 	OvnGatewayLoadBalancerIds = "lb_gateway_router"
 )
 

--- a/go-controller/pkg/ovn/gateway/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway/gateway_test.go
@@ -184,7 +184,7 @@ func TestCreateGatewayLoadBalancer(t *testing.T) {
 			if err != nil {
 				t.Errorf("fexec error: %v", err)
 			}
-			got, err := CreateGatewayLoadBalancer(tt.gatewayRouter, tt.protocol, tt.idkey)
+			got, err := createGatewayLoadBalancer(tt.gatewayRouter, tt.protocol, tt.idkey)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateGatewayLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -149,7 +149,9 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 				protoLBMap[proto], stderr, err = util.RunOVNNbctl("--", "create",
 					"load_balancer",
 					fmt.Sprintf("external_ids:%s_lb_gateway_router=%s", proto, gatewayRouter),
-					fmt.Sprintf("protocol=%s", strings.ToLower(string(proto))))
+					fmt.Sprintf("protocol=%s", strings.ToLower(string(proto))),
+					"options:reject=true",
+				)
 				if err != nil {
 					return fmt.Errorf("failed to create load balancer for gateway router %s for protocol %s: "+
 						"stderr: %q, error: %v", gatewayRouter, proto, stderr, err)

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -90,7 +90,6 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_test-node protocol=udp options:reject=true",
@@ -163,7 +162,6 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_test-node protocol=udp options:reject=true",
@@ -235,7 +233,6 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_test-node protocol=udp options:reject=true",

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -93,7 +93,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_test-node protocol=udp options:reject=true",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -166,7 +166,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_test-node protocol=udp options:reject=true",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -238,7 +238,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=GR_test-node protocol=udp options:reject=true",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -62,6 +62,18 @@ func DeleteLoadBalancerVIP(loadBalancer, vip string) error {
 	return nil
 }
 
+// CreateLoadBalancer creates a loadbalancer for the specified protocl
+func CreateLoadBalancer(protocol kapi.Protocol) error {
+	id := fmt.Sprintf("external_ids:k8s-cluster-lb-%s=yes", strings.ToLower(string(protocol)))
+	proto := fmt.Sprintf("protocol=%s", strings.ToLower(string(protocol)))
+	_, stderr, err := util.RunOVNNbctl("--", "create", "load_balancer", id, proto)
+	if err != nil {
+		klog.Errorf("Failed to create tcp load balancer, stderr: %q, error: %v", stderr, err)
+		return err
+	}
+	return nil
+}
+
 // UpdateLoadBalancer updates the VIP for sourceIP:sourcePort to point to targets (an
 // array of IP:port strings)
 func UpdateLoadBalancer(lb, vip string, targets []string) error {

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -125,6 +125,18 @@ func UpdateLoadBalancer(lb, vip string, targets []string) error {
 	return nil
 }
 
+// MigrateLoadBalancerVIP migrates a VIP from one loadbalancer to other
+// regarding if the VIP exists or no in the original loadbalancer it always
+// updates the destination loadbalancer.
+func MigrateLoadBalancerVIP(lbOrig, lbDest, vip string, targets []string) error {
+	// deleting must not fail if the vip doesn´t exist
+	err := DeleteLoadBalancerVIP(lbOrig, vip)
+	if err != nil {
+		return err
+	}
+	return UpdateLoadBalancer(lbDest, vip, targets)
+}
+
 // GetLogicalSwitchesForLoadBalancer get the switches associated to a LoadBalancer
 func GetLogicalSwitchesForLoadBalancer(lb string) ([]string, error) {
 	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
@@ -48,7 +48,7 @@ func TestGetOVNKubeLoadBalancer(t *testing.T) {
 				t.Errorf("fexec error: %v", err)
 			}
 
-			got, err := GetOVNKubeLoadBalancer(tt.protocol)
+			got, err := GetOVNKubeLoadBalancer(tt.protocol, OvnLoadBalancerClusterIds)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetOVNKubeLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
@@ -361,7 +361,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 			if err != nil {
 				t.Errorf("fexec error: %v", err)
 			}
-			if err := CreateLoadBalancer(tt.protocol, tt.idkey); (err != nil) != tt.wantErr {
+			if err := createLoadBalancer(tt.protocol, tt.idkey); (err != nil) != tt.wantErr {
 				t.Errorf("CreateLoadBalancer() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -416,6 +416,17 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 		}
 	}
 
+	// Create load balancers
+
+	// If we enable idling we have to set the option before creating the loadbalancers
+	if config.Kubernetes.OVNEmptyLbEvents {
+		_, _, err := util.RunOVNNbctl("set", "nb_global", ".", "options:controller_event=true")
+		if err != nil {
+			klog.Error("Unable to enable controller events. Unidling not possible")
+			return err
+		}
+	}
+
 	// Create 3 load-balancers for east-west traffic for UDP, TCP, SCTP
 	oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes")
 	if err != nil {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -437,13 +437,13 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 		protocols = append(protocols, v1.ProtocolSCTP)
 	}
 	for _, p := range protocols {
-		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p)
+		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p, loadbalancer.OvnLoadBalancerClusterIds)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to get OVN load balancer for protocol %s", p)
 		}
 		// create the load balancer if it doesn't exist yet
 		if lbUUID == "" {
-			err := loadbalancer.CreateLoadBalancer(p)
+			err := loadbalancer.CreateLoadBalancer(p, loadbalancer.OvnLoadBalancerClusterIds)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to create OVN load balancer for protocol %s", p)
 			}
@@ -790,7 +790,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 		protocols = append(protocols, v1.ProtocolSCTP)
 	}
 	for i, p := range protocols {
-		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p)
+		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p, loadbalancer.OvnLoadBalancerClusterIds)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to get OVN load balancer for protocol %s", p)
 		}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -153,7 +153,7 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-tcp=yes protocol=tcp",
+		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-tcp=yes protocol=tcp options:reject=true",
 		Output: tcpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -161,7 +161,7 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-udp=yes protocol=udp",
+		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-udp=yes protocol=udp options:reject=true",
 		Output: udpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -170,7 +170,7 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	})
 	if sctpSupport {
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-sctp=yes protocol=sctp",
+			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-sctp=yes protocol=sctp options:reject=true",
 			Output: sctpLBUUID,
 		})
 	}
@@ -268,15 +268,15 @@ func addNodeportLBs(fexec *ovntest.FakeExec, nodeName, tcpLBUUID, udpLBUUID, sct
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=" + types.GWRouterPrefix + nodeName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:TCP_lb_gateway_router=" + types.GWRouterPrefix + nodeName + " protocol=tcp",
+		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:TCP_lb_gateway_router=" + types.GWRouterPrefix + nodeName + " protocol=tcp options:reject=true",
 		Output: tcpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=" + types.GWRouterPrefix + nodeName + " protocol=udp",
+		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=" + types.GWRouterPrefix + nodeName + " protocol=udp options:reject=true",
 		Output: udpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:SCTP_lb_gateway_router=" + types.GWRouterPrefix + nodeName + " protocol=sctp",
+		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:SCTP_lb_gateway_router=" + types.GWRouterPrefix + nodeName + " protocol=sctp options:reject=true",
 		Output: sctpLBUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -215,10 +215,27 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists remove port_group clusterRtrPortGroup ports " + fakeUUID + " -- add port_group clusterRtrPortGroup ports " + fakeUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: tcpLBUUID + "\n",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+		Output: udpLBUUID + "\n",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 	})
+
 	if sctpSupport {
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-sctp=yes",
+			Output: sctpLBUUID + "\n",
+		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
 		})
@@ -1105,8 +1122,26 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 --if-exists remove port_group clusterRtrPortGroup ports " + fakeUUID + " -- add port_group clusterRtrPortGroup ports " + fakeUUID,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+				Output: tcpLBUUID + "\n",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+				Output: udpLBUUID + "\n",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-sctp=yes",
+				Output: sctpLBUUID + "\n",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.K8sPrefix + nodeName + " -- lsp-set-type " + types.K8sPrefix + nodeName + "  -- lsp-set-options " + types.K8sPrefix + nodeName + "  -- lsp-set-addresses " + types.K8sPrefix + nodeName + " " + nodeMgmtPortMAC + " " + nodeMgmtPortIP,
 			})
@@ -1199,9 +1234,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				addressset.NewFakeAddressSetFactory(), ovntest.NewMockOVNClient(goovn.DBNB),
 				ovntest.NewMockOVNClient(goovn.DBSB), record.NewFakeRecorder(0))
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
-			clusterController.TCPLoadBalancerUUID = tcpLBUUID
-			clusterController.UDPLoadBalancerUUID = udpLBUUID
-			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
 			clusterController.joinSwIPManager, _ = initJoinLogicalSwitchIPManager()
 			_, _ = clusterController.joinSwIPManager.ensureJoinLRPIPs(types.OVNClusterRouter)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -264,16 +264,20 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 func addNodeportLBs(fexec *ovntest.FakeExec, nodeName, tcpLBUUID, udpLBUUID, sctpLBUUID string) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=" + types.GWRouterPrefix + nodeName,
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=" + types.GWRouterPrefix + nodeName,
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=" + types.GWRouterPrefix + nodeName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:TCP_lb_gateway_router=" + types.GWRouterPrefix + nodeName + " protocol=tcp options:reject=true",
 		Output: tcpLBUUID,
 	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=" + types.GWRouterPrefix + nodeName,
+	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:UDP_lb_gateway_router=" + types.GWRouterPrefix + nodeName + " protocol=udp options:reject=true",
 		Output: udpLBUUID,
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=" + types.GWRouterPrefix + nodeName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:SCTP_lb_gateway_router=" + types.GWRouterPrefix + nodeName + " protocol=sctp options:reject=true",

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -413,12 +413,6 @@ func (oc *Controller) syncPeriodic() {
 func (oc *Controller) ovnControllerEventChecker() {
 	ticker := time.NewTicker(5 * time.Second)
 
-	_, _, err := util.RunOVNNbctl("set", "nb_global", ".", "options:controller_event=true")
-	if err != nil {
-		klog.Error("Unable to enable controller events. Unidling not possible")
-		return
-	}
-
 	for {
 		select {
 		case <-ticker.C:

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -319,13 +319,10 @@ func (oc *Controller) Run(wg *sync.WaitGroup) error {
 
 	oc.WatchPods()
 
-	// Services are handled differently depending on the Kubernetes API versions
-	// and the OVN configuration.
-	// We use a level triggered controller to handle services if k8s > 1.19,
-	// using endpoint slices instead endpoints if OVN is configured for dual stack.
-	if util.UseEndpointSlices(oc.client) && config.IPv4Mode && config.IPv6Mode {
-		// Services are handled differently depending on the Kubernetes API versions
-		klog.Infof("Dual Stack enabled: using EndpointSlices instead of Endpoints in k8s versions > 1.19")
+	// We use a level triggered controller to handle services if the cluster
+	// is using endpoint slices and it supports dual stack services.
+	if util.UseEndpointSlices(oc.client) {
+		klog.Infof("Starting OVN Service Controller: Using Endpoint Slices")
 		// Create our own informers to start compartamentalizing the code
 		// filter server side the things we don't care about
 		noProxyName, err := labels.NewRequirement("service.kubernetes.io/service-proxy-name", selection.DoesNotExist, nil)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -344,7 +344,6 @@ func (oc *Controller) Run(wg *sync.WaitGroup) error {
 			oc.client,
 			informerFactory.Core().V1().Services(),
 			informerFactory.Discovery().V1beta1().EndpointSlices(),
-			oc.clusterPortGroupUUID,
 		)
 		informerFactory.Start(oc.stopChan)
 		wg.Add(1)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -134,10 +134,7 @@ type Controller struct {
 
 	hoMaster *hocontroller.MasterController
 
-	TCPLoadBalancerUUID  string
-	UDPLoadBalancerUUID  string
-	SCTPLoadBalancerUUID string
-	SCTPSupport          bool
+	SCTPSupport bool
 
 	// For TCP, UDP, and SCTP type traffic, cache OVN load-balancers used for the
 	// cluster's east-west traffic.


### PR DESCRIPTION

    use OVN load balancer ACLs
    
    OVN automatically rejects packets to loadbalancer vips without
    backeds, so we don´t need to handle that logic anymore.
    
    Signed-off-by: Antonio Ojea <aojea@redhat.com>