### PR TITLE
nicstobridge.go: Improve logging message when address move fails

### DIFF
--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -84,7 +84,7 @@ func saveIPAddress(oldLink, newLink netlink.Link, addrs []netlink.Addr) error {
 			// Add to newLink
 			addr.Label = newLink.Attrs().Name
 			if err := netLinkOps.AddrAdd(newLink, &addr); err != nil {
-				klog.Errorf("Add addr to newLink %q failed: %v", addr.Label, err)
+				klog.Errorf("Add addr %q to newLink %q failed: %v", addr.String(), addr.Label, err)
 				return err
 			}
 			klog.Infof("Successfully saved addr %q to newLink %q", addr.String(), addr.Label)


### PR DESCRIPTION
Improve logging message when address move fails

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->