### PR TITLE
NetworkPolicy: bulk-add pods to new policies (or on restart)

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.8.7
 	github.com/coreos/go-iptables v0.4.5
-	github.com/ebay/go-ovn v0.1.1-0.20210505151822-f0122836cc35
+	github.com/ebay/go-ovn v0.1.1-0.20210603173524-8db200d06216
 	github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/mux v1.8.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -107,8 +107,8 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/ebay/go-ovn v0.1.1-0.20210505151822-f0122836cc35 h1:7QLMkuQBRBjK21hcJdHDBxSh68dJeeEUXYeBtoUijbU=
-github.com/ebay/go-ovn v0.1.1-0.20210505151822-f0122836cc35/go.mod h1:Du3Zt/R+DqyqtY5aNTd2gB9bg/igI1RR4fUj6AjmkjI=
+github.com/ebay/go-ovn v0.1.1-0.20210603173524-8db200d06216 h1:1hYH42WRIQSQgDArZwx80VXvfiEssgi6sBrJMKsUgxQ=
+github.com/ebay/go-ovn v0.1.1-0.20210603173524-8db200d06216/go.mod h1:Du3Zt/R+DqyqtY5aNTd2gB9bg/igI1RR4fUj6AjmkjI=
 github.com/ebay/libovsdb v0.0.0-20190718202342-e49b8c4e1142/go.mod h1:TPIbkgdnu8IfDA510pGDS3zYGmnvrPttnge3uhBQf/0=
 github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c h1:YSECgIEwf07ycYVwVM8KXCgkpXajecPqRyAuyFELZxA=
 github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c/go.mod h1:ZW5Fi5OPYcMy3EI20lW62TKBMHSlaDPlTqC3Gm4ev9Q=

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -126,15 +126,19 @@ func (gp *gressPolicy) deletePeerSvcVip(service *v1.Service) error {
 	return gp.peerAddressSet.DeleteIPs(ips)
 }
 
-func (gp *gressPolicy) addPeerPod(pod *v1.Pod) error {
+func (gp *gressPolicy) addPeerPods(pods ...*v1.Pod) error {
 	if gp.peerAddressSet == nil {
-		return fmt.Errorf("peer AddressSet is nil, cannot add peer pod: %s for gressPolicy: %s",
-			pod.ObjectMeta.Name, gp.policyName)
+		return fmt.Errorf("peer AddressSet is nil, cannot add peer pod(s): for gressPolicy: %s",
+			gp.policyName)
 	}
 
-	ips, err := util.GetAllPodIPs(pod)
-	if err != nil {
-		return err
+	ips := []net.IP{}
+	for _, pod := range pods {
+		podIPs, err := util.GetAllPodIPs(pod)
+		if err != nil {
+			return err
+		}
+		ips = append(ips, podIPs...)
 	}
 
 	return gp.peerAddressSet.AddIPs(ips)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -301,6 +301,7 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 
 	oc.WatchPods()
 
+	// WatchNetworkPolicy depends on WatchPods and WatchNamespaces
 	oc.WatchNetworkPolicy()
 
 	if config.OVNKubernetesFeature.EnableEgressIP {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -564,8 +564,12 @@ func podDeleteAllowMulticastPolicy(ovnNBClient goovn.Client, ns string, portInfo
 	return deleteFromPortGroup(ovnNBClient, hashedPortGroup(ns), portInfo)
 }
 
+// localPodAddDefaultDeny ensures ports (i.e. pods) are in the correct
+// default-deny portgroups. Whether or not pods are in default-deny depends
+// on whether or not any policies select this pod, so there is a reference
+// count to ensure we don't accidentally open up a pod.
 func (oc *Controller) localPodAddDefaultDeny(nsInfo *namespaceInfo,
-	policy *knet.NetworkPolicy, portInfo *lpInfo) {
+	policy *knet.NetworkPolicy, ports ...*lpInfo) {
 	oc.lspMutex.Lock()
 
 	// Default deny rule.
@@ -579,89 +583,140 @@ func (oc *Controller) localPodAddDefaultDeny(nsInfo *namespaceInfo,
 	// the PolicyTypes has 'egress' in it, we add a default
 	// egress deny rule.
 
-	addIngressDeny := false
-	addEgressDeny := false
+	addIngressPorts := []*lpInfo{}
+	addEgressPorts := []*lpInfo{}
 
 	// Handle condition 1 above.
 	if !(len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) {
-		if oc.lspIngressDenyCache[portInfo.name] == 0 {
-			addIngressDeny = true
+		for _, portInfo := range ports {
+			// if this is the first NP referencing this pod, then we
+			// need to add it to the port group.
+			if oc.lspIngressDenyCache[portInfo.name] == 0 {
+				addIngressPorts = append(addIngressPorts, portInfo)
+			}
+
+			// increment the reference count.
+			oc.lspIngressDenyCache[portInfo.name]++
 		}
-		oc.lspIngressDenyCache[portInfo.name]++
 	}
 
 	// Handle condition 2 above.
 	if (len(policy.Spec.PolicyTypes) == 1 && policy.Spec.PolicyTypes[0] == knet.PolicyTypeEgress) ||
 		len(policy.Spec.Egress) > 0 || len(policy.Spec.PolicyTypes) == 2 {
-		if oc.lspEgressDenyCache[portInfo.name] == 0 {
-			addEgressDeny = true
+		for _, portInfo := range ports {
+			if oc.lspEgressDenyCache[portInfo.name] == 0 {
+				// again, reference count is 0, so add to port
+				addEgressPorts = append(addEgressPorts, portInfo)
+			}
+
+			// bump reference count
+			oc.lspEgressDenyCache[portInfo.name]++
 		}
-		oc.lspEgressDenyCache[portInfo.name]++
 	}
 
 	// we're done with the lsp cache - release the lock before transacting
 	oc.lspMutex.Unlock()
 
-	if addIngressDeny {
-		if err := addToPortGroup(oc.ovnNBClient, nsInfo.portGroupIngressDenyName, portInfo); err != nil {
-			klog.Warningf("Failed to add port %s to ingress deny ACL: %v", portInfo.name, err)
+	// Generate a single OVN transaction that adds all ports to the
+	// appropriate port groups.
+	commands := make([]*goovn.OvnCommand, 0, len(addIngressPorts)+len(addEgressPorts))
+
+	for _, portInfo := range addIngressPorts {
+		cmd, err := oc.ovnNBClient.PortGroupAddPort(nsInfo.portGroupIngressDenyName, portInfo.uuid)
+		if err != nil {
+			klog.Warningf("Failed to create command: add port %s to ingress deny portgroup %s: %v",
+				portInfo.name, nsInfo.portGroupIngressDenyName, err)
+			continue
 		}
+		commands = append(commands, cmd)
 	}
 
-	if addEgressDeny {
-		if err := addToPortGroup(oc.ovnNBClient, nsInfo.portGroupEgressDenyName, portInfo); err != nil {
-			klog.Warningf("Failed to add port %s to egress deny ACL: %v", portInfo.name, err)
+	for _, portInfo := range addEgressPorts {
+		cmd, err := oc.ovnNBClient.PortGroupAddPort(nsInfo.portGroupEgressDenyName, portInfo.uuid)
+		if err != nil {
+			klog.Warningf("Failed to create command: add port %s to egress deny portgroup %s: %v",
+				portInfo.name, nsInfo.portGroupEgressDenyName, err)
+			continue
 		}
+		commands = append(commands, cmd)
 	}
 
+	err := oc.ovnNBClient.Execute(commands...)
+	if err != nil {
+		klog.Warningf("Failed to execute add-to-default-deny-portgroup transaction: %v", err)
+	}
 }
 
+// localPodDelDefaultDeny decrements a pod's policy reference count and removes a pod
+// from the default-deny portgroups if the reference count for the pod is 0
 func (oc *Controller) localPodDelDefaultDeny(
-	np *networkPolicy, nsInfo *namespaceInfo, portInfo *lpInfo) {
+	np *networkPolicy, nsInfo *namespaceInfo, ports ...*lpInfo) {
 	oc.lspMutex.Lock()
 
-	deleteFromIngress := false
-	deleteFromEgress := false
+	delIngressPorts := []*lpInfo{}
+	delEgressPorts := []*lpInfo{}
 
 	// Remove port from ingress deny port-group for [Ingress] and [ingress,egress] PolicyTypes
 	// If NOT [egress] PolicyType
 	if !(len(np.policyTypes) == 1 && np.policyTypes[0] == knet.PolicyTypeEgress) {
-		if oc.lspIngressDenyCache[portInfo.name] > 0 {
-			oc.lspIngressDenyCache[portInfo.name]--
-			if oc.lspIngressDenyCache[portInfo.name] == 0 {
-				deleteFromIngress = true
-				delete(oc.lspIngressDenyCache, portInfo.name)
+		for _, portInfo := range ports {
+			if oc.lspIngressDenyCache[portInfo.name] > 0 {
+				oc.lspIngressDenyCache[portInfo.name]--
+				if oc.lspIngressDenyCache[portInfo.name] == 0 {
+					delIngressPorts = append(delIngressPorts, portInfo)
+					delete(oc.lspIngressDenyCache, portInfo.name)
+				}
 			}
 		}
 	}
+
 	// Remove port from egress deny port group for [egress] and [ingress,egress] PolicyTypes
 	// if [egress] PolicyType OR there are any egress rules OR [ingress,egress] PolicyType
 	if (len(np.policyTypes) == 1 && np.policyTypes[0] == knet.PolicyTypeEgress) ||
 		len(np.egressPolicies) > 0 || len(np.policyTypes) == 2 {
-		if oc.lspEgressDenyCache[portInfo.name] > 0 {
-			oc.lspEgressDenyCache[portInfo.name]--
-			if oc.lspEgressDenyCache[portInfo.name] == 0 {
-				deleteFromEgress = true
-				delete(oc.lspEgressDenyCache, portInfo.name)
+		for _, portInfo := range ports {
+			if oc.lspEgressDenyCache[portInfo.name] > 0 {
+				oc.lspEgressDenyCache[portInfo.name]--
+				if oc.lspEgressDenyCache[portInfo.name] == 0 {
+					delEgressPorts = append(delEgressPorts, portInfo)
+					delete(oc.lspEgressDenyCache, portInfo.name)
+				}
 			}
 		}
 	}
 	oc.lspMutex.Unlock()
 
-	if deleteFromIngress {
-		if err := deleteFromPortGroup(oc.ovnNBClient, nsInfo.portGroupIngressDenyName, portInfo); err != nil {
-			klog.Warningf("Failed to remove port %s from ingress deny ACL: %v", portInfo.name, err)
+	commands := make([]*goovn.OvnCommand, 0, len(delIngressPorts)+len(delEgressPorts))
+
+	for _, portInfo := range delIngressPorts {
+		cmd, err := oc.ovnNBClient.PortGroupRemovePort(nsInfo.portGroupIngressDenyName, portInfo.uuid)
+		if err != nil {
+			klog.Warningf("Failed to create command: remove port %s from ingress deny portgroup %s: %v",
+				portInfo.name, nsInfo.portGroupIngressDenyName, err)
+			continue
 		}
+		commands = append(commands, cmd)
 	}
 
-	if deleteFromEgress {
-		if err := deleteFromPortGroup(oc.ovnNBClient, nsInfo.portGroupEgressDenyName, portInfo); err != nil {
-			klog.Warningf("Failed to remove port %s from egress deny ACL: %v", portInfo.name, err)
+	for _, portInfo := range delEgressPorts {
+		cmd, err := oc.ovnNBClient.PortGroupRemovePort(nsInfo.portGroupEgressDenyName, portInfo.uuid)
+		if err != nil {
+			klog.Warningf("Failed to create command: remove port %s from egress deny portgroup %s: %v",
+				portInfo.name, nsInfo.portGroupEgressDenyName, err)
+			continue
 		}
+		commands = append(commands, cmd)
 	}
 
+	err := oc.ovnNBClient.Execute(commands...)
+	if err != nil {
+		klog.Warningf("Failed to execute add-to-default-deny-portgroup transaction: %v", err)
+	}
 }
 
+// handleLocalPodSelectorAddFunc adds a new pod to an existing NetworkPolicy
+//
+// THIS MUST BE KEPT CONSISTENT WITH handleLocalPodSelectorSetPods!
 func (oc *Controller) handleLocalPodSelectorAddFunc(
 	policy *knet.NetworkPolicy, np *networkPolicy, nsInfo *namespaceInfo,
 	obj interface{}) {
@@ -704,6 +759,72 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(
 	}
 
 	np.localPods.Store(logicalPort, portInfo)
+}
+
+// handleLocalPodSelectorSetPods is a more efficient way of
+// bulk-setting the local pods in a newly-created network policy
+//
+// THIS MUST BE KEPT CONSISTENT WITH AddPod!
+func (oc *Controller) handleLocalPodSelectorSetPods(
+	policy *knet.NetworkPolicy, np *networkPolicy, nsInfo *namespaceInfo,
+	objs []interface{}) {
+
+	// Take the write lock since this is called once and we will want to bulk-update
+	// localPods
+	np.Lock()
+	defer np.Unlock()
+	if np.deleted {
+		return
+	}
+
+	klog.Infof("Setting NetworkPolicy %s/%s to have %d local pods...",
+		np.namespace, np.name, len(objs))
+
+	// get list of pods and their logical ports to add
+	// theoretically this should never filter any pods but it's always good to be
+	// paranoid.
+	portsToAdd := make([]*lpInfo, 0, len(objs))
+	for _, obj := range objs {
+		pod := obj.(*kapi.Pod)
+
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+
+		portInfo, err := oc.logicalPortCache.get(podLogicalPortName(pod))
+		// pod is not yet handled
+		// no big deal, we'll get the update when it is.
+		if err != nil {
+			continue
+		}
+
+		// this pod is somehow already added to this policy, then skip
+		if _, ok := np.localPods.Load(portInfo.name); ok {
+			continue
+		}
+
+		portsToAdd = append(portsToAdd, portInfo)
+	}
+
+	// add all ports to default deny
+	oc.localPodAddDefaultDeny(nsInfo, policy, portsToAdd...)
+
+	if np.portGroupUUID == "" {
+		return
+	}
+
+	err := setPortGroup(oc.ovnNBClient, np.portGroupName, portsToAdd...)
+	if err != nil {
+		klog.Errorf("Failed to set ports in PortGroup for network policy %s/%s: %v", np.namespace, np.name, err)
+	}
+
+	for _, portInfo := range portsToAdd {
+		np.localPods.Store(portInfo.name, portInfo)
+	}
+
+	klog.Infof("Done setting NetworkPolicy %s/%s local pods",
+		np.namespace, np.name)
+
 }
 
 func (oc *Controller) handleLocalPodSelectorDelFunc(
@@ -763,7 +884,9 @@ func (oc *Controller) handleLocalPodSelector(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				oc.handleLocalPodSelectorAddFunc(policy, np, nsInfo, newObj)
 			},
-		}, nil)
+		}, func(objs []interface{}) {
+			oc.handleLocalPodSelectorSetPods(policy, np, nsInfo, objs)
+		})
 
 	np.podHandlerList = append(np.podHandlerList, h)
 }
@@ -969,11 +1092,14 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, nsInfo *namespaceI
 	np.deleted = true
 	oc.shutdownHandlers(np)
 
+	ports := []*lpInfo{}
 	np.localPods.Range(func(_, value interface{}) bool {
 		portInfo := value.(*lpInfo)
-		oc.localPodDelDefaultDeny(np, nsInfo, portInfo)
+		ports = append(ports, portInfo)
 		return true
 	})
+
+	oc.localPodDelDefaultDeny(np, nsInfo, ports...)
 
 	if len(nsInfo.networkPolicies) == 0 {
 		err := deletePortGroup(oc.ovnNBClient, nsInfo.portGroupIngressDenyName)
@@ -1008,12 +1134,16 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, nsInfo *namespaceI
 // handlePeerPodSelectorAddUpdate adds the IP address of a pod that has been
 // selected as a peer by a NetworkPolicy's ingress/egress section to that
 // ingress/egress address set
-func (oc *Controller) handlePeerPodSelectorAddUpdate(gp *gressPolicy, obj interface{}) {
-	pod := obj.(*kapi.Pod)
-	if pod.Spec.NodeName == "" {
-		return
+func (oc *Controller) handlePeerPodSelectorAddUpdate(gp *gressPolicy, objs ...interface{}) {
+	pods := make([]*kapi.Pod, 0, len(objs))
+	for _, obj := range objs {
+		pod := obj.(*kapi.Pod)
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		pods = append(pods, pod)
 	}
-	if err := gp.addPeerPod(pod); err != nil {
+	if err := gp.addPeerPods(pods...); err != nil {
 		klog.Errorf(err.Error())
 	}
 }
@@ -1104,7 +1234,9 @@ func (oc *Controller) handlePeerPodSelector(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				oc.handlePeerPodSelectorAddUpdate(gp, newObj)
 			},
-		}, nil)
+		}, func(objs []interface{}) {
+			oc.handlePeerPodSelectorAddUpdate(gp, objs...)
+		})
 	np.podHandlerList = append(np.podHandlerList, h)
 }
 
@@ -1143,7 +1275,9 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 						UpdateFunc: func(oldObj, newObj interface{}) {
 							oc.handlePeerPodSelectorAddUpdate(gp, newObj)
 						},
-					}, nil)
+					}, func(objs []interface{}) {
+						oc.handlePeerPodSelectorAddUpdate(gp, objs...)
+					})
 				np.Lock()
 				defer np.Unlock()
 				if np.deleted {

--- a/go-controller/pkg/ovn/port_group_unit_test.go
+++ b/go-controller/pkg/ovn/port_group_unit_test.go
@@ -225,13 +225,16 @@ func TestAddToPortGroup(t *testing.T) {
 			},
 		},
 		{
-			desc:     "port exists",
+			desc:     "positive idempotency",
 			name:     pgName,
 			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
 			errMatch: nil,
 			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
 				{
-					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, goovn.ErrorExist},
+					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
+				},
+				{
+					OnCallMethodName: "Execute", OnCallMethodArgType: []string{"*goovn.OvnCommand"}, RetArgList: []interface{}{nil},
 				},
 			},
 		},
@@ -239,7 +242,7 @@ func TestAddToPortGroup(t *testing.T) {
 			desc:     "port group not found",
 			name:     pgName,
 			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
-			errMatch: fmt.Errorf("error adding port %s to port group %s (%v)", lspName, pgName, goovn.ErrorNotFound),
+			errMatch: fmt.Errorf("error preparing adding port %s to port group %s (%v)", lspName, pgName, goovn.ErrorNotFound),
 			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
 				{
 					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, goovn.ErrorNotFound},
@@ -250,7 +253,7 @@ func TestAddToPortGroup(t *testing.T) {
 			desc:     "other PortGroupAddPort error",
 			name:     pgName,
 			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
-			errMatch: fmt.Errorf("error adding port %s to port group %s (%v)", lspName, pgName, otherError),
+			errMatch: fmt.Errorf("error preparing adding port %s to port group %s (%v)", lspName, pgName, otherError),
 			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
 				{
 					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, otherError},
@@ -261,7 +264,7 @@ func TestAddToPortGroup(t *testing.T) {
 			desc:     "execute error",
 			name:     pgName,
 			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
-			errMatch: fmt.Errorf("execute error adding port %s to port group %s (%v)", lspName, pgName, execError),
+			errMatch: fmt.Errorf("error committing adding ports (%s) to port group %s (%v)", lspName, pgName, execError),
 			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
 				{
 					OnCallMethodName: "PortGroupAddPort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},
@@ -328,7 +331,7 @@ func TestDeleteFromPortGroup(t *testing.T) {
 			desc:     "other PortGroupAddPort error",
 			name:     pgName,
 			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
-			errMatch: fmt.Errorf("error removing port %s from port group %s (%v)", lspName, pgName, otherError),
+			errMatch: fmt.Errorf("error preparing removing port %s from port group %s (%v)", lspName, pgName, otherError),
 			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
 				{
 					OnCallMethodName: "PortGroupRemovePort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, otherError},
@@ -339,7 +342,7 @@ func TestDeleteFromPortGroup(t *testing.T) {
 			desc:     "execute error",
 			name:     pgName,
 			portInfo: &lpInfo{name: lspName, uuid: lspUUID},
-			errMatch: fmt.Errorf("execute error removing port %s from port group %s (%v)", lspName, pgName, execError),
+			errMatch: fmt.Errorf("error committing removing ports (%s) from port group %s (%v)", lspName, pgName, execError),
 			onRetArgMockGoOvnNBClient: []ovntest.TestifyMockHelper{
 				{
 					OnCallMethodName: "PortGroupRemovePort", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{&goovn.OvnCommand{}, nil},

--- a/go-controller/vendor/github.com/ebay/go-ovn/port_group.go
+++ b/go-controller/vendor/github.com/ebay/go-ovn/port_group.go
@@ -117,14 +117,8 @@ func (odbi *ovndb) pgUpdateImp(group string, ports []string, external_ids map[st
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
-func (odbi *ovndb) pgAddPortImp(group, port string)  (*OvnCommand, error) {
-	if pg, err := odbi.pgGetImp(group); err == nil {
-		for _, p := range pg.Ports {
-			if p == port {
-				return nil, ErrorExist
-			}
-		}
-	} else {
+func (odbi *ovndb) pgAddPortImp(group, port string) (*OvnCommand, error) {
+	if _, err := odbi.pgGetImp(group); err != nil {
 		return nil, err
 	}
 
@@ -148,18 +142,7 @@ func (odbi *ovndb) pgAddPortImp(group, port string)  (*OvnCommand, error) {
 }
 
 func (odbi *ovndb) pgRemovePortImp(group string, port string) (*OvnCommand, error) {
-	if pg, err := odbi.pgGetImp(group); err == nil {
-		portFound := false
-		for _, p := range pg.Ports {
-			if p == port {
-				portFound = true
-				break
-			}
-		}
-		if portFound != true {
-			return nil, ErrorNotFound
-		}
-	} else {
+	if _, err := odbi.pgGetImp(group); err != nil {
 		return nil, err
 	}
 

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -59,7 +59,7 @@ github.com/davecgh/go-spew/spew
 # github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
-# github.com/ebay/go-ovn v0.1.1-0.20210505151822-f0122836cc35
+# github.com/ebay/go-ovn v0.1.1-0.20210603173524-8db200d06216
 github.com/ebay/go-ovn
 # github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c
 github.com/ebay/libovsdb


### PR DESCRIPTION
Bumps go-ovn to pick up https://github.com/eBay/go-ovn/pull/149

This adds a factory sync function for network policy that bulk-sets all pods on policy create. This means that creating a network policy that selects a large number of pods is much more efficient.

Additionally, this means that ovn-kube startup time for large policies should be much faster.
