### PR TITLE
Avoid recursion when calculating max supported args

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -103,11 +103,17 @@ func findMaxArgsUsable(estimatedMax int) int {
 	for i := range args {
 		args[i] = "a"
 	}
-	if estimatedMax <= minOSArgs {
-		return minOSArgs
+
+	for estimatedMax > minOSArgs {
+		if _, err := exec.Command("/bin/true", args...).Output(); err == nil {
+			break
+		}
+		estimatedMax = int(float64(estimatedMax) * backoff)
+		args = args[:estimatedMax]
 	}
-	if _, err := exec.Command("/bin/true", args...).Output(); err != nil {
-		return findMaxArgsUsable(int(float64(estimatedMax) * backoff))
+
+	if estimatedMax < minOSArgs {
+		estimatedMax = minOSArgs
 	}
 	return estimatedMax
 }


### PR DESCRIPTION
This will reduce the memory footprint and possibly
run a bit faster as current implementation may
reach a depth of 52 calls where in each call it
allocates an array of size `estimatedMax` bytes

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>