### PR TITLE
informer: EventHandler now handles updates

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -62,6 +62,13 @@ func NewMaster(kube kube.Interface,
 			}
 			return m.DeleteNode(node)
 		},
+		func(old, new interface{}) error {
+			node, ok := new.(*kapi.Node)
+			if !ok {
+				return fmt.Errorf("object is not a node")
+			}
+			return m.AddNode(node)
+		},
 		informer.ReceiveAllUpdates,
 	)
 

--- a/go-controller/hybrid-overlay/pkg/controller/node.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node.go
@@ -96,6 +96,13 @@ func NewNode(
 			}
 			return n.controller.DeleteNode(node)
 		},
+		func(old, new interface{}) error {
+			newNode, ok := new.(*kapi.Node)
+			if !ok {
+				return fmt.Errorf("object is not a node")
+			}
+			return n.controller.AddNode(newNode)
+		},
 		nodeChanged,
 	)
 	n.podEventHandler = eventHandlerCreateFunction("pod", podInformer,
@@ -118,6 +125,13 @@ func NewNode(
 				return nil
 			}
 			return n.controller.DeletePod(pod)
+		},
+		func(old, new interface{}) error {
+			pod, ok := new.(*kapi.Pod)
+			if !ok {
+				return fmt.Errorf("object is not a pod")
+			}
+			return n.controller.AddPod(pod)
 		},
 		podChanged,
 	)

--- a/go-controller/pkg/informer/informer.go
+++ b/go-controller/pkg/informer/informer.go
@@ -5,6 +5,7 @@ package informer
 
 import (
 	"fmt"
+	"regexp"
 	"sync"
 	"time"
 
@@ -14,6 +15,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+)
+
+const (
+	addEvent    = "add"
+	updateEvent = "upd"
+	deleteEvent = "del"
 )
 
 // EventHandler is an event handler that responds to
@@ -31,14 +38,19 @@ type eventHandler struct {
 	name string
 	// informer is the underlying SharedIndexInformer that we're wrapping
 	informer cache.SharedIndexInformer
+	// updatedIndexer stores copies of objects *before* they were updated
+	// this allows for an update handler to have access to the old/new object
+	updatedIndexer cache.Indexer
 	// deletedIndexer stores copies of objects that have been deleted from
 	// the cache. This is needed as the OVN controller Delete functions expect
 	// to have a copy of the object that needs deleting
 	deletedIndexer cache.Indexer
 	// workqueue is the queue we use to store work
 	workqueue workqueue.RateLimitingInterface
-	// add is the handler function that gets called when something has been added/updated
+	// add is the handler function that gets called when something has been added
 	add func(obj interface{}) error
+	// update is the handler function that gets called when something has been updated
+	update func(old, new interface{}) error
 	// delete is handler function that gets called when something has been deleted
 	delete func(obj interface{}) error
 	// updateFilter is the function that we use to evaluate whether an update
@@ -66,37 +78,38 @@ type EventHandlerCreateFunction func(
 	name string,
 	informer cache.SharedIndexInformer,
 	addFunc, deleteFunc func(obj interface{}) error,
+	updateFunc func(old, new interface{}) error,
 	updateFilterFunc UpdateFilterFunction,
 ) EventHandler
 
-// NewDefaultEventHandler returns a new default event handler
-// The default event handler
+// NewDefaultEventHandler returns a new default event handler.
+// The default event handler:
 // - Enqueue Adds to the workqueue
-// - Enqueue Updates to the workqueue if they match the predicate function
+// - Enqueue Updates to the workqueue if they match the predicate function, and stores a copy of the old object in the updatedIndexer
 // - Enqueue Deletes to the workqueue, and places the deleted object on the deletedIndexer
-//
 // As the workqueue doesn't carry type information, adds/updates/deletes for a key are all colllapsed.
-// We can only differentiate between add/delete by whether an item exists in the cache or not.
-// Using this implementation, it's not possible to differentiate between adds and updates
 func NewDefaultEventHandler(
 	name string,
 	informer cache.SharedIndexInformer,
 	addFunc, deleteFunc func(obj interface{}) error,
+	updateFunc func(old, new interface{}) error,
 	updateFilterFunc UpdateFilterFunction,
 ) EventHandler {
 	e := &eventHandler{
 		name:           name,
 		informer:       informer,
 		deletedIndexer: cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{}),
+		updatedIndexer: cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
 		workqueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name),
 		add:            addFunc,
 		delete:         deleteFunc,
+		update:         updateFunc,
 		updateFilter:   updateFilterFunc,
 	}
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			// always enqueue adds
-			e.enqueue(obj)
+			e.enqueue(addEvent, obj)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			oldObj := old.(metav1.Object)
@@ -107,13 +120,16 @@ func NewDefaultEventHandler(
 			}
 			// check the update aginst the predicate functions
 			if e.updateFilter(old, new) {
+				if err := e.updatedIndexer.Add(old); err != nil {
+					utilruntime.HandleError(err)
+				}
 				// enqueue if it matches
-				e.enqueue(newObj)
+				e.enqueue(updateEvent, new)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			// dispatch to enqueueDelete to ensure deleted items are handled properly
-			e.enqueueDelete(obj)
+			// always enqueue deletes
+			e.enqueue(deleteEvent, obj)
 		},
 	})
 	return e
@@ -125,33 +141,39 @@ func NewTestEventHandler(
 	name string,
 	informer cache.SharedIndexInformer,
 	addFunc, deleteFunc func(obj interface{}) error,
+	updateFunc func(old, new interface{}) error,
 	updateFilterFunc UpdateFilterFunction,
 ) EventHandler {
 	e := &eventHandler{
 		name:           name,
 		informer:       informer,
 		deletedIndexer: cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{}),
+		updatedIndexer: cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
 		workqueue:      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		add:            addFunc,
 		delete:         deleteFunc,
+		update:         updateFunc,
 		updateFilter:   updateFilterFunc,
 	}
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			// always enqueue adds
-			e.enqueue(obj)
+			e.enqueue(addEvent, obj)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			newObj := new.(metav1.Object)
 			// check the update aginst the predicate functions
 			if e.updateFilter(old, new) {
+				if err := e.updatedIndexer.Add(old); err != nil {
+					utilruntime.HandleError(err)
+				}
 				// enqueue if it matches
-				e.enqueue(newObj)
+				e.enqueue(updateEvent, newObj)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			// dispatch to enqueueDelete to ensure deleted items are handled properly
-			e.enqueueDelete(obj)
+			// always enqueue deletes
+			e.enqueue(deleteEvent, obj)
 		},
 	})
 	return e
@@ -207,38 +229,35 @@ func (e *eventHandler) Run(threadiness int, stopCh <-chan struct{}) error {
 }
 
 // enqueue adds an item to the workqueue
-func (e *eventHandler) enqueue(obj interface{}) {
-	// ignore objects that are already set for deletion
-	if !obj.(metav1.Object).GetDeletionTimestamp().IsZero() {
-		return
-	}
+func (e *eventHandler) enqueue(event string, obj interface{}) {
 	var key string
 	var err error
-	// get the key for our object
-	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
-	// add the key to the workqueue
-	e.workqueue.Add(key)
-}
 
-// enqueueDelete is a special case of enqueue, where we must
-// add the deleted item to the deletedIndexer before we enqueue
-func (e *eventHandler) enqueueDelete(obj interface{}) {
-	var key string
-	var err error
-	// get the key for our object, which may have been deleted already
-	if key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err != nil {
-		utilruntime.HandleError(err)
-		return
+	if event != deleteEvent {
+		// ignore objects that are already set for deletion
+		if !obj.(metav1.Object).GetDeletionTimestamp().IsZero() {
+			return
+		}
+		// get the key for our object
+		if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+	} else {
+		// get the key for our object, which may have been deleted already
+		if key, err = cache.DeletionHandlingMetaNamespaceKeyFunc(obj); err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		// add to the deletedIndexer
+		if err := e.deletedIndexer.Add(obj); err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
 	}
-	// add the object to the deleted indexer
-	err = e.deletedIndexer.Add(obj)
-	if err != nil {
-		utilruntime.HandleError(err)
-	}
-	// add the key to the workqueue
+
+	key = fmt.Sprintf("%s#%s", event, key)
+	// enqueue
 	e.workqueue.Add(key)
 }
 
@@ -308,21 +327,24 @@ func (e *eventHandler) processNextWorkItem() bool {
 // syncHandler fetches an item from the informer's cache
 // and dispatches to the relevant handler function
 func (e *eventHandler) syncHandler(key string) error {
-	// get the object from the informer cache
-	obj, exists, err := e.informer.GetIndexer().GetByKey(key)
-	if err != nil {
-		return fmt.Errorf("error fetching object with key %s from store: %v", key, err)
+	// split the event type from the key
+	r := regexp.MustCompile(`^(add|upd|del)#(.*)$`)
+	matches := r.FindStringSubmatch(key)
+	if len(matches) != 3 {
+		return fmt.Errorf("%s is not a valid key", key)
 	}
-	// if it doesn't exist, it's been deleted
-	if !exists {
+	eventType := matches[1]
+	objectKey := matches[2]
+
+	if eventType == deleteEvent {
 		// get the deleted object from the deletedIndexer
 		// this shouldn't error, or fail to exist but we handle these cases to be thorough
-		obj, exists, err := e.deletedIndexer.GetByKey(key)
+		obj, exists, err := e.deletedIndexer.GetByKey(objectKey)
 		if err != nil {
-			return fmt.Errorf("error getting object with key %s from deletedIndexer: %v", key, err)
+			return fmt.Errorf("error getting object with key %s from deletedIndexer: %v", objectKey, err)
 		}
 		if !exists {
-			return fmt.Errorf("key %s doesn't exist in deletedIndexer: %v", key, err)
+			return fmt.Errorf("key %s doesn't exist in deletedIndexer: %v", objectKey, err)
 		}
 		// call the eventHandler's delete function for this object
 		if err := e.delete(obj); err != nil {
@@ -330,6 +352,29 @@ func (e *eventHandler) syncHandler(key string) error {
 		}
 		// finally, remove the deleted object from the deletedIndexer
 		return e.deletedIndexer.Delete(obj)
+	}
+
+	// get the object from the informer cache
+	obj, _, err := e.informer.GetIndexer().GetByKey(objectKey)
+	if err != nil {
+		return fmt.Errorf("error fetching object with key %s from store: %v", key, err)
+	}
+
+	if eventType == updateEvent {
+		// get the old object from the updatedIndexer
+		oldObj, exists, err := e.updatedIndexer.GetByKey(objectKey)
+		if err != nil {
+			return fmt.Errorf("error getting object with key %s from updatedIndexer: %v", objectKey, err)
+		}
+		if !exists {
+			return fmt.Errorf("key %s doesn't exist in updatedIndexer: %v", objectKey, err)
+		}
+		// call the eventHandler update function for this object
+		if err := e.update(oldObj, obj); err != nil {
+			return err
+		}
+		// finally, remove the deleted object from the deletedIndexer
+		return e.updatedIndexer.Delete(oldObj)
 	}
 	// call the eventHandler's add function in the case of add/update
 	return e.add(obj)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

The initial implementation of this package did not cater for updates.
This was intentional as add functions should be idempotent.
However, as this pattern is not implemented throughout the rest of
the codebase and changing those functions could take a very long time,
it seems sensible to instead adjust this package.

For this to work, we encode the eventType as part of the key in the
workqueue. This is less efficient, because we can't collapse all
event types for a given item so only the most recent is processed.
However, it is more efficient than processing every event as we
do today.

Additionally, we must also cache old copies of an object such that
we can provide the update event handler with the old/new objects.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->