### PR TITLE
Add configuration parameters to kind deployment

### DIFF
--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -28,20 +28,20 @@ endif
 	# This is the default in the ovnkube*.yaml files
 	# docker login -u ovnkube docker.io/ovnkube
 	# docker push docker.io/ovnkube/ovn-daemonset-u:latest
-	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-u:latest
+	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-u:latest $(OVN_CONF)
 
 centos: bld
 	docker build -t ovn-daemonset .
 	docker tag ovn-daemonset docker.io/ovnkube/ovn-daemonset:latest
 	# docker login -u ovnkube docker.io/ovnkube
 	# docker push docker.io/ovnkube/ovn-daemonset:latest
-	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset:latest
+	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset:latest $(OVN_CONF)
 
 fedora: bld
 	docker build -t ovn-kube-f -f Dockerfile.fedora .
 	# docker login -u ovnkube docker.io/ovnkube
 	# docker push docker.io/ovnkube/ovn-daemonset-f:latest
-	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest
+	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest $(OVN_CONF)
 
 fedora-dev: bld
 	# To build (OVN Datapath)  with specific kernel version, please override KERNEL_VERSION.

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -40,6 +40,24 @@ $ pushd dist/images
 $ make fedora
 $ popd
 ```
+If you want to specify logging levels for OVN components, set them to the `OVN_CONF` environment variable, before 
+running the ``` make fedora``` command
+
+For example:
+```
+export OVN_CONF="--master-loglevel='5' \
+--node-loglevel='5' \
+--dbchecker-loglevel='5' \
+--ovn-loglevel-northd='-vconsole:info -vfile:info' \
+--ovn-loglevel-nb='-vconsole:info -vfile:info' \
+--ovn-loglevel-sb='-vconsole:info -vfile:info' \
+--ovn-loglevel-controller='-vconsole:info' \
+--ovn-loglevel-nbctld='-vconsole:info' "
+```
+Notes:
+* The above values are the default values.
+* Put attention on the quotes.
+ 
 
 Launch the KIND Deployment.
 


### PR DESCRIPTION
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

Currently, all `kind` deployments have the default logging levels. The option to change it is to edit `Makefile` only. 
This PR allows specifying logging (and other `./daemonset.sh`) parameters as an environment variable. 