### PR TITLE
policy: fix gressPolicy data race on delete

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -322,12 +322,12 @@ func (as *ovnAddressSets) DeleteIPs(ips []net.IP) error {
 	v4ips, v6ips := splitIPsByFamily(ips)
 	if as.ipv6 != nil {
 		if err := as.ipv6.deleteIPs(v6ips); err != nil {
-			return fmt.Errorf("failed to AddIPs to the v6 set: %w", err)
+			return fmt.Errorf("failed to DeleteIPs to the v6 set: %w", err)
 		}
 	}
 	if as.ipv4 != nil {
 		if err := as.ipv4.deleteIPs(v4ips); err != nil {
-			return fmt.Errorf("failed to AddIPs to the v4 set: %w", err)
+			return fmt.Errorf("failed to DeleteIPs to the v4 set: %w", err)
 		}
 	}
 	return nil
@@ -342,12 +342,14 @@ func (as *ovnAddressSets) Destroy() error {
 		if err != nil {
 			return err
 		}
+		as.ipv4 = nil
 	}
 	if as.ipv6 != nil {
 		err := as.ipv6.destroy()
 		if err != nil {
 			return err
 		}
+		as.ipv6 = nil
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -477,7 +477,6 @@ func (gp *gressPolicy) destroy() error {
 		if err := gp.peerAddressSet.Destroy(); err != nil {
 			return err
 		}
-		gp.peerAddressSet = nil
 	}
 	return nil
 }


### PR DESCRIPTION
There is a race between handlers that unit tests found. Remove the offending racy write, and update AddresSets so that operations on a Destroy'd set are a no-op.

Signed-off-by: Casey Callendrello <cdc@redhat.com>

```
 WARNING: DATA RACE
Write at 0x00c0003c1f28 by goroutine 919:
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*gressPolicy).destroy()
      /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/gress_policy.go:480 +0x115
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).destroyNetworkPolicy()
      /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/policy.go:1128 +0x59c
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).deleteNetworkPolicy()
      /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/policy.go:1086 +0x433
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).WatchNetworkPolicy.func3()
      /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/ovn.go:537 +0x84
  k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete()
      /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:245 +0x90
      

Previous read at 0x00c0003c1f28 by goroutine 1009:
   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*gressPolicy).addPeerPods()
      /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/gress_policy.go:130 +0x7b
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).handlePeerPodSelectorAddUpdate()
      /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/policy.go:1146 +0x207
  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).handlePeerPodSelector.func3()
      /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/policy.go:1235 +0xb4
  k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate()
      /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:238 +0xa5
```