### PR TITLE
Temporarily downgrade OVN

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -27,6 +27,9 @@ RUN INSTALL_PKGS=" \
 
 RUN mkdir -p /var/run/openvswitch
 
+# REMOVEME once https://bugzilla.redhat.com/show_bug.cgi?id=1931599 is fixed
+RUN dnf downgrade -y ovn
+
 # Built in ../../go_controller, then the binaries are copied here.
 # put things where they are in the pkg
 RUN mkdir -p /usr/libexec/cni/


### PR DESCRIPTION
Due to a regression in OVN, service hairpinning no longer works, which
means some of our E2E tests are failing.

Signed-off-by: Tim Rozet <trozet@redhat.com>

