### PR TITLE
Bug 1961757: Add ovn-controller logical flow cache options

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -64,6 +64,7 @@ var (
 		EncapPort:         DefaultEncapPort,
 		InactivityProbe:   100000, // in Milliseconds
 		OpenFlowProbe:     180,    // in Seconds
+		LFlowCacheEnable:  true,
 		RawClusterSubnets: "10.128.0.0/14/23",
 	}
 
@@ -176,6 +177,19 @@ type DefaultConfig struct {
 	// Maximum number of seconds of idle time on the OpenFlow connection
 	// that ovn-controller will wait before it sends a connection health probe
 	OpenFlowProbe int `gcfg:"openflow-probe"`
+	// The  boolean  flag  indicates  if  ovn-controller  should
+	// enable/disable the logical flow in-memory cache  it  uses
+	// when processing Southbound database logical flow changes.
+	// By default caching is enabled.
+	LFlowCacheEnable bool `gcfg:"enable-lflow-cache"`
+	// Maximum  number  of logical flow cache entries ovn-controller
+	// may create when the logical flow  cache  is  enabled.  By
+	// default the size of the cache is unlimited.
+	LFlowCacheLimit uint `gcfg:"lflow-cache-limit"`
+	// Maximum  number  of logical flow cache entries ovn-controller
+	// may create when the logical flow  cache  is  enabled.  By
+	// default the size of the cache is unlimited.
+	LFlowCacheLimitKb uint `gcfg:"lflow-cache-limit-kb"`
 	// RawClusterSubnets holds the unparsed cluster subnets. Should only be
 	// used inside config module.
 	RawClusterSubnets string `gcfg:"cluster-subnets"`
@@ -568,6 +582,30 @@ var CommonFlags = []cli.Flag{
 			"connection for ovn-controller before it sends a inactivity probe",
 		Destination: &cliConfig.Default.OpenFlowProbe,
 		Value:       Default.OpenFlowProbe,
+	},
+	&cli.BoolFlag{
+		Name: "enable-lflow-cache",
+		Usage: "Enable the logical flow in-memory cache it uses " +
+			"when processing Southbound database logical flow changes. " +
+			"By default caching is enabled.",
+		Destination: &cliConfig.Default.LFlowCacheEnable,
+		Value:       Default.LFlowCacheEnable,
+	},
+	&cli.UintFlag{
+		Name: "lflow-cache-limit",
+		Usage: "Maximum number of logical flow cache entries ovn-controller " +
+			"may create when the logical flow cache is enabled. By " +
+			"default the size of the cache is unlimited.",
+		Destination: &cliConfig.Default.LFlowCacheLimit,
+		Value:       Default.LFlowCacheLimit,
+	},
+	&cli.UintFlag{
+		Name: "lflow-cache-limit-kb",
+		Usage: "Maximum size of the logical flow cache ovn-controller " +
+			"may create when the logical flow cache is enabled. By " +
+			"default the size of the cache is unlimited.",
+		Destination: &cliConfig.Default.LFlowCacheLimitKb,
+		Value:       Default.LFlowCacheLimitKb,
 	},
 	&cli.StringFlag{
 		Name:        "cluster-subnet",

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -136,6 +136,8 @@ func writeTestConfigFile(path string, overrides ...string) error {
 mtu=1500
 conntrack-zone=64321
 cluster-subnets=10.132.0.0/14/23
+lflow-cache-limit=1000
+lflow-cache-limit-kb=100000
 
 [kubernetes]
 kubeconfig=/path/to/kubeconfig
@@ -238,6 +240,9 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Default.MTU).To(gomega.Equal(1400))
 			gomega.Expect(Default.ConntrackZone).To(gomega.Equal(64000))
+			gomega.Expect(Default.LFlowCacheEnable).To(gomega.BeTrue())
+			gomega.Expect(Default.LFlowCacheLimit).To(gomega.Equal(uint(0)))
+			gomega.Expect(Default.LFlowCacheLimitKb).To(gomega.Equal(uint(0)))
 			gomega.Expect(Logging.File).To(gomega.Equal(""))
 			gomega.Expect(Logging.Level).To(gomega.Equal(5))
 			gomega.Expect(Monitoring.RawNetFlowTargets).To(gomega.Equal(""))
@@ -482,6 +487,9 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Default.MTU).To(gomega.Equal(1500))
 			gomega.Expect(Default.ConntrackZone).To(gomega.Equal(64321))
+			gomega.Expect(Default.LFlowCacheEnable).To(gomega.BeTrue())
+			gomega.Expect(Default.LFlowCacheLimit).To(gomega.Equal(uint(1000)))
+			gomega.Expect(Default.LFlowCacheLimitKb).To(gomega.Equal(uint(100000)))
 			gomega.Expect(Logging.File).To(gomega.Equal("/var/log/ovnkube.log"))
 			gomega.Expect(Logging.Level).To(gomega.Equal(5))
 			gomega.Expect(Logging.ACLLoggingRateLimit).To(gomega.Equal(20))
@@ -552,6 +560,9 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Default.MTU).To(gomega.Equal(1234))
 			gomega.Expect(Default.ConntrackZone).To(gomega.Equal(5555))
+			gomega.Expect(Default.LFlowCacheEnable).To(gomega.BeTrue())
+			gomega.Expect(Default.LFlowCacheLimit).To(gomega.Equal(uint(500)))
+			gomega.Expect(Default.LFlowCacheLimitKb).To(gomega.Equal(uint(50000)))
 			gomega.Expect(Logging.File).To(gomega.Equal("/some/logfile"))
 			gomega.Expect(Logging.Level).To(gomega.Equal(3))
 			gomega.Expect(Logging.ACLLoggingRateLimit).To(gomega.Equal(30))
@@ -597,6 +608,8 @@ var _ = Describe("Config Operations", func() {
 			"-config-file=" + cfgFile.Name(),
 			"-mtu=1234",
 			"-conntrack-zone=5555",
+			"-lflow-cache-limit=500",
+			"-lflow-cache-limit-kb=50000",
 			"-loglevel=3",
 			"-logfile=/some/logfile",
 			"-acl-logging-rate-limit=30",
@@ -866,6 +879,9 @@ mode=shared
 
 			gomega.Expect(Default.MTU).To(gomega.Equal(1234))
 			gomega.Expect(Default.ConntrackZone).To(gomega.Equal(5555))
+			gomega.Expect(Default.LFlowCacheEnable).To(gomega.BeTrue())
+			gomega.Expect(Default.LFlowCacheLimit).To(gomega.Equal(uint(500)))
+			gomega.Expect(Default.LFlowCacheLimitKb).To(gomega.Equal(uint(50000)))
 			gomega.Expect(Logging.File).To(gomega.Equal("/some/logfile"))
 			gomega.Expect(Logging.Level).To(gomega.Equal(3))
 			gomega.Expect(Monitoring.RawNetFlowTargets).To(gomega.Equal("2.2.2.2:2055"))
@@ -903,6 +919,8 @@ mode=shared
 			"-config-file=" + cfgFile.Name(),
 			"-mtu=1234",
 			"-conntrack-zone=5555",
+			"-lflow-cache-limit=500",
+			"-lflow-cache-limit-kb=50000",
 			"-loglevel=3",
 			"-logfile=/some/logfile",
 			"-netflow-targets=2.2.2.2:2055",
@@ -950,6 +968,9 @@ mode=shared
 
 			gomega.Expect(Default.MTU).To(gomega.Equal(1500))
 			gomega.Expect(Default.ConntrackZone).To(gomega.Equal(64321))
+			gomega.Expect(Default.LFlowCacheEnable).To(gomega.BeTrue())
+			gomega.Expect(Default.LFlowCacheLimit).To(gomega.Equal(uint(1000)))
+			gomega.Expect(Default.LFlowCacheLimitKb).To(gomega.Equal(uint(100000)))
 			gomega.Expect(Default.RawClusterSubnets).To(gomega.Equal("10.132.0.0/14/23"))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.132.0.0/14"), 23},


### PR DESCRIPTION
Adds configuration options to disable or set logical flow cache limits. Logical flow cache is enabled by default and no limits are assumed.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1961757