### PR TITLE
netpol: Changes to support network policy for host network traffic

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -175,9 +175,11 @@ parse_args() {
             -dl  | --ovn-loglevel-nbctld )      shift
                                                 OVN_LOG_LEVEL_NBCTLD=$1
                                                 ;;
-            --delete )                    	    delete
-                                          	    exit
-                                          	    ;;
+            -hns | --host-network-namespace )   OVN_HOST_NETWORK_NAMESPACE=$1
+                                                ;;
+            --delete )                          delete
+                                                exit
+                                                ;;
             -h | --help )                       usage
                                                 exit
                                                 ;;
@@ -216,6 +218,7 @@ print_params() {
      echo "OVN_LOG_LEVEL_SB = $OVN_LOG_LEVEL_SB"
      echo "OVN_LOG_LEVEL_CONTROLLER = $OVN_LOG_LEVEL_CONTROLLER"
      echo "OVN_LOG_LEVEL_NBCTLD = $OVN_LOG_LEVEL_NBCTLD"
+     echo "OVN_HOST_NETWORK_NAMESPACE = $OVN_HOST_NETWORK_NAMESPACE"
      echo ""
 }
 
@@ -270,6 +273,8 @@ set_default_params() {
   else
     KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}
   fi
+  OVN_HOST_NETWORK_NAMESPACE=${OVN_HOST_NETWORK_NAMESPACE:-ovn-host-network}
+
 }
 
 detect_apiserver_ip() {

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -45,6 +45,7 @@ OVN_V6_JOIN_SUBNET=""
 OVN_NETFLOW_TARGETS=""
 OVN_SFLOW_TARGETS=""
 OVN_IPFIX_TARGETS=""
+OVN_HOST_NETWORK_NAMESPACE=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -170,6 +171,9 @@ while [ "$1" != "" ]; do
     ;;
   --ipfix-targets)
     OVN_IPFIX_TARGETS=$VALUE
+    ;;
+  --host-network-namespace)
+    OVN_HOST_NETWORK_NAMESPACE=$VALUE
     ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
@@ -376,14 +380,16 @@ net_cidr=${OVN_NET_CIDR:-"10.128.0.0/14/23"}
 svc_cidr=${OVN_SVC_CIDR:-"172.30.0.0/16"}
 k8s_apiserver=${OVN_K8S_APISERVER:-"10.0.2.16:6443"}
 mtu=${OVN_MTU:-1400}
-
+host_network_namespace=${OVN_HOST_NETWORK_NAMESPACE:-ovn-host-network}
 echo "net_cidr: ${net_cidr}"
 echo "svc_cidr: ${svc_cidr}"
 echo "k8s_apiserver: ${k8s_apiserver}"
 echo "mtu: ${mtu}"
+echo "host_network_namespace: ${host_network_namespace}"
 
 net_cidr=${net_cidr} svc_cidr=${svc_cidr} \
   mtu_value=${mtu} k8s_apiserver=${k8s_apiserver} \
+  host_network_namespace=${host_network_namespace}	\
   j2 ../templates/ovn-setup.yaml.j2 -o ../yaml/ovn-setup.yaml
 
 cp ../templates/ovnkube-monitor.yaml.j2 ../yaml/ovnkube-monitor.yaml

--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -116,3 +116,18 @@ data:
   svc_cidr:      "{{ svc_cidr }}"
   k8s_apiserver: "{{ k8s_apiserver }}"
   mtu:           "{{ mtu_value }}"
+  host_network_namespace: "{{ host_network_namespace }}"
+
+
+---
+# ovn-host-network-namespace.yaml
+#
+# Create the namespace for classifying host network traffic.
+#
+# This provisioning is done as part of installation after the cluster is
+# up and before the ovn daemonsets are created.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ host_network_namespace }}"

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -258,6 +258,11 @@ spec:
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_ACL_LOGGING_RATE_LIMIT
           value: "{{ ovn_acl_logging_rate_limit }}"
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
       # end of container
 
       volumes:

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -175,6 +175,11 @@ spec:
         - name: OVNKUBE_NODE_MODE
           value: "smart-nic-host"
         {% endif -%}
+        - name: OVN_HOST_NETWORK_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: host_network_namespace
 
         readinessProbe:
           exec:

--- a/go-controller/pkg/ovn/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager.go
@@ -315,7 +315,14 @@ func initJoinLogicalSwitchIPManager() (*joinSwitchIPManager, error) {
 		lrpIPCache: make(map[string][]*net.IPNet),
 	}
 	var joinSubnets []*net.IPNet
-	for _, joinSubnetString := range []string{config.Gateway.V4JoinSubnet, config.Gateway.V6JoinSubnet} {
+	joinSubnetsConfig := []string{}
+	if config.IPv4Mode {
+		joinSubnetsConfig = append(joinSubnetsConfig, config.Gateway.V4JoinSubnet)
+	}
+	if config.IPv6Mode {
+		joinSubnetsConfig = append(joinSubnetsConfig, config.Gateway.V6JoinSubnet)
+	}
+	for _, joinSubnetString := range joinSubnetsConfig {
 		_, joinSubnet, err := net.ParseCIDR(joinSubnetString)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing join subnet string %s: %v", joinSubnetString, err)

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -7,11 +7,19 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
+	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -50,7 +58,9 @@ func newNamespace(namespace string) *v1.Namespace {
 
 var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 	const (
-		namespaceName = "namespace1"
+		namespaceName        = "namespace1"
+		clusterIPNet  string = "10.1.0.0"
+		clusterCIDR   string = clusterIPNet + "/16"
 	)
 	var (
 		app     *cli.App
@@ -121,7 +131,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				fakeOvn.start(ctx, &v1.NamespaceList{
 					Items: []v1.Namespace{
-						*newNamespace("namespace1"),
+						*newNamespace(namespaceName),
 					},
 				})
 				fakeOvn.controller.WatchNamespaces()
@@ -136,6 +146,152 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("creates an address set for existing nodes when the host network traffic namespace is created", func() {
+			app.Action = func(ctx *cli.Context) error {
+				node1 := tNode{
+					Name:                 "node1",
+					NodeIP:               "1.2.3.4",
+					NodeLRPMAC:           "0a:58:0a:01:01:01",
+					LrpMAC:               "0a:58:64:40:00:02",
+					LrpIP:                "100.64.0.2",
+					LrpIPv6:              "fd98::2",
+					DrLrpIP:              "100.64.0.1",
+					PhysicalBridgeMAC:    "11:22:33:44:55:66",
+					SystemID:             "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6",
+					TCPLBUUID:            "d2e858b2-cb5a-441b-a670-ed450f79a91f",
+					UDPLBUUID:            "12832f14-eb0f-44d4-b8db-4cccbc73c792",
+					SCTPLBUUID:           "0514c521-a120-4756-aec6-883fe5db7139",
+					NodeSubnet:           "10.1.1.0/24",
+					GWRouter:             ovntypes.GWRouterPrefix + "node1",
+					GatewayRouterIPMask:  "172.16.16.2/24",
+					GatewayRouterIP:      "172.16.16.2",
+					GatewayRouterNextHop: "172.16.16.1",
+					PhysicalBridgeName:   "br-eth0",
+					NodeGWIP:             "10.1.1.1/24",
+					NodeMgmtPortIP:       "10.1.1.2",
+					NodeMgmtPortMAC:      "0a:58:0a:01:01:02",
+					DnatSnatIP:           "169.254.0.1",
+				}
+				// create a test node and annotate it with host subnet
+				testNode := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1.Name,
+					},
+					Status: kapi.NodeStatus{
+						Addresses: []kapi.NodeAddress{
+							{
+								Type:    kapi.NodeExternalIP,
+								Address: node1.NodeIP,
+							},
+						},
+					},
+				}
+
+				hostNetworkNamespace := "test-host-network-ns"
+				config.Kubernetes.HostNetworkNamespace = hostNetworkNamespace
+				hostNetworkNs := *newNamespace(hostNetworkNamespace)
+
+				kubeFakeClient := fake.NewSimpleClientset(
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							hostNetworkNs,
+						},
+					},
+				)
+				egressFirewallFakeClient := &egressfirewallfake.Clientset{}
+				crdFakeClient := &apiextensionsfake.Clientset{}
+				egressIPFakeClient := &egressipfake.Clientset{}
+				fakeClient := &util.OVNClientset{
+					KubeClient:           kubeFakeClient,
+					EgressIPClient:       egressIPFakeClient,
+					EgressFirewallClient: egressFirewallFakeClient,
+					APIExtensionsClient:  crdFakeClient,
+				}
+
+				_, err := fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &testNode, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				nodeAnnotator := kube.NewNodeAnnotator(&kube.Kube{fakeClient.KubeClient, fakeClient.EgressIPClient, fakeClient.EgressFirewallClient}, &testNode)
+
+				ifaceID := node1.PhysicalBridgeName + "_" + node1.Name
+				vlanID := uint(1024)
+				err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
+					Mode:           config.GatewayModeShared,
+					ChassisID:      node1.SystemID,
+					InterfaceID:    ifaceID,
+					MACAddress:     ovntest.MustParseMAC(node1.PhysicalBridgeMAC),
+					IPAddresses:    ovntest.MustParseIPNets(node1.GatewayRouterIPMask),
+					NextHops:       ovntest.MustParseIPs(node1.GatewayRouterNextHop),
+					NodePortEnable: true,
+					VLANID:         &vlanID,
+				})
+				err = util.SetNodeManagementPortMACAddress(nodeAnnotator, ovntest.MustParseMAC(node1.NodeMgmtPortMAC))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = util.SetNodeHostSubnetAnnotation(nodeAnnotator, ovntest.MustParseIPNets(node1.NodeSubnet))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = util.SetNodeLocalNatAnnotation(nodeAnnotator, []net.IP{ovntest.MustParseIP(node1.DnatSnatIP)})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = nodeAnnotator.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				updatedNode, err := fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				nodeHostSubnetAnnotations, err := util.ParseNodeHostSubnetAnnotation(updatedNode)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(nodeHostSubnetAnnotations[0].String()).Should(gomega.Equal(node1.NodeSubnet))
+				_, err = config.InitConfig(ctx, fakeOvn.fakeExec, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.fakeClient = fakeClient
+				fakeOvn.init()
+				fakeOvn.controller.multicastSupport = false
+				fakeOvn.controller.clusterLBsUUIDs = []string{node1.TCPLBUUID, node1.UDPLBUUID, node1.SCTPLBUUID}
+				_, clusterNetwork, err := net.ParseCIDR(clusterCIDR)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				fakeOvn.controller.masterSubnetAllocator.AddNetworkRange(clusterNetwork, 24)
+
+				fakeOvn.controller.SCTPSupport = true
+
+				fexec := fakeOvn.fakeExec
+				addNodeLogicalFlows(fexec, &node1, clusterCIDR, config.IPv6Mode, false)
+				fakeOvn.controller.joinSwIPManager, _ = initJoinLogicalSwitchIPManager()
+				_, err = fakeOvn.controller.joinSwIPManager.ensureJoinLRPIPs(ovntypes.OVNClusterRouter)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gwLRPIPs, err := fakeOvn.controller.joinSwIPManager.ensureJoinLRPIPs(node1.Name)
+				gomega.Expect(len(gwLRPIPs) != 0).To(gomega.BeTrue())
+
+				// clusterController.WatchNodes() needs to following two port groups to have been created.
+				fakeOvn.controller.clusterRtrPortGroupUUID, err = createPortGroup(fakeOvn.controller.ovnNBClient, clusterRtrPortGroupName, clusterRtrPortGroupName)
+				fakeOvn.controller.clusterPortGroupUUID, err = createPortGroup(fakeOvn.controller.ovnNBClient, clusterPortGroupName, clusterPortGroupName)
+
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.asf.EventuallyExpectEmptyAddressSet(hostNetworkNamespace)
+
+				fakeOvn.controller.WatchNodes()
+
+				gomega.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc)
+
+				// check the namespace again and ensure the address set
+				// being created with the right set of IPs in it.
+				allowIPs := []string{node1.NodeMgmtPortIP}
+				for _, lrpIP := range gwLRPIPs {
+					allowIPs = append(allowIPs, lrpIP.IP.String())
+				}
+				fakeOvn.asf.ExpectAddressSetWithIPs(hostNetworkNamespace, allowIPs)
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+				"-cluster-subnets=" + clusterCIDR,
+				"--init-gateways",
+				"--nodeport",
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		})
 	})
 


### PR DESCRIPTION
This commit adds support for enabling network policy on host
network traffic pods such as the router pod in OpenShift.

Currently, if you have a default deny network policy on a namespace,
services within that namespace are not reachable via host network
using external routes. This feature will make that possible by allowing
users to create a separate network policy with a host network namespace selector.
   
The expectation is that the namespace you want to use to classify host network
traffic to is pre-created with the desired labels. These labels will then
be used as match fields for the network policy object's ingress selector.
It is also necessary that the users pass the host network namespace
as a command line parameter for ovnkube when it starts.

**How to test this feature:**
- Start ovnkube with --host-network-namespace parameter set to `ovn-host-network` namespace.
- Create the `ovn-host-network` namespace. This namespace will be used to classify host network traffic with appropriate labels.
```
apiVersion: v1
kind: Namespace
metadata:
  # NOTE: this namespace is the portal for host network traffic
  name: ovn-host-network
  labels:
    policy-group.k8s.ovn.org/host-network: ""
```
- Create a target namespace that can be used to test network policy 
```
apiVersion: v1
kind: Namespace
metadata:
  # NOTE: this namespace is the portal for host network traffic
  name: test
```
- Create a service in the `test` namespace that needs to be accessible from outside. 
For instance create an nginx service that runs on port 80:
```
kubectl create deployment nginx
kubectl expose deployment nginx --port=80
```
- Verify that this service is reachable from outside.
- Create a default-deny policy in the `test` namespace.
```
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: default-deny-ingress
spec:
  podSelector: {}
  policyTypes:
  - Ingress
```
- Verify that this service is now not reachable from outside.
- Create a network policy that matches on the labels on the `ovn-host-network` namespace and uses the 
pod selector to target the nginx service created above.
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: access-nginx
spec:
  podSelector:
    matchLabels:
      app: nginx
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          policy-group.k8s.ovn.org/host-network: ""
```
- Verify that the service is reachable again.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>
