### PR TITLE
Purge only the lprs with nexthops of the same family of new nexthop

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -627,7 +627,12 @@ func syncPolicyBasedRoutes(nodeName string, matches sets.String, priority, nexth
 	for _, policyCompare := range policiesCompare {
 		if strings.Contains(policyCompare, fmt.Sprintf("%s\"", nodeName)) {
 			// if the policy is for this node and has the wrong mgmtPortIP as nexthop, remove it
+			// FIXME we currently assume that foundNexthops is a single ip, this may
+			// change in the future.
 			foundNexthops := strings.Split(policyCompare, ",")[2]
+			if foundNexthops != "" && utilnet.IsIPv6String(foundNexthops) != utilnet.IsIPv6String(nexthop) {
+				continue
+			}
 			if !strings.Contains(foundNexthops, nexthop) {
 				uuid := strings.Split(policyCompare, ",")[0]
 				if err := deletePolicyBasedRoutes(uuid, priority); err != nil {
@@ -642,7 +647,6 @@ func syncPolicyBasedRoutes(nodeName string, matches sets.String, priority, nexth
 					desiredMatchFound = true
 					break
 				}
-				break
 			}
 			// if the policy is for this node/priority and does not contain a valid match, remove it
 			if !desiredMatchFound {


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

For each node, we add pbrs for each node subnet. When syncing pbrs, we purge
not expected rules. In case of dual stack, we are mistakenly purging the
rules that were added because of the subnet belonging to the other ip
family.
Here, we compare the family of the nexthop with the family of the new
nexthop and apply the logic only if they match.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->