### PR TITLE
Replace ACL reject rules with a reject=true loadbalancer for services without endpoints

### DIFF
--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/acl"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -25,14 +26,16 @@ import (
 type Repair struct {
 	interval time.Duration
 	// serviceTracker tracks services and maps them to OVN LoadBalancers
-	serviceLister corelisters.ServiceLister
+	serviceLister        corelisters.ServiceLister
+	clusterPortGroupUUID string
 }
 
 // NewRepair creates a controller that periodically ensures that there is no stale data in OVN
-func NewRepair(interval time.Duration, serviceLister corelisters.ServiceLister) *Repair {
+func NewRepair(interval time.Duration, serviceLister corelisters.ServiceLister, clusterPortGroupUUID string) *Repair {
 	return &Repair{
-		interval:      interval,
-		serviceLister: serviceLister,
+		interval:             interval,
+		serviceLister:        serviceLister,
+		clusterPortGroupUUID: clusterPortGroupUUID,
 	}
 }
 
@@ -113,6 +116,14 @@ func (r *Repair) runOnce() error {
 				}
 			}
 		}
+	}
+
+	// Remove existing reject rules. They are not used anymore
+	// given the introduction of idling loadbalancers
+	err = acl.PurgeRejectRules(r.clusterPortGroupUUID)
+	if err != nil {
+		klog.Errorf("Failed to purge existing reject rules: %v", err)
+		return err
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/controller/services/repair_test.go
+++ b/go-controller/pkg/ovn/controller/services/repair_test.go
@@ -63,6 +63,10 @@ func TestRepair_Empty(t *testing.T) {
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
 		Output: "",
 	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --columns=_uuid --format=csv --data=bare --no-headings find acl action=reject",
+		Output: "",
+	})
 
 	err := util.SetExec(fexec)
 	if err != nil {
@@ -120,6 +124,11 @@ func TestRepair_OVNStaleData(t *testing.T) {
 		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.1:443\"",
 		Output: "",
 	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --columns=_uuid --format=csv --data=bare --no-headings find acl action=reject",
+		Output: "",
+	})
+
 	// The repair loop must delete them
 	err := util.SetExec(fexec)
 	if err != nil {
@@ -171,6 +180,10 @@ func TestRepair_OVNSynced(t *testing.T) {
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
 		Output: "",
 	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --columns=_uuid --format=csv --data=bare --no-headings find acl action=reject",
+		Output: "",
+	})
 
 	err := util.SetExec(fexec)
 	if err != nil {
@@ -219,6 +232,10 @@ func TestRepair_OVNMissingService(t *testing.T) {
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer " + grUdpLBUUID + " vips",
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --columns=_uuid --format=csv --data=bare --no-headings find acl action=reject",
 		Output: "",
 	})
 

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -48,6 +48,7 @@ const (
 func NewController(client clientset.Interface,
 	serviceInformer coreinformers.ServiceInformer,
 	endpointSliceInformer discoveryinformers.EndpointSliceInformer,
+	clusterPortGroupUUID string,
 ) *Controller {
 	klog.V(4).Info("Creating event broadcaster")
 	broadcaster := record.NewBroadcaster()
@@ -89,7 +90,7 @@ func NewController(client clientset.Interface,
 	c.eventRecorder = recorder
 
 	// repair controller
-	c.repair = NewRepair(0, serviceInformer.Lister())
+	c.repair = NewRepair(0, serviceInformer.Lister(), clusterPortGroupUUID)
 
 	return c
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -1,12 +1,12 @@
 package services
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
@@ -20,10 +20,12 @@ import (
 )
 
 const (
-	loadbalancerTCP = "a08ea426-2288-11eb-a30b-a8a1590cda29"
-	portGroupUUID   = "58a1ef18-3649-11eb-bd94-a8a1590cda29"
-	gatewayRouter1  = "2e290f10-3652-11eb-839b-a8a1590cda29"
-	logicalSwitch1  = "17bde5e8-3652-11eb-b53b-a8a1590cda29"
+	loadbalancerTCP       = "a08ea426-2288-11eb-a30b-a8a1590cda29"
+	portGroupUUID         = "58a1ef18-3649-11eb-bd94-a8a1590cda29"
+	gatewayRouter1        = "2e290f10-3652-11eb-839b-a8a1590cda29"
+	logicalSwitch1        = "17bde5e8-3652-11eb-b53b-a8a1590cda29"
+	idlingloadbalancerTCP = "a08ea426-2288-11eb-a30b-a8a1590cda30"
+	clusterPortGroupUUID  = "a08ea426-2288-11eb-a30b-a8a1590cda31"
 )
 
 var alwaysReady = func() bool { return true }
@@ -41,7 +43,7 @@ func newController() *serviceController {
 	controller := NewController(client,
 		informerFactory.Core().V1().Services(),
 		informerFactory.Discovery().V1beta1().EndpointSlices(),
-		portGroupUUID,
+		clusterPortGroupUUID,
 	)
 	controller.servicesSynced = alwaysReady
 	controller.endpointSlicesSynced = alwaysReady
@@ -55,6 +57,10 @@ func newController() *serviceController {
 func TestSyncServices(t *testing.T) {
 	ns := "testns"
 	serviceName := "foo"
+	config.Kubernetes.OVNEmptyLbEvents = true
+	defer func() {
+		config.Kubernetes.OVNEmptyLbEvents = false
+	}()
 
 	tests := []struct {
 		name          string
@@ -63,35 +69,7 @@ func TestSyncServices(t *testing.T) {
 		updateTracker bool
 		ovnCmd        []ovntest.ExpectedCmd
 	}{
-		{
-			name: "delete endpoint slice with no service",
-			slice: &discovery.EndpointSlice{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName + "ab23",
-					Namespace: ns,
-					Labels:    map[string]string{discovery.LabelServiceName: serviceName},
-				},
-				Ports:       []discovery.EndpointPort{},
-				AddressType: discovery.AddressTypeIPv4,
-				Endpoints:   []discovery.Endpoint{},
-			},
-			service:       &v1.Service{},
-			updateTracker: true,
-			ovnCmd: []ovntest.ExpectedCmd{
-				{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
-					Output: loadbalancerTCP,
-				},
-				{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
-					Output: FakeGRs,
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-					Output: "",
-				},
-			},
-		},
+
 		{
 			name: "create service from Single Stack Service without endpoints",
 			slice: &discovery.EndpointSlice{
@@ -121,15 +99,35 @@ func TestSyncServices(t *testing.T) {
 			updateTracker: true,
 			ovnCmd: []ovntest.ExpectedCmd{
 				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+					Output: idlingloadbalancerTCP,
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"192.168.1.1:80\"",
+					Output: "",
+				},
+				{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 					Output: loadbalancerTCP,
 				},
 				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+					Cmd:    "ovn-nbctl --timeout=15 set load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips:\"192.168.1.1:80\"=\"\"",
 					Output: "",
 				},
 				{
-					Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=` + types.DirectionFromLPort + ` priority=` + types.DefaultDenyPriority + ` match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls @reject-acl`,
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+					Output: gatewayRouter1,
+				},
+				{
+					Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=%s", gatewayRouter1),
+					Output: "load_balancer_1",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips \"192.168.1.1:80\"",
+					Output: "",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
 					Output: "",
 				},
 			},
@@ -164,19 +162,7 @@ func TestSyncServices(t *testing.T) {
 			updateTracker: true,
 			ovnCmd: []ovntest.ExpectedCmd{
 				{
-					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
-					Output: loadbalancerTCP,
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-					Output: "",
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=` + types.DirectionFromLPort + ` priority=` + types.DefaultDenyPriority + ` match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add port_group 58a1ef18-3649-11eb-bd94-a8a1590cda29 acls @reject-acl`,
-					Output: "",
-				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null`,
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
 					Output: gatewayRouter1,
 				},
 				{
@@ -184,17 +170,76 @@ func TestSyncServices(t *testing.T) {
 					Output: "5.5.5.5",
 				},
 				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=` + gatewayRouter1,
-					Output: "",
-				},
-
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}a08ea426-2288-11eb-a30b-a8a1590cda29`,
-					Output: logicalSwitch1,
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+					Output: gatewayRouter1,
 				},
 				{
-					Cmd:    `ovn-nbctl --timeout=15 --id=@reject-acl create acl direction=` + types.DirectionFromLPort + ` priority=` + types.DefaultDenyPriority + ` match="ip4.dst==192.168.1.1 && tcp && tcp.dst==80" action=reject name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80 -- add logical_switch 17bde5e8-3652-11eb-b53b-a8a1590cda29 acls @reject-acl`,
+					Cmd:    `ovn-nbctl --timeout=15 get logical_router 2e290f10-3652-11eb-839b-a8a1590cda29 external_ids:physical_ips`,
+					Output: "5.5.5.5",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+					Output: idlingloadbalancerTCP,
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"192.168.1.1:80\"",
 					Output: "",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+					Output: idlingloadbalancerTCP,
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"5.5.5.5:32766\"",
+					Output: "",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
+					Output: loadbalancerTCP,
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 set load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips:\"192.168.1.1:80\"=\"\"",
+					Output: "",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+					Output: gatewayRouter1,
+				},
+				{
+					Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=%s", gatewayRouter1),
+					Output: "load_balancer_1",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips \"192.168.1.1:80\"",
+					Output: "",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+					Output: gatewayRouter1,
+				},
+				{
+					Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=%s", gatewayRouter1),
+					Output: "load_balancer_1",
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 get logical_router 2e290f10-3652-11eb-839b-a8a1590cda29 external_ids:physical_ips`,
+					Output: "5.5.5.5",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 set load_balancer load_balancer_1 vips:\"5.5.5.5:32766\"=\"\"",
+					Output: "",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+					Output: gatewayRouter1,
+				},
+				{
+					Cmd:    `ovn-nbctl --timeout=15 get logical_router 2e290f10-3652-11eb-839b-a8a1590cda29 external_ids:physical_ips`,
+					Output: "5.5.5.5",
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+					Output: gatewayRouter1,
 				},
 			},
 		},
@@ -241,6 +286,14 @@ func TestSyncServices(t *testing.T) {
 			updateTracker: false,
 			ovnCmd: []ovntest.ExpectedCmd{
 				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+					Output: idlingloadbalancerTCP,
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"192.168.1.1:80\"",
+					Output: "",
+				},
+				{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 					Output: loadbalancerTCP,
 				},
@@ -265,8 +318,8 @@ func TestSyncServices(t *testing.T) {
 					Output: "",
 				},
 				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-					Output: "",
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+					Output: gatewayRouter1,
 				},
 			},
 		},
@@ -313,6 +366,14 @@ func TestSyncServices(t *testing.T) {
 			updateTracker: false,
 			ovnCmd: []ovntest.ExpectedCmd{
 				{
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+					Output: idlingloadbalancerTCP,
+				},
+				{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"192.168.1.1:80\"",
+					Output: "",
+				},
+				{
 					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 					Output: loadbalancerTCP,
 				},
@@ -337,7 +398,7 @@ func TestSyncServices(t *testing.T) {
 					Output: "",
 				},
 				{
-					Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+					Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
 					Output: "",
 				},
 			},
@@ -364,16 +425,35 @@ func TestSyncServices(t *testing.T) {
 			if err != nil {
 				t.Errorf("fexec error: %v", err)
 			}
+			err = controller.syncServices(ns + "/" + serviceName)
+			if err != nil {
+				t.Errorf("syncServices error: %v", err)
+			}
 
-			controller.syncServices(ns + "/" + serviceName)
+			if !fexec.CalledMatchesExpected() {
+				t.Error(fexec.ErrorDesc())
+			}
 		})
 	}
 }
 
 // A service can mutate its ports, we need to be sure we don´t left dangling ports
 func TestUpdateServicePorts(t *testing.T) {
+	config.Kubernetes.OVNEmptyLbEvents = true
+	defer func() {
+		config.Kubernetes.OVNEmptyLbEvents = false
+	}()
+
 	// Expected OVN commands
 	fexec := ovntest.NewFakeExec()
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+		Output: idlingloadbalancerTCP,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"192.168.1.1:80\"",
+		Output: "",
+	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 		Output: loadbalancerTCP,
@@ -400,8 +480,16 @@ func TestUpdateServicePorts(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-		Output: "",
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+		Output: gatewayRouter1,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+		Output: idlingloadbalancerTCP,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"192.168.1.1:8888\"",
+		Output: idlingloadbalancerTCP,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
@@ -429,8 +517,8 @@ func TestUpdateServicePorts(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:8888`,
-		Output: "",
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+		Output: gatewayRouter1,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
@@ -441,14 +529,28 @@ func TestUpdateServicePorts(t *testing.T) {
 		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "192.168.1.1:80"`,
 		Output: "",
 	})
-	// Remove the ACL if exist
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=%s", gatewayRouter1),
+		Output: "load_balancer_1",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-worker-lb-tcp=2e290f10-3652-11eb-839b-a8a1590cda29"),
+		Output: "node_load_balancer_1",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"`,
 		Output: "",
 	})
-	// Check if there are NodePort LoadBalancers
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null`,
+		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer node_load_balancer_1 vips "192.168.1.1:80"`,
+		Output: "",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+		Output: idlingloadbalancerTCP,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"192.168.1.1:80\"",
 		Output: "",
 	})
 
@@ -516,12 +618,28 @@ func TestUpdateServicePorts(t *testing.T) {
 	if !controller.serviceTracker.hasServiceVIP(serviceName, ns, "192.168.1.1:8888", v1.ProtocolTCP) {
 		t.Fatalf("Service with port 8888 should exist")
 	}
+	if !fexec.CalledMatchesExpected() {
+		t.Error(fexec.ErrorDesc())
+	}
 }
 
 // A service can mutate its ports, we need to be sure we don´t left dangling ports
 func TestUpdateServiceEndpointsToHost(t *testing.T) {
+	config.Kubernetes.OVNEmptyLbEvents = true
+	defer func() {
+		config.Kubernetes.OVNEmptyLbEvents = false
+	}()
+
 	// Expected OVN commands
 	fexec := ovntest.NewFakeExec()
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+		Output: idlingloadbalancerTCP,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips \"192.168.1.1:80\"",
+		Output: "",
+	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 		Output: loadbalancerTCP,
@@ -568,7 +686,15 @@ func TestUpdateServiceEndpointsToHost(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+		Output: FakeGRs,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+		Output: idlingloadbalancerTCP,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips "192.168.1.1:80"`,
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -630,8 +756,8 @@ func TestUpdateServiceEndpointsToHost(t *testing.T) {
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-192.168.1.1\:80`,
-		Output: "",
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+		Output: FakeGRs,
 	})
 
 	err := util.SetExec(fexec)
@@ -708,6 +834,10 @@ func TestUpdateServiceEndpointsToHost(t *testing.T) {
 	controller.endpointSliceStore.Add(epsNew)
 	// sync service
 	controller.syncServices(ns + "/" + serviceName)
+
+	if !fexec.CalledMatchesExpected() {
+		t.Error(fexec.ErrorDesc())
+	}
 }
 
 // protoPtr takes a Protocol and returns a pointer to it.

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -3,95 +3,43 @@ package services
 import (
 	"fmt"
 	"net"
-	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/acl"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
-
 	"k8s.io/klog/v2"
 )
 
-type lbEndpoints struct {
-	IPs  []string
-	Port int32
+func deleteVIPsFromAllOVNBalancers(vips sets.String, name, namespace string) error {
+	err := deleteVIPsFromNonIdlingOVNBalancers(vips, name, namespace)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to delete vips from ovn balancers %s %s", name, namespace)
+	}
+	err = deleteVIPsFromIdlingBalancer(vips, name, namespace)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to delete vips from idling balancers %s %s", name, namespace)
+	}
+	return nil
 }
 
-// return the endpoints that belong to the IPFamily as a slice of IPs
-func getLbEndpoints(slices []*discovery.EndpointSlice, svcPort v1.ServicePort, family v1.IPFamily) lbEndpoints {
-	epsSet := sets.NewString()
-	lbEps := lbEndpoints{[]string{}, 0}
-	// return an empty object so the caller don't have to check for nil and can use it as an iterator
-	if len(slices) == 0 {
-		return lbEps
+// deleteVIPsFromNonIdlingOVNBalancers removes the given vips for all the loadbalancers but
+// the idling ones. This includes the cluster loadbalancer, the gateway routers loadbalancers
+// and the node switch ones.
+func deleteVIPsFromNonIdlingOVNBalancers(vips sets.String, name, namespace string) error {
+	// NodePort and ExternalIPs use loadbalancers in each node
+	gatewayRouters, _, err := gateway.GetOvnGateways()
+	if err != nil {
+		return errors.Wrapf(err, "failed to retrieve OVN gateway routers")
 	}
 
-	for _, slice := range slices {
-		klog.V(4).Infof("Getting endpoints for slice %s", slice.Name)
-		// Only return addresses that belong to the requested IP family
-		if slice.AddressType != discovery.AddressType(family) {
-			klog.V(4).Infof("Slice %s with different IP Family endpoints, requested: %s received: %s",
-				slice.Name, slice.AddressType, family)
-			continue
-		}
-
-		// build the list of endpoints in the slice
-		for _, port := range slice.Ports {
-			// If Service port name set it must match the name field in the endpoint
-			if svcPort.Name != "" && svcPort.Name != *port.Name {
-				klog.V(5).Infof("Slice %s with different Port name, requested: %s received: %s",
-					slice.Name, svcPort.Name, *port.Name)
-				continue
-			}
-
-			// Get the targeted port
-			tgtPort := int32(svcPort.TargetPort.IntValue())
-			// If this is a string, it will return 0
-			// it has to match the port name
-			// otherwise, it has to match the port number
-			if (tgtPort == 0 && svcPort.TargetPort.String() != *port.Name) ||
-				(tgtPort > 0 && tgtPort != *port.Port) {
-				continue
-			}
-
-			// Skip ports that doesn't match the protocol
-			if *port.Protocol != svcPort.Protocol {
-				klog.V(5).Infof("Slice %s with different Port protocol, requested: %s received: %s",
-					slice.Name, svcPort.Protocol, *port.Protocol)
-				continue
-			}
-
-			lbEps.Port = *port.Port
-			for _, endpoint := range slice.Endpoints {
-				// Skip endpoints that are not ready
-				if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
-					klog.V(4).Infof("Slice endpoints Not Ready")
-					continue
-				}
-				for _, ip := range endpoint.Addresses {
-					klog.V(4).Infof("Adding slice %s endpoints: %v, port: %d", slice.Name, endpoint.Addresses, *port.Port)
-					epsSet.Insert(ip)
-				}
-			}
-		}
-	}
-
-	lbEps.IPs = epsSet.List()
-	klog.V(4).Infof("LB Endpoints for %s are: %v on port: %d", slices[0].Labels[discovery.LabelServiceName],
-		lbEps.IPs, lbEps.Port)
-	return lbEps
-}
-
-func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace, clusterPortGroupUUID string) error {
 	// Obtain the VIPs associated to the Service from the Service Tracker
 	for vipKey := range vips {
 		// the VIP is stored with the format IP:Port/Protocol
@@ -108,37 +56,7 @@ func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace, cl
 			klog.Errorf("Error deleting VIP %s on OVN LoadBalancer %s", vip, lbID)
 			return err
 		}
-		// handle reject ACLs for services without endpoints
-		// eventually we have to remove this because it will
-		// be implemented by OVN
-		// https://github.com/ovn-org/ovn-kubernetes/pull/1887
-		ip, portString, err := net.SplitHostPort(vip)
-		if err != nil {
-			return err
-		}
-		port, err := strconv.Atoi(portString)
-		if err != nil {
-			return err
-		}
-		rejectACLName := loadbalancer.GenerateACLNameForOVNCommand(lbID, ip, int32(port))
-		aclID, err := acl.GetACLByName(rejectACLName)
-		if err != nil {
-			klog.Errorf("Error trying to get ACL for Service %s/%s: %v", name, namespace, err)
-		}
-		// delete the ACL if exist
-		if len(aclID) > 0 {
-			// remove acl
-			err = acl.RemoveACLFromPortGroup(aclID, clusterPortGroupUUID)
-			if err != nil {
-				klog.Errorf("Error trying to remove ACL for Service %s/%s: %v", name, namespace, err)
-			}
-		}
-		// end of reject ACL code
-		// NodePort and ExternalIPs use loadbalancers in each node
-		gatewayRouters, _, err := gateway.GetOvnGateways()
-		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve OVN gateway routers")
-		}
+
 		// Configure the NodePort in each Node Gateway Router
 		for _, gatewayRouter := range gatewayRouters {
 			gatewayLB, err := gateway.GetGatewayLoadBalancer(gatewayRouter, proto)
@@ -163,8 +81,30 @@ func deleteVIPsFromOVN(vips sets.String, st *serviceTracker, name, namespace, cl
 				}
 			}
 		}
-		// Delete the Service VIP from the Service Tracker
-		st.deleteServiceVIP(name, namespace, vip, proto)
+	}
+	return nil
+}
+
+func deleteVIPsFromIdlingBalancer(vips sets.String, name, namespace string) error {
+	// The idling lb is enabled only when configured
+	if !config.Kubernetes.OVNEmptyLbEvents {
+		return nil
+	}
+
+	// Obtain the VIPs associated to the Service
+	for _, vipKey := range vips.List() {
+		// the VIP is stored with the format IP:Port/Protocol
+		vip, proto := splitVirtualIPKey(vipKey)
+		klog.Infof("Deleting VIP from idling OVN LoadBalancer for service %s on namespace %s", name, namespace)
+		lbID, err := loadbalancer.GetOVNKubeIdlingLoadBalancer(proto)
+		if err != nil {
+			klog.Errorf("Error getting OVN idling LoadBalancer for protocol %s %v", proto, err)
+			return err
+		}
+		if err := loadbalancer.DeleteLoadBalancerVIP(lbID, vip); err != nil {
+			klog.Errorf("Error deleting VIP %s on idling OVN LoadBalancer %s %v", vip, lbID, err)
+			return err
+		}
 	}
 	return nil
 }
@@ -362,4 +302,62 @@ func getNodeIPs(isIPv6 bool) ([]string, error) {
 		nodeIPs = append(nodeIPs, physicalIPs...)
 	}
 	return nodeIPs, nil
+}
+
+// collectServiceVIPs collects all the vips associated to a given service
+// and returns them as a set.
+func collectServiceVIPs(service *v1.Service) sets.String {
+	res := sets.NewString()
+	for _, ip := range util.GetClusterIPs(service) {
+		for _, svcPort := range service.Spec.Ports {
+			vip := util.JoinHostPortInt32(ip, svcPort.Port)
+			key := virtualIPKey(vip, svcPort.Protocol)
+			res.Insert(key)
+		}
+	}
+	for _, svcPort := range service.Spec.Ports {
+		// Node Port
+		if svcPort.NodePort != 0 {
+			for _, isIPv6 := range []bool{false, true} {
+				nodeIPs, err := getNodeIPs(isIPv6)
+				if err != nil {
+					klog.Error(err)
+				}
+				for _, ip := range nodeIPs {
+					vip := util.JoinHostPortInt32(ip, svcPort.NodePort)
+					key := virtualIPKey(vip, svcPort.Protocol)
+					res.Insert(key)
+				}
+			}
+		}
+
+		for _, extIP := range service.Spec.ExternalIPs {
+			vip := util.JoinHostPortInt32(extIP, svcPort.Port)
+			key := virtualIPKey(vip, svcPort.Protocol)
+			res.Insert(key)
+		}
+		// LoadBalancer
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			vip := util.JoinHostPortInt32(ingress.IP, svcPort.Port)
+			key := virtualIPKey(vip, svcPort.Protocol)
+			res.Insert(key)
+		}
+	}
+	return res
+}
+
+const OvnServiceIdledSuffix = "idled-at"
+
+// When idling or empty LB events are enabled, we want to ensure we receive these packets and not reject them.
+func svcNeedsIdling(annotations map[string]string) bool {
+	if !config.Kubernetes.OVNEmptyLbEvents {
+		return false
+	}
+
+	for annotationKey := range annotations {
+		if strings.HasSuffix(annotationKey, OvnServiceIdledSuffix) {
+			return true
+		}
+	}
+	return false
 }

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -1,226 +1,23 @@
 package services
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilpointer "k8s.io/utils/pointer"
 )
 
-func Test_getLbEndpoints(t *testing.T) {
-	type args struct {
-		slices  []*discovery.EndpointSlice
-		svcPort v1.ServicePort
-		family  v1.IPFamily
-	}
-	tests := []struct {
-		name string
-		args args
-		want lbEndpoints
-	}{
-		{
-			name: "empty slices",
-			args: args{
-				slices: []*discovery.EndpointSlice{},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				family: v1.IPv4Protocol,
-			},
-			want: lbEndpoints{[]string{}, 0},
-		},
-		{
-			name: "slices with endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				family: v1.IPv4Protocol,
-			},
-			want: lbEndpoints{[]string{"10.0.0.2"}, 80},
-		},
-		{
-			name: "slices with different ports",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(8080)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.0.0.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				family: v1.IPv4Protocol,
-			},
-			want: lbEndpoints{[]string{}, 0},
-		},
-		{
-			name: "slices with different IP family",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"2001:db2::2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				family: v1.IPv4Protocol,
-			},
-			want: lbEndpoints{[]string{}, 0},
-		},
-		{
-			name: "multiples slices with duplicate endpoints",
-			args: args{
-				slices: []*discovery.EndpointSlice{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.0.0.2", "10.1.1.2"},
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc-ab23",
-							Namespace: "ns",
-							Labels:    map[string]string{discovery.LabelServiceName: "svc"},
-						},
-						Ports: []discovery.EndpointPort{
-							{
-								Name:     utilpointer.StringPtr("tcp-example"),
-								Protocol: protoPtr(v1.ProtocolTCP),
-								Port:     utilpointer.Int32Ptr(int32(80)),
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Conditions: discovery.EndpointConditions{
-									Ready: utilpointer.BoolPtr(true),
-								},
-								Addresses: []string{"10.0.0.2", "10.2.2.2"},
-							},
-						},
-					},
-				},
-				svcPort: v1.ServicePort{
-					Name:       "tcp-example",
-					TargetPort: intstr.FromInt(80),
-					Protocol:   v1.ProtocolTCP,
-				},
-				family: v1.IPv4Protocol,
-			},
-			want: lbEndpoints{[]string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, 80},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getLbEndpoints(tt.args.slices, tt.args.svcPort, tt.args.family); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getLbEndpoints() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_deleteVIPsFromOVN(t *testing.T) {
+	config.Kubernetes.OVNEmptyLbEvents = true
+	defer func() {
+		config.Kubernetes.OVNEmptyLbEvents = false
+	}()
+
 	type args struct {
 		vips   sets.String
 		svc    *v1.Service
@@ -236,6 +33,12 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 			args: args{
 				vips: sets.NewString(),
 				svc:  &v1.Service{},
+				ovnCmd: []ovntest.ExpectedCmd{
+					{
+						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+						Output: gatewayRouter1,
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -259,6 +62,10 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 				},
 				ovnCmd: []ovntest.ExpectedCmd{
 					{
+						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+						Output: gatewayRouter1,
+					},
+					{
 						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 						Output: loadbalancerTCP,
 					},
@@ -267,11 +74,27 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 						Output: "",
 					},
 					{
-						Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=a08ea426-2288-11eb-a30b-a8a1590cda29-10.0.0.1\:80`,
+						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=2e290f10-3652-11eb-839b-a8a1590cda29",
+						Output: "loadbalancer1",
+					},
+					{
+						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-worker-lb-tcp=2e290f10-3652-11eb-839b-a8a1590cda29",
+						Output: "workerlb",
+					},
+					{
+						Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer loadbalancer1 vips "10.0.0.1:80"`,
 						Output: "",
 					},
 					{
-						Cmd:    `ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null`,
+						Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer workerlb vips "10.0.0.1:80"`,
+						Output: "",
+					},
+					{
+						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+						Output: idlingloadbalancerTCP,
+					},
+					{
+						Cmd:    `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda30 vips "10.0.0.1:80"`,
 						Output: "",
 					},
 				},
@@ -295,15 +118,12 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 			if err != nil {
 				t.Errorf("fexec error: %v", err)
 			}
-			if err := deleteVIPsFromOVN(tt.args.vips, st, tt.args.svc.Name, tt.args.svc.Namespace); (err != nil) != tt.wantErr {
+			if err := deleteVIPsFromAllOVNBalancers(tt.args.vips, tt.args.svc.Name, tt.args.svc.Namespace); (err != nil) != tt.wantErr {
 				t.Errorf("deleteVIPsFromOVN() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if len(tt.args.svc.Spec.ClusterIP) > 0 {
-				vip := util.JoinHostPortInt32(tt.args.svc.Spec.ClusterIP, tt.args.svc.Spec.Ports[0].Port)
-				if st.hasServiceVIP(tt.args.svc.Name, tt.args.svc.Namespace, vip, tt.args.svc.Spec.Ports[0].Protocol) {
-					t.Fatalf("Error: VIP not deleted from Service Tracker")
-				}
+			if !fexec.CalledMatchesExpected() {
+				t.Error(fexec.ErrorDesc())
 			}
 		})
 	}

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -181,10 +181,6 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 	if !util.IsClusterIPSet(svc) {
 		return nil
 	}
-	gateways, _, err := ovn.getOvnGateways()
-	if err != nil {
-		klog.Error(err)
-	}
 
 	if svcNeedsIdling(svc.Annotations) {
 		ovn.addServiceToIdlingBalancer(svc)
@@ -192,6 +188,11 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		return nil
 	}
 	ovn.deleteServiceFromIdlingBalancer(svc)
+
+	gateways, _, err := ovn.getOvnGateways()
+	if err != nil {
+		klog.Error(err)
+	}
 
 	for _, svcPort := range svc.Spec.Ports {
 		clusterLB, err := ovn.getLoadBalancer(svcPort.Protocol)

--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -2,11 +2,13 @@ package ovn
 
 import (
 	"fmt"
+	"net"
+	"strings"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"net"
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -64,6 +66,15 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints, addClusterLBs bool) erro
 	klog.V(5).Infof("Matching service %s found for ep: %s, with cluster IP: %s", svc.Name, ep.Name, svc.Spec.ClusterIP)
 
 	protoPortMap := ovn.getLbEndpoints(ep)
+	if !svcNeedsIdling(svc.Annotations) || len(ep.Subsets) > 0 {
+		ovn.deleteServiceFromIdlingBalancer(svc)
+		// and let the existing logic go forward
+	} else {
+		ovn.addServiceToIdlingBalancer(svc)
+		ovn.deleteServiceFromBalancers(svc)
+		return nil
+	}
+
 	klog.V(5).Infof("Matching service %s ports: %v", svc.Name, svc.Spec.Ports)
 	for _, svcPort := range svc.Spec.Ports {
 		lbEps, isFound := protoPortMap[svcPort.Protocol][svcPort.Name]
@@ -74,6 +85,7 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints, addClusterLBs bool) erro
 			klog.Errorf("Rejecting endpoint creation for unsupported SCTP protocol: %s, %s", ep.Namespace, ep.Name)
 			continue
 		}
+
 		if util.ServiceTypeHasNodePort(svc) {
 			if err := ovn.createPerNodeVIPs(nil, svcPort.Protocol, svcPort.NodePort, lbEps.IPs, lbEps.Port); err != nil {
 				klog.Errorf("Error in creating Node Port for svc %s, node port: %d - %v\n", svc.Name, svcPort.NodePort, err)
@@ -175,6 +187,15 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		klog.Error(err)
 	}
 
+	if !svcNeedsIdling(svc.Annotations) {
+		ovn.deleteServiceFromIdlingBalancer(svc)
+		// and let the existing logic go forward
+	} else {
+		ovn.addServiceToIdlingBalancer(svc)
+		ovn.deleteServiceFromBalancers(svc)
+		return nil
+	}
+
 	for _, svcPort := range svc.Spec.Ports {
 		clusterLB, err := ovn.getLoadBalancer(svcPort.Protocol)
 		if err != nil {
@@ -182,7 +203,10 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 			continue
 		}
 		// Cluster IP service
-		ovn.clearVIPsAddRejectACL(svc, clusterLB, svc.Spec.ClusterIP, svcPort.Port, svcPort.Protocol)
+		err = ovn.configureLoadBalancer(clusterLB, svc.Spec.ClusterIP, svcPort.Port, nil)
+		if err != nil {
+			klog.Errorf("Error in configuring loadbalancer for lb %s - %s - %d: %v", clusterLB, svc.Spec.ClusterIP, svcPort.Port, err)
+		}
 
 		for _, gateway := range gateways {
 			gatewayLB, err := ovn.getGatewayLoadBalancer(gateway, svcPort.Protocol)
@@ -192,7 +216,10 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 			}
 			// ClusterIP may be on gateway or worker LBs, so need to remove here as well
 			if config.Gateway.Mode == config.GatewayModeShared {
-				ovn.clearVIPsAddRejectACL(svc, gatewayLB, svc.Spec.ClusterIP, svcPort.Port, svcPort.Protocol)
+				err = ovn.configureLoadBalancer(gatewayLB, svc.Spec.ClusterIP, svcPort.Port, nil)
+				if err != nil {
+					klog.Errorf("Error in configuring loadbalancer for lb %s - %s - %d: %v", gatewayLB, svc.Spec.ClusterIP, svcPort.Port, err)
+				}
 			}
 			workerNode := util.GetWorkerFromGatewayRouter(gateway)
 			workerLB, err := loadbalancer.GetWorkerLoadBalancer(workerNode, svcPort.Protocol)
@@ -201,7 +228,10 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 				continue
 			}
 			if config.Gateway.Mode == config.GatewayModeShared {
-				ovn.clearVIPsAddRejectACL(svc, workerLB, svc.Spec.ClusterIP, svcPort.Port, svcPort.Protocol)
+				err = ovn.configureLoadBalancer(workerLB, svc.Spec.ClusterIP, svcPort.Port, nil)
+				if err != nil {
+					klog.Errorf("Error in configuring loadbalancer for lb %s - %s - %d: %v", workerLB, svc.Spec.ClusterIP, svcPort.NodePort, err)
+				}
 			}
 
 			// Cloud load balancers: directly reject traffic from pods
@@ -209,8 +239,14 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 				if ing.IP == "" {
 					continue
 				}
-				ovn.clearVIPsAddRejectACL(svc, gatewayLB, ing.IP, svcPort.Port, svcPort.Protocol)
-				ovn.clearVIPsAddRejectACL(svc, workerLB, ing.IP, svcPort.Port, svcPort.Protocol)
+				err = ovn.configureLoadBalancer(gatewayLB, ing.IP, svcPort.Port, nil)
+				if err != nil {
+					klog.Errorf("Error in configuring loadbalancer for lb %s - %s - %d: %v", gatewayLB, ing.IP, svcPort.NodePort, err)
+				}
+				err = ovn.configureLoadBalancer(workerLB, ing.IP, svcPort.Port, nil)
+				if err != nil {
+					klog.Errorf("Error in configuring loadbalancer for lb %s - %s - %d: %v", workerLB, ing.IP, svcPort.NodePort, err)
+				}
 			}
 			// Node Port services
 			if util.ServiceTypeHasNodePort(svc) {
@@ -220,35 +256,30 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 					continue
 				}
 				for _, physicalIP := range physicalIPs {
-					ovn.clearVIPsAddRejectACL(svc, gatewayLB, physicalIP, svcPort.NodePort, svcPort.Protocol)
-					ovn.clearVIPsAddRejectACL(svc, workerLB, physicalIP, svcPort.NodePort, svcPort.Protocol)
+					err = ovn.configureLoadBalancer(gatewayLB, physicalIP, svcPort.NodePort, nil)
+					if err != nil {
+						klog.Errorf("Error in configuring loadbalancer for lb %s - %s - %d: %v", gatewayLB, physicalIP, svcPort.NodePort, err)
+					}
+					err = ovn.configureLoadBalancer(workerLB, physicalIP, svcPort.NodePort, nil)
+					if err != nil {
+						klog.Errorf("Error in configuring loadbalancer for lb %s - %s - %d: %v", workerLB, physicalIP, svcPort.NodePort, err)
+					}
 				}
 			}
 			// External IP services
 			for _, extIP := range svc.Spec.ExternalIPs {
-				ovn.clearVIPsAddRejectACL(svc, gatewayLB, extIP, svcPort.Port, svcPort.Protocol)
-				ovn.clearVIPsAddRejectACL(svc, workerLB, extIP, svcPort.NodePort, svcPort.Protocol)
+				err = ovn.configureLoadBalancer(gatewayLB, extIP, svcPort.Port, nil)
+				if err != nil {
+					klog.Errorf("Error in configuring loadbalancer for lb %s - %s - %d: %v", workerLB, extIP, svcPort.NodePort, err)
+				}
+				err = ovn.configureLoadBalancer(workerLB, extIP, svcPort.NodePort, nil)
+				if err != nil {
+					klog.Errorf("Error in configuring loadbalancer for lb %s - %s - %d: %v", workerLB, extIP, svcPort.NodePort, err)
+				}
 			}
 		}
 	}
 	return nil
-}
-
-func (ovn *Controller) clearVIPsAddRejectACL(svc *kapi.Service, lb, ip string, port int32, proto kapi.Protocol) {
-	aclLogging := ovn.GetNetworkPolicyACLLogging(svc.Namespace).Deny
-	if svcQualifiesForReject(svc) {
-		aclUUID, err := ovn.createLoadBalancerRejectACL(lb, ip, port, proto, aclLogging)
-		if err != nil {
-			klog.Errorf("Failed to create reject ACL for VIP: %s:%d, load balancer: %s, error: %v",
-				ip, port, lb, err)
-		} else {
-			klog.Infof("Reject ACL created for VIP: %s:%d, load balancer: %s, %s", ip, port, lb, aclUUID)
-		}
-	}
-	err := ovn.configureLoadBalancer(lb, ip, port, nil)
-	if err != nil {
-		klog.Errorf("Error in clearing endpoints for lb %s: %v", lb, err)
-	}
 }
 
 // hasHostEndpoints determines if a slice of endpoints contains a host networked pod
@@ -262,6 +293,20 @@ func hasHostEndpoints(endpointIPs []string) bool {
 			}
 		}
 		if !found {
+			return true
+		}
+	}
+	return false
+}
+
+// When idling or empty LB events are enabled, we want to ensure we receive these packets and not reject them.
+func svcNeedsIdling(annotations map[string]string) bool {
+	if !config.Kubernetes.OVNEmptyLbEvents {
+		return false
+	}
+
+	for annotationKey := range annotations {
+		if strings.HasSuffix(annotationKey, IdledServiceAnnotationSuffix) {
 			return true
 		}
 	}

--- a/go-controller/pkg/ovn/endpoints_test.go
+++ b/go-controller/pkg/ovn/endpoints_test.go
@@ -80,10 +80,59 @@ func (e endpoints) addNodePortPortCmds(fexec *ovntest.FakeExec, service v1.Servi
 
 func (e endpoints) delNodePortPortCmds(fexec *ovntest.FakeExec, service v1.Service, gatewayR string, idx int) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}load_balancer_%d", idx),
-		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router load_balancer{>=}load_balancer_%d", idx),
 		fmt.Sprintf("ovn-nbctl --timeout=15 set load_balancer load_balancer_%d vips:\"%s:%v\"=\"\"", idx, "169.254.33.2", service.Spec.Ports[0].NodePort),
 	})
+}
+
+func (e endpoints) removeFromIdlingLBAdd(fexec *ovntest.FakeExec, service v1.Service, endpoint v1.Endpoints) {
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+		Output: k8sIdlingTCPLoadBalancerIP,
+	})
+	fexec.AddFakeCmdsNoOutputNoError(
+		[]string{"ovn-nbctl --timeout=15 --if-exists remove load_balancer k8s_tcp_idling_load_balancer vips \"172.124.0.2:8032\""},
+	)
+}
+
+func (e endpoints) removeFromIdlingLBExternalIPs(fexec *ovntest.FakeExec, service v1.Service, endpoint v1.Endpoints) {
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+		Output: k8sIdlingTCPLoadBalancerIP,
+	})
+	fexec.AddFakeCmdsNoOutputNoError(
+		[]string{"ovn-nbctl --timeout=15 --if-exists remove load_balancer k8s_tcp_idling_load_balancer vips \"172.124.0.2:9100\""},
+	)
+	fexec.AddFakeCmdsNoOutputNoError(
+		[]string{"ovn-nbctl --timeout=15 --if-exists remove load_balancer k8s_tcp_idling_load_balancer vips \"1.1.1.1:9100\""},
+	)
+	fexec.AddFakeCmdsNoOutputNoError(
+		[]string{"ovn-nbctl --timeout=15 --if-exists remove load_balancer k8s_tcp_idling_load_balancer vips \"192.168.126.11:9100\""},
+	)
+}
+
+func (e endpoints) removeFromIdlingLBNodePort(fexec *ovntest.FakeExec, service v1.Service, nodePort int, endpoint v1.Endpoints) {
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+		Output: k8sIdlingTCPLoadBalancerIP,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+		Output: FakeGRs,
+	})
+	for idx, gatewayR := range strings.Fields(FakeGRs) {
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 get logical_router " + gatewayR + " external_ids:physical_ips",
+			Output: fmt.Sprintf("169.254.33.%d", idx),
+		})
+	}
+	for idx := range strings.Fields(FakeGRs) {
+		fexec.AddFakeCmdsNoOutputNoError(
+			[]string{fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer k8s_tcp_idling_load_balancer vips \"169.254.33.%d:%d\"", idx, nodePort)},
+		)
+	}
+	fexec.AddFakeCmdsNoOutputNoError(
+		[]string{"ovn-nbctl --timeout=15 --if-exists remove load_balancer k8s_tcp_idling_load_balancer vips \"172.124.0.2:4242\""},
+	)
 }
 
 func (e endpoints) addCmds(fexec *ovntest.FakeExec, service v1.Service, endpoint v1.Endpoints) {
@@ -118,7 +167,6 @@ func (e endpoints) addCmds(fexec *ovntest.FakeExec, service v1.Service, endpoint
 	}
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"%s:%v\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
-		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=%s-%s\\:%v", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 	})
 }
 
@@ -127,6 +175,7 @@ func (e endpoints) addExternalIPCmds(fexec *ovntest.FakeExec, loadBalancerIPs []
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
 		Output: FakeGRs,
 	})
+
 	for idx, gatewayR := range strings.Fields(FakeGRs) {
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + ovntypes.GatewayLBTCP + "=" + gatewayR,
@@ -155,15 +204,14 @@ func (e endpoints) addExternalIPCmds(fexec *ovntest.FakeExec, loadBalancerIPs []
 }
 
 func (e endpoints) delCmds(fexec *ovntest.FakeExec, service v1.Service, isNodePort bool) {
+	gatewayRouters := "GR_1 GR_2"
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
-		Output: FakeGRs,
+		Output: gatewayRouters,
 	})
 	for _, sPort := range service.Spec.Ports {
 		if sPort.Protocol == v1.ProtocolTCP {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}%s", k8sTCPLoadBalancerIP),
-				fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router load_balancer{>=}%s", k8sTCPLoadBalancerIP),
 				fmt.Sprintf("ovn-nbctl --timeout=15 set load_balancer %s vips:\"%s:%v\"=\"\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, sPort.Port),
 			})
 			for idx, gatewayR := range strings.Fields(FakeGRs) {
@@ -172,8 +220,6 @@ func (e endpoints) delCmds(fexec *ovntest.FakeExec, service v1.Service, isNodePo
 					Output: fmt.Sprintf("load_balancer_%d", idx),
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}load_balancer_%d", idx),
-					fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router load_balancer{>=}load_balancer_%d", idx),
 					fmt.Sprintf("ovn-nbctl --timeout=15 set load_balancer load_balancer_%d vips:\"%s:%v\"=\"\"", idx, service.Spec.ClusterIP, sPort.Port),
 				})
 				workerIdx := idx + 100
@@ -182,8 +228,6 @@ func (e endpoints) delCmds(fexec *ovntest.FakeExec, service v1.Service, isNodePo
 					Output: fmt.Sprintf("load_balancer_%d", workerIdx),
 				})
 				fexec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}load_balancer_%d", workerIdx),
-					fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router load_balancer{>=}load_balancer_%d", workerIdx),
 					fmt.Sprintf("ovn-nbctl --timeout=15 set load_balancer load_balancer_%d vips:\"%s:%v\"=\"\"", workerIdx, service.Spec.ClusterIP, sPort.Port),
 				})
 				if isNodePort {
@@ -195,6 +239,10 @@ func (e endpoints) delCmds(fexec *ovntest.FakeExec, service v1.Service, isNodePo
 					e.delNodePortPortCmds(fexec, service, strings.TrimPrefix(gatewayR, "GR_"), workerIdx)
 				}
 
+				//fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				//	Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
+				//	Output: FakeGRs,
+				//})
 			}
 		} else if sPort.Protocol == v1.ProtocolUDP {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -218,12 +266,13 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
-
+		config.Kubernetes.OVNEmptyLbEvents = true
 		tExec = ovntest.NewFakeExec()
 		fakeOvn = NewFakeOVN(tExec)
 	})
 
 	ginkgo.AfterEach(func() {
+		config.Kubernetes.OVNEmptyLbEvents = false
 		fakeOvn.shutdown()
 	})
 
@@ -259,7 +308,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 					v1.ServiceTypeClusterIP,
 					nil,
 				)
-
+				testE.removeFromIdlingLBAdd(tExec, serviceT, endpointsT)
 				testE.addCmds(tExec, serviceT, endpointsT)
 
 				fakeOvn.start(ctx,
@@ -277,8 +326,8 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				fakeOvn.controller.WatchEndpoints()
 
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Endpoints(endpointsT.Namespace).Get(context.TODO(), endpointsT.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(tExec.CalledMatchesExpected()).To(gomega.BeTrue(), tExec.ErrorDesc)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				return nil
 			}
@@ -321,6 +370,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 					loadBalancerIPs,
 				)
 
+				testE.removeFromIdlingLBExternalIPs(tExec, serviceT, endpointsT)
 				testE.addCmds(tExec, serviceT, endpointsT)
 				testE.addExternalIPCmds(tExec, loadBalancerIPs, serviceT, endpointsT)
 
@@ -339,8 +389,8 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				fakeOvn.controller.WatchEndpoints()
 
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Endpoints(endpointsT.Namespace).Get(context.TODO(), endpointsT.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(tExec.CalledMatchesExpected()).To(gomega.BeTrue(), tExec.ErrorDesc)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				return nil
 			}
@@ -373,6 +423,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 						{
 							Name:       "portTcp1",
 							NodePort:   31111,
+							Port:       4242,
 							Protocol:   v1.ProtocolTCP,
 							TargetPort: intstr.FromInt(8080),
 						},
@@ -380,7 +431,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 					v1.ServiceTypeNodePort,
 					nil,
 				)
-
+				testE.removeFromIdlingLBNodePort(tExec, serviceT, 31111, endpointsT)
 				testE.addNodePortPortCmds(tExec, serviceT, endpointsT)
 				testE.addCmds(tExec, serviceT, endpointsT)
 
@@ -439,6 +490,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 					v1.ServiceTypeClusterIP,
 					nil,
 				)
+				testE.removeFromIdlingLBAdd(tExec, serviceT, endpointsT)
 				testE.addCmds(tExec, serviceT, endpointsT)
 
 				fakeOvn.start(ctx,
@@ -460,6 +512,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				gomega.Eventually(tExec.CalledMatchesExpected).Should(gomega.BeTrue(), tExec.ErrorDesc)
 
 				// Delete the endpoint
+				testE.removeFromIdlingLBAdd(tExec, serviceT, endpointsT)
 				testE.delCmds(tExec, serviceT, false)
 
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Endpoints(endpointsT.Namespace).Delete(context.TODO(), endpointsT.Name, *metav1.NewDeleteOptions(0))
@@ -498,11 +551,14 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 							NodePort: 31100,
 							Protocol: v1.ProtocolTCP,
 							Name:     "portTcp1",
+							Port:     4242,
 						},
 					},
 					v1.ServiceTypeNodePort,
 					nil,
 				)
+
+				testE.removeFromIdlingLBNodePort(tExec, serviceT, 31100, endpointsT)
 				testE.addNodePortPortCmds(tExec, serviceT, endpointsT)
 				testE.addCmds(tExec, serviceT, endpointsT)
 
@@ -521,15 +577,16 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				fakeOvn.controller.WatchEndpoints()
 
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Endpoints(endpointsT.Namespace).Get(context.TODO(), endpointsT.Name, metav1.GetOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(tExec.CalledMatchesExpected).Should(gomega.BeTrue(), tExec.ErrorDesc)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Delete the endpoint
+				testE.removeFromIdlingLBNodePort(tExec, serviceT, 31100, endpointsT)
 				testE.delCmds(tExec, serviceT, true)
 
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Endpoints(endpointsT.Namespace).Delete(context.TODO(), endpointsT.Name, *metav1.NewDeleteOptions(0))
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(tExec.CalledMatchesExpected).Should(gomega.BeTrue(), tExec.ErrorDesc)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				return nil
 			}

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -134,6 +134,24 @@ func (ovn *Controller) deleteNodeVIPs(svcIPs []string, protocol kapi.Protocol, s
 	}
 }
 
+func (ovn *Controller) getNodeportIPs() ([]string, error) {
+	gatewayRouters, _, err := ovn.getOvnGateways()
+	if err != nil {
+		klog.Errorf("Error while searching for gateways: %v", err)
+		return nil, err
+	}
+	res := make([]string, 0)
+
+	for _, gatewayRouter := range gatewayRouters {
+		physicalIPs, err := ovn.getGatewayPhysicalIPs(gatewayRouter)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, physicalIPs...)
+	}
+	return res, nil
+}
+
 func (ovn *Controller) deleteExternalVIPs(service *kapi.Service, svcPort kapi.ServicePort) error {
 	if len(service.Spec.ExternalIPs) == 0 {
 		return nil

--- a/go-controller/pkg/ovn/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer.go
@@ -3,7 +3,6 @@ package ovn
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -18,7 +17,6 @@ func (ovn *Controller) getLoadBalancer(protocol kapi.Protocol) (string, error) {
 	if outStr, ok := ovn.loadbalancerClusterCache[protocol]; ok {
 		return outStr, nil
 	}
-
 	var out string
 	var err error
 	if protocol == kapi.ProtocolTCP {
@@ -61,18 +59,16 @@ func (ovn *Controller) getLoadBalancerVIPs(loadBalancer string) (map[string]inte
 	return raw, nil
 }
 
-// deleteLoadBalancerVIP removes the VIP as well as any reject ACLs associated to the LB
+// deleteLoadBalancerVIP removes the VIP
 func (ovn *Controller) deleteLoadBalancerVIP(loadBalancer, vip string) error {
 	vipQuotes := fmt.Sprintf("\"%s\"", vip)
 	stdout, stderr, err := util.RunOVNNbctl("--if-exists", "remove", "load_balancer", loadBalancer, "vips", vipQuotes)
 	if err != nil {
-		// if we hit an error and fail to remove load balancer, we skip removing the rejectACL
 		return fmt.Errorf("error in deleting load balancer vip %s for %s"+
 			"stdout: %q, stderr: %q, error: %v",
 			vip, loadBalancer, stdout, stderr, err)
 	}
 	ovn.removeServiceEndpoints(loadBalancer, vip)
-	ovn.deleteLoadBalancerRejectACL(loadBalancer, vip)
 	ovn.removeServiceLB(loadBalancer, vip)
 	return nil
 }
@@ -99,8 +95,7 @@ func (ovn *Controller) configureLoadBalancer(lb, sourceIP string, sourcePort int
 
 // createLoadBalancerVIPs either creates or updates a set of load balancer VIPs mapping
 // from sourcePort on each IP of a given address family in sourceIPs, to targetPort on
-// each IP of the same address family in targetIPs, removing the reject ACL for any
-// source IP that is now in use.
+// each IP of the same address family in targetIPs
 func (ovn *Controller) createLoadBalancerVIPs(lb string,
 	sourceIPs []string, sourcePort int32,
 	targetIPs []string, targetPort int32) error {
@@ -116,258 +111,9 @@ func (ovn *Controller) createLoadBalancerVIPs(lb string,
 			}
 		}
 		err := ovn.configureLoadBalancer(lb, sourceIP, sourcePort, targets)
-		if len(targets) > 0 {
-			// ensure the ACL is removed if it exists
-			ovn.deleteLoadBalancerRejectACL(lb, util.JoinHostPortInt32(sourceIP, sourcePort))
-		}
 		if err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func (ovn *Controller) getLogicalSwitchesForLoadBalancer(lb string) ([]string, error) {
-	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=_uuid", "find",
-		"logical_switch", fmt.Sprintf("load_balancer{>=}%s", lb))
-	if err != nil {
-		return nil, err
-	}
-	if len(strings.Fields(out)) > 0 {
-		return strings.Fields(out), nil
-	}
-
-	return nil, nil
-}
-
-// getGRLogicalSwitchesForLoadBalancer returns the external switch name if the load balancer is on a GR
-func (ovn *Controller) getGRLogicalSwitchesForLoadBalancer(lb string) ([]string, error) {
-	out, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=name", "find", "logical_router", fmt.Sprintf("load_balancer{>=}%s", lb))
-	if err != nil {
-		return nil, err
-	}
-	if len(out) == 0 {
-		return nil, nil
-	}
-
-	var switches []string
-	entries := strings.Split(out, "\n")
-	for _, entry := range entries {
-		if len(entry) == 0 {
-			continue
-		}
-		// if this is a GR we know the corresponding external switch, otherwise this is an unhandled case
-		if strings.HasPrefix(out, types.GWRouterPrefix) {
-			routerName := strings.TrimPrefix(entry, types.GWRouterPrefix)
-			switches = append(switches, types.ExternalSwitchPrefix+routerName)
-		}
-	}
-	if len(switches) == 0 {
-		return nil, fmt.Errorf("router detected with load balancer that is not a GR")
-	}
-	return switches, nil
-}
-
-// TODO: Add unittest for function.
-func generateACLName(lb string, sourceIP string, sourcePort int32) string {
-	aclName := fmt.Sprintf("%s-%s:%d", lb, sourceIP, sourcePort)
-	// ACL names are limited to 63 characters
-	if len(aclName) > 63 {
-		var ipPortLen int
-		srcPortStr := fmt.Sprintf("%d", sourcePort)
-		// Add the length of the IP (max 15 with periods, max 39 with colons),
-		// plus length of sourcePort (max 5 char),
-		// plus 1 for additional ':' to separate,
-		// plus 1 for '-' between lb and IP.
-		// With full IPv6 address and 5 char port, max ipPortLen is 62
-		// With full IPv4 address and 5 char port, max ipPortLen is 24.
-		ipPortLen = len(sourceIP) + len(srcPortStr) + 1 + 1
-		lbTrim := 63 - ipPortLen
-		// Shorten the Load Balancer name to allow full IP:port
-		tmpLb := lb[:lbTrim]
-		klog.Infof("Limiting ACL Name from %s to %s-%s:%d to keep under 63 characters", aclName, tmpLb, sourceIP, sourcePort)
-		aclName = fmt.Sprintf("%s-%s:%d", tmpLb, sourceIP, sourcePort)
-	}
-	return aclName
-}
-
-func generateACLNameForOVNCommand(lb string, sourceIP string, sourcePort int32) string {
-	return strings.ReplaceAll(generateACLName(lb, sourceIP, sourcePort), ":", "\\:")
-}
-
-func (ovn *Controller) createLoadBalancerRejectACL(lb, sourceIP string, sourcePort int32, proto kapi.Protocol, aclLogging string) (string, error) {
-	applyToPortGroup := false
-	ovn.serviceLBLock.Lock()
-	defer ovn.serviceLBLock.Unlock()
-	switches, err := ovn.getLogicalSwitchesForLoadBalancer(lb)
-	if err != nil {
-		return "", fmt.Errorf("error finding logical switch that contains load balancer %s: %v", lb, err)
-	}
-
-	if len(switches) > 0 {
-		applyToPortGroup = true
-	} else {
-		klog.V(5).Infof("Ignoring creating reject ACL for port group with load balancer %s. It has no "+
-			"logical switches", lb)
-	}
-
-	// check if the load balancer is on a GR, if so we need to get the external switches
-	gwRouterExtSwitches, err := ovn.getGRLogicalSwitchesForLoadBalancer(lb)
-	if err != nil {
-		return "", fmt.Errorf("unable to query logical switches for GR with load balancer: %s, error: %v", lb, err)
-	}
-
-	if len(switches) == 0 && len(gwRouterExtSwitches) == 0 {
-		return "", fmt.Errorf("load balancer %s does not apply to any switches in the cluster. Will not create "+
-			"Reject ACL", lb)
-	}
-
-	ip := net.ParseIP(sourceIP)
-	if ip == nil {
-		return "", fmt.Errorf("cannot create reject ACL, invalid source IP: %s", sourceIP)
-	}
-	var l3Prefix, aclMatch string
-	if utilnet.IsIPv6(ip) {
-		l3Prefix = "ip6"
-	} else {
-		l3Prefix = "ip4"
-	}
-	vip := util.JoinHostPortInt32(sourceIP, sourcePort)
-	// NOTE: doesn't use vip, to avoid having brackets in the name with IPv6
-	aclName := generateACLNameForOVNCommand(lb, sourceIP, sourcePort)
-	// If ovn-k8s was restarted, we lost the cache, and an ACL may already exist in OVN. In that case we need to check
-	// using ACL name
-	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
-		fmt.Sprintf("name=%s", aclName))
-	if err != nil {
-		klog.Errorf("Error while querying ACLs by name: %s, %v", stderr, err)
-	} else if len(aclUUID) > 0 {
-		klog.Infof("Existing Service Reject ACL found: %s for %s", aclUUID, aclName)
-		var cmd []string
-		if applyToPortGroup {
-			cmd = append(cmd, "--", "add", "port_group", ovn.clusterPortGroupUUID, "acls", aclUUID)
-		}
-		for _, extSwitch := range gwRouterExtSwitches {
-			cmd = append(cmd, "--", "add", "logical_switch", extSwitch, "acls", aclUUID)
-		}
-		if len(cmd) > 0 {
-			_, _, err = util.RunOVNNbctl(cmd...)
-			if err != nil {
-				klog.Errorf("Failed to add LB %s, ACL %s, %q, to cluster port group/switches, stderr: %q,"+
-					"error: %v", lb, aclUUID, aclName, stderr, err)
-			}
-		}
-
-		ovn.setServiceACLToLB(lb, vip, aclUUID)
-
-		// If reject ACL exist, ensures that the _uuid is removed from logical_switch acls list.
-		// This step is required to ensure the clean-up when ovn upgrades from logical_switch acls
-		// to port_group based acls.
-		ovn.removeACLFromNodeSwitches(switches, aclUUID)
-		return aclUUID, nil
-	}
-
-	aclMatch = fmt.Sprintf("match=\"%s.dst==%s && %s && %s.dst==%d\"", l3Prefix, sourceIP,
-		strings.ToLower(string(proto)), strings.ToLower(string(proto)), sourcePort)
-	cmd := []string{"--id=@reject-acl", "create", "acl", "direction=" + types.DirectionFromLPort, "priority=" + types.DefaultDenyPriority, aclMatch, "action=reject",
-		fmt.Sprintf("log=%t", aclLogging != ""), fmt.Sprintf("severity=%s", getACLLoggingSeverity(aclLogging)),
-		fmt.Sprintf("meter=%s", types.OvnACLLoggingMeter),
-		fmt.Sprintf("name=%s", aclName)}
-	if applyToPortGroup {
-		cmd = append(cmd, "--", "add", "port_group", ovn.clusterPortGroupUUID, "acls", "@reject-acl")
-	}
-	for _, extSwitch := range gwRouterExtSwitches {
-		cmd = append(cmd, "--", "add", "logical_switch", extSwitch, "acls", "@reject-acl")
-	}
-	aclUUID, stderr, err = util.RunOVNNbctl(cmd...)
-	if err != nil {
-		klog.Errorf("Failed to add LB: %s ACL: %s, %q, to cluster port group/switches, stderr: %q, error: %v",
-			lb, aclUUID, aclName, stderr, err)
-		return "", err
-	}
-
-	// Associate ACL UUID with load balancer and ip+port so we can remove this ACL if
-	// backends are re-added.
-	ovn.setServiceACLToLB(lb, vip, aclUUID)
-
-	return aclUUID, nil
-}
-
-func (ovn *Controller) deleteLoadBalancerRejectACL(lb, vip string) {
-	aclUUID, hasEndpoints := ovn.getServiceLBInfo(lb, vip)
-	if aclUUID == "" && !hasEndpoints {
-		// If no ACL and does not have endpoints, we can assume there is no valid entry in the cache here as
-		// this is an illegal state.
-		// Determine and remove ACL by name.
-		ip, port, err := util.SplitHostPortInt32(vip)
-		if err != nil {
-			klog.Errorf("Unable to parse vip for Reject ACL deletion: %v", err)
-			return
-		}
-		aclUUID, err = ovn.findStaleRejectACL(lb, ip, port)
-		if err != nil {
-			klog.Infof("Unable to delete Reject ACL for load-balancer: %s, vip: %s. No entry in cache and "+
-				"error occurred while trying to find the ACL by name in OVN, error: %v", lb, vip, err)
-			return
-		}
-		if aclUUID == "" {
-			klog.Infof("No reject ACL found in cache or in OVN to remove for load-balancer: %s, vip: %s", lb, vip)
-			return
-		}
-	} else if aclUUID == "" {
-		// Must have endpoints and no reject ACL to remove
-		klog.V(5).Infof("No reject ACL found to remove for load balancer: %s, vip: %s", lb, vip)
-		return
-	}
-	// check if the load balancer is on a GR, if so we need to get the join/external switches
-	gwRouterSwitches, err := ovn.getGRLogicalSwitchesForLoadBalancer(lb)
-	if err != nil {
-		klog.Errorf("Unable to query logical switches for GR with load balancer: %s, error: %v", lb, err)
-	} else {
-		ovn.removeACLFromNodeSwitches(gwRouterSwitches, aclUUID)
-	}
-	ovn.removeACLFromPortGroup(lb, aclUUID)
-	ovn.removeServiceACL(lb, vip)
-}
-
-func (ovn *Controller) findStaleRejectACL(lb, ip string, port int32) (string, error) {
-	aclName := generateACLNameForOVNCommand(lb, ip, port)
-	aclUUID, stderr, err := util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "acl",
-		fmt.Sprintf("name=%s", aclName))
-	if err != nil {
-		klog.Errorf("Error while querying ACLs by name: %s, %v", stderr, err)
-		return "", err
-	} else if len(aclUUID) == 0 {
-		klog.Infof("Reject ACL not found to remove for name: %s", aclName)
-		return "", fmt.Errorf("reject ACL not found to remove for name: %s", aclName)
-	}
-	return aclUUID, nil
-}
-
-// Remove the ACL uuid entry from Logical Switch acl's list.
-func (ovn *Controller) removeACLFromNodeSwitches(switches []string, aclUUID string) {
-	args := []string{}
-	for _, ls := range switches {
-		args = append(args, "--", "--if-exists", "remove", "logical_switch", ls, "acl", aclUUID)
-	}
-
-	if len(args) > 0 {
-		_, _, err := util.RunOVNNbctl(args...)
-		if err != nil {
-			klog.Errorf("Error while removing ACL: %s, from switches, error: %v", aclUUID, err)
-		} else {
-			klog.Infof("ACL: %s, removed from switches: %s", aclUUID, switches)
-		}
-	}
-}
-
-func (ovn *Controller) removeACLFromPortGroup(lb, aclUUID string) {
-	_, stderr, err := util.RunOVNNbctl("--", "--if-exists", "remove", "port_group", ovn.clusterPortGroupUUID, "acls", aclUUID)
-	if err != nil {
-		klog.Errorf("Failed to remove reject ACL %s from LB %s: stderr: %q, error: %v", aclUUID, lb, stderr, err)
-	} else {
-		klog.Infof("ACL: %s, removed from the port group : %s", aclUUID, ovn.clusterPortGroupUUID)
-	}
 }

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -197,16 +197,6 @@ func GenerateACLName(lb string, sourceIP string, sourcePort int32) string {
 	return aclName
 }
 
-// GenerateACLNameForOVNCommand sanitize the ACL name because the generateACLName
-// function was including backslash escapes for the ACL
-// name for use in OVN commands that have trouble with literal ":". That
-// was causing a mismatch when services were syncing because the name
-// actually returned from an OVN command does not include any backslashes
-// so the names would not match. #1749
-func GenerateACLNameForOVNCommand(lb string, sourceIP string, sourcePort int32) string {
-	return strings.ReplaceAll(GenerateACLName(lb, sourceIP, sourcePort), ":", "\\:")
-}
-
 func GetWorkerLoadBalancer(node string, protocol kapi.Protocol) (string, error) {
 	var out string
 	var err error

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
@@ -255,50 +255,6 @@ func TestGetLogicalRoutersForLoadBalancer(t *testing.T) {
 	}
 }
 
-func TestGenerateACLName(t *testing.T) {
-	type args struct {
-		lb         string
-		sourceIP   string
-		sourcePort int32
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GenerateACLName(tt.args.lb, tt.args.sourceIP, tt.args.sourcePort); got != tt.want {
-				t.Errorf("GenerateACLName() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestGenerateACLNameForOVNCommand(t *testing.T) {
-	type args struct {
-		lb         string
-		sourceIP   string
-		sourcePort int32
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GenerateACLNameForOVNCommand(tt.args.lb, tt.args.sourceIP, tt.args.sourcePort); got != tt.want {
-				t.Errorf("GenerateACLNameForOVNCommand() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestGetGRLogicalSwitchForLoadBalancer(t *testing.T) {
 	type args struct {
 		lb string

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	goovn "github.com/ebay/go-ovn"
+	"github.com/pkg/errors"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -21,12 +23,12 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
-	goovn "github.com/ebay/go-ovn"
 	hocontroller "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -438,44 +440,32 @@ func (oc *Controller) SetupMaster(masterNodeName string) error {
 		}
 	}
 
-	// Create 3 load-balancers for east-west traffic for UDP, TCP, SCTP
-	oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes")
-	if err != nil {
-		klog.Errorf("Failed to get tcp load balancer, stderr: %q, error: %v", stderr, err)
-		return err
+	// We have 3 load-balancers per protocol to implement the East-west traffic	//
+	protocols := []kapi.Protocol{kapi.ProtocolTCP, kapi.ProtocolUDP}
+	if oc.SCTPSupport {
+		protocols = append(protocols, kapi.ProtocolSCTP)
 	}
-
-	if oc.TCPLoadBalancerUUID == "" {
-		oc.TCPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-tcp=yes", "protocol=tcp")
+	// Create load-balancers for east-west traffic for each protocol UDP, TCP, SCTP
+	// and for Idling services if empty-lb-backends is enabled
+	lbExternalIds := []string{types.ClusterLBPrefix}
+	// If we enable idling we have to set the option before creating the loadbalancers
+	// and create the new set of loadbalancers.
+	if config.Kubernetes.OVNEmptyLbEvents {
+		_, _, err := util.RunOVNNbctl("set", "nb_global", ".", "options:controller_event=true")
 		if err != nil {
-			klog.Errorf("Failed to create tcp load balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
+			klog.Error("Unable to enable controller events. Unidling not possible")
 			return err
 		}
+		lbExternalIds = append(lbExternalIds, types.ClusterIdlingLBPrefix)
 	}
-
-	oc.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes")
-	if err != nil {
-		klog.Errorf("Failed to get udp load balancer, stderr: %q, error: %v", stderr, err)
-		return err
-	}
-	if oc.UDPLoadBalancerUUID == "" {
-		oc.UDPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-udp=yes", "protocol=udp")
-		if err != nil {
-			klog.Errorf("Failed to create udp load balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-			return err
-		}
-	}
-
-	oc.SCTPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--data=bare", "--no-heading", "--columns=_uuid", "find", "load_balancer", "external_ids:k8s-cluster-lb-sctp=yes")
-	if err != nil {
-		klog.Errorf("Failed to get sctp load balancer, stderr: %q, error: %v", stderr, err)
-		return err
-	}
-	if oc.SCTPLoadBalancerUUID == "" && oc.SCTPSupport {
-		oc.SCTPLoadBalancerUUID, stderr, err = util.RunOVNNbctl("--", "create", "load_balancer", "external_ids:k8s-cluster-lb-sctp=yes", "protocol=sctp")
-		if err != nil {
-			klog.Errorf("Failed to create sctp load balancer, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-			return err
+	// Create the LoadBalancers if they don´t exist
+	for _, lbExternalID := range lbExternalIds {
+		for _, p := range protocols {
+			uuid, err := loadbalancer.CreateLoadBalancer(p, lbExternalID)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to create OVN load balancer for protocol %s", p)
+			}
+			oc.clusterLBsUUIDs = append(oc.clusterLBsUUIDs, uuid)
 		}
 	}
 
@@ -639,12 +629,8 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 
 	// Add cluster load balancers to GR for Host -> Cluster IP Service traffic
 	if config.Gateway.Mode != config.GatewayModeLocal {
-		clusterLBs := []string{oc.TCPLoadBalancerUUID, oc.UDPLoadBalancerUUID}
-		if oc.SCTPSupport {
-			clusterLBs = append(clusterLBs, oc.SCTPLoadBalancerUUID)
-		}
 		gr := util.GetGatewayRouterFromNode(node.Name)
-		for _, clusterLB := range clusterLBs {
+		for _, clusterLB := range oc.clusterLBsUUIDs {
 			_, stderr, err := util.RunOVNNbctl("--may-exist", "lr-lb-add", gr, clusterLB)
 			if err != nil {
 				return fmt.Errorf("unable to add cluster LB: %s to %s, stderr: %q, error: %v",
@@ -829,36 +815,18 @@ func (oc *Controller) ensureNodeLogicalNetwork(nodeName string, hostSubnets []*n
 		klog.Errorf(err.Error())
 		return err
 	}
-
-	// Add our cluster TCP and UDP load balancers to the node switch
-	if oc.TCPLoadBalancerUUID == "" {
-		return fmt.Errorf("TCP cluster load balancer not created")
-	}
-	stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch", nodeName, "load_balancer="+oc.TCPLoadBalancerUUID)
-	if err != nil {
-		klog.Errorf("Failed to set logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
-		return err
-	}
-
-	if oc.UDPLoadBalancerUUID == "" {
-		return fmt.Errorf("UDP cluster load balancer not created")
-	}
-	stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", oc.UDPLoadBalancerUUID)
-	if err != nil {
-		klog.Errorf("Failed to add logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
-		return err
-	}
-
-	if oc.SCTPSupport {
-		if oc.SCTPLoadBalancerUUID == "" {
-			return fmt.Errorf("SCTP cluster load balancer not created")
+	for i, loadBalancerUUID := range oc.clusterLBsUUIDs {
+		if i == 0 {
+			stdout, stderr, err = util.RunOVNNbctl("set", "logical_switch", nodeName, "load_balancer="+loadBalancerUUID)
+		} else {
+			stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", loadBalancerUUID)
 		}
-		stdout, stderr, err = util.RunOVNNbctl("add", "logical_switch", nodeName, "load_balancer", oc.SCTPLoadBalancerUUID)
 		if err != nil {
-			klog.Errorf("Failed to add logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
+			klog.Errorf("Failed to set logical switch %v's load balancer, stdout: %q, stderr: %q, error: %v", nodeName, stdout, stderr, err)
 			return err
 		}
 	}
+
 	// Add the node to the logical switch cache
 	return oc.lsManager.AddNode(nodeName, hostSubnets)
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -34,9 +34,9 @@ import (
 )
 
 const (
-	// OvnServiceIdledAt is a constant string representing the Service annotation key
+	// IdledServiceAnnotationSuffix is a constant string representing the suffix of the Service annotation key
 	// whose value indicates the time stamp in RFC3339 format when a Service was idled
-	OvnServiceIdledAt              = "k8s.ovn.org/idled-at"
+	IdledServiceAnnotationSuffix   = "idled-at"
 	OvnNodeAnnotationRetryInterval = 100 * time.Millisecond
 	OvnNodeAnnotationRetryTimeout  = 1 * time.Second
 )

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1217,9 +1217,8 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				addressset.NewFakeAddressSetFactory(), ovntest.NewMockOVNClient(goovn.DBNB),
 				ovntest.NewMockOVNClient(goovn.DBSB), record.NewFakeRecorder(0))
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
-			clusterController.TCPLoadBalancerUUID = tcpLBUUID
-			clusterController.UDPLoadBalancerUUID = udpLBUUID
-			clusterController.SCTPLoadBalancerUUID = sctpLBUUID
+
+			clusterController.clusterLBsUUIDs = []string{tcpLBUUID, udpLBUUID, sctpLBUUID}
 			clusterController.SCTPSupport = true
 			clusterController.joinSwIPManager, _ = initJoinLogicalSwitchIPManager()
 			_, _ = clusterController.joinSwIPManager.ensureJoinLRPIPs(types.OVNClusterRouter)
@@ -1231,9 +1230,8 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			subnet := ovntest.MustParseIPNet(nodeSubnet)
 			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
 			gomega.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			return nil
 		}
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -1066,20 +1066,6 @@ func (oc *Controller) aclLoggingCanEnable(annotation string, nsInfo *namespaceIn
 	return okCnt > 0
 }
 
-// setServiceLBToACL associates an empty load balancer with its associated ACL reject rule
-func (oc *Controller) setServiceACLToLB(lb, vip, acl string) {
-	if _, ok := oc.serviceLBMap[lb]; !ok {
-		oc.serviceLBMap[lb] = make(map[string]*loadBalancerConf)
-		oc.serviceLBMap[lb][vip] = &loadBalancerConf{rejectACL: acl}
-		return
-	}
-	if _, ok := oc.serviceLBMap[lb][vip]; !ok {
-		oc.serviceLBMap[lb][vip] = &loadBalancerConf{rejectACL: acl}
-		return
-	}
-	oc.serviceLBMap[lb][vip].rejectACL = acl
-}
-
 // setServiceEndpointsToLB associates a load balancer with endpoints
 func (oc *Controller) setServiceEndpointsToLB(lb, vip string, eps []string) {
 	if _, ok := oc.serviceLBMap[lb]; !ok {
@@ -1110,15 +1096,6 @@ func (oc *Controller) removeServiceLB(lb, vip string) {
 	oc.serviceLBLock.Lock()
 	defer oc.serviceLBLock.Unlock()
 	delete(oc.serviceLBMap[lb], vip)
-}
-
-// removeServiceACL removes a specific ACL associated with a load balancer and ip:port
-func (oc *Controller) removeServiceACL(lb, vip string) {
-	oc.serviceLBLock.Lock()
-	defer oc.serviceLBLock.Unlock()
-	if _, ok := oc.serviceLBMap[lb][vip]; ok {
-		oc.serviceLBMap[lb][vip].rejectACL = ""
-	}
 }
 
 // removeServiceEndpoints removes endpoints associated with a load balancer and ip:port

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -128,10 +128,9 @@ type Controller struct {
 
 	hoMaster *hocontroller.MasterController
 
-	TCPLoadBalancerUUID  string
-	UDPLoadBalancerUUID  string
-	SCTPLoadBalancerUUID string
-	SCTPSupport          bool
+	// All the uuid related to global load balancers
+	clusterLBsUUIDs []string
+	SCTPSupport     bool
 
 	// For TCP, UDP, and SCTP type traffic, cache OVN load-balancers used for the
 	// cluster's east-west traffic.
@@ -286,6 +285,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory,
 		recorder:                 recorder,
 		ovnNBClient:              ovnNBClient,
 		ovnSBClient:              ovnSBClient,
+		clusterLBsUUIDs:          make([]string, 0),
 	}
 }
 
@@ -334,7 +334,6 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 			oc.client,
 			informerFactory.Core().V1().Services(),
 			informerFactory.Discovery().V1beta1().EndpointSlices(),
-			oc.clusterPortGroupUUID,
 		)
 		informerFactory.Start(oc.stopChan)
 		wg.Add(1)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -334,6 +334,7 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 			oc.client,
 			informerFactory.Core().V1().Services(),
 			informerFactory.Discovery().V1beta1().EndpointSlices(),
+			oc.clusterPortGroupUUID,
 		)
 		informerFactory.Start(oc.stopChan)
 		wg.Add(1)

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -22,12 +22,15 @@ import (
 )
 
 const (
-	k8sTCPLoadBalancerIP    = "k8s_tcp_load_balancer"
-	k8sUDPLoadBalancerIP    = "k8s_udp_load_balancer"
-	k8sSCTPLoadBalancerIP   = "k8s_sctp_load_balancer"
-	fakeUUID                = "8a86f6d8-7972-4253-b0bd-ddbef66e9303"
-	fakeUUIDv6              = "8a86f6d8-7972-4253-b0bd-ddbef66e9304"
-	ovnClusterPortGroupUUID = "740515f3-7ece-4cd1-9be5-6fdb9066d198"
+	k8sTCPLoadBalancerIP        = "k8s_tcp_load_balancer"
+	k8sUDPLoadBalancerIP        = "k8s_udp_load_balancer"
+	k8sSCTPLoadBalancerIP       = "k8s_sctp_load_balancer"
+	k8sIdlingTCPLoadBalancerIP  = "k8s_tcp_idling_load_balancer"
+	k8sIdlingUDPLoadBalancerIP  = "k8s_udp_idling_load_balancer"
+	k8sIdlingSCTPLoadBalancerIP = "k8s_sctp_idling_load_balancer"
+	fakeUUID                    = "8a86f6d8-7972-4253-b0bd-ddbef66e9303"
+	fakeUUIDv6                  = "8a86f6d8-7972-4253-b0bd-ddbef66e9304"
+	ovnClusterPortGroupUUID     = "740515f3-7ece-4cd1-9be5-6fdb9066d198"
 )
 
 type FakeOVN struct {

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -1,15 +1,13 @@
 package ovn
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"net"
 	"reflect"
-	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -17,16 +15,6 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
 )
-
-func addRejectACLs(rejectACLs map[string]map[string]bool, lb, ip string, port int32, hasEndpoints bool) {
-	if ip != "" {
-		name := generateACLName(lb, ip, port)
-		if _, ok := rejectACLs[name]; !ok {
-			rejectACLs[name] = make(map[string]bool)
-		}
-		rejectACLs[name][lb] = hasEndpoints
-	}
-}
 
 func (ovn *Controller) syncServices(services []interface{}) {
 	// For all clusterIP in k8s, we will populate the below slice with
@@ -43,9 +31,6 @@ func (ovn *Controller) syncServices(services []interface{}) {
 	// For all externalIPs in k8s, we will populate the below map of slices
 	// with load balancer type services based on each protocol.
 	lbServices := make(map[kapi.Protocol][]string)
-
-	// Track which services found should have reject ACLs. Format is name, load balancer, and value is if service has endpoints
-	svcRejectACLs := make(map[string]map[string]bool)
 
 	// Go through the k8s services and populate 'clusterServices',
 	// 'nodeportServices' and 'lbServices'
@@ -65,16 +50,6 @@ func (ovn *Controller) syncServices(services []interface{}) {
 			continue
 		}
 
-		// detect if service has endpoints for stale reject ACL check. If there are endpoints, we need to wipe any
-		// old stale ACLs
-		ep, err := ovn.watchFactory.GetEndpoint(service.Namespace, service.Name)
-		hasEndpoints := false
-		if err == nil {
-			if len(ep.Subsets) > 0 {
-				hasEndpoints = true
-			}
-		}
-
 		for _, svcPort := range service.Spec.Ports {
 			if err := util.ValidatePort(svcPort.Protocol, svcPort.Port); err != nil {
 				klog.Errorf("Error validating port %s: %v", svcPort.Name, err)
@@ -84,129 +59,14 @@ func (ovn *Controller) syncServices(services []interface{}) {
 			if util.ServiceTypeHasNodePort(service) {
 				port := fmt.Sprintf("%d", svcPort.NodePort)
 				nodeportServices[svcPort.Protocol] = append(nodeportServices[svcPort.Protocol], port)
-				gatewayRouters, _, err := ovn.getOvnGateways()
-				if err == nil {
-					for _, gatewayRouter := range gatewayRouters {
-						lb, err := ovn.getGatewayLoadBalancer(gatewayRouter, svcPort.Protocol)
-						if err != nil {
-							klog.Warningf("Service Sync: Gateway router %s does not have load balancer (%v)",
-								gatewayRouter, err)
-							continue
-						}
-						physicalIPs, err := ovn.getGatewayPhysicalIPs(gatewayRouter)
-						if err != nil {
-							klog.Warningf("Service Sync: Gateway router %s does not have physical ips: %v",
-								gatewayRouter, err)
-							continue
-						}
-						for _, physicalIP := range physicalIPs {
-							addRejectACLs(svcRejectACLs, lb, physicalIP, svcPort.NodePort, hasEndpoints)
-						}
-					}
-				}
 			}
 
 			key := util.JoinHostPortInt32(service.Spec.ClusterIP, svcPort.Port)
 			clusterServices[svcPort.Protocol] = append(clusterServices[svcPort.Protocol], key)
-			lb, err := ovn.getLoadBalancer(svcPort.Protocol)
-			if err != nil {
-				klog.Warningf("Unable to get existing load balancer from ovn. Reject ACLs may not be synced!")
-			} else {
-				addRejectACLs(svcRejectACLs, lb, service.Spec.ClusterIP, svcPort.Port, hasEndpoints)
 
-				// Cloud load balancers: directly load balance that traffic from pods
-				for _, ing := range service.Status.LoadBalancer.Ingress {
-					addRejectACLs(svcRejectACLs, lb, ing.IP, svcPort.Port, hasEndpoints)
-				}
-			}
 			for _, extIP := range service.Spec.ExternalIPs {
 				key := util.JoinHostPortInt32(extIP, svcPort.Port)
 				lbServices[svcPort.Protocol] = append(lbServices[svcPort.Protocol], key)
-				gateways, _, err := ovn.getOvnGateways()
-				if err != nil {
-					continue
-				}
-				for _, gateway := range gateways {
-					lb, err := ovn.getGatewayLoadBalancer(gateway, svcPort.Protocol)
-					if err != nil {
-						klog.Errorf("Service Sync: Gateway router %s does not have load balancer (%v)",
-							gateway, err)
-						continue
-					}
-					addRejectACLs(svcRejectACLs, lb, extIP, svcPort.Port, hasEndpoints)
-				}
-			}
-		}
-	}
-
-	// Get OVN's current reject ACLs. Note, currently only services use reject ACLs.
-	type ovnACLData struct {
-		Data [][]interface{}
-	}
-	data, stderr, err := util.RunOVNNbctl("--columns=name,_uuid", "--format=json", "find", "acl", "action=reject")
-	if err != nil {
-		klog.Errorf("Error while querying ACLs with reject action: %s, %v", stderr, err)
-	} else {
-		x := ovnACLData{}
-		if err := json.Unmarshal([]byte(data), &x); err != nil {
-			klog.Errorf("Unable to get current OVN reject ACLs. Unable to sync reject ACLs!: %v", err)
-		} else if len(x.Data) == 0 {
-			klog.Infof("Service Sync: No reject ACLs currently configured in OVN")
-		} else {
-			for _, entry := range x.Data {
-				// ACL entry format is a slice: [<aclName>, ["_uuid", <uuid>]]
-				if len(entry) != 2 {
-					continue
-				}
-				name, ok := entry[0].(string)
-				if !ok {
-					continue
-				}
-				uuidData, ok := entry[1].([]interface{})
-				if !ok || len(uuidData) != 2 {
-					continue
-				}
-				uuid, ok := uuidData[1].(string)
-				if !ok {
-					continue
-				}
-				if svcCacheEntry, ok := svcRejectACLs[name]; ok {
-					for lb, hasEps := range svcCacheEntry {
-						if hasEps {
-							klog.Infof("Service Sync: Removing OVN stale reject ACL: %s", name)
-							ovn.removeACLFromPortGroup(lb, uuid)
-							var foundSwitches []string
-							// For upgrade from a non-port group Reject ACL implementation
-							// Deprecated: remove in the future
-							switches, err := ovn.getLogicalSwitchesForLoadBalancer(lb)
-							if err != nil {
-								klog.Errorf("Error finding node logical switches for load balancer "+
-									"%s: %v", lb, err)
-							} else {
-								foundSwitches = append(foundSwitches, switches...)
-							}
-							// Look for load balancer on join/external switches
-							grExtSwitches, err := ovn.getGRLogicalSwitchesForLoadBalancer(lb)
-							if err != nil {
-								klog.Errorf("Error finding GR logical switches for load balancer "+
-									"%s: %v", lb, err)
-							} else {
-								// For upgrade from a previous implementation the ACL may also be on join switch
-								for _, grExtSwitch := range grExtSwitches {
-									routerName := strings.TrimPrefix(grExtSwitch, types.ExternalSwitchPrefix)
-									grJoinSwitch := types.JoinSwitchPrefix + routerName
-									foundSwitches = append(foundSwitches, grExtSwitch, grJoinSwitch)
-								}
-							}
-							if len(foundSwitches) > 0 {
-								klog.V(5).Infof("Service Sync: Removing OVN stale reject ACL (%s) "+
-									"from logical switches that contains load balancer %s, switches: %s", name, lb,
-									foundSwitches)
-								ovn.removeACLFromNodeSwitches(foundSwitches, uuid)
-							}
-						}
-					}
-				}
 			}
 		}
 	}
@@ -285,18 +145,19 @@ func (ovn *Controller) createService(service *kapi.Service) error {
 		return nil
 	}
 
-	// We can end up in a situation where the endpoint creation is triggered before the service creation,
-	// we should not be creating the reject ACLs if this endpoint exists, because that would result in an unreachable service
-	// eventough the endpoint exists.
+	// We can end up in a situation where the endpoint creation is triggered before the service creation.
 	// NOTE: we can also end up in a situation where a service matching no pods is created. Such a service still has an endpoint, but with no subsets.
-	// make sure to treat that service as an ACL reject.
 	ep, err := ovn.watchFactory.GetEndpoint(service.Namespace, service.Name)
 	if err == nil {
 		if len(ep.Subsets) > 0 {
 			klog.V(5).Infof("service: %s has endpoint, will create load balancer VIPs", service.Name)
 		} else {
 			klog.V(5).Infof("service: %s has empty endpoint", service.Name)
-			ep = nil
+			// No need to go further. AddEndpoints will add the service to the idling LB
+			if err := ovn.AddEndpoints(ep, true); err != nil {
+				return err
+			}
+			return nil
 		}
 	}
 
@@ -353,16 +214,6 @@ func (ovn *Controller) createService(service *kapi.Service) error {
 						if err := ovn.AddEndpoints(ep, true); err != nil {
 							return err
 						}
-					} else if svcQualifiesForReject(service) {
-						aclDenyLogging := ovn.GetNetworkPolicyACLLogging(service.Namespace).Deny
-						aclUUID, err := ovn.createLoadBalancerRejectACL(loadBalancer, physicalIP, port,
-							svcPort.Protocol, aclDenyLogging)
-						if err != nil {
-							return fmt.Errorf("failed to create service ACL: %v", err)
-						}
-						klog.Infof("Service Reject ACL created for NodePort service: %s, namespace: %s, via "+
-							"gateway router: %s:%s:%d, ACL UUID:%s", service.Name, service.Namespace,
-							svcPort.Protocol, physicalIP, port, aclUUID)
 					}
 				}
 			}
@@ -373,76 +224,13 @@ func (ovn *Controller) createService(service *kapi.Service) error {
 				klog.Errorf("Failed to get load balancer for %s (%v)", svcPort.Protocol, err)
 				break
 			}
-			if svcQualifiesForReject(service) {
-				gateways, _, err := ovn.getOvnGateways()
-				if err != nil {
+			vip := util.JoinHostPortInt32(service.Spec.ClusterIP, svcPort.Port)
+			// Skip creating LB if endpoints watcher already did it
+			if _, hasEps := ovn.getServiceLBInfo(loadBalancer, vip); hasEps {
+				klog.V(5).Infof("Load balancer already configured for %s, %s", loadBalancer, vip)
+			} else if ep != nil {
+				if err := ovn.AddEndpoints(ep, true); err != nil {
 					return err
-				}
-				vip := util.JoinHostPortInt32(service.Spec.ClusterIP, svcPort.Port)
-				// Skip creating LB if endpoints watcher already did it
-				if _, hasEps := ovn.getServiceLBInfo(loadBalancer, vip); hasEps {
-					klog.V(5).Infof("Load balancer already configured for %s, %s", loadBalancer, vip)
-				} else if ep != nil {
-					if err := ovn.AddEndpoints(ep, true); err != nil {
-						return err
-					}
-				} else {
-					aclDenyLogging := ovn.GetNetworkPolicyACLLogging(service.Namespace).Deny
-					aclUUID, err := ovn.createLoadBalancerRejectACL(loadBalancer, service.Spec.ClusterIP,
-						svcPort.Port, svcPort.Protocol, aclDenyLogging)
-					if err != nil {
-						return fmt.Errorf("failed to create service ACL: %v", err)
-					}
-					klog.Infof("Service Reject ACL created for ClusterIP service: %s, namespace: %s, via: "+
-						"%s:%s:%d, ACL UUID: %s", service.Name, service.Namespace, svcPort.Protocol,
-						service.Spec.ClusterIP, svcPort.Port, aclUUID)
-					// Cloud load balancers reject ACLs
-					for _, ing := range service.Status.LoadBalancer.Ingress {
-						if ing.IP == "" {
-							continue
-						}
-						for _, gateway := range gateways {
-							loadBalancer, err := ovn.getGatewayLoadBalancer(gateway, svcPort.Protocol)
-							if err != nil {
-								klog.Errorf("Gateway router %s does not have load balancer (%v)", gateway, err)
-								continue
-							}
-							aclUUID, err := ovn.createLoadBalancerRejectACL(loadBalancer, ing.IP, svcPort.Port, svcPort.Protocol, aclDenyLogging)
-							if err != nil {
-								klog.Errorf("Failed to create reject ACL for Ingress IP: %s, load balancer: %s, error: %v",
-									ing.IP, loadBalancer, err)
-							} else {
-								klog.Infof("Reject ACL created for Ingress IP: %s, load balancer: %s, %s", ing.IP,
-									loadBalancer, aclUUID)
-							}
-						}
-					}
-				}
-				if len(service.Spec.ExternalIPs) > 0 {
-					for _, extIP := range service.Spec.ExternalIPs {
-						for _, gateway := range gateways {
-							loadBalancer, err := ovn.getGatewayLoadBalancer(gateway, svcPort.Protocol)
-							if err != nil {
-								klog.Errorf("Gateway router %s does not have load balancer (%v)", gateway, err)
-								continue
-							}
-							vip := util.JoinHostPortInt32(extIP, svcPort.Port)
-							// Skip creating LB if endpoints watcher already did it
-							if _, hasEps := ovn.getServiceLBInfo(loadBalancer, vip); hasEps {
-								klog.V(5).Infof("Load Balancer already configured for %s, %s", loadBalancer, vip)
-							} else {
-								aclDenyLogging := ovn.GetNetworkPolicyACLLogging(service.Namespace).Deny
-								aclUUID, err := ovn.createLoadBalancerRejectACL(loadBalancer, extIP, svcPort.Port,
-									svcPort.Protocol, aclDenyLogging)
-								if err != nil {
-									return fmt.Errorf("failed to create service ACL for external IP")
-								}
-								klog.Infof("Service Reject ACL created for ExternalIP service: %s, namespace: %s,"+
-									"via: %s:%s:%d, ACL UUID: %s", service.Name, service.Namespace, svcPort.Protocol,
-									extIP, svcPort.Port, aclUUID)
-							}
-						}
-					}
 				}
 			}
 		}
@@ -468,6 +256,62 @@ func (ovn *Controller) updateService(oldSvc, newSvc *kapi.Service) error {
 }
 
 func (ovn *Controller) deleteService(service *kapi.Service) {
+	ovn.deleteServiceFromBalancers(service)
+	ovn.deleteServiceFromIdlingBalancer(service)
+}
+
+func (ovn *Controller) deleteServiceFromIdlingBalancer(service *kapi.Service) {
+	if !config.Kubernetes.OVNEmptyLbEvents {
+		return
+	}
+	if !util.IsClusterIPSet(service) {
+		return
+	}
+	klog.Infof("Deleting service %s from idling balancer", service.Name)
+	for _, svcPort := range service.Spec.Ports {
+		lb, err := loadbalancer.GetOVNKubeIdlingLoadBalancer(svcPort.Protocol)
+		if err != nil {
+			klog.Errorf("Failed to get idling loadbalancer for protocol %s %v", svcPort.Protocol, err)
+			continue
+		}
+
+		if util.ServiceTypeHasNodePort(service) {
+			nodeIPs, err := ovn.getNodeportIPs()
+			if err != nil {
+				klog.Error(err)
+			}
+			for _, nodeIP := range nodeIPs {
+				vip := util.JoinHostPortInt32(nodeIP, svcPort.NodePort)
+				if err := ovn.deleteLoadBalancerVIP(lb, vip); err != nil {
+					klog.Error(err)
+				}
+			}
+		}
+		if util.ServiceTypeHasClusterIP(service) {
+			vip := util.JoinHostPortInt32(service.Spec.ClusterIP, svcPort.Port)
+			if err := ovn.deleteLoadBalancerVIP(lb, vip); err != nil {
+				klog.Error(err)
+			}
+			for _, ing := range service.Status.LoadBalancer.Ingress {
+				if ing.IP == "" {
+					continue
+				}
+				vip := util.JoinHostPortInt32(ing.IP, svcPort.Port)
+				if err := ovn.deleteLoadBalancerVIP(lb, vip); err != nil {
+					klog.Error(err)
+				}
+			}
+			for _, extIP := range service.Spec.ExternalIPs {
+				vip := util.JoinHostPortInt32(extIP, svcPort.Port)
+				if err := ovn.deleteLoadBalancerVIP(lb, vip); err != nil {
+					klog.Error(err)
+				}
+			}
+		}
+	}
+}
+
+func (ovn *Controller) deleteServiceFromBalancers(service *kapi.Service) {
 	klog.Infof("Deleting service %s", service.Name)
 	if !util.IsClusterIPSet(service) {
 		return
@@ -484,7 +328,6 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 			klog.Errorf("Skipping delete for service port %s: %v", svcPort.Name, err)
 			continue
 		}
-
 		if util.ServiceTypeHasNodePort(service) {
 			// Delete the 'NodePort' service from a load balancer instantiated in gateways.
 			ovn.deleteNodeVIPs(nil, svcPort.Protocol, port)
@@ -511,13 +354,60 @@ func (ovn *Controller) deleteService(service *kapi.Service) {
 	}
 }
 
-// svcQualifiesForReject determines if a service should have a reject ACL on it when it has no endpoints
-// The reject ACL is only applied to terminate incoming connections immediately when idling is not used
-// or OVNEmptyLbEvents are not enabled. When idilng or empty LB events are enabled, we want to ensure we
-// receive these packets and not reject them.
-func svcQualifiesForReject(service *kapi.Service) bool {
-	_, ok := service.Annotations[OvnServiceIdledAt]
-	return !(config.Kubernetes.OVNEmptyLbEvents && ok)
+func (ovn *Controller) addServiceToIdlingBalancer(service *kapi.Service) {
+	// when adding to idling, it's because the service has no endpoints
+	targets := make([]string, 0)
+	for _, svcPort := range service.Spec.Ports {
+		var port int32
+		if util.ServiceTypeHasNodePort(service) {
+			port = svcPort.NodePort
+		} else {
+			port = svcPort.Port
+		}
+		lb, err := loadbalancer.GetOVNKubeIdlingLoadBalancer(svcPort.Protocol)
+		if err != nil {
+			klog.Errorf("Failed to get idling loadbalancer for protocol %s %v", svcPort.Protocol, err)
+			continue
+		}
+
+		if err := util.ValidatePort(svcPort.Protocol, port); err != nil {
+			klog.Errorf("Skipping delete for service port %s: %v", svcPort.Name, err)
+			continue
+		}
+		if util.ServiceTypeHasNodePort(service) {
+			nodeIPs, err := ovn.getNodeportIPs()
+			if err != nil {
+				klog.Error(err)
+			}
+			for _, nodeIP := range nodeIPs {
+				vip := util.JoinHostPortInt32(nodeIP, port)
+				if err := loadbalancer.UpdateLoadBalancer(lb, vip, targets); err != nil {
+					klog.Error(err)
+				}
+			}
+		}
+		if util.ServiceTypeHasClusterIP(service) {
+			vip := util.JoinHostPortInt32(service.Spec.ClusterIP, svcPort.Port)
+			if err := loadbalancer.UpdateLoadBalancer(lb, vip, targets); err != nil {
+				klog.Error(err)
+			}
+			for _, ing := range service.Status.LoadBalancer.Ingress {
+				if ing.IP == "" {
+					continue
+				}
+				vip := util.JoinHostPortInt32(ing.IP, svcPort.Port)
+				if err := loadbalancer.UpdateLoadBalancer(lb, vip, targets); err != nil {
+					klog.Error(err)
+				}
+			}
+			for _, extIP := range service.Spec.ExternalIPs {
+				vip := util.JoinHostPortInt32(extIP, svcPort.Port)
+				if err := loadbalancer.UpdateLoadBalancer(lb, vip, targets); err != nil {
+					klog.Error(err)
+				}
+			}
+		}
+	}
 }
 
 // SVC can be of types 1. clusterIP, 2. NodePort, 3. LoadBalancer,

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/acl"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -132,6 +133,12 @@ func (ovn *Controller) syncServices(services []interface{}) {
 				}
 			}
 		}
+	}
+	// Remove existing reject rules. They are not used anymore
+	// given the introduction of idling loadbalancers
+	err = acl.PurgeRejectRules(ovn.clusterPortGroupUUID)
+	if err != nil {
+		klog.Errorf("Failed to purge existing reject rules: %v", err)
 	}
 }
 

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -165,6 +165,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
+		config.Kubernetes.OVNEmptyLbEvents = true
 
 		app = cli.NewApp()
 		app.Name = "test"

--- a/go-controller/pkg/ovn/service_test.go
+++ b/go-controller/pkg/ovn/service_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,16 +45,12 @@ func (s service) baseCmds(fexec *ovntest.FakeExec, service v1.Service) {
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-tcp=yes",
 		Output: k8sTCPLoadBalancerIP,
 	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --columns=name,_uuid --format=json find acl action=reject",
-	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading get load_balancer %s vips", k8sTCPLoadBalancerIP),
 		Output: "{\"172.30.0.10:53\"=\"10.128.0.18:5353,10.129.0.3:5353\"}",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"172.30.0.10:53\"", k8sTCPLoadBalancerIP),
-		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=%s-172.30.0.10\\:53", k8sTCPLoadBalancerIP),
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-udp=yes",
@@ -67,7 +62,6 @@ func (s service) baseCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"172.30.0.10:53\"", k8sUDPLoadBalancerIP),
-		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=%s-172.30.0.10\\:53", k8sUDPLoadBalancerIP),
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-cluster-lb-sctp=yes",
@@ -79,7 +73,6 @@ func (s service) baseCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"172.30.0.10:53\"", k8sSCTPLoadBalancerIP),
-		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=%s-172.30.0.10\\:53", k8sSCTPLoadBalancerIP),
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
@@ -95,7 +88,6 @@ func (s service) baseCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists remove load_balancer tcp_load_balancer_id_1 vips \"172.30.0.10:53\"",
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=tcp_load_balancer_id_1-172.30.0.10\\:53",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=gateway1",
@@ -107,7 +99,6 @@ func (s service) baseCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists remove load_balancer udp_load_balancer_id_1 vips \"172.30.0.10:53\"",
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=udp_load_balancer_id_1-172.30.0.10\\:53",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=gateway1",
@@ -119,40 +110,34 @@ func (s service) baseCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists remove load_balancer sctp_load_balancer_id_1 vips \"172.30.0.10:53\"",
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=sctp_load_balancer_id_1-172.30.0.10\\:53",
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find logical_switch load_balancer{>=}%s", k8sTCPLoadBalancerIP),
-		Output: "62c672a4-1132-44ab-9202-e47d18784138",
-	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router load_balancer{>=}%s", k8sTCPLoadBalancerIP),
 	})
 }
 
 func (s service) addCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	s.baseCmds(fexec, service)
-	for _, port := range service.Spec.Ports {
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=%s-%s\\:%v",
-				k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
-			fmt.Sprintf("ovn-nbctl --timeout=15 --id=@reject-acl create acl direction="+types.DirectionFromLPort+" priority="+types.DefaultDenyPriority+" match=\"ip4.dst==%s && tcp "+
-				"&& tcp.dst==%v\" action=reject log=false severity=info meter=acl-logging name=%s-%s\\:%v -- add port_group %s acls @reject-acl", service.Spec.ClusterIP, port.Port,
-				k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port, ovnClusterPortGroupUUID),
-		})
-	}
 }
 
 func (s service) delCmds(fexec *ovntest.FakeExec, service v1.Service) {
 	for _, port := range service.Spec.Ports {
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"%s:%v\"", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
-			fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find acl name=%s-%s\\:%v", k8sTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name find logical_router options:chassis!=null",
 		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-idling-lb-tcp=yes",
+			Output: k8sIdlingTCPLoadBalancerIP,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			fmt.Sprintf("ovn-nbctl --timeout=15 --if-exists remove load_balancer %s vips \"%s:%v\"", k8sIdlingTCPLoadBalancerIP, service.Spec.ClusterIP, port.Port),
+		})
 	}
+}
+
+func (s service) syncCmds(fexec *ovntest.FakeExec) {
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		fmt.Sprintf("ovn-nbctl --timeout=15 --columns=_uuid --format=csv --data=bare --no-headings find acl action=reject"),
+	})
 }
 
 var _ = ginkgo.Describe("OVN Namespace Operations", func() {
@@ -198,6 +183,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				)
 
 				test.addCmds(fExec, service)
+				test.syncCmds(fExec)
 
 				fakeOvn.start(ctx,
 					&v1.ServiceList{
@@ -237,6 +223,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 				)
 
 				test.addCmds(fExec, service)
+				test.syncCmds(fExec)
 
 				fakeOvn.start(ctx,
 					&v1.ServiceList{

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -87,16 +87,18 @@ const (
 	OvnACLLoggingMeter = "acl-logging"
 
 	// LoadBalancer External Names
-	ClusterLBTCP   = "k8s-cluster-lb-tcp"
-	ClusterLBUDP   = "k8s-cluster-lb-udp"
-	ClusterLBSCTP  = "k8s-cluster-lb-sctp"
-	WorkerLBPrefix = "k8s-worker-lb"
-	WorkerLBTCP    = WorkerLBPrefix + "-tcp"
-	WorkerLBUDP    = WorkerLBPrefix + "-udp"
-	WorkerLBSCTP   = WorkerLBPrefix + "-sctp"
-	GatewayLBTCP   = "TCP_lb_gateway_router"
-	GatewayLBUDP   = "UDP_lb_gateway_router"
-	GatewayLBSCTP  = "SCTP_lb_gateway_router"
+	ClusterLBTCP          = "k8s-cluster-lb-tcp"
+	ClusterLBUDP          = "k8s-cluster-lb-udp"
+	ClusterLBSCTP         = "k8s-cluster-lb-sctp"
+	ClusterLBPrefix       = "k8s-cluster-lb"
+	ClusterIdlingLBPrefix = "k8s-idling-lb"
+	WorkerLBPrefix        = "k8s-worker-lb"
+	WorkerLBTCP           = WorkerLBPrefix + "-tcp"
+	WorkerLBUDP           = WorkerLBPrefix + "-udp"
+	WorkerLBSCTP          = WorkerLBPrefix + "-sctp"
+	GatewayLBTCP          = "TCP_lb_gateway_router"
+	GatewayLBUDP          = "UDP_lb_gateway_router"
+	GatewayLBSCTP         = "SCTP_lb_gateway_router"
 
 	// OVN-K8S Topology Versions
 	OvnSingleJoinSwitchTopoVersion = 1

--- a/go-controller/pkg/util/ovn.go
+++ b/go-controller/pkg/util/ovn.go
@@ -134,3 +134,14 @@ func GetDatapathUUID(datapathName string) (string, error) {
 	}
 	return datapath, nil
 }
+
+// Finds any OVN Load Balancer based on external ID and value
+func FindOVNLoadBalancer(externalID, externalValue string) (string, string, error) {
+	out, stderr, err := RunOVNNbctl("--data=bare",
+		"--no-heading", "--columns=_uuid", "find", "load_balancer",
+		"external_ids:"+externalID+"="+externalValue)
+	if err != nil {
+		return "", stderr, err
+	}
+	return out, "", nil
+}

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -771,17 +771,6 @@ func DetectSCTPSupport() (bool, error) {
 	return false, nil
 }
 
-// Finds any OVN Load Balancer based on external ID and value
-func FindOVNLoadBalancer(externalID, externalValue string) (string, string, error) {
-	out, stderr, err := RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=_uuid", "find", "load_balancer",
-		"external_ids:"+externalID+"="+externalValue)
-	if err != nil {
-		return "", stderr, err
-	}
-	return out, "", nil
-}
-
 // DetermineOVNTopoVersionFromOVN determines what OVN Topology version is being used
 // If "k8s-ovn-topo-version" key in external_ids column does not exist, it is prior to OVN topology versioning
 // and therefore set version number to OvnCurrentTopologyVersion


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

This PR replaces the current ACL reject rules for services with no endpoints with the creation of a "idling loadbalancer" where we moves the VIPs when a given service has no endpoints.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->