### PR TITLE
Kind script: add support for podman

### DIFF
--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -20,42 +20,43 @@ endif
 KERNEL_VERSION ?= `uname -r`
 OVS_BRANCH ?= master
 OVN_BRANCH ?= master
+OCI_BIN ?= docker
 
 # The image of ovnkube/ovn-daemonset-u should be multi-arched before using it on arm64
 ubuntu: bld
-	docker build -t ovn-kube-u$(IMAGE_ARCH) -f Dockerfile.ubuntu$(DOCKERFILE_ARCH) .
+	${OCI_BIN} build -t ovn-kube-u$(IMAGE_ARCH) -f Dockerfile.ubuntu$(DOCKERFILE_ARCH) .
 ifeq ($(ARCH),amd64)
-	docker tag "ovn-kube-u$(IMAGE_ARCH):latest" \
+	${OCI_BIN} tag "ovn-kube-u$(IMAGE_ARCH):latest" \
               "ovn-kube-u:latest"
 endif
 	# This is the default in the ovnkube*.yaml files
-	# docker login -u ovnkube docker.io/ovnkube
-	# docker push docker.io/ovnkube/ovn-daemonset-u:latest
+	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube
+	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-u:latest
 	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-u:latest
 
 centos: bld
-	docker build --build-arg rpmArch=$(shell uname -m) -t ovn-daemonset .
-	docker tag ovn-daemonset docker.io/ovnkube/ovn-daemonset:latest
-	# docker login -u ovnkube docker.io/ovnkube
-	# docker push docker.io/ovnkube/ovn-daemonset:latest
+	${OCI_BIN} build --build-arg rpmArch=$(shell uname -m) -t ovn-daemonset .
+	${OCI_BIN} tag ovn-daemonset docker.io/ovnkube/ovn-daemonset:latest
+	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube
+	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset:latest
 	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset:latest
 
 fedora: bld
-	docker build -t ovn-kube-f -f Dockerfile.fedora .
-	# docker login -u ovnkube docker.io/ovnkube
-	# docker push docker.io/ovnkube/ovn-daemonset-f:latest
+	${OCI_BIN} build -t ovn-kube-f -f Dockerfile.fedora .
+	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube
+	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-f:latest
 	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest
 
 fedora-dev: bld
 	# To build (OVN Datapath)  with specific kernel version, please override KERNEL_VERSION.
 	# By default it will build with the host machine's kernel version.
 
-	docker build --build-arg KERNEL_VERSION=$(KERNEL_VERSION) \
+	${OCI_BIN} build --build-arg KERNEL_VERSION=$(KERNEL_VERSION) \
 		     --build-arg OVS_BRANCH=$(OVS_BRANCH) \
 		     --build-arg OVN_BRANCH=$(OVN_BRANCH) \
 		     -t ovn-kube-f-dev -f Dockerfile.fedora.dev .
-	# docker login -u ovnkube docker.io/ovnkube
-	# docker push docker.io/ovnkube/ovn-daemonset-f:latest
+	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube
+	# ${OCI_BIN} push docker.io/ovnkube/ovn-daemonset-f:latest
 	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest \
                     --net-cidr=10.244.0.0/16 \
                     --svc-cidr=10.96.0.0/12 \

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -1,11 +1,11 @@
 # OVN kubernetes KIND Setup
 
-KIND (Kubernetes in Docker) deployment of OVN kubernetes is a fast and easy means to quickly install and test kubernetes with OVN kubernetes CNI.  The value proposition is really for developers who want to reproduce an issue or test a fix in an environment that can be brought up locally and within a few minutes.
+KIND (Kubernetes in Docker) deployment of OVN kubernetes is a fast and easy means to quickly install and test kubernetes with OVN kubernetes CNI. The value proposition is really for developers who want to reproduce an issue or test a fix in an environment that can be brought up locally and within a few minutes.
 
 ### Prerequisites 
 
 - 20 GB of free space in root file system
-- Docker run time
+- Docker run time or podman
 - [KIND]( https://kubernetes.io/docs/setup/learning-environment/kind/ )
    - Installation instructions can be found at https://github.com/kubernetes-sigs/kind#installation-and-usage. 
    - NOTE: The OVN-Kubernetes [ovn-kubernetes/contrib/kind.sh](https://github.com/ovn-org/ovn-kubernetes/blob/master/contrib/kind.sh) and [ovn-kubernetes/contrib/kind.yaml](https://github.com/ovn-org/ovn-kubernetes/blob/master/contrib/kind.yaml) files provision port 11337. If firewalld is enabled, this port will need to be unblocked:
@@ -18,7 +18,7 @@ KIND (Kubernetes in Docker) deployment of OVN kubernetes is a fast and easy mean
 
 **NOTE :**  In certain operating systems such as CentOS 8.x, pip2 and pip3 binaries are installed instead of pip. In such situations create a softlink for "pip" that points to "pip2".
 
-### Run the KIND deployment 
+### Run the KIND deployment with docker
 
 For OVN kubernetes KIND deployment, use the `kind.sh` script.
 
@@ -96,6 +96,42 @@ usage: kind.sh [[[-cf|--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]
 
 ```
 As seen above if you do not specify any options script will assume the default values.
+
+### Run the KIND deployment with podman
+
+To verify local changes, the steps are mostly the same as with docker, except the `fedora` make target:
+
+```
+$ OCI_BIN=podman make fedora
+```
+
+To deploy KIND however, you need to start it as root and then copy root's kube config to use it as non-root:
+
+```
+$ pushd contrib
+$ sudo ./kind.sh -ep podman
+$ sudo cp /root/admin.conf ~/.kube/kind-config
+$ sudo chown $(id -u):$(id -g) ~/.kube/kind-config
+$ export KUBECONFIG=~/.kube/kind-config
+$ popd
+```
+
+**Notes / troubleshooting:**
+
+- Issue with /dev/dma_heap: if you get the error `kind "Error: open /dev/dma_heap: permission denied"`, there's a [known issue](https://bugzilla.redhat.com/show_bug.cgi?id=1966158) about it (directory mislabelled with selinux).
+Workaround:
+
+```bash
+sudo setenforce 0
+sudo chcon system\_u:object\_r:device\_t:s0 /dev/dma\_heap/
+sudo setenforce 1
+```
+
+- If you see errors related to go, you may not have go configured as root. Make sure your `$GOPATH` / `$PATH` are configured as root, or define them while running `kind.sh`:
+
+```bash
+sudo GOPATH=/path/to/go PATH=$PATH:/usr/local/go/bin:$GOPATH/bin ./kind.sh -ep podman
+```
 
 ### Usage Notes 
 


### PR DESCRIPTION
- Support in Makefile (e.g. OCI_BIN=podman make fedora)
- Support in kind.sh with flag "-ep podman"

Signed-off-by: Joel Takvorian <jtakvori@redhat.com>

**- What this PR does and why is it needed**

This PR adds podman support for kind. Currently, only docker is supported, and building / deploying with podman fails.

**- Special notes for reviewers**

None

**- How to verify it**

- Non-regression with docker must be verified (I only have podman on my machine, didn't test with docker). Basically, need to check that the instructions here are still working: https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/kind.md

- I wrote a gist to give instructions with podman, as they slightly differ: https://gist.github.com/jotak/068cee03ef1ba9fea467d96daf811cbd . Not sure if they have to be integrated in the documentation, as it involves some workarounds , and starting kind as root. Or perhaps we can just link to this gist from the documentation.

**- Description for the changelog**

Added support for podman in script for Kind.