### PR TITLE
Remove namespaces after the tests

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -422,10 +422,6 @@ var _ = Describe("Gateway Init Operations", func() {
 	)
 
 	BeforeEach(func() {
-		var err error
-		testNS, err = testutils.NewNS()
-		Expect(err).NotTo(HaveOccurred())
-
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
 
@@ -434,6 +430,7 @@ var _ = Describe("Gateway Init Operations", func() {
 		app.Flags = config.Flags
 
 		// Set up a fake br-local & LocalnetGatewayNextHopPort
+		var err error
 		testNS, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 		err = testNS.Do(func(ns.NetNS) error {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -449,6 +449,7 @@ var _ = Describe("Gateway Init Operations", func() {
 
 	AfterEach(func() {
 		Expect(testNS.Close()).To(Succeed())
+		Expect(testutils.UnmountNS(testNS)).To(Succeed())
 	})
 	/* FIXME for updated local gw mode
 	Context("for localnet operations", func() {

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -268,6 +268,7 @@ var _ = Describe("Management Port Operations", func() {
 
 	AfterEach(func() {
 		Expect(testNS.Close()).To(Succeed())
+		Expect(testutils.UnmountNS(testNS)).To(Succeed())
 	})
 
 	const (


### PR DESCRIPTION
**- What this PR does and why is it needed**
Some namespace created remain after tests.
This PR remove these namespaces.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>

**- Special notes for reviewers**
None

**- How to verify it**
Run ```ip netns``` command after the test.

**- Description for the changelog**
None