### PR TITLE
Improvements to unit test scripts

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -39,7 +39,7 @@ windows:
 # tests in a container. Refer: https://www.projectatomic.io/blog/2016/03/dwalsh_selinux_containers/ for additional context
 check test:
 ifeq ($(CONTAINER_RUNNABLE), 0)
-	$(CONTAINER_RUNTIME) run --security-opt label=disable --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller -e COVERALLS=${COVERALLS} $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 COVERALLS=${COVERALLS} hack/test-go.sh ${PKGS}"
+	$(CONTAINER_RUNTIME) run --security-opt label=disable --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller -e COVERALLS=${COVERALLS} -e GINKGO_FOCUS="${GINKGO_FOCUS}" $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 COVERALLS=${COVERALLS} hack/test-go.sh focus \"${GINKGO_FOCUS}\" ${PKGS}"
 else
 	RACE=1 hack/test-go.sh ${PKGS}
 endif


### PR DESCRIPTION
This commit adds support for passing ginkgo focus arguments to
Makefile. In particular, this adds support for GINKGO_FOCUS
environment variable to be honored. Also certain tests that require
sudo were not working correctly with the test-go script. This
commit also fixes the error with running those unit tests.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>