### PR TITLE
fix for the linter

### DIFF
--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
-GO111MODULE=on ${GOPATH}/bin/golangci-lint run \
-    --timeout=15m0s --verbose --print-resources-usage --modules-download-mode=vendor \
-    && echo "lint OK!"
+
+# pin golangci-lint version to 1.33.2
+VERSION=v1.33.2
+
+docker run --rm -v $(pwd):/app -w /app -e GO111MODULE=on golangci/golangci-lint:${VERSION} \
+	golangci-lint run --verbose --print-resources-usage \
+	--modules-download-mode=vendor --timeout=15m0s && \
+	echo "lint OK!"


### PR DESCRIPTION
there seems to be a regression in golangci-lint where the "--modules-download-mode=vendor"
is not supported. Remove the modules-download-mode until the regression
is fixed

Regression Issue: https://github.com/golangci/golangci-lint/issues/1502

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->