### PR TITLE
Fix dead link for k8s test binaries

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -9,10 +9,13 @@ groomTestList() {
 }
 
 SKIPPED_TESTS="
-# PERFORMANCE AND DISRUPTIVE TESTS: NOT WANTED FOR CI
+# PERFORMANCE, DISRUPTIVE, OR UNRELATED TESTS: NOT WANTED FOR CI
 Networking IPerf IPv[46]
 \[Feature:PerformanceDNS\]
 Disruptive
+DisruptionController
+\[sig-apps\] CronJob
+\[sig-storage\]
 
 # FEATURES NOT AVAILABLE IN OUR CI ENVIRONMENT
 \[Feature:Federation\]
@@ -25,9 +28,6 @@ should set TCP CLOSE_WAIT timeout
 
 # TO BE IMPLEMENTED: https://github.com/ovn-org/ovn-kubernetes/issues/819
 Services.+session affinity
-
-# TO BE IMPLEMENTED: https://github.com/ovn-org/ovn-kubernetes/issues/1116
-EndpointSlices
 
 # NOT IMPLEMENTED; SEE DISCUSSION IN https://github.com/ovn-org/ovn-kubernetes/pull/1225
 named port.+\[Feature:NetworkPolicy\]

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -8,14 +8,8 @@ chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 
 # Install e2e test binary and ginkgo
-# The e2e binaries are published upstream so the ecosystem can consume then directly
-# xref https://github.com/kubernetes/enhancements/blob/master/keps/sig-testing/20190118-breaking-apart-the-kubernetes-test-tarball.md
-# Current e2e binary version for CI is kubernetes 1.20 with the fix for IPv6 network policies #96856
-# We can always get the latest version published from the URL dl.k8s.io/ci/latest.txt
-# curl -L dl.k8s.io/ci/latest.txt
-# v1.21.0-alpha.0.341+46d481b4556e33
-curl -LO https://dl.k8s.io/ci/v1.21.0-alpha.0.341+46d481b4556e33/kubernetes-test-linux-amd64.tar.gz
-tar xvzf kubernetes-test-linux-amd64.tar.gz --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test
+curl -L https://github.com/trozet/ovnFiles/blob/master/kubernetes-test-linux-v1.21.0-alpha.0.341%2B46d481b4556e33.tar.gz?raw=true -o kubernetes-test-linux-amd64.tar.gz
+tar xvzf kubernetes-test-linux-amd64.tar.gz
 sudo mv ./e2e.test /usr/local/bin/e2e.test
 sudo mv ./ginkgo /usr/local/bin/ginkgo
 rm kubernetes-test-linux-amd64.tar.gz


### PR DESCRIPTION
Just use latest and avoid hardcoding links which will be removed in the
future.

Signed-off-by: Tim Rozet <trozet@redhat.com>

