### PR TITLE
fix ForEachAddressSet() as it is not calling the callback functions

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -83,11 +83,7 @@ func (asf *ovnAddressSetFactory) ForEachAddressSet(iteratorFn AddressSetIterFunc
 
 	processedAddressSets := sets.String{}
 	for _, line := range strings.Split(output, "\n") {
-		parts := strings.Split(line, ",")
-		if len(parts) != 2 {
-			continue
-		}
-		for _, externalID := range strings.Fields(parts[1]) {
+		for _, externalID := range strings.Split(line, ",") {
 			if !strings.HasPrefix(externalID, "name=") {
 				continue
 			}

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -74,9 +74,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				}
 
 				var namespacesRes string
-				for _, n := range namespaces {
+				for i, n := range namespaces {
 					name := n.makeName()
-					namespacesRes += fmt.Sprintf("%s,name=%s\n", hashedAddressSet(name), name)
+					if i%2 == 0 {
+						namespacesRes += fmt.Sprintf("keyA=valA,name=%s\n", name)
+					} else {
+						namespacesRes += fmt.Sprintf("name=%s,keyB=valB\n", name)
+					}
 				}
 				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd:    "ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=external_ids find address_set",


### PR DESCRIPTION
we have,

```
# ovn-nbctl list address_set |grep external_ids
external_ids        : {name=kube-system_v4}
external_ids        : {name=default_v4}
external_ids        : {name=default.access-web.egress.3_v4}
external_ids        : {name=kube-public_v4}
external_ids        : {name=ovn-kubernetes_v4}
external_ids        : {name=default.access-web.ingress.0_v4}
external_ids        : {name=kube-node-lease_v4}
external_ids        : {name=default.access-mysql.ingress.0_v4}
external_ids        : {name=default.access-web.egress.0_v4}
```

so, there is only one part of key=value in `external_ids` and this
results in ForEachAddressSet() not calling the iterator function.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>


@dcbw PTAL