### PR TITLE
add 'make gofmt' back in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,8 @@ jobs:
       run: |
         set -x
         pushd go-controller
+           # exit early if there are gofmt issues
+           make gofmt
            make
            make windows
            COVERALLS=1 CONTAINER_RUNNABLE=1 make check

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -126,7 +126,7 @@ func checkForStaleOVSRepresentorInterfaces(nodeName string, wf factory.ObjectCac
 	out, stderr, err := util.RunOVSVsctl("--columns=name,external_ids", "--data=bare", "--no-headings",
 		"--format=csv", "find", "Interface", "external_ids:sandbox!=\"\"")
 	if err != nil {
-		klog.Errorf("failed to list ovn-k8s OVS interfaces:, stderr: %q, error: %v", stderr, err)
+		klog.Errorf("Failed to list ovn-k8s OVS interfaces:, stderr: %q, error: %v", stderr, err)
 		return
 	}
 
@@ -192,10 +192,10 @@ func checkForStaleOVSRepresentorInterfaces(nodeName string, wf factory.ObjectCac
 		if _, ok := expectedIfaceIds[ifaceId]; !ok {
 			// TODO(adrianc): To make this more strict we can check if the interface is a VF representor
 			// interface via sriovnet.
-			klog.Warningf("found stale OVS Interface, deleting OVS Port with interface %s", ifaceInfo.Name)
+			klog.Warningf("Found stale OVS Interface, deleting OVS Port with interface %s", ifaceInfo.Name)
 			_, stderr, err := util.RunOVSVsctl("--if-exists", "--with-iface", "del-port", ifaceInfo.Name)
 			if err != nil {
-				klog.Errorf("failed to delete interface %q . stderr: %q, error: %v",
+				klog.Errorf("Failed to delete interface %q . stderr: %q, error: %v",
 					ifaceInfo.Name, stderr, err)
 				continue
 			}


### PR DESCRIPTION
it got removed through the go 1.16 changes

Fixes: 676691772ec4 (CI: go 1.16, small fixes)
Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@squeed FYI