### PR TITLE
bumg golang version to 1.16.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
     paths: [ "dist/images/Dockerfile*"]
 
 env:
-  GO_VERSION: 1.13.4
+  GO_VERSION: 1.16.2
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,21 +56,17 @@ jobs:
       run: |
         set -x
         go get golang.org/x/tools/cmd/cover
+        go get github.com/modocache/gover
+        go get github.com/jandelgado/gcov2lcov
         pushd go-controller
            make
            make windows
            COVERALLS=1 make check
+           # Combine separate code coverage profiles into one
+           gover go-controller/ gover.coverprofile
+           # Convert coverage profile to LCOV format for coveralls github action
+           gcov2lcov -infile gover.coverprofile -outfile ../coverage.lcov
         popd
-
-        # Combine separate code coverage profiles into one
-        go get github.com/modocache/gover
-        gover go-controller/ gover.coverprofile
-
-        # Convert coverage profile to LCOV format for coveralls github action
-        go get github.com/jandelgado/gcov2lcov
-        mkdir -p src/github.com/ovn-org
-        ln -sf $(pwd) src/github.com/ovn-org/ovn-kubernetes
-        GOPATH=$(pwd) gcov2lcov -infile gover.coverprofile -outfile coverage.lcov
 
     - name: Build docker image
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 */12 * * *'
 
 env:
-  GO_VERSION: 1.15.5
+  GO_VERSION: 1.16.2
   K8S_VERSION: v1.20.2
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.15.3
+  GO_VERSION: 1.16.2
   K8S_VERSION: master
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -9,7 +9,7 @@ PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
 TEST_REPORT_DIR?=$(CURDIR)/_artifacts
 export TEST_REPORT_DIR
-GO_DOCKER_IMG = quay.io/giantswarm/golang:1.15.7
+GO_DOCKER_IMG = quay.io/giantswarm/golang:1.16.2
 # CONTAINER_RUNNABLE determines if the tests can be run inside a container. It checks to see if
 # podman/docker is installed on the system.
 PODMAN ?= $(shell podman -v > /dev/null 2>&1; echo $$?)


### PR DESCRIPTION
at scale, in certain cases we are seeing ovnkube-node not relesing the
memmory back to the host and does a lazy free. with 1.16.2, we pull in

   https://github.com/golang/go/commit/\
   05e6d28849293266028c0bc9e9b0f8d0da38a2e2

and memory release from ovnkube-node has been great

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>