### PR TITLE
Fix ovn-controller log level var name

### DIFF
--- a/dist/images/run-smart-nic-ovn.sh
+++ b/dist/images/run-smart-nic-ovn.sh
@@ -1,7 +1,7 @@
 docker run --pid host --network host --user=0 --name ovn -dit --cap-add=SYS_NICE -v /var/run/dbus:/var/run/dbus:ro -v \
  /var/log/openvswitch:/var/log/openvswitch -v /var/log/openvswitch:/var/log/ovn -v  \
  /var/run/openvswitch:/var/run/openvswitch -v /var/run/openvswitch:/var/run/ovn -v $K8S_CACERT:$K8S_CACERT -v \
- /etc/ovn:/ovn-cert:ro -e OVN_DAEMONSET_VERSION=3 -e OVN_LOG_CONTROLLER="-vconsole:info" \
+ /etc/ovn:/ovn-cert:ro -e OVN_DAEMONSET_VERSION=3 -e OVN_LOGLEVEL_CONTROLLER="-vconsole:info" \
  -e K8S_APISERVER=$K8S_APISERVER -e OVN_KUBERNETES_NAMESPACE=ovn-kubernetes -e OVN_SSL_ENABLE=no \
  -e K8S_NODE=$K8S_NODE -e K8S_TOKEN=$K8S_TOKEN -e K8S_CACERT=$K8S_CACERT --entrypoint=/root/ovnkube.sh \
  ovn-daemonset:latest "ovn-controller"

--- a/dist/images/run-smart-nic-ovnkube-node.sh
+++ b/dist/images/run-smart-nic-ovnkube-node.sh
@@ -3,7 +3,7 @@ docker run --pid host --network host --user=0 --name ovn-node -dit --cap-add=NET
   -v /var/log/ovn-kubernetes:/var/log/ovn-kubernetes  -v /var/run/openvswitch:/var/run/openvswitch/ \
   -v /var/run/openvswitch:/var/run/ovn/ -v /var/run/ovn-kubernetes:/var/run/ovn-kubernetes \
   -v /etc/ovn:/ovn-cert:ro -v /var/lib/openvswitch:/etc/openvswitch:ro -v /var/lib/openvswitch:/etc/ovn:ro \
-  -e OVN_DAEMONSET_VERSION=3 -e OVN_LOG_CONTROLLER="-vconsole:info" \
+  -e OVN_DAEMONSET_VERSION=3 -e OVN_LOGLEVEL_CONTROLLER="-vconsole:info" \
   -e OVN_NET_CIDR=$OVN_NET_CIDR -e OVN_SVC_CIDR=$OVN_SVC_CIDR -e K8S_NODE=$K8S_NODE  \
   -e OVN_GATEWAY_MODE="shared" -e  OVN_REMOTE_PROBE_INTERVAL=100000 -e K8S_APISERVER=$K8S_APISERVER \
   -e OVN_KUBERNETES_NAMESPACE=ovn-kubernetes -e OVN_SSL_ENABLE=no -e OVNKUBE_NODE_MODE="smart-nic" \

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -224,7 +224,7 @@ spec:
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"
-        - name: OVN_LOG_CONTROLLER
+        - name: OVN_LOGLEVEL_CONTROLLER
           value: "{{ ovn_loglevel_controller }}"
         - name: K8S_APISERVER
           valueFrom:


### PR DESCRIPTION
The `ovnkube.sh` script looks for the `OVN_LOGLEVEL_CONTROLLER environment variable for ovn-controller log level.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

