### PR TITLE
Fix typo in error log message

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1164,7 +1164,7 @@ func (oc *Controller) deleteNode(nodeName string, hostSubnets []*net.IPNet, node
 	}
 
 	if err := oc.deleteNodeChassis(nodeName); err != nil {
-		klog.Errorf("Failed to remove the chassis associated with node %s in the OVN SB Chassis table", nodeName, err)
+		klog.Errorf("Failed to remove the chassis associated with node %s in the OVN SB Chassis table: %v", nodeName, err)
 	}
 }
 


### PR DESCRIPTION
We're missing %v

@trozet @abhat 

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>
