### PR TITLE
Change assignmentRetry for egress IP to a proper map + mutex

### DIFF
--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -122,6 +122,12 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		return tmp.Status.Items
 	}
 
+	getEgressIPReassignmentCount := func() int {
+		fakeOvn.controller.eIPC.assignmentRetryMutex.Lock()
+		defer fakeOvn.controller.eIPC.assignmentRetryMutex.Unlock()
+		return len(fakeOvn.controller.eIPC.assignmentRetry)
+	}
+
 	isEgressAssignableNode := func(nodeName string) func() bool {
 		return func() bool {
 			fakeOvn.controller.eIPC.allocatorMutex.Lock()
@@ -1384,16 +1390,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(fakeOvn.controller.eIPC.allocator[node.Name].v4Subnet).To(gomega.Equal(ipv4Sub))
 				gomega.Expect(fakeOvn.controller.eIPC.allocator[node.Name].v6Subnet).To(gomega.Equal(ipv6Sub))
 
-				getCacheCount := func() int {
-					cacheCount := 0
-					fakeOvn.controller.eIPC.assignmentRetry.Range(func(key, value interface{}) bool {
-						cacheCount++
-						return true
-					})
-					return cacheCount
-				}
-
-				gomega.Eventually(getCacheCount).Should(gomega.Equal(0))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
 				return nil
 			}
 
@@ -1564,16 +1561,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 
-				getCacheCount := func() int {
-					cacheCount := 0
-					fakeOvn.controller.eIPC.assignmentRetry.Range(func(key, value interface{}) bool {
-						cacheCount++
-						return true
-					})
-					return cacheCount
-				}
-
-				gomega.Eventually(getCacheCount).Should(gomega.Equal(1))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(1))
 
 				recordedEvent := <-fakeOvn.fakeRecorder.Events
 				gomega.Expect(recordedEvent).To(gomega.ContainSubstring("Not all egress IPs for EgressIP: %s could be assigned, please tag more nodes", eIP.Name))
@@ -1694,16 +1682,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(0))
 				gomega.Eventually(isEgressAssignableNode(node1.Name)).Should(gomega.BeTrue())
 
-				calculateCacheCount := func() int {
-					cacheCount := 0
-					fakeOvn.controller.eIPC.assignmentRetry.Range(func(key, value interface{}) bool {
-						cacheCount++
-						return true
-					})
-					return cacheCount
-				}
-
-				gomega.Eventually(calculateCacheCount).Should(gomega.Equal(1))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(1))
 
 				node2.Labels = map[string]string{
 					"k8s.ovn.org/egress-assignable": "",
@@ -1722,7 +1701,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				statuses := getEgressIPStatus(egressIPName)
 				gomega.Expect(statuses[0].Node).To(gomega.Equal(node2.Name))
 				gomega.Expect(statuses[0].EgressIP).To(gomega.Equal(egressIP))
-				gomega.Eventually(calculateCacheCount).Should(gomega.Equal(0))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
 				return nil
 			}
 
@@ -1821,16 +1800,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(statuses[0].Node).To(gomega.Equal(node1.Name))
 				gomega.Expect(statuses[0].EgressIP).To(gomega.Equal(egressIP1))
 
-				getCacheCount := func() int {
-					cacheCount := 0
-					fakeOvn.controller.eIPC.assignmentRetry.Range(func(key, value interface{}) bool {
-						cacheCount++
-						return true
-					})
-					return cacheCount
-				}
-
-				gomega.Eventually(getCacheCount).Should(gomega.Equal(1))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(1))
 
 				node2.Labels = map[string]string{
 					"k8s.ovn.org/egress-assignable": "",
@@ -1846,7 +1816,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
-				gomega.Eventually(getCacheCount).Should(gomega.Equal(0))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
 
 				return nil
 			}


### PR DESCRIPTION
`assignmentRetry` was mistakenly assumed to be thread safe. This is not
the case for the `Range` function. This means that if we have two nodes labelled
as egress nodes concurrently, we will have a subtle data race and possibly
end up deleting the setup done for node 1 by node 2 (since also: the egress
IP setup is not idempotent - we delete then add).

This patch changes it to a proper map with a mutex as to ensure that the
entire iteration over the map during the re-assignment remains thread safe.
It also ensures that we have an ordered assignment of a new / updated egress
IP while a node is added for egress IP assignment.

This issue has been seen here: https://github.com/ovn-org/ovn-kubernetes/pull/2055/checks?check_run_id=1924245680

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->