### PR TITLE
fix RetryOnConflict() call for egressIP and egressFirewall code

### DIFF
--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -3,8 +3,6 @@ package kube
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-
 	"k8s.io/klog/v2"
 
 	egressfirewall "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
@@ -136,10 +134,8 @@ func (k *Kube) UpdateEgressFirewall(egressfirewall *egressfirewall.EgressFirewal
 // UpdateEgressIP updates the EgressIP with the provided EgressIP data
 func (k *Kube) UpdateEgressIP(eIP *egressipv1.EgressIP) error {
 	klog.Infof("Updating status on EgressIP %s", eIP.Name)
-	if _, err := k.EIPClient.K8sV1().EgressIPs().Update(context.TODO(), eIP, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("error in updating status on EgressIP %s: %v", eIP.Name, err)
-	}
-	return nil
+	_, err := k.EIPClient.K8sV1().EgressIPs().Update(context.TODO(), eIP, metav1.UpdateOptions{})
+	return err
 }
 
 // UpdateNodeStatus takes the node object and sets the provided update status

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -129,10 +129,8 @@ func (k *Kube) SetAnnotationsOnNamespace(namespace *kapi.Namespace, annotations 
 // UpdateEgressFirewall updates the EgressFirewall with the provided EgressFirewall data
 func (k *Kube) UpdateEgressFirewall(egressfirewall *egressfirewall.EgressFirewall) error {
 	klog.Infof("Updating status on EgressFirewall %s in namespace %s", egressfirewall.Name, egressfirewall.Namespace)
-	if _, err := k.EgressFirewallClient.K8sV1().EgressFirewalls(egressfirewall.Namespace).Update(context.TODO(), egressfirewall, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("error in updating status on EgressFirewall %s/%s: %v", egressfirewall.Namespace, egressfirewall.Name, err)
-	}
-	return nil
+	_, err := k.EgressFirewallClient.K8sV1().EgressFirewalls(egressfirewall.Namespace).Update(context.TODO(), egressfirewall, metav1.UpdateOptions{})
+	return err
 }
 
 // UpdateEgressIP updates the EgressIP with the provided EgressIP data

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -196,9 +196,14 @@ func (oc *Controller) deleteEgressFirewall(egressFirewall *egressfirewallapi.Egr
 }
 
 func (oc *Controller) updateEgressFirewallWithRetry(egressfirewall *egressfirewallapi.EgressFirewall) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		return oc.kube.UpdateEgressFirewall(egressfirewall)
 	})
+	if retryErr != nil {
+		return fmt.Errorf("error in updating status on EgressFirewall %s/%s: %v",
+			egressfirewall.Namespace, egressfirewall.Name, retryErr)
+	}
+	return nil
 }
 
 func (oc *Controller) addEgressFirewallRules(hashedAddressSetNameIPv4, hashedAddressSetNameIPv6, namespace string, efStartPriority int) error {

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -207,9 +207,13 @@ func (oc *Controller) isAnyClusterNodeIP(ip net.IP) *egressNode {
 }
 
 func (oc *Controller) updateEgressIPWithRetry(eIP *egressipv1.EgressIP) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		return oc.kube.UpdateEgressIP(eIP)
 	})
+	if retryErr != nil {
+		return fmt.Errorf("error in updating status on EgressIP %s: %v", eIP.Name, retryErr)
+	}
+	return nil
 }
 
 func (oc *Controller) addNamespaceEgressIP(eIP *egressipv1.EgressIP, namespace *kapi.Namespace) error {


### PR DESCRIPTION
RetryOnConflict() requires that the update function called returns the
error as is without modifying the error, however we were modifying the
error object. With that modification, RetryOnConflict() will not be
able to determine the "Conflict" error

@dcbw @alexanderConstantinescu @JacobTanenbaum PTAL. Thanks.