### PR TITLE
Fix egressFirewall segfault caused by restarting

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -783,13 +783,13 @@ func (oc *Controller) WatchCRD() {
 					klog.Errorf("Error Creating EgressFirewallWatchFactory: %v", err)
 					return
 				}
-				oc.egressFirewallHandler = oc.WatchEgressFirewall()
 
 				oc.egressFirewallDNS, err = NewEgressDNS(oc.addressSetFactory, oc.stopChan)
 				oc.egressFirewallDNS.Run(egressFirewallDNSDefaultDuration)
 				if err != nil {
 					klog.Errorf("Error Creating EgressFirewallDNS: %v", err)
 				}
+				oc.egressFirewallHandler = oc.WatchEgressFirewall()
 			}
 		},
 		UpdateFunc: func(old, newer interface{}) {


### PR DESCRIPTION
If there are egressFirewall Policies with dnsName filters on them when
restarting an ovnkube-master container the ovnkube-master pod will
segfault because the EgressFirewall tries to add the rule before the
EgressDNS object is created

fix the order in which the EgressFirewall is started so that the DNS
object is started before the Watcher.

https://bugzilla.redhat.com/show_bug.cgi?id=1909911

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->