### PR TITLE
Resync node management port on subnet change

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -1016,7 +1016,7 @@ func (oc *Controller) WatchNodes() {
 			}
 
 			_, failed = mgmtPortFailed.Load(node.Name)
-			if failed || macAddressChanged(oldNode, node) {
+			if failed || macAddressChanged(oldNode, node) || nodeSubnetChanged(oldNode, node) {
 				err := oc.syncNodeManagementPort(node, hostSubnets)
 				if err != nil {
 					if !util.IsAnnotationNotSetError(err) {
@@ -1198,6 +1198,12 @@ func macAddressChanged(oldNode, node *kapi.Node) bool {
 	oldMacAddress, _ := util.ParseNodeManagementPortMACAddress(oldNode)
 	macAddress, _ := util.ParseNodeManagementPortMACAddress(node)
 	return !bytes.Equal(oldMacAddress, macAddress)
+}
+
+func nodeSubnetChanged(oldNode, node *kapi.Node) bool {
+	oldSubnets, _ := util.ParseNodeHostSubnetAnnotation(oldNode)
+	newSubnets, _ := util.ParseNodeHostSubnetAnnotation(node)
+	return !reflect.DeepEqual(oldSubnets, newSubnets)
 }
 
 // noHostSubnet() compares the no-hostsubenet-nodes flag with node labels to see if the node is manageing its


### PR DESCRIPTION
Today when we process a node update we don't check if there has
been a change to the node subnet when determining if we should
resync the management port config in the OVN DB. This will lead
to stale data in the OVN DB and networking not fully working on the
affected node(s). This patch does that.

/assign @trozet 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->