### PR TITLE
Add --user arg to pip install wheel

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -149,7 +149,7 @@ print_params()
 parse_args $*
 
 # ensure j2 renderer installed
-pip install wheel
+pip install wheel --user
 pip freeze | grep j2cli || pip install j2cli[yaml] --user
 export PATH=~/.local/bin:$PATH
 


### PR DESCRIPTION
installing to system dir can fail with permission errors

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->