### PR TITLE
sflow configuration's agent column should use default setting

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -142,7 +142,6 @@ func setupOVNNode(node *kapi.Node) error {
 			"--id=@sflow",
 			"create",
 			"sflow",
-			"agent="+types.SFlowAgent,
 			fmt.Sprintf("targets=[%s]", collectors),
 			"--",
 			"set", "bridge", "br-int", "sflow=@sflow",

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -108,7 +108,4 @@ const (
 	// OVN-K8S annotation constants
 	OvnK8sPrefix   = "k8s.ovn.org"
 	OvnK8sTopoAnno = OvnK8sPrefix + "/" + "topology-version"
-
-	// Monitoring constants
-	SFlowAgent = "ovn-k8s-mp0"
 )


### PR DESCRIPTION
the code currently sets the agent IP to ovn-k8s-mp0, which makes all
the sFlow traffic to go over the OVN logical network and it's incorrect
(unless the collector itself is running as a Pod).

the agent column is optional and with the default setting ovs-vswitchd
daemon running on the K8s Host/Node is going to send the sFlow sampled
packets out through the interface as provided by the routing table based
on the first collector IP.

if the collector is a Pod, then it will choose ovn-k8s-mp0. on the other
hand if the collector is on the underlay, then it will choose K8s node
IP

@rcarrillocruz PTAL