### PR TITLE
LGW: Lookup node IPs on every NP/LB/EIP service event

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -29,7 +29,7 @@ const (
 	localnetGatewayExternalIDTable = "6"
 )
 
-func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net.IP, gwIntf string, nodeAnnotator kube.Annotator, recorder record.EventRecorder, cfg *managementPortConfig) (*gateway, error) {
+func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net.IP, gwIntf string, nodeAnnotator kube.Annotator, recorder record.EventRecorder, cfg *managementPortConfig, getLocalAddrs func() (map[string]net.IPNet, error)) (*gateway, error) {
 	gw := &gateway{}
 	var gatewayIfAddrs []*net.IPNet
 	for _, hostSubnet := range hostSubnets {
@@ -63,18 +63,13 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 	patchPort := "patch-" + bridgeName + "_" + nodeName + "-to-br-int"
 
 	if config.Gateway.NodeportEnable {
-		localAddrSet, err := getLocalAddrs()
-		if err != nil {
-			return nil, err
-		}
-
 		if err := initLocalGatewayIPTables(); err != nil {
 			return nil, err
 		}
 		if err := initRoutingRules(); err != nil {
 			return nil, err
 		}
-		gw.localPortWatcher = newLocalPortWatcher(gatewayIfAddrs, recorder, localAddrSet)
+		gw.localPortWatcher = newLocalPortWatcher(gatewayIfAddrs, recorder, getLocalAddrs)
 	}
 
 	gw.readyFunc = func() (bool, error) {
@@ -107,16 +102,16 @@ type localPortWatcher struct {
 	recorder     record.EventRecorder
 	gatewayIPv4  string
 	gatewayIPv6  string
-	localAddrSet map[string]net.IPNet
+	localAddrSet func() (map[string]net.IPNet, error)
 }
 
-func newLocalPortWatcher(gatewayIfAddrs []*net.IPNet, recorder record.EventRecorder, localAddrSet map[string]net.IPNet) *localPortWatcher {
+func newLocalPortWatcher(gatewayIfAddrs []*net.IPNet, recorder record.EventRecorder, localAddrFunc func() (map[string]net.IPNet, error)) *localPortWatcher {
 	gatewayIPv4, gatewayIPv6 := getGatewayFamilyAddrs(gatewayIfAddrs)
 	return &localPortWatcher{
 		recorder:     recorder,
 		gatewayIPv4:  gatewayIPv4,
 		gatewayIPv6:  gatewayIPv6,
-		localAddrSet: localAddrSet,
+		localAddrSet: localAddrFunc,
 	}
 }
 
@@ -155,25 +150,8 @@ func (l *localPortWatcher) DeleteService(svc *kapi.Service) {
 	}
 }
 
-func getLocalAddrs() (map[string]net.IPNet, error) {
-	localAddrSet := make(map[string]net.IPNet)
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return nil, err
-	}
-	for _, addr := range addrs {
-		ip, ipNet, err := net.ParseCIDR(addr.String())
-		if err != nil {
-			return nil, err
-		}
-		localAddrSet[ip.String()] = *ipNet
-	}
-	klog.V(5).Infof("Node local addresses initialized to: %v", localAddrSet)
-	return localAddrSet, nil
-}
-
-func (l *localPortWatcher) networkHasAddress(ip net.IP) bool {
-	for _, net := range l.localAddrSet {
+func (l *localPortWatcher) networkHasAddress(localAddrSet map[string]net.IPNet, ip net.IP) bool {
+	for _, net := range localAddrSet {
 		if net.Contains(ip) {
 			return true
 		}
@@ -185,6 +163,11 @@ func (l *localPortWatcher) addService(svc *kapi.Service) error {
 	// don't process headless service or services that doesn't have NodePorts or ExternalIPs
 	if !util.ServiceTypeHasClusterIP(svc) || !util.IsClusterIPSet(svc) {
 		return nil
+	}
+
+	localAddrSet, err := l.localAddrSet()
+	if err != nil {
+		klog.Errorf("Eror Getting node addresses: %v", err)
 	}
 
 	for _, ip := range util.GetClusterIPs(svc) {
@@ -215,10 +198,10 @@ func (l *localPortWatcher) addService(svc *kapi.Service) error {
 				if utilnet.IsIPv6String(externalIP) != isIPv6Service {
 					continue
 				}
-				if _, exists := l.localAddrSet[externalIP]; exists {
+				if _, exists := localAddrSet[externalIP]; exists {
 					iptRules = append(iptRules, getExternalIPTRules(port, externalIP, ip)...)
 					klog.V(5).Infof("Will add iptables rule for ExternalIP: %s", externalIP)
-				} else if l.networkHasAddress(net.ParseIP(externalIP)) {
+				} else if l.networkHasAddress(localAddrSet, net.ParseIP(externalIP)) {
 					klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip setup", externalIP)
 				} else {
 					if gatewayIP != "" {
@@ -251,6 +234,11 @@ func (l *localPortWatcher) deleteService(svc *kapi.Service) error {
 		return nil
 	}
 
+	localAddrSet, err := l.localAddrSet()
+	if err != nil {
+		klog.Errorf("Eror Getting node addresses: %v", err)
+	}
+
 	for _, ip := range util.GetClusterIPs(svc) {
 		iptRules := []iptRule{}
 		isIPv6Service := utilnet.IsIPv6String(ip)
@@ -276,10 +264,10 @@ func (l *localPortWatcher) deleteService(svc *kapi.Service) error {
 				if utilnet.IsIPv6String(externalIP) != isIPv6Service {
 					continue
 				}
-				if _, exists := l.localAddrSet[externalIP]; exists {
+				if _, exists := localAddrSet[externalIP]; exists {
 					iptRules = append(iptRules, getExternalIPTRules(port, externalIP, ip)...)
 					klog.V(5).Infof("Will delete iptables rule for ExternalIP: %s", externalIP)
-				} else if l.networkHasAddress(net.ParseIP(externalIP)) {
+				} else if l.networkHasAddress(localAddrSet, net.ParseIP(externalIP)) {
 					klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip cleanup", externalIP)
 				} else {
 					if gatewayIP != "" {

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -24,16 +24,6 @@ const (
 	v6localnetGatewayIP = "fd00:96:1::1"
 )
 
-func getFakeLocalAddrs() map[string]net.IPNet {
-	localAddrSet := make(map[string]net.IPNet)
-	for _, network := range []string{"127.0.0.1/32", "10.10.10.1/24", "fd00:96:1::1/64"} {
-		ip, ipNet, err := net.ParseCIDR(network)
-		Expect(err).NotTo(HaveOccurred())
-		localAddrSet[ip.String()] = *ipNet
-	}
-	return localAddrSet
-}
-
 func initFakeNodePortWatcher(fakeOvnNode *FakeOVNNode, iptV4, iptV6 util.IPTablesHelper) *localPortWatcher {
 	initIPTable := map[string]util.FakeTable{
 		"nat": {},
@@ -47,10 +37,20 @@ func initFakeNodePortWatcher(fakeOvnNode *FakeOVNNode, iptV4, iptV6 util.IPTable
 	err = f6.MatchState(initIPTable)
 	Expect(err).NotTo(HaveOccurred())
 
+	fakeLocalAddrSet := func() (map[string]net.IPNet, error) {
+		localAddrSet := make(map[string]net.IPNet)
+		for _, network := range []string{"127.0.0.1/32", "10.10.10.1/24", "fd00:96:1::1/64"} {
+			ip, ipNet, err := net.ParseCIDR(network)
+			Expect(err).NotTo(HaveOccurred())
+			localAddrSet[ip.String()] = *ipNet
+		}
+		return localAddrSet, nil
+	}
+
 	fNPW := localPortWatcher{
 		recorder:     fakeOvnNode.recorder,
 		gatewayIPv4:  v4localnetGatewayIP,
-		localAddrSet: getFakeLocalAddrs(),
+		localAddrSet: fakeLocalAddrSet,
 	}
 	return &fNPW
 }


### PR DESCRIPTION
This Commit ensures that the correct IPtables rules are added for
externalIP services in the case that a secondary node IP was added
after ovnkube-node had already been started.

It simply looks up the node ips for each service event rather than
storing the ips in memory.

This PR is in response to the [following bug](https://bugzilla.redhat.com/show_bug.cgi?id=1959798)

 closes #2226 