### PR TITLE
Smart-NIC Remove VF Representor port on OVS failure

### DIFF
--- a/go-controller/pkg/node/node_smartnic.go
+++ b/go-controller/pkg/node/node_smartnic.go
@@ -130,13 +130,14 @@ func (n *OvnNode) addRepPort(pod *kapi.Pod, vfRepName string, ifInfo *cni.PodInt
 
 	err := cni.ConfigureOVS(context.TODO(), pod.Namespace, pod.Name, vfRepName, ifInfo, smartNicCD.SandboxId)
 	if err != nil {
+		// Note(adrianc): we are lenient with cleanup in this method as pod is going to be retried anyway.
+		_ = n.delRepPort(vfRepName)
 		return err
 	}
 	klog.Infof("Port %s added to bridge br-int", vfRepName)
 
 	link, err := util.GetNetLinkOps().LinkByName(vfRepName)
 	if err != nil {
-		// Note(adrianc): we are lenient with cleanup in this method as pod is going to be retried anyway.
 		_ = n.delRepPort(vfRepName)
 		return fmt.Errorf("failed to get link device for interface %s", vfRepName)
 	}

--- a/go-controller/pkg/node/node_smartnic_test.go
+++ b/go-controller/pkg/node/node_smartnic_test.go
@@ -144,6 +144,12 @@ var _ = Describe("Node Smart NIC tests", func() {
 				Cmd: genOVSAddPortCmd(vfRep, genIfaceID(pod.Namespace, pod.Name), "", "", "a8d09931"),
 				Err: fmt.Errorf("failed to run ovs command"),
 			})
+			// Mock netlink/ovs calls for cleanup
+			netlinkOpsMock.On("LinkByName", vfRep).Return(vfLink, nil)
+			netlinkOpsMock.On("LinkSetDown", vfLink).Return(nil)
+			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd: genOVSDelPortCmd("pf0vf9"),
+			})
 
 			// call addRepPort()
 			err := node.addRepPort(&pod, vfRep, ifInfo)


### PR DESCRIPTION
ConfigureOVS() method may fail after adding VF representor
Port to br-int, e.g if timeout is reached while waiting for
OVS flows.

If this happens, remove VF representor from br-int to allow retry.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>