### PR TITLE
docs: Export KUBECONFIG in Run KIND deployment section

### DIFF
--- a/docs/kind.md
+++ b/docs/kind.md
@@ -45,7 +45,7 @@ Launch the KIND Deployment.
 
 ```
 $ pushd contrib
-$ KUBECONFIG=${HOME}/admin.conf
+$ export KUBECONFIG=${HOME}/admin.conf
 $ ./kind.sh
 $ popd
 ```


### PR DESCRIPTION
The example under `Launch the KIND Deployment` did not export the
KUBECONFIG. Run `export KUBECONFIG=${HOME}/admin.conf` instead.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->