### PR TITLE
Implement externalTrafficPolicy Feature 

### DIFF
--- a/docs/design/external_traffic_policy.md
+++ b/docs/design/external_traffic_policy.md
@@ -1,0 +1,128 @@
+# K8's Services' ExternalTraffic Policy Implementation
+
+## Background 
+
+For [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/) of type Nodeport or
+Loadbalancer a user can set the `service.spec.externalTrafficPolicy` field to either `cluster` or `local` to denote 
+whether or not external traffic is routed to cluster-wide or node-local endpoints. The default value for the 
+`externalTrafficPolicy` field is `cluster`. In this configuration in ingress traffic is equally disributed across all
+backends and the original client IP address is lost due to SNAT. If set to `local` then the client 
+source IP is propagated through the service and to the destination, while service traffic arriving at nodes without 
+local endpoints is dropped. 
+
+## Implementing `externalTrafficPolicy` In OVN-Kubernetes 
+
+To properly implement this feature for all relevant traffic flows, required changing how OVN, Iptables rules, and 
+Physical OVS flows are updated and managed in OVN-Kubernetes
+
+## New OVN Loabalancer 
+
+For services with `externalTrafficPolicy:local` traffic destined for a cluster networked pods will hit the new OVN 
+loadbalancer which resembles the following 
+
+```
+_uuid               : 8d317d7f-6818-4374-8dfa-fcf8685504b5
+external_ids        : {TCP_lb_gateway_router=GR_ovn-control-plane_local}
+health_check        : []
+ip_port_mappings    : {}
+name                : ""
+options             : {skip_snat="true"}
+protocol            : tcp
+selection_fields    : []
+vips                : {}
+```
+
+This new loabalancer contains the `_local` postfix along with the `skip_snat="true"` option and is applied to the
+GatewayRouters and Worker switches. It is needed to override the `lb_force_snat_ip=router_ip` option that is on all the Gateway Routers, which allows ingress traffic to arrive at OVN managed endpoints with the original client IP. All Vips 
+for services with `externalTrafficPolicy:local` will reside on this loadbalancer. 
+
+## Handling Flows between the overlay and underlay
+
+In this section I will explain some relevant traffic flows when a service's `externalTrafficPolicy` is `local`.  For 
+these examples we will be using a Nodeport service, but the flow is generally the same for ExternalIP and Loadbalancer 
+type services. 
+
+## Ingress Traffic 
+
+This section will cover the networking entities hit when traffic ingresses a cluster via a service to either host
+networked pods or cluster networked pods
+
+### External Source -> Service -> OVN pod
+
+This case is the same as normal shared gateway traffic ingress, meaning the externally sourced traffic is routed into 
+OVN via flows on breth0, except in this case the new local load balancer is hit on the GR, which ensures the ip of the 
+client is preserved  by the time it gets to the destination Pod. 
+
+```text
+          host (ovn-worker, 172.18.0.3) 
+           |
+eth0--->|breth0| -----> 172.18.0.3 OVN GR 100.64.0.4 --> join switch --> ovn_cluster_router --> 10.244.1.3 pod
+
+```
+
+### External Source -> Service -> Host Networked pod 
+
+This Scenario is a bit different, specifically traffic now needs to be directed from an external source to service and 
+then to the host itself(a host networked pod)
+
+In this flow, rather than going from breth0 into OVN we shortcircuit the path with physical flows on breth0 
+
+```text
+          host (ovn-worker, 172.18.0.3) 
+           ^
+           ^
+           |
+eth0--->|breth0| ---- 172.18.0.3 OVN GR 100.64.0.4 -- join switch -- ovn_cluster_router -- 10.244.1.3 pod
+
+```
+
+1. Match on the incoming traffic via it's nodePort, DNAT directly to the host networked endpoint, and send to `table=6` 
+
+```
+cookie=0x790ba3355d0c209b, duration=153.288s, table=0, n_packets=18, n_bytes=1468, idle_age=100, priority=100,tcp,in_port=1,tp_dst=<nodePort> actions=ct(commit,table=6,zone=64003,nat(dst=<nodeIP>:<targetIP>))
+```
+
+2. Send out the LOCAL ovs port on breth0, and traffic is delivered to host netwoked pod 
+
+```
+cookie=0x790ba3355d0c209b, duration=113.033s, table=6, n_packets=18, n_bytes=1468, priority=100 actions=LOCAL
+```
+
+3. Return traffic from the host networked pod to external source is matched in `table=7` based on the src_ip of the return 
+traffic being equal to `<targetIP>`, and un-Nat back to `<nodeIP>:<NodePort>`
+
+```
+ cookie=0x790ba3355d0c209b, duration=501.037s, table=0, n_packets=12, n_bytes=1259, idle_age=448, priority=100,tcp,in_port=LOCAL,tp_src=<targetIP> actions=ct(commit,table=7,zone=64003,nat)
+```
+
+4. Send the traffic back out breth0 back to the external source in `table=7`
+
+```
+cookie=0x790ba3355d0c209b, duration=501.037s, table=7, n_packets=12, n_bytes=1259, idle_age=448, priority=100 actions=output:1
+```
+
+## Host Traffic 
+
+This section will cover the networking entities hit when traffic travels from a cluster host via a service to either host
+networked pods or cluster networked pods
+
+### Host -> Service -> OVN Pod
+
+This case is similar to normal host -> Service -> OVN Pod except the SRC address of the Traffic will be that of the 
+management port `ovn-k8s-mp0` rather than the main address attatched to `eth0` on the host. 
+
+### Host -> Service -> Host 
+
+Again when the backend is a host networked pod we shortcircuit OVN to avoid SNAT and use iptables rules on the host
+to DNAT directly to the correct host endpoint.
+
+```
+-A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 32126 -j DNAT --to-destination <nodeIP>:<targetIP>
+```
+
+## Intra Cluster traffic 
+
+For all service traffic that stays in the overlay the flows will remain the same for `externaltrafficpolicy:local`.  
+
+## Sources 
+- https://www.asykim.com/blog/deep-dive-into-kubernetes-external-traffic-policies

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -41,6 +41,9 @@ type NodeWatchFactory interface {
 
 	NodeInformer() cache.SharedIndexInformer
 	LocalPodInformer() cache.SharedIndexInformer
+
+	GetService(namespace, name string) (*kapi.Service, error)
+	GetEndpoint(namespace, name string) (*kapi.Endpoints, error)
 }
 
 type Shutdownable interface {

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -33,10 +33,10 @@ type gateway struct {
 	loadBalancerHealthChecker informer.ServiceAndEndpointsEventHandler
 	// portClaimWatcher is for reserving ports for virtual IPs allocated by the cluster on the host
 	portClaimWatcher informer.ServiceEventHandler
-	// nodePortWatcher is used in Shared GW mode to handle nodePort flows in shared OVS bridge
-	nodePortWatcher informer.ServiceEventHandler
 	// nodePortWatcherIptables is used in Shared GW mode to handle nodePort IPTable rules
 	nodePortWatcherIptables informer.ServiceEventHandler
+	// nodePortWatcher is used in Shared GW mode to handle nodePort flows in shared OVS bridge
+	nodePortWatcher informer.ServiceAndEndpointsEventHandler
 	// localPortWatcher is used in Local GW mode to handle iptables rules and routes for services
 	localPortWatcher informer.ServiceEventHandler
 	openflowManager  *openflowManager
@@ -121,17 +121,26 @@ func (g *gateway) AddEndpoints(ep *kapi.Endpoints) {
 	if g.loadBalancerHealthChecker != nil {
 		g.loadBalancerHealthChecker.AddEndpoints(ep)
 	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.AddEndpoints(ep)
+	}
 }
 
 func (g *gateway) UpdateEndpoints(old, new *kapi.Endpoints) {
 	if g.loadBalancerHealthChecker != nil {
 		g.loadBalancerHealthChecker.UpdateEndpoints(old, new)
 	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.UpdateEndpoints(old, new)
+	}
 }
 
 func (g *gateway) DeleteEndpoints(ep *kapi.Endpoints) {
 	if g.loadBalancerHealthChecker != nil {
 		g.loadBalancerHealthChecker.DeleteEndpoints(ep)
+	}
+	if g.nodePortWatcher != nil {
+		g.nodePortWatcher.DeleteEndpoints(ep)
 	}
 }
 

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -306,8 +306,8 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		gw, err = newLocalGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator, n.recorder, managementPortConfig)
 	case config.GatewayModeShared:
 		klog.Info("Preparing Shared Gateway")
-		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs,
-			nodeAnnotator)
+		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator,
+			managementPortConfig, n.watchFactory)
 	case config.GatewayModeDisabled:
 		var chassisID string
 		klog.Info("Gateway Mode is disabled")

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -259,7 +259,7 @@ func (l *localPortWatcher) SyncServices(serviceInterface []interface{}) {
 			klog.Errorf("Spurious object in syncServices: %v", serviceInterface)
 			continue
 		}
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, []string{l.gatewayIPv4, l.gatewayIPv6})...)
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, []string{l.gatewayIPv4, l.gatewayIPv6}, false)...)
 	}
 	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
 		recreateIPTRules("nat", chain, keepIPTRules)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -10,11 +10,13 @@ import (
 	"sync"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -27,13 +29,11 @@ const (
 	ovsLocalPort = "LOCAL"
 )
 
-func serviceUpdateNeeded(old, new *kapi.Service) bool {
-	return reflect.DeepEqual(new.Spec.Ports, old.Spec.Ports) &&
-		reflect.DeepEqual(new.Spec.ExternalIPs, old.Spec.ExternalIPs) &&
-		reflect.DeepEqual(new.Spec.ClusterIP, old.Spec.ClusterIP) &&
-		reflect.DeepEqual(new.Spec.Type, old.Spec.Type) &&
-		reflect.DeepEqual(new.Status.LoadBalancer.Ingress, old.Status.LoadBalancer.Ingress)
-}
+var (
+	HostMasqCTZone     = config.Default.ConntrackZone + 1 //64001
+	OVNMasqCTZone      = HostMasqCTZone + 1               //64002
+	HostNodePortCTZone = config.Default.ConntrackZone + 3 //64003
+)
 
 // nodePortWatcherIptables manages iptables rules for shared gateway
 // to ensure that services using NodePorts are accessible.
@@ -44,52 +44,38 @@ func newNodePortWatcherIptables() *nodePortWatcherIptables {
 	return &nodePortWatcherIptables{}
 }
 
-func (npwipt *nodePortWatcherIptables) AddService(service *kapi.Service) {
-	// don't process headless service or services that doesn't have NodePorts or ExternalIPs
-	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
-		return
-	}
-	addSharedGatewayIptRules(service)
-}
-
-func (npwipt *nodePortWatcherIptables) UpdateService(old, new *kapi.Service) {
-	if serviceUpdateNeeded(old, new) {
-		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
-			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", new.Name)
-		return
-	}
-
-	if util.ServiceTypeHasClusterIP(old) && util.IsClusterIPSet(old) {
-		delSharedGatewayIptRules(old)
-	}
-
-	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
-		addSharedGatewayIptRules(new)
-	}
-}
-
-func (npwipt *nodePortWatcherIptables) DeleteService(service *kapi.Service) {
-	// don't process headless service
-	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
-		return
-	}
-	delSharedGatewayIptRules(service)
-}
-
-func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) {
-	syncSharedGatewayIptRules(services)
-}
-
-// nodePortWatcher manages OpenfLow and iptables rules
+// nodePortWatcher manages OpenFlow and iptables rules
 // to ensure that services using NodePorts are accessible
 type nodePortWatcher struct {
-	ofportPhys  string
-	ofportPatch string
-	gwBridge    string
-	ofm         *openflowManager
+	smartNICMode bool
+	gatewayIPv4  string
+	gatewayIPv6  string
+	ofportPhys   string
+	ofportPatch  string
+	gwBridge     string
+	// Map of service name to programmed iptables/OF rules
+	serviceInfo     map[ktypes.NamespacedName]*serviceConfig
+	serviceInfoLock sync.Mutex
+	ofm             *openflowManager
+	nodeIPManager   *addressManager
+	watchFactory    factory.NodeWatchFactory
 }
 
-func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bool) {
+type serviceConfig struct {
+	// Contains the current service
+	service *kapi.Service
+	// Were those rules etp:local + Host Networked rules
+	etpHostRules bool
+}
+
+// updateServiceFlowCache handles managing shared gateway flows for ingress traffic towards kubernetes services
+// (nodeport, external, ingress). By default incoming traffic into the node is steered directly into OVN.
+// If a service has externalTrafficPolicy local, and has host-networked endpoints, traffic instead will be steered directly
+// into the host.
+// add parameter indicates if the flows should exist or be removed from the cache
+// epHostLocal indicates if a host networked endpoint exists for this
+// service func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bool, epHostLocal bool) {
+func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bool, epHostLocal bool) {
 	var cookie, key string
 	var err error
 
@@ -124,8 +110,42 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 					cookie = "0"
 				}
 				key = strings.Join([]string{"NodePort", service.Namespace, service.Name, flowProtocol, fmt.Sprintf("%d", svcPort.NodePort)}, "_")
+				// Delete if needed and skip to next protocol
 				if !add {
 					npw.ofm.deleteFlowsByKey(key)
+					continue
+				}
+				// (astoycos) TODO combine flow generation into a single function
+				// This allows external traffic ingress when the svc's ExternalTrafficPolicy is
+				// set to Local, and the backend pod is HostNetworked. We need to add
+				// Flows that will DNAT all traffic coming into nodeport to the nodeIP:Port and
+				// ensure that the return traffic is UnDNATed to correct the nodeIP:Nodeport
+				if epHostLocal {
+					var nodeportFlows []string
+					klog.V(5).Infof("Adding flows on breth0 for Nodeport Service %s in Namespace: %s since ExternalTrafficPolicy=local", service.Name, service.Namespace)
+					// table 0, This rule matches on all traffic with dst port == NodePort, DNAT's it to the correct NodeIP
+					// If ipv6 make sure to choose the ipv6 node address), and sends to table 6
+					if strings.Contains(flowProtocol, "6") {
+						nodeportFlows = append(nodeportFlows,
+							fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
+								cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+					} else {
+						nodeportFlows = append(nodeportFlows,
+							fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
+								cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+					}
+					nodeportFlows = append(nodeportFlows,
+						// table 6, Sends the packet to the host
+						fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+							cookie),
+						// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
+						fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(zone=%d nat,table=7)",
+							cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
+						// table 7, Sends the packet back out eth0 to the external client
+						fmt.Sprintf("cookie=%s, priority=110, table=7, "+
+							"actions=output:%s", cookie, npw.ofportPhys))
+
+					npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 				} else {
 					npw.ofm.updateFlowCacheEntry(key, []string{
 						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, "+
@@ -137,7 +157,6 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 				}
 			}
 		}
-
 		// Flows for cloud load balancers on Azure/GCP
 		// Established traffic is handled by default conntrack rules
 		// NodePort/Ingress access in the OVS bridge will only ever come from outside of the host
@@ -165,8 +184,43 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 				nwSrc = "ipv6_src"
 			}
 			key = strings.Join([]string{"Ingress", service.Namespace, service.Name, ingIP.String(), fmt.Sprintf("%d", svcPort.Port)}, "_")
+			// Delete if needed and skip to next protocol
 			if !add {
 				npw.ofm.deleteFlowsByKey(key)
+				continue
+			}
+
+			// This allows external traffic ingress when the svc's ExternalTrafficPolicy is
+			// set to Local, and the backend pod is HostNetworked. We need to add
+			// Flows that will DNAT all external traffic destined for the lb service
+			// to the nodeIP and ensure That return traffic is UnDNATed correctly back
+			// to the ingress ip
+			if epHostLocal {
+				var nodeportFlows []string
+				klog.V(5).Infof("Adding flows on breth0 for Loadbalancer Service %s in Namespace: %s since ExternalTrafficPolicy=local", service.Name, service.Namespace)
+				// table 0, This rule matches on all traffic with dst port == LoadbalancerIP, DNAT's it to the correct NodeIP
+				// If ipv6 make sure to choose the ipv6 node address for rule
+				if strings.Contains(flowProtocol, "6") {
+					nodeportFlows = append(nodeportFlows,
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
+							cookie, npw.ofportPhys, flowProtocol, nwDst, ing.IP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+				} else {
+					nodeportFlows = append(nodeportFlows,
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
+							cookie, npw.ofportPhys, flowProtocol, nwDst, ing.IP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+				}
+				nodeportFlows = append(nodeportFlows,
+					// table 6, Sends the packet to the host
+					fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+						cookie),
+					// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
+					fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(commit,zone=%d nat,table=7)",
+						cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
+					// table 7, the packet back out eth0 to the external client
+					fmt.Sprintf("cookie=%s, priority=110, table=7, "+
+						"actions=output:%s", cookie, npw.ofportPhys))
+
+				npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 			} else {
 				npw.ofm.updateFlowCacheEntry(key, []string{
 					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
@@ -194,8 +248,42 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 				cookie = "0"
 			}
 			key := strings.Join([]string{"External", service.Namespace, service.Name, externalIP, fmt.Sprintf("%d", svcPort.Port)}, "_")
+			// Delete if needed and skip to next protocol
 			if !add {
 				npw.ofm.deleteFlowsByKey(key)
+				continue
+			}
+			// This allows external traffic ingress when the svc's ExternalTrafficPolicy is
+			// set to Local, and the backend pod is HostNetworked. We need to add
+			// Flows that will DNAT all external traffic destined for externalIP service
+			// to the nodeIP:port of the host networked backend. And Then ensure That return
+			// traffic is UnDNATed correctly back to the external IP
+			if epHostLocal {
+				var nodeportFlows []string
+				klog.V(5).Infof("Adding flows on breth0 for ExternalIP Service %s in Namespace: %s since ExternalTrafficPolicy=local", service.Name, service.Namespace)
+				// table 0, This rule matches on all traffic with dst ip == externalIP and DNAT's it to the correct NodeIP
+				// If ipv6 make sure to choose the ipv6 node address for rule
+				if strings.Contains(flowProtocol, "6") {
+					nodeportFlows = append(nodeportFlows,
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
+							cookie, npw.ofportPhys, flowProtocol, nwDst, externalIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+				} else {
+					nodeportFlows = append(nodeportFlows,
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
+							cookie, npw.ofportPhys, flowProtocol, nwDst, externalIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+				}
+				nodeportFlows = append(nodeportFlows,
+					// table 6, Sends the packet to the host
+					fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+						cookie),
+					// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
+					fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(commit,zone=%d nat,table=7)",
+						cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
+					// table 7, Sends the packet back out eth0 to the external client
+					fmt.Sprintf("cookie=%s, priority=110, table=7, "+
+						"actions=output:%s", cookie, npw.ofportPhys))
+
+				npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 			} else {
 				npw.ofm.updateFlowCacheEntry(key, []string{
 					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
@@ -209,49 +297,348 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 	}
 }
 
+// getAndDeleteServiceInfo returns the serviceConfig for a service and if it exists and then deletes the entry
+func (npw *nodePortWatcher) getAndDeleteServiceInfo(index ktypes.NamespacedName) (out *serviceConfig, exists bool) {
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+	out, exists = npw.serviceInfo[index]
+	delete(npw.serviceInfo, index)
+	return out, exists
+}
+
+// getServiceInfo returns the serviceConfig for a service and if it exists
+func (npw *nodePortWatcher) getServiceInfo(index ktypes.NamespacedName) (out *serviceConfig, exists bool) {
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+	out, exists = npw.serviceInfo[index]
+	return out, exists
+}
+
+// getAndSetServiceInfo creates and sets the serviceConfig, returns if it existed and whatever was there
+func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, etpHostRules bool) (old *serviceConfig, exists bool) {
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+
+	old, exists = npw.serviceInfo[index]
+	npw.serviceInfo[index] = &serviceConfig{service: service, etpHostRules: etpHostRules}
+	return old, exists
+}
+
+// addOrSetServiceInfo creates and sets the serviceConfig if it doesn't exist
+func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, etpHostRules bool) (exists bool) {
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+
+	if _, exists := npw.serviceInfo[index]; !exists {
+		// Only set this if it doesn't exist
+		npw.serviceInfo[index] = &serviceConfig{service: service, etpHostRules: etpHostRules}
+		return false
+	}
+	return true
+
+}
+
+// updateServiceInfo sets the serviceConfig for a service and returns the existing serviceConfig, if inputs are nil
+// do not update those fields, if it does not exist return nil.
+func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, service *kapi.Service, etpHostRules *bool) (old *serviceConfig, exists bool) {
+
+	npw.serviceInfoLock.Lock()
+	defer npw.serviceInfoLock.Unlock()
+
+	if old, exists = npw.serviceInfo[index]; !exists {
+		klog.V(5).Infof("No serviceConfig found for service %s in namespace %s", index.Name, index.Namespace)
+		return nil, exists
+	}
+
+	if service != nil {
+		npw.serviceInfo[index].service = service
+	}
+
+	if etpHostRules != nil {
+		npw.serviceInfo[index].etpHostRules = *etpHostRules
+	}
+
+	return old, exists
+}
+
+// addServiceRules ensures the correct iptables rules and OpenFlow physical
+// flows are programmed for a given service and hostNetwork endpoint configuration
+func addServiceRules(service *kapi.Service, hasHostNet bool, npw *nodePortWatcher) {
+	if util.ServiceExternalTrafficPolicyLocal(service) && hasHostNet {
+		klog.V(5).Infof("Adding externalTrafficPolicy:local and hostNetworked rules for %v", service)
+		// For smartnic or Full mode
+		if npw != nil {
+			npw.updateServiceFlowCache(service, true, true)
+			npw.ofm.requestFlowSync()
+			// Dont touch iptables if in smartNICMode
+			if !npw.smartNICMode {
+				addSharedGatewayIptRules(service, true)
+			}
+			return
+		}
+		// For Host Only Mode
+		addSharedGatewayIptRules(service, true)
+	} else {
+		// For smartnic or Full mode
+		if npw != nil {
+			npw.updateServiceFlowCache(service, true, false)
+			npw.ofm.requestFlowSync()
+			if !npw.smartNICMode {
+				addSharedGatewayIptRules(service, true)
+			}
+			return
+		}
+		// For Host Only Mode
+		addSharedGatewayIptRules(service, false)
+	}
+}
+
+// delServiceRules deletes all possible iptables rules and OpenFlow physical
+// flows for a service
+func delServiceRules(service *kapi.Service, npw *nodePortWatcher) {
+	if npw != nil {
+		npw.updateServiceFlowCache(service, false, false)
+		npw.ofm.requestFlowSync()
+		if !npw.smartNICMode {
+			// Always try and delete all rules here
+			delSharedGatewayIptRules(service, true)
+			delSharedGatewayIptRules(service, false)
+		}
+		return
+	}
+
+	// For host only node always try and delete rules here
+	// externalTrafficPolicy is not implemented for smartNic mode
+	delSharedGatewayIptRules(service, false)
+}
+
+func serviceUpdateNeeded(old, new *kapi.Service) bool {
+	return reflect.DeepEqual(new.Spec.Ports, old.Spec.Ports) &&
+		reflect.DeepEqual(new.Spec.ExternalIPs, old.Spec.ExternalIPs) &&
+		reflect.DeepEqual(new.Spec.ClusterIP, old.Spec.ClusterIP) &&
+		reflect.DeepEqual(new.Spec.Type, old.Spec.Type) &&
+		reflect.DeepEqual(new.Status.LoadBalancer.Ingress, old.Status.LoadBalancer.Ingress) &&
+		reflect.DeepEqual(new.Spec.ExternalTrafficPolicy, old.Spec.ExternalTrafficPolicy)
+}
+
 // AddService handles configuring shared gateway bridge flows to steer External IP, Node Port, Ingress LB traffic into OVN
 func (npw *nodePortWatcher) AddService(service *kapi.Service) {
-
-	// don't process headless service or services that doesn't have NodePorts or ExternalIPs
+	var etpHostRules bool
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return
 	}
-	npw.updateServiceFlowCache(service, true)
-	npw.ofm.requestFlowSync()
+
+	klog.V(5).Infof("Adding service %s in namespace %s", service.Name, service.Namespace)
+	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	ep, err := npw.watchFactory.GetEndpoint(service.Namespace, service.Name)
+	if err != nil {
+		klog.V(5).Infof("No endpoint found for service %s in namespace %s during service Add", service.Name, service.Namespace)
+		// No endpoints exist yet so default to false
+		etpHostRules = false
+	} else {
+		etpHostRules = hasHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+	}
+
+	// If something didn't already do it add correct Service rules
+	if exists := npw.addOrSetServiceInfo(name, service, etpHostRules); !exists {
+		klog.V(5).Infof("Service Add %s event in namespace %s came before endpoint event setting svcConfig", service.Name, service.Namespace)
+		addServiceRules(service, etpHostRules, npw)
+	} else {
+		klog.V(5).Infof("Rules already programmed for %s in namespace %s", service.Name, service.Namespace)
+	}
 }
 
 func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
+	name := ktypes.NamespacedName{Namespace: old.Namespace, Name: old.Name}
+
 	if serviceUpdateNeeded(old, new) {
 		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
 			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", new.Name)
 		return
 	}
-	needFlowSync := false
+
+	// Update the service in svcConfig if we need to so that other handler
+	// threads do the correct thing, leave etpHostRules alone in the cache
+	svcConfig, exists := npw.updateServiceInfo(name, new, nil)
+	if !exists {
+		klog.V(5).Infof("Service %s in namespace %s was deleted during service Update", old.Name, old.Namespace)
+		return
+	}
+
 	if util.ServiceTypeHasClusterIP(old) && util.IsClusterIPSet(old) {
-		npw.updateServiceFlowCache(old, false)
-		needFlowSync = true
+		// Delete old rules if needed, but don't delete svcConfig
+		// so that we don't miss any endpoint update events here
+		klog.V(5).Infof("Deleting old service rules for: %v", old)
+		delServiceRules(old, npw)
 	}
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
-		npw.updateServiceFlowCache(new, true)
-		needFlowSync = true
-	}
-
-	if needFlowSync {
-		npw.ofm.requestFlowSync()
+		klog.V(5).Infof("Adding new service rules for: %v", new)
+		addServiceRules(new, svcConfig.etpHostRules, npw)
 	}
 }
 
 func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
+	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
+		return
+	}
+
+	klog.V(5).Infof("Deleting service %s in namespace %s", service.Name, service.Namespace)
+	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	if svcConfig, exists := npw.getAndDeleteServiceInfo(name); exists {
+		delServiceRules(svcConfig.service, npw)
+	} else {
+		klog.Warningf("Deletion failed No service found in cache for endpoint %s in namespace %s", service.Name, service.Namespace)
+	}
+
+}
+
+func (npw *nodePortWatcher) SyncServices(services []interface{}) {
+	keepIPTRules := []iptRule{}
+	for _, serviceInterface := range services {
+		name := ktypes.NamespacedName{Namespace: serviceInterface.(*kapi.Service).Namespace, Name: serviceInterface.(*kapi.Service).Name}
+
+		service, ok := serviceInterface.(*kapi.Service)
+		if !ok {
+			klog.Errorf("Spurious object in syncServices: %v",
+				serviceInterface)
+			continue
+		}
+
+		ep, err := npw.watchFactory.GetEndpoint(service.Namespace, service.Name)
+		if err != nil {
+			klog.V(5).Infof("No endpoint found for service %s in namespace %s during sync", service.Name, service.Namespace)
+			continue
+		}
+
+		hasHostNet := hasHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+		npw.getAndSetServiceInfo(name, service, hasHostNet)
+		// Delete OF rules for service if they exist
+		npw.updateServiceFlowCache(service, false, hasHostNet)
+		npw.updateServiceFlowCache(service, true, hasHostNet)
+		// Add correct iptables rules
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, hasHostNet)...)
+	}
+	// sync OF rules once
+	npw.ofm.requestFlowSync()
+	// sync IPtables rules once
+	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
+		recreateIPTRules("nat", chain, keepIPTRules)
+	}
+}
+
+func (npw *nodePortWatcher) AddEndpoints(ep *kapi.Endpoints) {
+	var etpHostRules bool
+	name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
+
+	svc, err := npw.watchFactory.GetService(ep.Namespace, ep.Name)
+	if err != nil {
+		// This is not necessarily an error. For e.g when there are endpoints
+		// without a corresponding service.
+		klog.V(5).Infof("No service found for endpoint %s in namespace %s during add", ep.Name, ep.Namespace)
+		return
+	}
+
+	if !util.ServiceTypeHasClusterIP(svc) || !util.IsClusterIPSet(svc) {
+		return
+	}
+
+	klog.V(5).Infof("Adding endpoints %s in namespace %s", ep.Name, ep.Namespace)
+	etpHostRules = hasHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+
+	// Here we make sure the correct rules are programmed whenever an AddEndpoint
+	// event is received, only alter flows if we need to, i.e if cache wasn't
+	// set or if it was and etpHostRules state changed, to prevent flow churn
+	out, exists := npw.getAndSetServiceInfo(name, svc, etpHostRules)
+	if !exists {
+		klog.V(5).Infof("Endpoint %s ADD event in namespace %s is creating rules", ep.Name, ep.Namespace)
+		addServiceRules(svc, etpHostRules, npw)
+		return
+	}
+
+	if out.etpHostRules != etpHostRules {
+		klog.V(5).Infof("Endpoint %s ADD event in namespace %s is updating rules", ep.Name, ep.Namespace)
+		delServiceRules(svc, npw)
+		addServiceRules(svc, etpHostRules, npw)
+	}
+
+}
+
+func (npw *nodePortWatcher) DeleteEndpoints(ep *kapi.Endpoints) {
+	var etpHostRules = false
+
+	klog.V(5).Infof("Deleting endpoints %s in namespace %s", ep.Name, ep.Namespace)
+	// remove rules for endpoints and add back normal ones
+	name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
+	if svcConfig, exists := npw.updateServiceInfo(name, nil, &etpHostRules); exists {
+		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
+		// we have to do this because deleting and adding iptables rules is slow.
+		npw.serviceInfoLock.Lock()
+		defer npw.serviceInfoLock.Unlock()
+
+		delServiceRules(svcConfig.service, npw)
+		addServiceRules(svcConfig.service, etpHostRules, npw)
+	}
+}
+
+func (npw *nodePortWatcher) UpdateEndpoints(old *kapi.Endpoints, new *kapi.Endpoints) {
+	name := ktypes.NamespacedName{Namespace: old.Namespace, Name: old.Name}
+
+	if reflect.DeepEqual(new.Subsets, old.Subsets) {
+		return
+	}
+
+	klog.V(5).Infof("Updating endpoints %s in namespace %s", old.Name, old.Namespace)
+
+	// Delete old endpoint rules and add normal ones back
+	if len(new.Subsets) == 0 {
+		if _, exists := npw.getServiceInfo(name); exists {
+			npw.DeleteEndpoints(old)
+		}
+	}
+
+	// Update rules if hasHostNetworkEndpoints status changed
+	etpHostRulesNew := hasHostNetworkEndpoints(new, &npw.nodeIPManager.addresses)
+	if hasHostNetworkEndpoints(old, &npw.nodeIPManager.addresses) != etpHostRulesNew {
+		npw.DeleteEndpoints(old)
+		npw.AddEndpoints(new)
+	}
+}
+
+func (npwipt *nodePortWatcherIptables) AddService(service *kapi.Service) {
+	// don't process headless service or services that doesn't have NodePorts or ExternalIPs
+	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
+		return
+	}
+	addServiceRules(service, false, nil)
+}
+
+func (npwipt *nodePortWatcherIptables) UpdateService(old, new *kapi.Service) {
+	if serviceUpdateNeeded(old, new) {
+		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
+			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", new.Name)
+		return
+	}
+
+	if util.ServiceTypeHasClusterIP(old) && util.IsClusterIPSet(old) {
+		delServiceRules(old, nil)
+	}
+
+	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
+		addServiceRules(new, false, nil)
+	}
+}
+
+func (npwipt *nodePortWatcherIptables) DeleteService(service *kapi.Service) {
 	// don't process headless service
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return
 	}
-	npw.updateServiceFlowCache(service, false)
-	npw.ofm.requestFlowSync()
+	delServiceRules(service, nil)
 }
 
-func (npw *nodePortWatcher) SyncServices(services []interface{}) {
+func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) {
+	keepIPTRules := []iptRule{}
 	for _, serviceInterface := range services {
 		service, ok := serviceInterface.(*kapi.Service)
 		if !ok {
@@ -259,10 +646,14 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 				serviceInterface)
 			continue
 		}
-		npw.updateServiceFlowCache(service, true)
+		// Add correct iptables rules
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, false)...)
 	}
 
-	npw.ofm.requestFlowSync()
+	// sync IPtables rules once
+	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
+		recreateIPTRules("nat", chain, keepIPTRules)
+	}
 }
 
 // since we share the host's k8s node IP, add OpenFlow flows
@@ -270,6 +661,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 // -- to also connection track the outbound north-south traffic through l3 gateway so that
 //    the return traffic can be steered back to OVN logical topology
 // -- to handle host -> service access, via masquerading from the host to OVN GR
+// -- to handle external -> service(ExternalTrafficPolicy: Local) -> host access without SNAT
 func newSharedGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration) (*openflowManager, error) {
 	dftFlows, err := flowsForDefaultBridge(gwBridge.ofPortPhys, gwBridge.macAddress.String(), gwBridge.ofPortPatch,
 		gwBridge.ofPortHost, gwBridge.ips)
@@ -307,8 +699,6 @@ func newSharedGatewayOpenFlowManager(gwBridge, exGWBridge *bridgeConfiguration) 
 }
 
 func flowsForDefaultBridge(ofPortPhys, bridgeMacAddress, ofPortPatch, ofPortHost string, bridgeIPs []*net.IPNet) ([]string, error) {
-	HostMasqCTZone := config.Default.ConntrackZone + 1
-	OVNMasqCTZone := HostMasqCTZone + 1
 	var dftFlows []string
 	// 14 bytes of overhead for ethernet header (does not include VLAN)
 	maxPktLength := getMaxFrameLength()
@@ -630,7 +1020,7 @@ func setBridgeOfPorts(bridge *bridgeConfiguration) error {
 }
 
 func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string,
-	gwIPs []*net.IPNet, nodeAnnotator kube.Annotator) (*gateway, error) {
+	gwIPs []*net.IPNet, nodeAnnotator kube.Annotator, cfg *managementPortConfig, watchFactory factory.NodeWatchFactory) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
 
@@ -685,9 +1075,11 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			return err
 		}
 
+		gw.nodeIPManager = newAddressManager(nodeAnnotator, cfg)
+
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Shared Gateway Node Port Watcher")
-			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge.patchPort, gwBridge.bridgeName, gwBridge.uplinkName, gw.openflowManager)
+			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge.patchPort, gwBridge.bridgeName, gwBridge.uplinkName, gwBridge.ips, gw.openflowManager, gw.nodeIPManager, watchFactory)
 			if err != nil {
 				return err
 			}
@@ -700,7 +1092,6 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 				if err := initSharedGatewayIPTables(); err != nil {
 					return err
 				}
-				gw.nodePortWatcherIptables = newNodePortWatcherIptables()
 			}
 		} else {
 			// no service OpenFlows, request to sync flows now.
@@ -713,7 +1104,8 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 	return gw, nil
 }
 
-func newNodePortWatcher(patchPort, gwBridge, gwIntf string, ofm *openflowManager) (*nodePortWatcher, error) {
+func newNodePortWatcher(patchPort, gwBridge, gwIntf string, ips []*net.IPNet, ofm *openflowManager,
+	nodeIPManager *addressManager, watchFactory factory.NodeWatchFactory) (*nodePortWatcher, error) {
 	// Get ofport of patchPort
 	ofportPatch, stderr, err := util.GetOVSOfPort("--if-exists", "get",
 		"interface", patchPort, "ofport")
@@ -730,11 +1122,35 @@ func newNodePortWatcher(patchPort, gwBridge, gwIntf string, ofm *openflowManager
 			gwIntf, stderr, err)
 	}
 
+	// In the shared gateway mode, the NodePort service is handled by the OpenFlow flows configured
+	// on the OVS bridge in the host. These flows act only on the packets coming in from outside
+	// of the node. If someone on the node is trying to access the NodePort service, those packets
+	// will not be processed by the OpenFlow flows, so we need to add iptable rules that DNATs the
+	// NodePortIP:NodePort to ClusterServiceIP:Port.
+	if err := initSharedGatewayIPTables(); err != nil {
+		return nil, err
+	}
+
+	// used to tell addServiceRules which rules to add
+	smartNICMode := false
+	if config.OvnKubeNode.Mode != types.NodeModeFull {
+		smartNICMode = true
+	}
+
+	// Get Physical IPs of Node, Can be IPV4 IPV6 or both
+	gatewayIPv4, gatewayIPv6 := getGatewayFamilyAddrs(ips)
+
 	npw := &nodePortWatcher{
-		ofportPhys:  ofportPhys,
-		ofportPatch: ofportPatch,
-		gwBridge:    gwBridge,
-		ofm:         ofm,
+		smartNICMode:  smartNICMode,
+		gatewayIPv4:   gatewayIPv4,
+		gatewayIPv6:   gatewayIPv6,
+		ofportPhys:    ofportPhys,
+		ofportPatch:   ofportPatch,
+		gwBridge:      gwBridge,
+		serviceInfo:   make(map[ktypes.NamespacedName]*serviceConfig),
+		nodeIPManager: nodeIPManager,
+		ofm:           ofm,
+		watchFactory:  watchFactory,
 	}
 	return npw, nil
 }

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -13,6 +13,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -93,6 +94,20 @@ func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {
 		}
 	}
 	return num
+}
+
+func hasHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses *sets.String) bool {
+	for i := range ep.Subsets {
+		ss := &ep.Subsets[i]
+		for i := range ss.Addresses {
+			addr := &ss.Addresses[i]
+			if nodeAddresses.Has(addr.IP) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // checkForStaleOVSInternalPorts checks for OVS internal ports without any ofport assigned,

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
@@ -519,12 +520,17 @@ func TestUpdateServicePorts(t *testing.T) {
 		Output: "load_balancer_1",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=%s", gatewayRouter1+types.GWRouterLocalLBPostfix),
+		Output: "local_load_balancer_1",
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    fmt.Sprintf("ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-worker-lb-tcp=2e290f10-3652-11eb-839b-a8a1590cda29"),
 		Output: "node_load_balancer_1",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd: `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "192.168.1.1:80"` +
 			` -- --if-exists remove load_balancer load_balancer_1 vips "192.168.1.1:80"` +
+			` -- --if-exists remove load_balancer local_load_balancer_1 vips "192.168.1.1:80"` +
 			` -- --if-exists remove load_balancer node_load_balancer_1 vips "192.168.1.1:80"`,
 		Output: "",
 	})

--- a/go-controller/pkg/ovn/controller/services/utils_test.go
+++ b/go-controller/pkg/ovn/controller/services/utils_test.go
@@ -69,12 +69,17 @@ func Test_deleteVIPsFromOVN(t *testing.T) {
 						Output: "loadbalancer1",
 					},
 					{
+						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=2e290f10-3652-11eb-839b-a8a1590cda29_local",
+						Output: "localloadbalancer1",
+					},
+					{
 						Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:k8s-worker-lb-tcp=2e290f10-3652-11eb-839b-a8a1590cda29",
 						Output: "workerlb",
 					},
 					{
 						Cmd: `ovn-nbctl --timeout=15 --if-exists remove load_balancer a08ea426-2288-11eb-a30b-a8a1590cda29 vips "10.0.0.1:80"` +
 							` -- --if-exists remove load_balancer loadbalancer1 vips "10.0.0.1:80"` +
+							` -- --if-exists remove load_balancer localloadbalancer1 vips "10.0.0.1:80"` +
 							` -- --if-exists remove load_balancer workerlb vips "10.0.0.1:80"`,
 						Output: "",
 					},

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -137,6 +137,19 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 		kapi.ProtocolUDP:  k8sNSLbUDP,
 		kapi.ProtocolSCTP: k8sNSLbSCTP,
 	}
+
+	var k8sNSLbTCPLocal, k8sNSLbUDPLocal, k8sNSLbSCTPLocal string
+	k8sNSLbTCPLocal, k8sNSLbUDPLocal, k8sNSLbSCTPLocal, err = getGatewayLoadBalancers(gatewayRouter + types.GWRouterLocalLBPostfix)
+	if err != nil {
+		return err
+	}
+
+	localK8sLBMap := map[kapi.Protocol]string{
+		kapi.ProtocolTCP:  k8sNSLbTCPLocal,
+		kapi.ProtocolUDP:  k8sNSLbUDPLocal,
+		kapi.ProtocolSCTP: k8sNSLbSCTPLocal,
+	}
+
 	workerK8sNSLbTCP, workerK8sNSLbUDP, workerK8sNSLbSCTP, err := loadbalancer.GetWorkerLoadBalancers(nodeName)
 	if err != nil {
 		return err
@@ -156,7 +169,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 		// router: UDP, TCP, SCTP
 		for _, proto := range enabledProtos {
 			if gatewayProtoLBMap[proto] == "" {
-				gatewayProtoLBMap[proto], stderr, err = util.RunOVNNbctl("--", "create",
+				gatewayProtoLBMap[proto], stderr, err = util.RunOVNNbctl("create",
 					"load_balancer",
 					fmt.Sprintf("external_ids:%s_lb_gateway_router=%s", proto, gatewayRouter),
 					fmt.Sprintf("protocol=%s", strings.ToLower(string(proto))))
@@ -165,14 +178,28 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 						"stderr: %q, error: %v", gatewayRouter, proto, stderr, err)
 				}
 			}
+			// Make nodeLocal LBs if needed, only works for SGW
+			if localK8sLBMap[proto] == "" && config.Gateway.Mode != config.GatewayModeLocal {
+				// Create LB's for externalTrafficPolicy=local mode no snat
+				localK8sLBMap[proto], stderr, err = util.RunOVNNbctl("create",
+					"load_balancer",
+					fmt.Sprintf("external_ids:%s_lb_gateway_router=%s", proto, gatewayRouter+types.GWRouterLocalLBPostfix),
+					fmt.Sprintf("protocol=%s", strings.ToLower(string(proto))),
+					"options:skip_snat=true")
+				if err != nil {
+					return fmt.Errorf("failed to create nodeLocal load balancer for gateway router %s for protocol %s: "+
+						"stderr: %q, error: %v", gatewayRouter, proto, stderr, err)
+				}
+			}
 		}
 
 		// Local gateway mode does not use GR for ingress node port traffic, it uses mp0 instead
 		if config.Gateway.Mode != config.GatewayModeLocal {
-			// Add north-south load-balancers to the gateway router.
-			lbString := fmt.Sprintf("%s,%s", gatewayProtoLBMap[kapi.ProtocolTCP], gatewayProtoLBMap[kapi.ProtocolUDP])
+			// Add north-south load-balancers, both standard and local to the gateway router.
+			lbString := strings.Join([]string{gatewayProtoLBMap[kapi.ProtocolTCP], gatewayProtoLBMap[kapi.ProtocolUDP],
+				localK8sLBMap[kapi.ProtocolTCP], localK8sLBMap[kapi.ProtocolUDP]}, ",")
 			if sctpSupport {
-				lbString = lbString + "," + gatewayProtoLBMap[kapi.ProtocolSCTP]
+				lbString = strings.Join([]string{lbString, gatewayProtoLBMap[kapi.ProtocolSCTP], localK8sLBMap[kapi.ProtocolSCTP]}, ",")
 			}
 			stdout, stderr, err = util.RunOVNNbctl("set", "logical_router", gatewayRouter, "load_balancer="+lbString)
 			if err != nil {
@@ -203,7 +230,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 	// Create load balancers for workers (to be applied to GR and node switch)
 	for _, proto := range enabledProtos {
 		if workerProtoLBMap[proto] == "" {
-			workerProtoLBMap[proto], stderr, err = util.RunOVNNbctl("--", "create",
+			workerProtoLBMap[proto], stderr, err = util.RunOVNNbctl("create",
 				"load_balancer",
 				fmt.Sprintf("external_ids:%s-%s=%s", types.WorkerLBPrefix, strings.ToLower(string(proto)), nodeName),
 				fmt.Sprintf("protocol=%s", strings.ToLower(string(proto))))
@@ -233,7 +260,7 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 			}
 		}
 
-		// Add per worker switch specific load-balancers
+		// Add worker Loadbalancers to the node switch
 		for _, proto := range enabledProtos {
 			if !strings.Contains(stdout, workerProtoLBMap[proto]) {
 				_, stderr, err = util.RunOVNNbctl("ls-lb-add", nodeName, workerProtoLBMap[proto])

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -81,6 +81,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		})
 
 		const (
+			// (astoycos) TOOD add dedicated UUIDs for each LB for readability
 			tcpLBUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
 			udpLBUUID string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
 		)
@@ -93,6 +94,14 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node_local",
+			Output: tcpLBUUID,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node_local",
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node_local",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
 			Output: tcpLBUUID,
 		})
@@ -101,18 +110,23 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Output: udpLBUUID,
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node_local protocol=udp options:skip_snat=true",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID + "," + tcpLBUUID + "," + udpLBUUID,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 get logical_switch test-node load_balancer",
+			// add worker Lbs and local Lbs
 			"ovn-nbctl --timeout=15 ls-lb-add test-node " + tcpLBUUID,
 			"ovn-nbctl --timeout=15 ls-lb-add test-node " + udpLBUUID,
 		})
@@ -182,6 +196,14 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node_local",
+			Output: tcpLBUUID,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node_local",
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node_local",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
 			Output: tcpLBUUID,
 		})
@@ -190,14 +212,18 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Output: udpLBUUID,
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node_local protocol=udp options:skip_snat=true",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID + "," + tcpLBUUID + "," + udpLBUUID,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -270,6 +296,14 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node_local",
+			Output: tcpLBUUID,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node_local",
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node_local",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
 			Output: tcpLBUUID,
 		})
@@ -278,14 +312,18 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Output: udpLBUUID,
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node_local protocol=udp options:skip_snat=true",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID + "," + tcpLBUUID + "," + udpLBUUID,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -479,6 +517,14 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node_local",
+			Output: tcpLBUUID,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node_local",
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node_local",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
 			Output: tcpLBUUID,
 		})
@@ -487,14 +533,18 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Output: udpLBUUID,
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node_local protocol=udp options:skip_snat=true",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID + "," + tcpLBUUID + "," + udpLBUUID,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -178,16 +178,16 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-tcp=yes protocol=tcp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:k8s-cluster-lb-tcp=yes protocol=tcp",
 		Output: tcpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-udp=yes protocol=udp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:k8s-cluster-lb-udp=yes protocol=udp",
 		Output: udpLBUUID,
 	})
 	if sctpSupport {
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-sctp=yes protocol=sctp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:k8s-cluster-lb-sctp=yes protocol=sctp",
 			Output: sctpLBUUID,
 		})
 	}
@@ -272,36 +272,53 @@ func addNodeportLBs(fexec *ovntest.FakeExec, nodeName, tcpLBUUID, udpLBUUID, sct
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=" + types.GWRouterPrefix + nodeName,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=" + types.GWRouterPrefix + nodeName + "_local",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=" + types.GWRouterPrefix + nodeName + "_local",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=" + types.GWRouterPrefix + nodeName + "_local",
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=" + nodeName,
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBUDP + "=" + nodeName,
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=" + nodeName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBTCP + "=" + types.GWRouterPrefix + nodeName + " protocol=tcp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBTCP + "=" + types.GWRouterPrefix + nodeName + " protocol=tcp",
 		Output: tcpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=" + types.GWRouterPrefix + nodeName + " protocol=udp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBTCP + "=" + types.GWRouterPrefix + nodeName + "_local" + " protocol=tcp options:skip_snat=true",
+		Output: tcpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=" + types.GWRouterPrefix + nodeName + " protocol=udp",
 		Output: udpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBSCTP + "=" + types.GWRouterPrefix + nodeName + " protocol=sctp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=" + types.GWRouterPrefix + nodeName + "_local" + " protocol=udp options:skip_snat=true",
+		Output: udpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBSCTP + "=" + types.GWRouterPrefix + nodeName + " protocol=sctp",
+		Output: sctpLBUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBSCTP + "=" + types.GWRouterPrefix + nodeName + "_local" + " protocol=sctp options:skip_snat=true",
 		Output: sctpLBUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 set logical_router " + types.GWRouterPrefix + nodeName + " load_balancer=" + tcpLBUUID +
-			"," + udpLBUUID + "," + sctpLBUUID,
+			"," + udpLBUUID + "," + tcpLBUUID + "," + udpLBUUID + "," + sctpLBUUID + "," + sctpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBTCP + "=" + nodeName + " protocol=tcp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBTCP + "=" + nodeName + " protocol=tcp",
 		Output: tcpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=" + nodeName + " protocol=udp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=" + nodeName + " protocol=udp",
 		Output: udpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBSCTP + "=" + nodeName + " protocol=sctp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBSCTP + "=" + nodeName + " protocol=sctp",
 		Output: sctpLBUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -24,6 +24,7 @@ const (
 	JoinSwitchPrefix             = "join_"
 	ExternalSwitchPrefix         = "ext_"
 	GWRouterPrefix               = "GR_"
+	GWRouterLocalLBPostfix       = "_local"
 	RouterToSwitchPrefix         = "rtos-"
 	InterPrefix                  = "inter-"
 	HybridSubnetPrefix           = "hybrid-subnet-"

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -460,10 +460,14 @@ func Test_getLbEndpoints(t *testing.T) {
 		svcPort v1.ServicePort
 		family  v1.IPFamily
 	}
+	type fakelbEnd struct {
+		IPs  []string
+		Port int32
+	}
 	tests := []struct {
 		name string
 		args args
-		want LbEndpoints
+		want fakelbEnd
 	}{
 		{
 			name: "empty slices",
@@ -476,7 +480,7 @@ func Test_getLbEndpoints(t *testing.T) {
 				},
 				family: v1.IPv4Protocol,
 			},
-			want: LbEndpoints{[]string{}, 0},
+			want: fakelbEnd{[]string{}, 0},
 		},
 		{
 			name: "slices with endpoints",
@@ -513,7 +517,7 @@ func Test_getLbEndpoints(t *testing.T) {
 				},
 				family: v1.IPv4Protocol,
 			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, 80},
+			want: fakelbEnd{[]string{"10.0.0.2"}, 80},
 		},
 		{
 			name: "slices with different port name",
@@ -550,7 +554,7 @@ func Test_getLbEndpoints(t *testing.T) {
 				},
 				family: v1.IPv4Protocol,
 			},
-			want: LbEndpoints{[]string{}, 0},
+			want: fakelbEnd{[]string{}, 0},
 		},
 		{
 			name: "slices and service without port name",
@@ -585,7 +589,7 @@ func Test_getLbEndpoints(t *testing.T) {
 				},
 				family: v1.IPv4Protocol,
 			},
-			want: LbEndpoints{[]string{"10.0.0.2"}, 8080},
+			want: fakelbEnd{[]string{"10.0.0.2"}, 8080},
 		},
 		{
 			name: "slices with different IP family",
@@ -622,7 +626,7 @@ func Test_getLbEndpoints(t *testing.T) {
 				},
 				family: v1.IPv4Protocol,
 			},
-			want: LbEndpoints{[]string{}, 0},
+			want: fakelbEnd{[]string{}, 0},
 		},
 		{
 			name: "multiples slices with duplicate endpoints",
@@ -682,12 +686,14 @@ func Test_getLbEndpoints(t *testing.T) {
 				},
 				family: v1.IPv4Protocol,
 			},
-			want: LbEndpoints{[]string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, 80},
+			want: fakelbEnd{[]string{"10.0.0.2", "10.1.1.2", "10.2.2.2"}, 80},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetLbEndpoints(tt.args.slices, tt.args.svcPort, tt.args.family); !reflect.DeepEqual(got, tt.want) {
+			tmpGot := GetLbEndpoints(tt.args.slices, tt.args.svcPort, tt.args.family)
+			got := fakelbEnd{tmpGot.IPs(), tmpGot.Port}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getLbEndpoints() = %v, want %v", got, tt.want)
 			}
 		})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -184,7 +184,7 @@ func unmarshalPodAnnotation(annotations map[string]string) (*PodAnnotation, erro
 	return podAnnotation, nil
 }
 
-func nodePortServiceSpecFrom(svcName string, httpPort, updPort, clusterHTTPPort, clusterUDPPort int, selector map[string]string) *v1.Service {
+func nodePortServiceSpecFrom(svcName string, httpPort, updPort, clusterHTTPPort, clusterUDPPort int, selector map[string]string, local v1.ServiceExternalTrafficPolicyType) *v1.Service {
 	preferDual := v1.IPFamilyPolicyPreferDualStack
 
 	res := &v1.Service{
@@ -197,8 +197,9 @@ func nodePortServiceSpecFrom(svcName string, httpPort, updPort, clusterHTTPPort,
 				{Port: int32(clusterHTTPPort), Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(httpPort)},
 				{Port: int32(clusterUDPPort), Name: "udp", Protocol: v1.ProtocolUDP, TargetPort: intstr.FromInt(updPort)},
 			},
-			Selector:       selector,
-			IPFamilyPolicy: &preferDual,
+			Selector:              selector,
+			IPFamilyPolicy:        &preferDual,
+			ExternalTrafficPolicy: local,
 		},
 	}
 
@@ -228,6 +229,7 @@ func externalIPServiceSpecFrom(svcName string, httpPort, updPort, clusterHTTPPor
 
 // leverages a container running the netexec command to send a "hostname" request to a target running
 // netexec on the given target host / protocol / port
+// returns either the name of backend pod or "Timeout" if the curl request timed out
 func pokeEndpointHostname(clientContainer, protocol, targetHost string, targetPort int32) string {
 	ipPort := net.JoinHostPort("localhost", "80")
 	cmd := []string{"docker", "exec", clientContainer}
@@ -243,8 +245,64 @@ func pokeEndpointHostname(clientContainer, protocol, targetHost string, targetPo
 	res, err := runCommand(cmd...)
 	framework.ExpectNoError(err, "failed to run command on external container")
 	hostName, err := parseNetexecResponse(res)
+	if err != nil {
+		fmt.Printf("FAILED Command was %s", curlCommand)
+		fmt.Printf("FAILED Response was %v", res)
+	}
 	framework.ExpectNoError(err)
+
 	return hostName
+}
+
+// leverages a container running the netexec command to send a "clientip" request to a target running
+// netexec on the given target host / protocol / port
+// returns either the src ip of the packet or "Timeout" if the curl request timed out
+func pokeEndpointClientIP(clientContainer, protocol, targetHost string, targetPort int32) string {
+	ipPort := net.JoinHostPort("localhost", "80")
+	cmd := []string{"docker", "exec", clientContainer}
+
+	// we leverage the dial command from netexec, that is already supporting multiple protocols
+	curlCommand := strings.Split(fmt.Sprintf("curl -g -q -s http://%s/dial?request=clientip&protocol=%s&host=%s&port=%d&tries=1",
+		ipPort,
+		protocol,
+		targetHost,
+		targetPort), " ")
+
+	cmd = append(cmd, curlCommand...)
+	res, err := runCommand(cmd...)
+	framework.ExpectNoError(err, "failed to run command on external container")
+	clientIP, err := parseNetexecResponse(res)
+	framework.ExpectNoError(err)
+	ip, _, err := net.SplitHostPort(clientIP)
+	if err != nil {
+		fmt.Printf("FAILED Command was %s", curlCommand)
+		fmt.Printf("FAILED Response was %v", res)
+	}
+	framework.ExpectNoError(err, "failed to parse client ip:port")
+
+	return ip
+}
+
+// leverages a container running the netexec command to send a request to a target running
+// netexec on the given target host / protocol / port
+// returns either the name of backend pod or "Timeout" if the curl request timed out
+func curlInContainer(clientContainer, protocol, targetHost string, targetPort int32, endPoint string) string {
+	cmd := []string{"docker", "exec", clientContainer}
+	if utilnet.IsIPv6String(targetHost) {
+		targetHost = fmt.Sprintf("[%s]", targetHost)
+	}
+
+	// we leverage the dial command from netexec, that is already supporting multiple protocols
+	curlCommand := strings.Split(fmt.Sprintf("curl -g -q -s http://%s:%d/%s",
+		targetHost,
+		targetPort,
+		endPoint), " ")
+
+	cmd = append(cmd, curlCommand...)
+	res, err := runCommand(cmd...)
+	framework.ExpectNoError(err, "failed to run command on external container")
+
+	return res
 }
 
 func parseNetexecResponse(response string) (string, error) {
@@ -256,6 +314,9 @@ func parseNetexecResponse(response string) (string, error) {
 		return "", fmt.Errorf("failed to unmarshal curl response %s", response)
 	}
 	if len(res.Errors) > 0 {
+		if strings.Contains(strings.ToLower(res.Errors[0]), "timeout") {
+			return "Timeout", nil
+		}
 		return "", fmt.Errorf("curl response %s contains errors", response)
 	}
 	if len(res.Responses) == 0 {

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -57,6 +57,15 @@ if [ "$OVN_DISABLE_SNAT_MULTIPLE_GWS" == true ]; then
   SKIPPED_TESTS+="Should validate the egress IP functionality against remote hosts"
 fi
 
+if [ "$OVN_GATEWAY_MODE" == "local" ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+  	SKIPPED_TESTS+="|"
+  fi
+  SKIPPED_TESTS+="Should be allowed to node local cluster-networked endpoints by nodeport services with externalTrafficPolicy=local|\
+e2e ingress to host-networked pods traffic validation|\
+host to host-networked pods traffic validation"
+fi
+
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote
 export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
fixes #1951 

This PR implements the the k8's externalTrafficPolicy  Feature which is further described [here](https://www.asykim.com/blog/deep-dive-into-kubernetes-external-traffic-policies)

This feature is implemented only for SGW mode

It adds new Gateway Router load-balancers, explicitly formed to ignore the GWR option `options:lb_force_snat_ip=router_ip`  using a new OVN feature `options:lb_skip_snat=true` which is in the [following patch](http://patchwork.ozlabs.org/project/ovn/patch/327cc4c2e4f954a279dca02bad89682cb6eec7c9.1617288043.git.lorenzo.bianconi@redhat.com/)

Also it ensures that when externalTrafficPolicy=`Local` It adds only the node-local endpoints to the new Loadbalancers to ensure that traffic is only forwarded to local endpoints 

It is currently WIP since it requires a custom OVN patch that allows the `options:lb_force_snat_ip=router_ip` to be applied on a per LB level. 

Local manual testing can be seen [here](https://gist.github.com/astoycos/b7f3690204f01143013b8031346caa0f)

TODO: Add Unit tests for verifying Packets were not SNATed (FUTURE WORK)