### PR TITLE
[PoC] pods: add short node name hash to pod logical switch ports

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"net"
 	"os"
@@ -156,11 +155,6 @@ func (n *NodeController) DeletePod(pod *kapi.Pod) error {
 // Sync is not needed but must be implemented to fulfill the interface
 func (n *NodeController) Sync(objs []*kapi.Node) {}
 
-func nameToCookie(nodeName string) string {
-	hash := sha256.Sum256([]byte(nodeName))
-	return fmt.Sprintf("%02x%02x%02x%02x", hash[0], hash[1], hash[2], hash[3])
-}
-
 // hybridOverlayNodeUpdate sets up or tears down VXLAN tunnels to hybrid overlay
 // nodes in the cluster
 func (n *NodeController) hybridOverlayNodeUpdate(node *kapi.Node) error {
@@ -177,7 +171,7 @@ func (n *NodeController) hybridOverlayNodeUpdate(node *kapi.Node) error {
 	klog.Infof("Setting up hybrid overlay tunnel to node %s", node.Name)
 
 	// (re)add flows for the node
-	cookie := nameToCookie(node.Name)
+	cookie := util.NodeNameToCookie(node.Name)
 	drMACRaw := strings.Replace(drMAC.String(), ":", "", -1)
 
 	var flows []string
@@ -237,7 +231,7 @@ func (n *NodeController) DeleteNode(node *kapi.Node) error {
 		return nil
 	}
 
-	n.deleteFlowsByCookie(nameToCookie(node.Name))
+	n.deleteFlowsByCookie(util.NodeNameToCookie(node.Name))
 	return nil
 }
 

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 var minRsrc = resource.MustParse("1k")
@@ -158,7 +159,10 @@ func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternal
 		if len(hostIfaceName) == 0 {
 			return nil, fmt.Errorf("could not find host interface in the prevResult: %v", result)
 		}
-		ifaceID := fmt.Sprintf("%s_%s", namespace, podName)
+
+		nodeCookie := util.NodeNameToCookie(pr.NodeName)
+		ifaceID := fmt.Sprintf("%s_%s_%s", namespace, podName, nodeCookie)
+
 		ofPort, err := getIfaceOFPort(hostIfaceName)
 		if err != nil {
 			return nil, err
@@ -213,7 +217,7 @@ func HandleCNIRequest(request *PodRequest, podLister corev1listers.PodLister, us
 
 // getCNIResult get result from pod interface info.
 func (pr *PodRequest) getCNIResult(podInterfaceInfo *PodInterfaceInfo) (*current.Result, error) {
-	interfacesArray, err := pr.ConfigureInterface(pr.PodNamespace, pr.PodName, podInterfaceInfo)
+	interfacesArray, err := pr.ConfigureInterface(pr.PodNamespace, pr.PodName, pr.NodeName, podInterfaceInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure pod interface: %v", err)
 	}

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -170,7 +170,7 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 	if response.Result != nil {
 		result = response.Result
 	} else {
-		pr, _ := cniRequestToPodRequest(req)
+		pr, _ := cniRequestToPodRequest(req, conf.NodeName)
 		result, err = pr.getCNIResult(response.PodIFInfo)
 		if err != nil {
 			err = fmt.Errorf("failed to get CNI Result from pod interface info %v: %v", response.PodIFInfo, err)

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -76,6 +76,8 @@ type PodRequest struct {
 	PodNamespace string
 	// kubernetes pod name
 	PodName string
+	// node name
+	NodeName string
 	// kubernetes container ID
 	SandboxID string
 	// kernel network namespace path
@@ -105,6 +107,7 @@ type Server struct {
 	useOVSExternalIDs int32
 	kclient           kubernetes.Interface
 	podLister         corev1listers.PodLister
+	nodeName          string
 
 	// runningSandboxAdds is a map of sandbox ID to PodRequest for any CNIAdd operation
 	runningSandboxAddsLock sync.Mutex

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -8,6 +8,8 @@ import (
 // NetConf is CNI NetConf with DeviceID
 type NetConf struct {
 	types.NetConf
+	// NodeName is the node's Kubernetes API node name
+	NodeName string `json:"nodeName,omitempty"`
 	// PciAddrs in case of using sriov
 	DeviceID string `json:"deviceID,omitempty"`
 	// LogFile to log all the messages from cni shim binary to

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -14,13 +14,14 @@ import (
 )
 
 // WriteCNIConfig writes a CNI JSON config file to directory given by global config
-func WriteCNIConfig() error {
+func WriteCNIConfig(nodeName string) error {
 	netConf := &ovntypes.NetConf{
 		NetConf: types.NetConf{
 			CNIVersion: "0.4.0",
 			Name:       "ovn-kubernetes",
 			Type:       CNI.Plugin,
 		},
+		NodeName:          nodeName,
 		LogFile:           Logging.CNIFile,
 		LogLevel:          fmt.Sprintf("%d", Logging.Level),
 		LogFileMaxSize:    Logging.LogFileMaxSize,

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -307,7 +307,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 		if !ok {
 			return fmt.Errorf("cannot get kubeclient for starting CNI server")
 		}
-		cniServer, err = cni.NewCNIServer("", isOvnUpEnabled, n.watchFactory, kclient.KClient)
+		cniServer, err = cni.NewCNIServer("", n.name, isOvnUpEnabled, n.watchFactory, kclient.KClient)
 		if err != nil {
 			return err
 		}
@@ -461,7 +461,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 		confFile := filepath.Join(config.CNI.ConfDir, config.CNIConfFileName)
 		_, err = os.Stat(confFile)
 		if os.IsNotExist(err) {
-			err = config.WriteCNIConfig()
+			err = config.WriteCNIConfig(n.name)
 			if err != nil {
 				return err
 			}

--- a/go-controller/pkg/node/node_smartnic.go
+++ b/go-controller/pkg/node/node_smartnic.go
@@ -128,7 +128,7 @@ func (n *OvnNode) addRepPort(pod *kapi.Pod, vfRepName string, ifInfo *cni.PodInt
 		return fmt.Errorf("failed to get smart-nic annotation. %v", err)
 	}
 
-	err := cni.ConfigureOVS(context.TODO(), pod.Namespace, pod.Name, vfRepName, ifInfo, smartNicCD.SandboxId)
+	err := cni.ConfigureOVS(context.TODO(), pod.Namespace, pod.Name, n.name, vfRepName, ifInfo, smartNicCD.SandboxId)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -20,7 +20,7 @@ import (
 
 // Builds the logical switch port name for a given pod.
 func podLogicalPortName(pod *kapi.Pod) string {
-	return pod.Namespace + "_" + pod.Name
+	return fmt.Sprintf("%s_%s_%s", pod.Namespace, pod.Name, util.NodeNameToCookie(pod.Spec.NodeName))
 }
 
 func (oc *Controller) syncPods(pods []interface{}) {

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"hash/fnv"
 	"net"
@@ -224,4 +225,12 @@ func UpdateIPsSlice(s, oldIPs, newIPs []string) []string {
 		}
 	}
 	return n
+}
+
+// NodeNameToCookie converts a node name into the first 4 hex characters of
+// the SHA256 hash of it's name. Should not be used for security or cryptographically
+// important purposes.
+func NodeNameToCookie(nodeName string) string {
+	hash := sha256.Sum256([]byte(nodeName))
+	return fmt.Sprintf("%02x%02x%02x%02x", hash[0], hash[1], hash[2], hash[3])
 }


### PR DESCRIPTION
If ovn-kube node on a given node is wedged or crashlooping and a
pod is deleted and rescheduled on another node, the OVS interface will
still have the pod's iface-id. But now the new node will also have
the new pod's iface-id, and the ovn-controllers will fight over
the port binding of the pod.

Adding the node name to the logical switch port name ensures that no
two controllers will ever fight over the same pod's LSP.

TODO: figure out the backwards compat story

@trozet @fedepaol 