### PR TITLE
kind.sh: Kind route issue workaround

### DIFF
--- a/contrib/kind-route-fix/kind-route-fix.service
+++ b/contrib/kind-route-fix/kind-route-fix.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fix routes for kind cluster after container restart
+After=kubelet.service
+
+[Service]
+ExecStart=/usr/local/bin/kind-route-fix.sh
+Restart=always
+StartLimitInterval=0
+RestartSec=1s
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/kind-route-fix/kind-route-fix.sh
+++ b/contrib/kind-route-fix/kind-route-fix.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+while true; do
+  if [ "$(ip route | awk '/default/ {print $NF}')" == "eth0" ] && $(ip link ls dev eth0 | grep -q "master ovs-system") ; then
+    echo "Conditions met for route issue."
+    ovs_container_id=$(crictl ps | awk '/ovs-daemons/ {print $1}')
+    if [ "$ovs_container_id" != "" ]; then
+      echo "Rewiring network from eth0 to breth0."
+      crictl exec ${ovs_container_id} ovn-kube-util nics-to-bridge eth0
+    else
+      echo "Could not find ovs-daemons container."
+    fi
+  fi
+  sleep 30
+done


### PR DESCRIPTION
Restore connectivity after kind container restart by unbinding
eth0 from breth0.

Fixes #2020

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->