### PR TITLE
cni: cancel old pod sandbox add requests if the pod's UID or MAC changes

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -97,10 +97,11 @@ func (pr *PodRequest) cmdAdd(podLister corev1listers.PodLister, useOVSExternalID
 	}
 	// Get the IP address and MAC address of the pod
 	// for Smart-Nic, ensure connection-details is present
-	annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, namespace, podName, annotCondFn)
+	podUID, annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, namespace, podName, annotCondFn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod annotation: %v", err)
 	}
+	pr.PodUID = podUID
 
 	podInterfaceInfo, err := PodAnnotation2PodInfo(annotations, useOVSExternalIDs, pr.IsSmartNIC)
 	if err != nil {
@@ -149,10 +150,11 @@ func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternal
 	if pr.IsSmartNIC {
 		annotCondFn = isSmartNICReady
 	}
-	annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, pr.PodNamespace, pr.PodName, annotCondFn)
+	podUID, annotations, err := GetPodAnnotations(pr.ctx, podLister, kclient, pr.PodNamespace, pr.PodName, annotCondFn)
 	if err != nil {
 		return nil, err
 	}
+	pr.PodUID = podUID
 
 	if pr.CNIConf.PrevResult != nil {
 		result, err := current.NewResultFromResult(pr.CNIConf.PrevResult)
@@ -176,7 +178,8 @@ func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternal
 		}
 		for _, ip := range result.IPs {
 			if err = waitForPodInterface(pr.ctx, result.Interfaces[*ip.Interface].Mac, []*net.IPNet{&ip.Address},
-				hostIfaceName, ifaceID, ofPort, useOVSExternalIDs); err != nil {
+				hostIfaceName, ifaceID, ofPort, useOVSExternalIDs, podLister, kclient, pr.PodNamespace, pr.PodName,
+				pr.PodUID); err != nil {
 				return nil, fmt.Errorf("error while waiting on OVN pod interface: %s ip: %v, error: %v", ifaceID, ip, err)
 			}
 		}
@@ -231,7 +234,7 @@ func HandleCNIRequest(request *PodRequest, podLister corev1listers.PodLister, us
 
 // getCNIResult get result from pod interface info.
 func (pr *PodRequest) getCNIResult(podInterfaceInfo *PodInterfaceInfo) (*current.Result, error) {
-	interfacesArray, err := pr.ConfigureInterface(pr.PodNamespace, pr.PodName, podInterfaceInfo)
+	interfacesArray, err := pr.ConfigureInterface(podInterfaceInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure pod interface: %v", err)
 	}

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -77,6 +77,22 @@ func (pr *PodRequest) String() string {
 	return fmt.Sprintf("[%s/%s %s]", pr.PodNamespace, pr.PodName, pr.SandboxID)
 }
 
+// checkOrUpdatePodUID validates the given pod UID against the request's existing
+// pod UID. If the existing UID is empty the runtime did not support passing UIDs
+// and the best we can do is use the given UID for the duration of the request.
+// But if the existing UID is valid and does not match the given UID then the
+// sandbox request is for a different pod instance and should be terminated.
+func (pr *PodRequest) checkOrUpdatePodUID(podUID string) error {
+	if pr.PodUID == "" {
+		// Runtime didn't pass UID, use the one we got from the pod object
+		pr.PodUID = podUID
+	} else if podUID != pr.PodUID {
+		// Exit early if the pod was deleted and recreated already
+		return fmt.Errorf("pod deleted before sandbox %v operation began", pr.Command)
+	}
+	return nil
+}
+
 func (pr *PodRequest) cmdAdd(podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface) ([]byte, error) {
 	namespace := pr.PodNamespace
 	podName := pr.PodName
@@ -101,7 +117,9 @@ func (pr *PodRequest) cmdAdd(podLister corev1listers.PodLister, useOVSExternalID
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod annotation: %v", err)
 	}
-	pr.PodUID = podUID
+	if err := pr.checkOrUpdatePodUID(podUID); err != nil {
+		return nil, err
+	}
 
 	podInterfaceInfo, err := PodAnnotation2PodInfo(annotations, useOVSExternalIDs, pr.IsSmartNIC)
 	if err != nil {
@@ -154,7 +172,9 @@ func (pr *PodRequest) cmdCheck(podLister corev1listers.PodLister, useOVSExternal
 	if err != nil {
 		return nil, err
 	}
-	pr.PodUID = podUID
+	if err := pr.checkOrUpdatePodUID(podUID); err != nil {
+		return nil, err
+	}
 
 	if pr.CNIConf.PrevResult != nil {
 		result, err := current.NewResultFromResult(pr.CNIConf.PrevResult)

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -154,6 +154,15 @@ func cniRequestToPodRequest(cr *Request, podLister corev1listers.PodLister, kcli
 		return nil, fmt.Errorf("missing K8S_POD_NAME")
 	}
 
+	// UID may not be passed by all runtimes yet. Will be passed
+	// by CRIO 1.20+ and containerd 1.5+ soon.
+	// CRIO 1.20: https://github.com/cri-o/cri-o/pull/5029
+	// CRIO 1.21: https://github.com/cri-o/cri-o/pull/5028
+	// CRIO 1.22: https://github.com/cri-o/cri-o/pull/5026
+	// containerd 1.6: https://github.com/containerd/containerd/pull/5640
+	// containerd 1.5: https://github.com/containerd/containerd/pull/5643
+	req.PodUID = cniArgs["K8S_POD_UID"]
+
 	conf, err := config.ReadCNIConfig(cr.Config)
 	if err != nil {
 		return nil, fmt.Errorf("broken stdin args")

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -4,7 +4,6 @@ package cni
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -19,9 +18,6 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	cni020 "github.com/containernetworking/cni/pkg/types/020"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	utiltesting "k8s.io/client-go/util/testing"
@@ -246,98 +242,5 @@ func TestCNIServer(t *testing.T) {
 				t.Fatalf("[%s] unexpected error message '%v'", tc.name, string(body))
 			}
 		}
-	}
-}
-
-func newObjectMeta(name, namespace string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:      name,
-		UID:       types.UID(name),
-		Namespace: namespace,
-	}
-}
-
-func TestCNIServerCancelAdd(t *testing.T) {
-	tmpDir, err := utiltesting.MkTmpdir("cniserver")
-	if err != nil {
-		t.Fatalf("failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-	socketPath := filepath.Join(tmpDir, serverSocketName)
-
-	fakeClient := fake.NewSimpleClientset(
-		&v1.NamespaceList{
-			Items: []v1.Namespace{{ObjectMeta: newObjectMeta(name, name)}},
-		},
-		&v1.PodList{
-			Items: []v1.Pod{
-				{
-					ObjectMeta: newObjectMeta(name, namespace),
-					Spec:       v1.PodSpec{NodeName: nodeName},
-				},
-			},
-		},
-	)
-
-	fakeClientset := &util.OVNClientset{KubeClient: fakeClient}
-	wf, err := factory.NewNodeWatchFactory(fakeClientset, nodeName)
-	if err != nil {
-		t.Fatalf("failed to create watch factory: %v", err)
-	}
-
-	started := make(chan bool)
-
-	s, err := NewCNIServer(tmpDir, false, wf, fakeClient)
-	if err != nil {
-		t.Fatalf("error Creating CNI server: %v", err)
-	}
-	if err := s.Start(func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool,
-		kclient kubernetes.Interface) ([]byte, error) {
-		// Let the testcase know it can now delete the pod
-		close(started)
-		// Wait for the testcase to cancel us
-		<-request.ctx.Done()
-		return nil, fmt.Errorf("pod operation canceled")
-	}); err != nil {
-		t.Fatalf("error starting CNI server: %v", err)
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			Dial: func(proto, addr string) (net.Conn, error) {
-				return net.Dial("unix", socketPath)
-			},
-		},
-	}
-
-	request := &Request{
-		Env: map[string]string{
-			"CNI_COMMAND":     string(CNIAdd),
-			"CNI_CONTAINERID": sandboxID,
-			"CNI_NETNS":       "/some/path",
-			"CNI_ARGS":        makeCNIArgs(namespace, name),
-		},
-		Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"ovnkube\",\"type\": \"ovnkube\"}"),
-	}
-
-	var code int
-	var body []byte
-	done := make(chan bool)
-	go func() {
-		body, code = clientDoCNI(t, client, request)
-		close(done)
-	}()
-	<-started
-	err = fakeClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, *metav1.NewDeleteOptions(0))
-	if err != nil {
-		t.Fatalf("[ADD] failed to delete pod: %v", err)
-	}
-	<-done
-
-	if code != http.StatusBadRequest {
-		t.Fatalf("[ADD] expected status %v but got %v", http.StatusBadRequest, code)
-	}
-	if !strings.Contains(string(body), "pod operation canceled") {
-		t.Fatalf("[ADD] unexpected error message '%v'", string(body))
 	}
 }

--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -10,6 +10,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	kexec "k8s.io/utils/exec"
 )
@@ -233,10 +238,59 @@ func doPodFlowsExist(queries []openflowQuery) bool {
 	return true
 }
 
-func waitForPodInterface(ctx context.Context, mac string, ifAddrs []*net.IPNet, ifaceName, ifaceID string, ofPort int, checkExternalIDs bool) error {
+// checkCancelSandbox checks that this sandbox is still valid for the current
+// instance of the pod in the apiserver. Sandbox requests and pod instances
+// have a 1:1 relationship determined by pod UID. If we detect that the pod
+// has changed either UID or MAC terminate this sandbox request early instead
+// of waiting for OVN to set up flows that will never exist.
+func checkCancelSandbox(mac string, podLister corev1listers.PodLister, kclient kubernetes.Interface,
+	namespace, name, initialPodUID string) error {
+	pod, err := getPod(podLister, kclient, namespace, name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("pod deleted")
+		}
+		klog.Warningf("[%s/%s] failed to get pod while waiting for OVS port binding: %v", namespace, name, err)
+		return nil
+	}
+
+	if pod == nil {
+		// Not all node CNI modes can pass non-nil podLister or kclient in which
+		// case pod will be nil
+		return nil
+	}
+
+	if string(pod.UID) != initialPodUID {
+		// Pod UID changed and this sandbox should be canceled
+		// so the new pod sandbox can run
+		return fmt.Errorf("canceled old pod sandbox")
+	}
+
+	ovnAnnot, err := util.UnmarshalPodAnnotation(pod.Annotations)
+	if err != nil {
+		return fmt.Errorf("pod OVN annotations deleted or invalid")
+	}
+
+	// Pod OVN annotation changed and this sandbox should
+	// be canceled so the new pod sandbox can run with the
+	// updated MAC/IP
+	if mac != ovnAnnot.MAC.String() {
+		return fmt.Errorf("pod OVN annotations changed")
+	}
+
+	return nil
+}
+
+func waitForPodInterface(ctx context.Context, mac string, ifAddrs []*net.IPNet,
+	ifaceName, ifaceID string, ofPort int, checkExternalIDs bool,
+	podLister corev1listers.PodLister, kclient kubernetes.Interface,
+	namespace, name, initialPodUID string) error {
 	var queries []openflowQuery
+	var detail string
+
 	if checkExternalIDs {
 		queries = getMinimalFlowQueries(mac, ofPort)
+		detail = " (ovn-installed)"
 	} else {
 		queries = getLegacyFlowQueries(mac, ifAddrs, ofPort)
 	}
@@ -244,9 +298,9 @@ func waitForPodInterface(ctx context.Context, mac string, ifAddrs []*net.IPNet, 
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("canceled while waiting for OVS port binding")
+			return fmt.Errorf("canceled waiting for OVS port binding for %s %v", mac, ifAddrs)
 		case <-timeout:
-			return fmt.Errorf("timed out while waiting for OVS port binding")
+			return fmt.Errorf("timed out waiting for OVS port binding%s for %s %v", detail, mac, ifAddrs)
 		default:
 			if err := isIfaceIDSet(ifaceName, ifaceID); err != nil {
 				return err
@@ -259,6 +313,10 @@ func waitForPodInterface(ctx context.Context, mac string, ifAddrs []*net.IPNet, 
 				} else {
 					return nil
 				}
+			}
+
+			if err := checkCancelSandbox(mac, podLister, kclient, namespace, name, initialPodUID); err != nil {
+				return fmt.Errorf("%v waiting for OVS port binding for %s %v", err, mac, ifAddrs)
 			}
 
 			// try again later

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -3,7 +3,6 @@ package cni
 import (
 	"context"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -76,6 +75,8 @@ type PodRequest struct {
 	PodNamespace string
 	// kubernetes pod name
 	PodName string
+	// kubernetes pod UID
+	PodUID string
 	// kubernetes container ID
 	SandboxID string
 	// kernel network namespace path
@@ -92,6 +93,9 @@ type PodRequest struct {
 	cancel context.CancelFunc
 	// Interface to pod is a Smart-NIC interface
 	IsSmartNIC bool
+
+	podLister corev1listers.PodLister
+	kclient   kubernetes.Interface
 }
 
 type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface) ([]byte, error)
@@ -105,10 +109,6 @@ type Server struct {
 	useOVSExternalIDs int32
 	kclient           kubernetes.Interface
 	podLister         corev1listers.PodLister
-
-	// runningSandboxAdds is a map of sandbox ID to PodRequest for any CNIAdd operation
-	runningSandboxAddsLock sync.Mutex
-	runningSandboxAdds     map[string]*PodRequest
 
 	// CNI Server mode
 	mode string

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -23,6 +23,15 @@ type NetConf struct {
 	// LogFileMaxAge represents the maximum number
 	// of days to retain old log files
 	LogFileMaxAge int `json:"logfile-maxage"`
+
+	// Kubeconfig is the path to a kubeconfig
+	Kubeconfig string `json:"kubeconfig,omitempty"`
+	// KubeAPIServer is the URL of a Kubernetes API server (not required if kubeconfig is given)
+	KubeAPIServer string `json:"kube-api-server,omitempty"`
+	// KubeAPIToken is a Kubernetes API token (not required if kubeconfig is given)
+	KubeAPIToken string `json:"kube-api-token,omitempty"`
+	// KubeCACert is the absolute path to a Kubernetes API CA certificate (not required if kubeconfig is given)
+	KubeCACert string `json:"kube-ca-cert,omitempty"`
 }
 
 // NetworkSelectionElement represents one element of the JSON format

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -42,43 +42,55 @@ func isSmartNICReady(podAnnotation map[string]string) bool {
 	return false
 }
 
-// getPod returns a pod from the informer cache or (if that fails) the apiserver
+// getPod tries to read a Pod object from the informer cache, or if the pod
+// doesn't exist there, the apiserver. If neither a list or a kube client is
+// given, returns no pod and no error
 func getPod(podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string) (*kapi.Pod, error) {
-	pod, err := podLister.Pods(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
+	var pod *kapi.Pod
+	var err error
+
+	if podLister != nil {
+		pod, err = podLister.Pods(namespace).Get(name)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		// drop through
+	}
+
+	if kclient != nil {
 		// If the pod wasn't in our local cache, ask for it directly
 		pod, err = kclient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	}
+
 	return pod, err
 }
 
-// GetPodAnnotations obtains the pod annotation from the cache
-func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string, annotCond podAnnotWaitCond) (map[string]string, error) {
+// GetPodAnnotations obtains the pod UID and annotation from the cache or apiserver
+func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, kclient kubernetes.Interface, namespace, name string, annotCond podAnnotWaitCond) (string, map[string]string, error) {
 	var notFoundCount uint
 
 	timeout := time.After(30 * time.Second)
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("canceled waiting for annotations")
+			return "", nil, fmt.Errorf("canceled waiting for annotations")
 		case <-timeout:
-			return nil, fmt.Errorf("timed out waiting for annotations")
+			return "", nil, fmt.Errorf("timed out waiting for annotations")
 		default:
 			pod, err := getPod(podLister, kclient, namespace, name)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
-					return nil, fmt.Errorf("failed to get pod for annotations: %v", err)
+					return "", nil, fmt.Errorf("failed to get pod for annotations: %v", err)
 				}
 				// Allow up to 1 second for pod to be found
 				notFoundCount++
 				if notFoundCount >= 5 {
-					return nil, fmt.Errorf("timed out waiting for pod after 1s: %v", err)
+					return "", nil, fmt.Errorf("timed out waiting for pod after 1s: %v", err)
 				}
 				// drop through to try again
 			} else if pod != nil {
-				annotations := pod.ObjectMeta.Annotations
-				if annotCond(annotations) {
-					return annotations, nil
+				if annotCond(pod.Annotations) {
+					return string(pod.UID), pod.Annotations, nil
 				}
 			}
 

--- a/go-controller/pkg/cni/utils_test.go
+++ b/go-controller/pkg/cni/utils_test.go
@@ -113,9 +113,10 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(pod, nil)
-			annot, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			uid, annot, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(annot).To(Equal(podAnnot))
+			Expect(uid).To(Equal(string(pod.UID)))
 		})
 
 		It("Returns with Error if context is canceled", func() {
@@ -132,7 +133,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(pod, nil)
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -151,7 +152,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(pod, nil)
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -165,7 +166,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(nil, fmt.Errorf("failed to list pods"))
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to list pods"))
 		})
@@ -185,7 +186,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := newFakeKubeClientWithPod(pod)
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(nil, errors.NewNotFound(v1.Resource("pod"), name))
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -199,7 +200,7 @@ var _ = Describe("CNI Utils tests", func() {
 
 			fakeClient := fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{}})
 			podNamespaceLister.On("Get", mock.AnythingOfType("string")).Return(nil, errors.NewNotFound(v1.Resource("pod"), name))
-			_, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
+			_, _, err := GetPodAnnotations(ctx, &podLister, fakeClient, "some-ns", "some-pod", cond)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("timed out waiting for pod after 1s"))
 		})


### PR DESCRIPTION
If the the pod's UID changes that means the pod was deleted
and re-created. There's no point in continuing this sandbox
request as kubelet will just be tearing it down soon anyway.

If the pod's MAC changes, that means the master was behind and
set the IPAM annotation on a new instance of the pod (since
the master just uses Patch with namespace+name and ignores
UID), and this sandbox will be torn down soon as well so
kubelet can start the newer one.