### PR TITLE
OVN convert from single to dualstack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,6 +249,108 @@ jobs:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
 
+  e2e-dual-conversion:
+    name: e2e-dual-conversion
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        gateway-mode: [local, shared]
+    needs: [build]
+    env:
+      JOB_NAME: "DualStack-conversion-${{ matrix.gateway-mode }}"
+      OVN_HA: "true"
+      KIND_IPV4_SUPPORT: "true"
+      KIND_IPV6_SUPPORT: "false"
+      OVN_HYBRID_OVERLAY_ENABLE: "false"
+      OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
+      OVN_MULTICAST_ENABLE:  "false"
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Set up environment
+      run: |
+        export GOPATH=$(go env GOPATH)
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
+
+    - name: Disable ufw
+      # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
+      # Not needed for KIND deployments, so just disable all the time.
+      run: |
+        sudo ufw disable
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: test-image
+
+    - name: Load docker image
+      run: |
+        docker load --input image.tar
+
+    - name: kind IPv4 setup
+      run: |
+        export OVN_IMAGE="ovn-daemonset-f:dev"
+        make -C test install-kind
+
+    - name: Run Single-Stack Tests
+      run: |
+        make -C test shard-test WHAT="Networking Granular Checks"
+
+    - name: Convert IPv4 cluster to Dual Stack
+      run: |
+        ./contrib/kind-dual-stack-conversion.sh
+
+    - name: Run Dual-Stack Tests
+      run: |
+        KIND_IPV4_SUPPORT="true"
+        KIND_IPV6_SUPPORT="true"
+        make -C test shard-test WHAT="Networking Granular Checks\|DualStack"
+
+    - name: Upload Junit Reports
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
+        path: './test/_artifacts/*.xml'
+
+    - name: Generate Test Report
+      id: xunit-viewer
+      if: always()
+      uses: AutoModality/action-xunit-viewer@v1
+      with:
+        results: ./test/_artifacts/
+
+    - name: Upload Test Report
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-report-${{ env.JOB_NAME }}-${{ github.run_id }}
+        path: './test/_artifacts/index.html'
+
+    - name: Export logs
+      if: always()
+      run: |
+        mkdir -p /tmp/kind/logs
+        kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
+
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
+        path: /tmp/kind/logs
+
   e2e-periodic:
     name: e2e-periodic
     if: github.event_name == 'schedule'

--- a/contrib/kind-dual-stack-conversion.sh
+++ b/contrib/kind-dual-stack-conversion.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+
+convert_kubelet() {
+ echo "Converting kubelet on nodes $NODES"
+ for n in $NODES; do
+   docker exec $n cp /var/lib/kubelet/config.yaml /var/lib/kubelet/config.yaml.bak
+   # kubelet already has a featureGate configured so we need to ammend a new one
+   # NOTE: if there weren't feature gates configured we have to change this
+   docker exec $n sed -i '/featureGates/a\  IPv6DualStack: true' /var/lib/kubelet/config.yaml
+   # Restart kubelet
+   docker exec $n systemctl restart kubelet
+  echo "Converted kubelet on node $n"
+ done
+}
+
+convert_cni() {
+  # from kind hack/ci/e2e-k8s.sh
+  # Modify current OVN config
+  ORIGINAL_OVNCONFIG=$(kubectl get -oyaml -n=ovn-kubernetes configmap/ovn-config)
+  echo "Original OVN config:"
+  echo "${ORIGINAL_OVNCONFIG}"
+  # Patch it
+  FIXED_OVNCONFIG=$(
+    printf '%s' "${ORIGINAL_OVNCONFIG}" | sed \
+      -e "s#^  net_cidr.*#&\,${SECONDARY_CLUSTER_SUBNET}#" \
+      -e "s#^  svc_cidr:.*#&\,${SECONDARY_SERVICE_SUBNET}#" \
+  )
+  echo "Patched OVN config:"
+  echo "${FIXED_OVNCONFIG}"
+  printf '%s' "${FIXED_OVNCONFIG}" | kubectl apply -f -
+  # restart ovnkube-master
+  # FIXME: kubectl rollout restart deployment leaves the old pod hanging 
+  # as workaround we delete the master directly
+  kubectl -n ovn-kubernetes delete pod -l name=ovnkube-master
+  # restart ovnkube-node
+  kubectl -n ovn-kubernetes rollout restart daemonset ovnkube-node
+  kubectl -n ovn-kubernetes rollout status daemonset ovnkube-node
+  echo "Updated CNI"
+}
+
+convert_k8s_control_plane(){
+  # Kubeadm installs apiserver and controller-manager as static pods
+  # one the configuration has changed kubelet restart them
+  API_CONFIG_FILE="/etc/kubernetes/manifests/kube-apiserver.yaml"
+  CM_CONFIG_FILE="/etc/kubernetes/manifests/kube-controller-manager.yaml"
+
+  # update all the control plane nodes
+  for n in $CONTROL_PLANE_NODES; do
+    echo "Converting control-plane on node $n"
+    # kube-apiserver backup config file
+    docker exec $n cp ${API_CONFIG_FILE} /kind/kube-apiserver.yaml.bak
+    # append second service cidr --service-cluster-ip-range=<IPv4 CIDR>,<IPv6 CIDR>
+    docker exec $n sed -i -e "s#.*service-cluster-ip-range.*#&\,${SECONDARY_SERVICE_SUBNET}#" ${API_CONFIG_FILE}
+    # OVN has already the SCTP feature enable, we just need to append the new one
+    # NOTE: if there was not feature-gate enabled we must use    
+    # docker exec $n sed -i '/service-cluster-ip-range/i\    - --feature-gates=IPv6DualStack=true' ${API_CONFIG_FILE}
+    docker exec $n sed -i -e "s#.*feature-gates.*#&\,IPv6DualStack=true#" ${API_CONFIG_FILE}
+    # kube-controller-manager /etc/kubernetes/manifests/kube-controller-manager.yaml
+    docker exec $n cp ${CM_CONFIG_FILE} /kind/kube-controller-manager.bak
+    # append second service cidr --service-cluster-ip-range=<IPv4 CIDR>,<IPv6 CIDR>
+    docker exec $n sed -i -e "s#.*service-cluster-ip-range.*#&\,${SECONDARY_SERVICE_SUBNET}#" ${CM_CONFIG_FILE}
+    # append second cluster cidr --cluster-cidr=<IPv4 CIDR>,<IPv6 CIDR>
+    docker exec $n sed -i -e "s#.*cluster-cidr.*#&\,${SECONDARY_CLUSTER_SUBNET}#" ${CM_CONFIG_FILE}
+    # OVN has already the SCTP feature enable, we just need to append the new one
+    # NOTE: if there was not feature-gate enabled we must use    
+    # docker exec $n sed -i '/service-cluster-ip-range/i\    - --feature-gates=IPv6DualStack=true' ${CM_CONFIG_FILE}
+    docker exec $n sed -i -e "s#.*feature-gates.*#&\,IPv6DualStack=true#" ${CM_CONFIG_FILE}
+    echo "Finished converting control plane on node $n"
+  done
+
+}
+
+usage()
+{
+    echo "usage: kind_dual_conversion.sh [-n|--name <cluster_name>] [-ss secondary_service_subnet] [-sc secondary_cluster_subnet]"
+    echo "Convert a single stack cluster in a dual stack cluster"
+}
+
+parse_args()
+{
+    while [ "${1:-}" != "" ]; do
+        case $1 in
+            -n | --name )			                              shift
+                                          	                CLUSTER_NAME=$1
+                                          	;;
+            -ss | --secondary-service-subnet )	           	shift
+                                          	                SECONDARY_SERVICE_SUBNET=$1
+                                          	;;
+            -sc | --secondary-cluster-subnet )	           	shift
+                                          	                SECONDARY_CLUSTER_SUBNET=$1
+                                          	                ;;
+            -h | --help )                       usage
+                                                exit
+                                                ;;
+            * )                                 usage
+                                                exit 1
+        esac
+        shift
+    done
+}
+
+parse_args $*
+
+set -euxo pipefail
+
+# Set default values
+CLUSTER_NAME=${CLUSTER_NAME:-ovn}
+DUALSTACK_FEATURE_GATE="IPv6DualStack=true"
+SECONDARY_SERVICE_SUBNET=${SECONDARY_SERVICE_SUBNET:-"fd00:10:96::/112"}
+SECONDARY_CLUSTER_SUBNET=${SECONDARY_CLUSTER_SUBNET:-"fd00:10:244::/56"}
+
+# NOTE: ovn only
+export KUBECONFIG=${HOME}/admin.conf
+
+# KIND nodes
+NODES=$(kind get nodes --name ${CLUSTER_NAME})
+CONTROL_PLANE_NODES=$(kind get nodes --name ${CLUSTER_NAME} | grep control)
+WORKER_NODES=$(kind get nodes --name ${CLUSTER_NAME} | grep worker)
+
+# Create a deployment with 2 pods
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server-deployment
+  labels:
+    app: MyApp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: MyApp
+  template:
+    metadata:
+      labels:
+        app: MyApp
+    spec:
+      containers:
+      - name: agnhost
+        image: k8s.gcr.io/e2e-test-images/agnhost:2.21
+        args:
+          - netexec
+          - --http-port=80
+          - --udp-port=80
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodeport-service
+spec:
+  type: NodePort
+  selector:
+    app: MyApp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+EOF
+
+if ! kubectl wait --for=condition=ready pods --all --timeout=100s ; then
+  echo "deployment is not running"
+  kubectl get pods -o wide -A || true
+  exit 1
+fi
+
+# Start the conversion to dual stack
+# TODO revisit order
+convert_kubelet
+# FIXME: this is a random value to give time to pods to restart
+sleep 10
+convert_k8s_control_plane
+# FIXME: this is a random value to give time to pods to restart
+sleep 10
+convert_cni
+# FIXME: this is a random value to give time to pods to restart
+sleep 10
+
+# Check everything is fine
+if ! kubectl wait --for=condition=ready pods --all --timeout=100s ; then
+  echo "deployment is not running"
+  kubectl get pods -o wide -A || true
+  exit 1
+fi
+
+# Create dual stack services and check they work
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpd-deployment
+  labels:
+    app: MyDualApp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: MyDualApp
+  template:
+    metadata:
+      labels:
+        app: MyDualApp
+    spec:
+      containers:
+      - name: httpd
+        image: httpd:2.4
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-v4
+spec:
+  selector:
+    app: MyDualApp
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+    - protocol: TCP
+      port: 8081
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-v6
+spec:
+  selector:
+    app: MyDualApp
+  ipFamilies:
+  - IPv6
+  ipFamilyPolicy: SingleStack
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-require-dual
+spec:
+  selector:
+    app: MyDualApp
+  ipFamilyPolicy: RequireDualStack
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-prefer-dual
+spec:
+  selector:
+    app: MyDualApp
+  ipFamilyPolicy: PreferDualStack
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80
+EOF
+
+# Restart pods so they can acquire dual stack addresses
+kubectl delete pods -l app=MyApp
+kubectl delete pods -l app=MyDualApp
+
+# Check everything is fine
+if ! kubectl wait --for=condition=ready pods --all --timeout=100s ; then
+  echo "deployments are not running"
+  kubectl get pods -o wide -A || true
+  exit 1
+fi
+
+# Check that services are reachable on both IP Families
+IPS=()
+CLUSTER_IPV4=$(kubectl get services my-service-v4 -o jsonpath='{.spec.clusterIPs[0]}')
+IPS+=("${CLUSTER_IPV4}:8081")
+CLUSTER_IPV6=$(kubectl get services my-service-v6 -o jsonpath='{.spec.clusterIPs[0]}')
+IPS+=("\[${CLUSTER_IPV6}\]:8080")
+
+for n in $NODES; do
+  for ip in ${IPS[@]}; do
+    docker exec $n curl --connect-timeout 5 $ip
+  done
+done

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -589,8 +589,12 @@ func (oc *Controller) addNodeLocalNatEntries(node *kapi.Node, mgmtPortMAC string
 
 	mgmtPortName := types.K8sPrefix + node.Name
 	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "lr-nat-del", types.OVNClusterRouter,
-		"dnat_and_snat", externalIP.String(), "--",
-		"lr-nat-add", types.OVNClusterRouter, "dnat_and_snat",
+		"dnat_and_snat", externalIP.String())
+	if err != nil {
+		return fmt.Errorf("failed to delete dnat_and_snat entry for the management port on node %s, "+
+			"stdout: %s, stderr: %q, error: %v", node.Name, stdout, stderr, err)
+	}
+	stdout, stderr, err = util.RunOVNNbctl("lr-nat-add", types.OVNClusterRouter, "dnat_and_snat",
 		externalIP.String(), mgmtPortIfAddr.IP.String(), mgmtPortName, mgmtPortMAC)
 	if err != nil {
 		return fmt.Errorf("failed to add dnat_and_snat entry for the management port on node %s, "+

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -339,36 +339,64 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 	return nil
 }
 
+// This DistributedGWPort guarantees to always have both IPv4 and IPv6 regardless of dual-stack
 func addDistributedGWPort() error {
 	masterChassisID, err := util.GetNodeChassisID()
 	if err != nil {
 		return fmt.Errorf("failed to get master's chassis ID error: %v", err)
 	}
 
-	var dgpMac string
-	var nbctlArgs []string
-	// add a distributed gateway port to the distributed router
+	// the distributed gateway port is always dual-stack and uses the IPv4 address to generate its mac
 	dgpName := types.RouterToSwitchPrefix + types.NodeLocalSwitch
-	if config.IPv4Mode {
-		dgpMac = util.IPAddrToHWAddr(net.ParseIP(types.V4NodeLocalDistributedGWPortIP)).String()
-	} else {
-		dgpMac = util.IPAddrToHWAddr(net.ParseIP(types.V6NodeLocalDistributedGWPortIP)).String()
+	dgpMac := util.IPAddrToHWAddr(net.ParseIP(types.V4NodeLocalDistributedGWPortIP)).String()
+	dgpNetworkV4 := fmt.Sprintf("%s/%d", types.V4NodeLocalDistributedGWPortIP, types.V4NodeLocalNATSubnetPrefix)
+	dgpNetworkV6 := fmt.Sprintf("%s/%d", types.V6NodeLocalDistributedGWPortIP, types.V6NodeLocalNATSubnetPrefix)
+
+	// check if there is already a distributed gateway port
+	dgpUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+		"--columns=_uuid", "find", "logical_router_port", "name="+dgpName)
+	if err != nil {
+		return fmt.Errorf("error executing find logical_router_port for distributed GW port, stderr: %q, %+v", stderr, err)
 	}
-	nbctlArgs = append(nbctlArgs,
-		"--may-exist", "lrp-add", types.OVNClusterRouter, dgpName, dgpMac,
-	)
-	if config.IPv4Mode && config.IPv6Mode {
-		nbctlArgs = append(nbctlArgs,
-			fmt.Sprintf("%s/%d", types.V4NodeLocalDistributedGWPortIP, types.V4NodeLocalNATSubnetPrefix),
-			fmt.Sprintf("%s/%d", types.V6NodeLocalDistributedGWPortIP, types.V6NodeLocalNATSubnetPrefix),
-		)
-	} else if config.IPv4Mode {
-		nbctlArgs = append(nbctlArgs,
-			fmt.Sprintf("%s/%d", types.V4NodeLocalDistributedGWPortIP, types.V4NodeLocalNATSubnetPrefix),
-		)
-	} else if config.IPv6Mode {
-		nbctlArgs = append(nbctlArgs,
-			fmt.Sprintf("%s/%d", types.V6NodeLocalDistributedGWPortIP, types.V6NodeLocalNATSubnetPrefix),
+
+	// if the port exists convert it to dual-stack if needed
+	// otherwise create a new dual-stack port
+	var nbctlArgs []string
+	if len(dgpUUID) > 0 {
+		klog.V(5).Infof("Distributed GW port already exists with uuid %s", dgpUUID)
+		// update the mac address if necessary
+		currentMac, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+			"get", "logical_router_port", dgpUUID, "mac")
+		if err != nil {
+			return err
+		}
+		if currentMac != dgpMac {
+			_, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+				"set", "logical_router_port", dgpUUID, "mac=\""+dgpMac+"\"")
+			if err != nil {
+				return err
+			}
+			klog.V(5).Infof("Updated mac address of distributed GW port from %s to %s", currentMac, dgpMac)
+		}
+		// update the port networks if necessary
+		currentNetworks, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+			"get", "logical_router_port", dgpUUID, "networks")
+		if err != nil {
+			return err
+		}
+		// only consider converting from single to dual-stack
+		if len(strings.Split(currentNetworks, ",")) != 2 {
+			_, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
+				"set", "logical_router_port", dgpUUID, "networks=\""+dgpNetworkV4+"\",\""+dgpNetworkV6+"\"")
+			if err != nil {
+				return err
+			}
+			klog.V(5).Infof("Updated network addresses of distributed GW port from %s to %s,%s",
+				currentNetworks, dgpNetworkV4, dgpNetworkV6)
+		}
+	} else {
+		nbctlArgs = append(nbctlArgs, "lrp-add",
+			types.OVNClusterRouter, dgpName, dgpMac, dgpNetworkV4, dgpNetworkV6,
 		)
 	}
 	// set gateway chassis (the current master node) for distributed gateway port)
@@ -412,16 +440,8 @@ func addDistributedGWPort() error {
 	var dnatSnatNextHopMac string
 	// Only used for Error Strings
 	var nodeLocalNatSubnetNextHop string
-	if config.IPv4Mode && config.IPv6Mode {
-		dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(types.V4NodeLocalNATSubnetNextHop)).String()
-		nodeLocalNatSubnetNextHop = types.V4NodeLocalNATSubnetNextHop + " " + types.V6NodeLocalNATSubnetNextHop
-	} else if config.IPv4Mode {
-		dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(types.V4NodeLocalNATSubnetNextHop)).String()
-		nodeLocalNatSubnetNextHop = types.V4NodeLocalNATSubnetNextHop
-	} else if config.IPv6Mode {
-		dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(types.V6NodeLocalNATSubnetNextHop)).String()
-		nodeLocalNatSubnetNextHop = types.V6NodeLocalNATSubnetNextHop
-	}
+	dnatSnatNextHopMac = util.IPAddrToHWAddr(net.ParseIP(types.V4NodeLocalNATSubnetNextHop)).String()
+	nodeLocalNatSubnetNextHop = types.V4NodeLocalNATSubnetNextHop + " " + types.V6NodeLocalNATSubnetNextHop
 	stdout, stderr, err = util.RunOVNSbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "MAC_Binding",
 		"logical_port="+dgpName, fmt.Sprintf(`mac="%s"`, dnatSnatNextHopMac))
 	if err != nil {
@@ -447,21 +467,17 @@ func addDistributedGWPort() error {
 			"stdout: %q, stderr: %q, error: %v", types.OVNClusterRouter, datapath, stderr, err)
 	}
 
-	if config.IPv4Mode {
-		_, stderr, err = util.RunOVNSbctl("create", "mac_binding", "datapath="+datapath, "ip="+types.V4NodeLocalNATSubnetNextHop,
-			"logical_port="+dgpName, fmt.Sprintf(`mac="%s"`, dnatSnatNextHopMac))
-		if err != nil {
-			return fmt.Errorf("failed to create a MAC_Binding entry of (%s, %s) for distributed router port %s "+
-				"stderr: %q, error: %v", types.V4NodeLocalNATSubnetNextHop, dnatSnatNextHopMac, dgpName, stderr, err)
-		}
+	_, stderr, err = util.RunOVNSbctl("create", "mac_binding", "datapath="+datapath, "ip="+types.V4NodeLocalNATSubnetNextHop,
+		"logical_port="+dgpName, fmt.Sprintf(`mac="%s"`, dnatSnatNextHopMac))
+	if err != nil {
+		return fmt.Errorf("failed to create a MAC_Binding entry of (%s, %s) for distributed router port %s "+
+			"stderr: %q, error: %v", types.V4NodeLocalNATSubnetNextHop, dnatSnatNextHopMac, dgpName, stderr, err)
 	}
-	if config.IPv6Mode {
-		_, stderr, err = util.RunOVNSbctl("create", "mac_binding", "datapath="+datapath, fmt.Sprintf(`ip="%s"`, types.V6NodeLocalNATSubnetNextHop),
-			"logical_port="+dgpName, fmt.Sprintf(`mac="%s"`, dnatSnatNextHopMac))
-		if err != nil {
-			return fmt.Errorf("failed to create a MAC_Binding entry of (%s, %s) for distributed router port %s "+
-				"stderr: %q, error: %v", types.V6NodeLocalNATSubnetNextHop, dnatSnatNextHopMac, dgpName, stderr, err)
-		}
+	_, stderr, err = util.RunOVNSbctl("create", "mac_binding", "datapath="+datapath, fmt.Sprintf(`ip="%s"`, types.V6NodeLocalNATSubnetNextHop),
+		"logical_port="+dgpName, fmt.Sprintf(`mac="%s"`, dnatSnatNextHopMac))
+	if err != nil {
+		return fmt.Errorf("failed to create a MAC_Binding entry of (%s, %s) for distributed router port %s "+
+			"stderr: %q, error: %v", types.V6NodeLocalNATSubnetNextHop, dnatSnatNextHopMac, dgpName, stderr, err)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -214,9 +214,11 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 
 	// If current DB version is greater than OvnSingleJoinSwitchTopoVersion, no need to upgrade to single switch topology
 	if ver < OvnSingleJoinSwitchTopoVersion {
+		klog.Infof("Upgrading to Single Switch OVN Topology")
 		err = oc.upgradeToSingleSwitchOVNTopology(existingNodes)
 	}
 	if err == nil && ver < OvnNamespacedDenyPGTopoVersion {
+		klog.Infof("Upgrading to Namespace Deny PortGroup OVN Topology")
 		err = oc.upgradeToNamespacedDenyPGOVNTopology(existingNodes)
 	}
 	return err
@@ -231,6 +233,7 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 // TODO: Verify that the cluster was not already called with a different global subnet
 //  If true, then either quit or perform a complete reconfiguration of the cluster (recreate switches/routers with new subnet values)
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
+	klog.Infof("Starting cluster master")
 	// The gateway router need to be connected to the distributed router via a per-node join switch.
 	// We need a subnet allocator that allocates subnet for this per-node join switch.
 	if config.IPv4Mode {
@@ -255,24 +258,26 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		klog.Errorf("Error in fetching nodes: %v", err)
 		return err
 	}
-
+	klog.V(5).Infof("Existing number of nodes: %d", len(existingNodes.Items))
 	err = oc.upgradeOVNTopology(existingNodes)
 	if err != nil {
 		klog.Errorf("Failed to upgrade OVN topology to version %d: %v", OvnCurrentTopologyVersion, err)
 		return err
 	}
 
+	klog.Infof("Allocating subnets")
 	var v4HostSubnetCount, v6HostSubnetCount float64
-
 	for _, clusterEntry := range config.Default.ClusterSubnets {
 		err := oc.masterSubnetAllocator.AddNetworkRange(clusterEntry.CIDR, clusterEntry.HostSubnetLength)
 		if err != nil {
 			return err
 		}
+		klog.V(5).Infof("Added network range %s to the allocator", clusterEntry.CIDR)
 		util.CalculateHostSubnetsForClusterEntry(clusterEntry, &v4HostSubnetCount, &v6HostSubnetCount)
 	}
 	for _, node := range existingNodes.Items {
 		hostSubnets, _ := util.ParseNodeHostSubnetAnnotation(&node)
+		klog.V(5).Infof("Node %s contains subnets: %v", node.Name, hostSubnets)
 		for _, hostSubnet := range hostSubnets {
 			err := oc.masterSubnetAllocator.MarkAllocatedNetwork(hostSubnet)
 			if err != nil {
@@ -281,6 +286,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 			util.UpdateUsedHostSubnetsCount(hostSubnet, &oc.v4HostSubnetsUsed, &oc.v6HostSubnetsUsed, true)
 		}
 		nodeLocalNatIPs, _ := util.ParseNodeLocalNatIPAnnotation(&node)
+		klog.V(5).Infof("Node %s contains local NAT IPs: %v", node.Name, nodeLocalNatIPs)
 		for _, nodeLocalNatIP := range nodeLocalNatIPs {
 			var err error
 			if utilnet.IsIPv6(nodeLocalNatIP) {
@@ -842,31 +848,133 @@ func (oc *Controller) addNodeAnnotations(node *kapi.Node, hostSubnets []*net.IPN
 	return nil
 }
 
+func (oc *Controller) allocateNodeSubnets(node *kapi.Node) ([]*net.IPNet, []*net.IPNet, error) {
+	hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node)
+	if err != nil {
+		// Log the error and try to allocate new subnets
+		klog.Infof("Failed to get node %s host subnets annotations: %v", node.Name, err)
+	}
+	allocatedSubnets := []*net.IPNet{}
+
+	// OVN can work in single-stack or dual-stack only.
+	currentHostSubnets := len(hostSubnets)
+	expectedHostSubnets := 1
+	// if dual-stack mode we expect one subnet per each IP family
+	if config.IPv4Mode && config.IPv6Mode {
+		expectedHostSubnets = 2
+	}
+
+	// node already has the expected subnets annotated
+	// assume IP families match, i.e. no IPv6 config and node annotation IPv4
+	if expectedHostSubnets == currentHostSubnets {
+		klog.Infof("Allocated Subnets %v on Node %s", hostSubnets, node.Name)
+		return hostSubnets, allocatedSubnets, nil
+	}
+
+	// Node doesn't have the expected subnets annotated
+	// it may happen it has more subnets assigned that configured in OVN
+	// like in a dual-stack to single-stack conversion
+	// or that it needs to allocate new subnet because it is a new node
+	// or has been converted from single-stack to dual-stack
+	klog.Infof("Expected %d subnets on node %s, found %d: %v",
+		expectedHostSubnets, node.Name, currentHostSubnets, hostSubnets)
+	// release unexpected subnets
+	// filter in place slice
+	// https://github.com/golang/go/wiki/SliceTricks#filter-in-place
+	foundIPv4 := false
+	foundIPv6 := false
+	n := 0
+	for _, subnet := range hostSubnets {
+		// if the subnet is not going to be reused release it
+		if config.IPv4Mode && utilnet.IsIPv4CIDR(subnet) && !foundIPv4 {
+			klog.V(5).Infof("Valid IPv4 allocated subnet %v on node %s", subnet, node.Name)
+			hostSubnets[n] = subnet
+			n++
+			foundIPv4 = true
+			continue
+		}
+		if config.IPv6Mode && utilnet.IsIPv6CIDR(subnet) && !foundIPv6 {
+			klog.V(5).Infof("Valid IPv6 allocated subnet %v on node %s", subnet, node.Name)
+			hostSubnets[n] = subnet
+			n++
+			foundIPv6 = true
+			continue
+		}
+		// this subnet is no longer needed
+		klog.V(5).Infof("Releasing subnet %v on node %s", subnet, node.Name)
+		err = oc.masterSubnetAllocator.ReleaseNetwork(subnet)
+		if err != nil {
+			klog.Warningf("Error releasing subnet %v on node %s", subnet, node.Name)
+		}
+	}
+	// recreate hostSubnets with the valid subnets
+	hostSubnets = hostSubnets[:n]
+	// allocate new subnets if needed
+	if config.IPv4Mode && !foundIPv4 {
+		allocatedHostSubnet, err := oc.masterSubnetAllocator.AllocateIPv4Network()
+		if err != nil {
+			return nil, nil, fmt.Errorf("error allocating network for node %s: %v", node.Name, err)
+		}
+		// the allocator returns nil if it can't provide a subnet
+		// we should filter them out or they will be appended to the slice
+		if allocatedHostSubnet != nil {
+			klog.V(5).Infof("Allocating subnet %v on node %s", allocatedHostSubnet, node.Name)
+			allocatedSubnets = append(allocatedSubnets, allocatedHostSubnet)
+			// Release the allocation on error
+			defer func() {
+				if err != nil {
+					klog.Warningf("Releasing subnet %v on node %s: %v", allocatedHostSubnet, node.Name, err)
+					errR := oc.masterSubnetAllocator.ReleaseNetwork(allocatedHostSubnet)
+					if errR != nil {
+						klog.Warningf("Error releasing subnet %v on node %s", allocatedHostSubnet, node.Name)
+					}
+				}
+			}()
+		}
+	}
+	if config.IPv6Mode && !foundIPv6 {
+		allocatedHostSubnet, err := oc.masterSubnetAllocator.AllocateIPv6Network()
+		if err != nil {
+			return nil, nil, fmt.Errorf("error allocating network for node %s: %v", node.Name, err)
+		}
+		// the allocator returns nil if it can't provide a subnet
+		// we should filter them out or they will be appended to the slice
+		if allocatedHostSubnet != nil {
+			klog.V(5).Infof("Allocating subnet %v on node %s", allocatedHostSubnet, node.Name)
+			allocatedSubnets = append(allocatedSubnets, allocatedHostSubnet)
+		}
+	}
+	// check if we were able to allocate the new subnets require
+	// this can only happen if OVN is not configured correctly
+	// so it will require a reconfiguration and restart.
+	wantedSubnets := expectedHostSubnets - currentHostSubnets
+	if wantedSubnets > 0 && len(allocatedSubnets) != wantedSubnets {
+		return nil, nil, fmt.Errorf("error allocating networks for node %s: %d subnets expected only new %d subnets allocated",
+			node.Name, expectedHostSubnets, len(allocatedSubnets))
+	}
+	hostSubnets = append(hostSubnets, allocatedSubnets...)
+	klog.Infof("Allocated Subnets %v on Node %s", hostSubnets, node.Name)
+	return hostSubnets, allocatedSubnets, nil
+}
+
 func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 	oc.clearInitialNodeNetworkUnavailableCondition(node, nil)
-
-	hostSubnets, _ := util.ParseNodeHostSubnetAnnotation(node)
-	if hostSubnets != nil {
-		// Node already has subnet assigned; ensure its logical network is set up
-		return hostSubnets, oc.ensureNodeLogicalNetwork(node.Name, hostSubnets)
-	}
-
-	// Node doesn't have a subnet assigned; reserve a new one for it
-	hostSubnets, err := oc.masterSubnetAllocator.AllocateNetworks()
+	hostSubnets, allocatedSubnets, err := oc.allocateNodeSubnets(node)
 	if err != nil {
-		return nil, fmt.Errorf("error allocating network for node %s: %v", node.Name, err)
+		return nil, err
 	}
-	klog.Infof("Allocated node %s HostSubnet %s", node.Name, util.JoinIPNets(hostSubnets, ","))
-
+	// Release the allocation on error
 	defer func() {
-		// Release the allocation on error
 		if err != nil {
-			for _, hostSubnet := range hostSubnets {
-				_ = oc.masterSubnetAllocator.ReleaseNetwork(hostSubnet)
+			for _, allocatedSubnet := range allocatedSubnets {
+				klog.Warningf("Releasing subnet %v on node %s: %v", allocatedSubnet, node.Name, err)
+				errR := oc.masterSubnetAllocator.ReleaseNetwork(allocatedSubnet)
+				if errR != nil {
+					klog.Warningf("Error releasing subnet %v on node %s", allocatedSubnet, node.Name)
+				}
 			}
 		}
 	}()
-
 	// Ensure that the node's logical network has been created
 	err = oc.ensureNodeLogicalNetwork(node.Name, hostSubnets)
 	if err != nil {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -4,20 +4,16 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
+	"testing"
 
 	goovn "github.com/ebay/go-ovn"
-	"github.com/urfave/cli/v2"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/record"
-
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
 	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
-	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
@@ -25,9 +21,13 @@ import (
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	"github.com/urfave/cli/v2"
+	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 )
 
 // Please use following subnets for various networks that we have
@@ -1227,3 +1227,263 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })
+
+func TestController_allocateNodeSubnets(t *testing.T) {
+	tests := []struct {
+		name          string
+		networkRanges []string
+		networkLen    int
+		configIPv4    bool
+		configIPv6    bool
+		node          *kapi.Node
+		// to be converted during the test to []*net.IPNet
+		wantStr   []string
+		allocated int
+		wantErr   bool
+	}{
+		{
+			name:          "new node, IPv4 only cluster",
+			networkRanges: []string{"172.16.0.0/16"},
+			networkLen:    24,
+			configIPv4:    true,
+			configIPv6:    false,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testnode",
+					Annotations: map[string]string{},
+				},
+			},
+			wantStr:   []string{"172.16.0.0/24"},
+			allocated: 1,
+			wantErr:   false,
+		},
+		{
+			name:          "new node, IPv6 only cluster",
+			networkRanges: []string{"2001:db2::/56"},
+			networkLen:    64,
+			configIPv4:    false,
+			configIPv6:    true,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testnode",
+					Annotations: map[string]string{},
+				},
+			},
+			wantStr:   []string{"2001:db2::/64"},
+			allocated: 1,
+			wantErr:   false,
+		},
+		{
+			name:          "existing annotated node, IPv4 only cluster",
+			networkRanges: []string{"172.16.0.0/16"},
+			networkLen:    24,
+			configIPv4:    true,
+			configIPv6:    false,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default": "172.16.8.0/24"}`,
+					},
+				},
+			},
+			wantStr:   []string{"172.16.8.0/24"},
+			allocated: 0,
+			wantErr:   false,
+		},
+		{
+			name:          "existing annotated node, IPv6 only cluster",
+			networkRanges: []string{"2001:db2::/56"},
+			networkLen:    64,
+			configIPv4:    false,
+			configIPv6:    true,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default": "2001:db2:1:2:3:4::/64"}`,
+					}},
+			},
+			wantStr:   []string{"2001:db2:1:2:3:4::/64"},
+			allocated: 0,
+			wantErr:   false,
+		},
+		{
+			name:          "new node, dual stack cluster",
+			networkRanges: []string{"172.16.0.0/16", "2000::/12"},
+			networkLen:    24,
+			configIPv4:    true,
+			configIPv6:    true,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testnode",
+					Annotations: map[string]string{},
+				},
+			},
+			wantStr:   []string{"172.16.0.0/24", "2000::/24"},
+			allocated: 2,
+			wantErr:   false,
+		},
+		{
+			name:          "annotated node, dual stack cluster",
+			networkRanges: []string{"172.16.0.0/16", "2000::/12"},
+			networkLen:    24,
+			configIPv4:    true,
+			configIPv6:    true,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default": ["172.16.5.0/24","2000:2::/24"]}`,
+					},
+				},
+			},
+			wantStr:   []string{"172.16.5.0/24", "2000:2::/24"},
+			allocated: 0,
+			wantErr:   false,
+		},
+		{
+			name:          "single IPv4 to dual stack cluster",
+			networkRanges: []string{"172.16.0.0/16", "2000::/12"},
+			networkLen:    24,
+			configIPv4:    true,
+			configIPv6:    true,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default": "172.16.5.0/24"}`,
+					},
+				},
+			},
+			wantStr:   []string{"172.16.5.0/24", "2000::/24"},
+			allocated: 1,
+			wantErr:   false,
+		},
+		{
+			name:          "single IPv6 to dual stack cluster",
+			networkRanges: []string{"172.16.0.0/16", "2000:1::/12"},
+			networkLen:    24,
+			configIPv4:    true,
+			configIPv6:    true,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default": "2000:1::/24"}`,
+					},
+				},
+			},
+			wantStr:   []string{"2000::/24", "172.16.0.0/24"},
+			allocated: 1,
+			wantErr:   false,
+		},
+		{
+			name:          "dual stack cluster to single IPv4",
+			networkRanges: []string{"172.16.0.0/16"},
+			networkLen:    24,
+			configIPv4:    true,
+			configIPv6:    false,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default": ["172.16.5.0/24","2000:2::/24"]}`,
+					},
+				},
+			},
+			wantStr:   []string{"172.16.5.0/24"},
+			allocated: 0,
+			wantErr:   false,
+		},
+		{
+			name:          "dual stack cluster to single IPv6",
+			networkRanges: []string{"2001:db2::/56"},
+			networkLen:    64,
+			configIPv4:    false,
+			configIPv6:    true,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": `{"default": ["172.16.5.0/24","2001:db2:1:2:3:4::/64"]}`,
+					},
+				},
+			},
+			wantStr:   []string{"2001:db2:1:2:3:4::/64"},
+			allocated: 0,
+			wantErr:   false,
+		},
+		{
+			name:          "new node, OVN wrong configuration: IPv4 only cluster but IPv6 range",
+			networkRanges: []string{"2001:db2::/64"},
+			networkLen:    112,
+			configIPv4:    true,
+			configIPv6:    false,
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testnode",
+					Annotations: map[string]string{},
+				},
+			},
+			wantStr:   nil,
+			allocated: 0,
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create cluster config
+			config.IPv4Mode = tt.configIPv4
+			config.IPv6Mode = tt.configIPv6
+			// create fake OVN controller
+			stopChan := make(chan struct{})
+			defer close(stopChan)
+			kubeFakeClient := fake.NewSimpleClientset()
+			egressFirewallFakeClient := &egressfirewallfake.Clientset{}
+			crdFakeClient := &apiextensionsfake.Clientset{}
+			egressIPFakeClient := &egressipfake.Clientset{}
+			fakeClient := &util.OVNClientset{
+				KubeClient:           kubeFakeClient,
+				EgressIPClient:       egressIPFakeClient,
+				EgressFirewallClient: egressFirewallFakeClient,
+				APIExtensionsClient:  crdFakeClient,
+			}
+			f, err := factory.NewMasterWatchFactory(fakeClient)
+			clusterController := NewOvnController(fakeClient, f, stopChan,
+				addressset.NewFakeAddressSetFactory(), ovntest.NewMockOVNClient(goovn.DBNB),
+				ovntest.NewMockOVNClient(goovn.DBSB), record.NewFakeRecorder(0))
+
+			// configure the cluster allocators
+			for _, subnetString := range tt.networkRanges {
+				_, subnet, err := net.ParseCIDR(subnetString)
+				if err != nil {
+					t.Fatalf("Error parsing subnet %s", subnetString)
+				}
+				clusterController.masterSubnetAllocator.AddNetworkRange(subnet, tt.networkLen)
+			}
+			// test network allocation works correctly
+			got, allocated, err := clusterController.allocateNodeSubnets(tt.node)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Controller.addNode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			var want []*net.IPNet
+			for _, netStr := range tt.wantStr {
+				_, ipnet, err := net.ParseCIDR(netStr)
+				if err != nil {
+					t.Fatalf("Error parsing subnet %s", netStr)
+				}
+				want = append(want, ipnet)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("Controller.allocateNodeSubnets() = %v, want %v", got, want)
+			}
+
+			if len(allocated) != tt.allocated {
+				t.Errorf("Expected %d subnets allocated, received %d", tt.allocated, len(allocated))
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -778,8 +778,9 @@ func addPBRandNATRules(fexec *ovntest.FakeExec, nodeName, nodeSubnet, nodeIP, mg
 		"ovn-nbctl --timeout=15 lr-policy-add " + types.OVNClusterRouter + " " + types.MGMTPortPolicyPriority + " " + matchStr2 + " reroute " + types.V4NodeLocalNATSubnetNextHop,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + types.OVNClusterRouter + " dnat_and_snat " +
-			externalIP + " -- lr-nat-add " + types.OVNClusterRouter + " dnat_and_snat " +
+		"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + types.OVNClusterRouter + " dnat_and_snat " + externalIP})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 lr-nat-add " + types.OVNClusterRouter + " dnat_and_snat " +
 			externalIP + " " + mgmtPortIP + " " + types.K8sPrefix + nodeName + " " + mgmtPortMAC,
 	})
 }

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -17,6 +17,7 @@ Disruptive
 # FEATURES NOT AVAILABLE IN OUR CI ENVIRONMENT
 \[Feature:Federation\]
 should have ipv4 and ipv6 internal node ip
+should have ipv4 and ipv6 node podCIDRs
 
 # TESTS THAT ASSUME KUBE-PROXY
 kube-proxy


### PR DESCRIPTION
Fix several issues while converting an OVN IPv4 single stack deployment to dual stack.

It does an scripted conversion from single to dual stack:
- updates kubernetes components to enable the dualstack feature
- updates kubernetes components with secondary cidrs
- updates ovn config with secondary cidrs
- restart ovnkube-master and ovnkube-nodes to pick the new config

To run it just create the single stack cluster with `kind.sh` and once it finish run this new script.

Added 2 presubmit jobs that test the conversion.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
