### PR TITLE
detect if the cluster has endpoint slices

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -3,7 +3,6 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	kapi "k8s.io/api/core/v1"
@@ -243,22 +242,11 @@ func EventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
 	return recorder
 }
 
-// UseEndpointSlices if the EndpointSlice API is available
-// and if the kubernetes versions supports DualStack (Kubernetes >= 1.20)
+// UseEndpointSlices detect if Endpoints Slices are enabled in the cluster
 func UseEndpointSlices(kubeClient kubernetes.Interface) bool {
-	endpointSlicesEnabled := false
 	if _, err := kubeClient.Discovery().ServerResourcesForGroupVersion(discovery.SchemeGroupVersion.String()); err == nil {
-		// The EndpointSlice API is enabled check if is running in a supported version
 		klog.V(2).Infof("Kubernetes Endpoint Slices enabled on the cluster: %s", discovery.SchemeGroupVersion.String())
-		endpointSlicesEnabled = true
+		return true
 	}
-	// We only use Slices if > 1.19 since we only need them for Dual Stack
-	sv, _ := kubeClient.Discovery().ServerVersion()
-	major, _ := strconv.Atoi(sv.Major)
-	minor, _ := strconv.Atoi(sv.Minor)
-	klog.Infof("Kubernetes running with version %d.%d", major, minor)
-	if major <= 1 && minor < 20 || !endpointSlicesEnabled {
-		return false
-	}
-	return true
+	return false
 }


### PR DESCRIPTION
The detection of the kubernetes version fails in the CI, because the library doesn't parse minors versions that are not only numbers, i.e v1.21.0-alpha.1, that are typically all the clusters that run in the CI.
We really don't need to check the kubernetes version, because the controller can work without dual-stack , it only needs that the cluster has endpoint slices enabled.