### PR TITLE
Wait one second between checking the last event and generating a new one

### DIFF
--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -297,6 +297,9 @@ func createBackend(f *framework.Framework, serviceName, namespace, node string, 
 // hittingGeneratesNewEvents tells if by hitting a service a brand new needPods event is generated
 func hittingGeneratesNewEvents(service *v1.Service, cs clientset.Interface, clientPod *v1.Pod, cmd string) bool {
 	lastEventTime := lastIdlingEventForService(service, cs)
+	// the event time resolution is one second, which is what we use to check if there are new events
+	// we need to sleep 1 second to ensure two events are generated with different timestamps.
+	time.Sleep(1 * time.Second)
 	checkService(clientPod, cmd)
 	err := wait.PollImmediate(framework.Poll, 3*time.Second, func() (bool, error) {
 		newLastEvent := lastIdlingEventForService(service, cs)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

The way we check if hitting an idling service generates an idling event is
by checking the last event time, hitting the service and checking if an
event is created with a bigger time. If this happens within the second,
the two events will have the same time and the test will flake.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->