### PR TITLE
Revert np service dependency 2

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -387,11 +387,6 @@ func (wf *WatchFactory) AddServiceHandler(handlerFuncs cache.ResourceEventHandle
 	return wf.addHandler(serviceType, "", nil, handlerFuncs, processExisting)
 }
 
-// AddFilteredServiceHandler adds a handler function that will be executed on all Service object changes for a specific namespace
-func (wf *WatchFactory) AddFilteredServiceHandler(namespace string, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler {
-	return wf.addHandler(serviceType, namespace, nil, handlerFuncs, processExisting)
-}
-
 // RemoveServiceHandler removes a Service object event handler function
 func (wf *WatchFactory) RemoveServiceHandler(handler *Handler) {
 	wf.removeHandler(serviceType, handler)

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -29,7 +29,6 @@ type NodeWatchFactory interface {
 	Shutdownable
 
 	AddServiceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
-	AddFilteredServiceHandler(namespace string, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
 	RemoveServiceHandler(handler *Handler)
 
 	AddEndpointsHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler

--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -53,7 +53,7 @@ func (r *Repair) runOnce() error {
 	protocols := []v1.Protocol{v1.ProtocolSCTP, v1.ProtocolTCP, v1.ProtocolUDP}
 	// ClusterIP OVN load balancers
 	for _, p := range protocols {
-		lbUUID, err := loadbalancer.GetOVNKubeLoadBalancer(p)
+		lbUUID, err := loadbalancer.GetClusterLoadBalancer(p)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to get Cluster IP OVN load balancer for protocol %s", p)
 		}
@@ -66,9 +66,9 @@ func (r *Repair) runOnce() error {
 	} else {
 		for _, p := range protocols {
 			for _, gatewayRouter := range gatewayRouters {
-				lbUUID, err := gateway.GetGatewayLoadBalancer(gatewayRouter, p)
+				lbUUID, err := loadbalancer.GetGatewayLoadBalancer(gatewayRouter, p)
 				if err != nil {
-					if err != gateway.OVNGatewayLBIsEmpty {
+					if err != loadbalancer.LBNotFound {
 						klog.V(5).Infof("Failed to get OVN GR: %s load balancer for protocol %s, err: %v",
 							gatewayRouter, p, err)
 					}
@@ -78,7 +78,7 @@ func (r *Repair) runOnce() error {
 				workerNode := util.GetWorkerFromGatewayRouter(gatewayRouter)
 				workerLB, err := loadbalancer.GetWorkerLoadBalancer(workerNode, p)
 				if err != nil {
-					if err != gateway.OVNGatewayLBIsEmpty {
+					if err != loadbalancer.LBNotFound {
 						klog.V(5).Infof("Failed to get OVN Worker: %s load balancer for protocol %s, err: %v",
 							workerNode, p, err)
 					}
@@ -91,7 +91,7 @@ func (r *Repair) runOnce() error {
 
 	// Idling load balancers
 	for _, p := range protocols {
-		lb, err := loadbalancer.GetOVNKubeIdlingLoadBalancer(p)
+		lb, err := loadbalancer.GetIdlingLoadBalancer(p)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to get Idling OVN load balancer for protocol %s", p)
 		}

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -341,7 +341,7 @@ func (c *Controller) syncServices(key string) error {
 		}
 		for _, svcPort := range service.Spec.Ports {
 			// ClusterIP
-			clusterLB, err := loadbalancer.GetOVNKubeLoadBalancer(svcPort.Protocol)
+			clusterLB, err := loadbalancer.GetClusterLoadBalancer(svcPort.Protocol)
 			if err != nil {
 				c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToGetOVNLoadBalancer",
 					"Error trying to obtain the OVN LoadBalancer for Service %s/%s: %v", name, namespace, err)
@@ -468,7 +468,7 @@ func (c *Controller) syncServices(key string) error {
 func (c *Controller) addServiceToIdlingBalancer(vips sets.String, service *v1.Service) error {
 	for _, vipProtocol := range vips.List() {
 		vip, protocol := splitVirtualIPKey(vipProtocol)
-		lb, err := loadbalancer.GetOVNKubeIdlingLoadBalancer(protocol)
+		lb, err := loadbalancer.GetIdlingLoadBalancer(protocol)
 		if err != nil {
 			return errors.Wrapf(err, "Error getting OVN idling LoadBalancer for protocol %s", protocol)
 		}

--- a/go-controller/pkg/ovn/controller/services/utils.go
+++ b/go-controller/pkg/ovn/controller/services/utils.go
@@ -63,14 +63,14 @@ func deleteVIPsFromNonIdlingOVNBalancers(vips sets.String, name, namespace strin
 			// already got the load balancers for this protocol, don't do it again
 			continue
 		}
-		lbID, err := loadbalancer.GetOVNKubeLoadBalancer(proto)
+		lbID, err := loadbalancer.GetClusterLoadBalancer(proto)
 		if err != nil {
 			klog.Errorf("Error getting OVN LoadBalancer for protocol %s", proto)
 			return err
 		}
 		lbsPerProtocol[proto] = sets.NewString(lbID)
 		for _, gatewayRouter := range gatewayRouters {
-			gatewayLB, err := gateway.GetGatewayLoadBalancer(gatewayRouter, proto)
+			gatewayLB, err := loadbalancer.GetGatewayLoadBalancer(gatewayRouter, proto)
 			if err != nil {
 				klog.Warningf("Service Sync: Gateway router %s does not have load balancer (%v)",
 					gatewayRouter, err)
@@ -131,7 +131,7 @@ func deleteVIPsFromIdlingBalancer(vipProtocols sets.String, name, namespace stri
 			// lb already found for this protocol, don't do it again
 			continue
 		}
-		lbID, err := loadbalancer.GetOVNKubeIdlingLoadBalancer(proto)
+		lbID, err := loadbalancer.GetIdlingLoadBalancer(proto)
 		if err != nil {
 			klog.Errorf("Error getting OVN idling LoadBalancer for protocol %s %v", proto, err)
 			return err
@@ -172,7 +172,7 @@ func createPerNodeVIPs(svcIPs []string, protocol v1.Protocol, sourcePort int32, 
 	lbConfig := make([]loadbalancer.Entry, 0, len(gatewayRouters))
 
 	for _, gatewayRouter := range gatewayRouters {
-		gatewayLB, err := gateway.GetGatewayLoadBalancer(gatewayRouter, protocol)
+		gatewayLB, err := loadbalancer.GetGatewayLoadBalancer(gatewayRouter, protocol)
 		if err != nil {
 			klog.Errorf("Gateway router %s does not have load balancer (%v)",
 				gatewayRouter, err)
@@ -231,7 +231,7 @@ func createPerNodePhysicalVIPs(isIPv6 bool, protocol v1.Protocol, sourcePort int
 	lbConfig := make([]loadbalancer.Entry, 0, len(gatewayRouters))
 
 	for _, gatewayRouter := range gatewayRouters {
-		gatewayLB, err := gateway.GetGatewayLoadBalancer(gatewayRouter, protocol)
+		gatewayLB, err := loadbalancer.GetGatewayLoadBalancer(gatewayRouter, protocol)
 		if err != nil {
 			klog.Errorf("Gateway router %s does not have load balancer (%v)",
 				gatewayRouter, err)
@@ -295,7 +295,7 @@ func deleteNodeVIPs(svcIPs []string, protocol v1.Protocol, sourcePort int32) err
 	}
 	var loadBalancers []string
 	for _, gatewayRouter := range gatewayRouters {
-		gatewayLB, err := gateway.GetGatewayLoadBalancer(gatewayRouter, protocol)
+		gatewayLB, err := loadbalancer.GetGatewayLoadBalancer(gatewayRouter, protocol)
 		if err != nil {
 			klog.Errorf("Gateway router %s does not have load balancer (%v)", gatewayRouter, err)
 			continue

--- a/go-controller/pkg/ovn/gateway.go
+++ b/go-controller/pkg/ovn/gateway.go
@@ -8,21 +8,11 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
 
 func (ovn *Controller) getGatewayPhysicalIPs(gatewayRouter string) ([]string, error) {
 	return gateway.GetGatewayPhysicalIPs(gatewayRouter)
-}
-
-func (ovn *Controller) getGatewayLoadBalancer(gatewayRouter string, protocol kapi.Protocol) (string, error) {
-	return gateway.GetGatewayLoadBalancer(gatewayRouter, protocol)
-}
-
-// getGatewayLoadBalancers find TCP, SCTP, UDP load-balancers from gateway router.
-func getGatewayLoadBalancers(gatewayRouter string) (string, string, string, error) {
-	return gateway.GetGatewayLoadBalancers(gatewayRouter)
 }
 
 // getJoinLRPAddresses check if IPs of gateway logical router port are within the join switch IP range, and return them if true.

--- a/go-controller/pkg/ovn/gateway/gateway.go
+++ b/go-controller/pkg/ovn/gateway/gateway.go
@@ -4,22 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
-
-	kapi "k8s.io/api/core/v1"
-)
-
-const (
-	// OvnGatewayLoadBalancerIds represent the OVN loadbalancers used on nodes
-	OvnGatewayLoadBalancerIds = "lb_gateway_router"
-)
-
-var (
-	// It is perfectly normal to have OVN GW routers to not to have LB rules. This happens
-	// when NodePort is disabled for that node.
-	OVNGatewayLBIsEmpty = errors.New("load balancer item in OVN DB is an empty string")
 )
 
 // GetOvnGateways return all created gateways.
@@ -60,42 +46,4 @@ func GetGatewayPhysicalIPs(gatewayRouter string) ([]string, error) {
 		return nil, err
 	}
 	return []string{physicalIP}, nil
-}
-
-// GetGatewayLoadBalancer return the gateway load balancer
-func GetGatewayLoadBalancer(gatewayRouter string, protocol kapi.Protocol) (string, error) {
-	externalIDKey := fmt.Sprintf("%s_%s", string(protocol), OvnGatewayLoadBalancerIds)
-	loadBalancer, _, err := util.RunOVNNbctl("--data=bare", "--no-heading",
-		"--columns=_uuid", "find", "load_balancer",
-		"external_ids:"+externalIDKey+"="+
-			gatewayRouter)
-	if err != nil {
-		return "", err
-	}
-	if loadBalancer == "" {
-		return "", OVNGatewayLBIsEmpty
-	}
-	return loadBalancer, nil
-}
-
-// GetGatewayLoadBalancers find TCP, SCTP, UDP load-balancers from gateway router.
-func GetGatewayLoadBalancers(gatewayRouter string) (string, string, string, error) {
-	lbTCP, stderr, err := util.FindOVNLoadBalancer(types.GatewayLBTCP, gatewayRouter)
-	if err != nil {
-		return "", "", "", errors.Wrapf(err, "failed to get gateway router %q TCP "+
-			"load balancer, stderr: %q", gatewayRouter, stderr)
-	}
-
-	lbUDP, stderr, err := util.FindOVNLoadBalancer(types.GatewayLBUDP, gatewayRouter)
-	if err != nil {
-		return "", "", "", errors.Wrapf(err, "failed to get gateway router %q UDP "+
-			"load balancer, stderr: %q", gatewayRouter, stderr)
-	}
-
-	lbSCTP, stderr, err := util.FindOVNLoadBalancer(types.GatewayLBSCTP, gatewayRouter)
-	if err != nil {
-		return "", "", "", errors.Wrapf(err, "failed to get gateway router %q SCTP "+
-			"load balancer, stderr: %q", gatewayRouter, stderr)
-	}
-	return lbTCP, lbUDP, lbSCTP, nil
 }

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -84,31 +84,41 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			tcpLBUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
 			udpLBUUID string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
 		)
+		// None of the per node LBs(GWR + workers) should aleready be there
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node",
+		})
+
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node protocol=tcp",
 			Output: tcpLBUUID,
 		})
+
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node",
+		})
+
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Output: udpLBUUID,
+		})
+
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
+		})
+
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBTCP + "=test-node protocol=tcp",
 			Output: tcpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBUDP + "=test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
-			Output: udpLBUUID,
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -173,31 +183,41 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			tcpLBUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
 			udpLBUUID string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
 		)
+		// None of the per node LBs(GWR + workers) should aleready be there
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node",
+		})
+
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node protocol=tcp",
 			Output: tcpLBUUID,
 		})
+
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node",
+		})
+
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Output: udpLBUUID,
+		})
+
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
+		})
+
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBTCP + "=test-node protocol=tcp",
 			Output: tcpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBUDP + "=test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
-			Output: udpLBUUID,
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -261,31 +281,41 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			tcpLBUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
 			udpLBUUID string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
 		)
+		// None of the per node LBs(GWR + workers) should aleready be there
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node",
+		})
+
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node protocol=tcp",
 			Output: tcpLBUUID,
 		})
+
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node",
+		})
+
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Output: udpLBUUID,
+		})
+
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
+		})
+
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBTCP + "=test-node protocol=tcp",
 			Output: tcpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBUDP + "=test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
-			Output: udpLBUUID,
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -351,16 +381,14 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_test-node",
 			Output: tcpLBUUID,
 		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_test-node",
-			Output: "",
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
-			Output: "",
-		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 lb-del " + tcpLBUUID,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_test-node",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
 		})
 		cleanupPBRandNATRules(fexec, nodeName, []*net.IPNet{hostSubnet})
 
@@ -413,16 +441,14 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_test-node",
 			Output: tcpLBUUID,
 		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_test-node",
-			Output: "",
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
-			Output: "",
-		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 lb-del " + tcpLBUUID,
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:UDP_lb_gateway_router=GR_test-node",
+		})
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:SCTP_lb_gateway_router=GR_test-node",
 		})
 		cleanupPBRandNATRules(fexec, nodeName, hostSubnets)
 
@@ -468,31 +494,41 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			tcpLBUUID string = "1a3dfc82-2749-4931-9190-c30e7c0ecea3"
 			udpLBUUID string = "6d3142fc-53e8-4ac1-88e6-46094a5a9957"
 		)
+		// None of the per node LBs(GWR + workers) should aleready be there
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node",
+		})
+
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBTCP + "=GR_test-node protocol=tcp",
 			Output: tcpLBUUID,
 		})
+
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=GR_test-node",
+		})
+
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
+			Output: udpLBUUID,
+		})
+
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
+		})
+
+		fexec.AddFakeCmdsNoOutputNoError([]string{
+			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=test-node",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBTCP + "=test-node protocol=tcp",
 			Output: tcpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBUDP + "=test-node",
-			"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=test-node",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=GR_test-node protocol=udp",
-			Output: udpLBUUID,
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovn-nbctl --timeout=15 set logical_router GR_test-node load_balancer=" + tcpLBUUID + "," + udpLBUUID,
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=test-node protocol=udp",
 			Output: udpLBUUID,
 		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -178,16 +178,16 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 		Output: "",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-tcp=yes protocol=tcp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:k8s-cluster-lb-tcp=yes protocol=tcp options:hairpin_snat_ip=169.254.169.3 fd69::3",
 		Output: tcpLBUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-udp=yes protocol=udp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:k8s-cluster-lb-udp=yes protocol=udp options:hairpin_snat_ip=169.254.169.3 fd69::3",
 		Output: udpLBUUID,
 	})
 	if sctpSupport {
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:k8s-cluster-lb-sctp=yes protocol=sctp",
+			Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:k8s-cluster-lb-sctp=yes protocol=sctp options:hairpin_snat_ip=169.254.169.3 fd69::3",
 			Output: sctpLBUUID,
 		})
 	}
@@ -268,40 +268,48 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 func addNodeportLBs(fexec *ovntest.FakeExec, nodeName, tcpLBUUID, udpLBUUID, sctpLBUUID string) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBTCP + "=" + types.GWRouterPrefix + nodeName,
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=" + types.GWRouterPrefix + nodeName,
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=" + types.GWRouterPrefix + nodeName,
-	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=" + nodeName,
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBUDP + "=" + nodeName,
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=" + nodeName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBTCP + "=" + types.GWRouterPrefix + nodeName + " protocol=tcp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBTCP + "=" + types.GWRouterPrefix + nodeName + " protocol=tcp",
 		Output: tcpLBUUID,
 	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBUDP + "=" + types.GWRouterPrefix + nodeName + " protocol=udp",
-		Output: udpLBUUID,
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBUDP + "=" + types.GWRouterPrefix + nodeName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.GatewayLBSCTP + "=" + types.GWRouterPrefix + nodeName + " protocol=sctp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBUDP + "=" + types.GWRouterPrefix + nodeName + " protocol=udp",
+		Output: udpLBUUID,
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.GatewayLBSCTP + "=" + types.GWRouterPrefix + nodeName,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.GatewayLBSCTP + "=" + types.GWRouterPrefix + nodeName + " protocol=sctp",
 		Output: sctpLBUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 set logical_router " + types.GWRouterPrefix + nodeName + " load_balancer=" + tcpLBUUID +
 			"," + udpLBUUID + "," + sctpLBUUID,
 	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBTCP + "=" + nodeName,
+	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBTCP + "=" + nodeName + " protocol=tcp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBTCP + "=" + nodeName + " protocol=tcp",
 		Output: tcpLBUUID,
 	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBUDP + "=" + nodeName + " protocol=udp",
-		Output: udpLBUUID,
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBUDP + "=" + nodeName,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:" + types.WorkerLBSCTP + "=" + nodeName + " protocol=sctp",
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBUDP + "=" + nodeName + " protocol=udp",
+		Output: udpLBUUID,
+	})
+	fexec.AddFakeCmdsNoOutputNoError([]string{
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:" + types.WorkerLBSCTP + "=" + nodeName,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 create load_balancer external_ids:" + types.WorkerLBSCTP + "=" + nodeName + " protocol=sctp",
 		Output: sctpLBUUID,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -303,7 +303,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 	if aclAnnotation != oldACLAnnotation && (oc.aclLoggingCanEnable(aclAnnotation, nsInfo) || aclAnnotation == "") &&
 		len(nsInfo.networkPolicies) > 0 {
 		// deny rules are all one per namespace
-		if err := oc.setACLDenyLogging(old.Name, nsInfo, nsInfo.aclLogging.Deny); err != nil {
+		if err := oc.setDefaultACLsLogging(old.Name, nsInfo, &nsInfo.aclLogging); err != nil {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Namespace %s: ACL logging setting updated to deny=%s allow=%s",

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -140,6 +140,10 @@ func addAllowACLFromNode(logicalSwitch string, mgmtPortIP net.IP, ovnNBClient go
 	return nil
 }
 
+// Creates Match section for the default per Namespace ACLs to/from ports in a given port group
+// If input match is "" then the returned match string only contains "inport"/"outport" matching
+// If input match is "hairpin" then a specical match for LB hairpin traffic is returned
+// Otherwise the input match is appened to the "inport"/"outport" matching
 func getACLMatch(portGroupName, match string, policyType knet.PolicyType) string {
 	var aclMatch string
 	if policyType == knet.PolicyTypeIngress {
@@ -148,7 +152,11 @@ func getACLMatch(portGroupName, match string, policyType knet.PolicyType) string
 		aclMatch = "inport == @" + portGroupName
 	}
 
-	if match != "" {
+	if match == "hairpin" {
+		aclMatch += fmt.Sprintf(" && (ip4.src == %s || ip6.src ==  %s)", types.V4LBHairpinMasqueradeIP, types.V6LBHairpinMasqueradeIP)
+	}
+
+	if match != "" && match != "hairpin" {
 		aclMatch += " && " + match
 	}
 
@@ -310,6 +318,15 @@ func (oc *Controller) createDefaultDenyPortGroup(ns string, nsInfo *namespaceInf
 	if err != nil {
 		return fmt.Errorf("failed to create default allow ARP ACL for port group %v", err)
 	}
+	// Add acl to default allow ingress hairpin traffic
+	if policyType == knet.PolicyTypeIngress {
+		match = getACLMatch(portGroupName, "hairpin", policyType)
+		err = addACLPortGroup(ns, portGroupUUID, types.DirectionToLPort,
+			types.DefaultAllowPriority, match, "allow", policyType, "", "HairpinAllowPolicy")
+		if err != nil {
+			return fmt.Errorf("failed to create default Hairpin allow ACL for port group %v", err)
+		}
+	}
 
 	if policyType == knet.PolicyTypeIngress {
 		nsInfo.portGroupIngressDenyUUID = portGroupUUID
@@ -322,10 +339,12 @@ func (oc *Controller) createDefaultDenyPortGroup(ns string, nsInfo *namespaceInf
 }
 
 // modify ACL logging
-func (oc *Controller) setACLDenyLogging(ns string, nsInfo *namespaceInfo, aclLogging string) error {
+func (oc *Controller) setDefaultACLsLogging(ns string, nsInfo *namespaceInfo, aclLogging *ACLLoggingLevels) error {
 
-	aclLoggingSev := getACLLoggingSeverity(aclLogging)
+	aclLoggingSevDeny := getACLLoggingSeverity(aclLogging.Deny)
+	aclLoggingSevAllow := getACLLoggingSeverity(aclLogging.Allow)
 
+	// Set logging for the per namespace default ingress ACL
 	match := getACLMatch(defaultDenyPortGroup(ns, "ingressDefaultDeny"), "", knet.PolicyTypeIngress)
 	uuid, err := getACLPortGroupUUID(match, "drop", knet.PolicyTypeIngress)
 	if err != nil {
@@ -336,10 +355,26 @@ func (oc *Controller) setACLDenyLogging(ns string, nsInfo *namespaceInfo, aclLog
 		return fmt.Errorf("failed to find the ACL for pg=%s: %v", nsInfo.portGroupIngressDenyUUID, err)
 	}
 	if _, stderr, err := util.RunOVNNbctl("set", "acl", uuid,
-		fmt.Sprintf("log=%t", aclLogging != ""), fmt.Sprintf("severity=%s", aclLoggingSev)); err != nil {
-		return fmt.Errorf("failed to modify the pg=%s, stderr: %q (%v)", nsInfo.portGroupIngressDenyUUID, stderr, err)
+		fmt.Sprintf("log=%t", aclLogging.Deny != ""), fmt.Sprintf("severity=%s", aclLoggingSevDeny)); err != nil {
+		return fmt.Errorf("failed to modify the logging for acl=%s on pg=%s, stderr: %q (%v)", uuid, nsInfo.portGroupIngressDenyUUID, stderr, err)
 	}
 
+	// Set logging for the per namespace default hairpin ingress ACL
+	match = getACLMatch(defaultDenyPortGroup(ns, "ingressDefaultDeny"), "hairpin", knet.PolicyTypeIngress)
+	uuid, err = getACLPortGroupUUID(match, "allow", knet.PolicyTypeIngress)
+	if err != nil {
+		return err
+	}
+	if uuid == "" {
+		// not suppose to happen
+		return fmt.Errorf("failed to find the ACL for pg=%s: %v", nsInfo.portGroupEgressDenyUUID, err)
+	}
+	if _, stderr, err := util.RunOVNNbctl("set", "acl", uuid,
+		fmt.Sprintf("log=%t", aclLogging.Allow != ""), fmt.Sprintf("severity=%s", aclLoggingSevAllow)); err != nil {
+		return fmt.Errorf("failed to modify the logging for acl=%s on pg=%s, stderr: %q (%v)", uuid, nsInfo.portGroupEgressDenyUUID, stderr, err)
+	}
+
+	// Set logging for the per namespace default egress ACL
 	match = getACLMatch(defaultDenyPortGroup(ns, "egressDefaultDeny"), "", knet.PolicyTypeEgress)
 	uuid, err = getACLPortGroupUUID(match, "drop", knet.PolicyTypeEgress)
 	if err != nil {
@@ -350,8 +385,8 @@ func (oc *Controller) setACLDenyLogging(ns string, nsInfo *namespaceInfo, aclLog
 		return fmt.Errorf("failed to find the ACL for pg=%s: %v", nsInfo.portGroupEgressDenyUUID, err)
 	}
 	if _, stderr, err := util.RunOVNNbctl("set", "acl", uuid,
-		fmt.Sprintf("log=%t", aclLogging != ""), fmt.Sprintf("severity=%s", aclLoggingSev)); err != nil {
-		return fmt.Errorf("failed to modify the pg=%s, stderr: %q (%v)", nsInfo.portGroupEgressDenyUUID, stderr, err)
+		fmt.Sprintf("log=%t", aclLogging.Deny != ""), fmt.Sprintf("severity=%s", aclLoggingSevDeny)); err != nil {
+		return fmt.Errorf("failed to modify the logging for acl=%s on pg=%s, stderr: %q (%v)", uuid, nsInfo.portGroupEgressDenyUUID, stderr, err)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -94,6 +94,10 @@ func (n kNetworkPolicy) addDefaultDenyPGCmds(fexec *ovntest.FakeExec, networkPol
 		Output: fakeUUID,
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"outport == @" + pg_hash + "_" + ingressDenyPG + " && (ip4.src == 169.254.169.3 || ip6.src ==  fd69::3)\" action=allow external-ids:default-deny-policy-type=Ingress",
+		Output: fakeUUID,
+	})
+	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find ACL match=\"inport == @" + pg_hash + "_" + egressDenyPG + "\" action=drop external-ids:default-deny-policy-type=Egress",
 		Output: fakeUUID,
 	})

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -74,11 +74,13 @@ const (
 	V4NodeLocalNATSubnetNextHop    = "169.254.0.1"
 	V4NodeLocalDistributedGWPortIP = "169.254.0.2"
 
-	V4MasqueradeSubnet = "169.254.169.0/30"
-	V4HostMasqueradeIP = "169.254.169.2"
-	V6HostMasqueradeIP = "fd69::2"
-	V4OVNMasqueradeIP  = "169.254.169.1"
-	V6OVNMasqueradeIP  = "fd69::1"
+	V4MasqueradeSubnet      = "169.254.169.0/30"
+	V4LBHairpinMasqueradeIP = "169.254.169.3"
+	V6LBHairpinMasqueradeIP = "fd69::3"
+	V4HostMasqueradeIP      = "169.254.169.2"
+	V6HostMasqueradeIP      = "fd69::2"
+	V4OVNMasqueradeIP       = "169.254.169.1"
+	V6OVNMasqueradeIP       = "fd69::1"
 
 	// OpenFlow and Networking constants
 	RouteAdvertisementICMPType    = 134
@@ -96,9 +98,15 @@ const (
 	WorkerLBTCP           = WorkerLBPrefix + "-tcp"
 	WorkerLBUDP           = WorkerLBPrefix + "-udp"
 	WorkerLBSCTP          = WorkerLBPrefix + "-sctp"
+	GatewayLBPostfix      = "lb_gateway_router"
 	GatewayLBTCP          = "TCP_lb_gateway_router"
 	GatewayLBUDP          = "UDP_lb_gateway_router"
 	GatewayLBSCTP         = "SCTP_lb_gateway_router"
+
+	// This option forces an OVN LB's SNAT IP to be ip4.src == 169.254.169.3 ||
+	// ip6.src == fd69::3 in the hairpin case which allows for network policy to
+	// accurately handle the case for pod -> svc -> pod traffic flows.
+	LBHairpinOptions = "options:hairpin_snat_ip=" + V4LBHairpinMasqueradeIP + " " + V6LBHairpinMasqueradeIP
 
 	// OVN-K8S Topology Versions
 	OvnSingleJoinSwitchTopoVersion = 1

--- a/go-controller/pkg/util/ovn.go
+++ b/go-controller/pkg/util/ovn.go
@@ -134,14 +134,3 @@ func GetDatapathUUID(datapathName string) (string, error) {
 	}
 	return datapath, nil
 }
-
-// Finds any OVN Load Balancer based on external ID and value
-func FindOVNLoadBalancer(externalID, externalValue string) (string, string, error) {
-	out, stderr, err := RunOVNNbctl("--data=bare",
-		"--no-heading", "--columns=_uuid", "find", "load_balancer",
-		"external_ids:"+externalID+"="+externalValue)
-	if err != nil {
-		return "", stderr, err
-	}
-	return out, "", nil
-}


### PR DESCRIPTION
Dupe of #2268 Since CI keeps cancelling. 

Revert the changes made in #1921 Since the new hairpin_snat_ip option is now available in OVN

The main objective here was to remove the dependency between network policy and services that was created in response to this original bug which is

When a POD sends traffic to a service it is loadbalanced(DNAT-ed) and sometimes the same pod is chosen as the backend to the service. To ensure this traffic travels through OVN-K8s rather than the POD2POD network since (srcIP==dstIP), the traffic is SNAT-ed to the VIP of the service's loadbalancer, which results in some packet loss with hairpinned traffic since this is not currently accounted for in the network Policy code

This solution simply forces the SNAT IP to be ip4.src == 169.254.169.3 || ip6.src == fd69::3 in the hairpin case. And also adds a default ingress allow ACL upon network policy creation to always allow such ingress traffic from the "special" hairpin service traffic. It should always be allowed because in theory the only time an ingress packet will ever have a SRC-IP of ip4.src == 169.254.169.3 || ip6.src == fd69::3 is in the hairpin case

This PR also addresses some continuities in how OVN-K handles OVN Loadbalancers. Specifically it moves all code that touches OVN Loadbalancers to reside in the `ovn-kubernetes/go-controller/pkg/ovn/loadbalancer` package which helps with code sanity, and consolidates some duplicated efforts between the three sets of OVN loadbalancers OVN-K currently manages. 