### PR TITLE
Fix namespace locking and waiting

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -139,7 +139,8 @@ func NewMasterWatchFactory(ovnClientset *util.OVNClientset) (*WatchFactory, erro
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[namespaceType], err = newInformer(namespaceType, wf.iFactory.Core().V1().Namespaces().Informer())
+	wf.informers[namespaceType], err = newQueuedInformer(namespaceType, wf.iFactory.Core().V1().Namespaces().Informer(),
+		wf.stopChan)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -105,12 +105,6 @@ func (f *FakeAddressSetFactory) removeAddressSet(name string) {
 	delete(f.sets, name)
 }
 
-// ExpectNoAddressSet ensures the named address set does not exist
-func (f *FakeAddressSetFactory) ExpectNoAddressSet(name string) {
-	_, ok := f.sets[name]
-	gomega.Expect(ok).To(gomega.BeFalse())
-}
-
 // ExpectAddressSetWithIPs ensures the named address set exists with the given set of IPs
 func (f *FakeAddressSetFactory) ExpectAddressSetWithIPs(name string, ips []string) {
 	var lenAddressSet int

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -98,10 +98,7 @@ func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.P
 	}
 	klog.Infof("Adding routes for external gateway pod: %s, next hops: %q, namespace: %s, bfd-enabled: %t",
 		pod.Name, gws, namespace, egress.bfdEnabled)
-	nsInfo, err := oc.waitForNamespaceLocked(namespace)
-	if err != nil {
-		return err
-	}
+	nsInfo := oc.ensureNamespaceLocked(namespace)
 	defer nsInfo.Unlock()
 	nsInfo.routingExternalPodGWs[pod.Name] = egress
 	return oc.addGWRoutesForNamespace(namespace, egress, nsInfo)
@@ -130,6 +127,11 @@ func (oc *Controller) addGWRoutesForNamespace(namespace string, egress gatewayIn
 		for _, gw := range egress.gws {
 			for _, podIP := range pod.Status.PodIPs {
 				if utilnet.IsIPv6(gw) != utilnet.IsIPv6String(podIP.IP) {
+					continue
+				}
+
+				// if route was already programmed, skip it
+				if foundGR, ok := nsInfo.podExternalRoutes[podIP.IP][gw.String()]; ok && foundGR == gr {
 					continue
 				}
 
@@ -292,10 +294,7 @@ func (oc *Controller) deleteGWRoutesForPod(namespace string, podIPNets []*net.IP
 
 // addEgressGwRoutesForPod handles adding all routes to gateways for a pod on a specific GR
 func (oc *Controller) addGWRoutesForPod(gateways []gatewayInfo, podIfAddrs []*net.IPNet, namespace, node string) error {
-	nsInfo, err := oc.waitForNamespaceLocked(namespace)
-	if err != nil {
-		return err
-	}
+	nsInfo := oc.getNamespaceLocked(namespace)
 	defer nsInfo.Unlock()
 	gr := util.GetGatewayRouterFromNode(node)
 
@@ -309,6 +308,10 @@ func (oc *Controller) addGWRoutesForPod(gateways []gatewayInfo, podIfAddrs []*ne
 				podIP := podIPNet.IP.String()
 				for _, gw := range gws {
 					gwStr := gw.String()
+					// if route was already programmed, skip it
+					if foundGR, ok := nsInfo.podExternalRoutes[podIP][gwStr]; ok && foundGR == gr {
+						continue
+					}
 					mask := GetIPFullMask(podIP)
 					nbctlArgs := []string{"--may-exist", "--policy=src-ip", "--ecmp-symmetric-reply",
 						"lr-route-add", gr, podIP + mask, gw.String()}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -793,12 +793,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 	if err = func() error {
 		hostNetworkNamespace := config.Kubernetes.HostNetworkNamespace
 		if hostNetworkNamespace != "" {
-			nsInfo, err := oc.waitForNamespaceLocked(hostNetworkNamespace)
-			if err != nil {
-				klog.Errorf("Failed to get namespace %s (%v)",
-					hostNetworkNamespace, err)
-				return err
-			}
+			nsInfo := oc.ensureNamespaceLocked(hostNetworkNamespace)
 			defer nsInfo.Unlock()
 			if nsInfo.addressSet == nil {
 				nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(hostNetworkNamespace)

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -51,13 +51,11 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 }
 
 func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
-	nsInfo, err := oc.waitForNamespaceLocked(ns)
-	if err != nil {
-		return err
-	}
+	nsInfo := oc.ensureNamespaceLocked(ns)
 	defer nsInfo.Unlock()
 
 	if nsInfo.addressSet == nil {
+		var err error
 		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns)
 		if err != nil {
 			return fmt.Errorf("unable to add pod to namespace. Cannot create address set for namespace: %s,"+
@@ -198,14 +196,19 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 		klog.Infof("[%s] adding namespace took %v", ns.Name, time.Since(start))
 	}()
 
-	nsInfo := oc.createNamespaceLocked(ns.Name)
+	nsInfo := oc.ensureNamespaceLocked(ns.Name)
 	defer nsInfo.Unlock()
 
-	var err error
 	if annotation, ok := ns.Annotations[routingExternalGWsAnnotation]; ok {
-		nsInfo.routingExternalGWs.gws, err = parseRoutingExternalGWAnnotation(annotation)
+		exGateways, err := parseRoutingExternalGWAnnotation(annotation)
 		if err != nil {
 			klog.Errorf(err.Error())
+		} else {
+			_, bfdEnabled := ns.Annotations[bfdAnnotation]
+			err = oc.addExternalGWsForNamespace(gatewayInfo{gws: exGateways, bfdEnabled: bfdEnabled}, nsInfo, ns.Name)
+			if err != nil {
+				klog.Error(err.Error())
+			}
 		}
 		if _, ok := ns.Annotations[bfdAnnotation]; ok {
 			nsInfo.routingExternalGWs.bfdEnabled = true
@@ -220,9 +223,14 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 			klog.Warningf("Namespace %s: ACL logging is not enabled due to malformed annotation", ns.Name)
 		}
 	}
-	nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns.Name)
-	if err != nil {
-		klog.Errorf(err.Error())
+	if nsInfo.addressSet == nil {
+		var err error
+		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns.Name)
+		if err != nil {
+			klog.Errorf(err.Error())
+		}
+	} else {
+		klog.V(5).Infof("Address set already exists for namespace: %s", ns.Name)
 	}
 
 	// TODO(trozet) figure out if there is any possibility of detecting if a pod GW already exists, which
@@ -230,6 +238,7 @@ func (oc *Controller) AddNamespace(ns *kapi.Namespace) {
 	// For now it is required that a pod serving as a gateway for a namespace is added AFTER the serving namespace is
 	// created
 
+	// If multicast enabled, adds all current pods in the namespace to the allow policy
 	oc.multicastUpdateNamespace(ns, nsInfo)
 }
 
@@ -376,20 +385,41 @@ func (oc *Controller) getNamespaceLocked(ns string) *namespaceInfo {
 	return nsInfo
 }
 
-// createNamespaceLocked locks namespacesMutex, creates an entry for ns, and returns it
+// ensureNamespaceLocked locks namespacesMutex, gets/creates an entry for ns, and returns it
 // with its mutex locked.
-func (oc *Controller) createNamespaceLocked(ns string) *namespaceInfo {
+func (oc *Controller) ensureNamespaceLocked(ns string) *namespaceInfo {
 	oc.namespacesMutex.Lock()
-	defer oc.namespacesMutex.Unlock()
-
-	nsInfo := &namespaceInfo{
-		networkPolicies:       make(map[string]*networkPolicy),
-		podExternalRoutes:     make(map[string]map[string]string),
-		multicastEnabled:      false,
-		routingExternalPodGWs: make(map[string]gatewayInfo),
+	nsInfo := oc.namespaces[ns]
+	nsInfoExisted := false
+	if nsInfo == nil {
+		nsInfo = &namespaceInfo{
+			networkPolicies:       make(map[string]*networkPolicy),
+			podExternalRoutes:     make(map[string]map[string]string),
+			multicastEnabled:      false,
+			routingExternalPodGWs: make(map[string]gatewayInfo),
+		}
+		// we are creating nsInfo and going to set it in namespaces map
+		// so safe to hold the lock while we create and add it
+		defer oc.namespacesMutex.Unlock()
+		oc.namespaces[ns] = nsInfo
+	} else {
+		nsInfoExisted = true
+		// if we found and existing nsInfo, do not hold the namespaces lock
+		// while waiting for nsInfo to Lock
+		oc.namespacesMutex.Unlock()
 	}
+
 	nsInfo.Lock()
-	oc.namespaces[ns] = nsInfo
+
+	if nsInfoExisted {
+		// Check that the namespace wasn't deleted while we were waiting for the lock
+		oc.namespacesMutex.Lock()
+		defer oc.namespacesMutex.Unlock()
+		if nsInfo != oc.namespaces[ns] {
+			nsInfo.Unlock()
+			return nil
+		}
+	}
 
 	return nsInfo
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -480,7 +480,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	// Add the pod's logical switch port to the port cache
 	portInfo := oc.logicalPortCache.add(logicalSwitch, portName, lsp.UUID, podMac, podIfAddrs)
 
-	// Wait for namespace to exist, no calls after this should ever use waitForNamespaceLocked
+	// Ensure the namespace/nsInfo exists
 	if err = oc.addPodToNamespace(pod.Namespace, portInfo); err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -399,7 +399,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
-		ginkgo.It("retries a failed pod Add when namespace doesn't yet exist", func() {
+		ginkgo.It("pod Add should succeed even when namespace doesn't yet exist", func() {
 			app.Action = func(ctx *cli.Context) error {
 
 				namespaceT := newNamespace("namespace1")
@@ -427,13 +427,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(podJSON))
 
-				fakeOvn.asf.ExpectNoAddressSet(t.namespace)
-
-				// Now add the namespace
-				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Create(context.TODO(), namespaceT, metav1.CreateOptions{})
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				// Pod creation should be retried on Update event
+				// Add Pod logical port should succeed even without namespace
 				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
 				gomega.Expect(getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)).Should(gomega.MatchJSON(podJSON))
 


### PR DESCRIPTION
Make namespace handlers multi-threaded. Stop waiting for namespace where possible:

The pod handlers and egressgw code would wait for the namespace add
event before being able to actually create things. This wait could last
up to 10 seconds before failure, and possibly even longer depending on
how backed up the namespace handler is.

This patch removes waiting where it is unnecessary. Those cases are the
following:

 - Pod add only cares about the address sets for the namespace being
   available. We already create the address set if we detect it is nil
   during pod add so there is nothing we are really waiting for the ns
   event.
 - Egress GW waits for namespace to see what routes the annotation may
   have on the namespace for gateways. There is really no reason to wait
   as we can add the routes we know about, and then let the namespace
   add event cover any routes that were missing when it arrives.
 - Multicast enablement. This is configured via the namespace
   annotation. If it is missing because we get the pod add event first,
   the add namespace event will cover enabling multicast for all pods in
   the namespace.

Patch does not cover one case of waiting for namespace lock:

 - Network Policy ACL logging. The ACL logging levels for deny and allow
   are configured in the namespace. If the network policy does not wait,
   and the namespace event comes later, we have no method to iterate
   through all affected policies for that namespace and set there
   correct logging levels.