### PR TITLE
Set --num-nodes in e2e-kind.sh

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -132,6 +132,8 @@ export KUBE_CONTAINER_RUNTIME_NAME=containerd
 # to stop PR retriggers for totally broken code
 export FLAKE_ATTEMPTS=3
 export NUM_NODES=20
+# Kind clusters are three node clusters
+export NUM_WORKER_NODES=3
 ginkgo --nodes=${NUM_NODES} \
 	--focus=${FOCUS} \
 	--skip=${SKIPPED_TESTS} \
@@ -142,4 +144,5 @@ ginkgo --nodes=${NUM_NODES} \
 	--provider=local \
 	--dump-logs-on-failure=false \
 	--report-dir=${E2E_REPORT_DIR}	\
-	--disable-log-dump=true
+	--disable-log-dump=true \
+	--num-nodes=${NUM_WORKER_NODES}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

When doing:

```
WHAT="$TEST_NAME" make -C test/ shard-test
```

locally, the E2E tests were not launching and instead raising a failure and refusal to launch the tests with complaints such as:

```
S [SKIPPING] [38.319 seconds]
[sig-network] Networking
/home/aconstan/go/src/github.com/kubernetes/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:23
  Granular Checks: Services
  /home/aconstan/go/src/github.com/kubernetes/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/networking.go:149
    should function for service endpoints using hostNetwork [It]
    /home/aconstan/go/src/github.com/kubernetes/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/network/networking.go:490
    Requires at least 2 nodes (not -1)
```

It seems it's because we were not providing the `--num-nodes` arg for `e2e.test` binary. I am not sure how it works in CI, but I assume there might be an environment variable triggering the right behavior?

/assign @aojea 

 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->