### PR TITLE
Add libovsdb clients to controllers & test harness

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -6,16 +6,17 @@ require (
 	github.com/Mellanox/sriovnet v1.0.2
 	github.com/Microsoft/go-winio v0.4.15 // indirect
 	github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990
+	github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae
 	github.com/bhendo/go-powershell v0.0.0-20190719160123-219e7fb4e41e
+	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.8.7
 	github.com/coreos/go-iptables v0.4.5
 	github.com/ebay/go-ovn v0.1.1-0.20210603173524-8db200d06216
 	github.com/ebay/libovsdb v0.2.1-0.20200719163122-3332afaeb27c
-	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f // indirect
 	github.com/juju/testing v0.0.0-20200706033705-4c23f9c453cd // indirect
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc
@@ -24,7 +25,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.1
-	github.com/ovn-org/libovsdb v0.5.0
+	github.com/ovn-org/libovsdb v0.5.1-0.20210708171313-d17ab7f31fc4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/procfs v0.2.0 // indirect

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -21,6 +21,7 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.1/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
 github.com/Azure/go-autorest/autorest/adal v0.9.0/go.mod h1:/c022QCutn2P7uY+/oQWWNcK9YU+MH96NgK+jErpbcg=
@@ -36,6 +37,7 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Mellanox/sriovnet v1.0.2 h1:VTQHD7OHU6QejTtclt5a2obDfsW1ATRxTCgZmsiKmXI=
 github.com/Mellanox/sriovnet v1.0.2/go.mod h1:pXdSZwahlvP0Xn8nuXcVthBE38Nqf2czo449p5ALLXY=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
+github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/go-winio v0.4.15 h1:qkLXKzb1QoVatRyd/YlXZ/Kg0m5K3SPuoD82jjSOaBc=
 github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -43,6 +45,7 @@ github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXn
 github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990 h1:1xpVY4dSUSbW3PcSGxZJhI8Z+CJiqbd933kM7HIinTc=
 github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990/go.mod h1:ay/0dTb7NsG8QMDfsRfLHgZo/6xAJShLe1+ePPflihk=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -51,6 +54,7 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae h1:AMzIhMUqU3jMrZiTuW0zkYeKlKDAFD+DG20IoO421/Y=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -62,6 +66,9 @@ github.com/bhendo/go-powershell v0.0.0-20190719160123-219e7fb4e41e/go.mod h1:f7v
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cenk/hub v1.0.1 h1:RBwXNOF4a8KjD8BJ08XqN8KbrqaGiQLDrgvUGJSHuPA=
 github.com/cenk/hub v1.0.1/go.mod h1:rJM1LNAW0ppT8FMMuPK6c2NP/R2nH/UthtuRySSaf6Y=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
+github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/hub v1.0.1-0.20160527103212-11382a9960d3/go.mod h1:tcYwtS3a2d9NO/0xDXVJWx3IedurUjYCqFCmpi0lpHs=
 github.com/cenkalti/hub v1.0.1 h1:UMtjc6dHSaOQTO15SVA50MBIR9zQwvsukQupDrkIRtg=
 github.com/cenkalti/hub v1.0.1/go.mod h1:tcYwtS3a2d9NO/0xDXVJWx3IedurUjYCqFCmpi0lpHs=
@@ -81,6 +88,7 @@ github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
+github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
@@ -97,6 +105,7 @@ github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
@@ -105,6 +114,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -198,6 +210,7 @@ github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
@@ -218,8 +231,8 @@ github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
-github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
+github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
@@ -255,6 +268,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -268,8 +282,10 @@ github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -295,10 +311,14 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
+github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/ovn-org/libovsdb v0.5.0 h1:yK6Xru8dM+gcuvzx4sbsNDYOFQXOYj+ybsmL/3+hIjs=
-github.com/ovn-org/libovsdb v0.5.0/go.mod h1:e4Le0OKpNDsiuNOhkYjdB5JKWpVQjJCUYZRl3uYdEfw=
+github.com/ory/dockertest/v3 v3.7.0/go.mod h1:PvCCgnP7AfBZeVrzwiUTjZx/IUXlGLC1zQlUQrLIlUE=
+github.com/ovn-org/libovsdb v0.5.1-0.20210708171313-d17ab7f31fc4 h1:Z8PehReAsSzP2/CzLcjki2FDILrJgSKhoRSK5EUQVis=
+github.com/ovn-org/libovsdb v0.5.1-0.20210708171313-d17ab7f31fc4/go.mod h1:5Ld4X+oWvMlbPAGvbJyE/wp8TAWdydI67jatQ3qbsVc=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -342,6 +362,7 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
 github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -366,6 +387,9 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -500,6 +524,7 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
@@ -530,6 +555,7 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -650,6 +676,7 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
@@ -46,6 +47,7 @@ const (
 
 // NewController returns a new *Controller.
 func NewController(client clientset.Interface,
+	nbClient libovsdbclient.Client,
 	serviceInformer coreinformers.ServiceInformer,
 	endpointSliceInformer discoveryinformers.EndpointSliceInformer,
 	clusterPortGroupUUID string,
@@ -60,6 +62,7 @@ func NewController(client clientset.Interface,
 
 	c := &Controller{
 		client:           client,
+		nbClient:         nbClient,
 		serviceTracker:   st,
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
 		workerLoopPeriod: time.Second,
@@ -97,7 +100,11 @@ func NewController(client clientset.Interface,
 
 // Controller manages selector-based service endpoints.
 type Controller struct {
-	client           clientset.Interface
+	client clientset.Interface
+
+	// libovsdb northbound client interface
+	nbClient libovsdbclient.Client
+
 	eventBroadcaster record.EventBroadcaster
 	eventRecorder    record.EventRecorder
 

--- a/go-controller/pkg/ovn/controller/unidling/unidle.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,13 +24,15 @@ type unidlingController struct {
 	// Map of load balancers to service namespace
 	serviceVIPToName     map[ServiceVIPKey]types.NamespacedName
 	serviceVIPToNameLock sync.Mutex
+	sbClient             libovsdbclient.Client
 }
 
 // NewController creates a new unidling controller
-func NewController(recorder record.EventRecorder, serviceInformer cache.SharedIndexInformer) *unidlingController {
+func NewController(recorder record.EventRecorder, serviceInformer cache.SharedIndexInformer, sbClient libovsdbclient.Client) *unidlingController {
 	uc := &unidlingController{
 		eventRecorder:    recorder,
 		serviceVIPToName: map[ServiceVIPKey]types.NamespacedName{},
+		sbClient:         sbClient,
 	}
 
 	// we only process events on unidling, there is no reconcilation

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
@@ -618,6 +619,9 @@ type egressIPController struct {
 
 	// A mutex for allocator
 	allocatorMutex *sync.Mutex
+
+	// libovsdb northbound client interface
+	nbClient libovsdbclient.Client
 }
 
 func (e *egressIPController) addPodEgressIP(eIP *egressipv1.EgressIP, pod *kapi.Pod) error {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -20,6 +20,7 @@ import (
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
@@ -1268,9 +1269,14 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			f, err = factory.NewMasterWatchFactory(fakeClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			clusterController := NewOvnController(fakeClient, f, stopChan,
-				addressset.NewFakeAddressSetFactory(), ovntest.NewMockOVNClient(goovn.DBNB),
-				ovntest.NewMockOVNClient(goovn.DBSB), record.NewFakeRecorder(0))
+			dbSetup := libovsdbtest.TestSetup{}
+			libovsdbOvnNBClient, libovsdbOvnSBClient, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
+				ovntest.NewMockOVNClient(goovn.DBNB), ovntest.NewMockOVNClient(goovn.DBSB),
+				libovsdbOvnNBClient, libovsdbOvnSBClient,
+				record.NewFakeRecorder(0))
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 
 			clusterController.clusterLBsUUIDs = []string{node1.TCPLBUUID, node1.UDPLBUUID, node1.SCTPLBUUID}
@@ -1525,9 +1531,17 @@ func TestController_allocateNodeSubnets(t *testing.T) {
 				EgressFirewallClient: egressFirewallFakeClient,
 			}
 			f, err := factory.NewMasterWatchFactory(fakeClient)
-			clusterController := NewOvnController(fakeClient, f, stopChan,
-				addressset.NewFakeAddressSetFactory(), ovntest.NewMockOVNClient(goovn.DBNB),
-				ovntest.NewMockOVNClient(goovn.DBSB), record.NewFakeRecorder(0))
+
+			dbSetup := libovsdbtest.TestSetup{}
+			libovsdbOvnNBClient, libovsdbOvnSBClient, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+			if err != nil {
+				t.Fatalf("Error creating libovsdb test harness %v", err)
+			}
+
+			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
+				ovntest.NewMockOVNClient(goovn.DBNB), ovntest.NewMockOVNClient(goovn.DBSB),
+				libovsdbOvnNBClient, libovsdbOvnSBClient,
+				record.NewFakeRecorder(0))
 
 			// configure the cluster allocators
 			for _, subnetString := range tt.networkRanges {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -13,6 +13,7 @@ import (
 
 	goovn "github.com/ebay/go-ovn"
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	hocontroller "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
@@ -190,6 +191,12 @@ type Controller struct {
 	// go-ovn southbound client interface
 	ovnSBClient goovn.Client
 
+	// libovsdb northbound client interface
+	nbClient libovsdbclient.Client
+
+	// libovsdb southbound client interface
+	sbClient libovsdbclient.Client
+
 	// v4HostSubnetsUsed keeps track of number of v4 subnets currently assigned to nodes
 	v4HostSubnetsUsed float64
 
@@ -233,8 +240,9 @@ func GetIPFullMask(ip string) string {
 
 // NewOvnController creates a new OVN controller for creating logical network
 // infrastructure and policy
-func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory,
-	stopChan <-chan struct{}, addressSetFactory addressset.AddressSetFactory, ovnNBClient goovn.Client, ovnSBClient goovn.Client, recorder record.EventRecorder) *Controller {
+func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, stopChan <-chan struct{}, addressSetFactory addressset.AddressSetFactory,
+	ovnNBClient goovn.Client, ovnSBClient goovn.Client, libovsdbOvnNBClient libovsdbclient.Client, libovsdbOvnSBClient libovsdbclient.Client,
+	recorder record.EventRecorder) *Controller {
 	if addressSetFactory == nil {
 		addressSetFactory = addressset.NewOvnAddressSetFactory()
 	}
@@ -267,6 +275,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory,
 			podHandlerCache:       make(map[string]factory.Handler),
 			allocatorMutex:        &sync.Mutex{},
 			allocator:             make(map[string]*egressNode),
+			nbClient:              libovsdbOvnNBClient,
 		},
 		loadbalancerClusterCache: make(map[kapi.Protocol]string),
 		multicastSupport:         config.EnableMulticast,
@@ -276,6 +285,8 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory,
 		recorder:                 recorder,
 		ovnNBClient:              ovnNBClient,
 		ovnSBClient:              ovnSBClient,
+		nbClient:                 libovsdbOvnNBClient,
+		sbClient:                 libovsdbOvnSBClient,
 		clusterLBsUUIDs:          make([]string, 0),
 	}
 }
@@ -328,6 +339,7 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 		unidlingController := unidling.NewController(
 			oc.recorder,
 			oc.watchFactory.ServiceInformer(),
+			oc.sbClient,
 		)
 		wg.Add(1)
 		go func() {
@@ -1086,6 +1098,7 @@ func (oc *Controller) StartServiceController(wg *sync.WaitGroup, runRepair bool)
 
 	oc.svcController = svccontroller.NewController(
 		oc.client,
+		oc.nbClient,
 		svcFactory.Core().V1().Services(),
 		svcFactory.Discovery().V1beta1().EndpointSlices(),
 		oc.clusterPortGroupUUID,

--- a/go-controller/pkg/testing/libovsdb/libovsdb.go
+++ b/go-controller/pkg/testing/libovsdb/libovsdb.go
@@ -1,0 +1,207 @@
+package libovsdb
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/alexflint/go-filemutex"
+	"github.com/google/uuid"
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/mapper"
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/libovsdb/server"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+type TestSetup struct {
+	NBData []TestData
+	SBData []TestData
+}
+
+type TestData interface{}
+
+type clientBuilderFn func(config.OvnAuthConfig, chan struct{}) (libovsdbclient.Client, error)
+type serverBuilderFn func(config.OvnAuthConfig, []TestData) (*server.OvsdbServer, error)
+
+// NewNBSBTestHarness runs NB & SB OVSDB servers and returns corresponding clients
+func NewNBSBTestHarness(setup TestSetup, stopChan chan struct{}) (libovsdbclient.Client, libovsdbclient.Client, error) {
+	nbClient, err := NewNBTestHarness(setup, stopChan)
+	if err != nil {
+		return nil, nil, err
+	}
+	sbClient, err := NewSBTestHarness(setup, stopChan)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nbClient, sbClient, nil
+}
+
+// NewNBTestHarness runs NB server and returns corresponding client
+func NewNBTestHarness(setup TestSetup, stopChan chan struct{}) (libovsdbclient.Client, error) {
+	return newOVSDBTestHarness(setup.NBData, stopChan, newNBServer, newNBClient)
+}
+
+// NewSBTestHarness runs SB server and returns corresponding client
+func NewSBTestHarness(setup TestSetup, stopChan chan struct{}) (libovsdbclient.Client, error) {
+	return newOVSDBTestHarness(setup.SBData, stopChan, newSBServer, newSBClient)
+}
+
+func newOVSDBTestHarness(serverData []TestData, stopChan chan struct{}, newServer serverBuilderFn, newClient clientBuilderFn) (libovsdbclient.Client, error) {
+	cfg := config.OvnAuthConfig{
+		Scheme:  config.OvnDBSchemeUnix,
+		Address: "unix:" + tempOVSDBSocketFileName(),
+	}
+
+	s, err := newServer(cfg, serverData)
+	if err != nil {
+		return nil, err
+	}
+
+	internalStopChan := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stopChan:
+				s.Close()
+				return
+			case <-internalStopChan:
+				s.Close()
+				return
+			}
+		}
+	}()
+
+	c, err := newClient(cfg, stopChan)
+	if err != nil {
+		close(internalStopChan)
+	}
+
+	return c, err
+}
+
+func newNBClient(cfg config.OvnAuthConfig, stopChan chan struct{}) (libovsdbclient.Client, error) {
+	libovsdbOvnNBClient, err := util.NewNBClientWithConfig(cfg, stopChan)
+	if err != nil {
+		return nil, err
+	}
+	return libovsdbOvnNBClient, err
+}
+
+func newSBClient(cfg config.OvnAuthConfig, stopChan chan struct{}) (libovsdbclient.Client, error) {
+	libovsdbOvnSBClient, err := util.NewSBClientWithConfig(cfg, stopChan)
+	if err != nil {
+		return nil, err
+	}
+	return libovsdbOvnSBClient, err
+}
+
+func newSBServer(cfg config.OvnAuthConfig, data []TestData) (*server.OvsdbServer, error) {
+	dbModel, err := sbdb.FullDatabaseModel()
+	if err != nil {
+		return nil, err
+	}
+	schema := sbdb.Schema()
+	return newOVSDBServer(cfg, dbModel, schema, data)
+}
+
+func newNBServer(cfg config.OvnAuthConfig, data []TestData) (*server.OvsdbServer, error) {
+	dbModel, err := nbdb.FullDatabaseModel()
+	if err != nil {
+		return nil, err
+	}
+	schema := nbdb.Schema()
+	return newOVSDBServer(cfg, dbModel, schema, data)
+}
+
+func newOVSDBServer(cfg config.OvnAuthConfig, dbModel *model.DBModel, schema ovsdb.DatabaseSchema, data []TestData) (*server.OvsdbServer, error) {
+	db := server.NewInMemoryDatabase(map[string]*model.DBModel{
+		schema.Name: dbModel,
+	})
+	s, err := server.NewOvsdbServer(db, server.DatabaseModel{
+		Model:  dbModel,
+		Schema: &schema,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > 0 {
+		dbName := dbModel.Name()
+		m := mapper.NewMapper(&schema)
+		for _, d := range data {
+			tableName := dbModel.FindTable(reflect.TypeOf(d))
+			if tableName == "" {
+				return nil, fmt.Errorf("object of type %s is not part of the DBModel", reflect.TypeOf(m))
+			}
+			row, err := m.NewRow(tableName, d)
+			if err != nil {
+				return nil, err
+			}
+			res, _ := db.Insert(dbName, tableName, uuid.NewString(), row)
+			if res.Error != "" {
+				return nil, fmt.Errorf("%s: %s", res.Error, res.Details)
+			}
+		}
+	}
+
+	sockPath := strings.TrimPrefix(cfg.Address, "unix:")
+	lockPath := fmt.Sprintf("%s.lock", sockPath)
+	fileMutex, err := filemutex.New(lockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = fileMutex.Lock()
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		if err := s.Serve(string(cfg.Scheme), sockPath); err != nil {
+			log.Fatalf("libovsdb test harness error: %v", err)
+		}
+		fileMutex.Close()
+		os.RemoveAll(lockPath)
+		os.RemoveAll(sockPath)
+	}()
+
+	err = wait.Poll(100*time.Millisecond, 500*time.Millisecond, func() (bool, error) { return s.Ready(), nil })
+	if err != nil {
+		s.Close()
+		return nil, err
+	}
+
+	return s, nil
+}
+
+var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func tempOVSDBSocketFileName() string {
+	randBytes := make([]byte, 16)
+	random.Read(randBytes)
+	return filepath.Join(os.TempDir(), "ovsdb-"+hex.EncodeToString(randBytes))
+}
+
+func getTestDataFromClientCache(client libovsdbclient.Client) []TestData {
+	cache := client.Cache()
+	data := []TestData{}
+	for _, tname := range cache.Tables() {
+		table := cache.Table(tname)
+		for _, uuid := range table.Rows() {
+			row := table.Row(uuid)
+			data = append(data, row)
+		}
+	}
+	return data
+}

--- a/go-controller/pkg/testing/libovsdb/matchers.go
+++ b/go-controller/pkg/testing/libovsdb/matchers.go
@@ -1,0 +1,130 @@
+package libovsdb
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega"
+	gomegaformat "github.com/onsi/gomega/format"
+	gomegatypes "github.com/onsi/gomega/types"
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+)
+
+// If x and y are structs, interfaces that contain struct or pointers to struct,
+// it will perform deep equal ignoring any type field tagged with `ovsdb:"_uuid"`
+// in those structs. Otherwise it will perform a standard deep equal
+func testDataDeepEqualIgnoringUUID(x, y interface{}) bool {
+	if x == nil || y == nil {
+		return x == y
+	}
+	v1 := reflect.ValueOf(x)
+	v2 := reflect.ValueOf(y)
+	if !v1.IsValid() || !v2.IsValid() {
+		return v1.IsValid() == v2.IsValid()
+	}
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	return testDataDeepValueEqualIgnoringUUID(v1, v2, true)
+}
+
+func testDataDeepValueEqualIgnoringUUID(v1, v2 reflect.Value, ignoreUUID bool) bool {
+	switch v1.Kind() {
+	case reflect.Ptr:
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		if ignoreUUID {
+			return testDataDeepValueEqualIgnoringUUID(v1.Elem(), v2.Elem(), false)
+		}
+		return reflect.DeepEqual(v1.Elem().Interface(), v2.Elem().Interface())
+	case reflect.Interface:
+		if v1.IsNil() || v2.IsNil() {
+			return v1.IsNil() == v2.IsNil()
+		}
+		if ignoreUUID {
+			return testDataDeepValueEqualIgnoringUUID(v1.Elem(), v2.Elem(), false)
+		}
+		return reflect.DeepEqual(v1.Elem().Interface(), v2.Elem().Interface())
+	case reflect.Struct:
+		for i, n := 0, v1.NumField(); i < n; i++ {
+			if tag := v1.Type().Field(i).Tag.Get("ovsdb"); tag == "_uuid" {
+				continue
+			}
+			if !reflect.DeepEqual(v1.Field(i).Interface(), v2.Field(i).Interface()) {
+				return false
+			}
+		}
+		return true
+	}
+	return reflect.DeepEqual(v1.Interface(), v2.Interface())
+}
+
+func HaveTestData(expected ...TestData) gomegatypes.GomegaMatcher {
+	return haveTestData(false, expected)
+}
+
+func HaveTestDataIgnoringUUIDs(expected ...TestData) gomegatypes.GomegaMatcher {
+	return haveTestData(true, expected)
+}
+
+func HaveEmptyTestData() gomegatypes.GomegaMatcher {
+	transform := func(client libovsdbclient.Client) []TestData {
+		return getTestDataFromClientCache(client)
+	}
+	return gomega.WithTransform(transform, gomega.BeEmpty())
+}
+
+func haveTestData(ignoreUUID bool, expected []TestData) gomegatypes.GomegaMatcher {
+	if e, ok := expected[0].([]TestData); len(expected) == 1 && ok {
+		// flatten
+		expected = e
+	}
+	matchers := []gomegatypes.GomegaMatcher{}
+	for _, e := range expected {
+		matchers = append(matchers, matchTestData(ignoreUUID, e))
+	}
+	transform := func(client libovsdbclient.Client) []TestData {
+		return getTestDataFromClientCache(client)
+	}
+	return gomega.WithTransform(transform, gomega.ContainElements(matchers))
+}
+
+func MatchTestDataIgnoringUUID(expected TestData) gomegatypes.GomegaMatcher {
+	return matchTestData(true, expected)
+}
+
+func MatchTestData(expected TestData) gomegatypes.GomegaMatcher {
+	return matchTestData(false, expected)
+}
+
+func matchTestData(ignoreUUID bool, expected TestData) gomegatypes.GomegaMatcher {
+	return &testDataMatcher{
+		expected:   expected,
+		ignoreUUID: ignoreUUID,
+	}
+}
+
+type testDataMatcher struct {
+	expected   TestData
+	ignoreUUID bool
+}
+
+func (matcher *testDataMatcher) Match(actual interface{}) (bool, error) {
+	data, ok := actual.(TestData)
+	if !ok {
+		return false, fmt.Errorf("MatchServerData matcher expects an libovsdb.ServerData")
+	}
+	if matcher.ignoreUUID {
+		return testDataDeepEqualIgnoringUUID(data, matcher.expected), nil
+	}
+	return reflect.DeepEqual(data, matcher.expected), nil
+}
+
+func (matcher *testDataMatcher) FailureMessage(actual interface{}) string {
+	return gomegaformat.Message(actual, "to equal (except uuid)", matcher.expected)
+}
+
+func (matcher *testDataMatcher) NegatedFailureMessage(actual interface{}) string {
+	return gomegaformat.Message(actual, "not to equal (except uuid)", matcher.expected)
+}

--- a/go-controller/vendor/github.com/alexflint/go-filemutex/LICENSE
+++ b/go-controller/vendor/github.com/alexflint/go-filemutex/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2010-2017 Alex Flint.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/go-controller/vendor/github.com/alexflint/go-filemutex/README.md
+++ b/go-controller/vendor/github.com/alexflint/go-filemutex/README.md
@@ -1,0 +1,31 @@
+# FileMutex
+
+FileMutex is similar to `sync.RWMutex`, but also synchronizes across processes.
+On Linux, OSX, and other POSIX systems it uses the flock system call. On windows
+it uses the LockFileEx and UnlockFileEx system calls.
+
+```go
+import (
+	"log"
+	"github.com/alexflint/go-filemutex"
+)
+
+func main() {
+	m, err := filemutex.New("/tmp/foo.lock")
+	if err != nil {
+		log.Fatalln("Directory did not exist or file could not created")
+	}
+
+	m.Lock()  // Will block until lock can be acquired
+
+	// Code here is protected by the mutex
+
+	m.Unlock()
+}
+```
+
+### Installation
+
+    go get github.com/alexflint/go-filemutex
+
+Forked from https://github.com/golang/build/tree/master/cmd/builder/filemutex_*.go

--- a/go-controller/vendor/github.com/alexflint/go-filemutex/filemutex_flock.go
+++ b/go-controller/vendor/github.com/alexflint/go-filemutex/filemutex_flock.go
@@ -1,0 +1,67 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package filemutex
+
+import (
+	"syscall"
+)
+
+const (
+	mkdirPerm = 0750
+)
+
+// FileMutex is similar to sync.RWMutex, but also synchronizes across processes.
+// This implementation is based on flock syscall.
+type FileMutex struct {
+	fd int
+}
+
+func New(filename string) (*FileMutex, error) {
+	fd, err := syscall.Open(filename, syscall.O_CREAT|syscall.O_RDONLY, mkdirPerm)
+	if err != nil {
+		return nil, err
+	}
+	return &FileMutex{fd: fd}, nil
+}
+
+func (m *FileMutex) Lock() error {
+	if err := syscall.Flock(m.fd, syscall.LOCK_EX); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *FileMutex) Unlock() error {
+	if err := syscall.Flock(m.fd, syscall.LOCK_UN); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *FileMutex) RLock() error {
+	if err := syscall.Flock(m.fd, syscall.LOCK_SH); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *FileMutex) RUnlock() error {
+	if err := syscall.Flock(m.fd, syscall.LOCK_UN); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close does an Unlock() combined with closing and unlinking the associated
+// lock file. You should create a New() FileMutex for every Lock() attempt if
+// using Close().
+func (m *FileMutex) Close() error {
+	if err := syscall.Flock(m.fd, syscall.LOCK_UN); err != nil {
+		return err
+	}
+	return syscall.Close(m.fd)
+}

--- a/go-controller/vendor/github.com/alexflint/go-filemutex/filemutex_windows.go
+++ b/go-controller/vendor/github.com/alexflint/go-filemutex/filemutex_windows.go
@@ -1,0 +1,102 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package filemutex
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
+)
+
+const (
+	lockfileExclusiveLock = 2
+)
+
+func lockFileEx(h syscall.Handle, flags, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r1, _, e1 := syscall.Syscall6(procLockFileEx.Addr(), 6, uintptr(h), uintptr(flags), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func unlockFileEx(h syscall.Handle, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r1, _, e1 := syscall.Syscall6(procUnlockFileEx.Addr(), 5, uintptr(h), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+// FileMutex is similar to sync.RWMutex, but also synchronizes across processes.
+// This implementation is based on flock syscall.
+type FileMutex struct {
+	fd syscall.Handle
+}
+
+func New(filename string) (*FileMutex, error) {
+	fd, err := syscall.CreateFile(&(syscall.StringToUTF16(filename)[0]), syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE, nil, syscall.OPEN_ALWAYS, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &FileMutex{fd: fd}, nil
+}
+
+func (m *FileMutex) Lock() error {
+	var ol syscall.Overlapped
+	if err := lockFileEx(m.fd, lockfileExclusiveLock, 0, 1, 0, &ol); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *FileMutex) Unlock() error {
+	var ol syscall.Overlapped
+	if err := unlockFileEx(m.fd, 0, 1, 0, &ol); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *FileMutex) RLock() error {
+	var ol syscall.Overlapped
+	if err := lockFileEx(m.fd, 0, 0, 1, 0, &ol); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *FileMutex) RUnlock() error {
+	var ol syscall.Overlapped
+	if err := unlockFileEx(m.fd, 0, 1, 0, &ol); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close does an Unlock() combined with closing and unlinking the associated
+// lock file. You should create a New() FileMutex for every Lock() attempt if
+// using Close().
+func (m *FileMutex) Close() error {
+	var ol syscall.Overlapped
+	if err := unlockFileEx(m.fd, 0, 1, 0, &ol); err != nil {
+		return err
+	}
+	return syscall.Close(m.fd)
+}

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/.gitignore
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/.gitignore
@@ -1,0 +1,25 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+
+# IDEs
+.idea/

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/.travis.yml
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go:
+  - 1.13
+  - 1.x
+  - tip
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+script:
+  - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/LICENSE
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/README.md
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/README.md
@@ -1,0 +1,32 @@
+# Exponential Backoff [![GoDoc][godoc image]][godoc] [![Build Status][travis image]][travis] [![Coverage Status][coveralls image]][coveralls]
+
+This is a Go port of the exponential backoff algorithm from [Google's HTTP Client Library for Java][google-http-java-client].
+
+[Exponential backoff][exponential backoff wiki]
+is an algorithm that uses feedback to multiplicatively decrease the rate of some process,
+in order to gradually find an acceptable rate.
+The retries exponentially increase and stop increasing when a certain threshold is met.
+
+## Usage
+
+Import path is `github.com/cenkalti/backoff/v4`. Please note the version part at the end.
+
+Use https://pkg.go.dev/github.com/cenkalti/backoff/v4 to view the documentation.
+
+## Contributing
+
+* I would like to keep this library as small as possible.
+* Please don't send a PR without opening an issue and discussing it first.
+* If proposed change is not a common use case, I will probably not accept it.
+
+[godoc]: https://pkg.go.dev/github.com/cenkalti/backoff/v4
+[godoc image]: https://godoc.org/github.com/cenkalti/backoff?status.png
+[travis]: https://travis-ci.org/cenkalti/backoff
+[travis image]: https://travis-ci.org/cenkalti/backoff.png?branch=master
+[coveralls]: https://coveralls.io/github/cenkalti/backoff?branch=master
+[coveralls image]: https://coveralls.io/repos/github/cenkalti/backoff/badge.svg?branch=master
+
+[google-http-java-client]: https://github.com/google/google-http-java-client/blob/da1aa993e90285ec18579f1553339b00e19b3ab5/google-http-client/src/main/java/com/google/api/client/util/ExponentialBackOff.java
+[exponential backoff wiki]: http://en.wikipedia.org/wiki/Exponential_backoff
+
+[advanced example]: https://pkg.go.dev/github.com/cenkalti/backoff/v4?tab=doc#pkg-examples

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/backoff.go
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/backoff.go
@@ -1,0 +1,66 @@
+// Package backoff implements backoff algorithms for retrying operations.
+//
+// Use Retry function for retrying operations that may fail.
+// If Retry does not meet your needs,
+// copy/paste the function into your project and modify as you wish.
+//
+// There is also Ticker type similar to time.Ticker.
+// You can use it if you need to work with channels.
+//
+// See Examples section below for usage examples.
+package backoff
+
+import "time"
+
+// BackOff is a backoff policy for retrying an operation.
+type BackOff interface {
+	// NextBackOff returns the duration to wait before retrying the operation,
+	// or backoff. Stop to indicate that no more retries should be made.
+	//
+	// Example usage:
+	//
+	// 	duration := backoff.NextBackOff();
+	// 	if (duration == backoff.Stop) {
+	// 		// Do not retry operation.
+	// 	} else {
+	// 		// Sleep for duration and retry operation.
+	// 	}
+	//
+	NextBackOff() time.Duration
+
+	// Reset to initial state.
+	Reset()
+}
+
+// Stop indicates that no more retries should be made for use in NextBackOff().
+const Stop time.Duration = -1
+
+// ZeroBackOff is a fixed backoff policy whose backoff time is always zero,
+// meaning that the operation is retried immediately without waiting, indefinitely.
+type ZeroBackOff struct{}
+
+func (b *ZeroBackOff) Reset() {}
+
+func (b *ZeroBackOff) NextBackOff() time.Duration { return 0 }
+
+// StopBackOff is a fixed backoff policy that always returns backoff.Stop for
+// NextBackOff(), meaning that the operation should never be retried.
+type StopBackOff struct{}
+
+func (b *StopBackOff) Reset() {}
+
+func (b *StopBackOff) NextBackOff() time.Duration { return Stop }
+
+// ConstantBackOff is a backoff policy that always returns the same backoff delay.
+// This is in contrast to an exponential backoff policy,
+// which returns a delay that grows longer as you call NextBackOff() over and over again.
+type ConstantBackOff struct {
+	Interval time.Duration
+}
+
+func (b *ConstantBackOff) Reset()                     {}
+func (b *ConstantBackOff) NextBackOff() time.Duration { return b.Interval }
+
+func NewConstantBackOff(d time.Duration) *ConstantBackOff {
+	return &ConstantBackOff{Interval: d}
+}

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/context.go
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/context.go
@@ -1,0 +1,62 @@
+package backoff
+
+import (
+	"context"
+	"time"
+)
+
+// BackOffContext is a backoff policy that stops retrying after the context
+// is canceled.
+type BackOffContext interface { // nolint: golint
+	BackOff
+	Context() context.Context
+}
+
+type backOffContext struct {
+	BackOff
+	ctx context.Context
+}
+
+// WithContext returns a BackOffContext with context ctx
+//
+// ctx must not be nil
+func WithContext(b BackOff, ctx context.Context) BackOffContext { // nolint: golint
+	if ctx == nil {
+		panic("nil context")
+	}
+
+	if b, ok := b.(*backOffContext); ok {
+		return &backOffContext{
+			BackOff: b.BackOff,
+			ctx:     ctx,
+		}
+	}
+
+	return &backOffContext{
+		BackOff: b,
+		ctx:     ctx,
+	}
+}
+
+func getContext(b BackOff) context.Context {
+	if cb, ok := b.(BackOffContext); ok {
+		return cb.Context()
+	}
+	if tb, ok := b.(*backOffTries); ok {
+		return getContext(tb.delegate)
+	}
+	return context.Background()
+}
+
+func (b *backOffContext) Context() context.Context {
+	return b.ctx
+}
+
+func (b *backOffContext) NextBackOff() time.Duration {
+	select {
+	case <-b.ctx.Done():
+		return Stop
+	default:
+		return b.BackOff.NextBackOff()
+	}
+}

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/exponential.go
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/exponential.go
@@ -1,0 +1,158 @@
+package backoff
+
+import (
+	"math/rand"
+	"time"
+)
+
+/*
+ExponentialBackOff is a backoff implementation that increases the backoff
+period for each retry attempt using a randomization function that grows exponentially.
+
+NextBackOff() is calculated using the following formula:
+
+ randomized interval =
+     RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])
+
+In other words NextBackOff() will range between the randomization factor
+percentage below and above the retry interval.
+
+For example, given the following parameters:
+
+ RetryInterval = 2
+ RandomizationFactor = 0.5
+ Multiplier = 2
+
+the actual backoff period used in the next retry attempt will range between 1 and 3 seconds,
+multiplied by the exponential, that is, between 2 and 6 seconds.
+
+Note: MaxInterval caps the RetryInterval and not the randomized interval.
+
+If the time elapsed since an ExponentialBackOff instance is created goes past the
+MaxElapsedTime, then the method NextBackOff() starts returning backoff.Stop.
+
+The elapsed time can be reset by calling Reset().
+
+Example: Given the following default arguments, for 10 tries the sequence will be,
+and assuming we go over the MaxElapsedTime on the 10th try:
+
+ Request #  RetryInterval (seconds)  Randomized Interval (seconds)
+
+  1          0.5                     [0.25,   0.75]
+  2          0.75                    [0.375,  1.125]
+  3          1.125                   [0.562,  1.687]
+  4          1.687                   [0.8435, 2.53]
+  5          2.53                    [1.265,  3.795]
+  6          3.795                   [1.897,  5.692]
+  7          5.692                   [2.846,  8.538]
+  8          8.538                   [4.269, 12.807]
+  9         12.807                   [6.403, 19.210]
+ 10         19.210                   backoff.Stop
+
+Note: Implementation is not thread-safe.
+*/
+type ExponentialBackOff struct {
+	InitialInterval     time.Duration
+	RandomizationFactor float64
+	Multiplier          float64
+	MaxInterval         time.Duration
+	// After MaxElapsedTime the ExponentialBackOff returns Stop.
+	// It never stops if MaxElapsedTime == 0.
+	MaxElapsedTime time.Duration
+	Stop           time.Duration
+	Clock          Clock
+
+	currentInterval time.Duration
+	startTime       time.Time
+}
+
+// Clock is an interface that returns current time for BackOff.
+type Clock interface {
+	Now() time.Time
+}
+
+// Default values for ExponentialBackOff.
+const (
+	DefaultInitialInterval     = 500 * time.Millisecond
+	DefaultRandomizationFactor = 0.5
+	DefaultMultiplier          = 1.5
+	DefaultMaxInterval         = 60 * time.Second
+	DefaultMaxElapsedTime      = 15 * time.Minute
+)
+
+// NewExponentialBackOff creates an instance of ExponentialBackOff using default values.
+func NewExponentialBackOff() *ExponentialBackOff {
+	b := &ExponentialBackOff{
+		InitialInterval:     DefaultInitialInterval,
+		RandomizationFactor: DefaultRandomizationFactor,
+		Multiplier:          DefaultMultiplier,
+		MaxInterval:         DefaultMaxInterval,
+		MaxElapsedTime:      DefaultMaxElapsedTime,
+		Stop:                Stop,
+		Clock:               SystemClock,
+	}
+	b.Reset()
+	return b
+}
+
+type systemClock struct{}
+
+func (t systemClock) Now() time.Time {
+	return time.Now()
+}
+
+// SystemClock implements Clock interface that uses time.Now().
+var SystemClock = systemClock{}
+
+// Reset the interval back to the initial retry interval and restarts the timer.
+// Reset must be called before using b.
+func (b *ExponentialBackOff) Reset() {
+	b.currentInterval = b.InitialInterval
+	b.startTime = b.Clock.Now()
+}
+
+// NextBackOff calculates the next backoff interval using the formula:
+// 	Randomized interval = RetryInterval * (1 ± RandomizationFactor)
+func (b *ExponentialBackOff) NextBackOff() time.Duration {
+	// Make sure we have not gone over the maximum elapsed time.
+	elapsed := b.GetElapsedTime()
+	next := getRandomValueFromInterval(b.RandomizationFactor, rand.Float64(), b.currentInterval)
+	b.incrementCurrentInterval()
+	if b.MaxElapsedTime != 0 && elapsed+next > b.MaxElapsedTime {
+		return b.Stop
+	}
+	return next
+}
+
+// GetElapsedTime returns the elapsed time since an ExponentialBackOff instance
+// is created and is reset when Reset() is called.
+//
+// The elapsed time is computed using time.Now().UnixNano(). It is
+// safe to call even while the backoff policy is used by a running
+// ticker.
+func (b *ExponentialBackOff) GetElapsedTime() time.Duration {
+	return b.Clock.Now().Sub(b.startTime)
+}
+
+// Increments the current interval by multiplying it with the multiplier.
+func (b *ExponentialBackOff) incrementCurrentInterval() {
+	// Check for overflow, if overflow is detected set the current interval to the max interval.
+	if float64(b.currentInterval) >= float64(b.MaxInterval)/b.Multiplier {
+		b.currentInterval = b.MaxInterval
+	} else {
+		b.currentInterval = time.Duration(float64(b.currentInterval) * b.Multiplier)
+	}
+}
+
+// Returns a random value from the following interval:
+// 	[currentInterval - randomizationFactor * currentInterval, currentInterval + randomizationFactor * currentInterval].
+func getRandomValueFromInterval(randomizationFactor, random float64, currentInterval time.Duration) time.Duration {
+	var delta = randomizationFactor * float64(currentInterval)
+	var minInterval = float64(currentInterval) - delta
+	var maxInterval = float64(currentInterval) + delta
+
+	// Get a random value from the range [minInterval, maxInterval].
+	// The formula used below has a +1 because if the minInterval is 1 and the maxInterval is 3 then
+	// we want a 33% chance for selecting either 1, 2 or 3.
+	return time.Duration(minInterval + (random * (maxInterval - minInterval + 1)))
+}

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/go.mod
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/go.mod
@@ -1,0 +1,3 @@
+module github.com/cenkalti/backoff/v4
+
+go 1.13

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/retry.go
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/retry.go
@@ -1,0 +1,112 @@
+package backoff
+
+import (
+	"errors"
+	"time"
+)
+
+// An Operation is executing by Retry() or RetryNotify().
+// The operation will be retried using a backoff policy if it returns an error.
+type Operation func() error
+
+// Notify is a notify-on-error function. It receives an operation error and
+// backoff delay if the operation failed (with an error).
+//
+// NOTE that if the backoff policy stated to stop retrying,
+// the notify function isn't called.
+type Notify func(error, time.Duration)
+
+// Retry the operation o until it does not return error or BackOff stops.
+// o is guaranteed to be run at least once.
+//
+// If o returns a *PermanentError, the operation is not retried, and the
+// wrapped error is returned.
+//
+// Retry sleeps the goroutine for the duration returned by BackOff after a
+// failed operation returns.
+func Retry(o Operation, b BackOff) error {
+	return RetryNotify(o, b, nil)
+}
+
+// RetryNotify calls notify function with the error and wait duration
+// for each failed attempt before sleep.
+func RetryNotify(operation Operation, b BackOff, notify Notify) error {
+	return RetryNotifyWithTimer(operation, b, notify, nil)
+}
+
+// RetryNotifyWithTimer calls notify function with the error and wait duration using the given Timer
+// for each failed attempt before sleep.
+// A default timer that uses system timer is used when nil is passed.
+func RetryNotifyWithTimer(operation Operation, b BackOff, notify Notify, t Timer) error {
+	var err error
+	var next time.Duration
+	if t == nil {
+		t = &defaultTimer{}
+	}
+
+	defer func() {
+		t.Stop()
+	}()
+
+	ctx := getContext(b)
+
+	b.Reset()
+	for {
+		if err = operation(); err == nil {
+			return nil
+		}
+
+		var permanent *PermanentError
+		if errors.As(err, &permanent) {
+			return permanent.Err
+		}
+
+		if next = b.NextBackOff(); next == Stop {
+			if cerr := ctx.Err(); cerr != nil {
+				return cerr
+			}
+
+			return err
+		}
+
+		if notify != nil {
+			notify(err, next)
+		}
+
+		t.Start(next)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C():
+		}
+	}
+}
+
+// PermanentError signals that the operation should not be retried.
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PermanentError) Unwrap() error {
+	return e.Err
+}
+
+func (e *PermanentError) Is(target error) bool {
+	_, ok := target.(*PermanentError)
+	return ok
+}
+
+// Permanent wraps the given err in a *PermanentError.
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &PermanentError{
+		Err: err,
+	}
+}

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/ticker.go
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/ticker.go
@@ -1,0 +1,97 @@
+package backoff
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Ticker holds a channel that delivers `ticks' of a clock at times reported by a BackOff.
+//
+// Ticks will continue to arrive when the previous operation is still running,
+// so operations that take a while to fail could run in quick succession.
+type Ticker struct {
+	C        <-chan time.Time
+	c        chan time.Time
+	b        BackOff
+	ctx      context.Context
+	timer    Timer
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// NewTicker returns a new Ticker containing a channel that will send
+// the time at times specified by the BackOff argument. Ticker is
+// guaranteed to tick at least once.  The channel is closed when Stop
+// method is called or BackOff stops. It is not safe to manipulate the
+// provided backoff policy (notably calling NextBackOff or Reset)
+// while the ticker is running.
+func NewTicker(b BackOff) *Ticker {
+	return NewTickerWithTimer(b, &defaultTimer{})
+}
+
+// NewTickerWithTimer returns a new Ticker with a custom timer.
+// A default timer that uses system timer is used when nil is passed.
+func NewTickerWithTimer(b BackOff, timer Timer) *Ticker {
+	if timer == nil {
+		timer = &defaultTimer{}
+	}
+	c := make(chan time.Time)
+	t := &Ticker{
+		C:     c,
+		c:     c,
+		b:     b,
+		ctx:   getContext(b),
+		timer: timer,
+		stop:  make(chan struct{}),
+	}
+	t.b.Reset()
+	go t.run()
+	return t
+}
+
+// Stop turns off a ticker. After Stop, no more ticks will be sent.
+func (t *Ticker) Stop() {
+	t.stopOnce.Do(func() { close(t.stop) })
+}
+
+func (t *Ticker) run() {
+	c := t.c
+	defer close(c)
+
+	// Ticker is guaranteed to tick at least once.
+	afterC := t.send(time.Now())
+
+	for {
+		if afterC == nil {
+			return
+		}
+
+		select {
+		case tick := <-afterC:
+			afterC = t.send(tick)
+		case <-t.stop:
+			t.c = nil // Prevent future ticks from being sent to the channel.
+			return
+		case <-t.ctx.Done():
+			return
+		}
+	}
+}
+
+func (t *Ticker) send(tick time.Time) <-chan time.Time {
+	select {
+	case t.c <- tick:
+	case <-t.stop:
+		return nil
+	}
+
+	next := t.b.NextBackOff()
+	if next == Stop {
+		t.Stop()
+		return nil
+	}
+
+	t.timer.Start(next)
+	return t.timer.C()
+}

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/timer.go
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/timer.go
@@ -1,0 +1,35 @@
+package backoff
+
+import "time"
+
+type Timer interface {
+	Start(duration time.Duration)
+	Stop()
+	C() <-chan time.Time
+}
+
+// defaultTimer implements Timer interface using time.Timer
+type defaultTimer struct {
+	timer *time.Timer
+}
+
+// C returns the timers channel which receives the current time when the timer fires.
+func (t *defaultTimer) C() <-chan time.Time {
+	return t.timer.C
+}
+
+// Start starts the timer to fire after the given duration
+func (t *defaultTimer) Start(duration time.Duration) {
+	if t.timer == nil {
+		t.timer = time.NewTimer(duration)
+	} else {
+		t.timer.Reset(duration)
+	}
+}
+
+// Stop is called when the timer is not used anymore and resources may be freed.
+func (t *defaultTimer) Stop() {
+	if t.timer != nil {
+		t.timer.Stop()
+	}
+}

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/tries.go
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/tries.go
@@ -1,0 +1,38 @@
+package backoff
+
+import "time"
+
+/*
+WithMaxRetries creates a wrapper around another BackOff, which will
+return Stop if NextBackOff() has been called too many times since
+the last time Reset() was called
+
+Note: Implementation is not thread-safe.
+*/
+func WithMaxRetries(b BackOff, max uint64) BackOff {
+	return &backOffTries{delegate: b, maxTries: max}
+}
+
+type backOffTries struct {
+	delegate BackOff
+	maxTries uint64
+	numTries uint64
+}
+
+func (b *backOffTries) NextBackOff() time.Duration {
+	if b.maxTries == 0 {
+		return Stop
+	}
+	if b.maxTries > 0 {
+		if b.maxTries <= b.numTries {
+			return Stop
+		}
+		b.numTries++
+	}
+	return b.delegate.NextBackOff()
+}
+
+func (b *backOffTries) Reset() {
+	b.numTries = 0
+	b.delegate.Reset()
+}

--- a/go-controller/vendor/github.com/cenkalti/rpc2/jsonrpc/jsonrpc.go
+++ b/go-controller/vendor/github.com/cenkalti/rpc2/jsonrpc/jsonrpc.go
@@ -151,7 +151,20 @@ func (c *jsonCodec) ReadRequestBody(x interface{}) error {
 		return errMissingParams
 	}
 
-	return json.Unmarshal(*c.serverRequest.Params, x)
+	var err error
+
+	// Check if x points to a slice of any kind
+	rt := reflect.TypeOf(x)
+	if rt.Kind() == reflect.Ptr && rt.Elem().Kind() == reflect.Slice {
+		// If it's a slice, unmarshal as is
+		err = json.Unmarshal(*c.serverRequest.Params, x)
+	} else {
+		// Anything else unmarshal into a slice containing x
+		params := &[]interface{}{x}
+		err = json.Unmarshal(*c.serverRequest.Params, params)
+	}
+
+	return err
 }
 
 func (c *jsonCodec) ReadResponseBody(x interface{}) error {

--- a/go-controller/vendor/github.com/imdario/mergo/.deepsource.toml
+++ b/go-controller/vendor/github.com/imdario/mergo/.deepsource.toml
@@ -1,0 +1,12 @@
+version = 1
+
+test_patterns = [
+  "*_test.go"
+]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_path = "github.com/imdario/mergo"

--- a/go-controller/vendor/github.com/imdario/mergo/.travis.yml
+++ b/go-controller/vendor/github.com/imdario/mergo/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+arch:
+    - amd64
+    - ppc64le
 install:
   - go get -t
   - go get golang.org/x/tools/cmd/cover

--- a/go-controller/vendor/github.com/imdario/mergo/README.md
+++ b/go-controller/vendor/github.com/imdario/mergo/README.md
@@ -1,6 +1,36 @@
 # Mergo
 
+
+[![GoDoc][3]][4]
+[![GitHub release][5]][6]
+[![GoCard][7]][8]
+[![Build Status][1]][2]
+[![Coverage Status][9]][10]
+[![Sourcegraph][11]][12]
+[![FOSSA Status][13]][14]
+
+[![GoCenter Kudos][15]][16]
+
+[1]: https://travis-ci.org/imdario/mergo.png
+[2]: https://travis-ci.org/imdario/mergo
+[3]: https://godoc.org/github.com/imdario/mergo?status.svg
+[4]: https://godoc.org/github.com/imdario/mergo
+[5]: https://img.shields.io/github/release/imdario/mergo.svg
+[6]: https://github.com/imdario/mergo/releases
+[7]: https://goreportcard.com/badge/imdario/mergo
+[8]: https://goreportcard.com/report/github.com/imdario/mergo
+[9]: https://coveralls.io/repos/github/imdario/mergo/badge.svg?branch=master
+[10]: https://coveralls.io/github/imdario/mergo?branch=master
+[11]: https://sourcegraph.com/github.com/imdario/mergo/-/badge.svg
+[12]: https://sourcegraph.com/github.com/imdario/mergo?badge
+[13]: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fimdario%2Fmergo.svg?type=shield
+[14]: https://app.fossa.io/projects/git%2Bgithub.com%2Fimdario%2Fmergo?ref=badge_shield
+[15]: https://search.gocenter.io/api/ui/badge/github.com%2Fimdario%2Fmergo
+[16]: https://search.gocenter.io/github.com/imdario/mergo
+
 A helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
+
+Mergo merges same-type structs and maps by setting default values in zero-value fields. Mergo won't merge unexported (private) fields. It will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
 
 Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the Province of Ancona in the Italian region of Marche.
 
@@ -8,37 +38,17 @@ Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the
 
 It is ready for production use. [It is used in several projects by Docker, Google, The Linux Foundation, VMWare, Shopify, etc](https://github.com/imdario/mergo#mergo-in-the-wild).
 
-[![GoDoc][3]][4]
-[![GoCard][5]][6]
-[![Build Status][1]][2]
-[![Coverage Status][7]][8]
-[![Sourcegraph][9]][10]
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fimdario%2Fmergo.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fimdario%2Fmergo?ref=badge_shield)
-
-[1]: https://travis-ci.org/imdario/mergo.png
-[2]: https://travis-ci.org/imdario/mergo
-[3]: https://godoc.org/github.com/imdario/mergo?status.svg
-[4]: https://godoc.org/github.com/imdario/mergo
-[5]: https://goreportcard.com/badge/imdario/mergo
-[6]: https://goreportcard.com/report/github.com/imdario/mergo
-[7]: https://coveralls.io/repos/github/imdario/mergo/badge.svg?branch=master
-[8]: https://coveralls.io/github/imdario/mergo?branch=master
-[9]: https://sourcegraph.com/github.com/imdario/mergo/-/badge.svg
-[10]: https://sourcegraph.com/github.com/imdario/mergo?badge
-
-### Latest release
-
-[Release v0.3.7](https://github.com/imdario/mergo/releases/tag/v0.3.7).
-
 ### Important note
 
-Please keep in mind that in [0.3.2](//github.com/imdario/mergo/releases/tag/0.3.2) Mergo changed `Merge()`and `Map()` signatures to support [transformers](#transformers). An optional/variadic argument has been added, so it won't break existing code.
+Please keep in mind that a problematic PR broke [0.3.9](//github.com/imdario/mergo/releases/tag/0.3.9). I reverted it in [0.3.10](//github.com/imdario/mergo/releases/tag/0.3.10), and I consider it stable but not bug-free. Also, this version adds suppot for go modules.
 
-If you were using Mergo **before** April 6th 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause (I hope it won't!) in existing projects after the change (release 0.2.0).
+Keep in mind that in [0.3.2](//github.com/imdario/mergo/releases/tag/0.3.2), Mergo changed `Merge()`and `Map()` signatures to support [transformers](#transformers). I added an optional/variadic argument so that it won't break the existing code.
+
+If you were using Mergo before April 6th, 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause in existing projects after the change (release 0.2.0).
 
 ### Donations
 
-If Mergo is useful to you, consider buying me a coffee, a beer or making a monthly donation so I can keep building great free software. :heart_eyes:
+If Mergo is useful to you, consider buying me a coffee, a beer, or making a monthly donation to allow me to keep building great free software. :heart_eyes:
 
 <a href='https://ko-fi.com/B0B58839' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi1.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 [![Beerpay](https://beerpay.io/imdario/mergo/badge.svg)](https://beerpay.io/imdario/mergo)
@@ -87,8 +97,9 @@ If Mergo is useful to you, consider buying me a coffee, a beer or making a month
 - [mantasmatelis/whooplist-server](https://github.com/mantasmatelis/whooplist-server)
 - [jnuthong/item_search](https://github.com/jnuthong/item_search)
 - [bukalapak/snowboard](https://github.com/bukalapak/snowboard)
+- [containerssh/containerssh](https://github.com/containerssh/containerssh)
 
-## Installation
+## Install
 
     go get github.com/imdario/mergo
 
@@ -99,7 +110,7 @@ If Mergo is useful to you, consider buying me a coffee, a beer or making a month
 
 ## Usage
 
-You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as [they are not considered zero values](https://golang.org/ref/spec#The_zero_value) either. Also maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
+You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as [they are zero values](https://golang.org/ref/spec#The_zero_value) too. Also, maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
 
 ```go
 if err := mergo.Merge(&dst, src); err != nil {
@@ -125,9 +136,7 @@ if err := mergo.Map(&dst, srcMap); err != nil {
 
 Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as `map[string]interface{}`. They will be just assigned as values.
 
-More information and examples in [godoc documentation](http://godoc.org/github.com/imdario/mergo).
-
-### Nice example
+Here is a nice example:
 
 ```go
 package main
@@ -175,10 +184,10 @@ import (
         "time"
 )
 
-type timeTransfomer struct {
+type timeTransformer struct {
 }
 
-func (t timeTransfomer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+func (t timeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ == reflect.TypeOf(time.Time{}) {
 		return func(dst, src reflect.Value) error {
 			if dst.CanSet() {
@@ -202,7 +211,7 @@ type Snapshot struct {
 func main() {
 	src := Snapshot{time.Now()}
 	dest := Snapshot{}
-	mergo.Merge(&dest, src, mergo.WithTransformers(timeTransfomer{}))
+	mergo.Merge(&dest, src, mergo.WithTransformers(timeTransformer{}))
 	fmt.Println(dest)
 	// Will print
 	// { 2018-01-12 01:15:00 +0000 UTC m=+0.000000001 }

--- a/go-controller/vendor/github.com/imdario/mergo/doc.go
+++ b/go-controller/vendor/github.com/imdario/mergo/doc.go
@@ -4,41 +4,140 @@
 // license that can be found in the LICENSE file.
 
 /*
-Package mergo merges same-type structs and maps by setting default values in zero-value fields.
+A helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
 
-Mergo won't merge unexported (private) fields but will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
+Mergo merges same-type structs and maps by setting default values in zero-value fields. Mergo won't merge unexported (private) fields. It will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
+
+Status
+
+It is ready for production use. It is used in several projects by Docker, Google, The Linux Foundation, VMWare, Shopify, etc.
+
+Important note
+
+Please keep in mind that a problematic PR broke 0.3.9. We reverted it in 0.3.10. We consider 0.3.10 as stable but not bug-free. . Also, this version adds suppot for go modules.
+
+Keep in mind that in 0.3.2, Mergo changed Merge() and Map() signatures to support transformers. We added an optional/variadic argument so that it won't break the existing code.
+
+If you were using Mergo before April 6th, 2015, please check your project works as intended after updating your local copy with go get -u github.com/imdario/mergo. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause in existing projects after the change (release 0.2.0).
+
+Install
+
+Do your usual installation procedure:
+
+    go get github.com/imdario/mergo
+
+    // use in your .go code
+    import (
+        "github.com/imdario/mergo"
+    )
 
 Usage
 
-From my own work-in-progress project:
+You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as they are zero values too. Also, maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
 
-	type networkConfig struct {
-		Protocol string
-		Address string
-		ServerType string `json: "server_type"`
-		Port uint16
+	if err := mergo.Merge(&dst, src); err != nil {
+		// ...
 	}
 
-	type FssnConfig struct {
-		Network networkConfig
+Also, you can merge overwriting values using the transformer WithOverride.
+
+	if err := mergo.Merge(&dst, src, mergo.WithOverride); err != nil {
+		// ...
 	}
 
-	var fssnDefault = FssnConfig {
-		networkConfig {
-			"tcp",
-			"127.0.0.1",
-			"http",
-			31560,
-		},
+Additionally, you can map a map[string]interface{} to a struct (and otherwise, from struct to map), following the same restrictions as in Merge(). Keys are capitalized to find each corresponding exported field.
+
+	if err := mergo.Map(&dst, srcMap); err != nil {
+		// ...
 	}
 
-	// Inside a function [...]
+Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as map[string]interface{}. They will be just assigned as values.
 
-	if err := mergo.Merge(&config, fssnDefault); err != nil {
-		log.Fatal(err)
+Here is a nice example:
+
+	package main
+
+	import (
+		"fmt"
+		"github.com/imdario/mergo"
+	)
+
+	type Foo struct {
+		A string
+		B int64
 	}
 
-	// More code [...]
+	func main() {
+		src := Foo{
+			A: "one",
+			B: 2,
+		}
+		dest := Foo{
+			A: "two",
+		}
+		mergo.Merge(&dest, src)
+		fmt.Println(dest)
+		// Will print
+		// {two 2}
+	}
+
+Transformers
+
+Transformers allow to merge specific types differently than in the default behavior. In other words, now you can customize how some types are merged. For example, time.Time is a struct; it doesn't have zero value but IsZero can return true because it has fields with zero value. How can we merge a non-zero time.Time?
+
+	package main
+
+	import (
+		"fmt"
+		"github.com/imdario/mergo"
+			"reflect"
+			"time"
+	)
+
+	type timeTransformer struct {
+	}
+
+	func (t timeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+		if typ == reflect.TypeOf(time.Time{}) {
+			return func(dst, src reflect.Value) error {
+				if dst.CanSet() {
+					isZero := dst.MethodByName("IsZero")
+					result := isZero.Call([]reflect.Value{})
+					if result[0].Bool() {
+						dst.Set(src)
+					}
+				}
+				return nil
+			}
+		}
+		return nil
+	}
+
+	type Snapshot struct {
+		Time time.Time
+		// ...
+	}
+
+	func main() {
+		src := Snapshot{time.Now()}
+		dest := Snapshot{}
+		mergo.Merge(&dest, src, mergo.WithTransformers(timeTransformer{}))
+		fmt.Println(dest)
+		// Will print
+		// { 2018-01-12 01:15:00 +0000 UTC m=+0.000000001 }
+	}
+
+Contact me
+
+If I can help you, you have an idea or you are using Mergo in your projects, don't hesitate to drop me a line (or a pull request): https://twitter.com/im_dario
+
+About
+
+Written by Dario Castañé: https://da.rio.hn
+
+License
+
+BSD 3-Clause license, as Go language.
 
 */
 package mergo

--- a/go-controller/vendor/github.com/imdario/mergo/go.mod
+++ b/go-controller/vendor/github.com/imdario/mergo/go.mod
@@ -1,0 +1,5 @@
+module github.com/imdario/mergo
+
+go 1.13
+
+require gopkg.in/yaml.v2 v2.3.0

--- a/go-controller/vendor/github.com/imdario/mergo/go.sum
+++ b/go-controller/vendor/github.com/imdario/mergo/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go-controller/vendor/github.com/imdario/mergo/map.go
+++ b/go-controller/vendor/github.com/imdario/mergo/map.go
@@ -141,6 +141,9 @@ func MapWithOverwrite(dst, src interface{}, opts ...func(*Config)) error {
 }
 
 func _map(dst, src interface{}, opts ...func(*Config)) error {
+	if dst != nil && reflect.ValueOf(dst).Kind() != reflect.Ptr {
+		return ErrNonPointerAgument
+	}
 	var (
 		vDst, vSrc reflect.Value
 		err        error

--- a/go-controller/vendor/github.com/imdario/mergo/merge.go
+++ b/go-controller/vendor/github.com/imdario/mergo/merge.go
@@ -13,16 +13,28 @@ import (
 	"reflect"
 )
 
-func hasExportedField(dst reflect.Value) (exported bool) {
+func hasMergeableFields(dst reflect.Value) (exported bool) {
 	for i, n := 0, dst.NumField(); i < n; i++ {
 		field := dst.Type().Field(i)
 		if field.Anonymous && dst.Field(i).Kind() == reflect.Struct {
-			exported = exported || hasExportedField(dst.Field(i))
-		} else {
+			exported = exported || hasMergeableFields(dst.Field(i))
+		} else if isExportedComponent(&field) {
 			exported = exported || len(field.PkgPath) == 0
 		}
 	}
 	return
+}
+
+func isExportedComponent(field *reflect.StructField) bool {
+	pkgPath := field.PkgPath
+	if len(pkgPath) > 0 {
+		return false
+	}
+	c := field.Name[0]
+	if 'a' <= c && c <= 'z' || c == '_' {
+		return false
+	}
+	return true
 }
 
 type Config struct {
@@ -32,6 +44,8 @@ type Config struct {
 	Transformers                 Transformers
 	overwriteWithEmptyValue      bool
 	overwriteSliceWithEmptyValue bool
+	sliceDeepCopy                bool
+	debug                        bool
 }
 
 type Transformers interface {
@@ -46,7 +60,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 	typeCheck := config.TypeCheck
 	overwriteWithEmptySrc := config.overwriteWithEmptyValue
 	overwriteSliceWithEmptySrc := config.overwriteSliceWithEmptyValue
-	config.overwriteWithEmptyValue = false
+	sliceDeepCopy := config.sliceDeepCopy
 
 	if !src.IsValid() {
 		return
@@ -74,21 +88,34 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 
 	switch dst.Kind() {
 	case reflect.Struct:
-		if hasExportedField(dst) {
+		if hasMergeableFields(dst) {
 			for i, n := 0, dst.NumField(); i < n; i++ {
 				if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, config); err != nil {
 					return
 				}
 			}
 		} else {
-			if dst.CanSet() && (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) {
+			if dst.CanSet() && (isReflectNil(dst) || overwrite) && (!isEmptyValue(src) || overwriteWithEmptySrc) {
 				dst.Set(src)
 			}
 		}
 	case reflect.Map:
 		if dst.IsNil() && !src.IsNil() {
-			dst.Set(reflect.MakeMap(dst.Type()))
+			if dst.CanSet() {
+				dst.Set(reflect.MakeMap(dst.Type()))
+			} else {
+				dst = src
+				return
+			}
 		}
+
+		if src.Kind() != reflect.Map {
+			if overwrite {
+				dst.Set(src)
+			}
+			return
+		}
+
 		for _, key := range src.MapKeys() {
 			srcElement := src.MapIndex(key)
 			if !srcElement.IsValid() {
@@ -98,6 +125,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			switch srcElement.Kind() {
 			case reflect.Chan, reflect.Func, reflect.Map, reflect.Interface, reflect.Slice:
 				if srcElement.IsNil() {
+					if overwrite {
+						dst.SetMapIndex(key, srcElement)
+					}
 					continue
 				}
 				fallthrough
@@ -132,7 +162,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 						dstSlice = reflect.ValueOf(dstElement.Interface())
 					}
 
-					if (!isEmptyValue(src) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+					if (!isEmptyValue(src) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice && !sliceDeepCopy {
 						if typeCheck && srcSlice.Type() != dstSlice.Type() {
 							return fmt.Errorf("cannot override two slices with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
 						}
@@ -142,6 +172,24 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 							return fmt.Errorf("cannot append two slices with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
 						}
 						dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
+					} else if sliceDeepCopy {
+						i := 0
+						for ; i < srcSlice.Len() && i < dstSlice.Len(); i++ {
+							srcElement := srcSlice.Index(i)
+							dstElement := dstSlice.Index(i)
+
+							if srcElement.CanInterface() {
+								srcElement = reflect.ValueOf(srcElement.Interface())
+							}
+							if dstElement.CanInterface() {
+								dstElement = reflect.ValueOf(dstElement.Interface())
+							}
+
+							if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
+								return
+							}
+						}
+
 					}
 					dst.SetMapIndex(key, dstSlice)
 				}
@@ -161,26 +209,35 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		if !dst.CanSet() {
 			break
 		}
-		if (!isEmptyValue(src) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+		if (!isEmptyValue(src) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice && !sliceDeepCopy {
 			dst.Set(src)
 		} else if config.AppendSlice {
 			if src.Type() != dst.Type() {
 				return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
 			}
 			dst.Set(reflect.AppendSlice(dst, src))
+		} else if sliceDeepCopy {
+			for i := 0; i < src.Len() && i < dst.Len(); i++ {
+				srcElement := src.Index(i)
+				dstElement := dst.Index(i)
+				if srcElement.CanInterface() {
+					srcElement = reflect.ValueOf(srcElement.Interface())
+				}
+				if dstElement.CanInterface() {
+					dstElement = reflect.ValueOf(dstElement.Interface())
+				}
+
+				if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
+					return
+				}
+			}
 		}
 	case reflect.Ptr:
 		fallthrough
 	case reflect.Interface:
-		if src.IsNil() {
-			break
-		}
-
-		if dst.Kind() != reflect.Ptr && src.Type().AssignableTo(dst.Type()) {
-			if dst.IsNil() || overwrite {
-				if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
-					dst.Set(src)
-				}
+		if isReflectNil(src) {
+			if overwriteWithEmptySrc && dst.CanSet() && src.Type().AssignableTo(dst.Type()) {
+				dst.Set(src)
 			}
 			break
 		}
@@ -203,16 +260,28 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			}
 			break
 		}
+
 		if dst.IsNil() || overwrite {
 			if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
 				dst.Set(src)
 			}
-		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
-			return
+			break
+		}
+
+		if dst.Elem().Kind() == src.Elem().Kind() {
+			if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
+				return
+			}
+			break
 		}
 	default:
-		if dst.CanSet() && (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) {
-			dst.Set(src)
+		mustSet := (isEmptyValue(dst) || overwrite) && (!isEmptyValue(src) || overwriteWithEmptySrc)
+		if mustSet {
+			if dst.CanSet() {
+				dst.Set(src)
+			} else {
+				dst = src
+			}
 		}
 	}
 
@@ -246,7 +315,13 @@ func WithOverride(config *Config) {
 	config.Overwrite = true
 }
 
-// WithOverride will make merge override empty dst slice with empty src slice.
+// WithOverwriteWithEmptyValue will make merge override non empty dst attributes with empty src attributes values.
+func WithOverwriteWithEmptyValue(config *Config) {
+	config.Overwrite = true
+	config.overwriteWithEmptyValue = true
+}
+
+// WithOverrideEmptySlice will make merge override empty dst slice with empty src slice.
 func WithOverrideEmptySlice(config *Config) {
 	config.overwriteSliceWithEmptyValue = true
 }
@@ -261,7 +336,16 @@ func WithTypeCheck(config *Config) {
 	config.TypeCheck = true
 }
 
+// WithSliceDeepCopy will merge slice element one by one with Overwrite flag.
+func WithSliceDeepCopy(config *Config) {
+	config.sliceDeepCopy = true
+	config.Overwrite = true
+}
+
 func merge(dst, src interface{}, opts ...func(*Config)) error {
+	if dst != nil && reflect.ValueOf(dst).Kind() != reflect.Ptr {
+		return ErrNonPointerAgument
+	}
 	var (
 		vDst, vSrc reflect.Value
 		err        error
@@ -280,4 +364,17 @@ func merge(dst, src interface{}, opts ...func(*Config)) error {
 		return ErrDifferentArgumentsTypes
 	}
 	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, config)
+}
+
+// IsReflectNil is the reflect value provided nil
+func isReflectNil(v reflect.Value) bool {
+	k := v.Kind()
+	switch k {
+	case reflect.Interface, reflect.Slice, reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr:
+		// Both interface and slice are nil if first word is 0.
+		// Both are always bigger than a word; assume flagIndir.
+		return v.IsNil()
+	default:
+		return false
+	}
 }

--- a/go-controller/vendor/github.com/imdario/mergo/mergo.go
+++ b/go-controller/vendor/github.com/imdario/mergo/mergo.go
@@ -20,6 +20,7 @@ var (
 	ErrNotSupported                = errors.New("only structs and maps are supported")
 	ErrExpectedMapAsDestination    = errors.New("dst was expected to be a map")
 	ErrExpectedStructAsDestination = errors.New("dst was expected to be a struct")
+	ErrNonPointerAgument           = errors.New("dst must be a pointer")
 )
 
 // During deepMerge, must keep track of checks that are
@@ -74,24 +75,4 @@ func resolveValues(dst, src interface{}) (vDst, vSrc reflect.Value, err error) {
 		vSrc = vSrc.Elem()
 	}
 	return
-}
-
-// Traverses recursively both values, assigning src's fields values to dst.
-// The map argument tracks comparisons that have already been seen, which allows
-// short circuiting on recursive types.
-func deeper(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err error) {
-	if dst.CanAddr() {
-		addr := dst.UnsafeAddr()
-		h := 17 * addr
-		seen := visited[h]
-		typ := dst.Type()
-		for p := seen; p != nil; p = p.next {
-			if p.ptr == addr && p.typ == typ {
-				return nil
-			}
-		}
-		// Remember, remember...
-		visited[h] = &visit{addr, typ, seen}
-	}
-	return // TODO refactor
 }

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
@@ -82,24 +82,41 @@ type RowCache struct {
 func (r *RowCache) Row(uuid string) model.Model {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	return r.row(uuid)
-}
-
-func (r *RowCache) row(uuid string) model.Model {
 	if row, ok := r.cache[uuid]; ok {
 		return row.(model.Model)
 	}
 	return nil
 }
 
-// Create writes the provided content to the cache
-func (r *RowCache) Create(uuid string, m model.Model) error {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	return r.create(uuid, m)
+// RowByModel searches the cache using a the indexes for a provided model
+func (r *RowCache) RowByModel(m model.Model) model.Model {
+	if reflect.TypeOf(m) != r.dataType {
+		return nil
+	}
+	info, _ := mapper.NewInfo(&r.schema, m)
+	uuid, err := info.FieldByColumn("_uuid")
+	if err != nil {
+		return nil
+	}
+	if uuid.(string) != "" {
+		return r.Row(uuid.(string))
+	}
+	for index := range r.indexes {
+		val, err := valueFromIndex(info, index)
+		if err != nil {
+			continue
+		}
+		if uuid, ok := r.indexes[index][val]; ok {
+			return r.Row(uuid)
+		}
+	}
+	return nil
 }
 
-func (r *RowCache) create(uuid string, m model.Model) error {
+// Create writes the provided content to the cache
+func (r *RowCache) Create(uuid string, m model.Model, checkIndexes bool) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	if _, ok := r.cache[uuid]; ok {
 		return fmt.Errorf("row %s already exists", uuid)
 	}
@@ -111,23 +128,19 @@ func (r *RowCache) create(uuid string, m model.Model) error {
 		return err
 	}
 	newIndexes := newColumnToValue(r.schema.Indexes)
-	var errs []error
 	for index := range r.indexes {
-
 		val, err := valueFromIndex(info, index)
-
 		if err != nil {
 			return err
 		}
-		if existing, ok := r.indexes[index][val]; ok {
-			errs = append(errs,
-				NewIndexExistsError(r.name, val, index, uuid, existing))
+
+		if existing, ok := r.indexes[index][val]; ok && checkIndexes {
+			return NewIndexExistsError(r.name, val, index, uuid, existing)
 		}
+
 		newIndexes[index][val] = uuid
 	}
-	if len(errs) != 0 {
-		return fmt.Errorf("%v", errs)
-	}
+
 	// write indexes
 	for k1, v1 := range newIndexes {
 		for k2, v2 := range v1 {
@@ -139,13 +152,9 @@ func (r *RowCache) create(uuid string, m model.Model) error {
 }
 
 // Update updates the content in the cache
-func (r *RowCache) Update(uuid string, m model.Model) error {
+func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	return r.update(uuid, m)
-}
-
-func (r *RowCache) update(uuid string, m model.Model) error {
 	if _, ok := r.cache[uuid]; !ok {
 		return fmt.Errorf("row %s does not exist", uuid)
 	}
@@ -179,7 +188,8 @@ func (r *RowCache) update(uuid string, m model.Model) error {
 		// old and new values are NOT the same
 
 		// check that there are no conflicts
-		if conflict, ok := r.indexes[index][newVal]; ok && conflict != uuid {
+
+		if conflict, ok := r.indexes[index][newVal]; ok && checkIndexes && conflict != uuid {
 			errs = append(errs, NewIndexExistsError(
 				r.name,
 				newVal,
@@ -188,6 +198,7 @@ func (r *RowCache) update(uuid string, m model.Model) error {
 				conflict,
 			))
 		}
+
 		newIndexes[index][newVal] = uuid
 		oldIndexes[index][oldVal] = ""
 	}
@@ -214,10 +225,6 @@ func (r *RowCache) update(uuid string, m model.Model) error {
 func (r *RowCache) Delete(uuid string) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	return r.delete(uuid)
-}
-
-func (r *RowCache) delete(uuid string) error {
 	if _, ok := r.cache[uuid]; !ok {
 		return fmt.Errorf("row %s does not exist", uuid)
 	}
@@ -250,8 +257,8 @@ func (r *RowCache) Rows() []string {
 
 // Len returns the length of the cache
 func (r *RowCache) Len() int {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 	return len(r.cache)
 }
 
@@ -310,7 +317,9 @@ type TableCache struct {
 	eventProcessor *eventProcessor
 	mapper         *mapper.Mapper
 	dbModel        *model.DBModel
+	schema         *ovsdb.DatabaseSchema
 	ovsdb.NotificationHandler
+	mutex sync.RWMutex
 }
 
 // Data is the type for data that can be prepoulated in the cache
@@ -332,16 +341,18 @@ func NewTableCache(schema *ovsdb.DatabaseSchema, dbModel *model.DBModel, data Da
 			return nil, fmt.Errorf("table %s is not in schema", table)
 		}
 		for uuid, row := range rowData {
-			if err := cache[table].Create(uuid, row); err != nil {
+			if err := cache[table].Create(uuid, row, true); err != nil {
 				return nil, err
 			}
 		}
 	}
 	return &TableCache{
 		cache:          cache,
+		schema:         schema,
 		eventProcessor: eventProcessor,
 		mapper:         mapper.NewMapper(schema),
 		dbModel:        dbModel,
+		mutex:          sync.RWMutex{},
 	}, nil
 }
 
@@ -357,6 +368,8 @@ func (t *TableCache) DBModel() *model.DBModel {
 
 // Table returns the a Table from the cache with a given name
 func (t *TableCache) Table(name string) *RowCache {
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 	if table, ok := t.cache[name]; ok {
 		return table
 	}
@@ -365,6 +378,8 @@ func (t *TableCache) Table(name string) *RowCache {
 
 // Tables returns a list of table names that are in the cache
 func (t *TableCache) Tables() []string {
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 	var result []string
 	for k := range t.cache {
 		result = append(result, k)
@@ -397,24 +412,11 @@ func (t *TableCache) Echo([]interface{}) {
 func (t *TableCache) Disconnected() {
 }
 
-// lock acquires a lock on all tables in the cache
-func (t *TableCache) lock() {
-	for _, r := range t.cache {
-		r.mutex.Lock()
-	}
-}
-
-// unlock releases a lock on all tables in the cache
-func (t *TableCache) unlock() {
-	for _, r := range t.cache {
-		r.mutex.Unlock()
-	}
-}
-
 // Populate adds data to the cache and places an event on the channel
 func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) {
-	t.lock()
-	defer t.unlock()
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
 	for table := range t.dbModel.Types() {
 		updates, ok := tableUpdates[table]
 		if !ok {
@@ -427,9 +429,9 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) {
 				if err != nil {
 					panic(err)
 				}
-				if existing := tCache.row(uuid); existing != nil {
+				if existing := tCache.Row(uuid); existing != nil {
 					if !reflect.DeepEqual(newModel, existing) {
-						if err := tCache.update(uuid, newModel); err != nil {
+						if err := tCache.Update(uuid, newModel, false); err != nil {
 							panic(err)
 						}
 						t.eventProcessor.AddEvent(updateEvent, table, existing, newModel)
@@ -437,7 +439,7 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) {
 					// no diff
 					continue
 				}
-				if err := tCache.create(uuid, newModel); err != nil {
+				if err := tCache.Create(uuid, newModel, false); err != nil {
 					panic(err)
 				}
 				t.eventProcessor.AddEvent(addEvent, table, nil, newModel)
@@ -447,13 +449,24 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) {
 				if err != nil {
 					panic(err)
 				}
-				if err := tCache.delete(uuid); err != nil {
+				if err := tCache.Delete(uuid); err != nil {
 					panic(err)
 				}
 				t.eventProcessor.AddEvent(deleteEvent, table, oldModel, nil)
 				continue
 			}
 		}
+	}
+}
+
+// Purge drops all data in the cache and reinitializes it using the
+// provided schema
+func (t *TableCache) Purge(schema *ovsdb.DatabaseSchema) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	tableTypes := t.dbModel.Types()
+	for name, tableSchema := range t.schema.Tables {
+		t.cache[name] = newRowCache(name, tableSchema, tableTypes[name])
 	}
 }
 

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/cenkalti/rpc2"
 	"github.com/cenkalti/rpc2/jsonrpc"
+	"github.com/google/uuid"
 	"github.com/ovn-org/libovsdb/cache"
 	"github.com/ovn-org/libovsdb/mapper"
 	"github.com/ovn-org/libovsdb/model"
@@ -38,6 +40,7 @@ var ErrNotConnected = errors.New("not connected")
 type Client interface {
 	Connect(context.Context) error
 	Disconnect()
+	Close()
 	Schema() *ovsdb.DatabaseSchema
 	Cache() *cache.TableCache
 	SetOption(Option) error
@@ -45,25 +48,30 @@ type Client interface {
 	DisconnectNotify() chan struct{}
 	Echo() error
 	Transact(...ovsdb.Operation) ([]ovsdb.OperationResult, error)
-	Monitor(jsonContext interface{}, t ...TableMonitor) error
-	MonitorAll(jsonContext interface{}) error
-	MonitorCancel(jsonContext interface{}) error
+	Monitor(...TableMonitor) (string, error)
+	MonitorAll() (string, error)
+	MonitorCancel(id string) error
 	NewTableMonitor(m model.Model, fields ...interface{}) TableMonitor
 	API
 }
 
 // ovsdbClient is an OVSDB client
 type ovsdbClient struct {
-	options    *options
-	rpcClient  *rpc2.Client
-	dbModel    *model.DBModel
-	schema     *ovsdb.DatabaseSchema
-	cache      *cache.TableCache
-	stopCh     chan struct{}
-	connected  bool
-	disconnect chan struct{}
-	api        API
-	mutex      sync.Mutex
+	options       *options
+	rpcClient     *rpc2.Client
+	rpcMutex      sync.RWMutex
+	dbModel       *model.DBModel
+	schema        *ovsdb.DatabaseSchema
+	schemaMutex   sync.RWMutex
+	cache         *cache.TableCache
+	cacheMutex    sync.RWMutex
+	stopCh        chan struct{}
+	disconnect    chan struct{}
+	api           API
+	monitors      map[string][]TableMonitor
+	monitorsMutex sync.Mutex
+	shutdown      bool
+	shutdownMutex sync.Mutex
 }
 
 // NewOVSDBClient creates a new OVSDB Client with the provided
@@ -77,8 +85,12 @@ func NewOVSDBClient(databaseModel *model.DBModel, opts ...Option) (Client, error
 // newOVSDBClient creates a new ovsdbClient
 func newOVSDBClient(databaseModel *model.DBModel, opts ...Option) (*ovsdbClient, error) {
 	ovs := &ovsdbClient{
-		dbModel:    databaseModel,
-		disconnect: make(chan struct{}),
+		dbModel:       databaseModel,
+		disconnect:    make(chan struct{}),
+		rpcMutex:      sync.RWMutex{},
+		schemaMutex:   sync.RWMutex{},
+		monitorsMutex: sync.Mutex{},
+		shutdownMutex: sync.Mutex{},
 	}
 	var err error
 	ovs.options, err = newOptions(opts...)
@@ -93,11 +105,15 @@ func newOVSDBClient(databaseModel *model.DBModel, opts ...Option) (*ovsdbClient,
 // The connection can be configured using one or more Option(s), like WithTLSConfig
 // If no WithEndpoint option is supplied, the default of unix:/var/run/openvswitch/ovsdb.sock is used
 func (o *ovsdbClient) Connect(ctx context.Context) error {
-	if o.connected {
+	return o.connect(ctx, false)
+}
+
+func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
+	o.rpcMutex.Lock()
+	defer o.rpcMutex.Unlock()
+	if o.rpcClient != nil {
 		return nil
 	}
-	o.mutex.Lock()
-	defer o.mutex.Unlock()
 	var c net.Conn
 	var dialer net.Dialer
 	var err error
@@ -132,24 +148,6 @@ func (o *ovsdbClient) Connect(ctx context.Context) error {
 	if err := o.createRPC2Client(c); err != nil {
 		return err
 	}
-	o.connected = true
-	return nil
-}
-
-// createRPC2Client creates an rpcClient using the provided connection
-// It is also responsible for setting up go routines for handling disconnect notification
-// and cache population
-func (o *ovsdbClient) createRPC2Client(conn net.Conn) error {
-	o.stopCh = make(chan struct{})
-	o.rpcClient = rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(conn))
-	o.rpcClient.SetBlocking(true)
-	o.rpcClient.Handle("echo", func(_ *rpc2.Client, args []interface{}, reply *[]interface{}) error {
-		return o.echo(args, reply)
-	})
-	o.rpcClient.Handle("update", func(_ *rpc2.Client, args []json.RawMessage, reply *[]interface{}) error {
-		return o.update(args, reply)
-	})
-	go o.rpcClient.Run()
 
 	dbs, err := o.listDbs()
 	if err != nil {
@@ -180,8 +178,15 @@ func (o *ovsdbClient) createRPC2Client(conn net.Conn) error {
 			strings.Join(combined, ". "))
 	}
 
-	if err == nil {
-		o.schema = schema
+	if err != nil {
+		o.rpcClient.Close()
+		return err
+	}
+	o.schemaMutex.Lock()
+	o.schema = schema
+	o.schemaMutex.Unlock()
+	if o.cache == nil {
+		o.cacheMutex.Lock()
 		if cache, err := cache.NewTableCache(schema, o.dbModel, nil); err == nil {
 			o.cache = cache
 			o.api = newAPI(o.cache)
@@ -189,20 +194,56 @@ func (o *ovsdbClient) createRPC2Client(conn net.Conn) error {
 			o.rpcClient.Close()
 			return err
 		}
+		o.cacheMutex.Unlock()
 	} else {
-		o.rpcClient.Close()
-		return err
+		// purge cache contents and ensure we are using latest schema
+		// cache event handlers are untouched
+		o.cache.Purge(schema)
 	}
 
-	go o.cache.Run(o.stopCh)
-	go o.handleDisconnectNotification()
+	if reconnect {
+		o.monitorsMutex.Lock()
+		defer o.monitorsMutex.Unlock()
+		for id, request := range o.monitors {
+			err = o.monitor(id, reconnect, request...)
+			if err != nil {
+				o.rpcClient.Close()
+				return err
+			}
+		}
+	} else {
+		o.monitorsMutex.Lock()
+		defer o.monitorsMutex.Unlock()
+		o.monitors = make(map[string][]TableMonitor)
+	}
 
+	go o.handleDisconnectNotification()
+	go o.cache.Run(o.stopCh)
+	return nil
+}
+
+// createRPC2Client creates an rpcClient using the provided connection
+// It is also responsible for setting up go routines for client-side event handling
+// Should only be called when the mutex is held
+func (o *ovsdbClient) createRPC2Client(conn net.Conn) error {
+	o.stopCh = make(chan struct{})
+	o.rpcClient = rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(conn))
+	o.rpcClient.SetBlocking(true)
+	o.rpcClient.Handle("echo", func(_ *rpc2.Client, args []interface{}, reply *[]interface{}) error {
+		return o.echo(args, reply)
+	})
+	o.rpcClient.Handle("update", func(_ *rpc2.Client, args []json.RawMessage, reply *[]interface{}) error {
+		return o.update(args, reply)
+	})
+	go o.rpcClient.Run()
 	return nil
 }
 
 // Schema returns the DatabaseSchema that is being used by the client
 // it will be nil until a connection has been established
 func (o *ovsdbClient) Schema() *ovsdb.DatabaseSchema {
+	o.schemaMutex.RLock()
+	defer o.schemaMutex.RUnlock()
 	return o.schema
 }
 
@@ -210,13 +251,17 @@ func (o *ovsdbClient) Schema() *ovsdb.DatabaseSchema {
 // ovsdb update notifications. It will be nil until a connection
 // has been established, and empty unless you call Monitor
 func (o *ovsdbClient) Cache() *cache.TableCache {
+	o.cacheMutex.RLock()
+	defer o.cacheMutex.RUnlock()
 	return o.cache
 }
 
 // SetOption sets a new value for an option.
 // It may only be called when the client is not connected
 func (o *ovsdbClient) SetOption(opt Option) error {
-	if o.connected {
+	o.rpcMutex.RLock()
+	defer o.rpcMutex.RUnlock()
+	if o.rpcClient != nil {
 		return fmt.Errorf("cannot set option when client is connected")
 	}
 	return opt(o.options)
@@ -224,7 +269,9 @@ func (o *ovsdbClient) SetOption(opt Option) error {
 
 // Connected returns whether or not the client is currently connected to the server
 func (o *ovsdbClient) Connected() bool {
-	return o.connected
+	o.rpcMutex.RLock()
+	defer o.rpcMutex.RUnlock()
+	return o.rpcClient != nil
 }
 
 // DisconnectNotify returns a channel which will notify the caller when the
@@ -255,18 +302,24 @@ func (o *ovsdbClient) update(args []json.RawMessage, reply *[]interface{}) error
 		return err
 	}
 	// Update the local DB cache with the tableUpdates
+	o.cacheMutex.RLock()
 	o.cache.Update(value, updates)
+	o.cacheMutex.RUnlock()
 	*reply = []interface{}{}
 	return nil
 }
 
 // getSchema returns the schema in use for the provided database name
 // RFC 7047 : get_schema
+// Should only be called when mutex is held
 func (o *ovsdbClient) getSchema(dbName string) (*ovsdb.DatabaseSchema, error) {
 	args := ovsdb.NewGetSchemaArgs(dbName)
 	var reply ovsdb.DatabaseSchema
 	err := o.rpcClient.Call("get_schema", args, &reply)
 	if err != nil {
+		if err == rpc2.ErrShutdown {
+			return nil, ErrNotConnected
+		}
 		return nil, err
 	}
 	return &reply, err
@@ -274,10 +327,14 @@ func (o *ovsdbClient) getSchema(dbName string) (*ovsdb.DatabaseSchema, error) {
 
 // listDbs returns the list of databases on the server
 // RFC 7047 : list_dbs
+// Should only be called when mutex is held
 func (o *ovsdbClient) listDbs() ([]string, error) {
 	var dbs []string
 	err := o.rpcClient.Call("list_dbs", nil, &dbs)
 	if err != nil {
+		if err == rpc2.ErrShutdown {
+			return nil, ErrNotConnected
+		}
 		return nil, fmt.Errorf("listdbs failure - %v", err)
 	}
 	return dbs, err
@@ -286,52 +343,60 @@ func (o *ovsdbClient) listDbs() ([]string, error) {
 // Transact performs the provided Operations on the database
 // RFC 7047 : transact
 func (o *ovsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
-	if !o.connected {
-		return nil, ErrNotConnected
-	}
 	var reply []ovsdb.OperationResult
-
-	if ok := o.schema.ValidateOperations(operation...); !ok {
+	if ok := o.Schema().ValidateOperations(operation...); !ok {
 		return nil, fmt.Errorf("validation failed for the operation")
 	}
-
 	args := ovsdb.NewTransactArgs(o.schema.Name, operation...)
+
+	o.rpcMutex.Lock()
+	if o.rpcClient == nil {
+		o.rpcMutex.Unlock()
+		return nil, ErrNotConnected
+	}
 	err := o.rpcClient.Call("transact", args, &reply)
+	o.rpcMutex.Unlock()
 	if err != nil {
+		if err == rpc2.ErrShutdown {
+			return nil, ErrNotConnected
+		}
 		return nil, err
 	}
 	return reply, nil
 }
 
 // MonitorAll is a convenience method to monitor every table/column
-func (o *ovsdbClient) MonitorAll(jsonContext interface{}) error {
-	if !o.connected {
-		return ErrNotConnected
-	}
+func (o *ovsdbClient) MonitorAll() (string, error) {
 	var options []TableMonitor
 	for name := range o.dbModel.Types() {
 		options = append(options, TableMonitor{Table: name})
 	}
-	return o.Monitor(jsonContext, options...)
+	return o.Monitor(options...)
 }
 
 // MonitorCancel will request cancel a previously issued monitor request
 // RFC 7047 : monitor_cancel
-func (o *ovsdbClient) MonitorCancel(jsonContext interface{}) error {
-	if !o.connected {
+func (o *ovsdbClient) MonitorCancel(id string) error {
+	var reply ovsdb.OperationResult
+	args := ovsdb.NewMonitorCancelArgs(id)
+	o.rpcMutex.Lock()
+	defer o.rpcMutex.Unlock()
+	if o.rpcClient == nil {
 		return ErrNotConnected
 	}
-	var reply ovsdb.OperationResult
-
-	args := ovsdb.NewMonitorCancelArgs(jsonContext)
-
 	err := o.rpcClient.Call("monitor_cancel", args, &reply)
 	if err != nil {
+		if err == rpc2.ErrShutdown {
+			return ErrNotConnected
+		}
 		return err
 	}
 	if reply.Error != "" {
 		return fmt.Errorf("error while executing transaction: %s", reply.Error)
 	}
+	o.monitorsMutex.Lock()
+	defer o.monitorsMutex.Unlock()
+	delete(o.monitors, id)
 	return nil
 }
 
@@ -363,15 +428,17 @@ func (o *ovsdbClient) NewTableMonitor(m model.Model, fields ...interface{}) Tabl
 // and populate the cache with them. Subsequent updates will be processed
 // by the Update Notifications
 // RFC 7047 : monitor
-func (o *ovsdbClient) Monitor(jsonContext interface{}, options ...TableMonitor) error {
-	if !o.connected {
-		return ErrNotConnected
-	}
+func (o *ovsdbClient) Monitor(options ...TableMonitor) (string, error) {
+	id := uuid.NewString()
+	return id, o.monitor(id, false, options...)
+}
+
+func (o *ovsdbClient) monitor(id string, reconnect bool, options ...TableMonitor) error {
 	if len(options) == 0 {
 		return fmt.Errorf("no monitor options provided")
 	}
 	var reply ovsdb.TableUpdates
-	mapper := mapper.NewMapper(o.schema)
+	mapper := mapper.NewMapper(o.Schema())
 	typeMap := o.dbModel.Types()
 	requests := make(map[string]ovsdb.MonitorRequest)
 	for _, o := range options {
@@ -388,10 +455,25 @@ func (o *ovsdbClient) Monitor(jsonContext interface{}, options ...TableMonitor) 
 		}
 		requests[o.Table] = *request
 	}
-	args := ovsdb.NewMonitorArgs(o.schema.Name, jsonContext, requests)
+	args := ovsdb.NewMonitorArgs(o.Schema().Name, id, requests)
+	if !reconnect {
+		o.rpcMutex.RLock()
+		defer o.rpcMutex.RUnlock()
+	}
+	if o.rpcClient == nil {
+		return ErrNotConnected
+	}
 	err := o.rpcClient.Call("monitor", args, &reply)
 	if err != nil {
+		if err == rpc2.ErrShutdown {
+			return ErrNotConnected
+		}
 		return err
+	}
+	if !reconnect {
+		o.monitorsMutex.Lock()
+		defer o.monitorsMutex.Unlock()
+		o.monitors[id] = options
 	}
 	o.cache.Populate(reply)
 	return nil
@@ -399,14 +481,18 @@ func (o *ovsdbClient) Monitor(jsonContext interface{}, options ...TableMonitor) 
 
 // Echo tests the liveness of the OVSDB connetion
 func (o *ovsdbClient) Echo() error {
-	if !o.connected {
-		return ErrNotConnected
-	}
 	args := ovsdb.NewEchoArgs()
 	var reply []interface{}
+	o.rpcMutex.RLock()
+	defer o.rpcMutex.RUnlock()
+	if o.rpcClient == nil {
+		return ErrNotConnected
+	}
 	err := o.rpcClient.Call("echo", args, &reply)
 	if err != nil {
-		return err
+		if err == rpc2.ErrShutdown {
+			return ErrNotConnected
+		}
 	}
 	if !reflect.DeepEqual(args, reply) {
 		return fmt.Errorf("incorrect server response: %v, %v", args, reply)
@@ -415,16 +501,48 @@ func (o *ovsdbClient) Echo() error {
 }
 
 func (o *ovsdbClient) handleDisconnectNotification() {
-	// this will block until Connect() has released the lock via defer
-	o.mutex.Lock()
-	// we continue to hold the lock until the client has disconnected
-	// this prevents another call to Connect() changing the rpcClient
-	// while we're still listening for disconnects
-	defer o.mutex.Unlock()
 	<-o.rpcClient.DisconnectNotify()
+	// close the stopCh, which will stop the cache event processor
 	close(o.stopCh)
+	o.rpcMutex.Lock()
+	if o.options.reconnect && !o.shutdown {
+		o.rpcClient = nil
+		o.rpcMutex.Unlock()
+		connect := func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), o.options.timeout)
+			defer cancel()
+			return o.connect(ctx, true)
+		}
+		err := backoff.Retry(connect, o.options.backoff)
+		if err != nil {
+			// TODO: We should look at passing this back to the
+			// caller to handle
+			panic(err)
+		}
+		// this goroutine finishes, and is replaced with a new one (from Connect)
+		return
+	}
+
+	// clear connection state
 	o.rpcClient = nil
+	o.rpcMutex.Unlock()
+
+	o.cacheMutex.Lock()
+	defer o.cacheMutex.Unlock()
 	o.cache = nil
+
+	o.schemaMutex.Lock()
+	defer o.schemaMutex.Unlock()
+	o.schema = nil
+
+	o.monitorsMutex.Lock()
+	defer o.monitorsMutex.Unlock()
+	o.monitors = nil
+
+	o.shutdownMutex.Lock()
+	defer o.shutdownMutex.Unlock()
+	o.shutdown = false
+
 	select {
 	case o.disconnect <- struct{}{}:
 		// sent disconnect notification to client
@@ -434,11 +552,29 @@ func (o *ovsdbClient) handleDisconnectNotification() {
 }
 
 // Disconnect will close the connection to the OVSDB server
+// If the client was created with WithReconnect then the client
+// will reconnect afterwards
 func (o *ovsdbClient) Disconnect() {
-	if !o.connected {
+	o.rpcMutex.Lock()
+	defer o.rpcMutex.Unlock()
+	if o.rpcClient == nil {
 		return
 	}
-	o.connected = false
+	o.rpcClient.Close()
+}
+
+// Close will close the connection to the OVSDB server
+// It will remove all stored state ready for the next connection
+// Even If the client was created with WithReconnect it will not reconnect afterwards
+func (o *ovsdbClient) Close() {
+	o.rpcMutex.Lock()
+	defer o.rpcMutex.Unlock()
+	if o.rpcClient == nil {
+		return
+	}
+	o.shutdownMutex.Lock()
+	defer o.shutdownMutex.Unlock()
+	o.shutdown = true
 	o.rpcClient.Close()
 }
 

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/options.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/options.go
@@ -3,6 +3,9 @@ package client
 import (
 	"crypto/tls"
 	"net/url"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 const (
@@ -14,6 +17,9 @@ const (
 type options struct {
 	endpoints []string
 	tlsConfig *tls.Config
+	reconnect bool
+	timeout   time.Duration
+	backoff   backoff.BackOff
 }
 
 type Option func(o *options) error
@@ -69,6 +75,19 @@ func WithEndpoint(endpoint string) Option {
 			}
 		}
 		o.endpoints = append(o.endpoints, endpoint)
+		return nil
+	}
+}
+
+// WithReconnect tells the client to automatically reconnect when
+// disconnected. The timeout is used to construct the context on
+// each call to Connect, while backoff dicates the backoff
+// algorithm to use
+func WithReconnect(timeout time.Duration, backoff backoff.BackOff) Option {
+	return func(o *options) error {
+		o.reconnect = true
+		o.timeout = timeout
+		o.backoff = backoff
 		return nil
 	}
 }

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/condition.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/condition.go
@@ -78,7 +78,7 @@ func (c *Condition) UnmarshalJSON(b []byte) error {
 	default:
 		return fmt.Errorf("%s is not a valid function", function)
 	}
-	vv, err := interfaceToOVSDBNotationInterface(reflect.ValueOf(v[2]))
+	vv, err := ovsSliceToGoNotation(v[2])
 	if err != nil {
 		return err
 	}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/map.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/map.go
@@ -42,6 +42,21 @@ func (o *OvsMap) UnmarshalJSON(b []byte) (err error) {
 		innerSlice := oMap[1].([]interface{})
 		for _, val := range innerSlice {
 			f := val.([]interface{})
+			var k interface{}
+			switch f[0].(type) {
+			case []interface{}:
+				vSet := f[0].([]interface{})
+				if len(vSet) != 2 || vSet[0] == "map" {
+					return &json.UnmarshalTypeError{Value: reflect.ValueOf(oMap).String(), Type: reflect.TypeOf(*o)}
+				}
+				goSlice, err := ovsSliceToGoNotation(vSet)
+				if err != nil {
+					return err
+				}
+				k = goSlice
+			default:
+				k = f[0]
+			}
 			switch f[1].(type) {
 			case []interface{}:
 				vSet := f[1].([]interface{})
@@ -52,9 +67,9 @@ func (o *OvsMap) UnmarshalJSON(b []byte) (err error) {
 				if err != nil {
 					return err
 				}
-				o.GoMap[f[0]] = goSlice
+				o.GoMap[k] = goSlice
 			default:
-				o.GoMap[f[0]] = f[1]
+				o.GoMap[k] = f[1]
 			}
 		}
 	}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/mutation.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/mutation.go
@@ -3,7 +3,6 @@ package ovsdb
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 )
 
 type Mutator string
@@ -79,7 +78,7 @@ func (m *Mutation) UnmarshalJSON(b []byte) error {
 	default:
 		return fmt.Errorf("%s is not a valid mutator", mutator)
 	}
-	vv, err := interfaceToOVSDBNotationInterface(reflect.ValueOf(v[2]))
+	vv, err := ovsSliceToGoNotation(v[2])
 	if err != nil {
 		return err
 	}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/set.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/set.go
@@ -20,7 +20,7 @@ type OvsSet struct {
 // NewOvsSet creates a new OVSDB style set from a Go interface (object)
 func NewOvsSet(obj interface{}) (OvsSet, error) {
 	v := reflect.ValueOf(obj)
-	var ovsSet []interface{}
+	ovsSet := make([]interface{}, 0)
 	switch v.Kind() {
 	case reflect.Slice, reflect.Array:
 		for i := 0; i < v.Len(); i++ {
@@ -55,6 +55,7 @@ func (o OvsSet) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON will unmarshal a JSON byte array to an OVSDB style Set
 func (o *OvsSet) UnmarshalJSON(b []byte) (err error) {
+	o.GoSet = make([]interface{}, 0)
 	addToSet := func(o *OvsSet, v interface{}) error {
 		goVal, err := ovsSliceToGoNotation(v)
 		if err == nil {

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/server/database.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/server/database.go
@@ -1,0 +1,453 @@
+package server
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/ovn-org/libovsdb/cache"
+	"github.com/ovn-org/libovsdb/mapper"
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
+)
+
+// Database abstracts database operations from ovsdb
+type Database interface {
+	CreateDatabase(name string, model *ovsdb.DatabaseSchema) error
+	Exists(name string) bool
+	Transact(database string, operations []ovsdb.Operation) ([]ovsdb.OperationResult, ovsdb.TableUpdates)
+	Select(database string, table string, where []ovsdb.Condition, columns []string) ovsdb.OperationResult
+	Insert(database string, table string, uuidName string, row ovsdb.Row) (ovsdb.OperationResult, ovsdb.TableUpdates)
+	Update(database, table string, where []ovsdb.Condition, row ovsdb.Row) (ovsdb.OperationResult, ovsdb.TableUpdates)
+	Mutate(database, table string, where []ovsdb.Condition, mutations []ovsdb.Mutation) (ovsdb.OperationResult, ovsdb.TableUpdates)
+	Delete(database, table string, where []ovsdb.Condition) (ovsdb.OperationResult, ovsdb.TableUpdates)
+	Wait(database, table string, timeout int, conditions []ovsdb.Condition, columns []string, until string, rows []ovsdb.Row) ovsdb.OperationResult
+	Commit(database, table string, durable bool) ovsdb.OperationResult
+	Abort(database, table string) ovsdb.OperationResult
+	Comment(database, table string, comment string) ovsdb.OperationResult
+	Assert(database, table, lock string) ovsdb.OperationResult
+}
+
+type inMemoryDatabase struct {
+	databases map[string]*cache.TableCache
+	models    map[string]*model.DBModel
+	mutex     sync.RWMutex
+}
+
+func NewInMemoryDatabase(models map[string]*model.DBModel) Database {
+	return &inMemoryDatabase{
+		databases: make(map[string]*cache.TableCache),
+		models:    models,
+		mutex:     sync.RWMutex{},
+	}
+}
+
+func (db *inMemoryDatabase) CreateDatabase(name string, schema *ovsdb.DatabaseSchema) error {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+	var mo *model.DBModel
+	var ok bool
+	if mo, ok = db.models[schema.Name]; !ok {
+		return fmt.Errorf("no db model provided for schema with name %s", name)
+	}
+	database, err := cache.NewTableCache(schema, mo, nil)
+	if err != nil {
+		return nil
+	}
+	db.databases[name] = database
+	return nil
+}
+
+func (db *inMemoryDatabase) Exists(name string) bool {
+	db.mutex.RLock()
+	defer db.mutex.RUnlock()
+	_, ok := db.databases[name]
+	return ok
+}
+
+func (db *inMemoryDatabase) Transact(name string, operations []ovsdb.Operation) ([]ovsdb.OperationResult, ovsdb.TableUpdates) {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+	results := []ovsdb.OperationResult{}
+	updates := make(ovsdb.TableUpdates)
+	for _, op := range operations {
+		switch op.Op {
+		case ovsdb.OperationInsert:
+			r, tu := db.Insert(name, op.Table, op.UUIDName, op.Row)
+			results = append(results, r)
+			if tu != nil {
+				updates.Merge(tu)
+			}
+		case ovsdb.OperationSelect:
+			r := db.Select(name, op.Table, op.Where, op.Columns)
+			results = append(results, r)
+		case ovsdb.OperationUpdate:
+			r, tu := db.Update(name, op.Table, op.Where, op.Row)
+			results = append(results, r)
+			if tu != nil {
+				updates.Merge(tu)
+			}
+		case ovsdb.OperationMutate:
+			r, tu := db.Mutate(name, op.Table, op.Where, op.Mutations)
+			results = append(results, r)
+			if tu != nil {
+				updates.Merge(tu)
+			}
+		case ovsdb.OperationDelete:
+			r, tu := db.Delete(name, op.Table, op.Where)
+			results = append(results, r)
+			if tu != nil {
+				updates.Merge(tu)
+			}
+		case ovsdb.OperationWait:
+			r := db.Wait(name, op.Table, op.Timeout, op.Where, op.Columns, op.Until, op.Rows)
+			results = append(results, r)
+		case ovsdb.OperationCommit:
+			durable := op.Durable
+			r := db.Commit(name, op.Table, *durable)
+			results = append(results, r)
+		case ovsdb.OperationAbort:
+			r := db.Abort(name, op.Table)
+			results = append(results, r)
+		case ovsdb.OperationComment:
+			r := db.Comment(name, op.Table, *op.Comment)
+			results = append(results, r)
+		case ovsdb.OperationAssert:
+			r := db.Assert(name, op.Table, *op.Lock)
+			results = append(results, r)
+		default:
+			return nil, updates
+		}
+	}
+	return results, updates
+}
+
+func (db *inMemoryDatabase) Insert(database string, table string, rowUUID string, row ovsdb.Row) (ovsdb.OperationResult, ovsdb.TableUpdates) {
+	var targetDb *cache.TableCache
+	var ok bool
+	if targetDb, ok = db.databases[database]; !ok {
+		return ovsdb.OperationResult{
+			Error: "database does not exist",
+		}, nil
+	}
+	if rowUUID == "" {
+		rowUUID = uuid.NewString()
+	}
+	model, err := targetDb.CreateModel(table, &row, rowUUID)
+	if err != nil {
+		return ovsdb.OperationResult{
+			Error: err.Error(),
+		}, nil
+	}
+
+	// insert in to db
+	if err := targetDb.Table(table).Create(rowUUID, model, true); err != nil {
+		if indexErr, ok := err.(*cache.IndexExistsError); ok {
+			e := ovsdb.ConstraintViolation{}
+			return ovsdb.OperationResult{
+				Error:   e.Error(),
+				Details: indexErr.Error(),
+			}, nil
+		}
+		panic(err)
+	}
+
+	resultRow, err := targetDb.Mapper().NewRow(table, model)
+	if err != nil {
+		return ovsdb.OperationResult{
+			Error: err.Error(),
+		}, nil
+	}
+
+	result := ovsdb.OperationResult{
+		UUID: ovsdb.UUID{GoUUID: rowUUID},
+	}
+	return result, ovsdb.TableUpdates{
+		table: {
+			rowUUID: {
+				New: &resultRow,
+				Old: nil,
+			},
+		},
+	}
+}
+
+func (db *inMemoryDatabase) Select(database string, table string, where []ovsdb.Condition, columns []string) ovsdb.OperationResult {
+	var targetDb *cache.TableCache
+	var ok bool
+	if targetDb, ok = db.databases[database]; !ok {
+		return ovsdb.OperationResult{
+			Error: "database does not exist",
+		}
+	}
+
+	var results []ovsdb.Row
+	rows, err := matchCondition(targetDb, table, where)
+	if err != nil {
+		panic(err)
+	}
+	for _, row := range rows {
+		resultRow, err := targetDb.Mapper().NewRow(table, row)
+		if err != nil {
+			panic(err)
+		}
+		results = append(results, resultRow)
+	}
+	return ovsdb.OperationResult{
+		Rows: results,
+	}
+}
+
+func (db *inMemoryDatabase) Update(database, table string, where []ovsdb.Condition, row ovsdb.Row) (ovsdb.OperationResult, ovsdb.TableUpdates) {
+	var targetDb *cache.TableCache
+	var ok bool
+	if targetDb, ok = db.databases[database]; !ok {
+		return ovsdb.OperationResult{
+			Error: "database does not exist",
+		}, nil
+	}
+
+	schema := targetDb.Mapper().Schema.Table(table)
+	tableUpdate := make(ovsdb.TableUpdate)
+	rows, err := matchCondition(targetDb, table, where)
+	if err != nil {
+		return ovsdb.OperationResult{
+			Error: err.Error(),
+		}, nil
+	}
+	for _, old := range rows {
+		info, _ := mapper.NewInfo(schema, old)
+		uuid, _ := info.FieldByColumn("_uuid")
+		oldRow, err := targetDb.Mapper().NewRow(table, old)
+		if err != nil {
+			panic(err)
+		}
+		newRow, err := targetDb.Mapper().NewRow(table, row)
+		if err != nil {
+			panic(err)
+		}
+		if err = targetDb.Table(table).Update(uuid.(string), row, true); err != nil {
+			if indexErr, ok := err.(*cache.IndexExistsError); ok {
+				e := ovsdb.ConstraintViolation{}
+				return ovsdb.OperationResult{
+					Error: e.Error(),
+
+					Details: indexErr.Error(),
+				}, nil
+			}
+			panic(err)
+		}
+		tableUpdate.AddRowUpdate(uuid.(string), &ovsdb.RowUpdate{
+			Old: &oldRow,
+			New: &newRow,
+		})
+	}
+	// FIXME: We need to filter the returned columns
+	return ovsdb.OperationResult{
+			Count: len(rows),
+		}, ovsdb.TableUpdates{
+			table: tableUpdate,
+		}
+}
+
+func (db *inMemoryDatabase) Mutate(database, table string, where []ovsdb.Condition, mutations []ovsdb.Mutation) (ovsdb.OperationResult, ovsdb.TableUpdates) {
+	var targetDb *cache.TableCache
+	var ok bool
+	if targetDb, ok = db.databases[database]; !ok {
+		return ovsdb.OperationResult{
+			Error: "database does not exist",
+		}, nil
+	}
+
+	schema := targetDb.Mapper().Schema.Table(table)
+	tableUpdate := make(ovsdb.TableUpdate)
+
+	rows, err := matchCondition(targetDb, table, where)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, old := range rows {
+		info, err := mapper.NewInfo(schema, old)
+		if err != nil {
+			panic(err)
+		}
+		uuid, _ := info.FieldByColumn("_uuid")
+		oldRow, err := targetDb.Mapper().NewRow(table, old)
+		if err != nil {
+			panic(err)
+		}
+		for _, m := range mutations {
+			column := schema.Column(m.Column)
+			nativeValue, err := ovsdb.OvsToNative(column, m.Value)
+			if err != nil {
+				panic(err)
+			}
+			if err := ovsdb.ValidateMutation(column, m.Mutator, nativeValue); err != nil {
+				panic(err)
+			}
+			info, err := mapper.NewInfo(schema, old)
+			if err != nil {
+				panic(err)
+			}
+			current, err := info.FieldByColumn(m.Column)
+			if err != nil {
+				panic(err)
+			}
+			new := mutate(current, m.Mutator, nativeValue)
+			if err := info.SetField(m.Column, new); err != nil {
+				panic(err)
+			}
+			// the field in old has been set, write back to db
+			err = targetDb.Table(table).Update(uuid.(string), old, true)
+			if err != nil {
+				if indexErr, ok := err.(*cache.IndexExistsError); ok {
+					e := ovsdb.ConstraintViolation{}
+					return ovsdb.OperationResult{
+						Error:   e.Error(),
+						Details: indexErr.Error(),
+					}, nil
+				}
+				panic(err)
+			}
+			newRow, err := targetDb.Mapper().NewRow(table, old)
+			if err != nil {
+				panic(err)
+			}
+			tableUpdate.AddRowUpdate(uuid.(string), &ovsdb.RowUpdate{
+				Old: &oldRow,
+				New: &newRow,
+			})
+		}
+	}
+	return ovsdb.OperationResult{
+			Count: len(rows),
+		}, ovsdb.TableUpdates{
+			table: tableUpdate,
+		}
+}
+
+func (db *inMemoryDatabase) Delete(database, table string, where []ovsdb.Condition) (ovsdb.OperationResult, ovsdb.TableUpdates) {
+	var targetDb *cache.TableCache
+	var ok bool
+	if targetDb, ok = db.databases[database]; !ok {
+		return ovsdb.OperationResult{
+			Error: "database does not exist",
+		}, nil
+	}
+
+	schema := targetDb.Mapper().Schema.Table(table)
+	tableUpdate := make(ovsdb.TableUpdate)
+	rows, err := matchCondition(targetDb, table, where)
+	if err != nil {
+		panic(err)
+	}
+	for _, row := range rows {
+		info, _ := mapper.NewInfo(schema, row)
+		uuid, _ := info.FieldByColumn("_uuid")
+		oldRow, err := targetDb.Mapper().NewRow(table, row)
+		if err != nil {
+			panic(err)
+		}
+		if err := targetDb.Table(table).Delete(uuid.(string)); err != nil {
+			panic(err)
+		}
+		tableUpdate.AddRowUpdate(uuid.(string), &ovsdb.RowUpdate{
+			Old: &oldRow,
+			New: nil,
+		})
+	}
+	return ovsdb.OperationResult{
+			Count: len(rows),
+		}, ovsdb.TableUpdates{
+			table: tableUpdate,
+		}
+}
+
+func (db *inMemoryDatabase) Wait(database, table string, timeout int, conditions []ovsdb.Condition, columns []string, until string, rows []ovsdb.Row) ovsdb.OperationResult {
+	e := ovsdb.NotSupported{}
+	return ovsdb.OperationResult{Error: e.Error()}
+}
+
+func (db *inMemoryDatabase) Commit(database, table string, durable bool) ovsdb.OperationResult {
+	e := ovsdb.NotSupported{}
+	return ovsdb.OperationResult{Error: e.Error()}
+}
+
+func (db *inMemoryDatabase) Abort(database, table string) ovsdb.OperationResult {
+	e := ovsdb.NotSupported{}
+	return ovsdb.OperationResult{Error: e.Error()}
+}
+
+func (db *inMemoryDatabase) Comment(database, table string, comment string) ovsdb.OperationResult {
+	e := ovsdb.NotSupported{}
+	return ovsdb.OperationResult{Error: e.Error()}
+}
+
+func (db *inMemoryDatabase) Assert(database, table, lock string) ovsdb.OperationResult {
+	e := ovsdb.NotSupported{}
+	return ovsdb.OperationResult{Error: e.Error()}
+}
+func removeFromSlice(a, b reflect.Value) reflect.Value {
+	for i := 0; i < a.Len(); i++ {
+		if a.Index(i).Interface() == b.Interface() {
+			v := reflect.AppendSlice(a.Slice(0, i), a.Slice(i+1, a.Len()))
+			return v
+		}
+	}
+	return a
+}
+
+func matchCondition(targetDb *cache.TableCache, table string, conditions []ovsdb.Condition) ([]model.Model, error) {
+	var results []model.Model
+	if len(conditions) == 0 {
+		uuids := targetDb.Table(table).Rows()
+		for _, uuid := range uuids {
+			row := targetDb.Table(table).Row(uuid)
+			results = append(results, row)
+		}
+		return results, nil
+	}
+
+	for _, condition := range conditions {
+		if condition.Column == "_uuid" {
+			ovsdbUUID, ok := condition.Value.(ovsdb.UUID)
+			if !ok {
+				panic(fmt.Sprintf("%+v is not an ovsdb uuid", ovsdbUUID))
+			}
+			uuid := ovsdbUUID.GoUUID
+			for _, k := range targetDb.Table(table).Rows() {
+				ok, err := condition.Function.Evaluate(k, uuid)
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					row := targetDb.Table(table).Row(k)
+					results = append(results, row)
+				}
+			}
+		} else {
+			index, err := targetDb.Table(table).Index(condition.Column)
+			if err != nil {
+				return nil, fmt.Errorf("conditions on non-index fields not supported")
+			}
+			for k, v := range index {
+				tSchema := targetDb.Mapper().Schema.Tables[table].Columns[condition.Column]
+				nativeValue, err := ovsdb.OvsToNative(tSchema, condition.Value)
+				if err != nil {
+					return nil, err
+				}
+				ok, err := condition.Function.Evaluate(k, nativeValue)
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					row := targetDb.Table(table).Row(v)
+					results = append(results, row)
+				}
+			}
+		}
+	}
+	return results, nil
+}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/server/doc.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/server/doc.go
@@ -1,0 +1,8 @@
+/*
+Package server provides an alpha-quality implementation of an OVSDB Server
+
+It is designed only to be used for testing the functionality of the client
+library such that assertions can be made on the cache that backs the
+client's monitor or the server
+*/
+package server

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/server/monitor.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/server/monitor.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/cenkalti/rpc2"
+	"github.com/ovn-org/libovsdb/ovsdb"
+)
+
+// connectionMonitors maps a connection to a map or monitors
+type connectionMonitors struct {
+	monitors map[string]*monitor
+	mu       sync.RWMutex
+}
+
+func newConnectionMonitors() *connectionMonitors {
+	return &connectionMonitors{
+		monitors: make(map[string]*monitor),
+		mu:       sync.RWMutex{},
+	}
+}
+
+// monitor represents a connection to a client where db changes
+// will be reflected
+type monitor struct {
+	id      string
+	request map[string]*ovsdb.MonitorRequest
+	client  *rpc2.Client
+	updates chan ovsdb.TableUpdates
+	stopCh  chan struct{}
+}
+
+func newMonitor(id string, request map[string]*ovsdb.MonitorRequest, client *rpc2.Client) *monitor {
+	m := &monitor{
+		id:      id,
+		request: request,
+		client:  client,
+		updates: make(chan ovsdb.TableUpdates),
+		stopCh:  make(chan struct{}, 1),
+	}
+	go m.sendUpdates()
+	return m
+}
+
+func (m *monitor) sendUpdates() {
+	for {
+		select {
+		case update := <-m.updates:
+			args := []interface{}{m.id, update}
+			var reply interface{}
+			err := m.client.Call("update", args, &reply)
+			if err != nil {
+				log.Printf("client error handling update rpc: %v", err)
+			}
+		case <-m.stopCh:
+			return
+		}
+	}
+}
+
+// Enqueue will enqueue an update if it matches the tables and monitor select arguments
+// we take the update by value (not reference) so we can mutate it in place before
+// queuing it for dispatch
+func (m *monitor) Enqueue(update ovsdb.TableUpdates) {
+	// remove updates for tables that we aren't watching
+	if len(m.request) != 0 {
+		m.filter(update)
+	}
+	if len(update) == 0 {
+		return
+	}
+	m.updates <- update
+}
+
+func (m *monitor) filter(update ovsdb.TableUpdates) {
+	// remove updates for tables that we aren't watching
+	if len(m.request) != 0 {
+		for table, u := range update {
+			if _, ok := m.request[table]; !ok {
+				fmt.Println("dropping table update")
+				delete(update, table)
+				continue
+			}
+			for uuid, row := range u {
+				switch {
+				case row.Insert() && m.request[table].Select.Insert():
+					fallthrough
+				case row.Modify() && m.request[table].Select.Modify():
+					fallthrough
+				case row.Delete() && m.request[table].Select.Delete():
+					if len(m.request[table].Columns) > 0 {
+						cols := make(map[string]bool)
+						for _, c := range m.request[table].Columns {
+							cols[c] = true
+						}
+						if row.New != nil {
+							new := *row.New
+							for k := range new {
+								if _, ok := cols[k]; !ok {
+									delete(new, k)
+								}
+							}
+							update[table][uuid].New = &new
+						}
+						if row.Old != nil {
+							old := *row.Old
+							for k := range old {
+								if _, ok := cols[k]; !ok {
+									delete(old, k)
+								}
+							}
+							update[table][uuid].Old = &old
+						}
+					}
+				default:
+					delete(u, uuid)
+				}
+			}
+		}
+	}
+}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/server/mutate.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/server/mutate.go
@@ -1,0 +1,189 @@
+package server
+
+import (
+	"reflect"
+
+	"github.com/ovn-org/libovsdb/ovsdb"
+)
+
+func mutate(current interface{}, mutator ovsdb.Mutator, value interface{}) interface{} {
+	switch current.(type) {
+	case bool, string:
+		return current
+	}
+	switch mutator {
+	case ovsdb.MutateOperationInsert:
+		return mutateInsert(current, value)
+	case ovsdb.MutateOperationDelete:
+		return mutateDelete(current, value)
+	case ovsdb.MutateOperationAdd:
+		return mutateAdd(current, value)
+	case ovsdb.MutateOperationSubtract:
+		return mutateSubtract(current, value)
+	case ovsdb.MutateOperationMultiply:
+		return mutateMultiply(current, value)
+	case ovsdb.MutateOperationDivide:
+		return mutateDivide(current, value)
+	case ovsdb.MutateOperationModulo:
+		return mutateModulo(current, value)
+	}
+	return current
+}
+
+func mutateInsert(current, value interface{}) interface{} {
+	switch current.(type) {
+	case int, float64:
+		return current
+	}
+	vc := reflect.ValueOf(current)
+	vv := reflect.ValueOf(value)
+	if vc.Kind() == reflect.Slice && vc.Type() == reflect.SliceOf(vv.Type()) {
+		v := reflect.Append(vc, vv)
+		return v.Interface()
+	}
+	if vc.Kind() == reflect.Slice && vv.Kind() == reflect.Slice {
+		v := reflect.AppendSlice(vc, vv)
+		return v.Interface()
+	}
+	return current
+}
+
+func mutateDelete(current, value interface{}) interface{} {
+	switch current.(type) {
+	case int, float64:
+		return current
+	}
+	vc := reflect.ValueOf(current)
+	vv := reflect.ValueOf(value)
+	if vc.Kind() == reflect.Slice && vc.Type() == reflect.SliceOf(vv.Type()) {
+		v := removeFromSlice(vc, vv)
+		return v.Interface()
+	}
+	if vc.Kind() == reflect.Slice && vv.Kind() == reflect.Slice {
+		v := vc
+		for i := 0; i < vv.Len(); i++ {
+			v = removeFromSlice(v, vv.Index(i))
+		}
+		return v.Interface()
+	}
+	return current
+}
+
+func mutateAdd(current, value interface{}) interface{} {
+	if i, ok := current.(int); ok {
+		v := value.(int)
+		return i + v
+	}
+	if i, ok := current.(float64); ok {
+		v := value.(float64)
+		return i + v
+	}
+	if is, ok := current.([]int); ok {
+		v := value.(int)
+		for i, j := range is {
+			is[i] = j + v
+		}
+		return is
+	}
+	if is, ok := current.([]float64); ok {
+		v := value.(float64)
+		for i, j := range is {
+			is[i] = j + v
+		}
+		return is
+	}
+	return current
+}
+
+func mutateSubtract(current, value interface{}) interface{} {
+	if i, ok := current.(int); ok {
+		v := value.(int)
+		return i - v
+	}
+	if i, ok := current.(float64); ok {
+		v := value.(float64)
+		return i - v
+	}
+	if is, ok := current.([]int); ok {
+		v := value.(int)
+		for i, j := range is {
+			is[i] = j - v
+		}
+		return is
+	}
+	if is, ok := current.([]float64); ok {
+		v := value.(float64)
+		for i, j := range is {
+			is[i] = j - v
+		}
+		return is
+	}
+	return current
+}
+
+func mutateMultiply(current, value interface{}) interface{} {
+	if i, ok := current.(int); ok {
+		v := value.(int)
+		return i * v
+	}
+	if i, ok := current.(float64); ok {
+		v := value.(float64)
+		return i * v
+	}
+	if is, ok := current.([]int); ok {
+		v := value.(int)
+		for i, j := range is {
+			is[i] = j * v
+		}
+		return is
+	}
+	if is, ok := current.([]float64); ok {
+		v := value.(float64)
+		for i, j := range is {
+			is[i] = j * v
+		}
+		return is
+	}
+	return current
+}
+
+func mutateDivide(current, value interface{}) interface{} {
+	if i, ok := current.(int); ok {
+		v := value.(int)
+		return i / v
+	}
+	if i, ok := current.(float64); ok {
+		v := value.(float64)
+		return i / v
+	}
+	if is, ok := current.([]int); ok {
+		v := value.(int)
+		for i, j := range is {
+			is[i] = j / v
+		}
+		return is
+	}
+	if is, ok := current.([]float64); ok {
+		v := value.(float64)
+		for i, j := range is {
+			is[i] = j / v
+		}
+		return is
+	}
+	return current
+}
+
+func mutateModulo(current, value interface{}) interface{} {
+	if i, ok := current.(int); ok {
+		v := value.(int)
+		return i % v
+	}
+	if is, ok := current.([]int); ok {
+		v := value.(int)
+		for i, j := range is {
+			is[i] = j % v
+		}
+		return is
+	}
+	return current
+}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/server/server.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/server/server.go
@@ -1,0 +1,313 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2/jsonrpc"
+	"github.com/google/uuid"
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
+)
+
+// OvsdbServer is an ovsdb server
+type OvsdbServer struct {
+	srv          *rpc2.Server
+	listener     net.Listener
+	done         chan struct{}
+	db           Database
+	dbUpdates    chan ovsdb.TableUpdates
+	ready        bool
+	readyMutex   sync.RWMutex
+	models       map[string]DatabaseModel
+	modelsMutex  sync.RWMutex
+	monitors     map[*rpc2.Client]*connectionMonitors
+	monitorMutex sync.RWMutex
+}
+
+type DatabaseModel struct {
+	Model  *model.DBModel
+	Schema *ovsdb.DatabaseSchema
+}
+
+// NewOvsdbServer returns a new OvsdbServer
+func NewOvsdbServer(db Database, models ...DatabaseModel) (*OvsdbServer, error) {
+	o := &OvsdbServer{
+		done:         make(chan struct{}, 1),
+		db:           db,
+		models:       make(map[string]DatabaseModel),
+		modelsMutex:  sync.RWMutex{},
+		monitors:     make(map[*rpc2.Client]*connectionMonitors),
+		monitorMutex: sync.RWMutex{},
+		dbUpdates:    make(chan ovsdb.TableUpdates),
+	}
+	o.modelsMutex.Lock()
+	for _, model := range models {
+		o.models[model.Schema.Name] = model
+	}
+	o.modelsMutex.Unlock()
+	for database, model := range o.models {
+		if err := o.db.CreateDatabase(database, model.Schema); err != nil {
+			return nil, err
+		}
+	}
+	o.srv = rpc2.NewServer()
+	o.srv.Handle("list_dbs", o.ListDatabases)
+	o.srv.Handle("get_schema", o.GetSchema)
+	o.srv.Handle("transact", o.Transact)
+	o.srv.Handle("cancel", o.Cancel)
+	o.srv.Handle("monitor", o.Monitor)
+	o.srv.Handle("monitor_cancel", o.MonitorCancel)
+	o.srv.Handle("steal", o.Steal)
+	o.srv.Handle("unlock", o.Unlock)
+	o.srv.Handle("echo", o.Echo)
+	return o, nil
+}
+
+// Serve starts the OVSDB server on the given path and protocol
+func (o *OvsdbServer) Serve(protocol string, path string) error {
+	var err error
+	o.listener, err = net.Listen(protocol, path)
+	if err != nil {
+		return err
+	}
+	go o.dispatch()
+	o.readyMutex.Lock()
+	o.ready = true
+	o.readyMutex.Unlock()
+	for {
+		conn, err := o.listener.Accept()
+		if err != nil {
+			if !o.Ready() {
+				return nil
+			}
+			return err
+		}
+
+		// TODO: Need to cleanup when connection is closed
+		go o.srv.ServeCodec(jsonrpc.NewJSONCodec(conn))
+	}
+}
+
+// Close closes the OvsdbServer
+func (o *OvsdbServer) Close() {
+	o.readyMutex.Lock()
+	o.ready = false
+	o.readyMutex.Unlock()
+	o.listener.Close()
+	close(o.done)
+}
+
+// Ready returns true if a server is ready to handle connections
+func (o *OvsdbServer) Ready() bool {
+	o.readyMutex.RLock()
+	defer o.readyMutex.RUnlock()
+	return o.ready
+}
+
+// ListDatabases lists the databases in the current system
+func (o *OvsdbServer) ListDatabases(client *rpc2.Client, args []interface{}, reply *[]string) error {
+	dbs := []string{}
+	o.modelsMutex.RLock()
+	for _, db := range o.models {
+		dbs = append(dbs, db.Schema.Name)
+	}
+	o.modelsMutex.RUnlock()
+	*reply = dbs
+	return nil
+}
+
+func (o *OvsdbServer) GetSchema(client *rpc2.Client, args []interface{}, reply *ovsdb.DatabaseSchema,
+) error {
+	db, ok := args[0].(string)
+	if !ok {
+		return fmt.Errorf("database %v is not a string", args[0])
+	}
+	o.modelsMutex.RLock()
+	model, ok := o.models[db]
+	if !ok {
+		return fmt.Errorf("database %s does not exist", db)
+	}
+	o.modelsMutex.RUnlock()
+	*reply = *model.Schema
+	return nil
+}
+
+// Transact issues a new database transaction and returns the results
+func (o *OvsdbServer) Transact(client *rpc2.Client, args []json.RawMessage, reply *[]ovsdb.OperationResult) error {
+	if len(args) < 2 {
+		return fmt.Errorf("not enough args")
+	}
+	var db string
+	err := json.Unmarshal(args[0], &db)
+	if err != nil {
+		return fmt.Errorf("database %v is not a string", args[0])
+	}
+	if !o.db.Exists(db) {
+		return fmt.Errorf("db does not exist")
+	}
+	var ops []ovsdb.Operation
+	namedUUID := make(map[string]ovsdb.UUID)
+	for i := 1; i < len(args); i++ {
+		var op ovsdb.Operation
+		err = json.Unmarshal(args[i], &op)
+		if err != nil {
+			return err
+		}
+		if op.UUIDName != "" {
+			newUUID := uuid.NewString()
+			namedUUID[op.UUIDName] = ovsdb.UUID{GoUUID: newUUID}
+			op.UUIDName = newUUID
+		}
+		for i, condition := range op.Where {
+			op.Where[i].Value = expandNamedUUID(condition.Value, namedUUID)
+		}
+		for i, mutation := range op.Mutations {
+			op.Mutations[i].Value = expandNamedUUID(mutation.Value, namedUUID)
+		}
+		ops = append(ops, op)
+	}
+	response, update := o.db.Transact(db, ops)
+	*reply = response
+	o.dbUpdates <- update
+	return nil
+}
+
+// Cancel cancels the last transaction
+func (o *OvsdbServer) Cancel(client *rpc2.Client, args []interface{}, reply *[]interface{}) error {
+	return fmt.Errorf("not implemented")
+}
+
+// Monitor monitors a given database table and provides updates to the client via an RPC callback
+func (o *OvsdbServer) Monitor(client *rpc2.Client, args []json.RawMessage, reply *ovsdb.TableUpdates) error {
+	var db string
+	if err := json.Unmarshal(args[0], &db); err != nil {
+		return fmt.Errorf("database %v is not a string", args[0])
+	}
+	if !o.db.Exists(db) {
+		return fmt.Errorf("db does not exist")
+	}
+	var value string
+	if err := json.Unmarshal(args[1], &value); err != nil {
+		return fmt.Errorf("values %v is not a string", args[1])
+	}
+	var request map[string]*ovsdb.MonitorRequest
+	if err := json.Unmarshal(args[2], &request); err != nil {
+		return err
+	}
+	o.monitorMutex.Lock()
+	defer o.monitorMutex.Unlock()
+	clientMonitors, ok := o.monitors[client]
+	if !ok {
+		o.monitors[client] = newConnectionMonitors()
+	} else {
+		if _, ok := clientMonitors.monitors[value]; ok {
+			return fmt.Errorf("monitor with that value already exists")
+		}
+	}
+	tableUpdates := make(ovsdb.TableUpdates)
+	for t, request := range request {
+		rows := o.db.Select(db, t, nil, request.Columns)
+		for i := range rows.Rows {
+			tu := make(ovsdb.TableUpdate)
+			uuid := rows.Rows[i]["_uuid"].(ovsdb.UUID).GoUUID
+			tu[uuid] = &ovsdb.RowUpdate{
+				New: &rows.Rows[i],
+			}
+			tableUpdates.AddTableUpdate(t, tu)
+		}
+	}
+	*reply = tableUpdates
+	o.monitors[client].monitors[value] = newMonitor(value, request, client)
+	return nil
+}
+
+// MonitorCancel cancels a monitor on a given table
+func (o *OvsdbServer) MonitorCancel(client *rpc2.Client, args []interface{}, reply *[]interface{}) error {
+	return fmt.Errorf("not implemented")
+}
+
+// Lock acquires a lock on a table for a the client
+func (o *OvsdbServer) Lock(client *rpc2.Client, args []interface{}, reply *[]interface{}) error {
+	return fmt.Errorf("not implemented")
+}
+
+// Steal steals a lock for a client
+func (o *OvsdbServer) Steal(client *rpc2.Client, args []interface{}, reply *[]interface{}) error {
+	return fmt.Errorf("not implemented")
+}
+
+// Unlock releases a lock for a client
+func (o *OvsdbServer) Unlock(client *rpc2.Client, args []interface{}, reply *[]interface{}) error {
+	return fmt.Errorf("not implemented")
+}
+
+// Echo tests the liveness of the connection
+func (o *OvsdbServer) Echo(client *rpc2.Client, args []interface{}, reply *[]interface{}) error {
+	echoReply := make([]interface{}, len(args))
+	copy(echoReply, args)
+	*reply = echoReply
+	return nil
+}
+
+func (o *OvsdbServer) dispatch() {
+	for {
+		select {
+		case update := <-o.dbUpdates:
+			o.monitorMutex.RLock()
+			for _, c := range o.monitors {
+				for _, m := range c.monitors {
+					m.Enqueue(update)
+				}
+			}
+			o.monitorMutex.RUnlock()
+		case <-o.done:
+			o.monitorMutex.RLock()
+			for _, c := range o.monitors {
+				for _, m := range c.monitors {
+					close(m.stopCh)
+				}
+			}
+			o.monitorMutex.RUnlock()
+			return
+		}
+	}
+}
+
+func expandNamedUUID(value interface{}, namedUUID map[string]ovsdb.UUID) interface{} {
+	if uuid, ok := value.(ovsdb.UUID); ok {
+		if newUUID, ok := namedUUID[uuid.GoUUID]; ok {
+			return newUUID
+		}
+	}
+	if set, ok := value.(ovsdb.OvsSet); ok {
+		for i, s := range set.GoSet {
+			if _, ok := s.(ovsdb.UUID); !ok {
+				return value
+			}
+			uuid := s.(ovsdb.UUID)
+			if newUUID, ok := namedUUID[uuid.GoUUID]; ok {
+				set.GoSet[i] = newUUID
+			}
+		}
+	}
+	if m, ok := value.(ovsdb.OvsMap); ok {
+		for k, v := range m.GoMap {
+			if uuid, ok := v.(ovsdb.UUID); ok {
+				if newUUID, ok := namedUUID[uuid.GoUUID]; ok {
+					m.GoMap[k] = newUUID
+				}
+			}
+			if uuid, ok := k.(ovsdb.UUID); ok {
+				if newUUID, ok := namedUUID[uuid.GoUUID]; ok {
+					m.GoMap[newUUID] = m.GoMap[k]
+					delete(m.GoMap, uuid)
+				}
+			}
+		}
+	}
+	return value
+}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -21,12 +21,16 @@ github.com/Microsoft/hcsshim/internal/schema1
 github.com/Microsoft/hcsshim/internal/schema2
 github.com/Microsoft/hcsshim/internal/timeout
 github.com/Microsoft/hcsshim/internal/vmcompute
+# github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae
+github.com/alexflint/go-filemutex
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/bhendo/go-powershell v0.0.0-20190719160123-219e7fb4e41e
 github.com/bhendo/go-powershell
 github.com/bhendo/go-powershell/backend
 github.com/bhendo/go-powershell/utils
+# github.com/cenkalti/backoff/v4 v4.1.1
+github.com/cenkalti/backoff/v4
 # github.com/cenkalti/hub v1.0.1
 github.com/cenkalti/hub
 # github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1
@@ -101,7 +105,7 @@ github.com/gorilla/mux
 # github.com/hashicorp/golang-lru v0.5.3
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
-# github.com/imdario/mergo v0.3.8
+# github.com/imdario/mergo v0.3.12
 github.com/imdario/mergo
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
@@ -164,12 +168,13 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/ovn-org/libovsdb v0.5.0
+# github.com/ovn-org/libovsdb v0.5.1-0.20210708171313-d17ab7f31fc4
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
 github.com/ovn-org/libovsdb/mapper
 github.com/ovn-org/libovsdb/model
 github.com/ovn-org/libovsdb/ovsdb
+github.com/ovn-org/libovsdb/server
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
**- What this PR does and why is it needed**
Adds libovsdb clients to OVN, egressip, services and unidle controllers and the
relevant harness for each of its tests.

**- Special notes for reviewers**
Depends on https://github.com/ovn-org/libovsdb/pull/177
Pulled in through `go.mod` temporarily.

**- How to verify it**

**- Description for the changelog**

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>