### PR TITLE
Fixes stale routes after external gateway pods delete/update

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -89,6 +89,15 @@ func (oc *Controller) addPodExternalGW(pod *kapi.Pod) error {
 
 // addPodExternalGWForNamespace handles adding routes to all pods in that namespace for a pod GW
 func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.Pod, egress gatewayInfo) error {
+	var gws string
+	for _, ip := range egress.gws {
+		if len(gws) != 0 {
+			gws += ","
+		}
+		gws += ip.String()
+	}
+	klog.Infof("Adding routes for external gateway pod: %s, next hops: %q, namespace: %s, bfd-enabled: %t",
+		pod.Name, gws, namespace, egress.bfdEnabled)
 	nsInfo, err := oc.waitForNamespaceLocked(namespace)
 	if err != nil {
 		return err

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -475,6 +475,13 @@ func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
 		return false
 	}
 
+	if oldPod != nil && (exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod)) {
+		// No matter if a pod is ovn networked, or host networked, we still need to check for exgw
+		// annotations. If the pod is ovn networked and is in update reschedule, addLogicalPort will take
+		// care of updating the exgw updates
+		oc.deletePodExternalGW(oldPod)
+	}
+
 	if util.PodWantsNetwork(pod) && addPort {
 		if err := oc.addLogicalPort(pod); err != nil {
 			klog.Errorf(err.Error())
@@ -482,12 +489,6 @@ func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
 			return false
 		}
 	} else {
-		if oldPod != nil && (exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod)) {
-			// No matter if a pod is ovn networked, or host networked, we still need to check for exgw
-			// annotations. If the pod is ovn networked and is in update reschedule, addLogicalPort will take
-			// care of updating the exgw updates
-			oc.deletePodExternalGW(oldPod)
-		}
 		if err := oc.addPodExternalGW(pod); err != nil {
 			klog.Errorf(err.Error())
 			oc.recordPodEvent(err, pod)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -83,6 +83,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 }
 
 func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
+	oc.deletePodExternalGW(pod)
 	if pod.Spec.HostNetwork {
 		return
 	}
@@ -133,7 +134,6 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		oc.deletePerPodGRSNAT(pod.Spec.NodeName, portInfo.ips)
 	}
 	oc.deleteGWRoutesForPod(pod.Namespace, portInfo.ips)
-	oc.deletePodExternalGW(pod)
 	oc.logicalPortCache.remove(logicalPort)
 }
 


### PR DESCRIPTION
Fixes several paths where deleting or updating a pod serving as an external gateway may result in stale ECMP routes.