### PR TITLE
Should allow shared and local gateway dns resolution

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -410,8 +410,13 @@ docker_disable_ipv6() {
   done
 }
 
-coredns_patch_for_github_ci() {
-  # Patch CoreDNS to work in Github CI
+coredns_patch() {
+  dns_server="8.8.8.8"
+  if [ "$KIND_IPV6_SUPPORT" == true ]; then
+    dns_server="2001:4860:4860::8888"
+  fi
+
+  # Patch CoreDNS to work
   # 1. Github CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
   # to work in an offline environment:
   # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
@@ -429,7 +434,7 @@ coredns_patch_for_github_ci() {
       -e 's/^.*kubernetes cluster\.local/& net/' \
       -e '/^.*upstream$/d' \
       -e '/^.*fallthrough.*$/d' \
-      -e '/^.*forward . \/etc\/resolv.conf$/d' \
+      -e 's/^\(.*forward \.\).*$/\1 '"$dns_server"' {/' \
       -e '/^.*loop$/d' \
   )
   echo "Patched CoreDNS config:"
@@ -570,9 +575,7 @@ check_ipv6
 set_cluster_cidr_ip_families
 create_kind_cluster
 docker_disable_ipv6
-if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
-  coredns_patch_for_github_ci
-fi
+coredns_patch
 build_ovn_image
 detect_apiserver_url
 create_ovn_kube_manifests

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -441,6 +441,19 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 
 		framework.ExpectNoError(<-errChan)
 	})
+	ginkgo.It("should provide connection to external host by DNS name from a pod", func() {
+		ginkgo.By("Running container which tries to connect to www.google.com. in a loop")
+
+		podChan, errChan := make(chan *v1.Pod), make(chan error)
+		go checkContinuousConnectivity(f, "", "connectivity-test-continuous", "www.google.com.", 443, 30, podChan, errChan)
+
+		testPod := <-podChan
+		framework.Logf("Test pod running on %q", testPod.Spec.NodeName)
+
+		time.Sleep(10 * time.Second)
+
+		framework.ExpectNoError(<-errChan)
+	})
 })
 
 // Test e2e inter-node connectivity over br-int


### PR DESCRIPTION
it has been observed that in the github and local env. pods that are
deployed in a cluster using shared gateway mode cannot resolve dnsNames.

This patch fixes that and exlicitly tests e2e dnsName resolution in pods

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->