### PR TITLE
NewAddressSet: return nil in case of error

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -67,7 +67,11 @@ var _ AddressSetFactory = &ovnAddressSetFactory{}
 
 // NewAddressSet returns a new address set object
 func (asf *ovnAddressSetFactory) NewAddressSet(name string, ips []net.IP) (AddressSet, error) {
-	return newOvnAddressSets(name, ips)
+	res, err := newOvnAddressSets(name, ips)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // ForEachAddressSet will pass the unhashed address set name, namespace name


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

newOvnAddressSets returns a concrete type, that gets assigned to an
interface. This makes the interface not being nil (even if the backing
value is).  In particular, having
nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns)
called twice would result in having the interface not being nil but the
value behind it being nil and it will make sequent use of
nsInfo.addressSet refer to a nil value.

More references in 
https://glucn.medium.com/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->