### PR TITLE
Delete per pod nat when adding gw routes to namespace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,6 +261,11 @@ jobs:
            name: "HA"
          - enabled: "false"
            name: "noHA"
+        disable-snat-multiple-gws:
+         - enabled: "true"
+           name: "disableSnatGW"
+         - enabled: "false"
+           name: "enableSnatGW"
         gateway-mode: [local, shared]
         ipfamily:
          - ip: ipv4
@@ -303,6 +308,8 @@ jobs:
          # in agnhost images. Disable them for now.
          - {"ipfamily": {"ip": dualstack}, "target": {"shard": {"multicast-enable": "true"}}}
          - {"ipfamily": {"ip": ipv6}, "target": {"shard": {"multicast-enable": "true"}}}
+         # No need to run disable-snat-multiple-gws with local GW mode
+         - {"disable-snat-multiple-gws": {"enabled": "true"}, "gateway-mode": local}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
@@ -313,6 +320,7 @@ jobs:
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_MULTICAST_ENABLE:  "${{ matrix.target.multicast-enable }}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target.emptylb-enable }}"
+      OVN_DISABLE_SNAT_MULTIPLE_GWS: "${{ matrix.disable-snat-multiple-gws.enabled }}"
     steps:
 
     - name: Free up disk space

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -245,7 +245,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 	if gwAnnotation != oldGWAnnotation || newBFDEnabled != oldBFDEnabled {
 		// if old gw annotation was empty, new one must not be empty, so we should remove any per pod SNAT
 		if oldGWAnnotation == "" {
-			if config.Gateway.DisableSNATMultipleGWs && (len(nsInfo.routingExternalGWs.gws) != 0 || len(nsInfo.routingExternalPodGWs) != 0) {
+			if config.Gateway.DisableSNATMultipleGWs {
 				existingPods, err := oc.watchFactory.GetPods(old.Name)
 				if err != nil {
 					klog.Errorf("Failed to get all the pods (%v)", err)

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -55,6 +55,13 @@ if [ "$KIND_IPV6_SUPPORT" == true ]; then
   SKIPPED_TESTS+=$IPV6_SKIPPED_TESTS
 fi
 
+if [ "$OVN_DISABLE_SNAT_MULTIPLE_GWS" == true ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+  	SKIPPED_TESTS+="|"
+  fi
+  SKIPPED_TESTS+="Should validate the egress IP functionality against remote hosts"
+fi
+
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote
 export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

When a gw pod gets the external gateway annotation, it adds the specific
routes to the external gateway for existing pods, but it does not remove
the SNAT that was added when the pod was created.


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->