### PR TITLE
Increase timeouts to wait for kind setup

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -492,9 +492,9 @@ fi
 
 # Check that everything is fine and running. IPv6 cluster seems to take a little
 # longer to come up, so extend the wait time.
-OVN_TIMEOUT=300s
+OVN_TIMEOUT=480s
 if [ "$KIND_IPV6_SUPPORT" == true ]; then
-  OVN_TIMEOUT=480s
+  OVN_TIMEOUT=600s
 fi
 if ! kubectl wait -n ovn-kubernetes --for=condition=ready pods --all --timeout=${OVN_TIMEOUT} ; then
   echo "some pods in OVN Kubernetes are not running"


### PR DESCRIPTION
Periodically it seems kind is not quite ready after 5m
and maybe waiting a little longer will reduce the
flakey job failures. This bumps from 5m to 8m for v4
setups and 8m to 10m for v6 setups.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->