### PR TITLE
 policy: Refactor address set management to a separate controller.

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -71,7 +71,7 @@ func NewCNIServer(rundir string, useOVSExternalIDs bool, factory factory.NodeWat
 		},
 		rundir:             rundir,
 		useOVSExternalIDs:  ovnPortBinding,
-		podLister:          corev1listers.NewPodLister(factory.LocalPodInformer().GetIndexer()),
+		podLister:          corev1listers.NewPodLister(factory.LocalPodInformer().Informer().GetIndexer()),
 		kclient:            kclient,
 		runningSandboxAdds: make(map[string]*PodRequest),
 		mode:               config.OvnKubeNode.Mode,

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -526,26 +526,26 @@ func (wf *WatchFactory) GetNamespaces() ([]*kapi.Namespace, error) {
 	return namespaceLister.List(labels.Everything())
 }
 
-func (wf *WatchFactory) NodeInformer() cache.SharedIndexInformer {
-	return wf.informers[nodeType].inf
+func (wf *WatchFactory) NodeInformer() v1coreinformers.NodeInformer {
+	return wf.iFactory.Core().V1().Nodes()
 }
 
 // LocalPodInformer returns a shared Informer that may or may not only
 // return pods running on the local node.
-func (wf *WatchFactory) LocalPodInformer() cache.SharedIndexInformer {
-	return wf.informers[podType].inf
+func (wf *WatchFactory) LocalPodInformer() v1coreinformers.PodInformer {
+	return wf.PodInformer()
 }
 
-func (wf *WatchFactory) PodInformer() cache.SharedIndexInformer {
-	return wf.informers[podType].inf
+func (wf *WatchFactory) PodInformer() v1coreinformers.PodInformer {
+	return wf.iFactory.Core().V1().Pods()
 }
 
-func (wf *WatchFactory) NamespaceInformer() cache.SharedIndexInformer {
-	return wf.informers[namespaceType].inf
+func (wf *WatchFactory) NamespaceInformer() v1coreinformers.NamespaceInformer {
+	return wf.iFactory.Core().V1().Namespaces()
 }
 
-func (wf *WatchFactory) ServiceInformer() cache.SharedIndexInformer {
-	return wf.informers[serviceType].inf
+func (wf *WatchFactory) ServiceInformer() v1coreinformers.ServiceInformer {
+	return wf.iFactory.Core().V1().Services()
 }
 
 // noHeadlessServiceSelector is a LabelSelector added to the watch for

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -3,6 +3,7 @@ package factory
 import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	v1coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -39,8 +40,8 @@ type NodeWatchFactory interface {
 	AddPodHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
 	RemovePodHandler(handler *Handler)
 
-	NodeInformer() cache.SharedIndexInformer
-	LocalPodInformer() cache.SharedIndexInformer
+	NodeInformer() v1coreinformers.NodeInformer
+	LocalPodInformer() v1coreinformers.PodInformer
 }
 
 type Shutdownable interface {

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -429,8 +429,8 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 		nodeController, err := honode.NewNode(
 			n.Kube,
 			n.name,
-			n.watchFactory.NodeInformer(),
-			n.watchFactory.LocalPodInformer(),
+			n.watchFactory.NodeInformer().Informer(),
+			n.watchFactory.LocalPodInformer().Informer(),
 			informer.NewDefaultEventHandler,
 		)
 		if err != nil {

--- a/go-controller/pkg/ovn/controller/podset/controller.go
+++ b/go-controller/pkg/ovn/controller/podset/controller.go
@@ -1,0 +1,423 @@
+package podset
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	v1 "k8s.io/api/core/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const controllerName = "ovn-pod-set"
+const maxRetries = 15
+
+// PodSetController is a controller that maps selectors of pods to address sets.
+// The primary use case is for network policies - NetworkPolicy pods and the peers
+// to which it applies are implemented as AddressSets in ovn. This is controller
+// is responsibile for ensuring the address sets in OVN match their selector.
+//
+// On startup, we'll re-build each set and apply it directly to the database;
+// subsequent updates will be processed as deltas.
+type PodSetController struct {
+	podInformer coreinformers.PodInformer
+	podLister   corelisters.PodLister
+	podsSynced  cache.InformerSynced
+
+	namespaceInformer coreinformers.NamespaceInformer
+	namespaceLister   corelisters.NamespaceLister
+	namespacesSynced  cache.InformerSynced
+
+	queue workqueue.RateLimitingInterface
+
+	podSetsLock sync.RWMutex
+
+	// all podSets we know about
+	podSets map[string]*PodSet
+
+	// any podSets that are added before our informers are synced
+	podSetsToSync map[string]interface{}
+}
+
+func NewController(
+	podInformer coreinformers.PodInformer,
+	namespaceInformer coreinformers.NamespaceInformer,
+) *PodSetController {
+
+	psc := &PodSetController{
+		podInformer: podInformer,
+		podLister:   podInformer.Lister(),
+		podsSynced:  podInformer.Informer().HasSynced,
+
+		namespaceInformer: namespaceInformer,
+		namespaceLister:   namespaceInformer.Lister(),
+		namespacesSynced:  namespaceInformer.Informer().HasSynced,
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+
+		podSets:       map[string]*PodSet{},
+		podSetsToSync: map[string]interface{}{},
+	}
+	return psc
+}
+
+// Run starts the PodSetController, which syncs the caches and applies any
+// PodSets that were added during that time.
+func (psc *PodSetController) Run(threadiness int, stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer psc.queue.ShutDown()
+
+	klog.Infof("Starting controller %s", controllerName)
+	defer klog.Infof("Shutting down controller %s", controllerName)
+
+	psc.podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    psc.onPodAdd,
+		UpdateFunc: psc.onPodUpdate,
+		DeleteFunc: psc.onPodDelete,
+	})
+	psc.namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    psc.onNamespaceAdd,
+		UpdateFunc: psc.onNamespaceUpdate,
+		DeleteFunc: psc.onNamespaceDelete,
+	})
+
+	// Wait for the caches to be synced
+	klog.Info("Waiting for informer caches to sync")
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, psc.podsSynced, psc.namespacesSynced) {
+		return fmt.Errorf("error syncing cache")
+	}
+
+	// sync any PodSets that arrived while we were waiting for informer sync
+	go psc.syncPendingPodSets(stopCh)
+
+	// begin processing
+	klog.Info("PodSetController: Starting workers")
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(psc.worker, time.Second, stopCh)
+	}
+
+	<-stopCh
+	return nil
+}
+
+// syncPendingPodSets syncs any PodSets that arrived while we were waiting for
+// our informers to sync
+func (psc *PodSetController) syncPendingPodSets(stopCh <-chan struct{}) {
+	// cute: even though we're deleting from podSetsToSync, nothing will
+	// add to it, since by the time this function is called, the informers are synced
+	// and any new PodSets will be synced directly.
+	psc.podSetsLock.RLock()
+	defer psc.podSetsLock.RUnlock()
+
+	first := true
+	for len(psc.podSetsToSync) > 0 {
+		klog.Infof("Syncing %d pending PodSets", len(psc.podSetsToSync))
+		if !first {
+			time.Sleep(10 * time.Second)
+		}
+		for psname := range psc.podSetsToSync {
+			if err := psc.syncPodSet(psc.podSets[psname]); err != nil {
+				klog.Errorf("Failed to sync PodSet %s (will retry): %v", psname, err)
+			} else {
+				delete(psc.podSetsToSync, psname)
+			}
+
+			// abort if asked to stop
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+		}
+	}
+
+	klog.Infof("Done syncing all pending PodSets")
+}
+
+// worker runs a worker thread that just dequeues items, processes them, and
+// marks them done. You may run as many of these in parallel as you wish; the
+// workqueue guarantees that they will not end up processing the same namespace or pod
+// at the same time.
+func (psc *PodSetController) worker() {
+	for psc.processNextWorkItem() {
+	}
+}
+
+func (psc *PodSetController) processNextWorkItem() bool {
+	eKey, quit := psc.queue.Get()
+	if quit {
+		klog.V(5).Infof("PodSetController: stopping worker")
+		return false
+	}
+	defer psc.queue.Done(eKey)
+	key := eKey.(string)
+	klog.V(5).Infof("PodSetController: processing key %s", key)
+
+	// split & validate key
+	invalidKey := false
+
+	kind := ""
+	namespace := ""
+	name := ""
+
+	parts := strings.Split(key, "/")
+	if len(parts) < 2 {
+		invalidKey = true
+	}
+	kind = parts[0]
+	switch kind {
+	case "Namespace":
+		if len(parts) != 2 {
+			invalidKey = true
+		}
+		name = parts[1]
+	case "Pod":
+		if len(parts) != 3 {
+			invalidKey = true
+		}
+		namespace = parts[1]
+		name = parts[2]
+	default:
+		invalidKey = true
+	}
+
+	if invalidKey {
+		psc.queue.Forget(key)
+		klog.Errorf("PodSetController: invalid key: %s", eKey)
+		return true
+	}
+
+	var err error
+
+	switch parts[0] {
+	case "Namespace":
+		klog.V(5).InfoS("PodSet: processing namespace update", "obj", klog.KRef("", name))
+		err = psc.processNamespace(name)
+	case "Pod":
+		klog.V(5).InfoS("PodSet: processing pod update", "obj", klog.KRef(namespace, name))
+		err = psc.processPod(namespace, name)
+	default:
+		panic("unreachable")
+	}
+
+	if err == nil {
+		psc.queue.Forget(key)
+		return true
+	}
+
+	if psc.queue.NumRequeues(key) < maxRetries {
+		klog.V(2).InfoS("PodSetController: error syncing, retrying", "kind", kind, "obj", klog.KRef(namespace, name), "err", err)
+		psc.queue.AddRateLimited(key)
+	} else {
+		klog.Warningf("Dropping %q out of the queue: %v", key, err)
+		psc.queue.Forget(key)
+	}
+	utilruntime.HandleError(err)
+	return true
+}
+
+func (psc *PodSetController) processPod(namespace, name string) error {
+	pod, err := psc.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return psc.handlePodDelete(namespace, name)
+		}
+
+		return err
+	}
+
+	return psc.handlePodUpdate(pod)
+}
+
+func (psc *PodSetController) processNamespace(name string) error {
+	ns, err := psc.namespaceLister.Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return psc.handleNamespaceDelete(name)
+		}
+		return err
+	}
+	return psc.handleNamespaceUpdate(ns)
+}
+
+// AddPodSet adds an automatically-updating address set, based on one or
+// more selectors. This function is synchronous; it will block until the address set
+// is updated in nbdb.
+func (psc *PodSetController) AddPodSet(name string,
+	addressSet addressset.AddressSet,
+	selectors []Selector,
+) error {
+	psc.podSetsLock.Lock()
+	defer psc.podSetsLock.Unlock()
+
+	for _, selector := range selectors {
+		if selector.PodSelector == nil {
+			selector.PodSelector = labels.Everything()
+		}
+
+		if selector.NamespaceName == "" && selector.NamespaceSelector == nil {
+			// coding error, should never happen
+			panic("PodSet without namespace name or selector")
+		}
+	}
+
+	if len(selectors) == 0 {
+		klog.V(2).Infof("BUG: AddPodSet %s called with no selectors", name)
+		return nil
+	}
+
+	psc.podSets[name] = &PodSet{
+		name:       name,
+		addressSet: addressSet,
+
+		selectors: selectors,
+	}
+
+	klog.V(5).Infof("Adding PodSet %+v", psc.podSets[name])
+
+	// If the informers are still syncing, add this to the queue of
+	// pending podsets and exit.
+	if !(psc.podsSynced() && psc.namespacesSynced()) {
+		psc.podSetsToSync[name] = nil
+		return nil
+	}
+
+	return psc.syncPodSet(psc.podSets[name])
+}
+
+func (psc *PodSetController) RemovePodSet(name string) {
+	psc.podSetsLock.Lock()
+	defer psc.podSetsLock.Unlock()
+
+	delete(psc.podSets, name)
+}
+
+// informer functions here
+
+func (psc *PodSetController) onPodAdd(obj interface{}) {
+	psc.enqueuePod(obj)
+}
+
+func (psc *PodSetController) onPodUpdate(old, new interface{}) {
+	oldPod := old.(*v1.Pod)
+	newPod := new.(*v1.Pod)
+
+	if shouldSkipPodUpdate(oldPod, newPod) {
+		return
+	}
+	psc.enqueuePod(new)
+}
+
+func (psc *PodSetController) onPodDelete(obj interface{}) {
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		pod, ok = tombstone.Obj.(*v1.Pod)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod %#v", obj))
+			return
+		}
+	}
+	psc.enqueuePod(pod)
+}
+
+func (psc *PodSetController) enqueuePod(obj interface{}) {
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		return
+	}
+	key := "Pod/" + m.GetNamespace() + "/" + m.GetName()
+	psc.queue.Add(key)
+}
+
+func (psc *PodSetController) onNamespaceAdd(obj interface{}) {
+	psc.enqueueNamespace(obj)
+}
+
+func (psc *PodSetController) onNamespaceUpdate(old, new interface{}) {
+	oldNS := old.(*v1.Namespace)
+	newNS := new.(*v1.Namespace)
+
+	if shouldSkipNamespaceUpdate(oldNS, newNS) {
+		return
+	}
+	psc.enqueueNamespace(new)
+}
+
+func (psc *PodSetController) onNamespaceDelete(obj interface{}) {
+	ns, ok := obj.(*v1.Namespace)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		ns, ok = tombstone.Obj.(*v1.Namespace)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Namespace: %#v", obj))
+			return
+		}
+	}
+	psc.enqueueNamespace(ns)
+}
+
+func (psc *PodSetController) enqueueNamespace(obj interface{}) {
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		return
+	}
+	key := "Namespace/" + m.GetName()
+	psc.queue.Add(key)
+}
+
+// shouldSkipPodUpdate returns true if we don't care about a particular
+// pod change. Specifically, if the labels and ips are the same, then
+// there's nothing to do.
+func shouldSkipPodUpdate(old, new *v1.Pod) bool {
+	if old == nil {
+		return false
+	}
+
+	oldIPs, _ := util.GetAllPodIPs(old)
+	newIPs, _ := util.GetAllPodIPs(new)
+
+	// Ignore pods with no IPs
+	// This assumes pods don't go "backwards" and lose their IPs
+	if len(newIPs) == 0 {
+		return true
+	}
+
+	return reflect.DeepEqual(oldIPs, newIPs) && reflect.DeepEqual(old.Labels, new.Labels)
+}
+
+// shouldSkipNamespaceUpdate returns true if we don't care about a particular
+// namespace update. Specifically, if the labels are the same,
+// there's nothing to do.
+func shouldSkipNamespaceUpdate(old, new *v1.Namespace) bool {
+	if old == nil {
+		return false
+	}
+
+	return reflect.DeepEqual(old.Labels, new.Labels)
+}

--- a/go-controller/pkg/ovn/controller/podset/handle.go
+++ b/go-controller/pkg/ovn/controller/podset/handle.go
@@ -1,0 +1,193 @@
+package podset
+
+import (
+	"net"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// functions that actually process changes.
+
+// handleNamespaceUpdate re-syncs any PodSets that are newly selected or de-selected
+// by the namespace changing labels (or coming in to existence)
+func (psc *PodSetController) handleNamespaceUpdate(ns *v1.Namespace) error {
+	psc.podSetsLock.RLock()
+	defer psc.podSetsLock.RUnlock()
+
+	newPodSets := psc.setsForNamespace(ns)
+
+	oldPodSets := sets.String{}
+	for psName, ps := range psc.podSets {
+		if ps.hasNamespace(ns.Name) {
+			oldPodSets.Insert(psName)
+		}
+	}
+
+	addPodSets := newPodSets.Difference(oldPodSets)
+	removePodSets := oldPodSets.Difference(newPodSets)
+
+	errs := []error{}
+
+	klog.V(5).Infof("Syncing namespace %s - adding to %d and removing from %d PodSets",
+		ns.Name, addPodSets.Len(), removePodSets.Len())
+
+	// sync any actually-new and actually-stale podsets
+	for psName := range addPodSets {
+		if err := psc.syncPodSet(psc.podSets[psName]); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for psName := range removePodSets {
+		if err := psc.syncPodSet(psc.podSets[psName]); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// handleNamespaceDelete sync any PodSets that previously selected a namespace
+func (psc *PodSetController) handleNamespaceDelete(nsName string) error {
+	psc.podSetsLock.RLock()
+	defer psc.podSetsLock.RUnlock()
+
+	oldPodSets := sets.String{}
+	for psName, ps := range psc.podSets {
+		if ps.hasNamespace(nsName) {
+			oldPodSets.Insert(psName)
+		}
+	}
+
+	klog.V(5).Infof("Deleting namespace %s from %d PodSets", nsName, oldPodSets.Len())
+	errs := []error{}
+	for psName := range oldPodSets {
+		if err := psc.syncPodSet(psc.podSets[psName]); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// AddPod is called by the Pod controller, so we can pre-add a pod before
+// the apiserver gets to it
+func (psc *PodSetController) AddPodDirectly(pod *v1.Pod, ips []net.IP) error {
+	psc.podSetsLock.RLock()
+	defer psc.podSetsLock.RUnlock()
+
+	podSetNames, err := psc.setsForPod(pod)
+	if err != nil {
+		return err
+	}
+
+	errs := []error{}
+
+	klog.V(5).Infof("Adding pod %s/%s directly to %d PodSets", pod.Namespace, pod.Name, podSetNames.Len())
+
+	for psName := range podSetNames {
+		ps := psc.podSets[psName]
+		if err := ps.updatePod(pod, ips); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+
+	return nil
+}
+
+// handlePodUpdate applies any changes to pods:
+// - any podSets that no longer contain a pod will have it removed
+// - any podSets that now contain a pod will have it added
+// - if IP addresses change, that change will be applied
+func (psc *PodSetController) handlePodUpdate(pod *v1.Pod) error {
+	psc.podSetsLock.RLock()
+	defer psc.podSetsLock.RUnlock()
+
+	oldPodSets := sets.String{}
+	// find all podsets this pod is in
+	for name, ps := range psc.podSets {
+		if ps.hasPod(pod.Namespace, pod.Name) {
+			oldPodSets.Insert(name)
+		}
+	}
+
+	newPodSets, err := psc.setsForPod(pod)
+	if err != nil {
+		return err
+	}
+
+	// remove pod from old - new
+	removePodSets := oldPodSets.Difference(newPodSets)
+
+	klog.V(5).Infof("Syncing pod %s/%s to %d new/existing and %d stale PodSets",
+		pod.Namespace, pod.Name, newPodSets.Len(), removePodSets.Len())
+
+	errs := []error{}
+
+	for psName := range removePodSets {
+		ps := psc.podSets[psName]
+		if err := ps.removePod(pod.Namespace, pod.Name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// add pod to all containing PodSets, even if they didn't change
+	// just in case IPs changed (though unlikely)
+	for psName := range newPodSets {
+		ps := psc.podSets[psName]
+		if err := ps.updatePod(pod, nil); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+
+	return nil
+}
+
+// handlePodDelete deletes a pod from any sets that already contain it.
+func (psc *PodSetController) handlePodDelete(namespace, name string) error {
+	klog.V(5).Infof("PodSetController: handlePodDelete %s %s", namespace, name)
+
+	psc.podSetsLock.RLock()
+	defer psc.podSetsLock.RUnlock()
+
+	oldPodSets := sets.String{}
+	// find all podsets this pod is in
+	for psName, ps := range psc.podSets {
+		if ps.hasPod(namespace, name) {
+			oldPodSets.Insert(psName)
+		}
+	}
+
+	klog.V(5).Infof("PodSetController: Deleting pod %s/%s from %d podSets", namespace, name, oldPodSets.Len())
+	errs := []error{}
+
+	for psName := range oldPodSets {
+		ps := psc.podSets[psName]
+		if err := ps.removePod(namespace, name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+
+	return nil
+}

--- a/go-controller/pkg/ovn/controller/podset/podset.go
+++ b/go-controller/pkg/ovn/controller/podset/podset.go
@@ -1,0 +1,360 @@
+package podset
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// PodSet represents a union of 1 or more pod + namespace selectors, applied to an
+// AddressSet in OVN.
+type PodSet struct {
+	sync.Mutex
+
+	// synced is true if we've ever applied this PodSet to nbdb and thus can
+	// apply deltas. Otherwise, we need to re-compute and apply.
+	synced bool
+
+	name string // internal; used for keying
+
+	// addressSet is the destination address set for the pod
+	addressSet addressset.AddressSet
+
+	// cache of ips->pods. need this for two reasons: want to avoid
+	// unnecessary ovn updates, as well as handling the case where
+	// somehow two pods have the same ip.
+	podIPs map[string]sets.String
+
+	// list of pods already synced to this set; used for deletion
+	pods sets.String
+
+	// namepaces is the set of namespace names that we currently understand to match this set
+	// used for making pod selection more efficient as well as identifying PodSets that need
+	// to be resynced when a namespace is deleted.
+	namespaces sets.String
+
+	// Selectors are the list of desired pods in this PodSet
+	selectors []Selector
+}
+
+type Selector struct {
+	// NamespaceName selects a namespace by name directly
+	NamespaceName string
+
+	// NamespaceSelector and PodSelector are AND'd together - a pod must match both.
+	// If no PodSelector is supplied, it is defaulted to "any".
+	NamespaceSelector labels.Selector
+	PodSelector       labels.Selector
+
+	// pre-compute the list of namespaces this applies to, so we can efficiently determine
+	// pod membership
+	namespaces sets.String
+}
+
+// matchesPod evaluates if this pod mactches a given selector
+func (s *Selector) matchesPod(pod *v1.Pod) bool {
+	return s.namespaces.Has(pod.Namespace) && s.PodSelector.Matches(
+		labels.Set(pod.Labels))
+}
+
+// matches checks to see if a given pod matches this pod / pod + namespace selector
+func (ps *PodSet) matchesPod(pod *v1.Pod) bool {
+	ps.Lock()
+	defer ps.Unlock()
+
+	// shortcut - don't bother to evaluate selectors if the namespace is excluded
+	if !ps.namespaces.Has(pod.Namespace) {
+		return false
+	}
+
+	for _, sel := range ps.selectors {
+		if sel.matchesPod(pod) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPod returns true if a given pod has already been added to the PodSet
+func (ps *PodSet) hasPod(namespace, name string) bool {
+	ps.Lock()
+	defer ps.Unlock()
+	return ps.pods.Has(types.NamespacedName{Namespace: namespace, Name: name}.String())
+}
+
+// hasNamespace returns true if a given ns has already been added to the PodSet
+func (ps *PodSet) hasNamespace(nsName string) bool {
+	ps.Lock()
+	defer ps.Unlock()
+	return ps.namespaces.Has(nsName)
+}
+
+// setsForPod finds all PodSets that match a given pod.
+// TODO: this is somewhat inefficient. Lots of ways to make this faster.
+// - hash podsets by namespaces, so we can do direct lookups
+// - consider selector memoization
+//
+// Note: callers should already hold at least the read lock.
+func (psc *PodSetController) setsForPod(pod *v1.Pod) (sets.String, error) {
+	out := sets.String{}
+
+	for name, ps := range psc.podSets {
+		if ps.matchesPod(pod) {
+			out.Insert(name)
+		}
+	}
+
+	return out, nil
+}
+
+// setsForNamespace returns any podsets that match a given namespace
+// note: callers should already hold the read lock
+func (psc *PodSetController) setsForNamespace(ns *v1.Namespace) sets.String {
+	out := sets.String{}
+
+	for name, ps := range psc.podSets {
+		ps.Lock()
+		for _, selector := range ps.selectors {
+			// don't need to lock here, since these values are never written after
+			// initialization
+			if selector.NamespaceName == ns.Name {
+				out.Insert(name)
+				break
+			}
+			if selector.NamespaceName == "" && selector.NamespaceSelector.Matches(labels.Set(ns.Labels)) {
+				out.Insert(name)
+				break
+			}
+		}
+		ps.Unlock()
+	}
+
+	return out
+}
+
+// syncPodSet computes the list of pods that apply to a specific PodSet and applies
+// it down to the address set.
+func (psc *PodSetController) syncPodSet(ps *PodSet) error {
+	ps.Lock()
+	defer ps.Unlock()
+
+	// Build list of namespaces in the podset
+	// Either the name or the label-selector must be set
+	ps.namespaces = sets.String{}
+	for i := range ps.selectors {
+		ps.selectors[i].namespaces = sets.String{}
+		selector := ps.selectors[i]
+
+		if selector.NamespaceName != "" {
+			selector.namespaces.Insert(selector.NamespaceName)
+		} else {
+			namespaces, err := psc.namespaceLister.List(selector.NamespaceSelector)
+			if err != nil {
+				return fmt.Errorf("failed to list podset %s namespaces: %w", ps.name, err)
+			}
+
+			for _, namespace := range namespaces {
+				selector.namespaces.Insert(namespace.Name)
+			}
+		}
+
+		ps.namespaces.Insert(selector.namespaces.UnsortedList()...)
+	}
+
+	// Find all pods that are in the set
+	pods := []*v1.Pod{}
+
+	for _, selector := range ps.selectors {
+		for _, ns := range selector.namespaces.List() {
+			p, err := psc.podLister.Pods(ns).List(selector.PodSelector)
+			if err != nil {
+				return fmt.Errorf("failed to list podset %s pods: %w", ps.name, err)
+			}
+			pods = append(pods, p...)
+		}
+	}
+
+	// find all IPs for the pods
+	podIPs := make([]net.IP, 0, len(pods))
+	for _, pod := range pods {
+		ips, err := util.GetAllPodIPs(pod)
+		if err != nil {
+			return err
+		}
+		podIPs = append(podIPs, ips...)
+
+	}
+
+	// apply IPs to OVN
+	klog.V(5).Infof("Setting PodSet %s with %d IPs %v", ps.name, len(podIPs), podIPs)
+	if err := ps.addressSet.SetIPs(podIPs); err != nil {
+		return fmt.Errorf("failed to sync PodSet %s: %w", ps.name, err)
+	}
+
+	// build ip -> pod(s) registration
+	ps.podIPs = map[string]sets.String{}
+	ps.pods = sets.String{}
+	for _, pod := range pods {
+		ps.pods.Insert(podKey(pod))
+
+		ips, _ := util.GetAllPodIPs(pod)
+		for _, ip := range ips {
+			if set := ps.podIPs[ip.String()]; set != nil {
+				set.Insert(podKey(pod))
+			} else {
+				ps.podIPs[ip.String()] = sets.NewString(podKey(pod))
+			}
+		}
+	}
+
+	ps.synced = true
+
+	return nil
+}
+
+// updatePod adds or updates a pod in the PodSet.
+// If the pod's IPs have changed, it will compute the delta.
+//
+// If the list of IPs is already known (e.g. while a pod is being added),
+// ipsOverride can be passed. Otherwise, the IPs are taken from the Pod object.
+func (ps *PodSet) updatePod(pod *v1.Pod, ipsOverride []net.IP) error {
+	ps.Lock()
+	defer ps.Unlock()
+
+	// if we haven't synced, then don't even do anything
+	if !ps.synced {
+		return nil
+	}
+
+	podIPs := ipsOverride
+	if len(ipsOverride) == 0 {
+		var err error
+		podIPs, err = util.GetAllPodIPs(pod)
+		if err != nil {
+			return err
+		}
+	}
+
+	// compute the delta: find new ips for this pod, as well as any old ips
+	// this pod no longer has.
+
+	// ips that are new to the **podset and the pod**
+	ipsToAdd := make([]net.IP, 0, len(podIPs))
+	for _, ip := range podIPs {
+		if _, ok := ps.podIPs[ip.String()]; !ok {
+			ipsToAdd = append(ipsToAdd, ip)
+		}
+	}
+
+	// stale ips
+	oldPodIPs := []string{}
+	for ip, set := range ps.podIPs {
+		if set.Has(podKey(pod)) {
+			// check to see if pod stil has ips
+			found := false
+			for _, podIP := range podIPs {
+				if podIP.String() == ip {
+					found = true
+					break
+				}
+			}
+
+			if !found { // not in list of new ips
+				oldPodIPs = append(oldPodIPs, ip)
+			}
+		}
+	}
+
+	// if we have new IPs, add them to OVN.
+	if len(ipsToAdd) > 0 {
+		if err := ps.addressSet.AddIPs(ipsToAdd); err != nil {
+			return err
+		}
+	}
+
+	ps.pods.Insert(podKey(pod))
+
+	// associate all pod IPS with this pod
+	for _, ip := range podIPs {
+		if set := ps.podIPs[ip.String()]; set != nil {
+			set.Insert(podKey(pod))
+		} else {
+			ps.podIPs[ip.String()] = sets.NewString(podKey(pod))
+		}
+	}
+
+	// remove this pod from any old ips, deleting from OVN any now-orphaned IPs
+	ipsToDelete := []net.IP{}
+	for _, oldIP := range oldPodIPs {
+		set := ps.podIPs[oldIP]
+		set.Delete(podKey(pod))
+		if set.Len() == 0 {
+			delete(ps.podIPs, oldIP)
+			ipsToDelete = append(ipsToDelete, net.ParseIP(oldIP))
+		}
+	}
+
+	if err := ps.addressSet.DeleteIPs(ipsToDelete); err != nil {
+		return fmt.Errorf("failed to delete stale pod IPs: %w", err)
+	}
+
+	return nil
+}
+
+// removePod removes a given pod from an ovn address set
+func (ps *PodSet) removePod(namespace, name string) error {
+	ps.Lock()
+	defer ps.Unlock()
+
+	if !ps.synced {
+		return nil
+	}
+
+	key := types.NamespacedName{Namespace: namespace, Name: name}.String()
+
+	// find ips that contain this pod, and ips that contain
+	// only this pod
+	ipsToDelete := []net.IP{}
+	ipsToUnset := []string{}
+	for ip, set := range ps.podIPs {
+		if set.Has(key) {
+			ipsToUnset = append(ipsToUnset, ip)
+			if set.Len() == 1 {
+				ipsToDelete = append(ipsToDelete, net.ParseIP(ip))
+			}
+		}
+	}
+
+	// delete ips that are now no longer in the set
+	if err := ps.addressSet.DeleteIPs(ipsToDelete); err != nil {
+		return err
+	}
+
+	// bookkeeping: clear this pod from ip sets, removing any ips
+	// that are no longer associated with any pods
+	for _, ip := range ipsToUnset {
+		set := ps.podIPs[ip]
+		set.Delete(key)
+		if set.Len() == 0 {
+			delete(ps.podIPs, ip)
+		}
+	}
+
+	ps.pods.Delete(key)
+
+	return nil
+}
+
+func podKey(pod *v1.Pod) string {
+	return types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}.String()
+}

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"context"
 	"encoding/json"
+	"sync"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -85,7 +86,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					Output: "\n",
 				})
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 
 				gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
@@ -139,7 +140,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				}
 
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 
 				gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
@@ -205,7 +206,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						})
 					}
 					fakeOvn.controller.WatchNamespaces()
-					fakeOvn.controller.WatchPods()
+					fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 
 					gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 					gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
@@ -305,7 +306,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					}
 
 					fakeOvn.controller.WatchNamespaces()
-					fakeOvn.controller.WatchPods()
+					fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 
 					gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
 					gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
@@ -393,7 +394,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				)
 				t.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    nbctlCommand,
 					Output: "\n",
@@ -447,7 +448,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				)
 				t.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    nbctlCommand,
@@ -509,7 +510,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				)
 				t.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    nbctlCommand,
 					Output: "\n",
@@ -569,7 +570,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					)
 					t.populateLogicalSwitchCache(fakeOvn)
 					fakeOvn.controller.WatchNamespaces()
-					fakeOvn.controller.WatchPods()
+					fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 					gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
 					fExec.AddFakeCmd(&ovntest.ExpectedCmd{
 						Cmd:    nbctlCommand,
@@ -660,7 +661,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					Output: "\n",
 				})
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespaceX.Name).Create(context.TODO(), &gwPod, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
@@ -715,7 +716,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					Output: "\n",
 				})
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespaceX.Name).Create(context.TODO(), &gwPod, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
@@ -786,7 +787,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					Output: "\n",
 				})
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1"}
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Update(context.Background(), &namespaceT, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -357,9 +357,9 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	if config.HybridOverlay.Enabled {
 		oc.hoMaster, err = hocontroller.NewMaster(
 			oc.kube,
-			oc.watchFactory.NodeInformer(),
-			oc.watchFactory.NamespaceInformer(),
-			oc.watchFactory.PodInformer(),
+			oc.watchFactory.NodeInformer().Informer(),
+			oc.watchFactory.NamespaceInformer().Informer(),
+			oc.watchFactory.PodInformer().Informer(),
 			oc.ovnNBClient,
 			oc.ovnSBClient,
 			informer.NewDefaultEventHandler,

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -325,7 +325,7 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 		klog.Infof("Starting unidling controller")
 		unidlingController := unidling.NewController(
 			oc.recorder,
-			oc.watchFactory.ServiceInformer(),
+			oc.watchFactory.ServiceInformer().Informer(),
 		)
 		wg.Add(1)
 		go func() {

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -362,7 +363,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations with IP Address Family", f
 						tPod.populateLogicalSwitchCache(fakeOvn)
 					}
 					fakeOvn.controller.WatchNamespaces()
-					fakeOvn.controller.WatchPods()
+					fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 					ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(
 						context.TODO(), namespace1.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -430,7 +431,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations with IP Address Family", f
 						tPod.baseCmds(fExec)
 					}
 					fakeOvn.controller.WatchNamespaces()
-					fakeOvn.controller.WatchPods()
+					fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 					ns, err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Get(
 						context.TODO(), namespace1.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -648,7 +649,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
@@ -746,7 +747,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
@@ -836,7 +837,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
@@ -923,7 +924,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
@@ -1104,7 +1105,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				expectAddressSetsWithIP(fakeOvn, networkPolicy, nPodTest.podIP)
@@ -1208,7 +1209,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
@@ -1314,7 +1315,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
@@ -1411,7 +1412,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				)
 				nPodTest.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
-				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchPods(&sync.WaitGroup{})
 				fakeOvn.controller.WatchNetworkPolicy()
 
 				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})


### PR DESCRIPTION
This adds a separate controller, the PodSetController, that maintains address sets.

Additionally, we can ensure that pods are added to peer address sets earlier, by synchronously doing so on pod add. This means pods won't come up without address sets (at least on the peer side).

A further enhancement will be to add pods to their target address sets on add as well.

