### PR TITLE
log events for stale Pods scheduled on a node that was deleted then a…

### DIFF
--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -42,6 +42,19 @@ func (c *portCache) get(logicalPort string) (*lpInfo, error) {
 	return nil, fmt.Errorf("logical port %s not found in cache", logicalPort)
 }
 
+// check if there is any pod on the specified node (compare with the logicalSwitch name in the port cache)
+func (c *portCache) isPodOnNode(nodeName string) bool {
+	c.RLock()
+	defer c.RUnlock()
+
+	for _, lp := range c.cache {
+		if lp.logicalSwitch == nodeName {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *portCache) add(logicalSwitch, logicalPort, uuid string, mac net.HardwareAddr, ips []*net.IPNet) *lpInfo {
 	c.Lock()
 	defer c.Unlock()


### PR DESCRIPTION
…dded back

If a node is deleted then readded back before Pods on the node are
rescheduled to another node, it may result in Pods with stale IPs
within the previous node subnets.

This is due to problematic administration operation that is not
supported. We will just log warning events so that the problem can
be detected then corrrected in a timely manner.

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->