### PR TITLE
Fix ACL syntax for dual-stack

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -328,11 +328,11 @@ func getMulticastACLMatch() string {
 }
 
 func getMulticastACLIgrMatchV4(addrSetName string) string {
-	return "ip4.src == $" + addrSetName + " && ip4.mcast"
+	return "(ip4.src == $" + addrSetName + " && ip4.mcast)"
 }
 
 func getMulticastACLIgrMatchV6(addrSetName string) string {
-	return "ip6.src == $" + addrSetName + " && " + ipv6DynamicMulticastMatch
+	return "(ip6.src == $" + addrSetName + " && " + ipv6DynamicMulticastMatch + ")"
 }
 
 // Creates the match string used for ACLs allowing incoming multicast into a
@@ -483,14 +483,14 @@ func (oc *Controller) createDefaultAllowMulticastPolicy() error {
 	err := addACLPortGroup("", oc.clusterRtrPortGroupUUID, fromLport,
 		defaultRoutedMcastAllowPriority, match, "allow", knet.PolicyTypeEgress, "")
 	if err != nil {
-		return fmt.Errorf("failed to create default deny multicast egress ACL: %v", err)
+		return fmt.Errorf("failed to create default allow multicast egress ACL: %v", err)
 	}
 
 	match = getACLMatch(clusterRtrPortGroupName, mcastMatch, knet.PolicyTypeIngress)
 	err = addACLPortGroup("", oc.clusterRtrPortGroupUUID, toLport,
 		defaultRoutedMcastAllowPriority, match, "allow", knet.PolicyTypeIngress, "")
 	if err != nil {
-		return fmt.Errorf("failed to create default deny multicast ingress ACL: %v", err)
+		return fmt.Errorf("failed to create default allow multicast ingress ACL: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
While debugging on dual-stack KIND setup, ovn-trace
failed due to || and && grouping, with this error
msg:

ovntrace|WARN|reg0[7] == 1 && (outport == @a14390016336330567584 &&
(ip4.src == $a8720055785936351439 && ip4.mcast || ip6.src ==
$a8720057984959607861 && (ip6.dst[120..127] == 0xff && ip6.dst[116] == 1))):
parsing expression failed (&& and || must be parenthesized
when used together.)

Signed-off-by: vpickard <vpickard@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->