### PR TITLE
Use go-ovn bindings for port group commands

### DIFF
--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -2,7 +2,7 @@ package ovn
 
 import (
 	"fmt"
-
+	goovn "github.com/ebay/go-ovn"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/klog/v2"
 )
@@ -12,54 +12,39 @@ func hashedPortGroup(s string) string {
 	return util.HashForOVN(s)
 }
 
-func createPortGroup(name string, hashName string) (string, error) {
+func createPortGroup(ovnNBClient goovn.Client, name string, hashName string) (string, error) {
 	klog.V(5).Infof("createPortGroup with %s", name)
-	portGroup, stderr, err := util.RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=_uuid", "find", "port_group",
-		fmt.Sprintf("name=%s", hashName))
-	if err != nil {
-		return "", fmt.Errorf("find failed to get port_group, stderr: %q (%v)",
-			stderr, err)
+	externalIds := map[string]string{"name": name}
+	cmd, err := ovnNBClient.PortGroupAdd(hashName, nil, externalIds)
+	if err == nil {
+		if err = ovnNBClient.Execute(cmd); err != nil {
+			return "", fmt.Errorf("execute error for add port group: %s, %v", name, err)
+		}
+	} else if err != goovn.ErrorExist {
+		// Ignore goovn.ErrorExist to implement "--may-exist" behavior
+		return "", fmt.Errorf("add error for port group: %s, %v", name, err)
 	}
 
-	if portGroup != "" {
-		return portGroup, nil
+	pg, err := ovnNBClient.PortGroupGet(hashName)
+	if err == nil {
+		return pg.UUID, nil
+	} else {
+		return "", fmt.Errorf("failed to get port group UUID: %s, %v", name, err)
 	}
-
-	portGroup, stderr, err = util.RunOVNNbctl("create", "port_group",
-		fmt.Sprintf("name=%s", hashName),
-		fmt.Sprintf("external-ids:name=%s", name))
-	if err != nil {
-		return "", fmt.Errorf("failed to create port_group %s, "+
-			"stderr: %q (%v)", name, stderr, err)
-	}
-
-	return portGroup, nil
 }
 
-func deletePortGroup(hashName string) {
+func deletePortGroup(ovnNBClient goovn.Client, hashName string) error {
 	klog.V(5).Infof("deletePortGroup %s", hashName)
-
-	portGroup, stderr, err := util.RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=_uuid", "find", "port_group",
-		fmt.Sprintf("name=%s", hashName))
-	if err != nil {
-		klog.Errorf("Find failed to get port_group, stderr: %q (%v)",
-			stderr, err)
-		return
+	cmd, err := ovnNBClient.PortGroupDel(hashName)
+	if err == nil {
+		if err = ovnNBClient.Execute(cmd); err != nil {
+			return fmt.Errorf("execute error for delete port group: %s, %v", hashName, err)
+		}
+	} else if err != goovn.ErrorNotFound {
+		// Ignore goovn.ErrorNotFound to implement "--if-exist" behavior
+		return fmt.Errorf("delete error for port group: %s, %v", hashName, err)
 	}
-
-	if portGroup == "" {
-		return
-	}
-
-	_, stderr, err = util.RunOVNNbctl("--if-exists", "destroy",
-		"port_group", portGroup)
-	if err != nil {
-		klog.Errorf("Failed to destroy port_group %s, stderr: %q, (%v)",
-			hashName, stderr, err)
-		return
-	}
+	return nil
 }
 
 func stringSliceMembership(slice []string, key string) bool {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -139,10 +139,6 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	}
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 -- set logical_router ovn_cluster_router options:mcast_relay=\"true\"",
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=clusterPortGroup",
-		"ovn-nbctl --timeout=15 create port_group name=clusterPortGroup external-ids:name=clusterPortGroup",
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find port_group name=clusterRtrPortGroup",
-		"ovn-nbctl --timeout=15 create port_group name=clusterRtrPortGroup external-ids:name=clusterRtrPortGroup",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Egress",
 		"ovn-nbctl --timeout=15 --id=@acl create acl priority=" + types.DefaultMcastDenyPriority + " direction=" + types.DirectionFromLPort + " log=false match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Egress -- add port_group  acls @acl",
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")\" action=drop external-ids:default-deny-policy-type=Ingress",
@@ -214,7 +210,6 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	})
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove port_group clusterRtrPortGroup ports " + fakeUUID + " -- add port_group clusterRtrPortGroup ports " + fakeUUID,
 		"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 		"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 	})
@@ -229,9 +224,6 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + types.K8sPrefix + nodeName + " _uuid",
 		Output: fakeUUID + "\n",
-	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove port_group clusterPortGroup ports " + fakeUUID + " -- add port_group clusterPortGroup ports " + fakeUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 lsp-list " + nodeName,
@@ -693,9 +685,6 @@ subnet=%s
 				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + types.K8sPrefix + masterName + " _uuid",
 				Output: fakeUUID + "\n",
 			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --if-exists remove port_group clusterPortGroup ports " + fakeUUID + " -- add port_group clusterPortGroup ports " + fakeUUID,
-			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 lsp-list " + masterName,
 				Output: "29df5ce5-2802-4ee5-891f-4fb27ca776e9 (" + types.K8sPrefix + masterName + ")",
@@ -917,9 +906,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + types.K8sPrefix + nodeName + " _uuid",
 				Output: fakeUUID + "\n",
 			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --if-exists remove port_group clusterPortGroup ports " + fakeUUID + " -- add port_group clusterPortGroup ports " + fakeUUID,
-			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 lsp-list " + nodeName,
 				Output: "29df5ce5-2802-4ee5-891f-4fb27ca776e9 (" + types.K8sPrefix + nodeName + ")",
@@ -1114,7 +1100,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			})
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --if-exists remove port_group clusterRtrPortGroup ports " + fakeUUID + " -- add port_group clusterRtrPortGroup ports " + fakeUUID,
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
@@ -1123,9 +1108,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + types.K8sPrefix + nodeName + " _uuid",
 				Output: fakeUUID + "\n",
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --timeout=15 --if-exists remove port_group clusterPortGroup ports " + fakeUUID + " -- add port_group clusterPortGroup ports " + fakeUUID,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 lsp-list " + nodeName,
@@ -1224,6 +1206,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			_, _ = clusterController.joinSwIPManager.ensureJoinLRPIPs(types.OVNClusterRouter)
 
 			clusterController.nodeLocalNatIPv4Allocator, _ = ipallocator.NewCIDRRange(ovntest.MustParseIPNet(types.V4NodeLocalNATSubnet))
+
+			// clusterController.WatchNodes() needs to following two port groups to have been created.
+			clusterController.clusterRtrPortGroupUUID, err = createPortGroup(clusterController.ovnNBClient, clusterRtrPortGroupName, clusterRtrPortGroupName)
+			clusterController.clusterPortGroupUUID, err = createPortGroup(clusterController.ovnNBClient, clusterPortGroupName, clusterPortGroupName)
 
 			// Let the real code run and ensure OVN database sync
 			clusterController.WatchNodes()

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -10,6 +10,7 @@ import (
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	goovn "github.com/ebay/go-ovn"
 	kapi "k8s.io/api/core/v1"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -71,7 +72,7 @@ func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
 	// If multicast is allowed and enabled for the namespace, add the port
 	// to the allow policy.
 	if oc.multicastSupport && nsInfo.multicastEnabled {
-		if err := podAddAllowMulticastPolicy(ns, portInfo); err != nil {
+		if err := podAddAllowMulticastPolicy(oc.ovnNBClient, ns, portInfo); err != nil {
 			return err
 		}
 	}
@@ -94,7 +95,7 @@ func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) error 
 
 	// Remove the port from the multicast allow policy.
 	if oc.multicastSupport && nsInfo.multicastEnabled {
-		if err := podDeleteAllowMulticastPolicy(ns, portInfo); err != nil {
+		if err := podDeleteAllowMulticastPolicy(oc.ovnNBClient, ns, portInfo); err != nil {
 			return err
 		}
 	}
@@ -130,7 +131,7 @@ func (oc *Controller) multicastUpdateNamespace(ns *kapi.Namespace, nsInfo *names
 	if enabled {
 		err = oc.createMulticastAllowPolicy(ns.Name, nsInfo)
 	} else {
-		err = deleteMulticastAllowPolicy(ns.Name, nsInfo)
+		err = deleteMulticastAllowPolicy(oc.ovnNBClient, ns.Name, nsInfo)
 	}
 	if err != nil {
 		klog.Errorf(err.Error())
@@ -143,7 +144,7 @@ func (oc *Controller) multicastUpdateNamespace(ns *kapi.Namespace, nsInfo *names
 func (oc *Controller) multicastDeleteNamespace(ns *kapi.Namespace, nsInfo *namespaceInfo) {
 	if nsInfo.multicastEnabled {
 		nsInfo.multicastEnabled = false
-		if err := deleteMulticastAllowPolicy(ns.Name, nsInfo); err != nil {
+		if err := deleteMulticastAllowPolicy(oc.ovnNBClient, ns.Name, nsInfo); err != nil {
 			klog.Errorf(err.Error())
 		}
 	}
@@ -153,7 +154,7 @@ func (oc *Controller) multicastDeleteNamespace(ns *kapi.Namespace, nsInfo *names
 // that apply network configuration to all pods in a namespace will use the same port group.
 // This function ensures that the namespace wide port group will only be created once and
 // cleaned up when no object that relies on it exists.
-func (nsInfo *namespaceInfo) updateNamespacePortGroup(ns string) error {
+func (nsInfo *namespaceInfo) updateNamespacePortGroup(ovnNBClient goovn.Client, ns string) error {
 	if nsInfo.multicastEnabled {
 		if nsInfo.portGroupUUID != "" {
 			// Multicast is enabled and the port group exists so there is nothing to do.
@@ -161,13 +162,16 @@ func (nsInfo *namespaceInfo) updateNamespacePortGroup(ns string) error {
 		}
 
 		// The port group should exist but doesn't so create it
-		portGroupUUID, err := createPortGroup(ns, hashedPortGroup(ns))
+		portGroupUUID, err := createPortGroup(ovnNBClient, ns, hashedPortGroup(ns))
 		if err != nil {
 			return fmt.Errorf("failed to create port_group for %s (%v)", ns, err)
 		}
 		nsInfo.portGroupUUID = portGroupUUID
 	} else {
-		deletePortGroup(hashedPortGroup(ns))
+		err := deletePortGroup(ovnNBClient, hashedPortGroup(ns))
+		if err != nil {
+			klog.Errorf("%v", err)
+		}
 		nsInfo.portGroupUUID = ""
 	}
 	return nil

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -108,8 +108,10 @@ type namespaceInfo struct {
 	aclLogging ACLLoggingLevels
 
 	// Per-namespace port group default deny UUIDs
-	portGroupIngressDenyUUID string // Port group for ingress deny rule
-	portGroupEgressDenyUUID  string // Port group for egress deny rule
+	portGroupIngressDenyUUID string // Port group UUID for ingress deny rule
+	portGroupIngressDenyName string // Port group Name for ingress deny rule
+	portGroupEgressDenyUUID  string // Port group UUID for egress deny rule
+	portGroupEgressDenyName  string // Port group Name for egress deny rule
 }
 
 // Controller structure is the object which holds the controls for starting

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -30,7 +30,8 @@ const (
 	k8sIdlingSCTPLoadBalancerIP = "k8s_sctp_idling_load_balancer"
 	fakeUUID                    = "8a86f6d8-7972-4253-b0bd-ddbef66e9303"
 	fakeUUIDv6                  = "8a86f6d8-7972-4253-b0bd-ddbef66e9304"
-	ovnClusterPortGroupUUID     = "740515f3-7ece-4cd1-9be5-6fdb9066d198"
+	fakePgUUID                  = "bf02f460-5058-4689-8fcb-d31a1e484ed2"
+	ovnClusterPortGroupUUID     = fakePgUUID
 )
 
 type FakeOVN struct {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -145,10 +145,6 @@ func (p pod) addCmds(fexec *ovntest.FakeExec, fail bool) {
 			Cmd:    "ovn-nbctl --timeout=15 get logical_switch_port " + p.portName + " _uuid",
 			Output: fakeUUID + "\n",
 		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID + " -- add port_group mcastPortGroupDeny ports " + fakeUUID,
-		})
-
 	} else {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --if-exists get logical_switch_port" + " " + p.portName + " dynamic_addresses addresses",

--- a/go-controller/pkg/ovn/port_group_unit_test.go
+++ b/go-controller/pkg/ovn/port_group_unit_test.go
@@ -1,0 +1,368 @@
+package ovn
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	goovn_mock "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/ebay/go-ovn"
+
+	goovn "github.com/ebay/go-ovn"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	pgName     = "TestPortGroupName"
+	pgHashName = "TestPortGroupHashName"
+	pgUUUID    = "0d3b392e-15a0-46be-9b37-f9cb0dd4f9ec"
+	lspUUID    = "e72eb0bb-a1ce-45d5-b8a0-3200aed7e5e9"
+	lspName    = "TestLSPName"
+)
+
+var (
+	execError  = errors.New("transaction Failed due to an error")
+	otherError = errors.New("other error")
+)
+
+func TestCreatePortGroup(t *testing.T) {
+	mockGoOvnNBClient := new(goovn_mock.Client)
+
+	tests := []struct {
+		desc                      string
+		name                      string
+		hashName                  string
+		errMatch                  error
+		onRetArgMockGoOvnNBClient []ovntest.TestifyMockHelper
+	}{
+		{
+			desc:     "positive test case",
+			name:     pgName,
+			hashName: pgHashName,
+			errMatch: nil,
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAdd", OnCallMethodArgType: []string{"string", "[]string", "map[string]string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{nil},
+				},
+				{
+					OnCallMethodName: "PortGroupGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.PortGroup{UUID: pgUUUID, Name: pgName}, nil},
+				},
+			},
+		},
+		{
+			desc:     "port group already exists",
+			name:     pgName,
+			hashName: pgHashName,
+			errMatch: nil,
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAdd", OnCallMethodArgType: []string{"string", "[]string", "map[string]string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, goovn.ErrorExist},
+				},
+				{
+					OnCallMethodName: "PortGroupGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.PortGroup{UUID: pgUUUID, Name: pgName}, nil},
+				},
+			},
+		},
+		{
+			desc:     "other PortGroupAdd Error",
+			name:     pgName,
+			hashName: pgHashName,
+			errMatch: fmt.Errorf("add error for port group: %s, %v", pgName, otherError),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAdd", OnCallMethodArgType: []string{"string", "[]string", "map[string]string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, otherError},
+				},
+			},
+		},
+		{
+			desc:     "execute error",
+			name:     pgName,
+			hashName: pgHashName,
+			errMatch: fmt.Errorf("execute error for add port group: %s, %v", pgName, execError),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAdd", OnCallMethodArgType: []string{"string", "[]string", "map[string]string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{execError},
+				},
+			},
+		},
+		{
+			desc:     "PortGroupGet error",
+			name:     pgName,
+			hashName: pgHashName,
+			errMatch: fmt.Errorf("failed to get port group UUID: %s, %v", pgName, otherError),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAdd", OnCallMethodArgType: []string{"string", "[]string", "map[string]string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{nil},
+				},
+				{
+					OnCallMethodName: "PortGroupGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.PortGroup{UUID: pgUUUID, Name: pgName}, otherError},
+				},
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFnList(&mockGoOvnNBClient.Mock, tc.onRetArgMockGoOvnNBClient)
+
+			uuid, err := createPortGroup(mockGoOvnNBClient, tc.name, tc.hashName)
+
+			if tc.errMatch != nil {
+				assert.Contains(t, err.Error(), tc.errMatch.Error())
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, pgUUUID, uuid)
+			}
+			mockGoOvnNBClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDeletePortGroup(t *testing.T) {
+	mockGoOvnNBClient := new(goovn_mock.Client)
+
+	tests := []struct {
+		desc                      string
+		hashName                  string
+		errMatch                  error
+		onRetArgMockGoOvnNBClient []ovntest.TestifyMockHelper
+	}{
+		{
+			desc:     "positive test case",
+			hashName: pgHashName,
+			errMatch: nil,
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupDel", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{nil},
+				},
+			},
+		},
+		{
+			desc:     "port group not found",
+			hashName: pgHashName,
+			errMatch: nil,
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupDel", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, goovn.ErrorNotFound},
+				},
+			},
+		},
+		{
+			desc:     "other PortGroupDel Error",
+			hashName: pgHashName,
+			errMatch: fmt.Errorf("delete error for port group: %s, %v", pgHashName, otherError),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupDel", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, otherError},
+				},
+			},
+		},
+		{
+			desc:     "execute error",
+			hashName: pgHashName,
+			errMatch: fmt.Errorf("execute error for delete port group: %s, %v", pgHashName, execError),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupDel", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{execError},
+				},
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFnList(&mockGoOvnNBClient.Mock, tc.onRetArgMockGoOvnNBClient)
+
+			err := deletePortGroup(mockGoOvnNBClient, tc.hashName)
+
+			if tc.errMatch != nil {
+				assert.Contains(t, err.Error(), tc.errMatch.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+			mockGoOvnNBClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAddToPortGroup(t *testing.T) {
+	mockGoOvnNBClient := new(goovn_mock.Client)
+
+	tests := []struct {
+		desc                      string
+		name                      string
+		portInfo                  *lpInfo
+		errMatch                  error
+		onRetArgMockGoOvnNBClient []ovntest.TestifyMockHelper
+	}{
+		{
+			desc:     "positive test case",
+			name:     pgName,
+			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
+			errMatch: nil,
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{nil},
+				},
+			},
+		},
+		{
+			desc:     "port exists",
+			name:     pgName,
+			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
+			errMatch: nil,
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, goovn.ErrorExist},
+				},
+			},
+		},
+		{
+			desc:     "port group not found",
+			name:     pgName,
+			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
+			errMatch: fmt.Errorf("error adding port %s to port group %s (%v)", lspName, pgName, goovn.ErrorNotFound),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, goovn.ErrorNotFound},
+				},
+			},
+		},
+		{
+			desc:     "other PortGroupAddPort error",
+			name:     pgName,
+			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
+			errMatch: fmt.Errorf("error adding port %s to port group %s (%v)", lspName, pgName, otherError),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, otherError},
+				},
+			},
+		},
+		{
+			desc:     "execute error",
+			name:     pgName,
+			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
+			errMatch: fmt.Errorf("execute error adding port %s to port group %s (%v)", lspName, pgName, execError),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{execError},
+				},
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFnList(&mockGoOvnNBClient.Mock, tc.onRetArgMockGoOvnNBClient)
+
+			err := addToPortGroup(mockGoOvnNBClient, tc.name, tc.portInfo)
+
+			if tc.errMatch != nil {
+				assert.Contains(t, err.Error(), tc.errMatch.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+			mockGoOvnNBClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDeleteFromPortGroup(t *testing.T) {
+	mockGoOvnNBClient := new(goovn_mock.Client)
+
+	tests := []struct {
+		desc                      string
+		name                      string
+		portInfo                  *lpInfo
+		errMatch                  error
+		onRetArgMockGoOvnNBClient []ovntest.TestifyMockHelper
+	}{
+		{
+			desc:     "positive test case",
+			name:     pgName,
+			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
+			errMatch: nil,
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupRemovePort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{nil},
+				},
+			},
+		},
+		{
+			desc:     "port group or port not found",
+			name:     pgName,
+			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
+			errMatch: nil,
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupRemovePort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, goovn.ErrorNotFound},
+				},
+			},
+		},
+		{
+			desc:     "other PortGroupAddPort error",
+			name:     pgName,
+			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
+			errMatch: fmt.Errorf("error removing port %s from port group %s (%v)", lspName, pgName, otherError),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupRemovePort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, otherError},
+				},
+			},
+		},
+		{
+			desc:     "execute error",
+			name:     pgName,
+			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
+			errMatch: fmt.Errorf("execute error removing port %s from port group %s (%v)", lspName, pgName, execError),
+			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName: "PortGroupRemovePort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{execError},
+				},
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			ovntest.ProcessMockFnList(&mockGoOvnNBClient.Mock, tc.onRetArgMockGoOvnNBClient)
+
+			err := deleteFromPortGroup(mockGoOvnNBClient, tc.name, tc.portInfo)
+
+			if tc.errMatch != nil {
+				assert.Contains(t, err.Error(), tc.errMatch.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+			mockGoOvnNBClient.AssertExpectations(t)
+		})
+	}
+}

--- a/go-controller/pkg/testing/mock_ovn.go
+++ b/go-controller/pkg/testing/mock_ovn.go
@@ -18,6 +18,7 @@ const (
 	ChassisType           string = "Chassis"
 	ACLType               string = "ACL"
 	ChassisPrivateType    string = "Chassis_Private"
+	PortGroupType         string = "Port_Group"
 )
 
 const (
@@ -30,6 +31,7 @@ const (
 type UpdateCache struct {
 	FieldType  string
 	FieldValue interface{}
+	UpdateOp   string
 }
 
 // object cache for mock ovn client
@@ -80,7 +82,20 @@ func NewMockOVNClient(db string) *MockOVNClient {
 	mock.cache[LogicalSwitchType] = make(MockObjectCacheByName)
 	mock.cache[ChassisPrivateType] = make(MockObjectCacheByName)
 	mock.cache[LogicalRouterType] = make(MockObjectCacheByName)
+	mock.cache[ACLType] = make(MockObjectCacheByName)
+	mock.cache[PortGroupType] = make(MockObjectCacheByName)
 	return mock
+}
+
+// Debug function used to dump the mock cache
+func PrintCache(client *MockOVNClient) {
+	fmt.Printf("MockOVNClient cache:\n")
+	for k1, v1 := range client.cache {
+		fmt.Printf("  %+v cache:\n", k1)
+		for k2, v2 := range v1 {
+			fmt.Printf("    %+v : %+v\n", k2, v2)
+		}
+	}
 }
 
 func functionName() string {
@@ -99,6 +114,31 @@ func functionName() string {
 func (mock *MockOVNClient) Close() error {
 	mock.connected = false
 	return nil
+}
+
+type mockExecutionCount struct {
+	count int
+	mutex sync.Mutex
+}
+
+var mockExecutionCounter mockExecutionCount
+
+func GetNumMockExecutions() int {
+	mockExecutionCounter.mutex.Lock()
+	defer mockExecutionCounter.mutex.Unlock()
+	return mockExecutionCounter.count
+}
+
+func ResetNumMockExecutions() {
+	mockExecutionCounter.mutex.Lock()
+	defer mockExecutionCounter.mutex.Unlock()
+	mockExecutionCounter.count = 0
+}
+
+func incNumMockExecutions() {
+	mockExecutionCounter.mutex.Lock()
+	defer mockExecutionCounter.mutex.Unlock()
+	mockExecutionCounter.count++
 }
 
 func (mock *MockOVNClient) ExecuteMockCommand(e *MockExecution) error {
@@ -133,6 +173,7 @@ func (mock *MockOVNClient) ExecuteMockCommand(e *MockExecution) error {
 	default:
 		return fmt.Errorf("invalid command op: %s", e.op)
 	}
+	incNumMockExecutions()
 	return nil
 }
 
@@ -172,6 +213,8 @@ func (mock *MockOVNClient) updateCache(table string, objName string, update Upda
 	switch table {
 	case LogicalSwitchPortType:
 		return mock.updateLSPCache(objName, update, mockCache)
+	case PortGroupType:
+		return mock.updatePortGroupCache(objName, update, mockCache)
 	default:
 		return fmt.Errorf("mock cache updates for %s are not implemented yet", table)
 	}

--- a/go-controller/pkg/testing/mock_portgroup.go
+++ b/go-controller/pkg/testing/mock_portgroup.go
@@ -1,0 +1,191 @@
+package testing
+
+import (
+	"fmt"
+	goovn "github.com/ebay/go-ovn"
+	"k8s.io/klog/v2"
+)
+
+const (
+	PgLSPs     string = "PgLSPField"
+	fakePgUUID string = "bf02f460-5058-4689-8fcb-d31a1e484ed2"
+)
+
+// Creates a new port group in the Port_Group table named "group" with optional "ports"  and "external_ids".
+func (mock *MockOVNClient) PortGroupAdd(group string, ports []string, external_ids map[string]string) (*goovn.OvnCommand, error) {
+	if _, err := mock.PortGroupGet(group); err == nil {
+		return nil, goovn.ErrorExist
+	}
+
+	ext_ids := make(map[interface{}]interface{})
+	for k, v := range external_ids {
+		ext_ids[k] = v
+	}
+
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpAdd,
+			table:   PortGroupType,
+			objName: group,
+			obj: &goovn.PortGroup{
+				UUID:       fakePgUUID,
+				Name:       group,
+				Ports:      ports,
+				ACLs:       nil,
+				ExternalID: ext_ids,
+			},
+		},
+	}, nil
+}
+
+// Sets "ports" and/or "external_ids" on the port group named "group". It is an error if group does not exist.
+func (mock *MockOVNClient) PortGroupUpdate(group string, ports []string, external_ids map[string]string) (*goovn.OvnCommand, error) {
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// Add port to port group.
+func (mock *MockOVNClient) PortGroupAddPort(group string, port string) (*goovn.OvnCommand, error) {
+	var pg *goovn.PortGroup
+	if pg, _ = mock.PortGroupGet(group); pg == nil {
+		return nil, goovn.ErrorNotFound
+	}
+
+	// NOTE: to fully mock the real PortGroupAddPort, we should confirm that the port is not already in pg.Ports,
+	// however, since the mock code uses the same UUID for all LSPs, that would happen every time we try to
+	// add more than one port.  Therefore, this check is omitted.
+
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpUpdate,
+			table:   PortGroupType,
+			objName: group,
+			objUpdate: UpdateCache{
+				FieldType:  PgLSPs,
+				FieldValue: port,
+				UpdateOp:   OpAdd,
+			},
+		},
+	}, nil
+}
+
+// Remove port from port group.
+func (mock *MockOVNClient) PortGroupRemovePort(group string, port string) (*goovn.OvnCommand, error) {
+	var pg *goovn.PortGroup
+	if pg, _ = mock.PortGroupGet(group); pg == nil {
+		return nil, goovn.ErrorNotFound
+	}
+
+	if !listContains(pg.Ports, port) {
+		return nil, goovn.ErrorNotFound
+	}
+
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpUpdate,
+			table:   PortGroupType,
+			objName: group,
+			objUpdate: UpdateCache{
+				FieldType:  PgLSPs,
+				FieldValue: port,
+				UpdateOp:   OpDelete,
+			},
+		},
+	}, nil
+}
+
+// Deletes port group "group". It is an error if "group" does not exist.
+func (mock *MockOVNClient) PortGroupDel(group string) (*goovn.OvnCommand, error) {
+	if _, err := mock.PortGroupGet(group); err != nil {
+		return nil, goovn.ErrorNotFound
+	}
+
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpDelete,
+			table:   PortGroupType,
+			objName: group,
+			obj: &goovn.PortGroup{
+				UUID:       fakePgUUID,
+				Name:       group,
+				Ports:      nil,
+				ACLs:       nil,
+				ExternalID: nil,
+			},
+		},
+	}, nil
+}
+
+// Get PortGroup data structure if it exists
+func (mock *MockOVNClient) PortGroupGet(group string) (*goovn.PortGroup, error) {
+	mock.mutex.Lock()
+	defer mock.mutex.Unlock()
+
+	var pgCache MockObjectCacheByName
+	var ok bool
+	if pgCache, ok = mock.cache[PortGroupType]; !ok {
+		klog.V(5).Infof("Cache doesn't have any object of type %s", PortGroupType)
+		return nil, goovn.ErrorSchema
+	}
+	var port interface{}
+	if port, ok = pgCache[group]; !ok {
+		return nil, goovn.ErrorNotFound
+	}
+	if pgRet, ok := port.(*goovn.PortGroup); ok {
+		return pgRet, nil
+	}
+	return nil, fmt.Errorf("invalid object type assertion for %s", PortGroupType)
+}
+
+func listContains(list []string, element string) bool {
+	for _, e := range list {
+		if element == e {
+			return true
+		}
+	}
+	return false
+}
+
+// Remove element if it exists in list. otherwise, has no effect.
+func removeElement(list []string, element string) []string {
+	for i, e := range list {
+		if element == e {
+			list[i] = list[len(list)-1]
+		}
+	}
+	return list[:len(list)-1]
+}
+
+// helper function that applies field updates for a given port group to the mock object cache
+func (mock *MockOVNClient) updatePortGroupCache(pgName string, update UpdateCache, mockCache MockObjectCacheByName) error {
+	var entry interface{}
+	var pg *goovn.PortGroup
+	var ok bool
+
+	if entry, ok = mockCache[pgName]; !ok {
+		return fmt.Errorf("error updating Port Group with name %s, Port Group doesn't exist", pgName)
+	}
+
+	if pg, ok = entry.(*goovn.PortGroup); !ok {
+		panic("type assertion failed for Port Group cache entry")
+	}
+
+	switch update.FieldType {
+	case PgLSPs:
+		switch update.UpdateOp {
+		case OpAdd:
+			pg.Ports = append(pg.Ports, fmt.Sprintf("%v", update.FieldValue))
+		case OpDelete:
+			pg.Ports = removeElement(pg.Ports, fmt.Sprintf("%v", update.FieldValue))
+		default:
+			return fmt.Errorf("unrecognized update op: %s", update.UpdateOp)
+		}
+	default:
+		return fmt.Errorf("unrecognized field type: %s", update.FieldType)
+	}
+
+	return nil
+}

--- a/go-controller/pkg/testing/mock_stubs.go
+++ b/go-controller/pkg/testing/mock_stubs.go
@@ -198,36 +198,6 @@ func (mock *MockOVNClient) SBGlobalGetOptions() (map[string]string, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
 }
 
-// Creates a new port group in the Port_Group table named "group" with optional "ports"  and "external_ids".
-func (mock *MockOVNClient) PortGroupAdd(group string, ports []string, external_ids map[string]string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Sets "ports" and/or "external_ids" on the port group named "group". It is an error if group does not exist.
-func (mock *MockOVNClient) PortGroupUpdate(group string, ports []string, external_ids map[string]string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Add port to port group.
-func (mock *MockOVNClient) PortGroupAddPort(group string, port string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Remove port from port group.
-func (mock *MockOVNClient) PortGroupRemovePort(group string, port string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Deletes port group "group". It is an error if "group" does not exist.
-func (mock *MockOVNClient) PortGroupDel(group string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Get PortGroup data structure if it exists
-func (mock *MockOVNClient) PortGroupGet(group string) (*goovn.PortGroup, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
 // Get ovn-db schema
 func (mock *MockOVNClient) GetSchema() libovsdb.DatabaseSchema {
 	var dbSchema libovsdb.DatabaseSchema


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

This is part of an effort to use go-ovn bindings instead of RunOVNNbctl commands.

- Modified functions to add/delete port groups, and add/remove ports from port groups to use go-ovn instead of RunOVNNbctl
- Updated existing code to use these functions instead of RunOVNNbctl for port group operations.
- Implemented mocks for new commands.
- Updated integration/unit test cases to work with go-ovn-based code.
- Add new unit tests for port group functions.



**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

This was verified as follows:
- Running e2e policy test cases
- Excuting ginkgo-based integration test cases
- New unit test cases.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->