### PR TITLE
Fixes statically linking CNI binary

### DIFF
--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -24,10 +24,10 @@ build_binaries() {
     for bin in "$@"; do
         binbase=$(basename ${bin})
         CGO_ENABLED=1
-        if [[ "$binbase" == "ovn-k8s-cni-overlay" ]]; then
+        if [ "$binbase" = "ovn-k8s-cni-overlay" ]; then
             CGO_ENABLED=0
         fi
-        go build -v \
+        env CGO_ENABLED=$CGO_ENABLED go build -v \
             -mod vendor \
             -gcflags "${GCFLAGS}" \
             -ldflags "-B ${BUILDID} \


### PR DESCRIPTION
On F34 the binary is being built with dynamic linkage. This fixes it to
use static and prints out the value during make so we can ensure from
logs that it is built correctly.

Signed-off-by: Tim Rozet <trozet@redhat.com>

