### PR TITLE
Remove improper checks for pod routes

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -171,9 +171,7 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 			otherDefaultRoute = otherDefaultRouteV6
 		}
 		var gatewayIP net.IP
-		hasRoutingExternalGWs := len(oc.getRoutingExternalGWs(pod.Namespace).gws) > 0
-		hasPodRoutingGWs := len(oc.getRoutingPodGWs(pod.Namespace)) > 0
-		if otherDefaultRoute || (hasRoutingExternalGWs && hasPodRoutingGWs) {
+		if otherDefaultRoute {
 			for _, clusterSubnet := range config.Default.ClusterSubnets {
 				if isIPv6 == utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
 					podAnnotation.Routes = append(podAnnotation.Routes, util.PodRoute{
@@ -194,7 +192,7 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 			gatewayIP = gatewayIPnet.IP
 		}
 
-		if len(config.HybridOverlay.ClusterSubnets) > 0 && !hasRoutingExternalGWs && !hasPodRoutingGWs {
+		if len(config.HybridOverlay.ClusterSubnets) > 0 {
 			// Add a route for each hybrid overlay subnet via the hybrid
 			// overlay port on the pod's logical switch.
 			nextHop := util.GetNodeHybridOverlayIfAddr(nodeSubnet).IP


### PR DESCRIPTION
This was leftover from removing hybrid overlay external gateway.
Basically we dont need to add pod and service network routes when using
the routing external gateway. That traffic will always go to OVN anyway.

Also, we still need a route for hybrid overlay subnets in order to get
traffic to those subnets for HO purposes, regardless of if routing
external gateways are used for default egress traffic.

Signed-off-by: Tim Rozet <trozet@redhat.com>
