### PR TITLE
bump e2e test version

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -21,6 +21,9 @@ should have ipv4 and ipv6 internal node ip
 kube-proxy
 should set TCP CLOSE_WAIT timeout
 
+# LoadBalancer tests require Cloud Provider Integration
+GCE|LB.health.check|LoadBalancer|Loadbalancer|load.balancer|ESIPP
+
 # TO BE IMPLEMENTED: https://github.com/ovn-org/ovn-kubernetes/issues/819
 Services.+session affinity
 
@@ -29,9 +32,6 @@ EndpointSlices
 
 # NOT IMPLEMENTED; SEE DISCUSSION IN https://github.com/ovn-org/ovn-kubernetes/pull/1225
 named port.+\[Feature:NetworkPolicy\]
-
-# TO BE FIXED BY https://github.com/kubernetes/kubernetes/pull/93119
-GCE
 
 # Clean up SCTP tests https://github.com/kubernetes/kubernetes/issues/96717
 \[Feature:SCTP\]
@@ -50,6 +50,7 @@ ClusterDns \[Feature:Example\]
 should set default value on new IngressClass
 # RACE CONDITION IN TEST, SEE https://github.com/kubernetes/kubernetes/pull/90254
 should prevent Ingress creation if more than 1 IngressClass marked as default
+Disruptive
 "
 
 IPV4_ONLY_TESTS="

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -9,8 +9,14 @@ groomTestList() {
 }
 
 SKIPPED_TESTS="
+# New Network Policy tests cause CI to time out
+Netpol
+
+# OVN doesn´t implement HostPort, CRIO does
+HostPort
+
 # PERFORMANCE TESTS: NOT WANTED FOR CI
-Networking IPerf IPv[46]
+Networking IPerf
 \[Feature:PerformanceDNS\]
 
 # FEATURES NOT AVAILABLE IN OUR CI ENVIRONMENT

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -12,6 +12,9 @@ SKIPPED_TESTS="
 # New Network Policy tests cause CI to time out
 Netpol
 
+# Network Policy legacy tests are flake
+NetworkPolicy
+
 # OVN doesn´t implement HostPort, CRIO does
 HostPort
 

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -13,8 +13,8 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 # Current e2e binary version for CI is kubernetes 1.20 with the fix for IPv6 network policies #96856
 # We can always get the latest version published from the URL dl.k8s.io/ci/latest.txt
 # curl -L dl.k8s.io/ci/latest.txt
-# v1.21.0-alpha.2.248+074a5177209c36
-curl -LO https://dl.k8s.io/ci/v1.21.0-alpha.2.248+074a5177209c36/kubernetes-test-linux-amd64.tar.gz
+# v1.21.0-alpha.2.370+f266f60da9dadf
+curl -LO https://dl.k8s.io/ci/v1.21.0-alpha.2.370+f266f60da9dadf/kubernetes-test-linux-amd64.tar.gz
 tar xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
 sudo mv ./e2e.test /usr/local/bin/e2e.test
 sudo mv ./ginkgo /usr/local/bin/ginkgo

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -13,8 +13,8 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 # Current e2e binary version for CI is kubernetes 1.20 with the fix for IPv6 network policies #96856
 # We can always get the latest version published from the URL dl.k8s.io/ci/latest.txt
 # curl -L dl.k8s.io/ci/latest.txt
-# v1.21.0-alpha.0.341+46d481b4556e33
-curl -LO https://dl.k8s.io/ci/v1.21.0-alpha.0.341+46d481b4556e33/kubernetes-test-linux-amd64.tar.gz
+# v1.21.0-alpha.2.248+074a5177209c36
+curl -LO https://dl.k8s.io/ci/v1.21.0-alpha.2.248+074a5177209c36/kubernetes-test-linux-amd64.tar.gz
 tar xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
 sudo mv ./e2e.test /usr/local/bin/e2e.test
 sudo mv ./ginkgo /usr/local/bin/ginkgo


### PR DESCRIPTION
use the latest e2e binary with new tests and fixes

Signed-off-by: Antonio Ojea <aojea@redhat.com>

xref: https://github.com/kubernetes/kubernetes/pull/91592