### PR TITLE
services: don't assume Status.LoadBalancer.Ingress IPs are populated

### DIFF
--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -338,6 +338,9 @@ func collectServiceVIPs(service *v1.Service) sets.String {
 		}
 		// LoadBalancer
 		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if ingress.IP == "" {
+				continue
+			}
 			vip := util.JoinHostPortInt32(ingress.IP, svcPort.Port)
 			key := virtualIPKey(vip, svcPort.Protocol)
 			res.Insert(key)

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -459,7 +459,7 @@ func getSvcVips(service *kapi.Service) []net.IP {
 		for _, ing := range service.Status.LoadBalancer.Ingress {
 			ip := net.ParseIP(ing.IP)
 			if ip == nil {
-				klog.Errorf("Failed to parse pod IP %q", ing)
+				klog.Errorf("Failed to parse ingress IP %q", ing)
 				continue
 			}
 			klog.V(5).Infof("Adding ingress IPs from Service: %s to VIP set", service.Name)


### PR DESCRIPTION
Sometimes the LB Ingress is a hostname, in which case the IP is empty.

@trozet @fedepaol 