### PR TITLE
Unidling: make the wait shorter / check for longer time

### DIFF
--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -145,13 +145,13 @@ var _ = ginkgo.Describe("Unidling", func() {
 			})
 			serviceAddress := net.JoinHostPort(serviceName, strconv.Itoa(port))
 			framework.Logf("waiting up to %v to connect to %v", e2eservice.KubeProxyEndpointLagTimeout, serviceAddress)
-			cmd = fmt.Sprintf("/agnhost connect --timeout=3s %s", serviceAddress)
+			cmd = fmt.Sprintf("/agnhost connect --timeout=1s %s", serviceAddress)
 		})
 
 		ginkgo.It("Should generate a NeedPods event for traffic destined to idled services", func() {
 			gomega.Eventually(func() serviceStatus {
 				return checkService(clientPod, cmd)
-			}, 5*time.Second, 1*time.Second).Should(gomega.Equal(failsWithNoReject), "Service is rejecting")
+			}, 10*time.Second, 1*time.Second).Should(gomega.Equal(failsWithNoReject), "Service is rejecting")
 
 			generatesNewEvents := hittingGeneratesNewEvents(service, cs, clientPod, cmd)
 			framework.ExpectEqual(generatesNewEvents, true, "New events are not generated")
@@ -165,7 +165,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 
 			gomega.Eventually(func() serviceStatus {
 				return checkService(clientPod, cmd)
-			}, 5*time.Second, 1*time.Second).Should(gomega.Equal(rejects), "Service is not rejecting")
+			}, 10*time.Second, 1*time.Second).Should(gomega.Equal(rejects), "Service is not rejecting")
 
 			generatesNewEvents := hittingGeneratesNewEvents(service, cs, clientPod, cmd)
 			framework.ExpectEqual(generatesNewEvents, false, "New events are generated")
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 			createBackend(f, serviceName, namespace, node, jig.Labels, port)
 			gomega.Eventually(func() serviceStatus {
 				return checkService(clientPod, cmd)
-			}, 5*time.Second, 1*time.Second).Should(gomega.Equal(works), "Service is failing")
+			}, 10*time.Second, 1*time.Second).Should(gomega.Equal(works), "Service is failing")
 
 			generatesNewEvents := hittingGeneratesNewEvents(service, cs, clientPod, cmd)
 			framework.ExpectEqual(generatesNewEvents, false, "New events are generated")
@@ -189,7 +189,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 
 			gomega.Eventually(func() serviceStatus {
 				return checkService(clientPod, cmd)
-			}, 5*time.Second, 1*time.Second).Should(gomega.Equal(failsWithNoReject), "Service is not timing out")
+			}, 10*time.Second, 1*time.Second).Should(gomega.Equal(failsWithNoReject), "Service is not timing out")
 
 			generatesNewEvents := hittingGeneratesNewEvents(service, cs, clientPod, cmd)
 			framework.ExpectEqual(generatesNewEvents, true, "New events are not generated")
@@ -230,13 +230,13 @@ var _ = ginkgo.Describe("Unidling", func() {
 			})
 			serviceAddress := net.JoinHostPort(serviceName, strconv.Itoa(port))
 			framework.Logf("waiting up to %v to connect to %v", e2eservice.KubeProxyEndpointLagTimeout, serviceAddress)
-			cmd = fmt.Sprintf("/agnhost connect --timeout=3s %s", serviceAddress)
+			cmd = fmt.Sprintf("/agnhost connect --timeout=1s %s", serviceAddress)
 		})
 
 		ginkgo.It("Should not generate a NeedPods event for traffic destined to idled services", func() {
 			gomega.Eventually(func() serviceStatus {
 				return checkService(clientPod, cmd)
-			}, 5*time.Second, 1*time.Second).Should(gomega.Equal(rejects), "Service is not rejecting")
+			}, 10*time.Second, 1*time.Second).Should(gomega.Equal(rejects), "Service is not rejecting")
 
 			generatesNewEvents := hittingGeneratesNewEvents(service, cs, clientPod, cmd)
 			framework.ExpectEqual(generatesNewEvents, false, "New events are generated")
@@ -250,7 +250,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 
 			gomega.Eventually(func() serviceStatus {
 				return checkService(clientPod, cmd)
-			}, 5*time.Second, 1*time.Second).Should(gomega.Equal(failsWithNoReject), "Service is not timing out")
+			}, 10*time.Second, 1*time.Second).Should(gomega.Equal(failsWithNoReject), "Service is not timing out")
 
 			generatesNewEvents := hittingGeneratesNewEvents(service, cs, clientPod, cmd)
 			framework.ExpectEqual(generatesNewEvents, true, "New events are not generated")
@@ -260,7 +260,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 			createBackend(f, serviceName, namespace, node, jig.Labels, port)
 			gomega.Eventually(func() serviceStatus {
 				return checkService(clientPod, cmd)
-			}, 5*time.Second, 1*time.Second).Should(gomega.Equal(works), "Service is failing")
+			}, 10*time.Second, 1*time.Second).Should(gomega.Equal(works), "Service is failing")
 
 			generatesNewEvents := hittingGeneratesNewEvents(service, cs, clientPod, cmd)
 			framework.ExpectEqual(generatesNewEvents, false, "New events are generated")
@@ -274,7 +274,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 
 			gomega.Eventually(func() serviceStatus {
 				return checkService(clientPod, cmd)
-			}, 5*time.Second, 1*time.Second).Should(gomega.Equal(rejects), "Service is not rejecting")
+			}, 10*time.Second, 1*time.Second).Should(gomega.Equal(rejects), "Service is not rejecting")
 
 			generatesNewEvents := hittingGeneratesNewEvents(service, cs, clientPod, cmd)
 			framework.ExpectEqual(generatesNewEvents, false, "New events are generated")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

When the service times out but it should not, 5 seconds are not enough
for the eventually. 3 seconds are consumed by the first timeout, and it
could exceptionally happen that the second attempt lasts longer than 2.
Here we lower the timeout and wait for longer for the right config to
get in place.


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->