### PR TITLE
remove the unused fnCallTimes field in unit test related code

### DIFF
--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -698,18 +698,15 @@ func TestSetExecWithoutOVS(t *testing.T) {
 		desc        string
 		expectedErr error
 		onRetArgs   *ovntest.TestifyMockHelper
-		fnCallTimes int
 	}{
 		{
 			desc:        "positive, ip and arping path found",
 			expectedErr: nil,
-			fnCallTimes: 2,
 			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil, "arping", nil}, CallTimes: 2},
 		},
 		{
 			desc:        "negative, ip path not found",
 			expectedErr: fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`),
-			fnCallTimes: 1,
 			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`), "arping", nil}},
 		},
 	}


### PR DESCRIPTION
Fixes: 0589478720 (refactor boilerplate mock object processing code in
UT into its own struct/function)

@vjayaramrh FYI