### PR TITLE
[WIP] Implement LB functionalities in mock

### DIFF
--- a/go-controller/pkg/testing/mock_lb.go
+++ b/go-controller/pkg/testing/mock_lb.go
@@ -1,0 +1,146 @@
+package testing
+
+import (
+	"fmt"
+	goovn "github.com/ebay/go-ovn"
+	"k8s.io/klog/v2"
+	"strings"
+)
+
+const (
+	LoadBalancerVIPs            = "vips"
+	LoadBalancerProtocol        = "protocol"
+	LoadBalancerSelectionFields = "selectionFields"
+)
+
+// Get LB with given name
+func (mock *MockOVNClient) LBGet(lb string) ([]*goovn.LoadBalancer, error) {
+	mock.mutex.Lock()
+	defer mock.mutex.Unlock()
+	var lbCache MockObjectCacheByName
+	var ok bool
+	if lbCache, ok = mock.cache[LoadBalancerType]; !ok {
+		klog.V(5).Infof("Cache doesn't have any object of type %s", LoadBalancerType)
+		return nil, goovn.ErrorSchema
+	}
+	var port interface{}
+	if port, ok = lbCache[lb]; !ok {
+		return nil, goovn.ErrorNotFound
+	}
+	if lbRet, ok := port.(*goovn.LoadBalancer); ok {
+		return []*goovn.LoadBalancer{lbRet}, nil
+	}
+	return nil, fmt.Errorf("invalid object type assertion for %s", LoadBalancerType)
+}
+
+// Add LB
+func (mock *MockOVNClient) LBAdd(lb string, vipPort string, protocol string, addrs []string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("Adding load balancer %s", lb)
+	vipMap := make(map[interface{}]interface{})
+	// prepare vips map
+
+	vipMap[vipPort] = strings.Join(addrs, ",")
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpAdd,
+			table:   LoadBalancerType,
+			objName: lb,
+			obj:     &goovn.LoadBalancer{Name: lb, UUID: FakeUUID, VIPs: vipMap, Protocol: protocol},
+		},
+	}, nil
+}
+
+// Delete LB with given name
+func (mock *MockOVNClient) LBDel(lb string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("Deleting lb %s", lb)
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpDelete,
+			table:   LoadBalancerType,
+			objName: lb,
+		},
+	}, nil
+}
+
+// Update existing LB
+func (mock *MockOVNClient) LBUpdate(lb string, vipPort string, protocol string, addrs []string) (*goovn.OvnCommand, error) {
+	fieldVal := vipPort + "--" + strings.Join(addrs, ",") + ";" + protocol
+	fieldType := "vips;protocol"
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpUpdate,
+			table:   LoadBalancerType,
+			objName: lb,
+			objUpdate: UpdateCache{
+				FieldType:  fieldType,
+				FieldValue: fieldVal,
+			},
+		},
+	}, nil
+
+}
+
+// Set selection fields for LB session affinity
+func (mock *MockOVNClient) LBSetSelectionFields(lb string, selectionFields string) (*goovn.OvnCommand, error) {
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpUpdate,
+			table:   LoadBalancerType,
+			objName: lb,
+			objUpdate: UpdateCache{
+				FieldType:  LoadBalancerSelectionFields,
+				FieldValue: selectionFields,
+			},
+		},
+	}, nil
+}
+
+// helper function that applies field updates for a given lb to the mock object cache
+func (mock *MockOVNClient) updateLBCache(lbName string, update UpdateCache, mockCache MockObjectCacheByName) error {
+	var entry interface{}
+	var lb *goovn.LoadBalancer
+	var ok bool
+	var fieldValueStr string
+	if entry, ok = mockCache[lbName]; !ok {
+		return fmt.Errorf("error updating LB with name %s, LB doesn't exist", lbName)
+	}
+
+	if lb, ok = entry.(*goovn.LoadBalancer); !ok {
+		panic("type assertion failed for LB cache entry")
+	}
+
+	if fieldValueStr, ok = update.FieldValue.(string); !ok {
+		return fmt.Errorf("type assertion failed for LB field: %s", update.FieldType)
+	}
+
+	fieldValues := strings.Split(fieldValueStr, ";")
+	fieldNames := strings.Split(update.FieldType, ";")
+
+	for idx, entry := range fieldNames {
+		switch entry {
+		case LoadBalancerVIPs:
+			vipFields := strings.Split(fieldValues[idx], "--")
+			vipPort := vipFields[0]
+			addrs := vipFields[1]
+			lb.VIPs[vipPort] = addrs
+			klog.V(5).Infof("Setting addresses %s for vipPort %s on LB %s", addrs, vipPort, lbName)
+		case LoadBalancerProtocol:
+			protocol := fieldValues[idx]
+			lb.Protocol = protocol
+			klog.V(5).Infof("Setting Protocol to  %s on LB %s", protocol, lbName)
+		case LoadBalancerSelectionFields:
+			selectionFields := fieldValues[idx]
+			lb.SelectionFields = selectionFields
+			klog.V(5).Infof("Setting selectionFields to %s on LB %s", selectionFields, lbName)
+		default:
+			return fmt.Errorf("unrecognized field type: %s", update.FieldType)
+
+		}
+	}
+
+	return nil
+}

--- a/go-controller/pkg/testing/mock_ovn.go
+++ b/go-controller/pkg/testing/mock_ovn.go
@@ -18,6 +18,7 @@ const (
 	ChassisType           string = "Chassis"
 	ACLType               string = "ACL"
 	ChassisPrivateType    string = "Chassis_Private"
+	LoadBalancerType      string = "Logical_Load_Balancer"
 )
 
 const (
@@ -80,6 +81,7 @@ func NewMockOVNClient(db string) *MockOVNClient {
 	mock.cache[LogicalSwitchType] = make(MockObjectCacheByName)
 	mock.cache[ChassisPrivateType] = make(MockObjectCacheByName)
 	mock.cache[LogicalRouterType] = make(MockObjectCacheByName)
+	mock.cache[LoadBalancerType] = make(MockObjectCacheByName)
 	return mock
 }
 

--- a/go-controller/pkg/testing/mock_stubs.go
+++ b/go-controller/pkg/testing/mock_stubs.go
@@ -108,31 +108,6 @@ func (mock *MockOVNClient) ASList() ([]*goovn.AddressSet, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
 }
 
-// Get LB with given name
-func (mock *MockOVNClient) LBGet(name string) ([]*goovn.LoadBalancer, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Add LB
-func (mock *MockOVNClient) LBAdd(name string, vipPort string, protocol string, addrs []string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Delete LB with given name
-func (mock *MockOVNClient) LBDel(name string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Update existing LB
-func (mock *MockOVNClient) LBUpdate(name string, vipPort string, protocol string, addrs []string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Set selection fields for LB session affinity
-func (mock *MockOVNClient) LBSetSelectionFields(name string, selectionFields string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
 // Add dhcp options for cidr and provided external_ids
 func (mock *MockOVNClient) DHCPOptionsAdd(cidr string, options map[string]string, external_ids map[string]string) (*goovn.OvnCommand, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())


### PR DESCRIPTION
This PR

- moves Loadbalancer mock functions into a separate mock_lb.go file

- implements Loadbalancer functions for the mocks

This PR is blocked on go-ovn getting re-vendored in ovn-k   for a new go-ovn feature.
 
Co-authored by : Palani Kodeswaran palankod@in.ibm.com

Signed-off-by: Sayandeep <sayandes@in.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->