### PR TITLE
Ensure no SNAT on GR for DisableSNATMultipleGws

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -386,6 +386,16 @@ func gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet, hostSubnets []*n
 					entry.String(), gatewayRouter, err)
 			}
 		}
+	} else {
+		// ensure we do not have any leftover SNAT entries after an upgrade
+		for _, logicalSubnet := range clusterIPSubnet {
+			_, stderr, err = util.RunOVNNbctl("--if-exists", "lr-nat-del", gatewayRouter, "snat",
+				logicalSubnet.String())
+			if err != nil {
+				return fmt.Errorf("failed to delete GW SNAT rule for pod on router %s, for subnet: %s, "+
+					"stderr: %q, error: %v", gatewayRouter, logicalSubnet, stderr, err)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
When we have this configuration enabled, there should be no SNAT entry
for the pod subnet on the GR. Instead there should be per pod SNAT
entries added. On upgrade or enabling this feature we were failing to
remove any previous SNAT entries here.

Signed-off-by: Tim Rozet <trozet@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->