### PR TITLE
 Chassis_Private record must be deleted along with Chassis record

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.8.7
 	github.com/coreos/go-iptables v0.4.5
-	github.com/ebay/go-ovn v0.1.1-0.20210203103701-8bb6a085d599
+	github.com/ebay/go-ovn v0.1.1-0.20210225191205-f6ee8f3f087c
 	github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/mux v1.8.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -138,8 +138,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/ebay/go-ovn v0.1.1-0.20210203103701-8bb6a085d599 h1:TYkU7tQrZLjljJwD8FOM5zqPXPFomunresF2qjfTVgs=
-github.com/ebay/go-ovn v0.1.1-0.20210203103701-8bb6a085d599/go.mod h1:Du3Zt/R+DqyqtY5aNTd2gB9bg/igI1RR4fUj6AjmkjI=
+github.com/ebay/go-ovn v0.1.1-0.20210225191205-f6ee8f3f087c h1:ZhauuMfb01gW+x/QwV4vRQnBn8b5BX10r2fvC2FhvFs=
+github.com/ebay/go-ovn v0.1.1-0.20210225191205-f6ee8f3f087c/go.mod h1:Du3Zt/R+DqyqtY5aNTd2gB9bg/igI1RR4fUj6AjmkjI=
 github.com/ebay/libovsdb v0.0.0-20190718202342-e49b8c4e1142/go.mod h1:TPIbkgdnu8IfDA510pGDS3zYGmnvrPttnge3uhBQf/0=
 github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c h1:YSECgIEwf07ycYVwVM8KXCgkpXajecPqRyAuyFELZxA=
 github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c/go.mod h1:ZW5Fi5OPYcMy3EI20lW62TKBMHSlaDPlTqC3Gm4ev9Q=

--- a/go-controller/pkg/testing/mock_chassis_private.go
+++ b/go-controller/pkg/testing/mock_chassis_private.go
@@ -1,0 +1,19 @@
+package testing
+
+import (
+	goovn "github.com/ebay/go-ovn"
+	"k8s.io/klog/v2"
+)
+
+// Delete chassis row from Chassis_Private table with given name
+func (mock *MockOVNClient) ChassisPrivateDel(chName string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("Deleting chassis row from Chassis_Private table %s", chName)
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpDelete,
+			table:   ChassisPrivateType,
+			objName: chName,
+		},
+	}, nil
+}

--- a/go-controller/pkg/testing/mock_ovn.go
+++ b/go-controller/pkg/testing/mock_ovn.go
@@ -16,6 +16,7 @@ const (
 	LogicalSwitchPortType string = "Logical_Switch_Port"
 	ChassisType           string = "Chassis"
 	ACLType               string = "ACL"
+	ChassisPrivateType    string = "Chassis_Private"
 )
 
 const (
@@ -76,6 +77,7 @@ func NewMockOVNClient(db string) *MockOVNClient {
 	mock.cache[LogicalSwitchPortType] = make(MockObjectCacheByName)
 	mock.cache[ChassisType] = make(MockObjectCacheByName)
 	mock.cache[LogicalSwitchType] = make(MockObjectCacheByName)
+	mock.cache[ChassisPrivateType] = make(MockObjectCacheByName)
 	return mock
 }
 

--- a/go-controller/pkg/testing/mock_stubs.go
+++ b/go-controller/pkg/testing/mock_stubs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	goovn "github.com/ebay/go-ovn"
+	libovsdb "github.com/ebay/libovsdb"
 )
 
 // TODO: implement mock methods as we keep adding unit-tests
@@ -288,6 +289,16 @@ func (mock *MockOVNClient) EncapList(chname string) ([]*goovn.Encap, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
 }
 
+// List Chassis rows in chassis_private table
+func (mock *MockOVNClient) ChassisPrivateList() ([]*goovn.ChassisPrivate, error) {
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// Get Chassis row in chassis_private table by given name
+func (mock *MockOVNClient) ChassisPrivateGet(chName string) ([]*goovn.ChassisPrivate, error) {
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
 // Set NB_Global table options
 func (mock *MockOVNClient) NBGlobalSetOptions(options map[string]string) (*goovn.OvnCommand, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
@@ -336,4 +347,10 @@ func (mock *MockOVNClient) PortGroupDel(group string) (*goovn.OvnCommand, error)
 // Get PortGroup data structure if it exists
 func (mock *MockOVNClient) PortGroupGet(group string) (*goovn.PortGroup, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// Get ovn-db schema
+func (mock *MockOVNClient) GetSchema() libovsdb.DatabaseSchema {
+	var dbSchema libovsdb.DatabaseSchema
+	return dbSchema
 }

--- a/go-controller/pkg/testing/mocks/github.com/ebay/go-ovn/Client.go
+++ b/go-controller/pkg/testing/mocks/github.com/ebay/go-ovn/Client.go
@@ -4,6 +4,8 @@ package mocks
 
 import (
 	goovn "github.com/ebay/go-ovn"
+	libovsdb "github.com/ebay/libovsdb"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -357,6 +359,75 @@ func (_m *Client) ChassisList() ([]*goovn.Chassis, error) {
 	return r0, r1
 }
 
+// ChassisPrivateDel provides a mock function with given fields: chName
+func (_m *Client) ChassisPrivateDel(chName string) (*goovn.OvnCommand, error) {
+	ret := _m.Called(chName)
+
+	var r0 *goovn.OvnCommand
+	if rf, ok := ret.Get(0).(func(string) *goovn.OvnCommand); ok {
+		r0 = rf(chName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*goovn.OvnCommand)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(chName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ChassisPrivateGet provides a mock function with given fields: chName
+func (_m *Client) ChassisPrivateGet(chName string) ([]*goovn.ChassisPrivate, error) {
+	ret := _m.Called(chName)
+
+	var r0 []*goovn.ChassisPrivate
+	if rf, ok := ret.Get(0).(func(string) []*goovn.ChassisPrivate); ok {
+		r0 = rf(chName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*goovn.ChassisPrivate)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(chName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ChassisPrivateList provides a mock function with given fields:
+func (_m *Client) ChassisPrivateList() ([]*goovn.ChassisPrivate, error) {
+	ret := _m.Called()
+
+	var r0 []*goovn.ChassisPrivate
+	if rf, ok := ret.Get(0).(func() []*goovn.ChassisPrivate); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*goovn.ChassisPrivate)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Close provides a mock function with given fields:
 func (_m *Client) Close() error {
 	ret := _m.Called()
@@ -524,6 +595,20 @@ func (_m *Client) Execute(cmds ...*goovn.OvnCommand) error {
 		r0 = rf(cmds...)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// GetSchema provides a mock function with given fields:
+func (_m *Client) GetSchema() libovsdb.DatabaseSchema {
+	ret := _m.Called()
+
+	var r0 libovsdb.DatabaseSchema
+	if rf, ok := ret.Get(0).(func() libovsdb.DatabaseSchema); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(libovsdb.DatabaseSchema)
 	}
 
 	return r0

--- a/go-controller/vendor/github.com/ebay/go-ovn/chassis_private.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/chassis_private.go
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2020 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+import (
+	"fmt"
+	"github.com/ebay/libovsdb"
+)
+
+// Chassis_Private table OVN SB
+type ChassisPrivate struct {
+	UUID       string
+	ExternalID map[interface{}]interface{}
+	Name       string
+	NbCfg      int
+}
+
+func (odbi *ovndb) chassisPrivateAddImp(chName string,
+	external_ids map[string]string) (*OvnCommand, error) {
+
+	if len(chName) == 0 {
+		return nil, fmt.Errorf("chassis name cannot be empty")
+	}
+
+	namedUUID, err := newRowUUID()
+	if err != nil {
+		return nil, err
+	}
+	// row to insert
+	chPrivate := make(OVNRow)
+	chPrivate["name"] = chName
+
+	if uuid := odbi.getRowUUID(TableChassisPrivate, chPrivate); len(uuid) > 0 {
+		return nil, ErrorExist
+	}
+
+	if external_ids != nil {
+		oMap, err := libovsdb.NewOvsMap(external_ids)
+		if err != nil {
+			return nil, err
+		}
+		chPrivate["external_ids"] = oMap
+	}
+	insertOp := libovsdb.Operation{
+		Op:       opInsert,
+		Table:    TableChassisPrivate,
+		Row:      chPrivate,
+		UUIDName: namedUUID,
+	}
+	operations := []libovsdb.Operation{insertOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) chassisPrivateDelImp(name string) (*OvnCommand, error) {
+	var operations []libovsdb.Operation
+
+	condition := libovsdb.NewCondition("name", "==", name)
+	deleteOp := libovsdb.Operation{
+		Op:    opDelete,
+		Table: TableChassisPrivate,
+		Where: []interface{}{condition},
+	}
+	operations = append(operations, deleteOp)
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) chassisPrivateListImp() ([]*ChassisPrivate, error) {
+	odbi.cachemutex.RLock()
+	cacheChassisPrivate, ok := odbi.cache[TableChassisPrivate]
+	odbi.cachemutex.RUnlock()
+
+	if !ok {
+		return nil, ErrorSchema
+	}
+
+	listChassisPrivate := make([]*ChassisPrivate, 0, len(cacheChassisPrivate))
+	for uuid := range cacheChassisPrivate {
+		chPrivate, err := odbi.rowToChassisPrivate(uuid)
+		if err != nil {
+			return nil, err
+		}
+		listChassisPrivate = append(listChassisPrivate, chPrivate)
+	}
+	return listChassisPrivate, nil
+}
+
+func (odbi *ovndb) chassisPrivateGetImp(chassis string) ([]*ChassisPrivate, error) {
+	var listChassisPrivate []*ChassisPrivate
+
+	odbi.cachemutex.RLock()
+	cacheChassisPrivate, ok := odbi.cache[TableChassisPrivate]
+	odbi.cachemutex.RUnlock()
+
+	if !ok {
+		return nil, ErrorSchema
+	}
+
+	for uuid, drows := range cacheChassisPrivate {
+		if chName, ok := drows.Fields["name"].(string); ok && chName == chassis {
+			chPrivate, err := odbi.rowToChassisPrivate(uuid)
+			if err != nil {
+				return nil, err
+			}
+			listChassisPrivate = append(listChassisPrivate, chPrivate)
+		}
+	}
+	return listChassisPrivate, nil
+}
+
+func (odbi *ovndb) rowToChassisPrivate(uuid string) (*ChassisPrivate, error) {
+
+	odbi.cachemutex.RLock()
+	cacheChassisPrivate, ok := odbi.cache[TableChassisPrivate][uuid]
+	odbi.cachemutex.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("row in chassis_private with uuid %s not found", uuid)
+	}
+
+	chPrivate := &ChassisPrivate{
+		UUID:       uuid,
+		ExternalID: cacheChassisPrivate.Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		Name:       cacheChassisPrivate.Fields["name"].(string),
+		NbCfg:      cacheChassisPrivate.Fields["nb_cfg"].(int),
+	}
+	return chPrivate, nil
+}

--- a/go-controller/vendor/github.com/ebay/go-ovn/client.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/client.go
@@ -28,9 +28,10 @@ import (
 )
 
 type EntityType string
-const(
-	PORT_GROUP EntityType = "PORT_GROUP"
-	LOGICAL_SWITCH EntityType = "LOICAL_SWITCH"
+
+const (
+	PORT_GROUP     EntityType = "PORT_GROUP"
+	LOGICAL_SWITCH EntityType = "LOGICAL_SWITCH"
 )
 
 // Client ovnnb/sb client
@@ -203,6 +204,13 @@ type Client interface {
 	// List chassis
 	ChassisList() ([]*Chassis, error)
 
+	// Delete Chassis row from Chassis_Private with given name
+	ChassisPrivateDel(chName string) (*OvnCommand, error)
+	// List Chassis rows in chassis_private table
+	ChassisPrivateList() ([]*ChassisPrivate, error)
+	// Get Chassis row in chassis_private table by given name
+	ChassisPrivateGet(chName string) ([]*ChassisPrivate, error)
+
 	// Get encaps by chassis name
 	EncapList(chname string) ([]*Encap, error)
 
@@ -233,6 +241,9 @@ type Client interface {
 
 	// Close connection to OVN
 	Close() error
+
+	// GetSchema() returns ovn-db schema
+	GetSchema() libovsdb.DatabaseSchema
 }
 
 var _ Client = &ovndb{}
@@ -327,15 +338,30 @@ func (c *ovndb) reconnect() {
 	}()
 }
 
-func (c *ovndb) MonitorTables(jsonContext interface{}) (*libovsdb.TableUpdates, error) {
-	// get the table list based on the DB
+// filterTablesFromSchema checks whether tables in
+// NBTablesOrder / SBTablesOrder exists in current ovn-db schema
+func (c *ovndb) filterTablesFromSchema() []string {
 	var tables []string
+
+	// get the table list based on the DB
 	if c.db == DBNB {
 		tables = NBTablesOrder
 	} else {
 		tables = SBTablesOrder
 	}
 
+	dbSchema := c.GetSchema()
+	schemaTables := make([]string, 0)
+	for _, table := range tables {
+		if _, ok := dbSchema.Tables[table]; ok {
+			schemaTables = append(schemaTables, table)
+		}
+	}
+	return schemaTables
+}
+
+func (c *ovndb) MonitorTables(jsonContext interface{}) (*libovsdb.TableUpdates, error) {
+	tables := c.filterTablesFromSchema()
 	// verify whether user specified table and its columns are legit
 	if len(c.tableCols) != 0 {
 		supportedTableMaps := make(map[string]bool)
@@ -381,6 +407,10 @@ func (c *ovndb) Close() error {
 	return nil
 }
 
+func (c *ovndb) GetSchema() libovsdb.DatabaseSchema {
+	return c.client.Schema[c.db]
+}
+
 func (c *ovndb) EncapList(chname string) ([]*Encap, error) {
 	return c.encapListImp(chname)
 }
@@ -400,6 +430,22 @@ func (c *ovndb) ChassisAdd(name string, hostname string, etype []string, ip stri
 
 func (c *ovndb) ChassisDel(name string) (*OvnCommand, error) {
 	return c.chassisDelImp(name)
+}
+
+func (c *ovndb) chassisPrivateAdd(name string, external_ids map[string]string) (*OvnCommand, error) {
+	return c.chassisPrivateAddImp(name, external_ids)
+}
+
+func (c *ovndb) ChassisPrivateList() ([]*ChassisPrivate, error) {
+	return c.chassisPrivateListImp()
+}
+
+func (c *ovndb) ChassisPrivateGet(name string) ([]*ChassisPrivate, error) {
+	return c.chassisPrivateGetImp(name)
+}
+
+func (c *ovndb) ChassisPrivateDel(name string) (*OvnCommand, error) {
+	return c.chassisPrivateDelImp(name)
 }
 
 func (c *ovndb) LSAdd(ls string) (*OvnCommand, error) {

--- a/go-controller/vendor/github.com/ebay/go-ovn/common.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/common.go
@@ -52,6 +52,7 @@ const (
 	TableChassis                  string = "Chassis"
 	TableEncap                    string = "Encap"
 	TableSBGlobal                 string = "SB_Global"
+	TableChassisPrivate           string = "Chassis_Private"
 )
 
 var NBTablesOrder = []string{
@@ -78,6 +79,7 @@ var NBTablesOrder = []string{
 
 var SBTablesOrder = []string{
 	TableChassis,
+	TableChassisPrivate,
 	TableEncap,
 	TableSBGlobal,
 }

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/davecgh/go-spew/spew
 # github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
-# github.com/ebay/go-ovn v0.1.1-0.20210203103701-8bb6a085d599
+# github.com/ebay/go-ovn v0.1.1-0.20210225191205-f6ee8f3f087c
 github.com/ebay/go-ovn
 # github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c
 github.com/ebay/libovsdb


### PR DESCRIPTION
This PR contains
1)  Update to latest version of go-ovn to support chassis_private table 
       -updated to github.com/ebay/go-ovn v0.1.1-0.20210217205951-16f56680e2c0
 2) Latest release of OVN have introduced Chassis_Private Table which
     contains private information of given chassis. When a node is deleted,
     need to delete corresponding chassis record from Chassis_Private Table
     along with chassis Table.
 3) updated mocks to support new chassis_private table APIs.
 
 Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>
 