### PR TITLE
Fix issue with external GW setup + run CI with `--disable-snat-multiple-gws` on and off

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,6 +264,7 @@ jobs:
            name: "HA"
          - enabled: "false"
            name: "noHA"
+        disable-snat-multiple-gws: [true, false]
         gateway-mode: [local, shared]
         ipfamily:
          - ip: ipv4
@@ -307,6 +308,8 @@ jobs:
          # in agnhost images. Disable them for now.
          - {"ipfamily": {"ip": dualstack}, "target": {"shard": {"multicast-enable": "true"}}}
          - {"ipfamily": {"ip": ipv6}, "target": {"shard": {"multicast-enable": "true"}}}
+         # No need to run disable-snat-multiple-gws with local GW mode
+         - {"disable-snat-multiple-gws": true, "gateway-mode": local}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
@@ -317,6 +320,7 @@ jobs:
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_MULTICAST_ENABLE:  "${{ matrix.target.multicast-enable }}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target.emptylb-enable }}"
+      OVN_DISABLE_SNAT_MULTIPLE_GWS: "${{ matrix.disable-snat-multiple-gws }}"
     steps:
 
     - name: Free up disk space

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -245,7 +245,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 	if gwAnnotation != oldGWAnnotation || newBFDEnabled != oldBFDEnabled {
 		// if old gw annotation was empty, new one must not be empty, so we should remove any per pod SNAT
 		if oldGWAnnotation == "" {
-			if config.Gateway.DisableSNATMultipleGWs && (len(nsInfo.routingExternalGWs.gws) != 0 || len(nsInfo.routingExternalPodGWs) != 0) {
+			if config.Gateway.DisableSNATMultipleGWs {
 				existingPods, err := oc.watchFactory.GetPods(old.Name)
 				if err != nil {
 					klog.Errorf("Failed to get all the pods (%v)", err)

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -28,6 +28,13 @@ else
   SKIPPED_TESTS+="Should validate connectivity before and after deleting all the db-pods at once in Non-HA mode"
 fi
 
+if [ "$OVN_DISABLE_SNAT_MULTIPLE_GWS" == true ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+  	SKIPPED_TESTS+="|"
+  fi
+  SKIPPED_TESTS+="Should validate the egress IP functionality against remote hosts"
+fi
+
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote
 export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

Two issues:

1. This fixes an issue with the external GW setup when the flag  `--disable-snat-multiple-gws` is provided, namely: the conditional checks `(len(nsInfo.routingExternalGWs.gws) != 0 || len(nsInfo.routingExternalPodGWs) != 0)` was causing this bloc of code to be practically be considered dead code: https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/ovn/namespace.go#L249-L261 <br />
`nsInfo.routingExternalGWs` can only be set in `addExternalGWsForNamespace`, which comes after that conditional check. Moreover, `nsInfo.routingExternalPodGWs` concerns itself with unique pod setup for multiple gateway traffic and has dedicated pod labels for that configuration, those have no relation to the namespace labels (which might be independently [in]correct). Given that a namespace includes that pod, this should override it. All of this results in the fact that if the annotation is added to the namespace: this condition will block the deletion of the "per-pod snat" setup, which is required to make multiple gateway traffic work. 

2. OpenShift will run clusters with `--disable-snat-multiple-gws` provided, since it's a rather important change w.r.t how ovnkube runs in shared GW mode, enable it in CI. 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->