### PR TITLE
Add constants file for e2e package

### DIFF
--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -1,0 +1,13 @@
+package e2e
+
+import (
+	"time"
+)
+
+const (
+	vxlanPort            = "4789" // IANA assigned VXLAN UDP port - rfc7348
+	podNetworkAnnotation = "k8s.ovn.org/pod-networks"
+	retryInterval        = 1 * time.Second  // polling interval timer
+	retryTimeout         = 40 * time.Second // polling timeout
+	ciNetworkName        = "kind"
+)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,14 +22,6 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
-const (
-	vxlanPort            = "4789" // IANA assigned VXLAN UDP port - rfc7348
-	podNetworkAnnotation = "k8s.ovn.org/pod-networks"
-	retryInterval        = 1 * time.Second  // polling interval timer
-	retryTimeout         = 40 * time.Second // polling timeout
-	ciNetworkName        = "kind"
-)
-
 func checkContinuousConnectivity(f *framework.Framework, nodeName, podName, host string, port, timeout int, podChan chan *v1.Pod, errChan chan error) {
 	contName := fmt.Sprintf("%s-container", podName)
 


### PR DESCRIPTION
using a const from a file appended with _test.go will not be
seen at compile time. It will also show up as an error in
an IDE. It was only affecting podNetworkAnnotation in util.go
at this point, but going forward we can centralize all e2e
constants this way.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->