### PR TITLE
namespace: track how long namespace addition takes

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -191,7 +191,13 @@ func parseRoutingExternalGWAnnotation(annotation string) ([]net.IP, error) {
 
 // AddNamespace creates corresponding addressset in ovn db
 func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
-	klog.V(5).Infof("Adding namespace: %s", ns.Name)
+	klog.Infof("[%s] adding namespace", ns.Name)
+	// Keep track of how long syncs take.
+	start := time.Now()
+	defer func() {
+		klog.Infof("[%s] adding namespace took %v", ns.Name, time.Since(start))
+	}()
+
 	nsInfo := oc.createNamespaceLocked(ns.Name)
 	defer nsInfo.Unlock()
 
@@ -228,7 +234,7 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 }
 
 func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
-	klog.V(5).Infof("Updating namespace: %s", old.Name)
+	klog.Infof("[%s] updating namespace", old.Name)
 
 	nsInfo := oc.getNamespaceLocked(old.Name)
 	if nsInfo == nil {
@@ -308,7 +314,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 }
 
 func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
-	klog.V(5).Infof("Deleting namespace: %s", ns.Name)
+	klog.Infof("[%s] deleting namespace", ns.Name)
 
 	nsInfo := oc.deleteNamespaceLocked(ns.Name)
 	if nsInfo == nil {


### PR DESCRIPTION
Due to lock contention, and because our namespace handler is
single-threaded, namespace additions may pile up and take a
while. Log how long they take, and also when namespaces are
added and deleted so we can better debug these issues.