### PR TITLE
switch to newer fedora:34 so to enable ovn 20.12

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -9,7 +9,7 @@
 # are built locally and included in the image (instead of the rpm)
 #
 
-FROM fedora:32
+FROM fedora:34
 
 USER root
 

--- a/dist/images/Dockerfile.fedora.dev
+++ b/dist/images/Dockerfile.fedora.dev
@@ -23,7 +23,7 @@
 # this image in any production environment.
 #
 
-FROM fedora:32
+FROM fedora:34
 
 USER root
 

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -17,6 +17,9 @@ DOCKERFILE_ARCH =
 ifeq ($(ARCH),arm64)
         DOCKERFILE_ARCH=.arm64
 endif
+KERNEL_VERSION ?= `uname -r`
+OVS_BRANCH ?= master
+OVN_BRANCH ?= master
 
 # The image of ovnkube/ovn-daemonset-u should be multi-arched before using it on arm64
 ubuntu: bld
@@ -47,7 +50,10 @@ fedora-dev: bld
 	# To build (OVN Datapath)  with specific kernel version, please override KERNEL_VERSION.
 	# By default it will build with the host machine's kernel version.
 
-	docker build --build-arg KERNEL_VERSION=`uname -r` -t ovn-kube-f-dev -f Dockerfile.fedora.dev .
+	docker build --build-arg KERNEL_VERSION=$(KERNEL_VERSION) \
+		     --build-arg OVS_BRANCH=$(OVS_BRANCH) \
+		     --build-arg OVN_BRANCH=$(OVN_BRANCH) \
+		     -t ovn-kube-f-dev -f Dockerfile.fedora.dev .
 	# docker login -u ovnkube docker.io/ovnkube
 	# docker push docker.io/ovnkube/ovn-daemonset-f:latest
 	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest \


### PR DESCRIPTION
current version fedora:32 will install older version.
newer version needs to be tested on more periodic basis as per master branch

Signed-off-by: Dmitry Yusupov <dyusupov@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->