### PR TITLE
delete stale chassis from sbdb when nodes' chassis annotation change

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -198,13 +198,19 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		klog.Info("Preparing Shared Gateway")
 		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator)
 	case config.GatewayModeDisabled:
+		var chassisID string
 		klog.Info("Gateway Mode is disabled")
 		gw = &gateway{
 			initFunc:  func() error { return nil },
 			readyFunc: func() (bool, error) { return true, nil },
 		}
+		chassisID, err = util.GetNodeChassisID()
+		if err != nil {
+			return err
+		}
 		err = util.SetL3GatewayConfig(nodeAnnotator, &util.L3GatewayConfig{
-			Mode: config.GatewayModeDisabled,
+			Mode:      config.GatewayModeDisabled,
+			ChassisID: chassisID,
 		})
 	}
 	if err != nil {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1003,6 +1003,9 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 		return nil, err
 	}
 
+	// delete stale chassis in SBDB if any
+	oc.deleteStaleNodeChassis(node)
+
 	// If node annotation succeeds, update the used subnet count
 	for _, hostSubnet := range hostSubnets {
 		util.UpdateUsedHostSubnetsCount(hostSubnet,
@@ -1012,6 +1015,45 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 	metrics.RecordSubnetUsage(oc.v4HostSubnetsUsed, oc.v6HostSubnetsUsed)
 
 	return hostSubnets, nil
+}
+
+// check if any existing chassis entries in the SBDB mismatches with node's chassisID annotation
+func (oc *Controller) checkNodeChassisMismatch(node *kapi.Node) (bool, error) {
+	chassisID, err := util.ParseNodeChassisIDAnnotation(node)
+	if err != nil {
+		return false, nil
+	}
+
+	chassisList, err := oc.ovnSBClient.ChassisGet(node.Name)
+	if err != nil {
+		return false, fmt.Errorf("failed to get chassis list for node %s: error: %v", node.Name, err)
+	}
+
+	if len(chassisList) == 0 {
+		return false, nil
+	}
+
+	for _, chassis := range chassisList {
+		if chassis.Name == chassisID {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// delete stale chassis in SBDB if system-id of the specific node has changed.
+func (oc *Controller) deleteStaleNodeChassis(node *kapi.Node) {
+	mismatch, err := oc.checkNodeChassisMismatch(node)
+	if err != nil {
+		klog.Errorf("Failed to check if there is any stale chassis for node %s in SBDB: %v", node.Name, err)
+	} else if mismatch {
+		klog.V(5).Infof("Node %s is now with a new chassis ID, delete its stale chassis in SBDB", node.Name)
+		if err = oc.deleteNodeChassis(node.Name); err != nil {
+			oc.recorder.Eventf(node, kapi.EventTypeWarning, "ErrorMismatchChassis",
+				"Node %s is now with a new chassis ID. Its stale chassis entry is still in the SBDB",
+				node.Name)
+		}
+	}
 }
 
 func (oc *Controller) deleteNodeHostSubnet(nodeName string, subnet *net.IPNet) error {
@@ -1321,7 +1363,7 @@ func (oc *Controller) deleteNodeChassis(nodeName string) error {
 	}
 
 	if len(cmds) == 0 {
-		return fmt.Errorf("failed to find chassis for node %s", nodeName)
+		return nil
 	}
 
 	if err = oc.ovnSBClient.Execute(cmds...); err != nil {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -996,6 +996,11 @@ func (oc *Controller) WatchNodes() {
 				}
 			}
 
+			if nodeChassisChanged(oldNode, node) {
+				// delete stale chassis in SBDB if any
+				oc.deleteStaleNodeChassis(node)
+			}
+
 			oc.clearInitialNodeNetworkUnavailableCondition(oldNode, node)
 
 			_, failed = gatewaysFailed.Load(node.Name)
@@ -1131,6 +1136,12 @@ func nodeSubnetChanged(oldNode, node *kapi.Node) bool {
 	oldSubnets, _ := util.ParseNodeHostSubnetAnnotation(oldNode)
 	newSubnets, _ := util.ParseNodeHostSubnetAnnotation(node)
 	return !reflect.DeepEqual(oldSubnets, newSubnets)
+}
+
+func nodeChassisChanged(oldNode, node *kapi.Node) bool {
+	oldChassis, _ := util.ParseNodeChassisIDAnnotation(oldNode)
+	newChassis, _ := util.ParseNodeChassisIDAnnotation(node)
+	return oldChassis != newChassis
 }
 
 // noHostSubnet() compares the no-hostsubenet-nodes flag with node labels to see if the node is manageing its

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -225,6 +225,16 @@ func ParseNodeL3GatewayAnnotation(node *kapi.Node) (*L3GatewayConfig, error) {
 	return cfg, nil
 }
 
+// ParseNodeChassisIDAnnotation returns the node's ovnNodeChassisID annotation
+func ParseNodeChassisIDAnnotation(node *kapi.Node) (string, error) {
+	chassisID, ok := node.Annotations[ovnNodeChassisID]
+	if !ok {
+		return "", fmt.Errorf("%s annotation not found for node %s", ovnNodeChassisID, node.Name)
+	}
+
+	return chassisID, nil
+}
+
 func SetNodeManagementPortMACAddress(nodeAnnotator kube.Annotator, macAddress net.HardwareAddr) error {
 	return nodeAnnotator.Set(ovnNodeManagementPortMacAddress, macAddress.String())
 }


### PR DESCRIPTION
Today, when a node is deleted from the cluster, its chassis entry is
deleted from sbdb by ovnkube-master, but it can be soon added back by
ovn-controller. This stale chassis entry prevents new one being added to
sbdb when the node is added back to the cluster with a different
chassis id.

This commit checks node's chassis annotation and delete the stale
chassis from sbdb if the annotation suggests there is a change of
chassis id.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->