### PR TITLE
e2e test to validate persistence of the OVN databases

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -18,7 +18,7 @@ if [ "$OVN_HA" == false ]; then
   	SKIPPED_TESTS+="|"
   fi
   # No support for these features in no-ha mode yet
-  SKIPPED_TESTS+="e2e delete databases"
+  SKIPPED_TESTS+="recovering from deleting db files while maintain connectivity"
 fi
 
 # setting these is required to make RuntimeClass tests work ... :/


### PR DESCRIPTION
this PR continues #1918 .

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
this PR is adding an e2e test that will check that the database is saved on the node file system (and not on a particular pod file system). The test will delete all the db pods (1 pod when on `non-ha` mode or 3 pods when on `ha` mode) without deleting any database files. After all the db pods will be be ready again we will test that new pod can be created and pass simple connectivity test to the API server.


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
as said earlier this PR continues #1918 .

the test validate connectivity before and after deleting all the db pods .
(we are  deleting the pods in order to emulate the pod restart.)

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

in order to try it yourself you can run from the `test` directory:
```
make control-plane WHAT="Should validate connectivity before and after deleting all the db-pods at once"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
adding e2e test to validate persistence of the OVN databases.