### PR TITLE
fix upstream build failure in make check

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -865,6 +865,7 @@ var _ = Describe("OVN test basic functions", func() {
 		for _, tc := range testcases {
 			_, cidr, _ := net.ParseCIDR(tc.internalCIDR)
 			config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: cidr}}
+			config.Gateway.Mode = config.GatewayModeShared
 			matchExpression := generateMatch(tc.ipv4source, tc.ipv6source, tc.destinations, tc.ports)
 			Expect(tc.output).To(Equal(matchExpression))
 		}


### PR DESCRIPTION
Fixes: f18a027078c2 (implement egress firewall using join switch acls
in shared gateway mode)

@dcbw @trozet @danwinship @aojea FYI

Not sure what happened. The github CI didn't flag this error when I re-ran tests on the PR below this morning :-(

https://github.com/ovn-org/ovn-kubernetes/pull/1958/checks?check_run_id=1714304277
