### PR TITLE
Fix typo: delete -> update

### DIFF
--- a/go-controller/pkg/testing/mock_ovn.go
+++ b/go-controller/pkg/testing/mock_ovn.go
@@ -121,7 +121,7 @@ func (mock *MockOVNClient) ExecuteMockCommand(e *MockExecution) error {
 		delete(cache, e.objName)
 	case OpUpdate:
 		if cache, ok = mock.cache[e.table]; !ok {
-			return fmt.Errorf("command to delete entry from %s when cache doesn't exist", e.table)
+			return fmt.Errorf("command to update entry from %s when cache doesn't exist", e.table)
 		}
 		if err := mock.updateCache(e.table, e.objName, e.objUpdate, cache); err != nil {
 			return err


### PR DESCRIPTION
Co-authored by: Sayandeep Sen sayandes@in.ibm.com

Signed-off-by: Palani Kodeswaran <palankod@in.ibm.com>

This PR fixes a typo in ExecuteMockCommand() in pkg/testing/mock_ovn.go
