### PR TITLE
Added v6 e2e for external gateway

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,7 @@ jobs:
         # - {"ipfamily": {"ip": ipv4}, "ha": {"enabled": "false"}, "gateway-mode": shared, "target": {"shard": shard-n-other}}
         exclude:
          # Not currently supported but needs to be.
-         - {"ipfamily": {"ip": dualstack}, "target": {"shard": control-plane}}
+         # - {"ipfamily": {"ip": dualstack}, "target": {"shard": control-plane}}
          - {"ipfamily": {"ip": ipv6}, "target": {"shard": control-plane}}
          # Limit matrix combinations for CI. DISABLED items added to exclude list:
          #   DISABLED  v4  ha     local


### PR DESCRIPTION
- this commit adds support for v6 external gateway testing
- the tests verifies connectivity to an initial gateway running
  in an external container from the cluster
- the test then updates the gateway annotation to a new mock
  gateway and validates the new gateway is reachable

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>

**- What this PR does and why is it needed**

Adds v6 e2e for external gateway

**- How to verify it**

Verify with the following:
```
# Install kind v8
curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.8.1/kind-$(uname)-amd64
chmod +x ./kind
mv ./kind /some-dir-in-your-PATH/kind

# Start ovn-kube kind with dual stack enabled
pushd $GOPATH/src/github.com/ovn-org/ovn-kubernetes/contrib
./kind.sh -gm shared -i6 -n4
# From the Kubernetes repo run 
pushd $GOPATH/src/k8s.io/kubernetes
kubetest --provider=local --deployment=kind --kind-cluster-name=ovn --test
```
