### PR TITLE
Fixes data race in hybrid overlay tests

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node.go
@@ -35,6 +35,19 @@ type Node struct {
 	controller       nodeController
 	nodeEventHandler informer.EventHandler
 	podEventHandler  informer.EventHandler
+	sync.Mutex
+}
+
+func (n *Node) IsReady() bool {
+	n.Lock()
+	defer n.Unlock()
+	return n.ready
+}
+
+func (n *Node) setReady(b bool) {
+	n.Lock()
+	defer n.Unlock()
+	n.ready = b
 }
 
 func nodeChanged(old, new interface{}) bool {
@@ -157,7 +170,7 @@ func (n *Node) Run(stopCh <-chan struct{}) {
 	}()
 
 	klog.Info("Started Hybrid Overlay Node workers")
-	n.ready = true
+	n.setReady(true)
 	<-stopCh
 	klog.Info("Shutting down Hybrid Overlay Node workers")
 	wg.Wait()

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -571,7 +571,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			}()
 
 			// Wait for the controller to start
-			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.ready == true, nil })
+			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.IsReady() == true, nil })
 			Expect(err).NotTo(HaveOccurred())
 
 			// FIXME
@@ -648,7 +648,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			}()
 
 			// Wait for the controller to start
-			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.ready == true, nil })
+			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.IsReady() == true, nil })
 			Expect(err).NotTo(HaveOccurred())
 
 			// FIXME


### PR DESCRIPTION
There was some unsafe access to checking if the node was ready in the
tests.

Signed-off-by: Tim Rozet <trozet@redhat.com>

