### PR TITLE
master: cancel leader election on exit

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -240,7 +240,7 @@ func runOvnKube(ctx *cli.Context) error {
 		metrics.RegisterMasterMetrics(ovnNBClient, ovnSBClient)
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil, ovnNBClient, ovnSBClient, util.EventRecorder(ovnClientset.KubeClient))
-		if err := ovnController.Start(master, wg); err != nil {
+		if err := ovnController.Start(master, wg, ctx.Context); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When the master is terminated instead of just exiting, give leader
election a chance to release the leader lock so another ovnkube
master can grab it while this instance is down.

@trozet @abhat @squeed 