### PR TITLE
simplify loadbalancer creation

### DIFF
--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -62,6 +62,18 @@ func DeleteLoadBalancerVIP(loadBalancer, vip string) error {
 	return nil
 }
 
+// CreateLoadBalancer creates a loadbalancer for the specified protocl
+func CreateLoadBalancer(protocol kapi.Protocol) error {
+	id := fmt.Sprintf("external_ids:k8s-cluster-lb-%s=yes", strings.ToLower(string(protocol)))
+	proto := fmt.Sprintf("protocol=%s", strings.ToLower(string(protocol)))
+	_, stderr, err := util.RunOVNNbctl("--", "create", "load_balancer", id, proto)
+	if err != nil {
+		klog.Errorf("Failed to create tcp load balancer, stderr: %q, error: %v", stderr, err)
+		return err
+	}
+	return nil
+}
+
 // UpdateLoadBalancer updates the VIP for sourceIP:sourcePort to point to targets (an
 // array of IP:port strings)
 func UpdateLoadBalancer(lb, vip string, targets []string) error {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
@@ -27,8 +28,10 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -410,44 +413,25 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 		}
 	}
 
-	// Create 3 load-balancers for east-west traffic for UDP, TCP, SCTP
-	oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes")
-	if err != nil {
-		klog.Errorf("Failed to get tcp load balancer, stderr: %q, error: %v", stderr, err)
-		return err
+	// Create load balancers
+	// We have 3 load-balancers per protocol to implement the East-west traffic
+	// Create load-balancers for east-west traffic for each protocol UDP, TCP, SCTP
+	protocols := []v1.Protocol{v1.ProtocolTCP, v1.ProtocolUDP}
+	if oc.SCTPSupport {
+		protocols = append(protocols, v1.ProtocolSCTP)
 	}
-
-	if oc.TCPLoadBalancerUUID == "" {
-		oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes", "protocol=tcp")
+	for _, p := range protocols {
+		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p)
 		if err != nil {
-			klog.Errorf("Failed to create tcp load balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-			return err
+			return errors.Wrapf(err, "Failed to get OVN load balancer for protocol %s", p)
 		}
-	}
+		// create the load balancer if it doesn't exist yet
+		if lbUUID == "" {
+			err := loadbalancer.CreateLoadBalancer(p)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to create OVN load balancer for protocol %s", p)
+			}
 
-	oc.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes")
-	if err != nil {
-		klog.Errorf("Failed to get udp load balancer, stderr: %q, error: %v", stderr, err)
-		return err
-	}
-	if oc.UDPLoadBalancerUUID == "" {
-		oc.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes", "protocol=udp")
-		if err != nil {
-			klog.Errorf("Failed to create udp load balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-			return err
-		}
-	}
-
-	oc.SCTPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-sctp=yes")
-	if err != nil {
-		klog.Errorf("Failed to get sctp load balancer, stderr: %q, error: %v", stderr, err)
-		return err
-	}
-	if oc.SCTPLoadBalancerUUID == "" && oc.SCTPSupport {
-		oc.SCTPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-sctp=yes", "protocol=sctp")
-		if err != nil {
-			klog.Errorf("Failed to create sctp load balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-			return err
 		}
 	}
 
@@ -784,35 +768,29 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 		return err
 	}
 
-	// Add our cluster TCP and UDP load balancers to the node switch
-	if oc.TCPLoadBalancerUUID == "" {
-		return fmt.Errorf("TCP cluster load balancer not created")
-	}
-	stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch", nodeName, "load_balancer="+oc.TCPLoadBalancerUUID)
-	if err != nil {
-		klog.Errorf("Failed to set logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
-		return err
-	}
-
-	if oc.UDPLoadBalancerUUID == "" {
-		return fmt.Errorf("UDP cluster load balancer not created")
-	}
-	stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", oc.UDPLoadBalancerUUID)
-	if err != nil {
-		klog.Errorf("Failed to add logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
-		return err
-	}
-
+	// Add our cluster load balancers per protocol to the node switch
+	protocols := []v1.Protocol{v1.ProtocolTCP, v1.ProtocolUDP}
 	if oc.SCTPSupport {
-		if oc.SCTPLoadBalancerUUID == "" {
-			return fmt.Errorf("SCTP cluster load balancer not created")
-		}
-		stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", oc.SCTPLoadBalancerUUID)
+		protocols = append(protocols, v1.ProtocolSCTP)
+	}
+	for i, p := range protocols {
+		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p)
 		if err != nil {
-			klog.Errorf("Failed to add logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
+			return errors.Wrapf(err, "Failed to get OVN load balancer for protocol %s", p)
+		}
+		// First loadbalancer overwrites the loadbalancer field
+		// next loadbalancers are appended
+		if i == 0 {
+			stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch", nodeName, "load_balancer="+lbUUID)
+		} else {
+			stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", lbUUID)
+		}
+		if err != nil {
+			klog.Errorf("Failed to set logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 			return err
 		}
 	}
+
 	// Add the node to the logical switch cache
 	return oc.lsManager.AddNode(nodeName, hostSubnets)
 }

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -215,10 +215,27 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists remove port_group clusterRtrPortGroup ports " + fakeUUID + " -- add port_group clusterRtrPortGroup ports " + fakeUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+		Output: tcpLBUUID + "\n",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+		Output: udpLBUUID + "\n",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
 	})
+
 	if sctpSupport {
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-sctp=yes",
+			Output: sctpLBUUID + "\n",
+		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
 		})
@@ -1104,9 +1121,29 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 --if-exists remove port_group clusterRtrPortGroup ports " + fakeUUID + " -- add port_group clusterRtrPortGroup ports " + fakeUUID,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+				Output: tcpLBUUID + "\n",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 set logical_switch " + nodeName + " load_balancer=" + tcpLBUUID,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
+				Output: udpLBUUID + "\n",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + udpLBUUID,
+			})
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-sctp=yes",
+				Output: sctpLBUUID + "\n",
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 add logical_switch " + nodeName + " load_balancer " + sctpLBUUID,
+			})
+			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + types.K8sPrefix + nodeName + " -- lsp-set-type " + types.K8sPrefix + nodeName + "  -- lsp-set-options " + types.K8sPrefix + nodeName + "  -- lsp-set-addresses " + types.K8sPrefix + nodeName + " " + nodeMgmtPortMAC + " " + nodeMgmtPortIP,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -1198,9 +1235,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				addressset.NewFakeAddressSetFactory(), ovntest.NewMockOVNClient(goovn.DBNB),
 				ovntest.NewMockOVNClient(goovn.DBSB), record.NewFakeRecorder(0))
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
-			clusterController.TCPLoadBalancerUUID = tcpLBUUID
-			clusterController.UDPLoadBalancerUUID = udpLBUUID
-			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
 			clusterController.SCTPSupport = true
 			clusterController.joinSwIPManager, _ = initJoinLogicalSwitchIPManager()
 			_, _ = clusterController.joinSwIPManager.ensureJoinLRPIPs(types.OVNClusterRouter)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -134,10 +134,7 @@ type Controller struct {
 
 	hoMaster *hocontroller.MasterController
 
-	TCPLoadBalancerUUID  string
-	UDPLoadBalancerUUID  string
-	SCTPLoadBalancerUUID string
-	SCTPSupport          bool
+	SCTPSupport bool
 
 	// For TCP, UDP, and SCTP type traffic, cache OVN load-balancers used for the
 	// cluster's east-west traffic.


### PR DESCRIPTION
We'll need to create more loadbalancers for idling and service
affinity.

Current code creates the loadbalancers one by one, that doesn´t
scale well and is ugly to read.

We can simplify the loadbalancer creation, and also remove the
loadbalancer uuid variables from the controller, that only are
used once, and is not expensive to ask directly to the nbctl
cache.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
