### PR TITLE
quit retrying pod setup if the pod is already gone from informers cache

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"reflect"
 	"strconv"
 	"sync"
@@ -33,6 +34,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	kapisnetworking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -438,6 +440,16 @@ func (oc *Controller) iterateRetryPods() {
 		podTimer := podEntry.timeStamp.Add(time.Minute)
 		if now.After(podTimer) {
 			podDesc := fmt.Sprintf("[%s/%s/%s]", pod.UID, pod.Namespace, pod.Name)
+			// it could be that the Pod got deleted, but Pod's DeleteFunc has not been called yet, so don't retry
+			_, err := oc.watchFactory.GetPod(pod.Namespace, pod.Name)
+			if err != nil {
+				if e, ok := err.(*errors.StatusError); ok && e.ErrStatus.Code == http.StatusNotFound {
+					klog.Infof("%s pod not found in the informers cache, not going to retry pod setup", podDesc)
+					delete(oc.retryPods, uid)
+					continue
+				}
+			}
+
 			klog.Infof("%s retry pod setup", podDesc)
 
 			if oc.ensurePod(nil, pod, true) {


### PR DESCRIPTION
we have seen instances where the pod delete event gets queued up and the
pod's DeleteFunc() callback is delayed. in the meantime, we are trying
to do pod setup of the failed pod again and again. since the pod is gone
we fail in setting pod annotations in addLogicalPort(). we add the pod
back to the retryLoop and retry again after 1 minute.

we continue this until the pod's DeleteFunc() gets called and it removes
the deleted pod from the retryPod map.

Fixes: #2341 