### PR TITLE
cni: wait up to 1 second for pods to appear in the API

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -97,7 +97,7 @@ func (pr *PodRequest) cmdAdd(podLister corev1listers.PodLister, useOVSExternalID
 	}
 	// Get the IP address and MAC address of the pod
 	// for Smart-Nic, ensure connection-details is present
-	annotations, err := GetPodAnnotations(pr.ctx, podLister, namespace, podName, annotCondFn)
+	annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, namespace, podName, annotCondFn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod annotation: %v", err)
 	}
@@ -137,7 +137,7 @@ func (pr *PodRequest) cmdDel() ([]byte, error) {
 	return []byte{}, nil
 }
 
-func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternalIDs bool) ([]byte, error) {
+func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface) ([]byte, error) {
 	namespace := pr.PodNamespace
 	podName := pr.PodName
 	if namespace == "" || podName == "" {
@@ -149,7 +149,7 @@ func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternal
 	if pr.IsSmartNIC {
 		annotCondFn = isSmartNICReady
 	}
-	annotations, err := GetPodAnnotations(pr.ctx, podLister, pr.PodNamespace, pr.PodName, annotCondFn)
+	annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, pr.PodNamespace, pr.PodName, annotCondFn)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func HandleCNIRequest(request *PodRequest, podLister corev1listers.PodLister, us
 	case CNIDel:
 		result, err = request.cmdDel()
 	case CNICheck:
-		result, err = request.cmdCheck(podLister, useOVSExternalIDs)
+		result, err = request.cmdCheck(podLister, useOVSExternalIDs, kclient)
 	default:
 	}
 	klog.Infof("%s %s finished CNI request %+v, result %q, err %v", request, request.Command, request, string(result), err)

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -8,6 +8,11 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	kapi "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
@@ -37,8 +42,20 @@ func isSmartNICReady(podAnnotation map[string]string) bool {
 	return false
 }
 
+// getPod returns a pod from the informer cache or (if that fails) the apiserver
+func getPod(podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string) (*kapi.Pod, error) {
+	pod, err := podLister.Pods(namespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		// If the pod wasn't in our local cache, ask for it directly
+		pod, err = kclient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	}
+	return pod, err
+}
+
 // GetPodAnnotations obtains the pod annotation from the cache
-func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, namespace, name string, annotCond podAnnotWaitCond) (map[string]string, error) {
+func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string, annotCond podAnnotWaitCond) (map[string]string, error) {
+	var notFoundCount uint
+
 	timeout := time.After(30 * time.Second)
 	for {
 		select {
@@ -47,14 +64,24 @@ func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, n
 		case <-timeout:
 			return nil, fmt.Errorf("timed out waiting for annotations")
 		default:
-			pod, err := podLister.Pods(namespace).Get(name)
+			pod, err := getPod(podLister, kclient, namespace, name)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get annotations: %v", err)
+				if !apierrors.IsNotFound(err) {
+					return nil, fmt.Errorf("failed to get pod for annotations: %v", err)
+				}
+				// Allow up to 1 second for pod to be found
+				notFoundCount++
+				if notFoundCount >= 5 {
+					return nil, fmt.Errorf("timed out waiting for pod after 1s: %v", err)
+				}
+				// drop through to try again
+			} else if pod != nil {
+				annotations := pod.ObjectMeta.Annotations
+				if annotCond(annotations) {
+					return annotations, nil
+				}
 			}
-			annotations := pod.ObjectMeta.Annotations
-			if annotCond(annotations) {
-				return annotations, nil
-			}
+
 			// try again later
 			time.Sleep(200 * time.Millisecond)
 		}


### PR DESCRIPTION
The runtime might call ovnkube to set up the pod sandbox before
the pod informer has received the pod from the apiserver. Currently
the code simply returns an error and expects kubelet to retry.

Instead let's be nicer and wait a short bit of time for the pod
to show up before erroring out.

@trozet 

```
I0608 04:55:31.294649    3386 informer.go:294] Successfully synced 'e2e-test-job-controller-b886m/simplev1-4pwg8'
I0608 04:55:31.763896    3386 cni.go:213] [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca] ADD starting CNI request [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca]
I0608 04:55:31.763966    3386 cni.go:223] [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca] ADD finished CNI request [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca], result "", err failed to get pod annotation: failed to get annotations: pod "pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d" not found
I0608 04:55:31.784053    3386 cni.go:213] [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca] DEL starting CNI request [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca]
I0608 04:55:31.804894    3386 cni.go:223] [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca] DEL finished CNI request [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca], result "", err <nil>
E0608 04:55:31.808611    3386 informer.go:301] error syncing 'e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d': error getting pod details: could not find OVN pod annotation in map[openshift.io/scc:anyuid], requeuing
E0608 04:55:31.813815    3386 informer.go:301] error syncing 'e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d': error getting pod details: could not find OVN pod annotation in map[openshift.io/scc:anyuid], requeuing
E0608 04:55:31.824001    3386 informer.go:301] error syncing 'e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d': error getting pod details: could not find OVN pod annotation in map[openshift.io/scc:anyuid], requeuing
I0608 04:55:31.832013    3386 node_linux.go:150] Hybrid Overlay Gateway mode not enabled for pod pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d, namespace does not have hybridannotations, external gw: , VTEP: 
I0608 04:55:31.832054    3386 node_linux.go:222] Pod pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d wired for Hybrid Overlay
I0608 04:55:31.832067    3386 informer.go:294] Successfully synced 'e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d'
I0608 04:55:31.844318    3386 node_linux.go:150] Hybrid Overlay Gateway mode not enabled for pod pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d, namespace does not have hybridannotations, external gw: , VTEP: 
I0608 04:55:31.891398    3386 node_linux.go:222] Pod pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d wired for Hybrid Overlay
I0608 04:55:31.891439    3386 informer.go:294] Successfully synced 'e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d'
I0608 04:55:31.949209    3386 cni.go:213] [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca] DEL starting CNI request [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca]
I0608 04:55:31.971052    3386 cni.go:223] [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca] DEL finished CNI request [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 5692e102594ab44ca4a0d2adc866a421e50a9086fbe9e92ca6bf82af07f714ca], result "", err <nil>
I0608 04:55:32.335631    3386 cni.go:213] [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 68386f7dd9aca4277b08afb697640c2ea4ef7b9f43f791457c1ef9a2b184f5f5] ADD starting CNI request [e2e-configmap-4525/pod-configmaps-59b65ed6-a123-4f8c-ba52-7b6ecc0cda9d 68386f7dd9aca4277b08afb697640c2ea4ef7b9f43f791457c1ef9a2b184f5f5]
```