### PR TITLE
[WIP] Move worker switch LB to ovn_cluster_router

### DIFF
--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -98,9 +98,8 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
-			"ovn-nbctl --timeout=15 get logical_switch test-node load_balancer",
-			"ovn-nbctl --timeout=15 ls-lb-add test-node " + tcpLBUUID,
-			"ovn-nbctl --timeout=15 ls-lb-add test-node " + udpLBUUID,
+			"ovn-nbctl --timeout=15 --may-exist lr-lb-add ovn_cluster_router " + tcpLBUUID,
+			"ovn-nbctl --timeout=15 --may-exist lr-lb-add ovn_cluster_router " + udpLBUUID,
 		})
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -171,9 +170,8 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
-			"ovn-nbctl --timeout=15 get logical_switch test-node load_balancer",
-			"ovn-nbctl --timeout=15 ls-lb-add test-node " + tcpLBUUID,
-			"ovn-nbctl --timeout=15 ls-lb-add test-node " + udpLBUUID,
+			"ovn-nbctl --timeout=15 --may-exist lr-lb-add ovn_cluster_router " + tcpLBUUID,
+			"ovn-nbctl --timeout=15 --may-exist lr-lb-add ovn_cluster_router " + udpLBUUID,
 		})
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -243,9 +241,8 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
-			"ovn-nbctl --timeout=15 get logical_switch test-node load_balancer",
-			"ovn-nbctl --timeout=15 ls-lb-add test-node " + tcpLBUUID,
-			"ovn-nbctl --timeout=15 ls-lb-add test-node " + udpLBUUID,
+			"ovn-nbctl --timeout=15 --may-exist lr-lb-add ovn_cluster_router " + tcpLBUUID,
+			"ovn-nbctl --timeout=15 --may-exist lr-lb-add ovn_cluster_router " + udpLBUUID,
 		})
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{


### PR DESCRIPTION
The current implementation with empty-lb-events does not work correctly
with reject ACLs. This is because empty-lb-events is handled in OVN
table ls_in_pre_lb which comes before ls_in_acl. Therefore if
empty-lb-events is enabled, the packet will never reach the reject for a
service, even if that service is not idled.

By moving the LB to ovn_cluster_router ls_in_acl will happen first,
allowing the packet to get rejected if necessary, otherwise hitting
ovn_cluster_router and hitting empty-lb-events.

Additionally, this patch may help scale by reducing the LBs on every
worker node to just the single ovn_cluster_router.

NOTE: OVN docs claim that you can only add LB to a GR or a router with a DGP. We have a DGP now on ovn_cluster_router, but we want to remove it in the future. From talking with OVN team thus far this requirement is in place just because the packet needs to go through conntrack. We need to figure out exactly what the limitations/restrictions are here. We always send the packet through conntrack with allow-related on every worker switch.
