### PR TITLE
Shared Gateway Node Port Skip commit to CT-Zone 64000

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -73,9 +73,12 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 					npw.ofm.deleteFlowsByKey(key)
 				} else {
 					npw.ofm.updateFlowCacheEntry(key, []string{
-						fmt.Sprintf("cookie=%s, priority=100, in_port=%s, %s, tp_dst=%d, "+
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, "+
 							"actions=%s",
-							cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, actions)})
+							cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, actions),
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_src=%d, "+
+							"actions=output:%s",
+							cookie, npw.ofportPatch, flowProtocol, svcPort.NodePort, npw.ofportPhys)})
 				}
 			}
 		}
@@ -100,27 +103,34 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 			}
 			flowProtocol := protocol
 			nwDst := "nw_dst"
+			nwSrc := "nw_src"
 			if utilnet.IsIPv6String(ing.IP) {
 				flowProtocol = protocol + "6"
 				nwDst = "ipv6_dst"
+				nwSrc = "ipv6_src"
 			}
 			key = strings.Join([]string{"Ingress", service.Namespace, service.Name, ingIP.String(), fmt.Sprintf("%d", svcPort.Port)}, "_")
 			if !add {
 				npw.ofm.deleteFlowsByKey(key)
 			} else {
 				npw.ofm.updateFlowCacheEntry(key, []string{
-					fmt.Sprintf("cookie=%s, priority=100, in_port=%s, %s, %s=%s, tp_dst=%d, "+
+					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
 						"actions=%s",
-						cookie, npw.ofportPhys, flowProtocol, nwDst, ing.IP, svcPort.Port, actions)})
+						cookie, npw.ofportPhys, flowProtocol, nwDst, ing.IP, svcPort.Port, actions),
+					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_src=%d, "+
+						"actions=output:%s",
+						cookie, npw.ofportPatch, flowProtocol, nwSrc, ing.IP, svcPort.Port, npw.ofportPhys)})
 			}
 		}
 
 		for _, externalIP := range service.Spec.ExternalIPs {
 			flowProtocol := protocol
 			nwDst := "nw_dst"
+			nwSrc := "nw_src"
 			if utilnet.IsIPv6String(externalIP) {
 				flowProtocol = protocol + "6"
 				nwDst = "ipv6_dst"
+				nwSrc = "ipv6_src"
 			}
 			cookie, err = svcToCookie(service.Namespace, service.Name, externalIP, svcPort.Port)
 			if err != nil {
@@ -133,9 +143,12 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 				npw.ofm.deleteFlowsByKey(key)
 			} else {
 				npw.ofm.updateFlowCacheEntry(key, []string{
-					fmt.Sprintf("cookie=%s, priority=100, in_port=%s, %s, %s=%s, tp_dst=%d, "+
+					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
 						"actions=%s",
-						cookie, npw.ofportPhys, flowProtocol, nwDst, externalIP, svcPort.Port, actions)})
+						cookie, npw.ofportPhys, flowProtocol, nwDst, externalIP, svcPort.Port, actions),
+					fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_src=%d, "+
+						"actions=output:%s",
+						cookie, npw.ofportPatch, flowProtocol, nwSrc, externalIP, svcPort.Port, npw.ofportPhys)})
 			}
 		}
 	}


### PR DESCRIPTION
Today, node port traffic is steered directly to OVN
via patch port from phys bridge to br-int

return traffic then goes through conntrack zone 64000
before being sent to the physical port.

This leads for this type of traffic to never establish
on CT zone 64000 which prevents HW offload capable NICs
from offloading this traffic pattern.

For these type of flows we can optimize by not sending
to CT on zone 64000 when egressing patch port by matching
on the src port (nodeport).

Bump the priority of node port Openflow rules to 110
to avoid commiting to CT zone 64000 for traffic egressing
patch port.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>