### PR TITLE
Fixes errors when adding NAT with existing entry

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -366,18 +366,12 @@ func (oc *Controller) addPerPodGRSNAT(pod *kapi.Pod, podIfAddrs []*net.IPNet) er
 				continue
 			}
 			mask := GetIPFullMask(podIP)
-			// may-exist works only if the the nat rule being added has everything the same i.e.,
-			// the type, the router name, external IP and the logical IP must match
-			// else the tuple is considered different one than existing.
-			// If the type is snat and the logical IP is the same, but external IP is different,
-			// even with --may-exist, the add may error out. this is because, for snat,
-			// (type, router, logical ip) is considered a key for uniqueness
-			stdout, stderr, err := util.RunOVNNbctl("--if-exists", "lr-nat-del", gr, "snat", podIP+mask,
-				"--", "lr-nat-add",
-				gr, "snat", gwIP, podIP+mask)
+			_, fullMaskPodNet, err := net.ParseCIDR(podIP + mask)
 			if err != nil {
-				return fmt.Errorf("failed to create SNAT rule for pod on gateway router %s, "+
-					"stdout: %q, stderr: %q, error: %v", gr, stdout, stderr, err)
+				return fmt.Errorf("invalid IP: %s and mask: %s combination, error: %v", podIP, mask, err)
+			}
+			if err := util.UpdateRouterSNAT(gr, gwIPNet.IP, fullMaskPodNet); err != nil {
+				return fmt.Errorf("failed to update NAT for pod: %s, error: %v", pod.Name, err)
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -325,14 +325,9 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 				return fmt.Errorf("failed to create default SNAT rules for gateway router %s: %v",
 					gatewayRouter, err)
 			}
-			// delete the existing lr-nat rule first otherwise gateway init fails
-			// if the external ip has changed, but the logical ip has stayed the same
-			stdout, stderr, err := util.RunOVNNbctl("--if-exists", "lr-nat-del",
-				gatewayRouter, "snat", entry.String(), "--", "lr-nat-add",
-				gatewayRouter, "snat", externalIP[0].String(), entry.String())
-			if err != nil {
-				return fmt.Errorf("failed to create default SNAT rules for gateway router %s, "+
-					"stdout: %q, stderr: %q, error: %v", gatewayRouter, stdout, stderr, err)
+			if err := util.UpdateRouterSNAT(gatewayRouter, externalIP[0], entry); err != nil {
+				return fmt.Errorf("failed to update NAT entry for pod subnet: %s, GR: %s, error: %v",
+					entry.String(), gatewayRouter, err)
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -111,7 +111,9 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node 0.0.0.0/0 169.254.33.1 rtoe-GR_test-node",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add ovn_cluster_router 100.64.0.3 100.64.0.3",
 			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router 10.130.0.0/23 100.64.0.3",
-			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat 10.128.0.0/14 -- lr-nat-add GR_test-node snat 169.254.33.2 10.128.0.0/14",
+			"ovn-nbctl --timeout=15 --columns _uuid --format=csv --no-headings find nat external_ip=169.254.33.2 type=snat logical_ip=10.128.0.0/14",
+			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat 10.128.0.0/14",
+			"ovn-nbctl --timeout=15 lr-nat-add GR_test-node snat 169.254.33.2 10.128.0.0/14",
 		})
 
 		err = gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
@@ -184,7 +186,9 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add GR_test-node ::/0 fd99::1 rtoe-GR_test-node",
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add ovn_cluster_router fd98::3 fd98::3",
 			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router fd01:0:0:2::/64 fd98::3",
-			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat fd01::/48 -- lr-nat-add GR_test-node snat fd99::2 fd01::/48",
+			"ovn-nbctl --timeout=15 --columns _uuid --format=csv --no-headings find nat external_ip=fd99::2 type=snat logical_ip=fd01::/48",
+			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat fd01::/48",
+			"ovn-nbctl --timeout=15 lr-nat-add GR_test-node snat fd99::2 fd01::/48",
 		})
 
 		err = gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
@@ -259,8 +263,12 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --may-exist lr-route-add ovn_cluster_router fd98::3 fd98::3",
 			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router 10.130.0.0/23 100.64.0.3",
 			"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add ovn_cluster_router fd01:0:0:2::/64 fd98::3",
-			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat 10.128.0.0/14 -- lr-nat-add GR_test-node snat 169.254.33.2 10.128.0.0/14",
-			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat fd01::/48 -- lr-nat-add GR_test-node snat fd99::2 fd01::/48",
+			"ovn-nbctl --timeout=15 --columns _uuid --format=csv --no-headings find nat external_ip=169.254.33.2 type=snat logical_ip=10.128.0.0/14",
+			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat 10.128.0.0/14",
+			"ovn-nbctl --timeout=15 lr-nat-add GR_test-node snat 169.254.33.2 10.128.0.0/14",
+			"ovn-nbctl --timeout=15 --columns _uuid --format=csv --no-headings find nat external_ip=fd99::2 type=snat logical_ip=fd01::/48",
+			"ovn-nbctl --timeout=15 --if-exists lr-nat-del GR_test-node snat fd01::/48",
+			"ovn-nbctl --timeout=15 lr-nat-add GR_test-node snat fd99::2 fd01::/48",
 		})
 
 		err = gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1146,8 +1146,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + types.OVNClusterRouter + " " + lrpIP + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + types.OVNClusterRouter + " " + lrpIPv6 + " " + lrpIPv6,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + types.OVNClusterRouter + " " + nodeSubnet + " " + lrpIP,
-				"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + gwRouter + " snat " + clusterCIDR +
-					" -- lr-nat-add " + gwRouter + " snat " + gatewayRouterIP + " " + clusterCIDR,
+				"ovn-nbctl --timeout=15 --columns _uuid --format=csv --no-headings find nat external_ip=" + gatewayRouterIP + " type=snat logical_ip=" + clusterCIDR,
+				"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + gwRouter + " snat " + clusterCIDR,
+				"ovn-nbctl --timeout=15 lr-nat-add " + gwRouter + " snat " + gatewayRouterIP + " " + clusterCIDR,
 			})
 
 			addPBRandNATRules(fexec, nodeName, nodeSubnet, gatewayRouterIP, nodeMgmtPortIP, nodeMgmtPortMAC)
@@ -1181,8 +1182,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + types.OVNClusterRouter + " " + lrpIP + " " + lrpIP,
 				"ovn-nbctl --timeout=15 --may-exist lr-route-add " + types.OVNClusterRouter + " " + lrpIPv6 + " " + lrpIPv6,
 				"ovn-nbctl --timeout=15 --may-exist --policy=src-ip lr-route-add " + types.OVNClusterRouter + " " + nodeSubnet + " " + lrpIP,
-				"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + gwRouter + " snat " + clusterCIDR +
-					" -- lr-nat-add " + gwRouter + " snat " + gatewayRouterIP + " " + clusterCIDR,
+				"ovn-nbctl --timeout=15 --columns _uuid --format=csv --no-headings find nat external_ip=" + gatewayRouterIP + " type=snat logical_ip=" + clusterCIDR,
+				"ovn-nbctl --timeout=15 --if-exists lr-nat-del " + gwRouter + " snat " + clusterCIDR,
+				"ovn-nbctl --timeout=15 lr-nat-add " + gwRouter + " snat " + gatewayRouterIP + " " + clusterCIDR,
 			})
 
 			addPBRandNATRules(fexec, nodeName, nodeSubnet, gatewayRouterIP, nodeMgmtPortIP, nodeMgmtPortMAC)

--- a/go-controller/pkg/util/ovn.go
+++ b/go-controller/pkg/util/ovn.go
@@ -1,0 +1,77 @@
+package util
+
+// Contains helper functions for OVN
+// Eventually these should all be migrated to go-ovn bindings
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// UpdateRouterSNAT checks if a NAT entry exists in OVN for a specific router and updates it if necessary
+// may-exist works only if the the nat rule being added has everything the same i.e.,
+// the type, the router name, external IP and the logical IP must match
+// else the tuple is considered different one than existing.
+// If the type is snat and the logical IP is the same, but external IP is different,
+// even with --may-exist, the add may error out. this is because, for snat,
+// (type, router, logical ip) is considered a key for uniqueness
+// Combining lr-nat-del and lr-nat-add will fail OVSDB transaction check because
+// the entry will already exist so need to do these as two separate transactions
+// Therefore we need to iterate through existing SNAT rules on GR and decide if we need to delete/add
+// TODO(trozet) use go-bindings
+func UpdateRouterSNAT(router string, externalIP net.IP, logicalSubnet *net.IPNet) error {
+	natType := "snat"
+	logicalIPVal := logicalSubnet.String()
+	logicalIPMask, _ := logicalSubnet.Mask.Size()
+	// OVN Values with full prefix mask wont print the /mask
+	if logicalIPMask == 32 || logicalIPMask == 128 {
+		logicalIPVal = logicalSubnet.IP.String()
+	}
+
+	// Search for exact match to see if entry already exists
+	uuids, stderr, err := RunOVNNbctl("--columns", "_uuid", "--format=csv", "--no-headings", "find", "nat",
+		"external_ip="+externalIP.String(),
+		"type="+natType,
+		"logical_ip="+logicalIPVal,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to search NAT rules for external_ip %s, logicalSubnet: %s, "+
+			"stderr: %q, error: %v", externalIP, logicalSubnet, stderr, err)
+	}
+
+	for _, uuid := range strings.Split(uuids, "\n") {
+		if len(uuid) == 0 {
+			continue
+		}
+		// Potential matches found, check logical_router
+		routerID, stderr, err := RunOVNNbctl("--columns", "_uuid", "--no-headings", "find", "logical_router",
+			"name="+router,
+			"nat{>=}"+uuid,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to search logical_router for nat entry %s, router: %s, "+
+				"stderr: %q, error: %v", uuid, router, stderr, err)
+		}
+		if len(routerID) > 0 {
+			// entry already exists, no update needed
+			return nil
+		}
+	}
+
+	// If we made it here, need to create the entry. To avoid collision with another entry created on the router
+	// for the same logicalSubnet, ensure we remove any incorrect entry first
+	_, stderr, err = RunOVNNbctl("--if-exists", "lr-nat-del", router, natType, logicalSubnet.String())
+	if err != nil {
+		return fmt.Errorf("failed to delete NAT rule for pod on router %s, "+
+			"stderr: %q, error: %v", router, stderr, err)
+	}
+	stdout, stderr, err := RunOVNNbctl("lr-nat-add", router, natType, externalIP.String(),
+		logicalSubnet.String())
+	if err != nil {
+		return fmt.Errorf("failed to create NAT rule for pod on router %s, "+
+			"stdout: %q, stderr: %q, error: %v", router, stdout, stderr, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
When adding SNAT per pod with an existing entry, the code will fail and
report an error because with OVN we cannot do lr-nat-del and lr-nat-add
in the same OVSDB transaction. This is because OVSDB evaluates the
lr-nat-add and thinks there will be a conflict because an entry already
exists.

Additionally, during gateway init for a node, this failure may also
occur. In which case the GR will be left with missing config.

To handle this case, split add and delete into separate transactions,
and only del/add if the entry is missing.

Signed-off-by: Tim Rozet <trozet@redhat.com>
