### PR TITLE
Add ovn-k team as reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,25 @@
 reviewers:
-  - JacobTanenbaum
-  - pecameron
-  - squeed
-  - dcbw
-  - rajatchopra
-  - shettyg
-  - aserdean
+  - alexanderConstantinescu
   - alinbalutoiu
+  - aserdean
+  - astoycos
+  - danielmellado
+  - dcbw
+  - fedepaol
   - girishmg
-approvers:
+  - JacobTanenbaum
+  - jluhrsen
+  - pecameron
   - rajatchopra
+  - squeed
+  - trozet
   - shettyg
+  - vpickard
+approvers:
+  - aserdean
   - dcbw
   - girishmg
-  - aserdean
+  - rajatchopra
   - russellb
+  - shettyg
+  - trozet


### PR DESCRIPTION
This PR adds the current openshift ovn-k members to OWNERS file as
reviewer. I'm not adding trozet as he wasn't listed and he seems to
already have approver rights.

