### PR TITLE
Fix multicast querier.

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -795,7 +795,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 				stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch",
 					nodeName, "other-config:mcast_querier=\"true\"",
 					"other-config:mcast_eth_src=\""+nodeLRPMAC.String()+"\"",
-					"other-config:mcast_ip6_src=\""+v6Gateway.String()+"\"")
+					"other-config:mcast_ip6_src=\""+util.HWAddrToIPv6LLA(nodeLRPMAC).String()+"\"")
 				if err != nil {
 					klog.Errorf("Failed to enable MLD Querier on logical switch %v, stdout: %q, stderr: %q, error: %v",
 						nodeName, stdout, stderr, err)

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -327,12 +327,16 @@ func getMulticastACLMatch() string {
 	return "(ip4.mcast || mldv1 || mldv2 || " + ipv6DynamicMulticastMatch + ")"
 }
 
+// Allow IGMP traffic (e.g., IGMP queries) and namespace multicast traffic
+// towards pods.
 func getMulticastACLIgrMatchV4(addrSetName string) string {
-	return "(ip4.src == $" + addrSetName + " && ip4.mcast)"
+	return "(igmp || (ip4.src == $" + addrSetName + " && ip4.mcast))"
 }
 
+// Allow MLD traffic (e.g., MLD queries) and namespace multicast traffic
+// towards pods.
 func getMulticastACLIgrMatchV6(addrSetName string) string {
-	return "(ip6.src == $" + addrSetName + " && " + ipv6DynamicMulticastMatch + ")"
+	return "(mldv1 || mldv2 || (ip6.src == $" + addrSetName + " && " + ipv6DynamicMulticastMatch + "))"
 }
 
 // Creates the match string used for ACLs allowing incoming multicast into a

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -166,6 +166,29 @@ func IPAddrToHWAddr(ip net.IP) net.HardwareAddr {
 	return net.HardwareAddr{0x0A, 0x58, hash[0], hash[1], hash[2], hash[3]}
 }
 
+// HWAddrToIPv6LLA generates the IPv6 link local address from the given hwaddr,
+// with prefix 'fe80:/64'.
+func HWAddrToIPv6LLA(hwaddr net.HardwareAddr) net.IP {
+	return net.IP{
+		0xfe,
+		0x80,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		0x00,
+		(hwaddr[0] ^ 0x02),
+		hwaddr[1],
+		hwaddr[2],
+		0xff,
+		0xfe,
+		hwaddr[3],
+		hwaddr[4],
+		hwaddr[5],
+	}
+}
+
 // JoinIPs joins the string forms of an array of net.IP, as with strings.Join
 func JoinIPs(ips []net.IP, sep string) string {
 	b := &strings.Builder{}


### PR DESCRIPTION
- Fix the multicast allow policy to not drop IGMP/MLD packets generated by ovn-controller in namespaces with multicast enabled.
- Use a link local IPv6 address (based on router port MAC) for mcast_ip6_src to generate valid MLD queries.
