### PR TITLE
External gateway pod tests: Cover BFD

### DIFF
--- a/test/e2e/images/Dockerfile.frr
+++ b/test/e2e/images/Dockerfile.frr
@@ -1,0 +1,10 @@
+# This dockerfile is used to build the image
+# consumed by the external gateway tests as the BFD variants need to have
+# frr deployed on the external container
+FROM fedora:33
+
+RUN INSTALL_PKGS="tcpdump frr iputils iproute nc hostname" && \
+    dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    dnf clean all && rm -rf /var/cache/dnf/*
+
+RUN sed -i 's/^bfdd=no/bfdd=yes/g' /etc/frr/daemons


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

We clone the external gateway tests with a difference: bfd is enabled
both on ovn side and on the containers (using a custom container via frr).

We check that ecmp works with two containers, then we remove one
container and check that all the traffic reaches the remaining
container.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

This PR depends and needs to be merged after https://github.com/ovn-org/ovn-kubernetes/pull/2029 and https://github.com/ovn-org/ovn-kubernetes/pull/2077

It's currently consuming a dockerfile image from personal quay repo because I needed an image with FRR (the dockerfile is committed as part of this pr)

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->