### PR TITLE
need changes to adapt to the new cluster/status output

### DIFF
--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -151,7 +151,7 @@ set_election_timer() {
   echo "setting election timer for ${database} to ${election_timer} ms"
 
   current_election_timer=$(ovs-appctl -t ${OVN_RUNDIR}/ovn${db}_db.ctl cluster/status ${database} |
-    grep "Election" | sed "s/.*:[[:space:]]//")
+    grep "Election timer" | sed "s/.*:[[:space:]]//")
   if [[ -z "${current_election_timer}" ]]; then
     echo "Failed to get current election timer value. Exiting..."
     exit 11


### PR DESCRIPTION
The recent OVS commit e8451e144 updated cluster/status output and the
existing code to get election timer no longer works. This commit fixes
that.

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->