### PR TITLE
Implement LRSR functionalities for Mocks Testing

### DIFF
--- a/go-controller/pkg/testing/mock_lr.go
+++ b/go-controller/pkg/testing/mock_lr.go
@@ -111,23 +111,3 @@ func (mock *MockOVNClient) LRPDel(lr string, lrp string) (*goovn.OvnCommand, err
 func (mock *MockOVNClient) LRPList(lr string) ([]*goovn.LogicalRouterPort, error) {
 	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
 }
-
-// Add LRSR with given ip_prefix on given lr
-func (mock *MockOVNClient) LRSRAdd(lr string, ip_prefix string, nexthop string, output_port *string, policy *string, external_ids map[string]string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Delete LRSR with given ip_prefix, nexthop, outputPort and policy on given lr
-func (mock *MockOVNClient) LRSRDel(lr string, prefix string, nexthop, outputPort, policy *string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Delete LRSR by uuid given lr
-func (mock *MockOVNClient) LRSRDelByUUID(lr, uuid string) (*goovn.OvnCommand, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}
-
-// Get all LRSRs by lr
-func (mock *MockOVNClient) LRSRList(lr string) ([]*goovn.LogicalRouterStaticRoute, error) {
-	return nil, fmt.Errorf("method %s is not implemented yet", functionName())
-}

--- a/go-controller/pkg/testing/mock_lrsr.go
+++ b/go-controller/pkg/testing/mock_lrsr.go
@@ -1,0 +1,84 @@
+package testing
+
+import (
+	"encoding/base64"
+	"fmt"
+	goovn "github.com/ebay/go-ovn"
+	"k8s.io/klog/v2"
+)
+
+func makeUUID(params string) string {
+	return base64.StdEncoding.EncodeToString([]byte(params))
+
+}
+
+// Add LRSR with given ip_prefix on given lr
+func (mock *MockOVNClient) LRSRAdd(lr string, ip_prefix string, nexthop string, output_port *string, policy *string, external_ids map[string]string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("Adding  static route to router %s", lr)
+	extIdsMap := make(map[interface{}]interface{})
+	for k, v := range external_ids {
+		extIdsMap[k] = v
+	}
+	uuidParamStr := lr + ip_prefix + nexthop + *output_port + *policy
+	fakeUUID := makeUUID(uuidParamStr)
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpAdd,
+			table:   LogicalRouterStaticRouteType,
+			objName: fakeUUID,
+			obj:     &goovn.LogicalRouterStaticRoute{UUID: fakeUUID, IPPrefix: ip_prefix, Nexthop: nexthop, Policy: policy, ExternalID: extIdsMap, OutputPort: output_port},
+		},
+	}, nil
+
+}
+
+// Delete LRSR with given ip_prefix, nexthop, outputPort and policy on given lr
+func (mock *MockOVNClient) LRSRDel(lr string, prefix string, nexthop, outputPort, policy *string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("LRSRDel called for lr: %s and prefix: %s nexthop: %s outputPort: %s policy: %s", lr, prefix, *nexthop, *outputPort, *policy)
+	uuidParamStr := lr + prefix + *nexthop + *outputPort + *policy
+	fakeUUID := makeUUID(uuidParamStr)
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpDelete,
+			table:   LogicalRouterStaticRouteType,
+			objName: fakeUUID,
+		},
+	}, nil
+}
+
+// Delete LRSR by uuid given lr
+func (mock *MockOVNClient) LRSRDelByUUID(lr, uuid string) (*goovn.OvnCommand, error) {
+	klog.V(5).Infof("LRSRDelByUUID called for lr: %s and UUID: %s", lr, uuid)
+	return &goovn.OvnCommand{
+		Exe: &MockExecution{
+			handler: mock,
+			op:      OpDelete,
+			table:   LogicalRouterStaticRouteType,
+			objName: uuid,
+		},
+	}, nil
+}
+
+// Get all LRSRs by lr
+func (mock *MockOVNClient) LRSRList(lr string) ([]*goovn.LogicalRouterStaticRoute, error) {
+	klog.V(5).Infof("LRSRList called for lr: %s", lr)
+	var lrsrCache MockObjectCacheByName
+	var ok bool
+
+	lrsrArray := []*goovn.LogicalRouterStaticRoute{}
+	if lrsrCache, ok = mock.cache[LogicalRouterStaticRouteType]; !ok {
+		klog.V(5).Infof("Cache doesn't have any object of type %s", LogicalRouterStaticRouteType)
+		return nil, goovn.ErrorSchema
+	}
+	var lrsrEntry interface{}
+	for _, lrsrEntry = range lrsrCache {
+		lrsr, ok := lrsrEntry.(*goovn.LogicalRouterStaticRoute)
+		if !ok {
+			return nil, fmt.Errorf("invalid object type assertion for %s", LogicalRouterStaticRouteType)
+		}
+		lrsrArray = append(lrsrArray, lrsr)
+	}
+	return lrsrArray, nil
+}

--- a/go-controller/pkg/testing/mock_ovn.go
+++ b/go-controller/pkg/testing/mock_ovn.go
@@ -12,13 +12,14 @@ import (
 )
 
 const (
-	LogicalSwitchType     string = "Logical_Switch"
-	LogicalRouterType     string = "Logical_Router"
-	LogicalSwitchPortType string = "Logical_Switch_Port"
-	ChassisType           string = "Chassis"
-	ACLType               string = "ACL"
-	ChassisPrivateType    string = "Chassis_Private"
-	PortGroupType         string = "Port_Group"
+	LogicalSwitchType            string = "Logical_Switch"
+	LogicalRouterType            string = "Logical_Router"
+	LogicalSwitchPortType        string = "Logical_Switch_Port"
+	LogicalRouterStaticRouteType string = "Logical_Router_Static_Route"
+	ChassisType                  string = "Chassis"
+	ACLType                      string = "ACL"
+	ChassisPrivateType           string = "Chassis_Private"
+	PortGroupType                string = "Port_Group"
 )
 
 const (
@@ -82,6 +83,7 @@ func NewMockOVNClient(db string) *MockOVNClient {
 	mock.cache[LogicalSwitchType] = make(MockObjectCacheByName)
 	mock.cache[ChassisPrivateType] = make(MockObjectCacheByName)
 	mock.cache[LogicalRouterType] = make(MockObjectCacheByName)
+	mock.cache[LogicalRouterStaticRouteType] = make(MockObjectCacheByName)
 	mock.cache[ACLType] = make(MockObjectCacheByName)
 	mock.cache[PortGroupType] = make(MockObjectCacheByName)
 	return mock


### PR DESCRIPTION
This PR

- moves Logical Router Static Route (lrsr) mock functions into a separate mock_lr.go file
- implements Logical Router Static Route (lrsr) functions for the mocks

Co-author:  Palani Kodeswaran palani.kodeswaran@in.ibm.com
Signed-off-by: Sayandeep <sayandes@in.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->