### PR TITLE
remove the obsolete setting of NB DB address to OvS

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -264,7 +264,6 @@ type OvnAuthConfig struct {
 	Scheme         OvnDBScheme
 
 	northbound bool
-	externalID string // ovn-nb or ovn-remote
 
 	exec kexec.Interface
 }
@@ -1482,11 +1481,9 @@ func buildOvnAuth(exec kexec.Interface, northbound bool, cliAuth, confAuth *OvnA
 	var direction string
 	var defaultAuth *OvnAuthConfig
 	if northbound {
-		auth.externalID = "ovn-nb"
 		direction = "nb"
 		defaultAuth = &savedOvnNorth
 	} else {
-		auth.externalID = "ovn-remote"
 		direction = "sb"
 		defaultAuth = &savedOvnSouth
 	}
@@ -1616,9 +1613,13 @@ func (a *OvnAuthConfig) SetDBAuth() error {
 		}
 	}
 
-	if err := setOVSExternalID(a.exec, a.externalID, "\""+a.GetURL()+"\""); err != nil {
-		return err
+	if !a.northbound {
+		// store the Southbound Database address in an external id - "external_ids:ovn-remote"
+		if err := setOVSExternalID(a.exec, "ovn-remote", "\""+a.GetURL()+"\""); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -1131,7 +1131,6 @@ mode=shared
 			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --db=" + nbURL + " --timeout=5 --private-key=" + keyFile + " --certificate=" + certFile + " --bootstrap-ca-cert=" + caFile + " list nb_global",
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-nb=\"" + nbURL + "\"",
 			})
 
 			cliConfig := &OvnAuthConfig{
@@ -1150,7 +1149,6 @@ mode=shared
 			Expect(a.Address).To(Equal(nbURL))
 			Expect(a.CertCommonName).To(Equal(nbDummyCommonName))
 			Expect(a.northbound).To(BeTrue())
-			Expect(a.externalID).To(Equal("ovn-nb"))
 
 			Expect(a.GetURL()).To(Equal(nbURL))
 			err = a.SetDBAuth()
@@ -1183,7 +1181,6 @@ mode=shared
 			Expect(a.Address).To(Equal(sbURL))
 			Expect(a.CertCommonName).To(Equal(sbDummyCommonName))
 			Expect(a.northbound).To(BeFalse())
-			Expect(a.externalID).To(Equal("ovn-remote"))
 
 			Expect(a.GetURL()).To(Equal(sbURL))
 			err = a.SetDBAuth()
@@ -1192,49 +1189,25 @@ mode=shared
 		})
 
 		const (
-			nbURLLegacy    string = "tcp://1.2.3.4:6641"
-			nbURLConverted string = "tcp:1.2.3.4:6641"
 			sbURLLegacy    string = "tcp://1.2.3.4:6642"
 			sbURLConverted string = "tcp:1.2.3.4:6642"
 		)
 
-		It("configures client northbound TCP legacy address correctly", func() {
-			fexec := ovntest.NewFakeExec()
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-nb=\"" + nbURLConverted + "\"",
-			})
-
-			cliConfig := &OvnAuthConfig{Address: nbURLLegacy}
-			a, err := buildOvnAuth(fexec, true, cliConfig, &OvnAuthConfig{}, true)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(a.Scheme).To(Equal(OvnDBSchemeTCP))
-			// Config should convert :// to : in addresses
-			Expect(a.Address).To(Equal(nbURLConverted))
-			Expect(a.northbound).To(BeTrue())
-			Expect(a.externalID).To(Equal("ovn-nb"))
-
-			Expect(a.GetURL()).To(Equal(nbURLConverted))
-			err = a.SetDBAuth()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
-		})
-
 		It("configures client southbound TCP legacy address correctly", func() {
 			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-nb=\"" + nbURLConverted + "\"",
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-remote=\"" + sbURLConverted + "\"",
 			})
 
-			cliConfig := &OvnAuthConfig{Address: nbURLLegacy}
-			a, err := buildOvnAuth(fexec, true, cliConfig, &OvnAuthConfig{}, true)
+			cliConfig := &OvnAuthConfig{Address: sbURLLegacy}
+			a, err := buildOvnAuth(fexec, false, cliConfig, &OvnAuthConfig{}, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(a.Scheme).To(Equal(OvnDBSchemeTCP))
 			// Config should convert :// to : in addresses
-			Expect(a.Address).To(Equal(nbURLConverted))
-			Expect(a.northbound).To(BeTrue())
-			Expect(a.externalID).To(Equal("ovn-nb"))
+			Expect(a.Address).To(Equal(sbURLConverted))
+			Expect(a.northbound).To(BeFalse())
 
-			Expect(a.GetURL()).To(Equal(nbURLConverted))
+			Expect(a.GetURL()).To(Equal(sbURLConverted))
 			err = a.SetDBAuth()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)


### PR DESCRIPTION
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

Each ovnkube-node stores address of the Northbound DB as `external_ids:ovn-nb` in the `Open_vSwitch` table at the local OVSDB. This setting is not used anymore. 