### PR TITLE
Kind: add an option to create a second interface in all nodes

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -42,6 +42,7 @@ usage() {
     echo "                 [-nbl|--ovn-loglevel-nb <loglevel>] [-sbl|--ovn-loglevel-sb <loglevel>]"
     echo "                 [-cl |--ovn-loglevel-controller <loglevel>] [-dl|--ovn-loglevel-nbctld <loglevel>]"
     echo "                 [-ep |--experimental-provider <name>] |"
+    echo "                 [-eb |--egress-gw-separate-bridge]"
     echo "                 [-h]]"
     echo ""
     echo "-cf  | --config-file               Name of the KIND J2 configuration file."
@@ -77,6 +78,7 @@ usage() {
     echo "-cl  | --ovn-loglevel-controller   Log config for ovn-controller DEFAULT: '-vconsole:info'."
     echo "-dl  | --ovn-loglevel-nbctld       Log config for nbctl daemon DEFAULT: '-vconsole:info'."
     echo "-ep  | --experimental-provider     Use an experimental OCI provider such as podman, instead of docker. DEFAULT: Disabled."
+    echo "-eb  | --egress-gw-separate-bridge The external gateway traffic uses a separate bridge."
     echo "--delete                      	   Delete current cluster"
     echo ""
 }
@@ -169,6 +171,8 @@ parse_args() {
                                                 fi
                                                 DBCHECKER_LOG_LEVEL=$1
                                                 ;;
+            -eb | --egress-gw-separate-bridge ) OVN_ENABLE_EX_GW_NETWORK_BRIDGE=true
+                                                ;;
             -ndl | --ovn-loglevel-northd )      shift
                                                 OVN_LOG_LEVEL_NORTHD=$1
                                                 ;;
@@ -230,6 +234,8 @@ print_params() {
      echo "OVN_LOG_LEVEL_CONTROLLER = $OVN_LOG_LEVEL_CONTROLLER"
      echo "OVN_LOG_LEVEL_NBCTLD = $OVN_LOG_LEVEL_NBCTLD"
      echo "OVN_HOST_NETWORK_NAMESPACE = $OVN_HOST_NETWORK_NAMESPACE"
+     echo "OVN_ENABLE_EX_GW_NETWORK_BRIDGE = $OVN_ENABLE_EX_GW_NETWORK_BRIDGE"
+     echo "OVN_EX_GW_NETWORK_INTERFACE = $OVN_EX_GW_NETWORK_INTERFACE"
      echo ""
 }
 
@@ -266,13 +272,18 @@ set_default_params() {
   OVN_LOG_LEVEL_SB=${OVN_LOG_LEVEL_SB:-"-vconsole:info -vfile:info"}
   OVN_LOG_LEVEL_CONTROLLER=${OVN_LOG_LEVEL_CONTROLLER:-"-vconsole:info"}
   OVN_LOG_LEVEL_NBCTLD=${OVN_LOG_LEVEL_NBCTLD:-"-vconsole:info"}
-
+  OVN_ENABLE_EX_GW_NETWORK_BRIDGE=${OVN_ENABLE_EX_GW_NETWORK_BRIDGE:-false}
+  OVN_EX_GW_NETWORK_INTERFACE=""
+  if [ "$OVN_ENABLE_EX_GW_NETWORK_BRIDGE" == true ]; then
+    OVN_EX_GW_NETWORK_INTERFACE="eth1"
+  fi
   # Input not currently validated. Modify outside script at your own risk.
   # These are the same values defaulted to in KIND code (kind/default.go).
   # NOTE: KIND NET_CIDR_IPV6 default use a /64 but OVN have a /64 per host
   # so it needs to use a larger subnet
   #  Upstream - NET_CIDR_IPV6=fd00:10:244::/64 SVC_CIDR_IPV6=fd00:10:96::/112
   NET_CIDR_IPV4=${NET_CIDR_IPV4:-10.244.0.0/16}
+  NET_SECOND_CIDR_IPV4=${NET_SECOND_CIDR_IPV4:-172.19.0.0/16}
   SVC_CIDR_IPV4=${SVC_CIDR_IPV4:-10.96.0.0/16}
   NET_CIDR_IPV6=${NET_CIDR_IPV6:-fd00:10:244::/48}
   SVC_CIDR_IPV6=${SVC_CIDR_IPV6:-fd00:10:96::/112}
@@ -491,7 +502,8 @@ create_ovn_kube_manifests() {
     --egress-ip-enable=true \
     --egress-firewall-enable=true \
     --v4-join-subnet="${JOIN_SUBNET_IPV4}" \
-    --v6-join-subnet="${JOIN_SUBNET_IPV6}"
+    --v6-join-subnet="${JOIN_SUBNET_IPV6}" \
+    --ex-gw-network-interface="${OVN_EX_GW_NETWORK_INTERFACE}"
   popd
 }
 
@@ -557,6 +569,18 @@ kubectl_wait_pods() {
   fi
 }
 
+docker_create_second_interface() {
+  echo "adding second interfaces to nodes"
+
+  # Create the network as dual stack, regardless of the type of the deployment. Ignore if already exists.
+  docker network create --ipv6 --driver=bridge kind-exgw --subnet=172.19.0.0/16 --subnet=fc00:f853:ccd:e798::/64 || true
+
+  KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
+  for n in $KIND_NODES; do
+    docker network connect kind-exgw "$n"
+  done
+}
+
 sleep_until_pods_settle() {
   echo "Pods are all up, allowing things settle for 30 seconds..."
   sleep 30
@@ -574,6 +598,9 @@ check_ipv6
 set_cluster_cidr_ip_families
 create_kind_cluster
 docker_disable_ipv6
+if [ $OVN_ENABLE_EX_GW_NETWORK_BRIDGE == true ]; then
+  docker_create_second_interface
+fi
 coredns_patch
 build_ovn_image
 detect_apiserver_url

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -48,6 +48,7 @@ OVN_NETFLOW_TARGETS=""
 OVN_SFLOW_TARGETS=""
 OVN_IPFIX_TARGETS=""
 OVN_HOST_NETWORK_NAMESPACE=""
+OVN_EX_GW_NETWORK_INTERFACE=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -183,6 +184,9 @@ while [ "$1" != "" ]; do
   --host-network-namespace)
     OVN_HOST_NETWORK_NAMESPACE=$VALUE
     ;;
+  --ex-gw-network-interface)
+    OVN_EX_GW_NETWORK_INTERFACE=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -280,6 +284,8 @@ ovn_sflow_targets=${OVN_SFLOW_TARGETS}
 echo "ovn_sflow_targets: ${ovn_sflow_targets}"
 ovn_ipfix_targets=${OVN_IPFIX_TARGETS}
 echo "ovn_ipfix_targets: ${ovn_ipfix_targets}"
+ovn_ex_gw_networking_interface=${OVN_EX_GW_NETWORK_INTERFACE}
+echo "ovn_ex_gw_networking_interface: ${ovn_ex_gw_networking_interface}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -304,6 +310,7 @@ ovn_image=${image} \
   ovn_netflow_targets=${ovn_netflow_targets} \
   ovn_sflow_targets=${ovn_sflow_targets} \
   ovn_ipfix_targets=${ovn_ipfix_targets} \
+  ovn_ex_gw_networking_interface=${ovn_ex_gw_networking_interface} \
   ovnkube_app_name=ovnkube-node \
   j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node.yaml
 
@@ -332,6 +339,7 @@ ovn_image=${image} \
   ovn_netflow_targets=${ovn_netflow_targets} \
   ovn_sflow_targets=${ovn_sflow_targets} \
   ovn_ipfix_targets=${ovn_ipfix_targets} \
+  ovn_ex_gw_networking_interface=${ovn_ex_gw_networking_interface} \
   ovnkube_app_name=ovnkube-node-smart-nic-host \
   j2 ../templates/ovnkube-node.yaml.j2 -o ../yaml/ovnkube-node-smart-nic-host.yaml
 
@@ -357,6 +365,7 @@ ovn_image=${image} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_master_count=${ovn_master_count} \
   ovn_gateway_mode=${ovn_gateway_mode} \
+  ovn_ex_gw_networking_interface=${ovn_ex_gw_networking_interface} \
   j2 ../templates/ovnkube-master.yaml.j2 -o ../yaml/ovnkube-master.yaml
 
 ovn_image=${image} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -208,6 +208,8 @@ ovnkube_node_mode=${OVNKUBE_NODE_MODE:-"full"}
 # OVN_ENCAP_IP - encap IP to be used for OVN traffic on the node
 ovn_encap_ip=${OVN_ENCAP_IP:-}
 
+ovn_ex_gw_network_interface=${OVN_EX_GW_NETWORK_INTERFACE:-}
+
 # Determine the ovn rundir.
 if [[ -f /usr/bin/ovn-appctl ]]; then
   # ovn-appctl is present. Use new ovn run dir path.
@@ -1049,6 +1051,11 @@ ovn-node() {
       ipfix_targets="--ipfix-targets ${ovn_ipfix_targets}"
   fi
 
+  egress_interface=
+  if [[ -n ${ovn_ex_gw_network_interface} ]]; then
+      egress_interface="--exgw-interface ${ovn_ex_gw_network_interface}"
+  fi
+
   ovn_encap_ip_flag=
   if [[ ${ovn_encap_ip} != "" ]]; then
     ovn_encap_ip_flag="--encap-ip=${ovn_encap_ip}"
@@ -1126,6 +1133,7 @@ ovn-node() {
     --ovn-metrics-bind-address ${ovn_metrics_bind_address} \
     --metrics-bind-address ${ovnkube_node_metrics_bind_address} \
      ${ovnkube_node_mode_flag} \
+    ${egress_interface} \
     --host-network-namespace ${ovn_host_network_namespace} &
 
   wait_for_event attempts=3 process_ready ovnkube

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -169,6 +169,8 @@ spec:
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_UNPRIVILEGED_MODE
           value: "{{ ovn_unprivileged_mode }}"
+        - name: OVN_EX_GW_NETWORK_INTERFACE
+          value: "{{ ovn_ex_gw_networking_interface }}"
         {% if ovnkube_app_name=="ovnkube-node" -%}
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

When running kind with -eb, we create a second network and add all the
node-containers to it to create a second interface into "nodes".
Then, we use the value of the same parameter to instruct ovnkube that we
intend to use a different nic for external gateway traffic.


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

This is based to the additional parameters introduced in https://github.com/ovn-org/ovn-kubernetes/pull/2270

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->