### PR TITLE
Multi-threaded namespace informer

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -139,7 +139,8 @@ func NewMasterWatchFactory(ovnClientset *util.OVNClientset) (*WatchFactory, erro
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[namespaceType], err = newInformer(namespaceType, wf.iFactory.Core().V1().Namespaces().Informer())
+	wf.informers[namespaceType], err = newQueuedInformer(namespaceType, wf.iFactory.Core().V1().Namespaces().Informer(),
+		wf.stopChan)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We have up to 10 goroutines handling pod events, however handling pod
events depends on namespace existing, and the namespace handler is
single threaded. During a scale test where we create many namespaces
with a few pods in them, the pod handler can get bogged down waiting on
namespace handler to serially get each new namespace. It shouldn't
introduce significant performance cost to handle these also in parallel.

Signed-off-by: Tim Rozet <trozet@redhat.com>

