### PR TITLE
Fix duplicate incrementing of subnet allocation metric

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1063,14 +1063,15 @@ func (oc *Controller) addNode(node *kapi.Node) ([]*net.IPNet, error) {
 	// delete stale chassis in SBDB if any
 	oc.deleteStaleNodeChassis(node)
 
-	// If node annotation succeeds, update the used subnet count
-	for _, hostSubnet := range hostSubnets {
-		util.UpdateUsedHostSubnetsCount(hostSubnet,
-			&oc.v4HostSubnetsUsed,
-			&oc.v6HostSubnetsUsed, true)
+	// If node annotation succeeds and subnets were allocated, update the used subnet count
+	if len(allocatedSubnets) > 0 {
+		for _, hostSubnet := range hostSubnets {
+			util.UpdateUsedHostSubnetsCount(hostSubnet,
+				&oc.v4HostSubnetsUsed,
+				&oc.v6HostSubnetsUsed, true)
+		}
+		metrics.RecordSubnetUsage(oc.v4HostSubnetsUsed, oc.v6HostSubnetsUsed)
 	}
-	metrics.RecordSubnetUsage(oc.v4HostSubnetsUsed, oc.v6HostSubnetsUsed)
-
 	return hostSubnets, nil
 }
 


### PR DESCRIPTION
When the master is restarted, all the nodes are fed using
both a fetch of existing nodes and by the add node event.
In case the node already had subnet annotations, we were
updating the subnets allocated metric again. This commit
checks if new subnets were allocated and only then calls
the code to update metrics associated with allocated
subnets.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>
