### PR TITLE
Set the default value of host network namespace to empty string

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -96,7 +96,7 @@ var (
 		APIServer:            DefaultAPIServer,
 		RawServiceCIDRs:      "172.16.1.0/24",
 		OVNConfigNamespace:   "ovn-kubernetes",
-		HostNetworkNamespace: "ovn-host-network",
+		HostNetworkNamespace: "",
 	}
 
 	// OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides


### PR DESCRIPTION
The default value of host network namespace should be an empty string.
This way the feature is disabled unless someone specifically creates
and configures the host network namespace.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>