### PR TITLE
Fix error message

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -152,7 +152,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair bool) er
 		// and handles removal of stale data on upgrades
 		klog.Info("Remove stale OVN services")
 		if err := c.repair.runOnce(); err != nil {
-			klog.Errorf("Error repairing services: %v")
+			klog.Errorf("Error repairing services: %v", err)
 		}
 	}
 	// Start the workers after the repair loop to avoid races


### PR DESCRIPTION
prevents prints like:

`42 services_controller.go:154] Error repairing services: %!v(MISSING)`

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>

