### PR TITLE
Adding openvswitch-test package so that ovs-tcpdump is available in all pods

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -21,7 +21,7 @@ ARG ovnver=ovn-20.12.0-25.fc33
 RUN INSTALL_PKGS=" \
 	python3-pyyaml bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
 	libpcap hostname kubernetes-client \
-        ovn ovn-central ovn-host python3-openvswitch python3-pyOpenSSL \
+        ovn ovn-central ovn-host python3-openvswitch tcpdump openvswitch-test python3-pyOpenSSL \
 	iptables iproute iputils strace socat koji \
         " && \
 	dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \


### PR DESCRIPTION


Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>


**- What this PR does and why is it needed**

As I was poking around with ovn-kubernetes troubleshooting, going through some material from @dcbw , I stumbled upon `ovs-tcpdump`. Although this command was not found on any of the pods. In order to rectify that, it was suggested to me that we could add that to the `Dockerfile`.  Hence this PR. 


**- Special notes for reviewers**
Just added `openvswitch-test` package to Dockerfile.

**- How to verify it**

On any of the pods, you can check `rpm -qa | grep openvswitch-test` or just run `ovs-tcpdump -h` and command should output help text, and should not complain `command not found`. 

**- Description for the changelog**
Adding openvswitch-test package for easy debugging, as it provides commands such as `ovs-tcpdump`