### PR TITLE
avoid updating address sets if the pod is not scheduled to a node yet

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -924,6 +924,9 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, nsInfo *namespaceI
 // ingress/egress address set
 func (oc *Controller) handlePeerPodSelectorAddUpdate(gp *gressPolicy, obj interface{}) {
 	pod := obj.(*kapi.Pod)
+	if pod.Spec.NodeName == "" {
+		return
+	}
 	if err := gp.addPeerPod(pod); err != nil {
 		klog.Errorf(err.Error())
 	}
@@ -934,6 +937,9 @@ func (oc *Controller) handlePeerPodSelectorAddUpdate(gp *gressPolicy, obj interf
 // ingress/egress address set
 func (oc *Controller) handlePeerPodSelectorDelete(gp *gressPolicy, obj interface{}) {
 	pod := obj.(*kapi.Pod)
+	if pod.Spec.NodeName == "" {
+		return
+	}
 	if err := gp.deletePeerPod(pod); err != nil {
 		klog.Errorf(err.Error())
 	}


### PR DESCRIPTION
currently, we don't check if the pod is scheduled or not. we blindly
updated the address_set with the same set of IPs. this causes all of
the OVN chassis to receive updates from the oVN SB and act upon it.
avoid all this unnecessary churn.

@dcbw @trozet @danwinship PTAL

this was causing unnecessary churn in large scale cluster when pods were in this Pending -> Terminating cycle.