### PR TITLE
Fixes incorrect services in KIND CI and DGP MAC

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -507,5 +507,18 @@ if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=300s
   exit 1
 fi
 
+# Clean up any leftover kube-proxy iptables rules that handle services
+KIND_NODES=$(kind get nodes --name ${KIND_CLUSTER_NAME})
+for n in $KIND_NODES; do
+  if [ "$KIND_IPV4_SUPPORT" == true ]; then
+    docker exec $n iptables -F KUBE-SERVICES
+    docker exec $n iptables -F KUBE-SERVICES -t nat
+  fi
+  if [ "$KIND_IPV6_SUPPORT" == true ]; then
+    docker exec $n ip6tables -F KUBE-SERVICES
+    docker exec $n ip6tables -F KUBE-SERVICES -t nat
+  fi
+done
+
 echo "Pods are all up, allowing things settle for 30 seconds..."
 sleep 30

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -39,12 +39,7 @@ func setupLocalNodeAccessBridge(nodeName string, subnets []*net.IPNet) error {
 		return err
 	}
 
-	var macAddress string
-	if config.IPv4Mode {
-		macAddress = util.IPAddrToHWAddr(net.ParseIP(types.V4NodeLocalNATSubnetNextHop)).String()
-	} else {
-		macAddress = util.IPAddrToHWAddr(net.ParseIP(types.V6NodeLocalNATSubnetNextHop)).String()
-	}
+	macAddress := util.IPAddrToHWAddr(net.ParseIP(types.V4NodeLocalNATSubnetNextHop)).String()
 
 	_, stderr, err = util.RunOVSVsctl(
 		"--may-exist", "add-port", localBridgeName, localnetGatewayNextHopPort,


### PR DESCRIPTION
We found downstream https://github.com/openshift/ovn-kubernetes/pull/440 that the ipv6 bare metal job was failing. This was because the host -> kapi service was not working. This is because the DGP mac was changed in 380e80f389dad997f9f97c030eb89d8abce4204f for OVN config, but the corresponding change was not made to the OVS interface. Therefore all DGP traffic in ipv6 deployment was getting dropped in the host.

The question then was how was this passing in our upstream CI? This was passing because even though we delete kube-proxy post install, it was leaving behind its iptables rules, which includes DNAT for KAPI service. Thus our CI was falsely passing.

This PR removes those leftover kube-proxy iptables rules, and changes the OVS MAC to match the DGP.