### PR TITLE
correctly disable race detector for hybrid-overlay controller package

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -23,7 +23,8 @@ function testrun {
     local args="-mod vendor"
     local ginkgoargs=
     # enable go race detector
-    if [ ! -z "${RACE:-}" ]; then
+    # FIXME race detector fails with hybrid-overlay tests
+    if [[ ! -z "${RACE:-}" && "${pkg}" != "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller" ]]; then
         args="-race "
     fi
     if [[ "$USER" != root && " ${root_pkgs[@]} " =~ " $pkg " ]]; then


### PR DESCRIPTION
the current code that disables the golang race detector feature for
hybrid-overlay controller package is incorrect. for instance, if an user
running `make check` is root, we don't disable race detector for
the HO controller package.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>
