### PR TITLE
 [fixes BZ #1916872] Handle Multus network-status annotations on pod update

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	goovn "github.com/ebay/go-ovn"
+	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	hocontroller "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
@@ -505,6 +506,10 @@ func exGatewayAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 		oldPod.Annotations[routingNetworkAnnotation] != newPod.Annotations[routingNetworkAnnotation]
 }
 
+func networkStatusAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
+	return oldPod.Annotations[nettypes.NetworkStatusAnnot] != newPod.Annotations[nettypes.NetworkStatusAnnot]
+}
+
 // ensurePod tries to set up a pod. It returns success or failure; failure
 // indicates the pod should be retried later.
 func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
@@ -520,7 +525,7 @@ func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
 			return false
 		}
 	} else {
-		if oldPod != nil && exGatewayAnnotationsChanged(oldPod, pod) {
+		if oldPod != nil && (exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod)) {
 			// No matter if a pod is ovn networked, or host networked, we still need to check for exgw
 			// annotations. If the pod is ovn networked and is in update reschedule, addLogicalPort will take
 			// care of updating the exgw updates


### PR DESCRIPTION
Currently we require that if you specify an external gateway that corresponds
to a multus network, then you must do so as a pod update to add the exgw
annotations. This is due to the fact that multus will not add the network
attachment definition until after OVN CNI runs, and therefore OVN will not be
able to locate the exgw information. The current workflow is this:

1. Create exgw pod (OVN will add pod, multus will add network attachment def)
2. Once created, edit the pod and annotate it with the exgw annotations that
link to a multus network:

k8s.v1.cni.cncf.io/network-status: "[{\"name\":\"blah\",\"interface\":\"net1\",
\"ips\":[\"172.18.0.4\"],\"mac\":\"62:ff:69:f0:83:03\",\"dns\":{}}]"

k8s.ovn.org/routing-namespaces: exgw
k8s.ovn.org/routing-network: blah

However, we should be able to handle including the routing annotations on the
pod during pod add. When multus runs after OVN and annotates the network
attachment definition, OVN-Kube will get an update event from k8s and should
be able to then reconcile the routes.

Signed-off-by: vpickard <vpickard@redhat.com>



**- How to verify it**
Similiar to:
https://github.com/ovn-org/ovn-kubernetes/pull/1729

o Deploy kind with at least 1 worker node

o Create a pod in a namespace that will be used for exgw (i.e. create any basic pod in "exgw" namespace)
kubectl create namespace exgw
kubectl create -f testpod.yaml -n exgw

o Create another basic pod in default namespace, with host networking
kubectl create -f testpodhn.yaml

o Create an external docker container on the kind network.
docker run --network kind --privileged -it centos /bin/bash &

o Add an IP local to that container on lo like 9.0.0.1
docker ps
docker exec -it <cid> sh
ip a add 9.0.0.1/32 dev lo

o Add a route on the external docker container for the ip of pod in exgw via the IP of the node that exgw pod resides on
ip route add 10.244.0.0/16 via 172.18.0.2

o Attempt to ping from exgw pod to 9.0.0.1. This should fail.

o Edit the basic pod in default namespace with the network-status annotation that will come from multus via pod update:
kubectl edit pod testpod1 

metadata:
  annotations:
    k8s.v1.cni.cncf.io/network-status: "[{\"name\":\"blah\",\"interface\":\"net1\",\"ips\":[\"172.18.0.4\"],\"mac\":\"62:ff:69:f0:83:03\",\"dns\":{}}]"

Replace 172.18.0.4 above with the IP of your external docker container, 172.18.0.5

o Verify you can now ping from exgw pod to 9.0.0.1.

**- How to verify IP changing in network-status annotation**

o Follow all the steps above, verify ping.
o Edit ip of external docker container from 172.18.0.5 to 172.18.0.9.
docker exec -it <cid> sh
ip a del 172.18.0.5/16 dev eth0
ip a add 172.18.0.9/16 dev eth0

o Add a route on the external docker container for the ip of pod in exgw via the IP of the node that exgw pod resides on
Note: the route added earlier was deleted when the address was deleted above...
ip route add 10.244.0.0/16 via 172.18.0.4

o Verify that ping from exgw pod to 9.0.0.1 fails.
o Edit the basic pod in default namespace and update the network-status annotation with the
the new IP, 172.18.0.9. 

kubectl edit pod testpod1

metadata:
  annotations:
    k8s.v1.cni.cncf.io/network-status: "[{\"name\":\"blah\",\"interface\":\"net1\",\"ips\":[\"172.18.0.9\"],\"mac\":\"62:ff:69:f0:83:03\",\"dns\":{}}]"

o Verify that ping works from exgw pod to 9.0.0.1.

