### PR TITLE
remove ovnkube workaround for single-stack ipv4

### DIFF
--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
 )
@@ -224,10 +223,6 @@ func NicToBridge(iface string) (string, error) {
 
 	// Get ip addresses and routes before any real operations.
 	family := syscall.AF_UNSPEC
-	// FIXME: Should move all interfaces over, but in IPv4 only, breaks.
-	if config.IPv4Mode && !config.IPv6Mode {
-		family = syscall.AF_INET
-	}
 	addrs, err := netLinkOps.AddrList(ifaceLink, family)
 	if err != nil {
 		return "", err
@@ -266,10 +261,6 @@ func BridgeToNic(bridge string) error {
 
 	// Get ip addresses and routes before any real operations.
 	family := syscall.AF_UNSPEC
-	// FIXME: Should move all interfaces over, but in IPv4 only, breaks.
-	if config.IPv4Mode && !config.IPv6Mode {
-		family = syscall.AF_INET
-	}
 	addrs, err := netLinkOps.AddrList(bridgeLink, family)
 	if err != nil {
 		return err


### PR DESCRIPTION
    remove ovnkube workaround for single-stack ipv4
    
    always enable ipv6 inside kind nodes, docker disables ipv6
    globally inside containers by default, but in eth0.
    
    kind enables ipv6 for dual-stack and ipv6 deployments, not for
    the ipv4 ones.
    
    ovnkube-node, when trying to copy over the addresses from the
    gateway interface, fails because the IPv6 addresses can be
    added to the ovs bridge interface, since ipv6 is disabled on it.