### PR TITLE
modify CGO build flag for ovn-k8s-cni-overlay binary

### DIFF
--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -23,6 +23,10 @@ build_binaries() {
     set -x
     for bin in "$@"; do
         binbase=$(basename ${bin})
+        CGO_ENABLED=1
+        if [[ "$binbase" == "ovn-k8s-cni-overlay" ]]; then
+            CGO_ENABLED=0
+        fi
         go build -v \
             -mod vendor \
             -gcflags "${GCFLAGS}" \


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
modify CGO build flag for ovn-k8s-cni-overlay binary since its build at the host and it has runtime dependency on some libraries for more details pls. refer to  #2108  

**- Special notes for reviewers**
changed CGO_ENABLED env setting to 0 only when building ovn-k82-cni-overlay


**- How to verify it**
bring up ovn KIIND cluster on Fedora 33 where it has glibc33 while ovn CNI expects glibc32 w/o  the fix DNS POD stuck in Starting Container state forever



**- Description for the changelog**
build ovn-k8s-cni-overlay with CGO_ENABLED=0 while keep it enabled for other binaries
