### PR TITLE
don't compare endpoints on nodes

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -284,9 +283,6 @@ func (n *OvnNode) WatchEndpoints() {
 		UpdateFunc: func(old, new interface{}) {
 			epNew := new.(*kapi.Endpoints)
 			epOld := old.(*kapi.Endpoints)
-			if apiequality.Semantic.DeepEqual(epNew.Subsets, epOld.Subsets) {
-				return
-			}
 			newEpAddressMap := buildEndpointAddressMap(epNew.Subsets)
 			for item := range buildEndpointAddressMap(epOld.Subsets) {
 				if _, ok := newEpAddressMap[item]; !ok {


### PR DESCRIPTION
The nodes need to watch the endpoints in order to delete the stale
conntrack entries.

We were using DeepEqual to compare the endpoints structures, however,
this adds a big penalty that is unneccesary since we are going
to compare both the new and old Endpoints object later to obtain
only the new entries.

Signed-off-by: Antonio Ojea <aojea@redhat.com>
