### PR TITLE
node deletion tasks on ovnkube manager node is best effort

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -1044,10 +1044,7 @@ func (oc *Controller) WatchNodes() {
 
 			nodeSubnets, _ := util.ParseNodeHostSubnetAnnotation(node)
 			dnatSnatIPs, _ := util.ParseNodeLocalNatIPAnnotation(node)
-			err := oc.deleteNode(node.Name, nodeSubnets, dnatSnatIPs)
-			if err != nil {
-				klog.Error(err)
-			}
+			oc.deleteNode(node.Name, nodeSubnets, dnatSnatIPs)
 			oc.lsManager.DeleteNode(node.Name)
 			addNodeFailed.Delete(node.Name)
 			mgmtPortFailed.Delete(node.Name)


### PR DESCRIPTION
The clean up of OVN Logical Topology and other runtime state that we do
on ovnkube is best effort. in deleteNode() callback we were doing both,
-- continuing on some errors
-- returning on some errors
As it stands today, the cleanup is best effort as it stands today. So,
the code needs to be consistent in what it is doing.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@dcbw @trozet others PTAL