### PR TITLE
avoid prometheus cardinality explosion

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -73,35 +73,28 @@ var MetricResourceUpdateLatency = prometheus.NewHistogramVec(prometheus.Histogra
 )
 
 // MetricRequeueServiceCount is the number of times a particular service has been requeued.
-var MetricRequeueServiceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+var MetricRequeueServiceCount = prometheus.NewCounter(prometheus.CounterOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "requeue_service_total",
 	Help:      "A metric that captures the number of times a service is requeued after failing to sync with OVN"},
-	[]string{
-		"name",
-	},
 )
 
 // MetricSyncServiceCount is the number of times a particular service has been synced.
-var MetricSyncServiceCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+var MetricSyncServiceCount = prometheus.NewCounter(prometheus.CounterOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "sync_service_total",
 	Help:      "A metric that captures the number of times a service is synced with OVN load balancers"},
-	[]string{
-		"name",
-	},
 )
 
 // MetricSyncServiceLatency is the time taken to sync a service with the OVN load balancers.
-var MetricSyncServiceLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+var MetricSyncServiceLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "sync_service_latency_seconds",
 	Help:      "The latency of syncing a service with the OVN load balancers",
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
-	[]string{"name"},
 )
 
 var MetricMasterReadyDuration = prometheus.NewGauge(prometheus.GaugeOpts{

--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/acl"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
@@ -45,7 +44,6 @@ func (r *Repair) runOnce() error {
 	klog.V(4).Infof("Starting repairing loop for services")
 	defer func() {
 		klog.V(4).Infof("Finished repairing loop for services: %v", time.Since(startTime))
-		metrics.MetricSyncServiceLatency.WithLabelValues("repair-loop").Observe(time.Since(startTime).Seconds())
 	}()
 
 	// Obtain all the load balancers UUID

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -197,7 +197,7 @@ func (c *Controller) handleErr(err error, key interface{}) {
 	if keyErr != nil {
 		klog.ErrorS(err, "Failed to split meta namespace cache key", "key", key)
 	}
-	metrics.MetricRequeueServiceCount.WithLabelValues(key.(string)).Inc()
+	metrics.MetricRequeueServiceCount.Inc()
 
 	if c.queue.NumRequeues(key) < maxRetries {
 		klog.V(2).InfoS("Error syncing service, retrying", "service", klog.KRef(ns, name), "err", err)
@@ -217,11 +217,11 @@ func (c *Controller) syncServices(key string) error {
 		return err
 	}
 	klog.Infof("Processing sync for service %s on namespace %s ", name, namespace)
-	metrics.MetricSyncServiceCount.WithLabelValues(key).Inc()
+	metrics.MetricSyncServiceCount.Inc()
 
 	defer func() {
 		klog.V(4).Infof("Finished syncing service %s on namespace %s : %v", name, namespace, time.Since(startTime))
-		metrics.MetricSyncServiceLatency.WithLabelValues(key).Observe(time.Since(startTime).Seconds())
+		metrics.MetricSyncServiceLatency.Observe(time.Since(startTime).Seconds())
 	}()
 
 	// Get current Service from the cache


### PR DESCRIPTION
The Service controller was adding metrics per sevice, this creates
scalability problems due to the cardinality explosiong.

OVN doesn't need that granularity for the services metrics, so it just
simply removes the service name/namespace label to have only
one global metrics.

xref:
https://blog.freshtracks.io/bomb-squad-automatic-detection-and-suppression-of-prometheus-cardinality-explosions-62ca8e02fa32

Signed-off-by: Antonio Ojea <aojea@redhat.com>
