### PR TITLE
Properly log when hybrid overlay errors out

### DIFF
--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
@@ -50,7 +50,7 @@ func main() {
 		}
 
 		if err := runHybridOverlay(c); err != nil {
-			panic(err.Error())
+			klog.Exit(err)
 		}
 		return nil
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
hybrid-overlay is experiencing an issue where fatal errors are not being
logged when logging to a file using the `logfile` flag. This commit
makes it so that the error is logged properly before the program exits.
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
hybrid-overlay logs errors properly before exiting due to an error