### PR TITLE
De-flake unit test

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -217,6 +217,8 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				return updatedNode.Annotations, nil
 			}, 2).Should(HaveKeyWithValue(hotypes.HybridOverlayDRMAC, nodeHOMAC))
 
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+
 			// Test that deleting the node cleans up the OVN objects
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --if-exists lsp-del int-node1",

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -133,6 +133,14 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		}
 	}
 
+	nodeSwitch := func() string {
+		statuses := getEgressIPStatus(egressIPName)
+		if len(statuses) != 1 {
+			return ""
+		}
+		return statuses[0].Node
+	}
+
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
@@ -264,11 +272,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				nodeSwitch := func() string {
-					statuses = getEgressIPStatus(egressIPName)
-					return statuses[0].Node
-				}
 
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				gomega.Eventually(nodeSwitch).Should(gomega.Equal(node2.Name))
@@ -407,11 +410,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				nodeSwitch := func() string {
-					statuses = getEgressIPStatus(egressIPName)
-					return statuses[0].Node
-				}
 
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				gomega.Eventually(nodeSwitch).Should(gomega.Equal(node2.Name))


### PR DESCRIPTION
The hybrid overlay test: `sets up and cleans up a Linux node with a OVN hostsubnet annotation`
was flaking because those tests don't use `NewLooseCompareFakeExec` and it didn't wait for the
add commands to be evaluated before proceeding to the delete part of the test. This patch
does that.

Flake seen here: https://github.com/ovn-org/ovn-kubernetes/pull/2051/checks?check_run_id=1914437125

The egress IP test: `should re-assign EgressIPs and perform proper OVN transactions when pod
is created after node egress label switch` was flaking because the retrieved status might be
empty while the tests are running, in which case we had panics observed during the test
execution. Thus check the status length

Flake seen here: https://github.com/ovn-org/ovn-kubernetes/runs/1919318009?check_suite_focus=true

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->