### PR TITLE
Infer subnet for node /128 IPv6 addresses

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -86,7 +86,13 @@ func getNetworkInterfaceIPAddresses(iface string) ([]*net.IPNet, error) {
 	for _, ip := range allIPs {
 		if utilnet.IsIPv6CIDR(ip) {
 			if config.IPv6Mode && !foundIPv6 {
-				ips = append(ips, ip)
+				// For IPv6 addresses with 128 prefix, let's try to find an appropriate subnet
+				// in the routing table
+				subnetIP, err := util.GetIPv6OnSubnet(iface, ip)
+				if err != nil {
+					return nil, fmt.Errorf("could not find IPv6 address on subnet: %v", err)
+				}
+				ips = append(ips, subnetIP)
 				foundIPv6 = true
 			}
 		} else if config.IPv4Mode && !foundIPv4 {


### PR DESCRIPTION
**- What this PR does and why is it needed**
When node addresses are allocated through DHCPv6 IA_NA, they might get
a /128 prefix address. These node addresses are set on the gateway
router port as well. OVN routers infers on-link routes from subnet
information on the address itself. Since /128 addresses are not on a
subnet, cluster traffic is routed through the node gatway instead of
directly.

Note that OVN does not support learning routes from ICMPv6 route
advertisement and does not support adding on-link static routes.

This patch infers a subnet for the interface looking at the node
routing information and replaces the /128 prefix with the subnet
prefix.

**- How to verify it**
Added unit tests

**- Description for the changelog**
Infer subnet for /128 IPv6 addresses allocated through DHCPv6 IA_NA