### PR TITLE
Enable OVN control plane metrics when ovn-metrics-bind-address is not set

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -278,12 +278,15 @@ func runOvnKube(ctx *cli.Context) error {
 	// start the prometheus server to serve OVN K8s Metrics (default master port: 9409, node port: 9410)
 	if config.Kubernetes.MetricsBindAddress != "" {
 		metrics.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof)
+		if config.OvnKubeNode.Mode != types.NodeModeSmartNICHost && config.Kubernetes.OVNMetricsBindAddress == "" {
+			metrics.RegisterOvnMetrics(ovnClientset.KubeClient, master)
+		}
 	}
 
 	// start the prometheus server to serve OVN Metrics (default port: 9476)
 	// Note: for ovnkube node mode smart-nic-host no ovn metrics is required as ovn is not running on the node.
 	if config.OvnKubeNode.Mode != types.NodeModeSmartNICHost && config.Kubernetes.OVNMetricsBindAddress != "" {
-		metrics.RegisterOvnMetrics(ovnClientset.KubeClient, node)
+		metrics.RegisterOvnMetrics(ovnClientset.KubeClient, master)
 		metrics.StartOVNMetricsServer(config.Kubernetes.OVNMetricsBindAddress)
 	}
 

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -204,8 +204,15 @@ func StartOVNMetricsServer(bindAddress string) {
 	}, 5*time.Second, utilwait.NeverStop)
 }
 
-func RegisterOvnMetrics(clientset kubernetes.Interface, k8sNodeName string) {
-	go RegisterOvnDBMetrics(clientset, k8sNodeName)
-	go RegisterOvnControllerMetrics()
-	go RegisterOvnNorthdMetrics(clientset, k8sNodeName)
+// RegisterOvnMetrics registers OVSDB and Northd metrics if k8sMasterName != "",
+// otherwise registers ovn-controller metrics
+func RegisterOvnMetrics(clientset kubernetes.Interface, k8sMasterName string) {
+	if k8sMasterName != "" {
+		klog.V(5).Infof("Registering OVN master metrics")
+		go RegisterOvnDBMetrics(clientset, k8sMasterName)
+		go RegisterOvnNorthdMetrics(clientset, k8sMasterName)
+	} else {
+		klog.V(5).Infof("Registering OVN node metrics")
+		go RegisterOvnControllerMetrics()
+	}
 }


### PR DESCRIPTION
**- What this PR does and why is it needed**
There was a previous effort to expose these metrics on the same mux at https://github.com/ovn-org/ovn-kubernetes/pull/1979 when the flag `ovn-metrics-bind-address` was not set.

With this PR ovnkube exposes OVN metrics (ovsdb, northd and ovn-controller) and has the logic to figure out when exposing master (nbdb, sbdb, northd) or node (ovn-controller) metrics w/o requiring the `ovn-metrics-bind-address` flag to be set.

**- Special notes for reviewers**
The current implementation is not 100% correct as is tries to expose all these metrics when `ovn-metrics-bind-address` is set, this could lead to collect some of these metrics twice in master nodes (ovnkube-node and ovnkube-master running in the same master node).

**- Description for the changelog**
Expose OVN core metrics on `--metrics-bind-address` when `ovn-metrics-bind-address` is not set.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>