### PR TITLE
Add hbo-lr-policy only if config.HybridOverlay.ClusterSubnets is set

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -213,9 +213,11 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 
 	// we need to setup a reroute policy for hybrid overlay subnet
 	// this is so hybrid pod -> service -> hybrid endpoint will reroute to the DR IP
-	if err := setupHybridLRPolicySharedGw(subnets, node.Name, portMAC); err != nil {
-		return fmt.Errorf("unable to setup Hybrid Subnet Logical Route Policy for node: %s, error: %v",
-			node.Name, err)
+	if len(config.HybridOverlay.ClusterSubnets) > 0 {
+		if err := setupHybridLRPolicySharedGw(subnets, node.Name, portMAC); err != nil {
+			return fmt.Errorf("unable to setup Hybrid Subnet Logical Route Policy for node: %s, error: %v",
+				node.Name, err)
+		}
 	}
 
 	if !lspOK {


### PR DESCRIPTION
Since we do not have a config parser that checks if
HybridOverlay.ClusterSubnets is set if HybridOverlay.Enabled is true,
before adding the lr-in-policy we should check if there are any
clustersubnets in the config. Since we don't have a default value
for this field it ends up creating policies that have nil dst
fields.

Fixes #2313 

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

