### PR TITLE
cni: cancel old pod sandbox add requests if the pod's MAC changes

### DIFF
--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -92,6 +92,8 @@ type PodRequest struct {
 	cancel context.CancelFunc
 	// Interface to pod is a Smart-NIC interface
 	IsSmartNIC bool
+	// MAC address
+	MAC string
 }
 
 type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface) ([]byte, error)

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -92,8 +92,12 @@ type PodRequest struct {
 	cancel context.CancelFunc
 	// Interface to pod is a Smart-NIC interface
 	IsSmartNIC bool
-	// MAC address
-	MAC string
+	// Pod's udpated MAC address as zero-padded BE uint64, if changed after
+	// the request started
+	UpdatedMAC uint64
+	// The MAC read from pod annotations at the start of the request, as a
+	// zero-padded BE uint64
+	InitialMAC uint64
 }
 
 type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface) ([]byte, error)


### PR DESCRIPTION
If the the pod's MAC annotation changes, that also means the pod was
deleted and re-created. We should cancel any outstanding pod
sandbox ADD request that doesn't match the latest MAC address
for the pod.

@trozet 