### PR TITLE
Batching: Fixes finding maximum bash arguments

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -553,7 +553,7 @@ func (oc *Controller) WatchEgressFirewall() *factory.Handler {
 			} else {
 				_, stderr, err := txn.Commit()
 				if err != nil {
-					klog.Errorf("failed to commit db changes for egressFirewall in namespace %s stderr: %q, err: %+v", egressFirewall.Namespace, stderr, err)
+					klog.Errorf("Failed to commit db changes for egressFirewall in namespace %s stderr: %q, err: %+v", egressFirewall.Namespace, stderr, err)
 					egressFirewall.Status.Status = egressFirewallAddError
 				} else {
 					egressFirewall.Status.Status = egressFirewallAppliedCorrectly
@@ -577,7 +577,7 @@ func (oc *Controller) WatchEgressFirewall() *factory.Handler {
 				} else {
 					_, stderr, err := txn.Commit()
 					if err != nil {
-						klog.Errorf("failed to commit db changes for egressFirewall in namespace %s stderr: %q, err: %+v", newEgressFirewall.Namespace, stderr, err)
+						klog.Errorf("Failed to commit db changes for egressFirewall in namespace %s stderr: %q, err: %+v", newEgressFirewall.Namespace, stderr, err)
 						newEgressFirewall.Status.Status = egressFirewallUpdateError
 
 					} else {
@@ -600,7 +600,7 @@ func (oc *Controller) WatchEgressFirewall() *factory.Handler {
 			}
 			stdout, stderr, err := txn.Commit()
 			if err != nil {
-				klog.Errorf("failed to commit db changes for egressFirewall in namespace %s stdout: %q, stderr: %q, err: %+v", egressFirewall.Namespace, stdout, stderr, err)
+				klog.Errorf("Failed to commit db changes for egressFirewall in namespace %s stdout: %q, stderr: %q, err: %+v", egressFirewall.Namespace, stdout, stderr, err)
 			}
 		},
 	}, oc.syncEgressFirewall)

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -1993,3 +1993,42 @@ func TestDetectSCTPSupport(t *testing.T) {
 		})
 	}
 }
+
+func TestFindMaxArgsUsable(t *testing.T) {
+	tests := []struct {
+		desc            string
+		initialMaxWorks bool
+		maxArgs         int
+	}{
+		{
+			desc:            "positive test: small value should be usable",
+			initialMaxWorks: true,
+			maxArgs:         minOSArgs + 10,
+		},
+		{
+			desc:            "negative test: value smaller than minimum should result in minimum",
+			initialMaxWorks: false,
+			maxArgs:         minOSArgs - 10,
+		},
+		{
+			desc:            "negative test: giant initial value should not be usable and return a smaller int",
+			initialMaxWorks: false,
+			maxArgs:         10000000,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+
+			val := findMaxArgsUsable(tc.maxArgs)
+
+			if tc.initialMaxWorks {
+				assert.EqualValues(t, val, tc.maxArgs, "max args should equal found value")
+			} else if tc.maxArgs < minOSArgs {
+				assert.EqualValues(t, val, minOSArgs)
+			} else {
+				assert.Less(t, val, tc.maxArgs, "value should be less than max args")
+			}
+		})
+	}
+}


### PR DESCRIPTION
It turns out what the system reports for maximum arguments may not be
the real amount of arguments that are usable in a shell. Different
kernels calculate it differently, but the gist is that the only reliable
way to know is to test for it. This patch does an initial search based
on the given max args in the kernel to find the actual usable amount.

The search is only done one time during initialization, so it shouldn't
impact performance.

Signed-off-by: Tim Rozet <trozet@redhat.com>

