### PR TITLE
 Fix a bug that tries to add a LSP when table is not in cache

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -283,7 +283,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	// UUID and and the port cache, address sets, and port groups
 	// will still have the old UUID.
 	lsp, err := oc.ovnNBClient.LSPGet(portName)
-	if err != nil && err != goovn.ErrorNotFound && err != goovn.ErrorSchema {
+	if err != nil && err != goovn.ErrorNotFound {
 		return fmt.Errorf("unable to get the lsp: %s from the nbdb: %s", portName, err)
 	}
 


### PR DESCRIPTION
Co-authored by : Sayandeep Sen sayandes@in.ibm.com

Signed-off-by: Palani Kodeswaran <palankod@in.ibm.com>

While using go-ovn bindings, the code does a LSPGet(portName) and checks if the err is *not* a goovn.ErrorSchema before returning an error. However, it then tries to add a LSP even when the table may not exist in the cache.

This PR fixes that and returns an error when the table does not exist in cache. 


