### PR TITLE
RetryOnConflict() is meant for resource update and expects unchanged err

### DIFF
--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -13,10 +13,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	corelisters "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -39,20 +36,6 @@ func NewRepair(interval time.Duration,
 		interval:      interval,
 		serviceLister: serviceLister,
 	}
-}
-
-// RunUntil starts the controller until the provided ch is closed.
-func (r *Repair) RunUntil(stopCh <-chan struct{}) {
-	wait.Until(func() {
-		if err := r.RunOnce(); err != nil {
-			klog.Errorf("Error repairing services: %v")
-		}
-	}, r.interval, stopCh)
-}
-
-// RunOnce verifies the state of Services and OVN LBs and returns an error if an unrecoverable problem occurs.
-func (r *Repair) RunOnce() error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, r.runOnce)
 }
 
 // runOnce verifies the state of the cluster OVN LB VIP allocations and returns an error if an unrecoverable problem occurs.

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -155,7 +155,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
 	// it keeps in sync Kubernetes and OVN
 	// and handles removal of stale data on upgrades
 	klog.Info("Remove stale OVN services")
-	if err := c.repair.RunOnce(); err != nil {
+	if err := c.repair.runOnce(); err != nil {
 		klog.Errorf("Error repairing services: %v")
 	}
 


### PR DESCRIPTION
we don't need RetryOnConflict() in RunOnce() since we are not making
any resource update in the function it calls. so, there is not going
to be any conflict that will be returned

while there also remove RunUntil() since its not currently being used

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@aojea @trozet PTAL