### PR TITLE
images: ignore ovnkube-trace

### DIFF
--- a/dist/images/.gitignore
+++ b/dist/images/.gitignore
@@ -1,6 +1,7 @@
 ovn-k8s-cni-overlay
 ovn-kube-util
 ovnkube
+ovnkube-trace
 ovndbchecker
 hybrid-overlay-node
 git_info


### PR DESCRIPTION
ovnkube-trace is now built in go-controllers, and copied to the images
directory, but not included in .gitignore. This fixes that.

Signed-off-by: Stephen Kitt <skitt@redhat.com>