### PR TITLE
changed EventuallyExpectEmptyAddressSet() to do what it says

### DIFF
--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -143,7 +143,9 @@ func (f *FakeAddressSetFactory) EventuallyExpectEmptyAddressSet(name string) {
 	name4, _ := MakeAddressSetName(name)
 	gomega.Eventually(func() bool {
 		as := f.getAddressSet(name4)
-		gomega.Expect(as).NotTo(gomega.BeNil())
+		if as == nil {
+			return false
+		}
 		defer as.Unlock()
 		return len(as.ips) == 0
 	}).Should(gomega.BeTrue())


### PR DESCRIPTION
The way the testing function EventuallyExpectEmptyAddressSet() can
fail the first time it is run with the right configuration options
and not do what the developer expects which is retry until timeout

switching the check will make sure that the test function is always
working as intended

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->