### PR TITLE
retry on unit tests failures

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -53,7 +53,7 @@ function testrun {
     fi
     if grep -q -r "ginkgo" ."${path}"; then
 	    prefix=$(echo "${path}" | cut -c 2- | sed 's,/,_,g')
-        ginkgoargs="-ginkgo.v -ginkgo.reportFile ${TEST_REPORT_DIR}/junit-${prefix}.xml"
+        ginkgoargs="-ginkgo.v -ginkgo.reportFile ${TEST_REPORT_DIR}/junit-${prefix}.xml -ginkgo.flakeAttempts=3"
         if [[ -n "$gingko_focus" ]]; then
             ginkgoargs="-ginkgo.v ${gingko_focus} -ginkgo.reportFile ${TEST_REPORT_DIR}/junit-${prefix}.xml"
         fi


### PR DESCRIPTION
unit test has been flaky for a long time and there is
no sympton that they will be fixed soon.

We can implement the same ginkgo mechanism to retry a few times
in case of failure, to deal with the flaky tests.

This is not great, but we were doing it manually, retesting the PRs,
so at least the developer experience is improved and the test
failures will be more evident.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
