### PR TITLE
Revert "1) Expose OVN DB metrics on same mux as MetricsServer if OVNM…

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -283,11 +283,6 @@ func runOvnKube(ctx *cli.Context) error {
 	// now that ovnkube master/node are running, lets expose the metrics HTTP endpoint if configured
 	// start the prometheus server to serve OVN K8s Metrics (default master port: 9409, node port: 9410)
 	if config.Kubernetes.MetricsBindAddress != "" {
-		if config.Kubernetes.OVNMetricsBindAddress == "" {
-			//Expose OVNRegistry Metrics on same mux as Metrics Server
-			metrics.MakeOvnRegistryPointToDefault()
-			metrics.RegisterOvnMetrics(ovnClientset.KubeClient, master)
-		}
 		metrics.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof)
 	}
 

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -166,12 +166,6 @@ func checkPodRunsOnGivenNode(clientset kubernetes.Interface, label, k8sNodeName 
 	return false, fmt.Errorf("the Pod matching the label %q doesn't exist on this node %s", label, k8sNodeName)
 }
 
-var ovnRegistry = prometheus.NewRegistry()
-
-func MakeOvnRegistryPointToDefault() {
-	ovnRegistry = prometheus.DefaultRegisterer.(*prometheus.Registry)
-}
-
 // StartMetricsServer runs the prometheus listener so that OVN K8s metrics can be collected
 func StartMetricsServer(bindAddress string, enablePprof bool) {
 	mux := http.NewServeMux()
@@ -192,6 +186,8 @@ func StartMetricsServer(bindAddress string, enablePprof bool) {
 		}
 	}, 5*time.Second, utilwait.NeverStop)
 }
+
+var ovnRegistry = prometheus.NewRegistry()
 
 // StartOVNMetricsServer runs the prometheus listener so that OVN metrics can be collected
 func StartOVNMetricsServer(bindAddress string) {

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -362,7 +362,7 @@ func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 		}
 		return
 	}
-	klog.Info("Found OVN DB Pod running on this node. Registering OVN DB Metrics on Node.")
+	klog.Info("Found OVN DB Pod running on this node. Registering OVN DB Metrics")
 
 	// get the ovsdb server version info
 	getOvnDbVersionInfo()


### PR DESCRIPTION
…etricsBindAddress is not defined"

This reverts commit f25e3f97c712fe1e4ffd83f0d3acb94e80bba22d.

Needs more work. It breaks metric collection and OVN metrics are now collected twice on the master node, by the ovnkube-master process and by the ovnkube-node process.