### PR TITLE
don't run disruptive tests on CI

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -9,9 +9,10 @@ groomTestList() {
 }
 
 SKIPPED_TESTS="
-# PERFORMANCE TESTS: NOT WANTED FOR CI
+# PERFORMANCE AND DISRUPTIVE TESTS: NOT WANTED FOR CI
 Networking IPerf IPv[46]
 \[Feature:PerformanceDNS\]
+Disruptive
 
 # FEATURES NOT AVAILABLE IN OUR CI ENVIRONMENT
 \[Feature:Federation\]


### PR DESCRIPTION
disruptive tests create disruption in the cluster, so it will make
other tests that run in parallel to fail.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
