### PR TITLE
Always mount /var/run/netns for ovnkube node

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -463,7 +463,6 @@ create_ovn_kube_manifests() {
     --multicast-enabled="${OVN_MULTICAST_ENABLE}" \
     --k8s-apiserver="${API_URL}" \
     --ovn-master-count="${KIND_NUM_MASTER}" \
-    --kind \
     --ovn-unprivileged-mode=no \
     --master-loglevel="${MASTER_LOG_LEVEL}" \
     --node-loglevel="${NODE_LOG_LEVEL}" \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -20,7 +20,6 @@ OVN_GATEWAY_OPTS=""
 OVN_DB_REPLICAS=""
 OVN_MTU=""
 OVN_SSL_ENABLE=""
-KIND=""
 OVN_UNPRIVILEGED_MODE=""
 MASTER_LOGLEVEL=""
 NODE_LOGLEVEL=""
@@ -78,9 +77,6 @@ while [ "$1" != "" ]; do
     ;;
   --mtu)
     OVN_MTU=$VALUE
-    ;;
-  --kind)
-    KIND=true
     ;;
   --ovn-unprivileged-mode)
     OVN_UNPRIVILEGED_MODE=$VALUE
@@ -271,7 +267,6 @@ echo "ovn_ipfix_targets: ${ovn_ipfix_targets}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
-  kind=${KIND} \
   ovn_unprivileged_mode=${ovn_unprivileged_mode} \
   ovn_gateway_mode=${ovn_gateway_mode} \
   ovn_gateway_opts=${ovn_gateway_opts} \

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -140,11 +140,9 @@ spec:
         - mountPath: /etc/ovn/
           name: host-var-lib-ovs
           readOnly: true
-        {% if kind is defined and kind -%}
         - mountPath: /var/run/netns
           name: host-netns
           mountPropagation: Bidirectional
-        {% endif %}
 
         resources:
           requests:
@@ -300,11 +298,9 @@ spec:
       - name: host-var-lib-ovs
         hostPath:
           path: /var/lib/openvswitch
-      {% if kind is defined and kind -%}
       - name: host-netns
         hostPath:
           path: /var/run/netns
-      {% endif %}
 
       tolerations:
       - operator: "Exists"


### PR DESCRIPTION
Newer container runtimes pass to CNI the Pods
network namespace path in /var/run/netns.

If the Pod's network interface plumbing is done
in ovnkube-node and not ovn-k8s-cni-overlay.
it will fail to find the namespace as the Pod's
network namespace path is not available in ovnkube
node container.

This was encountered in:
CRI-O 1.19
Containerd 1.4.4

To solve it, mount host /var/run/netns in ovnkube-node
container.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>
