### PR TITLE
Fix pod -> svc -> host LGW flow

### DIFF
--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -134,8 +134,14 @@ func createPerNodeVIPs(svcIPs []string, protocol v1.Protocol, sourcePort int32, 
 			continue
 		}
 
-		// If self ip is in target list, we need to use special IP to allow hairpin back to host
-		newTargets := util.UpdateIPsSlice(targetIPs, physicalIPs, []string{types.V4HostMasqueradeIP, types.V6HostMasqueradeIP})
+		var newTargets []string
+
+		if config.Gateway.Mode == config.GatewayModeShared {
+			// If self ip is in target list, we need to use special IP to allow hairpin back to host
+			newTargets = util.UpdateIPsSlice(targetIPs, physicalIPs, []string{types.V4HostMasqueradeIP, types.V6HostMasqueradeIP})
+		} else {
+			newTargets = targetIPs
+		}
 
 		err = loadbalancer.CreateLoadBalancerVIPs(gatewayLB, svcIPs, sourcePort, newTargets, targetPort)
 		if err != nil {
@@ -188,8 +194,14 @@ func createPerNodePhysicalVIPs(isIPv6 bool, protocol v1.Protocol, sourcePort int
 			return err
 		}
 
-		// If self ip is in target list, we need to use special IP to allow hairpin back to host
-		newTargets := util.UpdateIPsSlice(targetIPs, physicalIPs, []string{types.V4HostMasqueradeIP, types.V6HostMasqueradeIP})
+		var newTargets []string
+
+		if config.Gateway.Mode == config.GatewayModeShared {
+			// If self ip is in target list, we need to use special IP to allow hairpin back to host
+			newTargets = util.UpdateIPsSlice(targetIPs, physicalIPs, []string{types.V4HostMasqueradeIP, types.V6HostMasqueradeIP})
+		} else {
+			newTargets = targetIPs
+		}
 
 		err = loadbalancer.CreateLoadBalancerVIPs(gatewayLB, physicalIPs, sourcePort, newTargets, targetPort)
 		if err != nil {


### PR DESCRIPTION
In LGW mode the special SGW Hairpin Masquerade IP
is being used in the loadbalancer where it should not
be.  This PR ensures we only use the Masquerade IP
In shared GW when adding backends to loadbalancers
that have the same IP as the VIP.

More information can be found in [BZ 1957039](https://bugzilla.redhat.com/show_bug.cgi?id=1957039)

For Example, Before the Fix the GW LB resembled the following 

```
_uuid               : c3617307-f109-4d2e-9c2d-704166ffd970
external_ids        : {TCP_lb_gateway_router=GR_ovn-worker}
health_check        : []
ip_port_mappings    : {}
name                : ""
options             : {}
protocol            : tcp
selection_fields    : []
vips                : {"172.18.0.2:30081"="169.254.169.2:8081"}
```
Where it incorrectly DNATS Pod -> Svc traffic to `169.254.169.2:8081` Now 
it correctly DNATs the traffic back to the host. 

```
_uuid               : d5d909c3-7e72-4a88-9aa7-7742ee43b8a1
external_ids        : {TCP_lb_gateway_router=GR_ovn-worker2}
health_check        : []
ip_port_mappings    : {}
name                : ""
options             : {}
protocol            : tcp
selection_fields    : []
vips                : {"172.18.0.3:32330"="172.18.0.3:8080"}
```