### PR TITLE
enable new endpoint slice controller (and fix service idling)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,9 +112,11 @@ jobs:
           - shard: shard-conformance
             hybrid-overlay: false
             multicast-enable: false
+            emptylb-enable: false
           - shard: control-plane
             hybrid-overlay: true
             multicast-enable: true
+            emptylb-enable: true
         ha:
          - enabled: "true"
            name: "HA"
@@ -172,6 +174,7 @@ jobs:
       OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target.hybrid-overlay }}"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_MULTICAST_ENABLE:  "${{ matrix.target.multicast-enable }}"
+      OVN_EMPTY_LB_EVENTS: "${{ matrix.target.emptylb-enable }}"
     steps:
 
     - name: Free up disk space

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -566,6 +566,10 @@ func (wf *WatchFactory) NamespaceInformer() cache.SharedIndexInformer {
 	return wf.informers[namespaceType].inf
 }
 
+func (wf *WatchFactory) ServiceInformer() cache.SharedIndexInformer {
+	return wf.informers[serviceType].inf
+}
+
 // noHeadlessServiceSelector is a LabelSelector added to the watch for
 // Endpoints (and, eventually, EndpointSlices) that excludes endpoints
 // for headless services.

--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -98,7 +98,7 @@ func (r *Repair) runOnce() error {
 		return errors.Wrapf(err, "Failed to list Services from the cache")
 	}
 	for _, svc := range services {
-		for _, ip := range svc.Spec.ClusterIPs {
+		for _, ip := range util.GetClusterIPs(svc) {
 			for _, svcPort := range svc.Spec.Ports {
 				vip := util.JoinHostPortInt32(ip, svcPort.Port)
 				key := virtualIPKey(vip, svcPort.Protocol)

--- a/go-controller/pkg/ovn/controller/services/service_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/service_tracker.go
@@ -147,7 +147,7 @@ func (st *serviceTracker) getService(name, namespace string) sets.String {
 // updateKubernetesService adds or updates the tracker from a Kubernetes service
 // added for testing purposes
 func (st *serviceTracker) updateKubernetesService(service *v1.Service) {
-	for _, ip := range service.Spec.ClusterIPs {
+	for _, ip := range util.GetClusterIPs(service) {
 		for _, svcPort := range service.Spec.Ports {
 			vip := util.JoinHostPortInt32(ip, svcPort.Port)
 			st.updateService(service.Name, service.Namespace, vip, svcPort.Protocol)

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -270,7 +270,7 @@ func (c *Controller) syncServices(key string) error {
 		return err
 	}
 	// Iterate over the ClusterIPs and Ports fields to create the corresponding OVN loadbalancers
-	for _, ip := range service.Spec.ClusterIPs {
+	for _, ip := range util.GetClusterIPs(service) {
 		family := v1.IPv4Protocol
 		if utilnet.IsIPv6String(ip) {
 			family = v1.IPv6Protocol

--- a/go-controller/pkg/ovn/controller/unidling/ovn_event.go
+++ b/go-controller/pkg/ovn/controller/unidling/ovn_event.go
@@ -1,4 +1,4 @@
-package ovn
+package unidling
 
 import (
 	"encoding/json"

--- a/go-controller/pkg/ovn/controller/unidling/ovn_event_test.go
+++ b/go-controller/pkg/ovn/controller/unidling/ovn_event_test.go
@@ -1,4 +1,4 @@
-package ovn
+package unidling
 
 import (
 	"reflect"

--- a/go-controller/pkg/ovn/controller/unidling/unidle.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle.go
@@ -1,0 +1,138 @@
+package unidling
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+
+	"k8s.io/klog/v2"
+)
+
+// unidlingController checks periodically the OVN events db
+// and generates a Kubernetes NeedPods events with the Service
+// associated to the VIP
+type unidlingController struct {
+	eventRecorder record.EventRecorder
+	// Map of load balancers to service namespace
+	serviceVIPToName     map[ServiceVIPKey]types.NamespacedName
+	serviceVIPToNameLock sync.Mutex
+}
+
+// NewController creates a new unidling controller
+func NewController(recorder record.EventRecorder, serviceInformer cache.SharedIndexInformer) *unidlingController {
+	uc := &unidlingController{
+		eventRecorder:    recorder,
+		serviceVIPToName: map[ServiceVIPKey]types.NamespacedName{},
+	}
+
+	// we only process events on unidling, there is no reconcilation
+	klog.Info("Setting up event handlers for services")
+	serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: uc.onServiceAdd,
+		UpdateFunc: func(old, new interface{}) {
+			uc.onServiceDelete(old)
+			uc.onServiceAdd(new)
+		},
+		DeleteFunc: uc.onServiceDelete,
+	})
+	return uc
+}
+
+func (uc *unidlingController) onServiceAdd(obj interface{}) {
+	svc := obj.(*v1.Service)
+	if util.ServiceTypeHasClusterIP(svc) && util.IsClusterIPSet(svc) {
+		for _, ip := range util.GetClusterIPs(svc) {
+			for _, svcPort := range svc.Spec.Ports {
+				vip := util.JoinHostPortInt32(ip, svcPort.Port)
+				uc.AddServiceVIPToName(vip, svcPort.Protocol, svc.Namespace, svc.Name)
+			}
+		}
+	}
+}
+
+func (uc *unidlingController) onServiceDelete(obj interface{}) {
+	svc := obj.(*v1.Service)
+	if util.ServiceTypeHasClusterIP(svc) && util.IsClusterIPSet(svc) {
+		for _, ip := range util.GetClusterIPs(svc) {
+			for _, svcPort := range svc.Spec.Ports {
+				vip := util.JoinHostPortInt32(ip, svcPort.Port)
+				uc.DeleteServiceVIPToName(vip, svcPort.Protocol)
+			}
+		}
+	}
+}
+
+// ServiceVIPKey is used for looking up service namespace information for a
+// particular load balancer
+type ServiceVIPKey struct {
+	// Load balancer VIP in the form "ip:port"
+	vip string
+	// Protocol used by the load balancer
+	protocol v1.Protocol
+}
+
+// AddServiceVIPToName associates a k8s service name with a load balancer VIP
+func (uc *unidlingController) AddServiceVIPToName(vip string, protocol v1.Protocol, namespace, name string) {
+	uc.serviceVIPToNameLock.Lock()
+	defer uc.serviceVIPToNameLock.Unlock()
+	uc.serviceVIPToName[ServiceVIPKey{vip, protocol}] = types.NamespacedName{Namespace: namespace, Name: name}
+}
+
+// GetServiceVIPToName retrieves the associated k8s service name for a load balancer VIP
+func (uc *unidlingController) GetServiceVIPToName(vip string, protocol v1.Protocol) (types.NamespacedName, bool) {
+	uc.serviceVIPToNameLock.Lock()
+	defer uc.serviceVIPToNameLock.Unlock()
+	namespace, ok := uc.serviceVIPToName[ServiceVIPKey{vip, protocol}]
+	return namespace, ok
+}
+
+// DeleteServiceVIPToName retrieves the associated k8s service name for a load balancer VIP
+func (uc *unidlingController) DeleteServiceVIPToName(vip string, protocol v1.Protocol) {
+	uc.serviceVIPToNameLock.Lock()
+	defer uc.serviceVIPToNameLock.Unlock()
+	delete(uc.serviceVIPToName, ServiceVIPKey{vip, protocol})
+}
+
+func (uc *unidlingController) Run(stopCh <-chan struct{}) {
+	ticker := time.NewTicker(5 * time.Second)
+
+	for {
+		select {
+		case <-ticker.C:
+			out, _, err := util.RunOVNSbctl("--format=json", "list", "controller_event")
+			if err != nil {
+				continue
+			}
+
+			events, err := extractEmptyLBBackendsEvents([]byte(out))
+			if err != nil || len(events) == 0 {
+				continue
+			}
+
+			for _, event := range events {
+				_, _, err := util.RunOVNSbctl("destroy", "controller_event", event.uuid)
+				if err != nil {
+					// Don't unidle until we are able to remove the controller event
+					klog.Errorf("Unable to remove controller event %s", event.uuid)
+					continue
+				}
+				if serviceName, ok := uc.GetServiceVIPToName(event.vip, event.protocol); ok {
+					serviceRef := v1.ObjectReference{
+						Kind:      "Service",
+						Namespace: serviceName.Namespace,
+						Name:      serviceName.Name,
+					}
+					klog.V(5).Infof("Sending a NeedPods event for service %s in namespace %s.", serviceName.Name, serviceName.Namespace)
+					uc.eventRecorder.Eventf(&serviceRef, v1.EventTypeNormal, "NeedPods", "The service %s needs pods", serviceName.Name)
+				}
+			}
+		case <-stopCh:
+			return
+		}
+	}
+}

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -89,8 +89,6 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 				klog.Errorf("Error in creating Cluster IP for svc %s, target port: %d - %v\n", svc.Name, lbEps.Port, err)
 				continue
 			}
-			vip := util.JoinHostPortInt32(svc.Spec.ClusterIP, svcPort.Port)
-			ovn.AddServiceVIPToName(vip, svcPort.Protocol, svc.Namespace, svc.Name)
 			if len(svc.Spec.ExternalIPs) > 0 {
 				gateways, _, err := ovn.getOvnGateways()
 				if err != nil {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -446,6 +446,17 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 		}
 	}
 
+	// Create load balancers
+
+	// If we enable idling we have to set the option before creating the loadbalancers
+	if config.Kubernetes.OVNEmptyLbEvents {
+		_, _, err := util.RunOVNNbctl("set", "nb_global", ".", "options:controller_event=true")
+		if err != nil {
+			klog.Error("Unable to enable controller events. Unidling not possible")
+			return err
+		}
+	}
+
 	// Create 3 load-balancers for east-west traffic for UDP, TCP, SCTP
 	oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes")
 	if err != nil {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -413,12 +413,6 @@ func (oc *Controller) syncPeriodic() {
 func (oc *Controller) ovnControllerEventChecker() {
 	ticker := time.NewTicker(5 * time.Second)
 
-	_, _, err := util.RunOVNNbctl("set", "nb_global", ".", "options:controller_event=true")
-	if err != nil {
-		klog.Error("Unable to enable controller events. Unidling not possible")
-		return
-	}
-
 	for {
 		select {
 		case <-ticker.C:

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -319,13 +319,10 @@ func (oc *Controller) Run(wg *sync.WaitGroup) error {
 
 	oc.WatchPods()
 
-	// Services are handled differently depending on the Kubernetes API versions
-	// and the OVN configuration.
-	// We use a level triggered controller to handle services if k8s > 1.19,
-	// using endpoint slices instead endpoints if OVN is configured for dual stack.
-	if util.UseEndpointSlices(oc.client) && config.IPv4Mode && config.IPv6Mode {
-		// Services are handled differently depending on the Kubernetes API versions
-		klog.Infof("Dual Stack enabled: using EndpointSlices instead of Endpoints in k8s versions > 1.19")
+	// We use a level triggered controller to handle services if the cluster
+	// has endpoint slices enabled.
+	if util.UseEndpointSlices(oc.client) {
+		klog.Infof("Starting OVN Service Controller: Using Endpoint Slices")
 		// Create our own informers to start compartamentalizing the code
 		// filter server side the things we don't care about
 		noProxyName, err := labels.NewRequirement("service.kubernetes.io/service-proxy-name", selection.DoesNotExist, nil)

--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -1,0 +1,101 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+)
+
+// Validate that Services with the well-known annotation k8s.ovn.org/idled-at
+// generate a NeedPods Event if the service doesn´t have endpoints and
+// OVN EmptyLB-Backends feature is enabled
+var _ = ginkgo.Describe("Unidling", func() {
+	const (
+		serviceName       = "empty-service"
+		podName           = "execpod-noendpoints"
+		ovnServiceIdledAt = "k8s.ovn.org/idled-at"
+		port              = 80
+	)
+
+	f := framework.NewDefaultFramework("unidling")
+
+	var cs clientset.Interface
+
+	ginkgo.BeforeEach(func() {
+		cs = f.ClientSet
+	})
+
+	// We simulate the idling feature that is Openshift specific creating a service and removing the pods
+	ginkgo.It("Should generate a NeedPods event for traffic destined to idled services", func() {
+		namespace := f.Namespace.Name
+		jig := e2eservice.NewTestJig(cs, namespace, serviceName)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, e2eservice.MaxNodesForEndpointsTests)
+		framework.ExpectNoError(err)
+		nodeName := nodes.Items[0].Name
+
+		ginkgo.By("creating an annotated service with no endpoints and idle annotation")
+		_, err = jig.CreateTCPServiceWithPort(func(svc *v1.Service) {
+			svc.Annotations = map[string]string{ovnServiceIdledAt: "true"}
+		}, int32(port))
+		framework.ExpectNoError(err)
+
+		// Add a backend pod to the service in one node
+		ginkgo.By("creating a backend pod for the service " + serviceName)
+		serverPod := e2epod.NewAgnhostPod(namespace, "pod-backend", nil, nil, []v1.ContainerPort{{ContainerPort: 9376}}, "serve-hostname")
+		serverPod.Labels = jig.Labels
+		serverPod.Spec.NodeName = nodeName
+		f.PodClient().CreateSync(serverPod)
+
+		// Emulate the idling feature deleting the pod
+		f.PodClient().DeleteSync(serverPod.Name, metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
+
+		// Create exec pod to test the PodEvent is generated if it receives traffic to the idled service
+		ginkgo.By(fmt.Sprintf("creating %v on node %v", podName, nodeName))
+		execPod := e2epod.CreateExecPodOrFail(f.ClientSet, namespace, podName, func(pod *v1.Pod) {
+			pod.Spec.NodeName = nodeName
+		})
+
+		serviceAddress := net.JoinHostPort(serviceName, strconv.Itoa(port))
+		framework.Logf("waiting up to %v to connect to %v", e2eservice.KubeProxyEndpointLagTimeout, serviceAddress)
+		cmd := fmt.Sprintf("/agnhost connect --timeout=3s %s", serviceAddress)
+
+		ginkgo.By(fmt.Sprintf("hitting service %v from pod %v on node %v", serviceAddress, podName, nodeName))
+		nonExpectedErr := "REFUSED"
+		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyEndpointLagTimeout, func() (bool, error) {
+			_, err := framework.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
+			if err != nil && strings.Contains(err.Error(), nonExpectedErr) {
+				return false, fmt.Errorf("Service is rejecting packets")
+			}
+			// An event like this must be generated
+			// oc.recorder.Eventf(&serviceRef, kapi.EventTypeNormal, "NeedPods", "The service %s needs pods", serviceName.Name)
+			events, err := cs.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				return false, err
+			}
+			for _, e := range events.Items {
+				framework.Logf("At %v - event for %v: %v %v: %v", e.FirstTimestamp, e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
+				if e.Reason == "NeedPods" && strings.Contains(e.Message, serviceName) {
+					return true, nil
+				}
+			}
+			return false, nil
+
+		}); pollErr != nil {
+			framework.ExpectNoError(pollErr)
+		}
+	})
+
+})


### PR DESCRIPTION
Enable new endpoint slice controller.

Move the unidling controller code to its own package.

Add e2e test.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
