### PR TITLE
[Draft]Support go-ovn LS bindings in mock infrastructure

### DIFF
--- a/go-controller/pkg/testing/mock_ls.go
+++ b/go-controller/pkg/testing/mock_ls.go
@@ -1,0 +1,144 @@
+package testing
+
+import (
+	"fmt"
+
+	goovn "github.com/ebay/go-ovn"
+	"k8s.io/klog/v2"
+)
+
+const (
+	LoadBalancer = "LoadBalancer"
+)
+
+// TODO: implement mock methods as we keep adding unit-tests
+// Get logical switch by name
+func (mock *MockOVNClient) LSGet(ls string) ([]*goovn.LogicalSwitch, error) {
+	mock.mutex.Lock()
+	defer mock.mutex.Unlock()
+	var lsCache MockObjectCacheByName
+	var ok bool
+	if lsCache, ok = mock.cache[LogicalSwitchType]; !ok {
+		klog.V(5).Infof("Cache doesn't have any object of type %s", LogicalSwitchType)
+		return nil, goovn.ErrorSchema
+	}
+	var lswitch interface{}
+	if lswitch, ok = lsCache[ls]; !ok {
+		return nil, goovn.ErrorNotFound
+	}
+	if lsRet, ok := lswitch.(*goovn.LogicalSwitch); ok {
+		return []*goovn.LogicalSwitch{lsRet}, nil
+	}
+	return nil, fmt.Errorf("invalid object type assertion for %s", LogicalSwitchType)
+
+}
+
+// Create ls named SWITCH
+func (mock *MockOVNClient) LSAdd(ls string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("Adding  switch %s", ls)
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpAdd,
+			table:   LogicalSwitchType,
+			objName: ls,
+			obj:     &goovn.LogicalSwitch{Name: ls, UUID: FakeUUID},
+		},
+	}, nil
+}
+
+// Del ls and all its ports
+func (mock *MockOVNClient) LSDel(ls string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("Deleting ls %s", ls)
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpDelete,
+			table:   LogicalSwitchType,
+			objName: ls,
+		},
+	}, nil
+
+}
+
+// Get all logical switches
+func (mock *MockOVNClient) LSList() ([]*goovn.LogicalSwitch, error) {
+	var lsCache MockObjectCacheByName
+	var ok bool
+
+	lsArray := []*goovn.LogicalSwitch{}
+	if lsCache, ok = mock.cache[LogicalSwitchType]; !ok {
+		klog.V(5).Infof("Cache doesn't have any object of type %s", LogicalSwitchType)
+		return nil, goovn.ErrorSchema
+	}
+	var lsEntry interface{}
+	for _, lsEntry = range lsCache {
+		ls, ok := lsEntry.(*goovn.LogicalSwitch)
+		if !ok {
+			return nil, fmt.Errorf("invalid object type assertion for %s", LogicalSwitchType)
+		}
+		lsArray = append(lsArray, ls)
+	}
+	return lsArray, nil
+
+}
+
+// Add external_ids to logical switch
+func (mock *MockOVNClient) LSExtIdsAdd(ls string, external_ids map[string]string) (*goovn.OvnCommand, error) {
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// Del external_ids from logical_switch
+func (mock *MockOVNClient) LSExtIdsDel(ls string, external_ids map[string]string) (*goovn.OvnCommand, error) {
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// Link logical switch to router
+func (mock *MockOVNClient) LinkSwitchToRouter(lsw, lsp, lr, lrp, lrpMac string, networks []string, externalIds map[string]string) (*goovn.OvnCommand, error) {
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// Add LB to LSW
+func (mock *MockOVNClient) LSLBAdd(ls string, lb string) (*goovn.OvnCommand, error) {
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// Delete LB from LSW
+func (mock *MockOVNClient) LSLBDel(ls string, lb string) (*goovn.OvnCommand, error) {
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// List Load balancers for a LSW
+func (mock *MockOVNClient) LSLBList(ls string) ([]*goovn.LoadBalancer, error) {
+
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// helper function that applies field updates for a given ls to the mock object cache
+func (mock *MockOVNClient) updateLSCache(lsName string, update UpdateCache, mockCache MockObjectCacheByName) error {
+	var entry interface{}
+	var ls *goovn.LogicalSwitch
+	var ok bool
+
+	if entry, ok = mockCache[lsName]; !ok {
+		return fmt.Errorf("error updating LS with name %s, LS doesn't exist", lsName)
+	}
+
+	if ls, ok = entry.(*goovn.LogicalSwitch); !ok {
+		panic("type assertion failed for LS cache entry")
+	}
+	fmt.Printf("fieldType: %v\n", update.FieldType)
+	switch update.FieldType {
+	case LoadBalancer:
+		klog.V(5).Infof("Adding Load Balancer for LS %s", lsName)
+		if lbs, ok := update.FieldValue.([]string); ok {
+			ls.LoadBalancer = lbs
+		} else {
+			return fmt.Errorf("type assertion failed for LS field: %s", update.FieldType)
+		}
+	default:
+		return fmt.Errorf("unrecognized field type: %s", update.FieldType)
+	}
+
+	return nil
+}

--- a/go-controller/pkg/testing/mock_ovn.go
+++ b/go-controller/pkg/testing/mock_ovn.go
@@ -168,6 +168,8 @@ func (mock *MockOVNClient) updateCache(table string, objName string, update Upda
 	switch table {
 	case LogicalSwitchPortType:
 		return mock.updateLSPCache(objName, update, mockCache)
+	case LogicalSwitchType:
+		return mock.updateLSCache(objName, update, mockCache)
 	default:
 		return fmt.Errorf("mock cache updates for %s are not implemented yet", table)
 	}

--- a/go-controller/pkg/testing/mock_stubs.go
+++ b/go-controller/pkg/testing/mock_stubs.go
@@ -6,64 +6,14 @@ import (
 	goovn "github.com/ebay/go-ovn"
 )
 
-// TODO: implement mock methods as we keep adding unit-tests
-// Get logical switch by name
-func (mock *MockOVNClient) LSGet(ls string) ([]*goovn.LogicalSwitch, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Create ls named SWITCH
-func (mock *MockOVNClient) LSAdd(ls string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Del ls and all its ports
-func (mock *MockOVNClient) LSDel(ls string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Get all logical switches
-func (mock *MockOVNClient) LSList() ([]*goovn.LogicalSwitch, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Add external_ids to logical switch
-func (mock *MockOVNClient) LSExtIdsAdd(ls string, external_ids map[string]string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Del external_ids from logical_switch
-func (mock *MockOVNClient) LSExtIdsDel(ls string, external_ids map[string]string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Link logical switch to router
-func (mock *MockOVNClient) LinkSwitchToRouter(lsw, lsp, lr, lrp, lrpMac string, networks []string, externalIds map[string]string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Add LB to LSW
-func (mock *MockOVNClient) LSLBAdd(ls string, lb string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Delete LB from LSW
-func (mock *MockOVNClient) LSLBDel(ls string, lb string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// List Load balancers for a LSW
-func (mock *MockOVNClient) LSLBList(ls string) ([]*goovn.LoadBalancer, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Add ACL to entity (PORT_GROUP or LOGICAL_SWITCH)
-func (mock *MockOVNClient) ACLAddEntity(entityType goovn.EntityType, entity, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
 // Delete acl from entity (PORT_GROUP or LOGICAL_SWITCH)
 func (mock *MockOVNClient) ACLDelEntity(entityType goovn.EntityType, entity, direct, match string, priority int, external_ids map[string]string) (*goovn.OvnCommand, error) {
+	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
+}
+
+// Add ACL
+func (mock *MockOVNClient) ACLAdd(ls, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*goovn.OvnCommand, error) {
+
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
 }
 


### PR DESCRIPTION
Co-authored by : Sayandeep Sen sayandes@in.ibm.com

Signed-off-by: Palani Kodeswaran <palankod@in.ibm.com>

This PR adds support for go-ovn bindings for Logical Switch to the mock execution infrastructure.