### PR TITLE
services: batch LoadBalancer VIP deletions when possible

### DIFF
--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -123,15 +124,22 @@ func (r *Repair) runOnce() error {
 				klog.V(4).Infof("Failed to get vips for %s load balancer %s, err: %v", p, lb, err)
 				continue
 			}
+			txn := util.NewNBTxn()
 			for vip := range vips {
 				key := virtualIPKey(vip, p)
 				// Virtual IP and protocol doesn't belong to a Kubernetes service
 				if !svcVIPsProtocolMap.Has(key) {
 					klog.Infof("Deleting non-existing Kubernetes vip %s from OVN %s load balancer %s", vip, p, lb)
-					if err := loadbalancer.DeleteLoadBalancerVIP(lb, vip); err != nil {
+					if err := loadbalancer.DeleteLoadBalancerVIP(txn, lb, vip); err != nil {
 						klog.V(4).Infof("Failed to delete %s load balancer vips %s for %s, err: %v", p, vip, lb, err)
 					}
 				}
+			}
+			stdout, stderr, err := txn.Commit()
+			if err != nil {
+				return fmt.Errorf("error in deleting %s load balancer %s stale vips, "+
+					"stdout: %q, stderr: %q, err: %v",
+					p, lb, stdout, stderr, err)
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/controller/services/repair_test.go
+++ b/go-controller/pkg/ovn/controller/services/repair_test.go
@@ -167,16 +167,9 @@ func TestRepair_OVNStaleData(t *testing.T) {
 	})
 	// The repair loop must delete the remaining entries in OVN
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.10:53\"",
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.10:9153\"",
-		Output: "",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.1:443\"",
-		Output: "",
+		Cmd:               "ovn-nbctl --timeout=15 --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.10:53\" -- --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.10:9153\" -- --if-exists remove load_balancer " + udpLBUUID + " vips \"10.96.0.1:443\"",
+		LooseBatchCompare: true,
+		Output:            "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --columns=_uuid --format=csv --data=bare --no-headings find acl action=reject",

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -88,12 +88,20 @@ func deleteVIPsFromNonIdlingOVNBalancers(vips sets.String, name, namespace strin
 		}
 	}
 
+	txn := util.NewNBTxn()
 	for proto := range foundProtocols {
-		if err := loadbalancer.DeleteLoadBalancerVIPs(lbsPerProtocol[proto].List(), vipsPerProtocol[proto].List()); err != nil {
+		if err := loadbalancer.DeleteLoadBalancerVIPs(txn, lbsPerProtocol[proto].List(), vipsPerProtocol[proto].List()); err != nil {
 			klog.Errorf("Error deleting VIP %v on OVN LoadBalancer %v: %v", vipsPerProtocol[proto].List(), lbsPerProtocol[proto].List(), err)
 			return err
 		}
 	}
+	if stdout, stderr, err := txn.Commit(); err != nil {
+		klog.Errorf("Error deleting VIPs %v on OVN LoadBalancers %v", vips.List(), lbsPerProtocol)
+		return fmt.Errorf("error deleting load balancer %v VIPs %v"+
+			"stdout: %q, stderr: %q, error: %v",
+			lbsPerProtocol, vips.List(), stdout, stderr, err)
+	}
+
 	return nil
 }
 
@@ -130,13 +138,22 @@ func deleteVIPsFromIdlingBalancer(vipProtocols sets.String, name, namespace stri
 		}
 		lbsPerProtocol[proto] = sets.NewString(lbID)
 	}
+
+	txn := util.NewNBTxn()
 	for proto := range foundProtocols {
-		if err := loadbalancer.DeleteLoadBalancerVIPs(lbsPerProtocol[proto].List(), vipsPerProtocol[proto].List()); err != nil {
+		if err := loadbalancer.DeleteLoadBalancerVIPs(txn, lbsPerProtocol[proto].List(), vipsPerProtocol[proto].List()); err != nil {
 			klog.Errorf("Error deleting VIPs %v on idling OVN LoadBalancer %s %v",
 				vipsPerProtocol[proto].List(), lbsPerProtocol[proto].List(), err)
 			return err
 		}
 	}
+	if stdout, stderr, err := txn.Commit(); err != nil {
+		klog.Errorf("Error deleting VIPs %v on idling OVN LoadBalancers %v", vipProtocols.List(), lbsPerProtocol)
+		return fmt.Errorf("error deleting idling load balancer %v VIPs %v"+
+			"stdout: %q, stderr: %q, error: %v",
+			lbsPerProtocol, vipProtocols.List(), stdout, stderr, err)
+	}
+
 	return nil
 }
 
@@ -300,9 +317,16 @@ func deleteNodeVIPs(svcIPs []string, protocol v1.Protocol, sourcePort int32) err
 	}
 
 	klog.V(5).Infof("Removing gateway VIPs: %v from load balancers: %v", vips, loadBalancers)
-	if err := loadbalancer.DeleteLoadBalancerVIPs(loadBalancers, vips); err != nil {
+	txn := util.NewNBTxn()
+	if err := loadbalancer.DeleteLoadBalancerVIPs(txn, loadBalancers, vips); err != nil {
 		return err
 	}
+	if stdout, stderr, err := txn.Commit(); err != nil {
+		return fmt.Errorf("error deleting node load balancer %v VIPs %v"+
+			"stdout: %q, stderr: %q, error: %v",
+			loadBalancers, vips, stdout, stderr, err)
+	}
+
 	return nil
 }
 

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
@@ -151,7 +151,12 @@ func TestDeleteLoadBalancerVIP(t *testing.T) {
 			if err != nil {
 				t.Errorf("fexec error: %v", err)
 			}
-			err = DeleteLoadBalancerVIP(tt.loadBalancer, tt.vip)
+			txn := util.NewNBTxn()
+			err = DeleteLoadBalancerVIP(txn, tt.loadBalancer, tt.vip)
+			if err != nil {
+				t.Errorf("DeleteLoadBalancerVIP error: %v", err)
+			}
+			_, _, err = txn.Commit()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DeleteLoadBalancerVIP() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
In some scale scenarios it takes 20s to repair services on startup:

```
2021-07-08T15:46:57.601Z|01774|ovn_dbctl|INFO|Running command run --if-exists -- remove load_balancer 13a0737b-9859-4654-9a45-df034a2d1098 vips "\"172.30.9.247:80\""
I0708 15:46:57.658232       1 repair.go:132] Deleting non-existing Kubernetes vip 172.30.135.31:80 from OVN TCP load balancer 13a0737b-9859-4654-9a45-df034a2d1098
...
I0708 15:47:08.113637       1 repair.go:132] Deleting non-existing Kubernetes vip 10.0.141.143:30666 from OVN TCP load balancer aaa40b67-8c2b-4c29-bdf7-8d0802b89c49
2021-07-08T15:47:08.117Z|02031|ovn_dbctl|INFO|Running command run --if-exists -- remove load_balancer aaa40b67-8c2b-4c29-bdf7-8d0802b89c49 vips "\"10.0.141.143:30666\""
I0708 15:47:08.477075       1 repair.go:47] Finished repairing loop for services: 21.111423982s
```

A good chunk of that time is sequential calls to delete stale VIPs
in the repair loop. Batch them instead.