### PR TITLE
ovnkube-trace: Autodetermine ovnNamespace

### DIFF
--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -480,6 +480,23 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 	return podInfo, err
 }
 
+func getOvnNamespace(coreclient *corev1client.CoreV1Client, override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app=ovnkube-node",
+	}
+	pods, err := coreclient.Pods("").List(context.TODO(), listOptions)
+	if err != nil || len(pods.Items) == 0 {
+		klog.V(0).Infof("Cannot find ovnkube pods in any namespace")
+		return "", err
+	}
+
+	return pods.Items[0].Namespace, nil
+}
+
 var (
 	level klog.Level
 )
@@ -492,7 +509,7 @@ func main() {
 	var ovnNamespace string
 	var err error
 
-	pcfgNamespace = flag.String("ovn-config-namespace", "openshift-ovn-kubernetes", "namespace used by ovn-config itself")
+	pcfgNamespace = flag.String("ovn-config-namespace", "", "namespace used by ovn-config itself")
 	psrcNamespace = flag.String("src-namespace", "default", "k8s namespace of source pod")
 	pdstNamespace = flag.String("dst-namespace", "default", "k8s namespace of dest pod")
 
@@ -521,8 +538,6 @@ func main() {
 
 	srcNamespace := *psrcNamespace
 	dstNamespace := *pdstNamespace
-
-	ovnNamespace = *pcfgNamespace
 
 	if *srcPodName == "" {
 		fmt.Printf("Usage: source pod must be specified\n")
@@ -594,6 +609,14 @@ func main() {
 		klog.V(1).Infof(" Unexpected error: %v", err)
 		os.Exit(-1)
 	}
+
+	// Get OVN Namespace
+	ovnNamespace, err = getOvnNamespace(coreclient, *pcfgNamespace)
+	if err != nil {
+		klog.V(1).Infof(" Unexpected error: %v", err)
+		os.Exit(-1)
+	}
+	klog.V(5).Infof("OVN Kubernetes namespace is %s", ovnNamespace)
 
 	// List all Nodes.
 	nodes, err := coreclient.Nodes().List(context.TODO(), metav1.ListOptions{})


### PR DESCRIPTION
ovnkube-trace will now look for ovnkube pods in all namespaces and it
will pick the namespace of the first matching pod that it finds.
A manual override with -ovn-config-namespace still takes precedence.

Fixes #2305

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->