### PR TITLE
E2E: Add a nodeport connectivity test

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -226,19 +227,20 @@ func getPodGWRoute(f *framework.Framework, nodeName string, podName string) net.
 }
 
 // Create a pod on the specified node using the agnostic host image
-func createGenericPod(f *framework.Framework, podName, nodeSelector, namespace string, command []string) {
-	createPod(f, podName, nodeSelector, namespace, command, nil)
+func createGenericPod(f *framework.Framework, podName, nodeSelector, namespace string, command []string) *v1.Pod {
+	return createPod(f, podName, nodeSelector, namespace, command, nil)
 }
 
 // Create a pod on the specified node using the agnostic host image
-func createGenericPodWithLabel(f *framework.Framework, podName, nodeSelector, namespace string, command []string, labels map[string]string) {
-	createPod(f, podName, nodeSelector, namespace, command, labels)
+func createGenericPodWithLabel(f *framework.Framework, podName, nodeSelector, namespace string, command []string, labels map[string]string) *v1.Pod {
+	return createPod(f, podName, nodeSelector, namespace, command, labels)
 }
 
-func createClusterExternalContainer(containerName string, containerImage string, additionalArgs []string) string {
+func createClusterExternalContainer(containerName string, containerImage string, dockerArgs []string, entrypointArgs []string) string {
 	args := []string{"docker", "run", "-itd"}
-	args = append(args, additionalArgs...)
+	args = append(args, dockerArgs...)
 	args = append(args, []string{"--name", containerName, containerImage}...)
+	args = append(args, entrypointArgs...)
 	_, err := runCommand(args...)
 	if err != nil {
 		framework.Failf("failed to start external test container: %v", err)
@@ -273,7 +275,7 @@ func getPod(f *framework.Framework, podName string) *v1.Pod {
 }
 
 // Create a pod on the specified node using the agnostic host image
-func createPod(f *framework.Framework, podName, nodeSelector, namespace string, command []string, labels map[string]string) {
+func createPod(f *framework.Framework, podName, nodeSelector, namespace string, command []string, labels map[string]string, options ...func(*v1.Pod)) *v1.Pod {
 
 	contName := fmt.Sprintf("%s-container", podName)
 
@@ -294,12 +296,18 @@ func createPod(f *framework.Framework, podName, nodeSelector, namespace string, 
 			RestartPolicy: v1.RestartPolicyNever,
 		},
 	}
+
+	for _, o := range options {
+		o(pod)
+	}
+
 	podClient := f.ClientSet.CoreV1().Pods(namespace)
-	_, err := podClient.Create(context.Background(), pod, metav1.CreateOptions{})
+	res, err := podClient.Create(context.Background(), pod, metav1.CreateOptions{})
 	if err != nil {
 		framework.Logf("Warning: Failed to get logs from pod %q: %v", pod.Name, err)
 	}
-	err = e2epod.WaitForPodNotPending(f.ClientSet, podName, namespace)
+	err = e2epod.WaitForPodNotPending(f.ClientSet, namespace, podName)
+
 	if err != nil {
 		logs, logErr := e2epod.GetPodLogs(f.ClientSet, namespace, pod.Name, contName)
 		if logErr != nil {
@@ -308,6 +316,7 @@ func createPod(f *framework.Framework, podName, nodeSelector, namespace string, 
 			framework.Logf("pod %s/%s logs:\n%s", namespace, pod.Name, logs)
 		}
 	}
+	return res
 }
 
 // Get the IP address of a pod in the specified namespace
@@ -562,7 +571,7 @@ var _ = ginkgo.Describe("e2e egress IP validation", func() {
 		targetNode = node{
 			name: egressTargetNode,
 		}
-		targetNode.nodeIP = createClusterExternalContainer(targetNode.name, "docker.io/httpd", []string{"--network", ciNetworkName, "-P"})
+		targetNode.nodeIP = createClusterExternalContainer(targetNode.name, "docker.io/httpd", []string{"--network", ciNetworkName, "-P"}, []string{})
 	})
 
 	ginkgo.AfterEach(func() {
@@ -1517,6 +1526,123 @@ var _ = ginkgo.Describe("e2e multiple ecmp external gateway validation", func() 
 		}
 		if len(errs) > 0 {
 			framework.Failf("failed to reach the mock gateway(s):\n%v", errs)
+		}
+	})
+})
+
+// This test validates ingress traffic to nodeports.
+// It creates a nodeport service on both udp and tcp, and creates a backend pod on each node.
+// The backend pods are using the agnhost - netexec command which replies to commands
+// with different protocols. We use the "hostname" command to have each backend pod to reply
+// with its hostname.
+// We use an external container to poke the service exposed on the node and we iterate until
+// all the hostnames are returned.
+// In case of dual stack enabled cluster, we iterate over all the nodes ips and try to hit the
+// endpoints from both each node's ips.
+var _ = ginkgo.Describe("e2e ingress to nodeport traffic validation", func() {
+	const (
+		endpointHTTPPort    = 80
+		endpointUDPPort     = 90
+		clusterHTTPPort     = 81
+		clusterUDPPort      = 91
+		nodePortServiceName = "npservice"
+		clientContainerName = "npclient"
+	)
+
+	f := framework.NewDefaultFramework("nodeport-ingress-test")
+	endpointsSelector := map[string]string{"servicebackend": "true"}
+
+	var endPoints []*v1.Pod
+	var nodesHostnames sets.String
+	maxTries := 0
+	var nodeTCPPort, nodeUDPPort int32
+	var nodes *v1.NodeList
+
+	ginkgo.BeforeEach(func() {
+		endPoints = make([]*v1.Pod, 0)
+		nodesHostnames = sets.NewString()
+
+		var err error
+		nodes, err = e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
+		framework.ExpectNoError(err)
+
+		if len(nodes.Items) < 3 {
+			framework.Failf(
+				"Test requires >= 3 Ready nodes, but there are only %v nodes",
+				len(nodes.Items))
+		}
+
+		ginkgo.By("Creating the endpoints pod, one for each worker")
+		for _, node := range nodes.Items {
+			// this create a udp / http netexec listener which is able to receive the "hostname"
+			// command. We use this to validate that each endpoint is received at least once
+			args := []string{
+				"netexec",
+				fmt.Sprintf("--http-port=%d", endpointHTTPPort),
+				fmt.Sprintf("--udp-port=%d", endpointUDPPort),
+			}
+			pod := createPod(f, node.Name+"-ep", node.Name, f.Namespace.Name, []string{}, endpointsSelector, func(p *v1.Pod) {
+				p.Spec.Containers[0].Args = args
+			})
+			endPoints = append(endPoints, pod)
+			nodesHostnames.Insert(pod.Name)
+
+			// this is arbitrary and mutuated from k8s network e2e tests. We aim to hit all the endpoints at least once
+			maxTries = len(endPoints)*len(endPoints) + 30
+		}
+
+		ginkgo.By("Creating the nodeport service")
+		npSpec := nodePortServiceSpecFrom(nodePortServiceName, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector)
+		np, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), npSpec, metav1.CreateOptions{})
+		nodeTCPPort, nodeUDPPort = nodePortsFromService(np)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for the endpoints to pop up")
+		err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name, nodePortServiceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+		framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", nodePortServiceName, f.Namespace.Name)
+
+		ginkgo.By("Creating an external container to send the traffic from")
+		// the client uses the netexec command from the agnhost image, which is able to receive commands for poking other
+		// addresses.
+		createClusterExternalContainer(clientContainerName, agnhostImage, []string{"--network", "kind", "-P"}, []string{"netexec", "--http-port=80"})
+	})
+
+	ginkgo.AfterEach(func() {
+		deleteClusterExternalContainer(clientContainerName)
+	})
+
+	ginkgo.It("Should provide external connectivity via nodeport", func() {
+		for _, protocol := range []string{"http", "udp"} {
+			for _, node := range nodes.Items {
+				for _, nodeAddress := range node.Status.Addresses {
+					// skipping hostnames
+					addr := net.ParseIP(nodeAddress.Address)
+					if addr == nil {
+						continue
+					}
+
+					responses := sets.NewString()
+					valid := false
+					nodePort := nodeTCPPort
+					if protocol == "udp" {
+						nodePort = nodeUDPPort
+					}
+
+					ginkgo.By("Hitting the nodeport on " + node.Name + " and reaching all the endpoints " + protocol)
+					for i := 0; i < maxTries; i++ {
+						epHostname := pokeEndpointHostname(clientContainerName, protocol, nodeAddress.Address, nodePort)
+						responses.Insert(epHostname)
+
+						// each endpoint returns its hostname. By doing this, we validate that each ep was reached at least once.
+						if responses.Equal(nodesHostnames) {
+							framework.Logf("Validated node %s on address %s after %d tries", node.Name, nodeAddress.Address, i)
+							valid = true
+							break
+						}
+					}
+					framework.ExpectEqual(valid, true, "Validation failed for node", node, responses, nodePort)
+				}
+			}
 		}
 	})
 })


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

Add a test that verifies the ingress traffic to nodeport services.
This is heavily inspired by kubernetes networking tests, and done by creating an external container and using the agnhost netexec command to connect to each node's exposed service checking if endpoints on each node can be reached through that.


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

This depends on https://github.com/ovn-org/ovn-kubernetes/pull/1990 , and includes its commit.
This is because we needed to be able to set the ipfamily of the service as "preferdualstack" in order to validate both ip families.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->