### PR TITLE
Fix: egress IP flakes, wrap update in mutex execution

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -812,10 +812,10 @@ func (oc *Controller) WatchEgressIP() {
 		AddFunc: func(obj interface{}) {
 			eIP := obj.(*egressipv1.EgressIP).DeepCopy()
 			oc.eIPC.assignmentRetryMutex.Lock()
+			defer oc.eIPC.assignmentRetryMutex.Unlock()
 			if err := oc.addEgressIP(eIP); err != nil {
 				klog.Error(err)
 			}
-			oc.eIPC.assignmentRetryMutex.Unlock()
 			if err := oc.updateEgressIPWithRetry(eIP); err != nil {
 				klog.Error(err)
 			}
@@ -831,10 +831,10 @@ func (oc *Controller) WatchEgressIP() {
 					Items: []egressipv1.EgressIPStatusItem{},
 				}
 				oc.eIPC.assignmentRetryMutex.Lock()
+				defer oc.eIPC.assignmentRetryMutex.Unlock()
 				if err := oc.addEgressIP(newEIP); err != nil {
 					klog.Error(err)
 				}
-				oc.eIPC.assignmentRetryMutex.Unlock()
 				if err := oc.updateEgressIPWithRetry(newEIP); err != nil {
 					klog.Error(err)
 				}


### PR DESCRIPTION
Egress IP is still flaking in CI. I believe the cause of this is due
to not wrapping updating the egress IP status in the retry assignment
executin. On slow servers there can be a conflicting update when the
nodes are labelled and the egress IP is added during our e2e tests.
Wrapping the update part in the mutex execution will enforce that only
one update is done at a time, either when a node is added and the egress
IP is re-assigned, or when the egress IP is added / updated.

Flakes seen here: https://github.com/ovn-org/ovn-kubernetes/pull/2093/checks?check_run_id=2036750987 and here: https://github.com/ovn-org/ovn-kubernetes/pull/2074/checks?check_run_id=2010128791

/assign @trozet 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->