### PR TITLE
Adding docutext and fixing usage of target

### DIFF
--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -163,7 +163,7 @@ spec:
 
         readinessProbe:
           exec:
-            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-nbctld"]
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-nbctl"]
           initialDelaySeconds: 30
           timeoutSeconds: 30
           periodSeconds: 60

--- a/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
+++ b/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
@@ -18,7 +18,7 @@ var callbacks = map[string]readinessFunc{
 	"ovnnb-db":       ovnNBDBReadiness,
 	"ovnsb-db":       ovnSBDBReadiness,
 	"ovn-northd":     ovnNorthdReadiness,
-	"ovn-nbctl":     ovnNbCtlReadiness,
+	"ovn-nbctl":      ovnNbCtlReadiness,
 	"ovs-daemons":    ovsDaemonsReadiness,
 	"ovnkube-node":   ovnNodeReadiness,
 	"ovnnb-db-raft":  ovnNBDBRaftReadiness,

--- a/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
+++ b/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
@@ -18,7 +18,7 @@ var callbacks = map[string]readinessFunc{
 	"ovnnb-db":       ovnNBDBReadiness,
 	"ovnsb-db":       ovnSBDBReadiness,
 	"ovn-northd":     ovnNorthdReadiness,
-	"ovn-nbctld":     ovnNbCtldReadiness,
+	"ovn-nbctl":     ovnNbCtlReadiness,
 	"ovs-daemons":    ovsDaemonsReadiness,
 	"ovnkube-node":   ovnNodeReadiness,
 	"ovnnb-db-raft":  ovnNBDBRaftReadiness,
@@ -103,6 +103,8 @@ func ovnSBDBReadiness(target string) error {
 }
 
 func ovnNorthdReadiness(target string) error {
+	// checking version works as it conntects to northd and returns the version
+	// if northd isn't ready, version may fail to return
 	_, _, err := util.RunOVNAppctlWithTimeout(5, "-t", target, "version")
 	if err != nil {
 		return fmt.Errorf("failed to get version from %s: (%v)", target, err)
@@ -110,8 +112,10 @@ func ovnNorthdReadiness(target string) error {
 	return nil
 }
 
-func ovnNbCtldReadiness(target string) error {
-	_, _, err := util.RunOVNAppctlWithTimeout(5, "-t", "ovn-nbctl", "version")
+func ovnNbCtlReadiness(target string) error {
+	// checking version works as it conntects to nbctld and returns the version
+	// if nbctld isn't ready, version may fail to return
+	_, _, err := util.RunOVNAppctlWithTimeout(5, "-t", target, "version")
 	if err != nil {
 		return fmt.Errorf("failed to get version from %s: (%v)", target, err)
 	}

--- a/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
+++ b/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
@@ -103,7 +103,7 @@ func ovnSBDBReadiness(target string) error {
 }
 
 func ovnNorthdReadiness(target string) error {
-	// checking version works as it conntects to northd and returns the version
+	// checking version works as it connects to northd and returns the version
 	// if northd isn't ready, version may fail to return
 	_, _, err := util.RunOVNAppctlWithTimeout(5, "-t", target, "version")
 	if err != nil {
@@ -113,8 +113,10 @@ func ovnNorthdReadiness(target string) error {
 }
 
 func ovnNbCtlReadiness(target string) error {
-	// checking version works as it conntects to nbctld and returns the version
-	// if nbctld isn't ready, version may fail to return
+	// checking version works as it connects to the ovn-nbctl daemon and returns the version
+	// if nbctl isn't ready, version may fail to return
+	// NOTE: There is no nbctld process, but nbctl provides a daemon mode,
+	// which is invoked by using --detach option to start an ovn-nbctl in a daemon mode.
 	_, _, err := util.RunOVNAppctlWithTimeout(5, "-t", target, "version")
 	if err != nil {
 		return fmt.Errorf("failed to get version from %s: (%v)", target, err)


### PR DESCRIPTION

**- What this PR does and why is it needed**
While reading through the readiness probes, I found it odd to call "version" as to check the readiness of nbctl and northd. But checking with @trozet @dcbw helped understand it is still valid and acceptable to check the version to determine readiness of the pods, because `ovn-appctl` still connecting to the app/daemon to determine the version. To remove the confusion, specially for readability to new contributors, it could be useful to have some comments there. 

In addition to that, I found that the `target` parameter was being not used/passed to readiness probe function correctly. Fixing that too. 

**- Special notes for reviewers**
This is my 1st PR to this repo. Hoping to get your kind reviews and get it merged. 

**- How to verify it**
I was able to run local development env using `./contrib/kind.sh` pre and post making these changes and pods came up correctly. Also verified if the changes I made to daemonset template took effect on launching cluster after I made changes. 
Happy to run any additional tests.


Signed-off-by:  Kedar Kulkarni <kkulkarni@redhat.com>