### PR TITLE
Fix lgw external ip

### DIFF
--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -63,18 +63,10 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 	patchPort := "patch-" + bridgeName + "_" + nodeName + "-to-br-int"
 
 	if config.Gateway.NodeportEnable {
-		localAddrSet, err := getLocalAddrs()
-		if err != nil {
-			return nil, err
-		}
-
 		if err := initLocalGatewayIPTables(); err != nil {
 			return nil, err
 		}
-		if err := initRoutingRules(); err != nil {
-			return nil, err
-		}
-		gw.localPortWatcher = newLocalPortWatcher(gatewayIfAddrs, recorder, localAddrSet)
+		gw.localPortWatcher = newLocalPortWatcher(gatewayIfAddrs, recorder)
 	}
 
 	gw.readyFunc = func() (bool, error) {
@@ -104,19 +96,17 @@ func getGatewayFamilyAddrs(gatewayIfAddrs []*net.IPNet) (string, string) {
 }
 
 type localPortWatcher struct {
-	recorder     record.EventRecorder
-	gatewayIPv4  string
-	gatewayIPv6  string
-	localAddrSet map[string]net.IPNet
+	recorder    record.EventRecorder
+	gatewayIPv4 string
+	gatewayIPv6 string
 }
 
-func newLocalPortWatcher(gatewayIfAddrs []*net.IPNet, recorder record.EventRecorder, localAddrSet map[string]net.IPNet) *localPortWatcher {
+func newLocalPortWatcher(gatewayIfAddrs []*net.IPNet, recorder record.EventRecorder) *localPortWatcher {
 	gatewayIPv4, gatewayIPv6 := getGatewayFamilyAddrs(gatewayIfAddrs)
 	return &localPortWatcher{
-		recorder:     recorder,
-		gatewayIPv4:  gatewayIPv4,
-		gatewayIPv6:  gatewayIPv6,
-		localAddrSet: localAddrSet,
+		recorder:    recorder,
+		gatewayIPv4: gatewayIPv4,
+		gatewayIPv6: gatewayIPv6,
 	}
 }
 
@@ -172,17 +162,8 @@ func getLocalAddrs() (map[string]net.IPNet, error) {
 	return localAddrSet, nil
 }
 
-func (l *localPortWatcher) networkHasAddress(ip net.IP) bool {
-	for _, net := range l.localAddrSet {
-		if net.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
-
 func (l *localPortWatcher) addService(svc *kapi.Service) error {
-	// don't process headless service or services that doesn't have NodePorts or ExternalIPs
+	// don't process headless service or services that do not have NodePorts or ExternalIPs
 	if !util.ServiceTypeHasClusterIP(svc) || !util.IsClusterIPSet(svc) {
 		return nil
 	}
@@ -194,8 +175,6 @@ func (l *localPortWatcher) addService(svc *kapi.Service) error {
 		if isIPv6Service {
 			gatewayIP = l.gatewayIPv6
 		}
-		// holds map of external ips and if they are currently using routes
-		routeUsage := make(map[string]bool)
 		for _, port := range svc.Spec.Ports {
 			// Fix Azure/GCP LoadBalancers. They will forward traffic directly to the node with the
 			// dest address as the load-balancer ingress IP and port
@@ -215,26 +194,10 @@ func (l *localPortWatcher) addService(svc *kapi.Service) error {
 				if utilnet.IsIPv6String(externalIP) != isIPv6Service {
 					continue
 				}
-				if _, exists := l.localAddrSet[externalIP]; exists {
-					iptRules = append(iptRules, getExternalIPTRules(port, externalIP, ip)...)
-					klog.V(5).Infof("Will add iptables rule for ExternalIP: %s", externalIP)
-				} else if l.networkHasAddress(net.ParseIP(externalIP)) {
-					klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip setup", externalIP)
-				} else {
-					if gatewayIP != "" {
-						routeUsage[externalIP] = true
-					} else {
-						klog.Warningf("No gateway of appropriate IP family for ExternalIP %s for Service %s/%s",
-							externalIP, svc.Namespace, svc.Name)
-					}
-				}
-			}
-		}
-		for externalIP := range routeUsage {
-			if stdout, stderr, err := util.RunIP("route", "replace", externalIP, "via", gatewayIP, "dev", types.K8sMgmtIntfName, "table", localnetGatewayExternalIDTable); err != nil {
-				klog.Errorf("Error adding routing table entry for ExternalIP %s, via gw: %s: stdout: %s, stderr: %s, err: %v", externalIP, gatewayIP, stdout, stderr, err)
-			} else {
-				klog.Infof("Successfully added route for ExternalIP: %s", externalIP)
+
+				iptRules = append(iptRules, getExternalIPTRules(port, externalIP, ip)...)
+				klog.V(5).Infof("Adding iptables rules for service: %s with external IP: %s", svc.Name, externalIP)
+
 			}
 		}
 		klog.Infof("Adding iptables rules: %v for service: %v", iptRules, svc.Name)
@@ -258,8 +221,6 @@ func (l *localPortWatcher) deleteService(svc *kapi.Service) error {
 		if isIPv6Service {
 			gatewayIP = l.gatewayIPv6
 		}
-		// holds map of external ips and if they are currently using routes
-		routeUsage := make(map[string]bool)
 		// Note that unlike with addService we just silently ignore IPv4/IPv6 mismatches here
 		for _, port := range svc.Spec.Ports {
 			// Fix Azure/GCP LoadBalancers. They will forward traffic directly to the node with the
@@ -276,24 +237,10 @@ func (l *localPortWatcher) deleteService(svc *kapi.Service) error {
 				if utilnet.IsIPv6String(externalIP) != isIPv6Service {
 					continue
 				}
-				if _, exists := l.localAddrSet[externalIP]; exists {
-					iptRules = append(iptRules, getExternalIPTRules(port, externalIP, ip)...)
-					klog.V(5).Infof("Will delete iptables rule for ExternalIP: %s", externalIP)
-				} else if l.networkHasAddress(net.ParseIP(externalIP)) {
-					klog.V(5).Infof("ExternalIP: %s is reachable through one of the interfaces on this node, will skip cleanup", externalIP)
-				} else {
-					if gatewayIP != "" {
-						routeUsage[externalIP] = true
-					}
-				}
-			}
-		}
 
-		for externalIP := range routeUsage {
-			if stdout, stderr, err := util.RunIP("route", "del", externalIP, "via", gatewayIP, "dev", types.K8sMgmtIntfName, "table", localnetGatewayExternalIDTable); err != nil {
-				klog.Errorf("Error delete routing table entry for ExternalIP %s: stdout: %s, stderr: %s, err: %v", externalIP, stdout, stderr, err)
-			} else {
-				klog.Infof("Successfully deleted route for ExternalIP: %s", externalIP)
+				iptRules = append(iptRules, getExternalIPTRules(port, externalIP, ip)...)
+				klog.V(5).Infof("Will delete iptables rule for ExternalIP: %s", externalIP)
+
 			}
 		}
 
@@ -306,31 +253,7 @@ func (l *localPortWatcher) deleteService(svc *kapi.Service) error {
 }
 
 func (l *localPortWatcher) SyncServices(serviceInterface []interface{}) {
-	removeStaleRoutes := func(keepRoutes []string) {
-		stdout, stderr, err := util.RunIP("route", "list", "table", localnetGatewayExternalIDTable)
-		if err != nil || stdout == "" {
-			klog.Infof("No routing table entries for ExternalIP table %s: stdout: %s, stderr: %s, err: %v",
-				localnetGatewayExternalIDTable, stdout, strings.Replace(stderr, "\n", "", -1), err)
-			return
-		}
-		for _, existingRoute := range strings.Split(stdout, "\n") {
-			isFound := false
-			for _, keepRoute := range keepRoutes {
-				if strings.Contains(existingRoute, keepRoute) {
-					isFound = true
-					break
-				}
-			}
-			if !isFound {
-				klog.Infof("Deleting stale routing rule: %s", existingRoute)
-				if _, stderr, err := util.RunIP("route", "del", existingRoute, "table", localnetGatewayExternalIDTable); err != nil {
-					klog.Errorf("Error deleting stale routing rule: stderr: %s, err: %v", stderr, err)
-				}
-			}
-		}
-	}
 	keepIPTRules := []iptRule{}
-	keepRoutes := []string{}
 	for _, service := range serviceInterface {
 		svc, ok := service.(*kapi.Service)
 		if !ok {
@@ -338,25 +261,17 @@ func (l *localPortWatcher) SyncServices(serviceInterface []interface{}) {
 			continue
 		}
 		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, []string{l.gatewayIPv4, l.gatewayIPv6})...)
-		keepRoutes = append(keepRoutes, svc.Spec.ExternalIPs...)
 	}
 	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
 		recreateIPTRules("nat", chain, keepIPTRules)
 	}
-	removeStaleRoutes(keepRoutes)
-}
 
-func initRoutingRules() error {
-	stdout, stderr, err := util.RunIP("rule")
-	if err != nil {
-		return fmt.Errorf("error listing routing rules, stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+	// Previously LGW used routes in the localnetGatewayExternalIDTable, to handle
+	// upgrades correctly make sure we flush this table of all routes
+	klog.Infof("Flushing host's routing table: %s", localnetGatewayExternalIDTable)
+	if _, stderr, err := util.RunIP("route", "flush", "table", localnetGatewayExternalIDTable); err != nil {
+		klog.Errorf("Error flushing host's routing table: %s stderr: %s err: %v", localnetGatewayExternalIDTable, stderr, err)
 	}
-	if !strings.Contains(stdout, fmt.Sprintf("from all lookup %s", localnetGatewayExternalIDTable)) {
-		if stdout, stderr, err := util.RunIP("rule", "add", "from", "all", "table", localnetGatewayExternalIDTable); err != nil {
-			return fmt.Errorf("error adding routing rule for ExternalIP table (%s): stdout: %s, stderr: %s, err: %v", localnetGatewayExternalIDTable, stdout, stderr, err)
-		}
-	}
-	return nil
 }
 
 func cleanupLocalnetGateway(physnet string) error {

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"fmt"
-	"net"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,16 +23,6 @@ const (
 	v6localnetGatewayIP = "fd00:96:1::1"
 )
 
-func getFakeLocalAddrs() map[string]net.IPNet {
-	localAddrSet := make(map[string]net.IPNet)
-	for _, network := range []string{"127.0.0.1/32", "10.10.10.1/24", "fd00:96:1::1/64"} {
-		ip, ipNet, err := net.ParseCIDR(network)
-		Expect(err).NotTo(HaveOccurred())
-		localAddrSet[ip.String()] = *ipNet
-	}
-	return localAddrSet
-}
-
 func initFakeNodePortWatcher(fakeOvnNode *FakeOVNNode, iptV4, iptV6 util.IPTablesHelper) *localPortWatcher {
 	initIPTable := map[string]util.FakeTable{
 		"nat": {},
@@ -48,9 +37,8 @@ func initFakeNodePortWatcher(fakeOvnNode *FakeOVNNode, iptV4, iptV6 util.IPTable
 	Expect(err).NotTo(HaveOccurred())
 
 	fNPW := localPortWatcher{
-		recorder:     fakeOvnNode.recorder,
-		gatewayIPv4:  v4localnetGatewayIP,
-		localAddrSet: getFakeLocalAddrs(),
+		recorder:    fakeOvnNode.recorder,
+		gatewayIPv4: v4localnetGatewayIP,
 	}
 	return &fNPW
 }
@@ -59,9 +47,7 @@ func startLocalPortWatcher(l *localPortWatcher, wf factory.NodeWatchFactory) err
 	if err := initLocalGatewayIPTables(); err != nil {
 		return err
 	}
-	if err := initRoutingRules(); err != nil {
-		return err
-	}
+
 	wf.AddServiceHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			svc := obj.(*kapi.Service)
@@ -127,76 +113,13 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on startup", func() {
-		It("inits physical routing rules", func() {
-			app.Action = func(ctx *cli.Context) error {
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ip rule",
-					Output: "0:	from all lookup local\n32766:	from all lookup main\n32767:	from all lookup default\n",
-				})
-				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					"ip rule add from all table " + localnetGatewayExternalIDTable,
-				})
-				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					"ip route list table " + localnetGatewayExternalIDTable,
-				})
-
-				fakeOvnNode.start(ctx)
-				startLocalPortWatcher(fNPW, fakeOvnNode.watcher)
-
-				expectedTables := map[string]util.FakeTable{
-					"nat": {
-						"PREROUTING": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OUTPUT": []string{
-							"-j OVN-KUBE-EXTERNALIP",
-							"-j OVN-KUBE-NODEPORT",
-						},
-						"OVN-KUBE-NODEPORT":   []string{},
-						"OVN-KUBE-EXTERNALIP": []string{},
-					},
-				}
-				f4 := iptV4.(*util.FakeIPTables)
-				err := f4.MatchState(expectedTables)
-				Expect(err).NotTo(HaveOccurred())
-
-				expectedTables = map[string]util.FakeTable{
-					"nat": {},
-				}
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables)
-				Expect(err).NotTo(HaveOccurred())
-
-				fakeOvnNode.shutdown()
-				return nil
-			}
-			err := app.Run([]string{app.Name})
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("removes stale physical routing rules while keeping remaining intact", func() {
+		It("removes stale iptables rules while keeping remaining intact", func() {
 			app.Action = func(ctx *cli.Context) error {
 				externalIP := "1.1.1.1"
 				externalIPPort := int32(8032)
-
-				// Create some fake routing and iptable rules
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ip rule",
-					Output: "0:	from all lookup local\n32766:	from all lookup main\n32767:	from all lookup default\n",
-				})
+				// create fake ip route commands
 				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					"ip rule add from all table " + localnetGatewayExternalIDTable,
-				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd:    "ip route list table " + localnetGatewayExternalIDTable,
-					Output: fmt.Sprintf("%s via %s dev %s\n9.9.9.9 via %s dev %s\n", externalIP, v4localnetGatewayIP, types.K8sMgmtIntfName, v4localnetGatewayIP, types.K8sMgmtIntfName),
-				})
-				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route del 9.9.9.9 via %s dev %s table %s", v4localnetGatewayIP, types.K8sMgmtIntfName, localnetGatewayExternalIDTable),
-				})
-				fakeOvnNode.fakeExec.AddFakeCmdsNoOutputNoError([]string{
-					fmt.Sprintf("ip route replace %s via %s dev %s table %s", externalIP, v4localnetGatewayIP, types.K8sMgmtIntfName, localnetGatewayExternalIDTable),
+					fmt.Sprintf("ip route flush table %s", localnetGatewayExternalIDTable),
 				})
 
 				service := *newService("service1", "namespace1", "10.129.0.2",
@@ -276,7 +199,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	Context("on add", func() {
-		It("inits physical routing rules with ExternalIP outside any local network", func() {
+		It("inits iptables rules with ExternalIP outside any local network", func() {
 			app.Action = func(ctx *cli.Context) error {
 				externalIP := "1.1.1.1"
 
@@ -298,15 +221,15 @@ var _ = Describe("Node Operations", func() {
 				fNPW.addService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"nat": {},
+					"nat": {
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
 				err := f4.MatchState(expectedTables)
-				Expect(err).NotTo(HaveOccurred())
-
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
 
 				return nil
@@ -315,7 +238,7 @@ var _ = Describe("Node Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("does nothing when ExternalIP on shared network", func() {
+		It("inits iptables rules with ExternalIP on shared network", func() {
 			app.Action = func(ctx *cli.Context) error {
 				externalIP := "10.10.10.2"
 
@@ -333,15 +256,15 @@ var _ = Describe("Node Operations", func() {
 				fNPW.addService(&service)
 
 				expectedTables := map[string]util.FakeTable{
-					"nat": {},
+					"nat": {
+						"OVN-KUBE-EXTERNALIP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
 				err := f4.MatchState(expectedTables)
-				Expect(err).NotTo(HaveOccurred())
-
-				f6 := iptV6.(*util.FakeIPTables)
-				err = f6.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
 
 				return nil

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1935,6 +1935,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 	var nodesHostnames sets.String
 	maxTries := 0
 	var nodes *v1.NodeList
+	var newNodeAddresses []string
 
 	ginkgo.Context("Validating ingress traffic", func() {
 		ginkgo.BeforeEach(func() {
@@ -2067,6 +2068,122 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 
 			for _, protocol := range []string{"http", "udp"} {
 				for _, externalAddress := range addresses {
+					responses := sets.NewString()
+					valid := false
+					externalPort := int32(clusterHTTPPort)
+					if protocol == "udp" {
+						externalPort = int32(clusterUDPPort)
+					}
+
+					ginkgo.By("Hitting the external service on " + externalAddress + " and reaching all the endpoints " + protocol)
+					for i := 0; i < maxTries; i++ {
+						epHostname := pokeEndpointHostname(clientContainerName, protocol, externalAddress, externalPort)
+						responses.Insert(epHostname)
+
+						// each endpoint returns its hostname. By doing this, we validate that each ep was reached at least once.
+						if responses.Equal(nodesHostnames) {
+							framework.Logf("Validated external address %s after %d tries", externalAddress, i)
+							valid = true
+							break
+						}
+					}
+					framework.ExpectEqual(valid, true, "Validation failed for external address", externalAddress)
+				}
+			}
+		})
+	})
+	ginkgo.Context("Validating ExternalIP ingress traffic to manually added node IPs", func() {
+		ginkgo.BeforeEach(func() {
+			endPoints = make([]*v1.Pod, 0)
+			nodesHostnames = sets.NewString()
+
+			var err error
+			nodes, err = e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
+			framework.ExpectNoError(err)
+
+			if len(nodes.Items) < 3 {
+				framework.Failf(
+					"Test requires >= 3 Ready nodes, but there are only %v nodes",
+					len(nodes.Items))
+			}
+
+			ginkgo.By("Creating the endpoints pod, one for each worker")
+			for _, node := range nodes.Items {
+				// this create a udp / http netexec listener which is able to receive the "hostname"
+				// command. We use this to validate that each endpoint is received at least once
+				args := []string{
+					"netexec",
+					fmt.Sprintf("--http-port=%d", endpointHTTPPort),
+					fmt.Sprintf("--udp-port=%d", endpointUDPPort),
+				}
+				pod, err := createPod(f, node.Name+"-ep", node.Name, f.Namespace.Name, []string{}, endpointsSelector, func(p *v1.Pod) {
+					p.Spec.Containers[0].Args = args
+				})
+				framework.ExpectNoError(err)
+				endPoints = append(endPoints, pod)
+				nodesHostnames.Insert(pod.Name)
+
+				// this is arbitrary and mutuated from k8s network e2e tests. We aim to hit all the endpoints at least once
+				maxTries = len(endPoints)*len(endPoints) + 30
+			}
+
+			ginkgo.By("Creating an external container to send the traffic from")
+			// the client uses the netexec command from the agnhost image, which is able to receive commands for poking other
+			// addresses.
+			createClusterExternalContainer(clientContainerName, agnhostImage, []string{"--network", "kind", "-P"}, []string{"netexec", "--http-port=80"})
+
+			ginkgo.By("Adding ip addresses to each node")
+			// add new secondary IP from node subnet to all nodes, if the cluster is v6 add an ipv6 address
+			var newIP string
+			for i, node := range nodes.Items {
+				if utilnet.IsIPv6String(e2enode.GetAddresses(&node, v1.NodeInternalIP)[0]) {
+					newIP = "fc00:f853:ccd:e794::" + strconv.Itoa(i)
+				} else {
+					newIP = "172.18.1." + strconv.Itoa(i)
+				}
+				// manually add the a secondary IP to each node
+				_, err := runCommand("docker", "exec", node.Name, "ip", "addr", "add", newIP, "dev", "breth0")
+				if err != nil {
+					framework.Failf("failed to add new Addresses to node %s: %v", node.Name, err)
+				}
+
+				newNodeAddresses = append(newNodeAddresses, newIP)
+			}
+		})
+
+		ginkgo.AfterEach(func() {
+			deleteClusterExternalContainer(clientContainerName)
+
+			for i, node := range nodes.Items {
+				// delete the secondary IP previoulsy added to the nodes
+				_, err := runCommand("docker", "exec", node.Name, "ip", "addr", "delete", newNodeAddresses[i], "dev", "breth0")
+				if err != nil {
+					framework.Failf("failed to delete new Addresses to node %s: %v", node.Name, err)
+				}
+			}
+		})
+		// This test validates ingress traffic to externalservices after a new node Ip is added.
+		// It creates a service on both udp and tcp and assigns the new node IPs as
+		// external Addresses. Then, creates a backend pod on each node.
+		// The backend pods are using the agnhost - netexec command which replies to commands
+		// with different protocols. We use the "hostname" command to have each backend pod to reply
+		// with its hostname.
+		// We use an external container to poke the service exposed on the node and we iterate until
+		// all the hostnames are returned.
+		ginkgo.It("Should be allowed by externalip services to a new node ip", func() {
+			serviceName := "externalipsvc"
+
+			ginkgo.By("Creating the externalip service")
+			externalIPsvcSpec := externalIPServiceSpecFrom(serviceName, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector, newNodeAddresses)
+			_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), externalIPsvcSpec, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for the endpoints to pop up")
+			err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name, serviceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+			framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", serviceName, f.Namespace.Name)
+
+			for _, protocol := range []string{"http", "udp"} {
+				for _, externalAddress := range newNodeAddresses {
 					responses := sets.NewString()
 					valid := false
 					externalPort := int32(clusterHTTPPort)


### PR DESCRIPTION
Closes #2232 #2235

The Current per node ExternalIP implementation in Local gateway is designed to work this way:

There are three paths OVN-K takes w.r.t external IP type services

1. The external IP is associated with an interface on one of the cluster nodes. In this case we set up iptables rules on that node only to DNAT to the cluster IP

2. The external IP is on the subnet of one of the NICs on node X, in this case we do nothing (since it's already "routable")

3. Else (which means it's not reachable from the node and not associated with any interface), we setup routing rules to forward traffic to the management port (so that traffic intended for the external IP which hits the node, is forwarded into OVN and the OVN external IP LB which will then forward traffic to the endpoint)

There are 2 bugs in current implementation.

The ovnkube-node on restart takes the logic from the shared-gateway mode and install iptables rules for the external-ip despite it is not present on the node https://bugzilla.redhat.com/show_bug.cgi?id=1955192

The ovnkube-node only considers the local IPs that are present at boot time https://bugzilla.redhat.com/show_bug.cgi?id=1959798

This PR makes it much simpler by just adding an iptables rule to each node that DNAT's from ExternalIP directly to the clusterIP of the service (Similar to what Shared-Gateway does). This will essentially "short-circuit" any traffic originating at the node straight to the service backend. 