### PR TITLE
Enable IPv6 e2e tests for control-plane

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,7 +280,6 @@ jobs:
         exclude:
          # Not currently supported but needs to be.
          - {"ipfamily": {"ip": dualstack}, "target": {"shard": control-plane}}
-         - {"ipfamily": {"ip": ipv6}, "target": {"shard": control-plane}}
          # Limit matrix combinations for CI. DISABLED items added to exclude list:
          #   DISABLED  v4  ha     local
          #   ENABLED   v4  ha     shared

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -6,6 +6,25 @@ set -ex
 export KUBERNETES_CONFORMANCE_TEST=y
 export KUBECONFIG=${HOME}/admin.conf
 
+# Skip tests which are not IPv6 ready yet (see description of https://github.com/ovn-org/ovn-kubernetes/pull/2276)
+IPV6_SKIPPED_TESTS="Should be allowed by externalip services|\
+should provide connection to external host by DNS name from a pod|\
+should provide Internet connection continuously when master is killed|\
+should provide Internet connection continuously when ovn-k8s pod is killed|\
+Should validate connectivity from a pod to a non-node host address on same node|\
+Should validate connectivity to an external gateway\'s loopback address via a pod with external gateway annotations enabled|\
+Should validate connectivity to multiple external gateways for an ECMP scenario|\
+Should validate connectivity without vxlan before and after updating the namespace annotation to a new external gateway|\
+Should validate ICMP connectivity to an external gateway\'s loopback address via a pod with external gateway annotations enabled|\
+Should validate ICMP connectivity to multiple external gateways for an ECMP scenario|\
+Should validate ingress connectivity from an external gateway|\
+Should validate NetFlow data of br-int is sent to an external gateway|\
+Should validate TCP/UDP connectivity to an external gateway\'s loopback address via a pod with external gateway annotations enabled|\
+Should validate TCP/UDP connectivity to multiple external gateways for a UDP / TCP scenario|\
+Should validate the egress firewall policy functionality against remote hosts|\
+Should validate the egress IP functionality against remote hosts|\
+recovering from deleting db files while maintain connectivity"
+
 SKIPPED_TESTS=""
 if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
     # No support for these features in dual-stack yet
@@ -26,6 +45,14 @@ else
   fi
 
   SKIPPED_TESTS+="Should validate connectivity before and after deleting all the db-pods at once in Non-HA mode"
+fi
+
+if [ "$KIND_IPV6_SUPPORT" == true ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+  	SKIPPED_TESTS+="|"
+  fi
+  # No support for these tests in IPv6 mode yet
+  SKIPPED_TESTS+=$IPV6_SKIPPED_TESTS
 fi
 
 # setting these is required to make RuntimeClass tests work ... :/


### PR DESCRIPTION
**- What this PR does and why is it needed**

This PR enables the e2e tests for IPv6 for the control-plane.
Currently not-IPv6-ready tests are excluded/skipped. 

**- Special notes for reviewers**
A list of the skipped tests can be found at the end of this PR with failure messages and links to the failed CI jobs. This can be taken as a starting point to make the failed tests IPv6 ready and include them step by step in the test suite. 

**- How to verify it**
The ovn-ci workflows include two new "steps" for control-plane IPv6 e2e tests (gateway-mode: local & shared). 

**- Description for the changelog**
none

---

The following contains a list of the excluded and failing tests and a short info about the failure:

**Test: Should be allowed by externalip services**
```
• Failure [14.829 seconds]
e2e ingress traffic validation
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1922
  Validating ingress traffic
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1939
    Should be allowed by externalip services [It]
    /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:2048

    Jun 24 07:25:29.909: Unexpected error:
        <*errors.errorString | 0xc000aa1300>: {
            s: "curl response {\"errors\":[\"Get \\\"http://[fc00:f853:ccd:e793::3]:81/hostname\\\": read tcp [fc00:f853:ccd:e793::5]:46032-\\u003e[fc00:f853:ccd:e793::3]:81: read: connection reset by peer\"]} contains errors",
        }
        curl response {"errors":["Get \"http://[fc00:f853:ccd:e793::3]:81/hostname\": read tcp [fc00:f853:ccd:e793::5]:46032-\u003e[fc00:f853:ccd:e793::3]:81: read: connection reset by peer"]} contains errors
    occurred
```
Example for Failed CI run:
* [2902350792#step:11:651](https://github.com/creydr/ovn-kubernetes/runs/2902350792?check_suite_focus=true#step:11:651)

**Test: should provide connection to external host by DNS name from a pod**
```
• Failure [17.793 seconds]
e2e control plane
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:411
  should provide connection to external host by DNS name from a pod [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:492

  Jun 23 15:05:39.535: Unexpected error:
      <*errors.errorString | 0xc000657780>: {
          s: "pod \"connectivity-test-continuous\" failed with status: {Phase:Failed Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:05:22 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:05:33 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:05:33 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:05:22 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:fc00:f853:ccd:e793::4 PodIP:fd00:10:244:1::6 PodIPs:[{IP:fd00:10:244:1::6}] StartTime:2021-06-23 15:05:22 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:connectivity-test-continuous-container State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2021-06-23 15:05:27 +0000 UTC,FinishedAt:2021-06-23 15:05:32 +0000 UTC,ContainerID:containerd://4cb089be4c0c7f7c1cb0fbebf1bbf996c813c28e8b079723ece1cb569424b824,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:k8s.gcr.io/e2e-test-images/agnhost:2.26 ImageID:k8s.gcr.io/e2e-test-images/agnhost@sha256:a3f7549ea04c419276e8b84e90a515bbce5bc8a057be2ed974ec45492eca346e ContainerID:containerd://4cb089be4c0c7f7c1cb0fbebf1bbf996c813c28e8b079723ece1cb569424b824 Started:0xc00004dcc5}] QOSClass:BestEffort EphemeralContainerStatuses:[]}",
      }
      pod "connectivity-test-continuous" failed with status: {Phase:Failed Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:05:22 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:05:33 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:05:33 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:05:22 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:fc00:f853:ccd:e793::4 PodIP:fd00:10:244:1::6 PodIPs:[{IP:fd00:10:244:1::6}] StartTime:2021-06-23 15:05:22 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:connectivity-test-continuous-container State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2021-06-23 15:05:27 +0000 UTC,FinishedAt:2021-06-23 15:05:32 +0000 UTC,ContainerID:containerd://4cb089be4c0c7f7c1cb0fbebf1bbf996c813c28e8b079723ece1cb569424b824,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:k8s.gcr.io/e2e-test-images/agnhost:2.26 ImageID:k8s.gcr.io/e2e-test-images/agnhost@sha256:a3f7549ea04c419276e8b84e90a515bbce5bc8a057be2ed974ec45492eca346e ContainerID:containerd://4cb089be4c0c7f7c1cb0fbebf1bbf996c813c28e8b079723ece1cb569424b824 Started:0xc00004dcc5}] QOSClass:BestEffort EphemeralContainerStatuses:[]}
  occurred

  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:506
```
Example for failed CI runs: 
* [2896226573#step:11:236](https://github.com/creydr/ovn-kubernetes/runs/2896226573?check_suite_focus=true#step:11:236)
* [2896226573#step:11:418](https://github.com/creydr/ovn-kubernetes/runs/2896226573?check_suite_focus=true#step:11:418)

**Test: should provide Internet connection continuously when master is killed**
```
• Failure [10.792 seconds]
e2e control plane
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:411
  should provide Internet connection continuously when master is killed [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:462

  Jun 23 15:06:41.343: Unexpected error:
      <*errors.errorString | 0xc0008ebbe0>: {
          s: "pod \"connectivity-test-continuous\" failed with status: {Phase:Failed Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:06:31 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:06:31 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:06:31 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:06:31 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:fc00:f853:ccd:e793::2 PodIP:fd00:10:244:3::6 PodIPs:[{IP:fd00:10:244:3::6}] StartTime:2021-06-23 15:06:31 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:connectivity-test-continuous-container State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2021-06-23 15:06:35 +0000 UTC,FinishedAt:2021-06-23 15:06:35 +0000 UTC,ContainerID:containerd://31c10d4e382c6d00f7c9089dec839d53c60d0923b3bc5954aa916bb7ae2a8964,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:k8s.gcr.io/e2e-test-images/agnhost:2.26 ImageID:k8s.gcr.io/e2e-test-images/agnhost@sha256:a3f7549ea04c419276e8b84e90a515bbce5bc8a057be2ed974ec45492eca346e ContainerID:containerd://31c10d4e382c6d00f7c9089dec839d53c60d0923b3bc5954aa916bb7ae2a8964 Started:0xc000906c65}] QOSClass:BestEffort EphemeralContainerStatuses:[]}",
      }
      pod "connectivity-test-continuous" failed with status: {Phase:Failed Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:06:31 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:06:31 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:06:31 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:06:31 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:fc00:f853:ccd:e793::2 PodIP:fd00:10:244:3::6 PodIPs:[{IP:fd00:10:244:3::6}] StartTime:2021-06-23 15:06:31 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:connectivity-test-continuous-container State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2021-06-23 15:06:35 +0000 UTC,FinishedAt:2021-06-23 15:06:35 +0000 UTC,ContainerID:containerd://31c10d4e382c6d00f7c9089dec839d53c60d0923b3bc5954aa916bb7ae2a8964,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:k8s.gcr.io/e2e-test-images/agnhost:2.26 ImageID:k8s.gcr.io/e2e-test-images/agnhost@sha256:a3f7549ea04c419276e8b84e90a515bbce5bc8a057be2ed974ec45492eca346e ContainerID:containerd://31c10d4e382c6d00f7c9089dec839d53c60d0923b3bc5954aa916bb7ae2a8964 Started:0xc000906c65}] QOSClass:BestEffort EphemeralContainerStatuses:[]}
  occurred

  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:490
```
Example for failed CI runs:
* [2896226573#step:11:720](https://github.com/creydr/ovn-kubernetes/runs/2896226573?check_suite_focus=true#step:11:720)
* [2896226573#step:11:901](https://github.com/creydr/ovn-kubernetes/runs/2896226573?check_suite_focus=true#step:11:901)

**Test: should provide Internet connection continuously when ovn-k8s pod is killed**
```
• Failure [10.843 seconds]
e2e control plane
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:411
  should provide Internet connection continuously when ovn-k8s pod is killed [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:430

  Jun 23 15:55:50.959: Unexpected error:
      <*errors.errorString | 0xc0008c3900>: {
          s: "pod \"connectivity-test-continuous\" failed with status: {Phase:Failed Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:55:40 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:55:40 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:55:40 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:55:40 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:fc00:f853:ccd:e793::4 PodIP:fd00:10:244:3::9 PodIPs:[{IP:fd00:10:244:3::9}] StartTime:2021-06-23 15:55:40 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:connectivity-test-continuous-container State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2021-06-23 15:55:43 +0000 UTC,FinishedAt:2021-06-23 15:55:43 +0000 UTC,ContainerID:containerd://84a511d311f9f94c7b49d149afc4d1dcbf4609053c07f8e928df75cc70876171,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:k8s.gcr.io/e2e-test-images/agnhost:2.26 ImageID:k8s.gcr.io/e2e-test-images/agnhost@sha256:a3f7549ea04c419276e8b84e90a515bbce5bc8a057be2ed974ec45492eca346e ContainerID:containerd://84a511d311f9f94c7b49d149afc4d1dcbf4609053c07f8e928df75cc70876171 Started:0xc00056bda5}] QOSClass:BestEffort EphemeralContainerStatuses:[]}",
      }
      pod "connectivity-test-continuous" failed with status: {Phase:Failed Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:55:40 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:55:40 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:55:40 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [connectivity-test-continuous-container]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:55:40 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:fc00:f853:ccd:e793::4 PodIP:fd00:10:244:3::9 PodIPs:[{IP:fd00:10:244:3::9}] StartTime:2021-06-23 15:55:40 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:connectivity-test-continuous-container State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2021-06-23 15:55:43 +0000 UTC,FinishedAt:2021-06-23 15:55:43 +0000 UTC,ContainerID:containerd://84a511d311f9f94c7b49d149afc4d1dcbf4609053c07f8e928df75cc70876171,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:k8s.gcr.io/e2e-test-images/agnhost:2.26 ImageID:k8s.gcr.io/e2e-test-images/agnhost@sha256:a3f7549ea04c419276e8b84e90a515bbce5bc8a057be2ed974ec45492eca346e ContainerID:containerd://84a511d311f9f94c7b49d149afc4d1dcbf4609053c07f8e928df75cc70876171 Started:0xc00056bda5}] QOSClass:BestEffort EphemeralContainerStatuses:[]}
  occurred

  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:459
```
Example for failed CI runs:
* [2896267023#step:11:1168](https://github.com/creydr/ovn-kubernetes/runs/2896267023?check_suite_focus=true#step:11:1168)
* [2896267023#step:11:1352](https://github.com/creydr/ovn-kubernetes/runs/2896267023?check_suite_focus=true#step:11:1352)

**Test: Should validate connectivity from a pod to a non-node host address on same node**
```
• Failure [43.906 seconds]
test e2e pod connectivity to host addresses
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:511
  Should validate connectivity from a pod to a non-node host address on same node [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:525

  Jun 23 15:57:09.714: Unexpected error:
      <*errors.errorString | 0xc00087ffa0>: {
          s: "pod \"e2e-src-ping-pod\" failed with status: {Phase:Failed Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:56:26 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:57:09 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [e2e-src-ping-pod-container]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:57:09 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [e2e-src-ping-pod-container]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:56:26 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:fc00:f853:ccd:e793::4 PodIP:fd00:10:244:3::b PodIPs:[{IP:fd00:10:244:3::b}] StartTime:2021-06-23 15:56:26 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:e2e-src-ping-pod-container State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2021-06-23 15:56:48 +0000 UTC,FinishedAt:2021-06-23 15:57:08 +0000 UTC,ContainerID:containerd://8c44592bb0f1cbdb974d095f207ba787df04dfb1bb9250996e2ed35162f6f8d4,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:k8s.gcr.io/e2e-test-images/agnhost:2.26 ImageID:k8s.gcr.io/e2e-test-images/agnhost@sha256:a3f7549ea04c419276e8b84e90a515bbce5bc8a057be2ed974ec45492eca346e ContainerID:containerd://8c44592bb0f1cbdb974d095f207ba787df04dfb1bb9250996e2ed35162f6f8d4 Started:0xc000980dd5}] QOSClass:BestEffort EphemeralContainerStatuses:[]}",
      }
      pod "e2e-src-ping-pod" failed with status: {Phase:Failed Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:56:26 +0000 UTC Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:57:09 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [e2e-src-ping-pod-container]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:57:09 +0000 UTC Reason:ContainersNotReady Message:containers with unready status: [e2e-src-ping-pod-container]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-06-23 15:56:26 +0000 UTC Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:fc00:f853:ccd:e793::4 PodIP:fd00:10:244:3::b PodIPs:[{IP:fd00:10:244:3::b}] StartTime:2021-06-23 15:56:26 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[{Name:e2e-src-ping-pod-container State:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2021-06-23 15:56:48 +0000 UTC,FinishedAt:2021-06-23 15:57:08 +0000 UTC,ContainerID:containerd://8c44592bb0f1cbdb974d095f207ba787df04dfb1bb9250996e2ed35162f6f8d4,}} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:k8s.gcr.io/e2e-test-images/agnhost:2.26 ImageID:k8s.gcr.io/e2e-test-images/agnhost@sha256:a3f7549ea04c419276e8b84e90a515bbce5bc8a057be2ed974ec45492eca346e ContainerID:containerd://8c44592bb0f1cbdb974d095f207ba787df04dfb1bb9250996e2ed35162f6f8d4 Started:0xc000980dd5}] QOSClass:BestEffort EphemeralContainerStatuses:[]}
  occurred

  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:532
```
Example for failed CI runs:
* [2896267023#step:11:1553](https://github.com/creydr/ovn-kubernetes/runs/2896267023?check_suite_focus=true#step:11:1553)
* [2896267023#step:11:1739](https://github.com/creydr/ovn-kubernetes/runs/2896267023?check_suite_focus=true#step:11:1739)

**Test: Should validate connectivity to an external gateway's loopback address via a pod with external gateway annotations**
```
• Failure [352.811 seconds]
e2e non-vxlan external gateway through a gateway pod
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1544
  Should validate connectivity to an external gateway's loopback address via a pod with external gateway annotations enabled [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1600

  Jun 23 16:03:26.188: Error trying to get the pod IP address

  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/internal/leafnodes/runner.go:113
```
Example for failed CI runs:
* [2896267023#step:11:2059](https://github.com/creydr/ovn-kubernetes/runs/2896267023?check_suite_focus=true#step:11:2059)
* [2896267023#step:11:2244](https://github.com/creydr/ovn-kubernetes/runs/2896267023?check_suite_focus=true#step:11:2244) (different error message)

**Test: Should validate connectivity to multiple external gateways for an ECMP scenario**
```
• Failure [388.663 seconds]
e2e multiple ecmp external gateway validation
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1704
  Should validate connectivity to multiple external gateways for an ECMP scenario [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1757

  Jun 23 15:49:50.081: Error trying to get the pod IP address

  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/internal/leafnodes/runner.go:113
```
Example for failed CI runs:
* [2896267023#step:11:677](https://github.com/creydr/ovn-kubernetes/runs/2896267023?check_suite_focus=true#step:11:677)
* [2896267023#step:11:990](https://github.com/creydr/ovn-kubernetes/runs/2896267023?check_suite_focus=true#step:11:990)

**Test: Should validate connectivity without vxlan before and after updating the namespace annotation to a new external gateway**
```
• Failure [347.572 seconds]
e2e non-vxlan external gateway and update validation
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1129
  Should validate connectivity without vxlan before and after updating the namespace annotation to a new external gateway [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1190

  Jun 23 16:18:46.440: Error trying to get the pod IP address

  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/internal/leafnodes/runner.go:113
```
Example for failed CI runs:
* [2896250600#step:11:3129](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:3129)
* [2896250600#step:11:3448](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:3448)

**Test: Should validate ICMP connectivity to an external gateway's loopback address via a pod with external gateway annotations enabled**
```
• Failure [157.723 seconds]
e2e non-vxlan external gateway through a gateway pod
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:41
  Should validate ICMP connectivity to an external gateway's loopback address via a pod with external gateway annotations enabled
  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table.go:92
    ipv6 [It]
    /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table_entry.go:43

    Jun 23 16:36:31.468: Failed to ping %!(EXTRA string=fd00:10:244:1::22, string=ex-gw-container1)
    Unexpected error:
        <*errors.errorString | 0xc000578160>: {
            s: "failed to run \"docker exec ex-gw-container1 ping -c 20 fd00:10:244:1::22\": exit status 1 (PING fd00:10:244:1::22(fd00:10:244:1::22) 56 data bytes\n\n--- fd00:10:244:1::22 ping statistics ---\n20 packets transmitted, 0 received, 100% packet loss, time 19446ms\n\n)",
        }
        failed to run "docker exec ex-gw-container1 ping -c 20 fd00:10:244:1::22": exit status 1 (PING fd00:10:244:1::22(fd00:10:244:1::22) 56 data bytes
        
        --- fd00:10:244:1::22 ping statistics ---
        20 packets transmitted, 0 received, 100% packet loss, time 19446ms
        
        )
    occurred

    /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:140
```
Example for failed CI runs:
* [2896250600#step:11:4246](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:4246)
* [2896250600#step:11:4527](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:4527)

**Test: Should validate ICMP connectivity to multiple external gateways for an ECMP scenario**
```
• Failure [94.869 seconds]
e2e multiple external gateway validation
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:212
  Should validate ICMP connectivity to multiple external gateways for an ECMP scenario
  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table.go:92
    IPV6 [It]
    /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table_entry.go:43

    Jun 23 15:32:22.091: Failed to ping %!(EXTRA string=fd00:10:244:1::7, string=gw-test-container1)
    Unexpected error:
        <*errors.errorString | 0xc000792300>: {
            s: "failed to run \"docker exec gw-test-container1 ping -c 30 fd00:10:244:1::7\": exit status 1 (PING fd00:10:244:1::7(fd00:10:244:1::7) 56 data bytes\n\n--- fd00:10:244:1::7 ping statistics ---\n30 packets transmitted, 0 received, 100% packet loss, time 29677ms\n\n)",
        }
        failed to run "docker exec gw-test-container1 ping -c 30 fd00:10:244:1::7": exit status 1 (PING fd00:10:244:1::7(fd00:10:244:1::7) 56 data bytes
        
        --- fd00:10:244:1::7 ping statistics ---
        30 packets transmitted, 0 received, 100% packet loss, time 29677ms
        
        )
    occurred

    /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:310
```
Example for failed CI runs:
* [2896250600#step:11:430](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:430)
* [2896250600#step:11:705](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:705) (different error message)

**Test: Should validate ingress connectivity from an external gateway**
```
• Failure [373.617 seconds]
e2e ingress gateway traffic validation
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:2101
  Should validate ingress connectivity from an external gateway [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:2145

  Jun 23 15:48:44.359: Error trying to get the pod IP address

  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/internal/leafnodes/runner.go:113
```
Example for failed CI runs:
* [2896250600#step:11:1448](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:1448)
* [2896250600#step:11:1761](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:1761)

**Test: Should validate NetFlow data of br-int is sent to an external gateway**
```
• Failure [44.988 seconds]
e2e br-int NetFlow export validation
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:2235
  Should validate NetFlow data of br-int is sent to an external gateway [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:2254

  Jun 23 16:28:33.206: failed to verify that NetFlow collector container received NetFlow data from br-int
  Unexpected error:
      <*errors.errorString | 0xc0001f4260>: {
          s: "timed out waiting for the condition",
      }
      timed out waiting for the condition
  occurred

  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:2305
```
Example for failed CI runs:
* [2896250600#step:11:3744](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:3744)
* [2896250600#step:11:3913](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:3913)

**Test: Should validate TCP/UDP connectivity to an external gateway's loopback address via a pod with external gateway annotations enabled**
```
• Failure [241.504 seconds]
e2e non-vxlan external gateway through a gateway pod
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:41
  Should validate TCP/UDP connectivity to an external gateway's loopback address via a pod with external gateway annotations enabled
  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table.go:92
    TCP ipv6 [It]
    /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table_entry.go:43

    Jun 23 15:58:58.428: Failed to reach pod from external container %!(EXTRA string=fd00:10:244:1::12, string=ex-gw-container1, string=tcp)
    Unexpected error:
        <*errors.errorString | 0xc0007ee040>: {
            s: "failed to run \"docker exec ex-gw-container1 bash -c curl -s http://[fd00:10:244:1::12]:80/hostname\": exit status 28 ()",
        }
        failed to run "docker exec ex-gw-container1 bash -c curl -s http://[fd00:10:244:1::12]:80/hostname": exit status 28 ()
    occurred

    /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:884
```
or 
```
• Failure [108.027 seconds]
e2e non-vxlan external gateway through a gateway pod
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:41
  Should validate TCP/UDP connectivity to an external gateway's loopback address via a pod with external gateway annotations enabled
  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table.go:92
    UDP ipv6 [It]
    /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table_entry.go:43

    Jun 23 16:05:43.247: Expected
        <string>: 
    to equal
        <string>: e2e-exgw-src-ping-pod

    /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:885
```
Example for failed CI runs:
* TCP IPv6 [2896250600#step:11:2033](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:2033)
* TCP IPv6 [2896250600#step:11:2254](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:2254)
* UDP IPv6 [2896250600#step:11:2474](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:2474)
* UDP IPv6 [2896250600#step:11:2689](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:2689)

BFD succeeds: [2896250600#step:11:3579](https://github.com/creydr/ovn-kubernetes/runs/2896250600?check_suite_focus=true#step:11:3579) 

**Test: Should validate TCP/UDP connectivity to multiple external gateways for a UDP / TCP scenario**
```
• Failure [50.817 seconds]
BFD
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:370
  e2e multiple external gateway validation
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:570
    Should validate TCP/UDP connectivity to multiple external gateways for a UDP / TCP scenario
    /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table.go:92
      IPV6 tcp [It]
      /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table_entry.go:43

      Jun 23 16:42:54.595: failed to reach %!(EXTRA string=fc00:f853:ccd:e794::1, string=tcp)
      Unexpected error:
          <exec.CodeExitError>: {
              Err: {
                  s: "error running /usr/local/bin/kubectl --server=https://10.1.0.48:11337 --kubeconfig=/home/runner/admin.conf --namespace=novxlan-externalgw-ecmp-8081 exec e2e-exgw-src-pod -- bash -c echo | nc -w 1 fc00:f853:ccd:e794::1 80:\nCommand stdout:\n\nstderr:\ncommand terminated with exit code 1\n\nerror:\nexit status 1",
              },
              Code: 1,
          }
          error running /usr/local/bin/kubectl --server=https://10.1.0.48:11337 --kubeconfig=/home/runner/admin.conf --namespace=novxlan-externalgw-ecmp-8081 exec e2e-exgw-src-pod -- bash -c echo | nc -w 1 fc00:f853:ccd:e794::1 80:
          Command stdout:
          
          stderr:
          command terminated with exit code 1
          
          error:
          exit status 1
      occurred

      /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/external_gateways.go:949
```
Example for failed CI runs:
* [2896285118#step:11:281](https://github.com/creydr/ovn-kubernetes/runs/2896285118?check_suite_focus=true#step:11:281)

Succeeded in [2896285118#step:11:428](https://github.com/creydr/ovn-kubernetes/runs/2896285118?check_suite_focus=true#step:11:428)

**Test: Should validate the egress firewall policy functionality against remote hosts**
```
• Failure [7.231 seconds]
e2e egress firewall policy validation
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1323
  Should validate the egress firewall policy functionality against remote hosts [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:1367

  Jun 24 07:27:33.541: Failed to connect to the remote host 8.8.8.8 from container ovnkube-node on node ovn-worker: error running /usr/local/bin/kubectl --server=https://10.1.0.102:11337 --kubeconfig=/home/runner/admin.conf --namespace=egress-firewall-policy-8081 exec e2e-egress-fw-src-pod --container=e2e-egress-fw-src-pod-container -- nc -vz -w 5 8.8.8.8 53:
  Command stdout:
  
  stderr:
  nc: connect to 8.8.8.8 port 53 (tcp) failed: Network unreachable
  command terminated with exit code 1
  
  error:
  exit status 1

  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/internal/leafnodes/runner.go:113
```
Example for failed CI runs:
* [2902387165#step:11:236](https://github.com/creydr/ovn-kubernetes/runs/2902387165?check_suite_focus=true#step:11:236)
* [2902387165#step:11:424](https://github.com/creydr/ovn-kubernetes/runs/2902387165?check_suite_focus=true#step:11:424)

**Test: Should validate the egress IP functionality against remote hosts**
```
• Failure [113.005 seconds]
e2e egress IP validation
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:624
  Should validate the egress IP functionality against remote hosts [It]
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:830

  Jun 23 16:49:18.608: Step 12. Check connectivity from the remaining pod to an external "node" and verify that the IP is one of the egress IPs, failed, err: timed out waiting for the condition
  Unexpected error:
      <*errors.errorString | 0xc000200240>: {
          s: "timed out waiting for the condition",
      }
      timed out waiting for the condition
  occurred

  /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:945
```
Example for failed CI runs:
* [2896285118#step:11:1155](https://github.com/creydr/ovn-kubernetes/runs/2896285118?check_suite_focus=true#step:11:1155)

Succeeded in [2896285118#step:11:1309](https://github.com/creydr/ovn-kubernetes/runs/2896285118?check_suite_focus=true#step:11:1309)

**Test: recovering from deleting db files while maintain connectivity**
```
• Failure [365.652 seconds]
e2e delete databases
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:2330
  recovering from deleting db files while maintain connectivity
  /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table.go:92
    when delete both db files on ovnkube-db-1 [It]
    /home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.12.0/extensions/table/table_entry.go:43

    Jun 23 16:56:37.663: pod ovnkube-db-1 is not arrived to running and ready state: Gave up after waiting 5m0s for pod "ovnkube-db-1" to be "running and ready"

    /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:2540
```
Example for failed CI runs:
* [2896285118#step:11:2221](https://github.com/creydr/ovn-kubernetes/runs/2896285118?check_suite_focus=true#step:11:2221)

Succeeded in [2896285118#step:11:841](https://github.com/creydr/ovn-kubernetes/runs/2896285118?check_suite_focus=true#step:11:841)