### PR TITLE
Upgrade to kind 0.11.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,10 +183,8 @@ jobs:
       run: |
         docker load --input image-master.tar
 
-    - name: Check out code into the Go module directory - from master
+    - name: Check out code into the Go module directory - from PR branch
       uses: actions/checkout@v2
-      with:
-        ref: master
 
     - name: kind setup
       run: |
@@ -218,9 +216,6 @@ jobs:
     - name: Load docker image
       run: |
         docker load --input image-pr.tar
-
-    - name: Check out code into the Go module directory - from PR branch
-      uses: actions/checkout@v2
 
     - name: ovn upgrade
       run: |

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -1,6 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
+  # kube proxy will be disabled
+  kubeProxyMode: "none"
   # the default CNI will not be installed
   disableDefaultCNI: true
   apiServerAddress: {{ ovn_apiServerAddress | default('0.0.0.0') }}
@@ -16,6 +18,9 @@ networking:
 {%- endif %}
 featureGates:
   SCTPSupport: true
+{%- if ovn_ip_family == "dual" %}
+  IPv6DualStack: true
+{%- endif %}
 kubeadmConfigPatches:
 - |
   kind: ClusterConfiguration

--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -14,15 +14,9 @@ sudo mv ./e2e.test /usr/local/bin/e2e.test
 sudo mv ./ginkgo /usr/local/bin/ginkgo
 rm kubernetes-test-linux-amd64.tar.gz
 
-# Install kind (dual-stack is not released upstream so we have to use our own version)
-if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
-  sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind
-  sudo chmod +x /usr/local/bin/kind
-else
-  curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64
-  chmod +x ./kind
-  sudo mv ./kind /usr/local/bin/
-fi
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/
 
 pushd ../contrib
 ./kind.sh


### PR DESCRIPTION
**- What this PR does and why is it needed**
Upgrade to kind 0.11.1 and make use of builtin support to disable kube-proxy and simplify `kind.sh` script. kind 0.11.1 includes dual stack support so we dont need to use @aojea kind fork any longer for dual stack tests.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>




