### PR TITLE
Taint nodes with a too small MTU

### DIFF
--- a/go-controller/pkg/kube/kube_test.go
+++ b/go-controller/pkg/kube/kube_test.go
@@ -11,6 +11,123 @@ import (
 )
 
 var _ = Describe("Kube", func() {
+
+	Describe("Taint node operations", func() {
+		var kube Kube
+		var existingNodeTaints []v1.Taint
+		var taint v1.Taint
+		var node *v1.Node
+
+		BeforeEach(func() {
+			fakeClient := fake.NewSimpleClientset()
+			kube = Kube{
+				KClient: fakeClient,
+			}
+			taint = v1.Taint{Key: "my-taint-key", Value: "my-taint-value", Effect: v1.TaintEffectNoSchedule}
+		})
+
+		JustBeforeEach(func() {
+			// create the node with the specified taints just before the tests
+			newNode := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-node",
+				},
+				Spec: v1.NodeSpec{
+					Taints: existingNodeTaints,
+				},
+			}
+
+			var err error
+			node, err = kube.KClient.CoreV1().Nodes().Create(context.TODO(), newNode, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(node).NotTo(BeZero())
+		})
+
+		Context("with a node not having the taint", func() {
+
+			BeforeEach(func() {
+				existingNodeTaints = make([]v1.Taint, 0)
+			})
+
+			Context("SetTaintOnNode", func() {
+				It("should add the taint to the node", func() {
+					err := kube.SetTaintOnNode(node.Name, &taint)
+					Expect(err).ToNot(HaveOccurred())
+
+					loadedNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(loadedNode.Spec.Taints).To(ContainElement(taint))
+				})
+			})
+
+			Context("RemoveTaintFromNode", func() {
+				It("should remove nothing from the node", func() {
+					err := kube.RemoveTaintFromNode(node.Name, &taint)
+					Expect(err).ToNot(HaveOccurred())
+
+					loadedNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(loadedNode.Spec.Taints).To(HaveLen(len(node.Spec.Taints)))
+				})
+			})
+		})
+
+		Context("with a node having the same taint already", func() {
+
+			BeforeEach(func() {
+				existingNodeTaints = []v1.Taint{taint}
+			})
+
+			Context("SetTaintOnNode", func() {
+				It("should update the taint of the node if effect differs", func() {
+					updatedTaint := taint.DeepCopy()
+					updatedTaint.Effect = v1.TaintEffectPreferNoSchedule
+
+					err := kube.SetTaintOnNode(node.Name, updatedTaint)
+					Expect(err).ToNot(HaveOccurred())
+
+					loadedNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(loadedNode.Spec.Taints).To(ContainElement(*updatedTaint))
+				})
+
+				It("should update nothing if taint is the same", func() {
+					err := kube.SetTaintOnNode(node.Name, &taint)
+					Expect(err).ToNot(HaveOccurred())
+
+					updatedNode, err := kube.GetNode(node.Name)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updatedNode.Spec.Taints).To(Equal([]v1.Taint{taint}))
+				})
+			})
+
+			Context("RemoveTaintFromNode", func() {
+				It("should remove the taint from the node", func() {
+					err := kube.RemoveTaintFromNode(node.Name, &taint)
+					Expect(err).ToNot(HaveOccurred())
+
+					loadedNode, err := kube.KClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(loadedNode.Spec.Taints).NotTo(ContainElement(taint))
+					Expect(loadedNode.Spec.Taints).To(HaveLen(len(node.Spec.Taints) - 1))
+				})
+			})
+		})
+
+		Context("with references to a node which doesn't exist", func() {
+
+			Context("SetTaintOnNode", func() {
+
+				It("should return an error, if node doesn't exist", func() {
+					nodeName := "targaryen"
+					err := kube.SetTaintOnNode(nodeName, &taint)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("nodes \"targaryen\" not found"))
+				})
+			})
+		})
+	})
+
 	Describe("SetAnnotationsOnPod", func() {
 		var kube Kube
 
@@ -77,59 +194,4 @@ var _ = Describe("Kube", func() {
 			})
 		})
 	})
-
-	Describe("NodeTainting", func() {
-		var kube Kube
-		var nodeName string
-		var taint v1.Taint
-		var node *v1.Node
-
-		fakeClient := fake.NewSimpleClientset()
-		kube = Kube{
-			KClient: fakeClient,
-		}
-		newNode := &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "my-node",
-			},
-			Spec: v1.NodeSpec{
-				Taints: []v1.Taint{},
-			},
-		}
-		var err error
-		node, err = kube.KClient.CoreV1().Nodes().Create(context.TODO(), newNode, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(node).NotTo(BeZero())
-		nodeName = node.Name
-		taint = v1.Taint{Key: "GlobalWarming", Value: "OnRise", Effect: "NoSchedule"}
-
-		Context("SetAndRemoveTaintOnNode", func() {
-			It("Add a new taint", func() {
-				err := kube.SetTaintOnNode(nodeName, &taint)
-				Expect(err).ToNot(HaveOccurred())
-				node, err = kube.GetNode(nodeName)
-				Expect(node.Spec.Taints).To(Equal([]v1.Taint{taint}))
-			})
-			It("Taint already exists, no-op", func() {
-				err = kube.SetTaintOnNode(nodeName, &taint)
-				Expect(err).ToNot(HaveOccurred())
-				node, err = kube.GetNode(nodeName)
-				Expect(node.Spec.Taints).To(Equal([]v1.Taint{taint}))
-			})
-			It("Remove a taint", func() {
-				// remove the added taint
-				err = kube.RemoveTaintFromNode(nodeName, &taint)
-				Expect(err).ToNot(HaveOccurred())
-				node, err = kube.GetNode(nodeName)
-				Expect(node.Spec.Taints).To(BeNil())
-			})
-			It("Node doesn't exist", func() {
-				nodeName = "targaryen"
-				err := kube.SetTaintOnNode(nodeName, &taint)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("nodes \"targaryen\" not found"))
-			})
-		})
-	})
-
 })

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -265,6 +265,34 @@ func (_m *KubeInterface) GetPods(namespace string, labelSelector metav1.LabelSel
 	return r0, r1
 }
 
+// PatchNode provides a mock function with given fields: old, new
+func (_m *KubeInterface) PatchNode(old *v1.Node, new *v1.Node) error {
+	ret := _m.Called(old, new)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.Node, *v1.Node) error); ok {
+		r0 = rf(old, new)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// RemoveTaintFromNode provides a mock function with given fields: nodeName, taint
+func (_m *KubeInterface) RemoveTaintFromNode(nodeName string, taint *v1.Taint) error {
+	ret := _m.Called(nodeName, taint)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *v1.Taint) error); ok {
+		r0 = rf(nodeName, taint)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetAnnotationsOnNamespace provides a mock function with given fields: namespace, annotations
 func (_m *KubeInterface) SetAnnotationsOnNamespace(namespace *v1.Namespace, annotations map[string]string) error {
 	ret := _m.Called(namespace, annotations)
@@ -300,6 +328,20 @@ func (_m *KubeInterface) SetAnnotationsOnPod(namespace string, podName string, a
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, string, map[string]string) error); ok {
 		r0 = rf(namespace, podName, annotations)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetTaintOnNode provides a mock function with given fields: nodeName, taint
+func (_m *KubeInterface) SetTaintOnNode(nodeName string, taint *v1.Taint) error {
+	ret := _m.Called(nodeName, taint)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *v1.Taint) error); ok {
+		r0 = rf(nodeName, taint)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -243,7 +243,8 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 
 	waiter.AddWait(gw.readyFunc, initGw)
 	n.gateway = gw
-	return err
+
+	return n.validateGatewayMTU(gatewayIntf)
 }
 
 // CleanupClusterNode cleans up OVS resources on the k8s node on ovnkube-node daemonset deletion.

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -3,11 +3,16 @@ package node
 import (
 	"fmt"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/urfave/cli/v2"
+	"github.com/vishvananda/netlink"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	netlink_mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
+	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -15,192 +20,348 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Node Operations", func() {
-	var app *cli.App
+var _ = Describe("Node", func() {
 
-	BeforeEach(func() {
-		// Restore global default values before each testcase
-		config.PrepareTestConfig()
+	Describe("validateMTU", func() {
+		var (
+			kubeMock        *mocks.KubeInterface
+			netlinkOpsMock  *utilMocks.NetLinkOps
+			netlinkLinkMock *netlink_mocks.Link
 
-		app = cli.NewApp()
-		app.Name = "test"
-		app.Flags = config.Flags
-	})
+			ovnNode *OvnNode
+		)
 
-	It("sets correct OVN external IDs", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				nodeIP   string = "1.2.5.6"
-				nodeName string = "cannot.be.resolv.ed"
-				interval int    = 100000
-				ofintval int    = 180
-			)
-			node := kapi.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nodeName,
-				},
-				Status: kapi.NodeStatus{
-					Addresses: []kapi.NodeAddress{
-						{
-							Type:    kapi.NodeExternalIP,
-							Address: nodeIP,
-						},
-					},
-				},
+		const (
+			nodeName = "my-node"
+			linkName = "breth0"
+
+			// TODO take constants from node.go
+			geneveHeaderLengthIPv4 = 58
+			geneveHeaderLengthIPv6 = geneveHeaderLengthIPv4 + 20
+
+			configDefaultMTU               = 1500 //value for config.Default.MTU
+			mtuTooSmallForIPv4AndIPv6      = configDefaultMTU + geneveHeaderLengthIPv4 - 1
+			mtuOkForIPv4ButTooSmallForIPv6 = configDefaultMTU + geneveHeaderLengthIPv4
+			mtuOkForIPv4AndIPv6            = configDefaultMTU + geneveHeaderLengthIPv6
+		)
+
+		BeforeEach(func() {
+			kubeMock = new(mocks.KubeInterface)
+			netlinkOpsMock = new(utilMocks.NetLinkOps)
+			netlinkLinkMock = new(netlink_mocks.Link)
+
+			util.SetNetLinkOpMockInst(netlinkOpsMock)
+			netlinkOpsMock.On("LinkByName", linkName).Return(netlinkLinkMock, nil)
+
+			ovnNode = &OvnNode{
+				name: nodeName,
+				Kube: kubeMock,
 			}
 
-			fexec := ovntest.NewFakeExec()
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
-					"external_ids:ovn-encap-type=geneve "+
-					"external_ids:ovn-encap-ip=%s "+
-					"external_ids:ovn-remote-probe-interval=%d "+
-					"external_ids:ovn-openflow-probe-interval=%d "+
-					"external_ids:hostname=\"%s\" "+
-					"external_ids:ovn-monitor-all=true "+
-					"external_ids:ovn-enable-lflow-cache=true",
-					nodeIP, interval, ofintval, nodeName),
+			config.Default.MTU = configDefaultMTU
+
+			kubeMock.On("SetTaintOnNode", nodeName, mock.AnythingOfType("*v1.Taint")).Return(nil)
+			kubeMock.On("RemoveTaintFromNode", nodeName, mock.AnythingOfType("*v1.Taint")).Return(nil)
+		})
+
+		AfterEach(func() {
+			util.ResetNetLinkOpMockInst() // other tests in this package rely directly on netlink (e.g. gateway_init_linux_test.go)
+		})
+
+		Context("with a cluster in IPv4 mode", func() {
+
+			BeforeEach(func() {
+				config.IPv4Mode = true
+				config.IPv6Mode = false
 			})
 
-			err := util.SetExec(fexec)
-			Expect(err).NotTo(HaveOccurred())
+			Context("with the node having a too small MTU", func() {
 
-			_, err = config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
+				It("should taint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU: mtuTooSmallForIPv4AndIPv6,
+					})
 
-			err = setupOVNNode(&node)
-			Expect(err).NotTo(HaveOccurred())
+					err := ovnNode.validateGatewayMTU(linkName)
+					Expect(err).NotTo(HaveOccurred())
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "SetTaintOnNode", 1)
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "RemoveTaintFromNode", 0)
+				})
+			})
 
-			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
+			Context("with the node having a big enough MTU", func() {
 
-		err := app.Run([]string{app.Name})
-		Expect(err).NotTo(HaveOccurred())
+				It("should untaint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU: mtuOkForIPv4ButTooSmallForIPv6,
+					})
+
+					err := ovnNode.validateGatewayMTU(linkName)
+					Expect(err).NotTo(HaveOccurred())
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "SetTaintOnNode", 0)
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "RemoveTaintFromNode", 1)
+				})
+			})
+		})
+
+		Context("with a cluster in IPv6 mode", func() {
+			BeforeEach(func() {
+				config.IPv4Mode = false
+				config.IPv6Mode = true
+			})
+
+			Context("with the node having a too small MTU", func() {
+
+				It("should taint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU: mtuTooSmallForIPv4AndIPv6,
+					})
+
+					err := ovnNode.validateGatewayMTU(linkName)
+					Expect(err).NotTo(HaveOccurred())
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "SetTaintOnNode", 1)
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "RemoveTaintFromNode", 0)
+				})
+			})
+
+			Context("with the node having a big enough MTU", func() {
+
+				It("should untaint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU: mtuOkForIPv4AndIPv6,
+					})
+
+					err := ovnNode.validateGatewayMTU(linkName)
+					Expect(err).NotTo(HaveOccurred())
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "SetTaintOnNode", 0)
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "RemoveTaintFromNode", 1)
+				})
+			})
+		})
+
+		Context("with a cluster in dual-stack mode", func() {
+			BeforeEach(func() {
+				config.IPv4Mode = true
+				config.IPv6Mode = true
+			})
+
+			Context("with the node having a too small MTU", func() {
+
+				It("should taint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU: mtuOkForIPv4ButTooSmallForIPv6,
+					})
+
+					err := ovnNode.validateGatewayMTU(linkName)
+					Expect(err).NotTo(HaveOccurred())
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "SetTaintOnNode", 1)
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "RemoveTaintFromNode", 0)
+				})
+			})
+
+			Context("with the node having a big enough MTU", func() {
+
+				It("should untaint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU: mtuOkForIPv4AndIPv6,
+					})
+
+					err := ovnNode.validateGatewayMTU(linkName)
+					Expect(err).NotTo(HaveOccurred())
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "SetTaintOnNode", 0)
+					kubeMock.AssertNumberOfCalls(GinkgoT(), "RemoveTaintFromNode", 1)
+				})
+			})
+		})
 	})
-	It("sets non-default OVN encap port", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				nodeIP      string = "1.2.5.6"
-				nodeName    string = "cannot.be.resolv.ed"
-				encapPort   uint   = 666
-				interval    int    = 100000
-				ofintval    int    = 180
-				chassisUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
-				encapUUID   string = "e4437094-0094-4223-9f14-995d98d5fff8"
-			)
-			node := kapi.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nodeName,
-				},
-				Status: kapi.NodeStatus{
-					Addresses: []kapi.NodeAddress{
-						{
-							Type:    kapi.NodeExternalIP,
-							Address: nodeIP,
+
+	Describe("Node Operations", func() {
+		var app *cli.App
+
+		BeforeEach(func() {
+			// Restore global default values before each testcase
+			config.PrepareTestConfig()
+
+			app = cli.NewApp()
+			app.Name = "test"
+			app.Flags = config.Flags
+		})
+
+		It("sets correct OVN external IDs", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					nodeIP   string = "1.2.5.6"
+					nodeName string = "cannot.be.resolv.ed"
+					interval int    = 100000
+					ofintval int    = 180
+				)
+				node := kapi.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+					},
+					Status: kapi.NodeStatus{
+						Addresses: []kapi.NodeAddress{
+							{
+								Type:    kapi.NodeExternalIP,
+								Address: nodeIP,
+							},
 						},
 					},
-				},
+				}
+
+				fexec := ovntest.NewFakeExec()
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+						"external_ids:ovn-encap-type=geneve "+
+						"external_ids:ovn-encap-ip=%s "+
+						"external_ids:ovn-remote-probe-interval=%d "+
+						"external_ids:ovn-openflow-probe-interval=%d "+
+						"external_ids:hostname=\"%s\" "+
+						"external_ids:ovn-monitor-all=true "+
+						"external_ids:ovn-enable-lflow-cache=true",
+						nodeIP, interval, ofintval, nodeName),
+				})
+
+				err := util.SetExec(fexec)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = setupOVNNode(&node)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
 			}
 
-			fexec := ovntest.NewFakeExec()
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
-					"external_ids:ovn-encap-type=geneve "+
-					"external_ids:ovn-encap-ip=%s "+
-					"external_ids:ovn-remote-probe-interval=%d "+
-					"external_ids:ovn-openflow-probe-interval=%d "+
-					"external_ids:hostname=\"%s\" "+
-					"external_ids:ovn-monitor-all=true "+
-					"external_ids:ovn-enable-lflow-cache=true",
-					nodeIP, interval, ofintval, nodeName),
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 " +
-					"--if-exists get Open_vSwitch . external_ids:system-id"),
-				Output: chassisUUID,
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: fmt.Sprintf("ovn-sbctl --timeout=15 --data=bare --no-heading --columns=_uuid find "+
-					"Encap chassis_name=%s", chassisUUID),
-				Output: encapUUID,
-			})
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: fmt.Sprintf("ovn-sbctl --timeout=15 set encap "+
-					"%s options:dst_port=%d", encapUUID, encapPort),
-			})
-
-			err := util.SetExec(fexec)
+			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
-
-			_, err = config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-			config.Default.EncapPort = encapPort
-
-			err = setupOVNNode(&node)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
-
-		err := app.Run([]string{app.Name})
-		Expect(err).NotTo(HaveOccurred())
-	})
-	It("sets non-default logical flow cache limits", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				nodeIP   string = "1.2.5.6"
-				nodeName string = "cannot.be.resolv.ed"
-				interval int    = 100000
-				ofintval int    = 180
-			)
-			node := kapi.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nodeName,
-				},
-				Status: kapi.NodeStatus{
-					Addresses: []kapi.NodeAddress{
-						{
-							Type:    kapi.NodeExternalIP,
-							Address: nodeIP,
+		})
+		It("sets non-default OVN encap port", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					nodeIP      string = "1.2.5.6"
+					nodeName    string = "cannot.be.resolv.ed"
+					encapPort   uint   = 666
+					interval    int    = 100000
+					ofintval    int    = 180
+					chassisUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
+					encapUUID   string = "e4437094-0094-4223-9f14-995d98d5fff8"
+				)
+				node := kapi.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+					},
+					Status: kapi.NodeStatus{
+						Addresses: []kapi.NodeAddress{
+							{
+								Type:    kapi.NodeExternalIP,
+								Address: nodeIP,
+							},
 						},
 					},
-				},
+				}
+
+				fexec := ovntest.NewFakeExec()
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+						"external_ids:ovn-encap-type=geneve "+
+						"external_ids:ovn-encap-ip=%s "+
+						"external_ids:ovn-remote-probe-interval=%d "+
+						"external_ids:ovn-openflow-probe-interval=%d "+
+						"external_ids:hostname=\"%s\" "+
+						"external_ids:ovn-monitor-all=true "+
+						"external_ids:ovn-enable-lflow-cache=true",
+						nodeIP, interval, ofintval, nodeName),
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 " +
+						"--if-exists get Open_vSwitch . external_ids:system-id"),
+					Output: chassisUUID,
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ovn-sbctl --timeout=15 --data=bare --no-heading --columns=_uuid find "+
+						"Encap chassis_name=%s", chassisUUID),
+					Output: encapUUID,
+				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ovn-sbctl --timeout=15 set encap "+
+						"%s options:dst_port=%d", encapUUID, encapPort),
+				})
+
+				err := util.SetExec(fexec)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+				config.Default.EncapPort = encapPort
+
+				err = setupOVNNode(&node)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
 			}
 
-			fexec := ovntest.NewFakeExec()
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
-					"external_ids:ovn-encap-type=geneve "+
-					"external_ids:ovn-encap-ip=%s "+
-					"external_ids:ovn-remote-probe-interval=%d "+
-					"external_ids:ovn-openflow-probe-interval=%d "+
-					"external_ids:hostname=\"%s\" "+
-					"external_ids:ovn-monitor-all=true "+
-					"external_ids:ovn-enable-lflow-cache=false "+
-					"external_ids:ovn-limit-lflow-cache=1000 "+
-					"external_ids:ovn-limit-lflow-cache-kb=100000",
-					nodeIP, interval, ofintval, nodeName),
-			})
-
-			err := util.SetExec(fexec)
+			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
+		})
+		It("sets non-default logical flow cache limits", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					nodeIP   string = "1.2.5.6"
+					nodeName string = "cannot.be.resolv.ed"
+					interval int    = 100000
+					ofintval int    = 180
+				)
+				node := kapi.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+					},
+					Status: kapi.NodeStatus{
+						Addresses: []kapi.NodeAddress{
+							{
+								Type:    kapi.NodeExternalIP,
+								Address: nodeIP,
+							},
+						},
+					},
+				}
 
-			_, err = config.InitConfig(ctx, fexec, nil)
+				fexec := ovntest.NewFakeExec()
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: fmt.Sprintf("ovs-vsctl --timeout=15 set Open_vSwitch . "+
+						"external_ids:ovn-encap-type=geneve "+
+						"external_ids:ovn-encap-ip=%s "+
+						"external_ids:ovn-remote-probe-interval=%d "+
+						"external_ids:ovn-openflow-probe-interval=%d "+
+						"external_ids:hostname=\"%s\" "+
+						"external_ids:ovn-monitor-all=true "+
+						"external_ids:ovn-enable-lflow-cache=false "+
+						"external_ids:ovn-limit-lflow-cache=1000 "+
+						"external_ids:ovn-limit-lflow-cache-kb=100000",
+						nodeIP, interval, ofintval, nodeName),
+				})
+
+				err := util.SetExec(fexec)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = config.InitConfig(ctx, fexec, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				config.Default.LFlowCacheEnable = false
+				config.Default.LFlowCacheLimit = 1000
+				config.Default.LFlowCacheLimitKb = 100000
+				err = setupOVNNode(&node)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
-
-			config.Default.LFlowCacheEnable = false
-			config.Default.LFlowCacheLimit = 1000
-			config.Default.LFlowCacheLimitKb = 100000
-			err = setupOVNNode(&node)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
-
-		err := app.Run([]string{app.Name})
-		Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -107,9 +107,10 @@ const (
 	OvnPortBindingTopoVersion      = 4
 	OvnCurrentTopologyVersion      = OvnPortBindingTopoVersion
 
-	// OVN-K8S annotation constants
-	OvnK8sPrefix   = "k8s.ovn.org"
-	OvnK8sTopoAnno = OvnK8sPrefix + "/" + "topology-version"
+	// OVN-K8S annotation & taint constants
+	OvnK8sPrefix           = "k8s.ovn.org"
+	OvnK8sTopoAnno         = OvnK8sPrefix + "/" + "topology-version"
+	OvnK8sSmallMTUTaintKey = OvnK8sPrefix + "/" + "mtu-too-small"
 
 	// Monitoring constants
 	SFlowAgent = "ovn-k8s-mp0"

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -48,6 +48,11 @@ func SetNetLinkOpMockInst(mockInst NetLinkOps) {
 	netLinkOps = mockInst
 }
 
+// ResetNetLinkOpMockInst resets the mock instance for netlink to the defaultNetLinkOps
+func ResetNetLinkOpMockInst() {
+	netLinkOps = &defaultNetLinkOps{}
+}
+
 // GetNetLinkOps will be invoked by functions in other packages that would need access to the netlink library methods.
 func GetNetLinkOps() NetLinkOps {
 	return netLinkOps
@@ -410,4 +415,14 @@ func GetIPv6OnSubnet(iface string, ip *net.IPNet) (*net.IPNet, error) {
 	}
 
 	return &dst, nil
+}
+
+// GetNetworkInterfaceMTU returns the MTU for the given network interface
+func GetNetworkInterfaceMTU(iface string) (int, error) {
+	link, err := netLinkOps.LinkByName(iface)
+	if err != nil {
+		return 0, fmt.Errorf("failed to lookup link %s: %v", iface, err)
+	}
+
+	return link.Attrs().MTU, nil
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -2875,6 +2875,7 @@ var _ = ginkgo.Describe("e2e delete databases", func() {
 		for _, pod := range dbPods {
 			wg.Add(1)
 			go func(pod v1.Pod) {
+				defer ginkgo.GinkgoRecover()
 				defer wg.Done()
 				waitForPodToFinishFullRestart(f, &pod)
 			}(pod)

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -23,7 +23,8 @@ Should validate TCP/UDP connectivity to an external gateway\'s loopback address 
 Should validate TCP/UDP connectivity to multiple external gateways for a UDP / TCP scenario|\
 Should validate the egress firewall policy functionality against remote hosts|\
 Should validate the egress IP functionality against remote hosts|\
-recovering from deleting db files while maintain connectivity"
+recovering from deleting db files while maintain connectivity|\
+test tainting a node according to its defaults interface MTU size"
 
 SKIPPED_TESTS=""
 if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then


### PR DESCRIPTION
**- What this PR does and why is it needed**
This PR taints nodes, if the nodes default interface MTU is not big enough to contain the Geneve header and the configured MTU (`config.Default.MTU`).

The taint has the key `k8s.ovn.org/mtu-too-small` and `NoSchedule` effect.

**- Special notes for reviewers**
I cherry-picked @tssurya s commit 28babd42 from #2183, so you might see some changes twice.


**- How to verify it**
For most parts I included unit tests. In addition an e2e test was included to test the whole procedure. 
To verify it locally, the MTU of one nodes default interface can be adjusted and the ovnkube-node pod restarted to trigger the validation (as done in the following with node ovn-worker2).

1. Get all pods in ovn-kubernetes namespace
```
$ k get po -o wide
NAME                              READY   STATUS    RESTARTS   AGE   IP           NODE                NOMINATED NODE   READINESS GATES
ovnkube-db-7ccf8cf86c-5f6r8       2/2     Running   0          11m   172.18.0.4   ovn-control-plane   <none>           <none>
ovnkube-master-75cfc8566c-hlrzm   3/3     Running   0          11m   172.18.0.4   ovn-control-plane   <none>           <none>
ovnkube-node-mm6b8                3/3     Running   1          11m   172.18.0.3   ovn-worker          <none>           <none>
ovnkube-node-pd6kj                3/3     Running   1          11m   172.18.0.4   ovn-control-plane   <none>           <none>
ovnkube-node-shz2q                3/3     Running   1          11m   172.18.0.2   ovn-worker2         <none>           <none>
ovs-node-d9wfz                    1/1     Running   0          11m   172.18.0.4   ovn-control-plane   <none>           <none>
ovs-node-kzs7k                    1/1     Running   0          11m   172.18.0.3   ovn-worker          <none>           <none>
ovs-node-sf49v                    1/1     Running   0          11m   172.18.0.2   ovn-worker2         <none>           <none>
```
2. Validate ovn-worker2 is not tainted:
```
$ k get no ovn-worker2 -o jsonpath='{.spec.taints[*]}'
```
3. Check the logs of the ovnkube-node pod running on ovn-worker2 about MTU actions:
```
$ k logs ovnkube-node-shz2q -c ovnkube-node| grep mtu
...
I0714 07:25:33.862117    1475 node.go:551] MTU (1500) is big enough to deal with Geneve header overhead (sum 1458). Making sure node is not tainted with {k8s.ovn.org/mtu-too-small  NoSchedule <nil>}...
```
4. Set the MTU of ovn-worker2s default interface very low: 
```
$ docker exec ovn-worker2 ip link show breth0 
6: breth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 02:42:ac:12:00:02 brd ff:ff:ff:ff:ff:ff
$ docker exec ovn-worker2 ip link set breth0 mtu 1000 
$ docker exec ovn-worker2 ip link show breth0        
6: breth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1000 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 02:42:ac:12:00:02 brd ff:ff:ff:ff:ff:ff
```
5. Restart the ovnkube-node pod from ovn-worker2
```
$ k delete po ovnkube-node-shz2q
pod "ovnkube-node-shz2q" deleted
$ k get po -o wide -w
NAME                              READY   STATUS    RESTARTS   AGE   IP           NODE                NOMINATED NODE   READINESS GATES
ovnkube-db-7ccf8cf86c-5f6r8       2/2     Running   0          13m   172.18.0.4   ovn-control-plane   <none>           <none>
ovnkube-master-75cfc8566c-hlrzm   3/3     Running   0          13m   172.18.0.4   ovn-control-plane   <none>           <none>
ovnkube-node-mm6b8                3/3     Running   1          13m   172.18.0.3   ovn-worker          <none>           <none>
ovnkube-node-pd6kj                3/3     Running   1          13m   172.18.0.4   ovn-control-plane   <none>           <none>
ovnkube-node-vggg9                1/3     Running   0          10s   172.18.0.2   ovn-worker2         <none>           <none>
ovs-node-d9wfz                    1/1     Running   0          13m   172.18.0.4   ovn-control-plane   <none>           <none>
ovs-node-kzs7k                    1/1     Running   0          13m   172.18.0.3   ovn-worker          <none>           <none>
ovs-node-sf49v                    1/1     Running   0          13m   172.18.0.2   ovn-worker2         <none>           <none>

ovnkube-node-vggg9                2/3     Running   0          32s   172.18.0.2   ovn-worker2         <none>           <none>
ovnkube-node-vggg9                3/3     Running   0          48s   172.18.0.2   ovn-worker2         <none>           <none>
^C%        
```
6. Check the logs from the restarted ovnkube-node pod form MTU actions:
```
$ k logs ovnkube-node-vggg9 -c ovnkube-node| grep mtu
...
I0714 07:38:44.773637    6259 node.go:547] MTU (1000) is not big enough to deal with Geneve header overhead (sum 1458). Tainting node with {k8s.ovn.org/mtu-too-small  NoSchedule <nil>}...
```
7. Validate that ovn-worker2 got tainted:
```
$ k get no ovn-worker2 -o jsonpath='{.spec.taints[*]}'
{"effect":"NoSchedule","key":"k8s.ovn.org/mtu-too-small"}
```
8. Reset the MTU of ovn-worker2 to its original value, restart the ovnkube-node pod and validate that the taint got removed from ovn-worker2 again
```
$ docker exec ovn-worker2 ip link show breth0        
6: breth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1000 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 02:42:ac:12:00:02 brd ff:ff:ff:ff:ff:ff
$ docker exec ovn-worker2 ip link set breth0 mtu 1500
$ docker exec ovn-worker2 ip link show breth0        
6: breth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 02:42:ac:12:00:02 brd ff:ff:ff:ff:ff:ff
$ k delete po ovnkube-node-vggg9
pod "ovnkube-node-vggg9" deleted
$ k get po -o wide -w                        
NAME                              READY   STATUS    RESTARTS   AGE   IP           NODE                NOMINATED NODE   READINESS GATES
ovnkube-db-7ccf8cf86c-5f6r8       2/2     Running   0          26m   172.18.0.4   ovn-control-plane   <none>           <none>
ovnkube-master-75cfc8566c-hlrzm   3/3     Running   0          26m   172.18.0.4   ovn-control-plane   <none>           <none>
ovnkube-node-mm6b8                3/3     Running   1          26m   172.18.0.3   ovn-worker          <none>           <none>
ovnkube-node-pd6kj                3/3     Running   1          26m   172.18.0.4   ovn-control-plane   <none>           <none>
ovnkube-node-tjstv                1/3     Running   0          11s   172.18.0.2   ovn-worker2         <none>           <none>
ovs-node-d9wfz                    1/1     Running   0          26m   172.18.0.4   ovn-control-plane   <none>           <none>
ovs-node-kzs7k                    1/1     Running   0          26m   172.18.0.3   ovn-worker          <none>           <none>
ovs-node-sf49v                    1/1     Running   0          26m   172.18.0.2   ovn-worker2         <none>           <none>

ovnkube-node-tjstv                2/3     Running   0          53s   172.18.0.2   ovn-worker2         <none>           <none>
ovnkube-node-tjstv                3/3     Running   0          78s   172.18.0.2   ovn-worker2         <none>           <none>
^C%
$ k logs ovnkube-node-tjstv -c ovnkube-node| grep mtu
...
I0714 07:51:24.751469   10599 node.go:551] MTU (1500) is big enough to deal with Geneve header overhead (sum 1458). Making sure node is not tainted with {k8s.ovn.org/mtu-too-small  NoSchedule <nil>}...
$ k get no ovn-worker2 -o jsonpath='{.spec.taints[*]}'
```

**- Description for the changelog**
Taint nodes with a too small MTU with `k8s.ovn.org/mtu-too-small`