### PR TITLE
fix SIGSEGV issue with addressset.AddressSet interface

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -800,7 +800,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 				return err
 			}
 			defer nsInfo.Unlock()
-			if nsInfo.addressSet == nil {
+			if reflect.ValueOf(nsInfo.addressSet).IsNil() {
 				nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(hostNetworkNamespace)
 				if err != nil {
 					return fmt.Errorf("cannot create address set for namespace: %s,"+

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"time"
 
@@ -57,7 +58,7 @@ func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
 	}
 	defer nsInfo.Unlock()
 
-	if nsInfo.addressSet == nil {
+	if reflect.ValueOf(nsInfo.addressSet).IsNil() {
 		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns)
 		if err != nil {
 			return fmt.Errorf("unable to add pod to namespace. Cannot create address set for namespace: %s,"+
@@ -87,7 +88,7 @@ func (oc *Controller) deletePodFromNamespace(ns string, portInfo *lpInfo) error 
 	}
 	defer nsInfo.Unlock()
 
-	if nsInfo.addressSet != nil {
+	if !reflect.ValueOf(nsInfo.addressSet).IsNil() {
 		if err := nsInfo.addressSet.DeleteIPs(createIPAddressSlice(portInfo.ips)); err != nil {
 			return err
 		}
@@ -408,7 +409,7 @@ func (oc *Controller) deleteNamespaceLocked(ns string) *namespaceInfo {
 		nsInfo.Unlock()
 		return nil
 	}
-	if nsInfo.addressSet != nil {
+	if !reflect.ValueOf(nsInfo.addressSet).IsNil() {
 		// Empty the address set, then delete it after an interval.
 		if err := nsInfo.addressSet.SetIPs(nil); err != nil {
 			klog.Errorf("Warning: failed to empty address set for deleted NS %s: %v", ns, err)
@@ -427,7 +428,7 @@ func (oc *Controller) deleteNamespaceLocked(ns string) *namespaceInfo {
 				nsInfo := oc.getNamespaceLocked(ns)
 				if nsInfo != nil {
 					defer nsInfo.Unlock()
-					if nsInfo.addressSet != nil {
+					if !reflect.ValueOf(nsInfo.addressSet).IsNil() {
 						klog.V(5).Infof("Skipping deferred deletion of AddressSet for NS %s: re-created", ns)
 						return
 					}


### PR DESCRIPTION
this is an another instance of golang interface holding nil is not
always nil since it holds type too. a golang interface has two values
<type, value>. an interface is nil if both type and value is nil. so,
you cannot directly set the value to an interface and later check if
value was nil by comparing the interface to nil. this is because if the
value is `nil`, then the interface will still hold the type of the
value being set.

with the current code we were hitting SIGSEGV while acquiring as' lock

```
--------8<-----------8<-----
addPodtoNamespace() {
    <snip>
	if nsInfo.addressSet == nil {   <--- addressSet is really nil here
		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns)
		if err != nil {
			return fmt.Errorf("unable to add pod to namespace., "+
				"error: %v", ns, err)
		}
	}

	if err := nsInfo.addressSet.AddIPs \
	     (createIPAddressSlice(portInfo.ips)); err != nil {
	}
	<snip>
}
--------8<-----------8<-----
```

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@dcbw @danwinship @trozet @squeed PTAL