### PR TITLE
Bug 1940233: setting max offset for IPv6 CIR to prevent overflow

### DIFF
--- a/go-controller/pkg/ovn/ipallocator/allocator.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator.go
@@ -23,6 +23,7 @@ import (
 	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator/allocator"
+	utilnet "k8s.io/utils/net"
 )
 
 // Interface manages the allocation of IP addresses out of a range. Interface
@@ -80,14 +81,28 @@ type Range struct {
 
 // NewAllocatorCIDRRange creates a Range over a net.IPNet, calling allocatorFactory to construct the backing store.
 func NewAllocatorCIDRRange(cidr *net.IPNet, allocatorFactory allocator.AllocatorFactory) (*Range, error) {
-	max := RangeSize(cidr)
-	base := bigForIP(cidr.IP)
+	max := utilnet.RangeSize(cidr)
+	base := utilnet.BigForIP(cidr.IP)
 	rangeSpec := cidr.String()
+
+	if utilnet.IsIPv6CIDR(cidr) {
+		// Limit the max size, since the allocator keeps a bitmap of that size.
+		if max > 65536 {
+			max = 65536
+		}
+	} else {
+		// Don't use the IPv4 network's broadcast address.
+		max--
+	}
+
+	// Don't use the network's ".0" address.
+	base.Add(base, big.NewInt(1))
+	max--
 
 	r := Range{
 		net:  cidr,
-		base: base.Add(base, big.NewInt(1)), // don't use the network base
-		max:  maximum(0, int(max-2)),        // don't use the network broadcast,
+		base: base,
+		max:  maximum(0, int(max)),
 	}
 	var err error
 	r.alloc, err = allocatorFactory(r.max, rangeSpec)
@@ -153,7 +168,7 @@ func (r *Range) AllocateNext() (net.IP, error) {
 	if !ok {
 		return nil, ErrFull
 	}
-	return addIPOffset(r.base, offset), nil
+	return utilnet.AddIPOffset(r.base, offset), nil
 }
 
 // Release releases the IP back to the pool. Releasing an
@@ -171,7 +186,7 @@ func (r *Range) Release(ip net.IP) error {
 // ForEach calls the provided function for each allocated IP.
 func (r *Range) ForEach(fn func(net.IP)) {
 	r.alloc.ForEach(func(offset int) {
-		ip, _ := GetIndexedIP(r.net, offset+1) // +1 because Range doesn't store IP 0
+		ip, _ := utilnet.GetIndexedIP(r.net, offset+1) // +1 because Range doesn't store IP 0
 		fn(ip)
 	})
 }
@@ -201,49 +216,8 @@ func (r *Range) contains(ip net.IP) (bool, int) {
 	return true, offset
 }
 
-// bigForIP creates a big.Int based on the provided net.IP
-func bigForIP(ip net.IP) *big.Int {
-	b := ip.To4()
-	if b == nil {
-		b = ip.To16()
-	}
-	return big.NewInt(0).SetBytes(b)
-}
-
-// addIPOffset adds the provided integer offset to a base big.Int representing a
-// net.IP
-func addIPOffset(base *big.Int, offset int) net.IP {
-	return net.IP(big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes())
-}
-
 // calculateIPOffset calculates the integer offset of ip from base such that
 // base + offset = ip. It requires ip >= base.
 func calculateIPOffset(base *big.Int, ip net.IP) int {
-	return int(big.NewInt(0).Sub(bigForIP(ip), base).Int64())
-}
-
-// RangeSize returns the size of a range in valid addresses.
-func RangeSize(subnet *net.IPNet) int64 {
-	ones, bits := subnet.Mask.Size()
-	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
-		return 0
-	}
-	// For IPv6, the max size will be limited to 65536
-	// This is due to the allocator keeping track of all the
-	// allocated IP's in a bitmap. This will keep the size of
-	// the bitmap to 64k.
-	if bits == 128 && (bits-ones) >= 16 {
-		return int64(1) << uint(16)
-	} else {
-		return int64(1) << uint(bits-ones)
-	}
-}
-
-// GetIndexedIP returns a net.IP that is subnet.IP + index in the contiguous IP space.
-func GetIndexedIP(subnet *net.IPNet, index int) (net.IP, error) {
-	ip := addIPOffset(bigForIP(subnet.IP), index)
-	if !subnet.Contains(ip) {
-		return nil, fmt.Errorf("can't generate IP with index %d from subnet. subnet too small. subnet: %q", index, subnet)
-	}
-	return ip, nil
+	return int(big.NewInt(0).Sub(utilnet.BigForIP(ip), base).Int64())
 }

--- a/go-controller/pkg/ovn/ipallocator/allocator_test.go
+++ b/go-controller/pkg/ovn/ipallocator/allocator_test.go
@@ -29,30 +29,47 @@ func TestAllocate(t *testing.T) {
 		cidr             string
 		free             int
 		released         string
-		outOfRange1      string
-		outOfRange2      string
-		outOfRange3      string
+		outOfRange       []string
 		alreadyAllocated string
 	}{
 		{
-			name:             "IPv4",
-			cidr:             "192.168.1.0/24",
-			free:             254,
-			released:         "192.168.1.5",
-			outOfRange1:      "192.168.0.1",
-			outOfRange2:      "192.168.1.0",
-			outOfRange3:      "192.168.1.255",
+			name:     "IPv4",
+			cidr:     "192.168.1.0/24",
+			free:     254,
+			released: "192.168.1.5",
+			outOfRange: []string{
+				"192.168.0.1",   // not in 192.168.1.0/24
+				"192.168.1.0",   // reserved (base address)
+				"192.168.1.255", // reserved (broadcast address)
+				"192.168.2.2",   // not in 192.168.1.0/24
+			},
 			alreadyAllocated: "192.168.1.1",
 		},
 		{
-			name:             "IPv6",
-			cidr:             "2001:db8:1::/48",
-			free:             65534,
-			released:         "2001:db8:1::5",
-			outOfRange1:      "2001:db8::1",
-			outOfRange2:      "2001:db8:1::",
-			outOfRange3:      "2001:db8:1::ffff",
+			name:     "IPv6",
+			cidr:     "2001:db8:1::/48",
+			free:     65535,
+			released: "2001:db8:1::5",
+			outOfRange: []string{
+				"2001:db8::1",     // not in 2001:db8:1::/48
+				"2001:db8:1::",    // reserved (base address)
+				"2001:db8:1::1:0", // not in the low 16 bits of 2001:db8:1::/48
+				"2001:db8:2::2",   // not in 2001:db8:1::/48
+			},
 			alreadyAllocated: "2001:db8:1::1",
+		},
+		{
+			name:     "IPv6",
+			cidr:     "2605:b100:283:1::/64",
+			free:     65535,
+			released: "2605:b100:283:1::e",
+			outOfRange: []string{
+				"2605:b100:283:0::1",   // not in 2605:b100:283:1::/64
+				"2605:b100:283:1::",    // reserved (base address)
+				"2605:b100:283:1::1:0", // not in the low 16 bits of 2605:b100:283:1::/64
+				"2605:b100:284:2::2",   // not in 2605:b100:283:1::/64
+			},
+			alreadyAllocated: "2605:b100:283:1::1",
 		},
 	}
 	for _, tc := range testCases {
@@ -96,7 +113,6 @@ func TestAllocate(t *testing.T) {
 		if _, err := r.AllocateNext(); err != ErrFull {
 			t.Fatal(err)
 		}
-
 		released := net.ParseIP(tc.released)
 		if err := r.Release(released); err != nil {
 			t.Fatal(err)
@@ -118,19 +134,14 @@ func TestAllocate(t *testing.T) {
 		if err := r.Release(released); err != nil {
 			t.Fatal(err)
 		}
-		err = r.Allocate(net.ParseIP(tc.outOfRange1))
-		if _, ok := err.(*ErrNotInRange); !ok {
-			t.Fatal(err)
+		for _, outOfRange := range tc.outOfRange {
+			err = r.Allocate(net.ParseIP(outOfRange))
+			if _, ok := err.(*ErrNotInRange); !ok {
+				t.Fatal(err)
+			}
 		}
+
 		if err := r.Allocate(net.ParseIP(tc.alreadyAllocated)); err != ErrAllocated {
-			t.Fatal(err)
-		}
-		err = r.Allocate(net.ParseIP(tc.outOfRange2))
-		if _, ok := err.(*ErrNotInRange); !ok {
-			t.Fatal(err)
-		}
-		err = r.Allocate(net.ParseIP(tc.outOfRange3))
-		if _, ok := err.(*ErrNotInRange); !ok {
 			t.Fatal(err)
 		}
 		if f := r.Free(); f != 1 {
@@ -210,51 +221,6 @@ func TestAllocateSmall(t *testing.T) {
 	}
 
 	t.Logf("allocated: %v", found)
-}
-
-func TestRangeSize(t *testing.T) {
-	testCases := []struct {
-		name  string
-		cidr  string
-		addrs int64
-	}{
-		{
-			name:  "supported IPv4 cidr",
-			cidr:  "192.168.1.0/24",
-			addrs: 256,
-		},
-		{
-			name:  "supported large IPv4 cidr",
-			cidr:  "10.96.0.0/12",
-			addrs: 1048576,
-		},
-		{
-			name:  "unsupported IPv4 cidr",
-			cidr:  "192.168.1.0/1",
-			addrs: 0,
-		},
-		{
-			name:  "supported IPv6 cidr",
-			cidr:  "2001:db8::/48",
-			addrs: 65536,
-		},
-		{
-			name:  "unsupported IPv6 mask",
-			cidr:  "2001:db8::/1",
-			addrs: 0,
-		},
-	}
-
-	for _, tc := range testCases {
-		_, cidr, err := net.ParseCIDR(tc.cidr)
-		if err != nil {
-			t.Errorf("failed to parse cidr for test %s, unexpected error: '%s'", tc.name, err)
-		}
-		if size := RangeSize(cidr); size != tc.addrs {
-			t.Errorf("test %s failed. %s should have a range size of %d, got %d",
-				tc.name, tc.cidr, tc.addrs, size)
-		}
-	}
 }
 
 func TestForEach(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

Changed the code to use utilnet and place IPv6 CIDR max limit to avoid overflow
Updated allocator test cases accordingly
```
Note: 
Valid IPv6 IPs ranges from base to base + 65536 where base is the IPv6CIDR + 1
this is a known limitation for the current POD's IP allocation algorithm.
```
**- What this PR does and why is it needed**
Calculating bitmap index used by allocator using IPv6 CIDR can exceed Int64 value which is the max that the allocator alg can manage, switching to utilnet prevent exceeding that limit
**- Special notes for reviewers**
**- Unit test**
[mmahmoud@mmahmoud ipallocator]$ go test -v -vet=off
=== RUN   TestAllocate
    allocator_test.go:84: base: [255 255 192 168 1 1]
    allocator_test.go:84: base: [32 1 13 184 0 1 0 0 0 0 0 0 0 0 0 1]
    allocator_test.go:84: base: [38 5 177 0 2 131 0 1 0 0 0 0 0 0 0 1]
--- PASS: TestAllocate (0.45s)
=== RUN   TestAllocateTiny
--- PASS: TestAllocateTiny (0.00s)
=== RUN   TestAllocateSmall
    allocator_test.go:223: allocated: map[192.168.1.241:{} 192.168.1.242:{}]
--- PASS: TestAllocateSmall (0.00s)
=== RUN   TestForEach
--- PASS: TestForEach (0.00s)
PASS
ok      github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator     0.453s
