### PR TITLE
policy: remove incorrect deletion from lsp cache

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -595,7 +595,7 @@ func (oc *Controller) localPodDelDefaultDeny(
 			oc.lspIngressDenyCache[portInfo.name]--
 			if oc.lspIngressDenyCache[portInfo.name] == 0 {
 				deleteFromIngress = true
-
+				delete(oc.lspIngressDenyCache, portInfo.name)
 			}
 		}
 	}
@@ -607,6 +607,7 @@ func (oc *Controller) localPodDelDefaultDeny(
 			oc.lspEgressDenyCache[portInfo.name]--
 			if oc.lspEgressDenyCache[portInfo.name] == 0 {
 				deleteFromEgress = true
+				delete(oc.lspEgressDenyCache, portInfo.name)
 			}
 		}
 	}
@@ -699,11 +700,6 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 	}
 
 	oc.localPodDelDefaultDeny(np, nsInfo, portInfo)
-
-	oc.lspMutex.Lock()
-	delete(oc.lspIngressDenyCache, logicalPort)
-	delete(oc.lspEgressDenyCache, logicalPort)
-	oc.lspMutex.Unlock()
 
 	if np.portGroupUUID == "" {
 		return


### PR DESCRIPTION
We were deleting pods from the default-deny lsp caches, even if they
still have other policies that may apply to them.

This could leave pods in the default-deny portgroup even if they no
longer have any policies selecting them (due to label changes).


**- Description for the changelog**
Fixes a bug where pods could still have a default-deny ACL applied to them if their labels were changed. This is very unlikely to be triggered.