### PR TITLE
capture version of kubernetes client used by ouvnkube in HTTP user-agent

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1032,7 +1032,6 @@ ovn-node() {
     --mtu=${mtu} \
     ${OVN_ENCAP_IP} \
     --loglevel=${ovnkube_loglevel} \
-    --loglevel=${ovnkube_loglevel} \
     --logfile-maxsize=${ovnkube_logfile_maxsize} \
     --logfile-maxbackups=${ovnkube_logfile_maxbackups} \
     --logfile-maxage=${ovnkube_logfile_maxage} \

--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -18,6 +18,7 @@ build_binaries() {
     GIT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
     BUILD_USER=$(whoami)
     BUILD_DATE=$(date +"%Y-%m-%d")
+    K8S_CLIENT_VERSION=$(grep 'k8s.io/client-go' ${OVN_KUBE_GO_PACKAGE}/go.sum | head -1 |cut -f2 -d' ')
 
     set -x
     for bin in "$@"; do
@@ -29,7 +30,8 @@ build_binaries() {
                 -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.Commit=${GIT_COMMIT} \
                 -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.Branch=${GIT_BRANCH} \
                 -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.BuildUser=${BUILD_USER} \
-                -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.BuildDate=${BUILD_DATE}" \
+                -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.BuildDate=${BUILD_DATE} \
+                -X k8s.io/client-go/pkg/version.gitVersion=${K8S_CLIENT_VERSION}" \
             -o "${OVN_KUBE_OUTPUT_BINPATH}/${binbase}"\
             "./${bin}"
     done


### PR DESCRIPTION
Currently, on the API Server we don't see the version of K8s client-go
bindings that ovnkube is using. We see this:

user-agent:ovnkube/v0.0.0 (linux/amd64) kubernetes/$Format

With the fix, you will see

user-agent:\
ovn-worker1/ovnkube@d085b888c981 (linux/amd64) kubernetes/v0.20.0

@aojea @dcbw @trozet PTAL