### PR TITLE
Fix some warnings at make clean

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -58,8 +58,8 @@ install:
 clean:
 	rm -rf ${OUT_DIR}
 	rm -rf ${TEST_REPORT_DIR}
-	rm ./pkg/nbdb/ovn-nb.ovsschema
-	rm ./pkg/sbdb/ovn-sb.ovsschema
+	rm -f ./pkg/nbdb/ovn-nb.ovsschema
+	rm -f ./pkg/sbdb/ovn-sb.ovsschema
 
 .PHONY: install.tools lint gofmt
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
Fix some warnings at ```make clean``` when removes a non-existent file.

```
$ make clean
rm -rf _output
rm -rf /home/honma/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/_artifacts
rm ./pkg/nbdb/ovn-nb.ovsschema
rm: cannot remove './pkg/nbdb/ovn-nb.ovsschema': No such file or directory
make: *** [Makefile:61: clean] Error 1
```
```
$ make clean
rm -rf _output
rm -rf /home/honma/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/_artifacts
rm -f ./pkg/nbdb/ovn-nb.ovsschema
rm ./pkg/sbdb/ovn-sb.ovsschema
rm: cannot remove './pkg/sbdb/ovn-sb.ovsschema': No such file or directory
make: *** [Makefile:62: clean] Error 1
```

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>

**- Special notes for reviewers**
None


**- How to verify it**
Run ```make clean``` at ```go-controller``` directory.

**- Description for the changelog**
Fix some warnings at make clean