### PR TITLE
golang interface holding nil is not always nil since it holds type too

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -206,9 +206,16 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	if err != nil {
 		return err
 	}
-	gw.loadBalancerHealthChecker = loadBalancerHealthChecker
-	gw.portClaimWatcher = portClaimWatcher
-
+	// a golang interface has two values <type, value>. an interface is nil if both type and
+	// value is nil. so, you cannot directly set the value to an interface and later check if
+	// value was nil by comparing the interface to nil. this is because if the value is `nil`,
+	// then the interface will still hold the type of the value being set.
+	if loadBalancerHealthChecker != nil {
+		gw.loadBalancerHealthChecker = loadBalancerHealthChecker
+	}
+	if portClaimWatcher != nil {
+		gw.portClaimWatcher = portClaimWatcher
+	}
 	initGw := func() error {
 		return gw.Init(n.watchFactory)
 	}


### PR DESCRIPTION
a golang interface has two values <type, value>. an interface is nil
if both type and value is nil. so, you cannot directly set the value to
an interface and later check if value was nil by comparing the
interface to nil. this is because if the value is `nil`, then the
interface will still hold the type of the value being set.

with the current code we were hitting SIGSEGV in Service's AddService
handler() where we were doing this:

```
func (g *gateway) AddService(svc *kapi.Service) {
        if g.portClaimWatcher != nil {
                g.portClaimWatcher.AddService(svc)
        }
        if g.loadBalancerHealthChecker != nil {
                g.loadBalancerHealthChecker.AddService(svc)
        }

        <Snip>
}
```

even though `portClaimWatcher` was not set we were calling its
AddService function and thereby causing the panic

@dcbw @trozet @danwinship @dave-tucker FYI and PTAL
