### PR TITLE
Alert definition for OVS dropped packets due to resource constraints.

### DIFF
--- a/dist/templates/ovnkube-alerts.yaml.j2
+++ b/dist/templates/ovnkube-alerts.yaml.j2
@@ -365,5 +365,15 @@ spec:
          {{ range query "ovn_controller_integration_bridge_geneve_ports_total{job='ovnkube-node', namespace='ovn-kubernetes'} !=  scalar(count(kube_node_info)) - 1" }}
          {{ .Labels.instance }}: {{ .Value }}
          {{ end }}.
- 
+
+    - alert: OvsPacketInDrops
+      expr: |
+        rate(ovs_vswitchd_packet_in_drop{namespace="ovn-kubernetes",job="ovnkube-node"}[1m]) > 0
+      for: 10m
+      labels:
+       severity: critical
+      annotations:
+       description: |
+         Pod ovn-kubernetes/ {{ $labels.pod }} ovn-controller containers
+         packet-in-drops is {{ printf "%.2f" $value }} per second.
 


### PR DESCRIPTION
This is the define an alert when OVS drops packets due to resource constraints. I've taken the path of determining the rate and and then alert if we have any dropped packets but I am open to suggestions if we need to do something else. Please let me know.

Signed-off-by: Balaji Varadaraju <bvaradar@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->