### PR TITLE
Adding upgrade testing as part of e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
         working-directory: go-controller
         args: --modules-download-mode=vendor --timeout=15m0s --verbose
 
-  build:
-    name: Build
+  build-master:
+    name: Build-master
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
@@ -43,10 +43,48 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
-    - name: Check out code into the Go module directory
+    - name: Check out code into the Go module directory - from master branch
+      uses: actions/checkout@v2
+      with:
+        ref: master
+
+    - name: Build - from master branch
+      run: |
+        set -x
+        pushd go-controller
+           make
+           make windows
+        popd
+
+    - name: Build docker image - from master branch
+      run: |
+        pushd dist/images
+          sudo cp -f ../../go-controller/_output/go/bin/ovn* .
+          echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
+          docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
+          mkdir _output
+          docker save ovn-daemonset-f:dev > _output/image-master.tar
+        popd
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: test-image-master
+        path: dist/images/_output/image-master.tar
+
+  build-pr:
+    name: Build-PR
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      id: go
+
+    - name: Check out code into the Go module directory - from current pr branch
       uses: actions/checkout@v2
 
-    - name: Build and Test
+    - name: Build and Test - from current pr branch
       run: |
         set -x
         pushd go-controller
@@ -55,20 +93,20 @@ jobs:
            COVERALLS=1 CONTAINER_RUNNABLE=1 make check
         popd
 
-    - name: Build docker image
+    - name: Build docker image - from current pr branch
       run: |
         pushd dist/images
           sudo cp -f ../../go-controller/_output/go/bin/ovn* .
           echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
-          docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
+          docker build -t ovn-daemonset-f:pr -f Dockerfile.fedora .
           mkdir _output
-          docker save ovn-daemonset-f:dev > _output/image.tar
+          docker save ovn-daemonset-f:pr > _output/image-pr.tar
         popd
 
     - uses: actions/upload-artifact@v2
       with:
-        name: test-image
-        path: dist/images/_output/image.tar
+        name: test-image-pr
+        path: dist/images/_output/image-pr.tar
 
     - name: Upload Junit Reports
       if: always()
@@ -92,6 +130,117 @@ jobs:
 
         gover
         goveralls -coverprofile=gover.coverprofile -service=github
+
+  ovn-upgrade-e2e:
+    name: Upgrade OVN from Master to PR branch based image
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs:
+      - build-master
+      - build-pr
+    strategy:
+      fail-fast: false
+      matrix:
+        gateway-mode: [local, shared]
+    env:
+      JOB_NAME: "Upgrade-Tests-${{ matrix.gateway-mode }}"
+      OVN_HA: "false"
+      KIND_IPV4_SUPPORT: "true"
+      KIND_IPV6_SUPPORT: "false"
+      OVN_HYBRID_OVERLAY_ENABLE: "false"
+      OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
+      OVN_MULTICAST_ENABLE:  "false"
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      id: go
+
+    - name: Set up environment
+      run: |
+        export GOPATH=$(go env GOPATH)
+        echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+        echo "$GOPATH/bin" >> $GITHUB_PATH
+
+    - name: Free up disk space
+      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: test-image-master
+
+    - name: Disable ufw
+      # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
+      # Not needed for KIND deployments, so just disable all the time.
+      run: |
+        sudo ufw disable
+
+    - name: Load docker image
+      run: |
+        docker load --input image-master.tar
+
+    - name: Check out code into the Go module directory - from master
+      uses: actions/checkout@v2
+      with:
+        ref: master
+
+    - name: kind setup
+      run: |
+        export OVN_IMAGE="ovn-daemonset-f:dev"
+        make -C test install-kind
+
+    - name: Export logs
+      if: always()
+      run: |
+        mkdir -p /tmp/kind/logs
+        kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
+        set -x
+        docker ps -a
+        docker exec ovn-control-plane crictl images 
+        docker exec ovn-worker crictl images
+        docker exec ovn-worker2 crictl images 
+
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
+        path: /tmp/kind/logs
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: test-image-pr
+
+    - name: Load docker image
+      run: |
+        docker load --input image-pr.tar
+
+    - name: Check out code into the Go module directory - from PR branch
+      uses: actions/checkout@v2
+
+    - name: ovn upgrade
+      run: |
+        export OVN_IMAGE="ovn-daemonset-f:pr"
+        make -C test upgrade-ovn
+
+    - name: Run Single-Stack Tests
+      run: |
+        make -C test shard-test WHAT="Networking Granular Checks"
+
+    - name: Export logs
+      if: always()
+      run: |
+        mkdir -p /tmp/kind/logs-kind-pr-branch
+        kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs-kind-pr-branch
+
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}-after-upgrade
+        path: /tmp/kind/logs-kind-pr-branch
 
   e2e:
     name: e2e
@@ -158,7 +307,7 @@ jobs:
          # in agnhost images. Disable them for now.
          - {"ipfamily": {"ip": dualstack}, "target": {"shard": {"multicast-enable": "true"}}}
          - {"ipfamily": {"ip": ipv6}, "target": {"shard": {"multicast-enable": "true"}}}
-    needs: [build]
+    needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
       OVN_HA: "${{ matrix.ha.enabled }}"
@@ -187,30 +336,25 @@ jobs:
         export GOPATH=$(go env GOPATH)
         echo "GOPATH=$GOPATH" >> $GITHUB_ENV
         echo "$GOPATH/bin" >> $GITHUB_PATH
-
     - name: Disable ufw
       # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
       # Not needed for KIND deployments, so just disable all the time.
       run: |
         sudo ufw disable
-
     - uses: actions/download-artifact@v2
       with:
-        name: test-image
+        name: test-image-pr
 
     - name: Load docker image
       run: |
-        docker load --input image.tar
-
+        docker load --input image-pr.tar
     - name: kind setup
       run: |
-        export OVN_IMAGE="ovn-daemonset-f:dev"
+        export OVN_IMAGE="ovn-daemonset-f:pr"
         make -C test install-kind
-
     - name: Run Tests
       run: |
         make -C test ${{ matrix.target.shard }}
-
     - name: Upload Junit Reports
       if: always()
       uses: actions/upload-artifact@v2
@@ -237,7 +381,6 @@ jobs:
       run: |
         mkdir -p /tmp/kind/logs
         kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
-
     - name: Upload logs
       if: always()
       uses: actions/upload-artifact@v2
@@ -254,7 +397,7 @@ jobs:
       fail-fast: false
       matrix:
         gateway-mode: [local, shared]
-    needs: [build]
+    needs: [ build-pr ]
     env:
       JOB_NAME: "DualStack-conversion-${{ matrix.gateway-mode }}"
       OVN_HA: "true"
@@ -279,40 +422,33 @@ jobs:
         export GOPATH=$(go env GOPATH)
         echo "GOPATH=$GOPATH" >> $GITHUB_ENV
         echo "$GOPATH/bin" >> $GITHUB_PATH
-
     - name: Disable ufw
       # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
       # Not needed for KIND deployments, so just disable all the time.
       run: |
         sudo ufw disable
-
     - uses: actions/download-artifact@v2
       with:
-        name: test-image
+        name: test-image-pr
 
     - name: Load docker image
       run: |
-        docker load --input image.tar
-
+        docker load --input image-pr.tar
     - name: kind IPv4 setup
       run: |
-        export OVN_IMAGE="ovn-daemonset-f:dev"
+        export OVN_IMAGE="ovn-daemonset-f:pr"
         make -C test install-kind
-
     - name: Run Single-Stack Tests
       run: |
         make -C test shard-test WHAT="Networking Granular Checks"
-
     - name: Convert IPv4 cluster to Dual Stack
       run: |
         ./contrib/kind-dual-stack-conversion.sh
-
     - name: Run Dual-Stack Tests
       run: |
         KIND_IPV4_SUPPORT="true"
         KIND_IPV6_SUPPORT="true"
         make -C test shard-test WHAT="Networking Granular Checks\|DualStack"
-
     - name: Upload Junit Reports
       if: always()
       uses: actions/upload-artifact@v2
@@ -339,7 +475,6 @@ jobs:
       run: |
         mkdir -p /tmp/kind/logs
         kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
-
     - name: Upload logs
       if: always()
       uses: actions/upload-artifact@v2
@@ -375,7 +510,7 @@ jobs:
             name: "Dualstack"
             ipv4: true
             ipv6: true
-    needs: [ build ]
+    needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
       OVN_HA: "${{ matrix.ha.enabled }}"
@@ -402,29 +537,24 @@ jobs:
           export GOPATH=$(go env GOPATH)
           echo "GOPATH=$GOPATH" >> $GITHUB_ENV
           echo "$GOPATH/bin" >> $GITHUB_PATH
-
       - name: Disable ufw
         # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
         # Not needed for KIND deployments, so just disable all the time.
         run: |
           sudo ufw disable
-
       - uses: actions/download-artifact@v2
         with:
-          name: test-image
+          name: test-image-pr
       - name: Load docker image
         run: |
-          docker load --input image.tar
-
+          docker load --input image-pr.tar
       - name: kind setup
         run: |
-          export OVN_IMAGE="ovn-daemonset-f:dev"
+          export OVN_IMAGE="ovn-daemonset-f:pr"
           make -C test install-kind
-
       - name: Run Tests
         run: |
           make -C test ${{ matrix.target.shard }}
-
       - name: Upload Junit Reports
         if: always()
         uses: actions/upload-artifact@v2
@@ -451,7 +581,6 @@ jobs:
         run: |
           mkdir -p /tmp/kind/logs
           kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
-
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v2

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,6 +12,10 @@ install-kind:
 	KIND_IPV6_SUPPORT=$(KIND_IPV6_SUPPORT) \
 	./scripts/install-kind.sh
 
+.PHONY : upgrade-ovn
+upgrade-ovn:
+	./scripts/upgrade-ovn.sh
+
 .PHONY: shard-%
 shard-%:
 	E2E_REPORT_DIR=$(E2E_REPORT_DIR) \

--- a/test/scripts/upgrade-ovn.sh
+++ b/test/scripts/upgrade-ovn.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+# always exit on errors
+set -ex
+
+
+export KUBECONFIG=${HOME}/admin.conf
+export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-f:pr}
+
+kubectl_wait_pods() {
+  # Check that everything is fine and running. IPv6 cluster seems to take a little
+  # longer to come up, so extend the wait time.
+  OVN_TIMEOUT=900s
+  if [ "$KIND_IPV6_SUPPORT" == true ]; then
+    OVN_TIMEOUT=1400s
+  fi
+  if ! kubectl wait -n ovn-kubernetes --for=condition=ready pods --all --timeout=${OVN_TIMEOUT} ; then
+    echo "some pods in OVN Kubernetes are not running"
+    kubectl get pods -A -o wide || true
+    kubectl describe po -n ovn-kubernetes
+    exit 1
+  fi
+  if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=300s ; then
+    echo "some pods in the system are not running"
+    kubectl get pods -A -o wide || true
+    kubectl describe po -A
+    exit 1
+  fi
+}
+
+kubectl_wait_daemonset(){
+  # takes one daemonset and makes sure its desiredNumberScheduled and numberReady are equal
+  local retries=0
+  local attempts=15
+  while true; do
+    sleep 30
+    run_kubectl get daemonsets.apps $1 -n ovn-kubernetes
+    DESIRED_REPLICAS=$(run_kubectl get daemonsets.apps $1 -n ovn-kubernetes -o=jsonpath='{.status.desiredNumberScheduled}')
+    READY_REPLICAS=$(run_kubectl get daemonsets.apps $1 -n ovn-kubernetes -o=jsonpath='{.status.numberReady}')
+    echo "CURRENT READY REPLICAS: $READY_REPLICAS, CURRENT DESIRED REPLICAS: $DESIRED_REPLICAS for the DaemonSet $1"
+    if [[ $READY_REPLICAS -eq $DESIRED_REPLICAS ]]; then
+      UP_TO_DATE_REPLICAS=$(run_kubectl get daemonsets.apps ovnkube-node -n ovn-kubernetes  -o=jsonpath='{.status.updatedNumberScheduled}')
+      echo "CURRENT UP TO DATE REPLICAS: $UP_TO_DATE_REPLICAS for the Deployment $1"
+      if [[ $READY_REPLICAS -eq $UP_TO_DATE_REPLICAS ]]; then
+        break
+      fi
+    fi
+    ((retries += 1))
+    if [[ "${retries}" -gt ${attempts} ]]; then
+      echo "error: daemonset did not succeed, failing"
+      exit 1
+    fi
+  done
+  
+}
+
+kubectl_wait_deployment(){
+  # takes one deployment and makes sure its replicas and readyReplicas are equal
+  local retries=0
+  local attempts=30
+  while true; do
+    sleep 30
+    run_kubectl get deployments.apps $1 -n ovn-kubernetes 
+    DESIRED_REPLICAS=$(run_kubectl get deployments.apps $1 -n ovn-kubernetes -o=jsonpath='{.status.replicas}')
+    READY_REPLICAS=$(run_kubectl get deployments.apps $1 -n ovn-kubernetes -o=jsonpath='{.status.readyReplicas}')
+    echo "CURRENT READY REPLICAS: $READY_REPLICAS, CURRENT DESIRED REPLICAS: $DESIRED_REPLICAS for the Deployment $1"
+    if [[ $READY_REPLICAS -eq $DESIRED_REPLICAS ]]; then
+      UP_TO_DATE_REPLICAS=$(run_kubectl get deployments.apps ovnkube-master -n ovn-kubernetes -o=jsonpath='{.status.updatedReplicas}')
+      echo "CURRENT UP TO DATE REPLICAS: $UP_TO_DATE_REPLICAS for the Deployment $1"
+      if [[ $READY_REPLICAS -eq $UP_TO_DATE_REPLICAS ]]; then
+        break
+      fi
+    fi
+    ((retries += 1))
+    if [[ "${retries}" -gt ${attempts} ]]; then
+      echo "error: deployment did not succeed, failing"
+      exit 1
+    fi
+  done
+  
+}
+
+run_kubectl() {
+  local retries=0
+  local attempts=10
+  while true; do
+    if kubectl "$@"; then
+      break
+    fi
+
+    ((retries += 1))
+    if [[ "${retries}" -gt ${attempts} ]]; then
+      echo "error: 'kubectl $*' did not succeed, failing"
+      exit 1
+    fi
+    echo "info: waiting for 'kubectl $*' to succeed..."
+    sleep 1
+  done
+}
+
+
+install_ovn_image() {
+  kind load docker-image "${OVN_IMAGE}" --name "${KIND_CLUSTER_NAME}"
+}
+
+kubectl_wait_for_upgrade(){
+    # waits until new image is updated into all relevant pods
+    count=0
+    while [ $count -lt 5 ];
+    do
+        echo "waiting for ovnkube-master, ovnkube-node, ovnkube-db to have new image, ${OVN_IMAGE}, sleeping 30 seconds"
+        sleep 30
+        count=$(run_kubectl get pods -n ovn-kubernetes -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}'|grep -c ${OVN_IMAGE})
+        echo "Currently count is $count, expected 5"
+    done;
+
+}
+
+## This script is responsible to upgrade ovn daemonsets to run new pods with image built from a PR
+install_ovn_image
+run_kubectl set image daemonsets.apps ovnkube-node ovnkube-node="${OVN_IMAGE}" ovs-metrics-exporter="${OVN_IMAGE}"  ovn-controller="${OVN_IMAGE}" -n ovn-kubernetes
+kubectl_wait_daemonset ovnkube-node
+
+run_kubectl get all -n ovn-kubernetes
+CURRENT_REPLICAS_OVNKUBE_DB=$(run_kubectl get deploy -n ovn-kubernetes ovnkube-db -o=jsonpath='{.spec.replicas}')
+run_kubectl scale deploy -n ovn-kubernetes ovnkube-db --replicas=0
+run_kubectl set image deploy  ovnkube-db nb-ovsdb="${OVN_IMAGE}" sb-ovsdb="${OVN_IMAGE}" -n ovn-kubernetes
+run_kubectl scale deploy -n ovn-kubernetes ovnkube-db --replicas=$CURRENT_REPLICAS_OVNKUBE_DB
+kubectl_wait_deployment ovnkube-db
+
+CURRENT_REPLICAS_OVNKUBE_MASTER=$(run_kubectl get deploy -n ovn-kubernetes ovnkube-master -o=jsonpath='{.spec.replicas}')
+
+# scaling down replica before changing image briefly helps get around an issue seen with KIND
+# The issue was sometimes the KIND cluster won't scale down the ovnkube-master pod in time
+# and the new pod with the new image would be stuck in "Pending" state
+run_kubectl scale deploy -n ovn-kubernetes ovnkube-master --replicas=0
+
+run_kubectl set image deploy  ovnkube-master ovn-northd="${OVN_IMAGE}" nbctl-daemon="${OVN_IMAGE}" ovnkube-master="${OVN_IMAGE}" -n ovn-kubernetes
+
+run_kubectl scale deploy -n ovn-kubernetes ovnkube-master --replicas=$CURRENT_REPLICAS_OVNKUBE_MASTER
+kubectl_wait_deployment ovnkube-master
+kubectl_wait_for_upgrade
+
+run_kubectl describe ds ovnkube-node -n ovn-kubernetes
+
+run_kubectl describe deployments.apps ovnkube-master -n ovn-kubernetes


### PR DESCRIPTION


**- What this PR does and why is it needed**
Addresses issue #2132


1.  Deploys KIND using current origin/master HEAD
2.  Builds a new docker image for current PR.
3.  Rolls out new image for ovnkube-node daemonset.
4.  Rolls out new image for ovnkube-master daemonset (workers need to upgrade before masters)
5.  Run e2e tests suite

I'd be happy to address any required changes, and reserve any "Nice to Haves" for a follow-up PR, as this is my first time working on GH actions, would like to keep it simple.

**- Special notes for reviewers**
As per discussion in the community meeting on 21st Apr, added Upgrade procedure as part of e2e tests, so for every new PR, and every test, we are upgrading from a KIND-OVN cluster built on master branch to the cluster built using the code in the PR. And then conduct the usual e2e testing.

**- How to verify it**
If all the jobs on this PR pass, the code can be considered as verified. I have seen some flakey failures in coveralls and sometimes in upgrade process where KIND cluster doesn't properly roll out new version of ovnkuber-master deployment.
