### PR TITLE
Taint node with NoSchedule effect when ovnkube pod is down

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -270,8 +270,24 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 	var mgmtPortConfig *managementPortConfig
 	var cniServer *cni.Server
 	var isOvnUpEnabled bool
+	networkUnavailableTaint := &kapi.Taint{
+		Key:    types.OvnK8sNetworkUnavailable,
+		Effect: kapi.TaintEffectNoSchedule,
+	}
 
 	klog.Infof("OVN Kube Node initialization, Mode: %s", config.OvnKubeNode.Mode)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-n.stopChan
+		klog.Infof("Received node's stop channel signal. Adding taint %s.", networkUnavailableTaint.ToString())
+		// Add the NoSchedule Taint on the node, before ovnkube pod gets deleted. Ignore errors.
+		err := n.Kube.SetTaintOnNode(n.name, networkUnavailableTaint)
+		if err != nil {
+			klog.Infof("Unable to add taint %s on node %s: %v", networkUnavailableTaint.ToString(), n.name, err)
+		}
+	}()
 
 	// Setting debug log level during node bring up to expose bring up process.
 	// Log level is returned to configured value when bring up is complete.
@@ -482,6 +498,12 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 				return err
 			}
 		}
+	}
+
+	// Remove the NoSchedule Taint from the node, now that networking setup is done. Ignore errors.
+	err = n.Kube.RemoveTaintFromNode(n.name, networkUnavailableTaint)
+	if err != nil {
+		klog.Infof("Unable to remove taint %s on node %s: %v", networkUnavailableTaint.ToString(), n.name, err)
 	}
 
 	if config.OvnKubeNode.Mode == types.NodeModeSmartNIC {

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	netlink_mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
 	kapi "k8s.io/api/core/v1"
@@ -360,6 +361,74 @@ var _ = Describe("Node", func() {
 				return nil
 			}
 
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("add taint on shutdown", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					nodeIP   string = "1.2.5.6"
+					nodeName string = "node"
+					interval int    = 100000
+					ofintval int    = 180
+				)
+				taint := kapi.Taint{
+					Key:    "YouKnowNothing",
+					Value:  "JonSnow",
+					Effect: "NoSchedule",
+				}
+				expectedTaint := kapi.Taint{
+					Key:    types.OvnK8sNetworkUnavailable,
+					Effect: kapi.TaintEffectNoSchedule,
+				}
+
+				node := kapi.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.0.0/24\"}",
+						},
+					},
+					Status: kapi.NodeStatus{
+						Addresses: []kapi.NodeAddress{
+							{
+								Type:    kapi.NodeExternalIP,
+								Address: nodeIP,
+							},
+						},
+					},
+					Spec: kapi.NodeSpec{
+						Taints: []kapi.Taint{taint},
+					},
+				}
+
+				fexec := ovntest.NewFakeExec()
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+						"external_ids:ovn-encap-type=geneve "+
+						"external_ids:ovn-encap-ip=%s "+
+						"external_ids:ovn-remote-probe-interval=%d "+
+						"external_ids:ovn-openflow-probe-interval=%d "+
+						"external_ids:hostname=\"%s\" "+
+						"external_ids:ovn-monitor-all=true "+
+						"external_ids:ovn-enable-lflow-cache=true",
+						nodeIP, interval, ofintval, nodeName),
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ovn-sbctl --timeout=15 --columns=up list Port_Binding"),
+				})
+
+				fakeOvnNode := NewFakeOVNNode(fexec)
+				fakeOvnNode.start(ctx, &node)
+				res, err := fakeOvnNode.node.Kube.GetNode(node.Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Spec.Taints).To(Equal([]kapi.Taint{taint}))
+				fakeOvnNode.shutdown() // stop and see if taint gets added.
+				res, err = fakeOvnNode.node.Kube.GetNode(node.Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.Spec.Taints).To(Equal([]kapi.Taint{taint, expectedTaint}))
+				return nil
+			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -110,9 +110,10 @@ const (
 	OvnCurrentTopologyVersion      = OvnPortBindingTopoVersion
 
 	// OVN-K8S annotation & taint constants
-	OvnK8sPrefix           = "k8s.ovn.org"
-	OvnK8sTopoAnno         = OvnK8sPrefix + "/" + "topology-version"
-	OvnK8sSmallMTUTaintKey = OvnK8sPrefix + "/" + "mtu-too-small"
+	OvnK8sPrefix             = "k8s.ovn.org"
+	OvnK8sTopoAnno           = OvnK8sPrefix + "/" + "topology-version"
+	OvnK8sSmallMTUTaintKey   = OvnK8sPrefix + "/" + "mtu-too-small"
+	OvnK8sNetworkUnavailable = OvnK8sPrefix + "/" + "network-unavailable"
 
 	// Monitoring constants
 	SFlowAgent = "ovn-k8s-mp0"


### PR DESCRIPTION
- What this PR does and why is it needed

UseCase: During upgrades, when the ovnkube pod is deleted and
before/while it gets recreated if a new pod request comes, it
will fail.

When node networking is down, we should not allow pods to be created
on that node. This PR fixes this by adding a taint on the node with
the NoScedule effect when the ovnkube pod receives a SIGTERM and then
removes the taint when the ovnkube pod finishes setting up networking
and initializing the CNI config.

- How to verify it
The added taint will be visible on the node for the brief period of time between the deletion of ovnkube-node pod and creation of the new one that takes its place which roughly takes ~60sec.

```
I0718 09:41:21.603487  396533 kube.go:161] Added taint k8s.ovn.org/network-unavailable:NoSchedule on node ci-ln-sz84n3b-f76d1-h69qs-worker-b-q2vsm
Taints:             k8s.ovn.org/network-unavailable:NoSchedule
I0718 09:12:24.775588  396533 kube.go:191] Removed taint k8s.ovn.org/network-unavailable:NoSchedule on node ci-ln-sz84n3b-f76d1-h69qs-worker-b-q2vsm
Taints:             <none>
```

- Description for the changelog
Taint node with NoSchedule effect when ovnkube pod is down and remove the taint when the pod is available again