### PR TITLE
don't panic on mgmt port teardown

### DIFF
--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -197,6 +197,9 @@ func LinkRoutesDel(link netlink.Link, subnets []*net.IPNet) error {
 	}
 	for _, subnet := range subnets {
 		for _, route := range routes {
+			if route.Dst == nil {
+				continue
+			}
 			if route.Dst.String() == subnet.String() {
 				err = netLinkOps.RouteDel(&route)
 				if err != nil {


### PR DESCRIPTION
The ovnkube-node daemon panics if there is a default route
pointing to the management interface.

It shouldn't be normal to have this scenario, but it is possible,
so we need to protect against it.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

Stack trace with the failure

```
0308 11:11:02.102276   28259 ovs.go:170] exec(7): stderr: ""
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6128c6]

goroutine 1 [running]:
net.networkNumberAndMask(0x0, 0xc00036dcb0, 0xa, 0x1ba9356, 0x1, 0xc00036dc98, 0x2)
	/usr/lib/golang/src/net/ip.go:476 +0x26
net.(*IPNet).String(0x0, 0xc00036dcc0, 0xd)
	/usr/lib/golang/src/net/ip.go:526 +0x45
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util.LinkRoutesDel(0x1de4400, 0xc00020c120, 0xc00051b9e0, 0x2, 0x2, 0x1baa095, 0xc0003f3500)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/util/net_linux.go:200 +0x1a5
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.tearDownManagementPortConfig(0xc00035d450, 0xb, 0xc00006e3d0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/management-port_linux.go:138 +0x1d9
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.createPlatformManagementPort(0x1bb475f, 0xb, 0xc00006e3d0, 0x2, 0x2, 0x0, 0x0, 0x0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/management-port_linux.go:268 +0x7d
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.createManagementPort(0x7ffc3897da43, 0x28, 0xc00006e3d0, 0x2, 0x2, 0x1e1ef40, 0xc00000e720, 0xc00000e740, 0xc0005a7540, 0x2, ...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/management-port.go:54 +0x9ed
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.(*OvnNode).Start(0xc00007bb60, 0xc000460000, 0x1e19ec0, 0xc0003e0440)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/node.go:213 +0x945
main.runOvnKube(0xc00012b380, 0x0, 0x0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/cmd/ovnkube/ovnkube.go:276 +0x68f
main.main.func1(0xc00012b380, 0xc00011f000, 0x60)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/cmd/ovnkube/ovnkube.go:102 +0x2b
github.com/urfave/cli/v2.(*App).RunContext(0xc00044a300, 0x1e1ec40, 0xc0004c4f00, 0xc00012c000, 0x21, 0x24, 0x0, 0x0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/github.com/urfave/cli/v2/app.go:315 +0x70d
main.main()
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/cmd/ovnkube/ovnkube.go:129 +0x7fe
```