### PR TITLE
allows for running all tests inside a container

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -9,6 +9,12 @@ PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
 TEST_REPORT_DIR?=$(CURDIR)/_artifacts
 export TEST_REPORT_DIR
+GO_DKR_IMG = golang:1.15.7-buster
+# DOCKER_RUNNABLE determines if the tests can be run inside a docker container. It checks to see if
+# docker is installed on the system and also confirms that it is not running in a CI environment by checking that the
+# GITHUB_ACTIONS environment variable is not set. NOTE: Running tests in a docker container inside of a CI environment
+# fails some of the tests needing mount options inspite of starting the container with the right linux capabilities.
+DOCKER_RUNNABLE ?= $(shell docker -v > /dev/null 2>&1 && ! printenv GITHUB_ACTIONS > /dev/null 2>&1; echo $$?)
 
 .PHONY: all build check test
 
@@ -27,7 +33,11 @@ windows:
 	WINDOWS_BUILD="yes" hack/build-go.sh hybrid-overlay/cmd/hybrid-overlay-node
 
 check test:
+ifeq ($(DOCKER_RUNNABLE), 0)
+	docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller $(GO_DKR_IMG) sh -c "RACE=1 DOCKER_TEST=1 hack/test-go.sh ${PKGS}"
+else
 	RACE=1 hack/test-go.sh ${PKGS}
+endif
 
 codegen:
 	hack/update-codegen.sh
@@ -51,4 +61,8 @@ lint:
 	@GOPATH=${GOPATH} ./hack/lint.sh
 
 gofmt:
+ifeq ($(DOCKER_RUNNABLE), 0)
+	docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller $(GO_DKR_IMG) hack/verify-gofmt.sh
+else
 	@./hack/verify-gofmt.sh
+endif

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -9,12 +9,18 @@ PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
 TEST_REPORT_DIR?=$(CURDIR)/_artifacts
 export TEST_REPORT_DIR
-GO_DKR_IMG = golang:1.15.7-buster
-# DOCKER_RUNNABLE determines if the tests can be run inside a docker container. It checks to see if
-# docker is installed on the system and also confirms that it is not running in a CI environment by checking that the
-# GITHUB_ACTIONS environment variable is not set. NOTE: Running tests in a docker container inside of a CI environment
+GO_DOCKER_IMG = quay.io/giantswarm/golang:1.15.7
+# CONTAINER_RUNNABLE determines if the tests can be run inside a container. It checks to see if
+# podman/docker is installed on the system and also confirms that it is not running in a CI environment by checking
+# that the GITHUB_ACTIONS environment variable is not set. NOTE: Running tests in a container inside of a CI environment
 # fails some of the tests needing mount options inspite of starting the container with the right linux capabilities.
-DOCKER_RUNNABLE ?= $(shell docker -v > /dev/null 2>&1 && ! printenv GITHUB_ACTIONS > /dev/null 2>&1; echo $$?)
+PODMAN ?= $(shell podman -v > /dev/null 2>&1; echo $$?)
+ifeq ($(PODMAN), 0)
+CONTAINER_RUNTIME=podman
+else
+CONTAINER_RUNTIME=docker
+endif
+CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1 && ! printenv GITHUB_ACTIONS > /dev/null 2>&1; echo $$?)
 
 .PHONY: all build check test
 
@@ -25,16 +31,17 @@ DOCKER_RUNNABLE ?= $(shell docker -v > /dev/null 2>&1 && ! printenv GITHUB_ACTIO
 #       (disables compiler optimization and inlining to aid source debugging tools
 #        like delve)
 
-
 all build:
 	hack/build-go.sh cmd/ovnkube cmd/ovn-k8s-cni-overlay cmd/ovn-kube-util hybrid-overlay/cmd/hybrid-overlay-node cmd/ovndbchecker cmd/ovnkube-trace
 
 windows:
 	WINDOWS_BUILD="yes" hack/build-go.sh hybrid-overlay/cmd/hybrid-overlay-node
 
+# Note: `--security-opt label=disable` option is required on systems where SELinux is enabled for `podman` to successfully run the
+# tests in a container. Refer: https://www.projectatomic.io/blog/2016/03/dwalsh_selinux_containers/ for additional context
 check test:
-ifeq ($(DOCKER_RUNNABLE), 0)
-	docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller $(GO_DKR_IMG) sh -c "RACE=1 DOCKER_TEST=1 hack/test-go.sh ${PKGS}"
+ifeq ($(CONTAINER_RUNNABLE), 0)
+	$(CONTAINER_RUNTIME) run --security-opt label=disable --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 hack/test-go.sh ${PKGS}"
 else
 	RACE=1 hack/test-go.sh ${PKGS}
 endif
@@ -61,8 +68,8 @@ lint:
 	@GOPATH=${GOPATH} ./hack/lint.sh
 
 gofmt:
-ifeq ($(DOCKER_RUNNABLE), 0)
-	docker run --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller $(GO_DKR_IMG) hack/verify-gofmt.sh
+ifeq ($(CONTAINER_RUNNABLE), 0)
+	$(CONTAINER_RUNTIME) run --security-opt label=disable -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller $(GO_DOCKER_IMG) hack/verify-gofmt.sh
 else
 	@./hack/verify-gofmt.sh
 endif

--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -27,7 +27,7 @@ function testrun {
     if [[ ! -z "${RACE:-}" && "${pkg}" != "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller" ]]; then
         args="-race "
     fi
-    if [[ "$USER" != root && " ${root_pkgs[@]} " =~ " $pkg " ]]; then
+    if [[ "$USER" != root && " ${root_pkgs[@]} " =~ " $pkg " && -z "${DOCKER_TEST:-}" ]]; then
         testfile=$(mktemp --tmpdir ovn-test.XXXXXXXX)
         echo "sudo required for ${pkg}, compiling test to ${testfile}"
         if [[ ! -z "${RACE:-}" && "${pkg}" != "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller" ]]; then


### PR DESCRIPTION
Co-authored-by: Aniket Bhat <anbhat@redhat.com>
Signed-off-by: Vishwanath Jayaraman <vjayaram@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR adds the ability to run tests (including those requiring sudo such as tests in pkg/node and hybrid-overlay/pkg/controller) inside of a golang 1.15 docker container. Allows for running tests on non-linux systems as well.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Execute `make check` or `make test` on your development system that has docker installed from the ovn-kuberentes/go-controller directory.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->