### PR TITLE
Fix the db mount point for ovnkube-master pods.

### DIFF
--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -193,6 +193,10 @@ spec:
         - mountPath: /ovn-cert
           name: host-ovn-cert
           readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
 
         resources:
           requests:
@@ -274,5 +278,9 @@ spec:
         hostPath:
           path: /etc/ovn
           type: DirectoryOrCreate
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+
       tolerations:
       - operator: "Exists"


### PR DESCRIPTION
For KIND deployments the master container and db containers are
deployed in separate pods. This commit makes sure when the containers
are deployed on the same node, the master mounts the same host path
as the db pods.

This doesn't address the case where the ovndb and ovnkube-master containers 
are deployed on different nodes.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>

Fixes: #1967, #1968 