### PR TITLE
ovnkube-node Pod restart will break external nw connectivity for pods

### DIFF
--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -214,10 +214,6 @@ spec:
         - name: OVN_UNPRIVILEGED_MODE
           value: "{{ ovn_unprivileged_mode }}"
 
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/root/ovnkube.sh", "cleanup-ovn-node"]
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]


### PR DESCRIPTION
ovnkube-node Pod has preStop hook defined that cleans up bunch of things
on the k8s node.
-- deletes the patch port between the br-int and physical ovs bridge
-- replaces the OVS bridge flow with a single flow with NORMAL action
-- in some instances, where applicable, it also deletes the physical
   ovs bridge.

All of the above cleanup needs to be done on Node deletion. So, remove
the preStop hook for now and determine later on how to use the cleanup
code on node deletion.

@trozet PTAL
