### PR TITLE
cni: Use new port-up OVN notification mechanism (when possible).

### DIFF
--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -51,7 +51,7 @@ func clientDoCNI(t *testing.T, client *http.Client, req *Request) ([]byte, int) 
 
 var expectedResult cnitypes.Result
 
-func serverHandleCNI(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error) {
+func serverHandleCNI(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool) ([]byte, error) {
 	if request.Command == CNIAdd {
 		return json.Marshal(&expectedResult)
 	} else if request.Command == CNIDel || request.Command == CNIUpdate || request.Command == CNICheck {
@@ -88,7 +88,7 @@ func TestCNIServer(t *testing.T) {
 		t.Fatalf("failed to create watch factory: %v", err)
 	}
 
-	s := NewCNIServer(tmpDir, wf)
+	s := NewCNIServer(tmpDir, false, wf)
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
@@ -283,8 +283,8 @@ func TestCNIServerCancelAdd(t *testing.T) {
 
 	started := make(chan bool)
 
-	s := NewCNIServer(tmpDir, wf)
-	if err := s.Start(func(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error) {
+	s := NewCNIServer(tmpDir, false, wf)
+	if err := s.Start(func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool) ([]byte, error) {
 		// Let the testcase know it can now delete the pod
 		close(started)
 		// Wait for the testcase to cancel us

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -377,8 +377,12 @@ func (pr *PodRequest) ConfigureInterface(namespace string, podName string, ifInf
 		return nil, err
 	}
 
-	if err = waitForPodFlows(pr.ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID, ofPort); err != nil {
-		return nil, fmt.Errorf("error while waiting on flows for pod: %v", err)
+	if err = waitForPodInterface(pr.ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIface.Name, ifaceID, ofPort, ifInfo.CheckExtIDs); err != nil {
+		if ifInfo.CheckExtIDs {
+			return nil, fmt.Errorf("error while waiting on OVS.Interface.external-ids:ovn-installed for pod: %v", err)
+		} else {
+			return nil, fmt.Errorf("error while waiting on flows for pod: %v", err)
+		}
 	}
 
 	return []*current.Interface{hostIface, contIface}, nil

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -22,9 +22,10 @@ const serverSocketPath string = serverRunDir + "/" + serverSocketName
 type PodInterfaceInfo struct {
 	util.PodAnnotation
 
-	MTU     int   `json:"mtu"`
-	Ingress int64 `json:"ingress"`
-	Egress  int64 `json:"egress"`
+	MTU         int   `json:"mtu"`
+	Ingress     int64 `json:"ingress"`
+	Egress      int64 `json:"egress"`
+	CheckExtIDs bool  `json:"check-external-ids"`
 }
 
 // Explicit type for CNI commands the server handles
@@ -88,15 +89,16 @@ type PodRequest struct {
 	cancel context.CancelFunc
 }
 
-type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister) ([]byte, error)
+type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool) ([]byte, error)
 
 // Server object that listens for JSON-marshaled Request objects
 // on a private root-only Unix domain socket.
 type Server struct {
 	http.Server
-	requestFunc cniRequestFunc
-	rundir      string
-	podLister   corev1listers.PodLister
+	requestFunc       cniRequestFunc
+	rundir            string
+	useOVSExternalIDs int32
+	podLister         corev1listers.PodLister
 
 	// runningSandboxAdds is a map of sandbox ID to PodRequest for any CNIAdd operation
 	runningSandboxAddsLock sync.Mutex

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -165,6 +165,22 @@ func isOVNControllerReady(name string) (bool, error) {
 	return true, nil
 }
 
+// Starting with v21.03.0 OVN sets OVS.Interface.external-id:ovn-installed
+// and OVNSB.Port_Binding.up when all OVS flows associated to a
+// logical port have been successfully programmed.
+func getOVNIfUpCheckMode() (bool, error) {
+	if _, stderr, err := util.RunOVNSbctl("--columns=up", "list", "Port_Binding"); err != nil {
+		if strings.Contains(stderr, "does not contain a column") {
+			klog.Infof("Falling back to using legacy CNI OVS flow readiness checks")
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check if port_binding is supported in OVN, stderr: %q, error: %v",
+			stderr, err)
+	}
+	klog.Infof("Detected support for port binding with external IDs")
+	return true, nil
+}
+
 // Start learns the subnets assigned to it by the master controller
 // and calls the SetupNode script which establishes the logical switch
 func (n *OvnNode) Start(wg *sync.WaitGroup) error {
@@ -243,34 +259,47 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 	go n.gateway.Run(n.stopChan, wg)
 	klog.Infof("Gateway and management port readiness took %v", time.Since(start))
 
+	isOvnUpEnabled, err := getOVNIfUpCheckMode()
+	if err != nil {
+		return err
+	}
+	cniServer := cni.NewCNIServer("", isOvnUpEnabled, n.watchFactory)
+
 	// Upgrade for Node. If we upgrade workers before masters, then we need to keep service routing via
 	// mgmt port until masters have been updated and modified OVN config. Run a goroutine to handle this case
-	if config.GatewayModeShared == config.Gateway.Mode {
-		// note this will change in the future to control-plane:
-		// https://github.com/kubernetes/kubernetes/pull/95382
-		masterNode, err := labels.NewRequirement("node-role.kubernetes.io/master", selection.Exists, nil)
-		if err != nil {
+
+	// note this will change in the future to control-plane:
+	// https://github.com/kubernetes/kubernetes/pull/95382
+	masterNode, err := labels.NewRequirement("node-role.kubernetes.io/master", selection.Exists, nil)
+	if err != nil {
+		return err
+	}
+
+	labelSelector := labels.NewSelector()
+	labelSelector = labelSelector.Add(*masterNode)
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(n.client, 0,
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = labelSelector.String()
+		}))
+
+	upgradeController := upgrade.NewController(n.Kube, informerFactory.Core().V1().Nodes())
+	initialTopoVersion := upgradeController.GetInitialTopoVersion()
+	bridgeName := n.gateway.GetGatewayBridgeIface()
+
+	needLegacySvcRoute := true
+	if initialTopoVersion >= types.OvnHostToSvcOFTopoVersion && config.GatewayModeShared == config.Gateway.Mode {
+		// Configure route for svc towards shared gw bridge
+		// Have to have the route to bridge for multi-NIC mode, where the default gateway may go to a non-OVS interface
+		if err := configureSvcRouteViaBridge(bridgeName); err != nil {
 			return err
 		}
+		needLegacySvcRoute = false
+	}
 
-		labelSelector := labels.NewSelector()
-		labelSelector = labelSelector.Add(*masterNode)
-
-		informerFactory := informers.NewSharedInformerFactoryWithOptions(n.client, 0,
-			informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-				options.LabelSelector = labelSelector.String()
-			}))
-
-		upgradeController := upgrade.NewController(n.Kube, informerFactory.Core().V1().Nodes())
-		initialTopoVersion := upgradeController.GetInitialTopoVersion()
-		bridgeName := n.gateway.GetGatewayBridgeIface()
-		if initialTopoVersion >= types.OvnHostToSvcOFTopoVersion {
-			// We dont need to run any goroutine, can just configure route for svc towards shared gw bridge
-			// Have to have the route to bridge for multi-NIC mode, where the default gateway may go to a non-OVS interface
-			if err := configureSvcRouteViaBridge(bridgeName); err != nil {
-				return err
-			}
-		} else {
+	// Determine if we need to run upgrade checks
+	if initialTopoVersion != types.OvnCurrentTopologyVersion {
+		if needLegacySvcRoute && config.GatewayModeShared == config.Gateway.Mode {
 			klog.Info("System may be upgrading, falling back to to legacy K8S Service via mp0")
 			// add back legacy route for service via mp0
 			link, err := util.LinkSetUp(types.K8sMgmtIntfName)
@@ -289,21 +318,26 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 					return fmt.Errorf("unable to add legacy route for services via mp0, error: %v", err)
 				}
 			}
-			// need to run upgrade controller
-			informerStop := make(chan struct{})
-			informerFactory.Start(informerStop)
-			go func() {
-				if err := upgradeController.Run(n.stopChan, informerStop); err != nil {
-					klog.Fatalf("Error while running upgrade controller: %v", err)
-				}
-				// upgrade complete now see what needs upgrading
-				if initialTopoVersion < types.OvnHostToSvcOFTopoVersion {
-					if err := upgradeServiceRoute(bridgeName); err != nil {
-						klog.Fatalf("Failed to upgrade service route for node, error: %v", err)
-					}
-				}
-			}()
 		}
+		// need to run upgrade controller
+		informerStop := make(chan struct{})
+		informerFactory.Start(informerStop)
+		go func() {
+			if err := upgradeController.Run(n.stopChan, informerStop); err != nil {
+				klog.Fatalf("Error while running upgrade controller: %v", err)
+			}
+			// upgrade complete now see what needs upgrading
+			// migrate service route from ovn-k8s-mp0 to shared gw bridge
+			if initialTopoVersion < types.OvnHostToSvcOFTopoVersion && config.GatewayModeShared == config.Gateway.Mode {
+				if err := upgradeServiceRoute(bridgeName); err != nil {
+					klog.Fatalf("Failed to upgrade service route for node, error: %v", err)
+				}
+			}
+			// ensure CNI support for port binding built into OVN, as masters have been upgraded
+			if initialTopoVersion < types.OvnPortBindingTopoVersion {
+				cniServer.EnableOVNPortUpSupport()
+			}
+		}()
 	}
 
 	if config.HybridOverlay.Enabled {
@@ -345,7 +379,6 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 
 	n.WatchEndpoints()
 
-	cniServer := cni.NewCNIServer("", n.watchFactory)
 	err = cniServer.Start(cni.HandleCNIRequest)
 
 	return err

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -85,7 +85,8 @@ const (
 	OvnSingleJoinSwitchTopoVersion = 1
 	OvnNamespacedDenyPGTopoVersion = 2
 	OvnHostToSvcOFTopoVersion      = 3
-	OvnCurrentTopologyVersion      = OvnHostToSvcOFTopoVersion
+	OvnPortBindingTopoVersion      = 4
+	OvnCurrentTopologyVersion      = OvnPortBindingTopoVersion
 
 	// OVN-K8S annotation constants
 	OvnK8sPrefix   = "k8s.ovn.org"


### PR DESCRIPTION
Detect if OVN supports setting the OVS.Interface "ovn-installed"
external id [0] when OVS flows corresponding to a logical flow have
been installed.  If so then change the pod interface readiness check
to wait for the external id to be set by ovn-controller

For backwards compatibility, on older OVN versions, use the legacy
pod readiness checks, i.e., check for specific OVS flows to be
installed.

On upgrade, CNI Server will dynamically switch to new mode after master
upgrade.

[0] ovn-org/ovn@4d3cb42

Co-authored-by: Tim Rozet <trozet@redhat.com>
Signed-off-by: Tim Rozet <trozet@redhat.com>