### PR TITLE
Remove obsolete references to 3.19.28.122

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,7 @@ Open vSwitch kernel module from the Open vSwitch repository to get all the
 features OVN needs (and any possible bug fixes) for any kernel.
 
 To install Open vSwitch kernel module from Open vSwitch repo manually, please
-read [INSTALL.rst].  For a quick start on Ubuntu,  you can install
-the kernel module package by:
-
-```
-sudo apt-get install apt-transport-https
-echo "deb http://3.19.28.122/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
-wget -O - http://3.19.28.122/openvswitch/keyFile |  sudo apt-key add -
-sudo apt-get update
-sudo apt-get build-dep dkms
-sudo apt-get install openvswitch-datapath-dkms -y
-```
+read [INSTALL.rst](https://docs.openvswitch.org/en/latest/intro/install/). 
 
 ## Run DaemonSet and Deployment
 

--- a/docs/INSTALL.UBUNTU.md
+++ b/docs/INSTALL.UBUNTU.md
@@ -2,24 +2,11 @@
 
 ## Installing OVS and OVN from packages
 
-For testing and POCs, we maintain OVS and OVN packages in a AWS VM.
-(For production, it is recommended that you build your own OVS packages.)
-To install packages from there, you can run:
-
-```
-sudo apt-get install apt-transport-https
-echo "deb http://3.19.28.122/openvswitch/stable /" |  sudo tee /etc/apt/sources.list.d/openvswitch.list
-wget -O - http://3.19.28.122/openvswitch/keyFile |  sudo apt-key add -
-sudo apt-get update
-```
-
 To install OVS bits on all nodes, run:
 
 ```
-sudo apt-get build-dep dkms
 sudo apt-get install python-six openssl -y
 
-sudo apt-get install openvswitch-datapath-dkms -y
 sudo apt-get install openvswitch-switch openvswitch-common -y
 ```
 


### PR DESCRIPTION
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

The AWS server (3.19.28.122) that hosted the debian packages is unavailable, references to the server mislead users.
This PR removes these references.