### PR TITLE
Idling: check existing loadbalancer before moving the vip to the idling

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -272,19 +272,19 @@ func (c *Controller) syncServices(key string) error {
 
 	vipProtocols := collectServiceVIPs(service)
 	if svcNeedsIdling(service.Annotations) && !util.HasValidEndpoint(service, endpointSlices) {
-		// addServiceToIdlingBalancer adds the vips to service tracker
-		err = c.addServiceToIdlingBalancer(vipProtocols, service)
-		if err != nil {
-			c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToAddToIdlingBalancer",
-				"Error trying to add to Idling LoadBalancer for Service %s/%s: %v", name, namespace, err)
-			return err
-		}
 		toRemoveFromNonIdling := sets.NewString()
 		for vipProtocol := range vipProtocols {
 			if c.serviceTracker.getLoadBalancer(name, namespace, vipProtocol) != loadbalancer.IdlingLoadBalancer {
 				toRemoveFromNonIdling.Insert(vipProtocol)
 			}
 			vipsTracked.Delete(vipProtocol)
+		}
+		// addServiceToIdlingBalancer adds the vips to service tracker
+		err = c.addServiceToIdlingBalancer(vipProtocols, service)
+		if err != nil {
+			c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToAddToIdlingBalancer",
+				"Error trying to add to Idling LoadBalancer for Service %s/%s: %v", name, namespace, err)
+			return err
 		}
 		err = deleteVIPsFromNonIdlingOVNBalancers(toRemoveFromNonIdling, name, namespace)
 		if err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

Right now we add the vipProtocol to the list of vipProtocols to remove
only if the loadbalancer is not the idling one. The problem is, we
update the loadbalancer just before this check, with the effect of not
removing the vip from the existing balancers. This causes the vip to
stay both on the idling and non idling loadbalancers, with non
predictable effects.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->