### PR TITLE
Go 1.16 + CI fixes

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -1,0 +1,25 @@
+name: 'Generate Junit Report'
+# this needs to be a separate workflow, as it needs
+# permissons to create annotations on the PR, so
+# needs to run in the "upstream" context.
+on:
+  workflow_run:
+    workflows: ['ovn-ci']                     # runs after CI workflow
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        workflow_conclusion: completed
+        name: junit-unit
+
+    - name: Publish Test Report 2
+      uses: mikepenz/action-junit-report@v2
+      with:
+        report_paths: '**/*.xml'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        commit: ${{ github.event.workflow_run.head_commit.id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 */12 * * *'
 
 env:
-  GO_VERSION: 1.15.5
+  GO_VERSION: "1.16.3"
   K8S_VERSION: v1.20.2
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true
@@ -18,12 +18,27 @@ env:
   PARALLEL: true
 
 jobs:
+  # separate job for parallelism
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Verify
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.33.2
+        working-directory: go-controller
+        args: --modules-download-mode=vendor --timeout=15m0s --verbose
+
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -31,46 +46,14 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Set up environment
-      run: |
-        export GOPATH=$(go env GOPATH)
-        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
-        echo "$GOPATH/bin" >> $GITHUB_PATH
-
-    - name: Verify
-      run: |
-        pushd go-controller
-          make gofmt
-          make install.tools
-          make lint
-        popd
-
-    - name: Test
+    - name: Build and Test
       run: |
         set -x
-        pushd go-controller
-        make check
-        popd
-
-    - name: Build
-      run: |
-        set -x
-        go get golang.org/x/tools/cmd/cover
         pushd go-controller
            make
            make windows
-           COVERALLS=1 make check
+           COVERALLS=1 CONTAINER_RUNNABLE=1 make check
         popd
-
-        # Combine separate code coverage profiles into one
-        go get github.com/modocache/gover
-        gover go-controller/ gover.coverprofile
-
-        # Convert coverage profile to LCOV format for coveralls github action
-        go get github.com/jandelgado/gcov2lcov
-        mkdir -p src/github.com/ovn-org
-        ln -sf $(pwd) src/github.com/ovn-org/ovn-kubernetes
-        GOPATH=$(pwd) gcov2lcov -infile gover.coverprofile -outfile coverage.lcov
 
     - name: Build docker image
       run: |
@@ -91,14 +74,24 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: junit-${{ github.run_id }}
+        name: junit-unit
         path: '**/_artifacts/**.xml'
 
     - name: Submit code coverage to Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: coverage.lcov
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GO111MODULE: off
+      run: |
+        set -x
+        go get github.com/mattn/goveralls
+        go get github.com/modocache/gover
+        PATH=$PATH:$(go env GOPATH)/bin
+
+        mkdir -p $(go env GOPATH)/src/github.com/ovn-org
+        ln -sf $(pwd) $(go env GOPATH)/src/github.com/ovn-org/ovn-kubernetes
+
+        gover
+        goveralls -coverprofile=gover.coverprofile -service=github
 
   e2e:
     name: e2e
@@ -181,7 +174,7 @@ jobs:
       run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -273,7 +266,7 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -396,7 +389,7 @@ jobs:
         run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -9,7 +9,8 @@ PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
 TEST_REPORT_DIR?=$(CURDIR)/_artifacts
 export TEST_REPORT_DIR
-GO_DOCKER_IMG = quay.io/giantswarm/golang:1.15.7
+GO_VERSION ?= 1.16.3
+GO_DOCKER_IMG = quay.io/giantswarm/golang:${GO_VERSION}
 # CONTAINER_RUNNABLE determines if the tests can be run inside a container. It checks to see if
 # podman/docker is installed on the system.
 PODMAN ?= $(shell podman -v > /dev/null 2>&1; echo $$?)
@@ -39,9 +40,9 @@ windows:
 # tests in a container. Refer: https://www.projectatomic.io/blog/2016/03/dwalsh_selinux_containers/ for additional context
 check test:
 ifeq ($(CONTAINER_RUNNABLE), 0)
-	$(CONTAINER_RUNTIME) run -it --rm --security-opt label=disable --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller -e COVERALLS=${COVERALLS} -e GINKGO_FOCUS="${GINKGO_FOCUS}" $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 COVERALLS=${COVERALLS} hack/test-go.sh focus \"${GINKGO_FOCUS}\" ${PKGS}"
+	$(CONTAINER_RUNTIME) run -it --rm --security-opt label=disable --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller -e COVERALLS=${COVERALLS} -e GINKGO_FOCUS="${GINKGO_FOCUS}" $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 COVERALLS=${COVERALLS} PKGS="${PKGS}" hack/test-go.sh focus \"${GINKGO_FOCUS}\" "
 else
-	RACE=1 hack/test-go.sh ${PKGS}
+	RACE=1 hack/test-go.sh
 endif
 
 codegen:

--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -38,25 +38,16 @@ function testrun {
         args=""
         go_test="sudo ${testfile}"
     fi
-    # set gomaxprocs to 1 in CI, because actions are run in containers and we don't know what cpu
-    # limits are being imposed
-    if [ -n "${CI}" ]; then
-        args="${args}-test.cpu 1 "
-    fi
     if [[ -n "$gingko_focus" ]]; then
         local ginkgoargs=${ginkgo_focus:-}
     fi
     local path=${pkg#github.com/ovn-org/ovn-kubernetes/go-controller}
-    # coverage is incompatible with the race detector
     if [ ! -z "${COVERALLS:-}" ]; then
-        args="-test.coverprofile=${idx}.coverprofile "
+        args="${args} -test.coverprofile=${idx}.coverprofile "
     fi
     if grep -q -r "ginkgo" ."${path}"; then
 	    prefix=$(echo "${path}" | cut -c 2- | sed 's,/,_,g')
-        ginkgoargs="-ginkgo.v -ginkgo.reportFile ${TEST_REPORT_DIR}/junit-${prefix}.xml"
-        if [[ -n "$gingko_focus" ]]; then
-            ginkgoargs="-ginkgo.v ${gingko_focus} -ginkgo.reportFile ${TEST_REPORT_DIR}/junit-${prefix}.xml"
-        fi
+        ginkgoargs="-ginkgo.v ${ginkgo_focus} -ginkgo.reportFile ${TEST_REPORT_DIR}/junit-${prefix}.xml"
     fi
     args="${args}${otherargs}"
     if [ "$go_test" == "go test -mod=vendor" ]; then

--- a/go-controller/pkg/informer/informer_test.go
+++ b/go-controller/pkg/informer/informer_test.go
@@ -404,10 +404,13 @@ var _ = Describe("Informer Event Handler Tests", func() {
 			return pod != nil, nil
 		}, 2).Should(BeTrue())
 
+		// initial add from the cache
+		Eventually(func() int32 { return atomic.LoadInt32(&adds) }).Should(Equal(int32(1)), "adds")
+
 		err := k.CoreV1().Pods(namespace).Delete(context.TODO(), "foo", *metav1.NewDeleteOptions(0))
 		Expect(err).NotTo(HaveOccurred())
 
-		// initial add from the cache
+		// we stay at 1
 		Consistently(func() int32 { return atomic.LoadInt32(&adds) }).Should(Equal(int32(1)), "adds")
 		// one delete event
 		Eventually(func() int32 { return atomic.LoadInt32(&deletes) }).Should(Equal(int32(1)), "deletes")


### PR DESCRIPTION
CI: go 1.16, small fixes
    
- bump to go 1.16
- coverage fixes for go1.16
- run race detector and coverage at the same time - stop testing twice
- run lint in parallel
- don't run tests in a container on CI - save build times
- add junit summarization
- fix handling of PKGS var
- stop forcing a single CPU

Tests are much faster now.
