### PR TITLE
cni: pass Kube API auth via cnishim response, not CNI config file

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -2,6 +2,7 @@ package cni
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -72,7 +73,17 @@ func NewCNIServer(rundir string, useOVSExternalIDs bool, factory factory.NodeWat
 		podLister:         corev1listers.NewPodLister(factory.LocalPodInformer().GetIndexer()),
 		kclient:           kclient,
 		mode:              config.OvnKubeNode.Mode,
+		kubeAuth: &KubeAPIAuth{
+			Kubeconfig:    config.Kubernetes.Kubeconfig,
+			KubeAPIServer: config.Kubernetes.APIServer,
+			KubeAPIToken:  config.Kubernetes.Token,
+		},
 	}
+
+	if len(config.Kubernetes.CAData) > 0 {
+		s.kubeAuth.KubeCAData = base64.StdEncoding.EncodeToString(config.Kubernetes.CAData)
+	}
+
 	router.NotFoundHandler = http.HandlerFunc(http.NotFound)
 	router.HandleFunc("/metrics", s.handleCNIMetrics).Methods("POST")
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -120,9 +131,7 @@ func cniRequestToPodRequest(cr *Request, podLister corev1listers.PodLister, kcli
 	}
 
 	req := &PodRequest{
-		Command:   command(cmd),
-		podLister: podLister,
-		kclient:   kclient,
+		Command: command(cmd),
 	}
 
 	req.SandboxID, ok = cr.Env["CNI_CONTAINERID"]
@@ -194,7 +203,7 @@ func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 	if atomic.LoadInt32(&s.useOVSExternalIDs) > 0 {
 		useOVSExternalIDs = true
 	}
-	result, err := s.requestFunc(req, s.podLister, useOVSExternalIDs, s.kclient)
+	result, err := s.requestFunc(req, s.podLister, useOVSExternalIDs, s.kclient, s.kubeAuth)
 	if err != nil {
 		// Prefix error with request information for easier debugging
 		return nil, fmt.Errorf("%s %v", req, err)

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -48,7 +48,7 @@ func clientDoCNI(t *testing.T, client *http.Client, req *Request) ([]byte, int) 
 
 var expectedResult cnitypes.Result
 
-func serverHandleCNI(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface) ([]byte, error) {
+func serverHandleCNI(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface, kubeAuth *KubeAPIAuth) ([]byte, error) {
 	if request.Command == CNIAdd {
 		return json.Marshal(&expectedResult)
 	} else if request.Command == CNIDel || request.Command == CNIUpdate || request.Command == CNICheck {

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -322,7 +322,7 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 }
 
 // ConfigureInterface sets up the container interface
-func (pr *PodRequest) ConfigureInterface(ifInfo *PodInterfaceInfo) ([]*current.Interface, error) {
+func (pr *PodRequest) ConfigureInterface(podLister corev1listers.PodLister, kclient kubernetes.Interface, ifInfo *PodInterfaceInfo) ([]*current.Interface, error) {
 	netns, err := ns.GetNS(pr.Netns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open netns %q: %v", pr.Netns, err)
@@ -349,7 +349,7 @@ func (pr *PodRequest) ConfigureInterface(ifInfo *PodInterfaceInfo) ([]*current.I
 
 	if !ifInfo.IsSmartNic {
 		err = ConfigureOVS(pr.ctx, pr.PodNamespace, pr.PodName, hostIface.Name, ifInfo, pr.SandboxID,
-			pr.podLister, pr.kclient, pr.PodUID)
+			podLister, kclient, pr.PodUID)
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -23,15 +23,6 @@ type NetConf struct {
 	// LogFileMaxAge represents the maximum number
 	// of days to retain old log files
 	LogFileMaxAge int `json:"logfile-maxage"`
-
-	// Kubeconfig is the path to a kubeconfig
-	Kubeconfig string `json:"kubeconfig,omitempty"`
-	// KubeAPIServer is the URL of a Kubernetes API server (not required if kubeconfig is given)
-	KubeAPIServer string `json:"kube-api-server,omitempty"`
-	// KubeAPIToken is a Kubernetes API token (not required if kubeconfig is given)
-	KubeAPIToken string `json:"kube-api-token,omitempty"`
-	// KubeCACert is the absolute path to a Kubernetes API CA certificate (not required if kubeconfig is given)
-	KubeCACert string `json:"kube-ca-cert,omitempty"`
 }
 
 // NetworkSelectionElement represents one element of the JSON format

--- a/go-controller/pkg/config/cni.go
+++ b/go-controller/pkg/config/cni.go
@@ -15,47 +15,6 @@ import (
 
 // WriteCNIConfig writes a CNI JSON config file to directory given by global config
 func WriteCNIConfig() error {
-	var err error
-	var f *os.File
-	var bytes []byte
-
-	// Install the CNI config file after all initialization is done
-	// MkdirAll() returns no error if the path already exists
-	err = os.MkdirAll(CNI.ConfDir, os.ModeDir)
-	if err != nil {
-		return err
-	}
-
-	// CACert might be a secret valid only in the container; copy into
-	// the CNI directory
-	caFile := Kubernetes.CACert
-	if caFile != "" {
-		bytes, err = ioutil.ReadFile(caFile)
-		if err != nil {
-			return err
-		}
-		f, err = ioutil.TempFile(CNI.ConfDir, "ovnkube-ca-*.cert")
-		if err != nil {
-			return err
-		}
-
-		caFile = f.Name()
-		defer func() {
-			if err != nil {
-				os.Remove(caFile)
-			}
-		}()
-
-		_, err = f.Write(bytes)
-		if err != nil {
-			return err
-		}
-		err = f.Close()
-		if err != nil {
-			return err
-		}
-	}
-
 	netConf := &ovntypes.NetConf{
 		NetConf: types.NetConf{
 			CNIVersion: "0.4.0",
@@ -67,24 +26,29 @@ func WriteCNIConfig() error {
 		LogFileMaxSize:    Logging.LogFileMaxSize,
 		LogFileMaxBackups: Logging.LogFileMaxBackups,
 		LogFileMaxAge:     Logging.LogFileMaxAge,
-		Kubeconfig:        Kubernetes.Kubeconfig,
-		KubeCACert:        caFile,
-		KubeAPIServer:     Kubernetes.APIServer,
-		KubeAPIToken:      Kubernetes.Token,
 	}
 
-	bytes, err = json.Marshal(netConf)
+	bytes, err := json.Marshal(netConf)
 	if err != nil {
 		return fmt.Errorf("failed to marshal CNI config JSON: %v", err)
+	}
+
+	// Install the CNI config file after all initialization is done
+	// MkdirAll() returns no error if the path already exists
+	err = os.MkdirAll(CNI.ConfDir, os.ModeDir)
+	if err != nil {
+		return err
 	}
 
 	// Always create the CNI config for consistency.
 	confFile := filepath.Join(CNI.ConfDir, CNIConfFileName)
 
+	var f *os.File
 	f, err = ioutil.TempFile(CNI.ConfDir, "ovnkube-")
 	if err != nil {
 		return err
 	}
+
 	_, err = f.Write(bytes)
 	if err != nil {
 		return err

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -245,6 +245,7 @@ type CNIConfig struct {
 type KubernetesConfig struct {
 	Kubeconfig            string `gcfg:"kubeconfig"`
 	CACert                string `gcfg:"cacert"`
+	CAData                []byte
 	APIServer             string `gcfg:"apiserver"`
 	Token                 string `gcfg:"token"`
 	CompatServiceCIDR     string `gcfg:"service-cidr"`
@@ -1183,8 +1184,13 @@ func buildKubernetesConfig(exec kexec.Interface, cli, file *config, saPath strin
 	if Kubernetes.Kubeconfig != "" && !pathExists(Kubernetes.Kubeconfig) {
 		return fmt.Errorf("kubernetes kubeconfig file %q not found", Kubernetes.Kubeconfig)
 	}
-	if Kubernetes.CACert != "" && !pathExists(Kubernetes.CACert) {
-		return fmt.Errorf("kubernetes CA certificate file %q not found", Kubernetes.CACert)
+
+	if Kubernetes.CACert != "" {
+		bytes, err := ioutil.ReadFile(Kubernetes.CACert)
+		if err != nil {
+			return err
+		}
+		Kubernetes.CAData = bytes
 	}
 
 	url, err := url.Parse(Kubernetes.APIServer)

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -113,12 +113,13 @@ var _ = AfterSuite(func() {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 })
 
-func createTempFile(name string) (string, error) {
+func createTempFile(name string) (string, []byte, error) {
+	fileData := []byte{0x20}
 	fname := filepath.Join(tmpDir, name)
-	if err := ioutil.WriteFile(fname, []byte{0x20}, 0644); err != nil {
-		return "", err
+	if err := ioutil.WriteFile(fname, fileData, 0644); err != nil {
+		return "", nil, err
 	}
-	return fname, nil
+	return fname, fileData, nil
 }
 
 func createTempFileContent(name, value string) (string, error) {
@@ -252,6 +253,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(CNI.Plugin).To(gomega.Equal("ovn-k8s-cni-overlay"))
 			gomega.Expect(Kubernetes.Kubeconfig).To(gomega.Equal(""))
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(""))
+			gomega.Expect(Kubernetes.CAData).To(gomega.Equal([]byte{}))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal(""))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal(DefaultAPIServer))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.16.1.0/24"))
@@ -294,7 +296,7 @@ var _ = Describe("Config Operations", func() {
 				Output: "asadfasdfasrw3atr3r3rf33fasdaa3233",
 			})
 			// k8s-ca-certificate
-			fname, err := createTempFile("ca.crt")
+			fname, fdata, err := createTempFile("ca.crt")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-ca-certificate",
@@ -318,6 +320,7 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://somewhere.com:8081"))
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(fname))
+			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(fdata))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("asadfasdfasrw3atr3r3rf33fasdaa3233"))
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeTCP))
@@ -356,7 +359,7 @@ var _ = Describe("Config Operations", func() {
 				Output: "asadfasdfasrw3atr3r3rf33fasdaa3233",
 			})
 			// k8s-ca-certificate
-			fname, err := createTempFile("kube-cacert.pem")
+			fname, fdata, err := createTempFile("kube-cacert.pem")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-ca-certificate",
@@ -384,6 +387,7 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://somewhere.com:8081"))
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(fname))
+			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(fdata))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("asadfasdfasrw3atr3r3rf33fasdaa3233"))
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeTCP))
@@ -408,9 +412,9 @@ var _ = Describe("Config Operations", func() {
 	})
 
 	It("uses serviceaccount files", func() {
-		kubeCAcertFile, err := createTempFile("ca.crt")
+		caFile, caData, err := createTempFile("ca.crt")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		defer os.Remove(kubeCAcertFile)
+		defer os.Remove(caFile)
 
 		tokenFile, err1 := createTempFileContent("token", "TG9yZW0gaXBzdW0gZ")
 		gomega.Expect(err1).NotTo(gomega.HaveOccurred())
@@ -420,7 +424,8 @@ var _ = Describe("Config Operations", func() {
 			_, err := InitConfigSa(ctx, kexec.New(), tmpDir, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAcertFile))
+			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(caFile))
+			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(caData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("TG9yZW0gaXBzdW0gZ"))
 
 			return nil
@@ -431,7 +436,7 @@ var _ = Describe("Config Operations", func() {
 	})
 
 	It("uses environment variables", func() {
-		kubeconfigEnvFile, err := createTempFile("kubeconfig.env")
+		kubeconfigEnvFile, _, err := createTempFile("kubeconfig.env")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeconfigEnvFile)
 		os.Setenv("KUBECONFIG", kubeconfigEnvFile)
@@ -443,7 +448,7 @@ var _ = Describe("Config Operations", func() {
 		os.Setenv("K8S_APISERVER", "https://9.2.3.4:6443")
 		defer os.Setenv("K8S_APISERVER", "")
 
-		kubeCAFile, err1 := createTempFile("kube-ca.crt")
+		kubeCAFile, kubeCAData, err1 := createTempFile("kube-ca.crt")
 		gomega.Expect(err1).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeCAFile)
 		os.Setenv("K8S_CACERT", kubeCAFile)
@@ -457,6 +462,7 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Kubernetes.Kubeconfig).To(gomega.Equal(kubeconfigEnvFile))
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
+			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("this is the  token test"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://9.2.3.4:6443"))
 
@@ -468,11 +474,11 @@ var _ = Describe("Config Operations", func() {
 	})
 
 	It("overrides defaults with config file options", func() {
-		kubeconfigFile, err := createTempFile("kubeconfig")
+		kubeconfigFile, _, err := createTempFile("kubeconfig")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeconfigFile)
 
-		kubeCAFile, err := createTempFile("kube-ca.crt")
+		kubeCAFile, kubeCAData, err := createTempFile("kube-ca.crt")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeCAFile)
 
@@ -500,6 +506,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(CNI.Plugin).To(gomega.Equal("ovn-k8s-cni-overlay22"))
 			gomega.Expect(Kubernetes.Kubeconfig).To(gomega.Equal(kubeconfigFile))
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
+			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("TG9yZW0gaXBzdW0gZ"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://1.2.3.4:6443"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.18.0.0/24"))
@@ -541,11 +548,11 @@ var _ = Describe("Config Operations", func() {
 	})
 
 	It("overrides config file and defaults with CLI options", func() {
-		kubeconfigFile, err := createTempFile("kubeconfig")
+		kubeconfigFile, _, err := createTempFile("kubeconfig")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeconfigFile)
 
-		kubeCAFile, err := createTempFile("kube-ca.crt")
+		kubeCAFile, kubeCAData, err := createTempFile("kube-ca.crt")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeCAFile)
 
@@ -570,6 +577,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(CNI.Plugin).To(gomega.Equal("a-plugin"))
 			gomega.Expect(Kubernetes.Kubeconfig).To(gomega.Equal(kubeconfigFile))
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
+			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("asdfasdfasdfasfd"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://4.4.3.2:8080"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.15.0.0/24"))
@@ -860,11 +868,11 @@ mode=shared
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 	It("overrides config file and defaults with CLI options (multi-master)", func() {
-		kubeconfigFile, err := createTempFile("kubeconfig")
+		kubeconfigFile, _, err := createTempFile("kubeconfig")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeconfigFile)
 
-		kubeCAFile, err := createTempFile("kube-ca.crt")
+		kubeCAFile, kubeCAData, err := createTempFile("kube-ca.crt")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeCAFile)
 
@@ -891,6 +899,7 @@ mode=shared
 			gomega.Expect(CNI.Plugin).To(gomega.Equal("a-plugin"))
 			gomega.Expect(Kubernetes.Kubeconfig).To(gomega.Equal(kubeconfigFile))
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
+			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("asdfasdfasdfasfd"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://4.4.3.2:8080"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal("label=another-test-label"))
@@ -949,11 +958,11 @@ mode=shared
 	})
 
 	It("does not override config file settings with default cli options", func() {
-		kubeconfigFile, err := createTempFile("kubeconfig")
+		kubeconfigFile, _, err := createTempFile("kubeconfig")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeconfigFile)
 
-		kubeCAFile, err := createTempFile("kube-ca.crt")
+		kubeCAFile, kubeCAData, err := createTempFile("kube-ca.crt")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		defer os.Remove(kubeCAFile)
 
@@ -981,6 +990,7 @@ mode=shared
 			gomega.Expect(CNI.Plugin).To(gomega.Equal("ovn-k8s-cni-overlay22"))
 			gomega.Expect(Kubernetes.Kubeconfig).To(gomega.Equal(kubeconfigFile))
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
+			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("TG9yZW0gaXBzdW0gZ"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.18.0.0/24"))
 
@@ -1145,9 +1155,9 @@ mode=shared
 
 		BeforeEach(func() {
 			var err error
-			certFile, err = createTempFile("cert.crt")
+			certFile, _, err = createTempFile("cert.crt")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			keyFile, err = createTempFile("priv.key")
+			keyFile, _, err = createTempFile("priv.key")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			caFile = filepath.Join(tmpDir, "ca.crt")
 		})
@@ -1303,7 +1313,7 @@ mode=shared
 	Describe("Kubernetes config options", func() {
 		Context("returns an error when the", func() {
 			generateTestsSimple("CA cert does not exist",
-				"kubernetes CA certificate file \"/foo/bar/baz.cert\" not found",
+				"open /foo/bar/baz.cert: no such file or directory",
 				"-k8s-apiserver=https://localhost:8443", "-k8s-cacert=/foo/bar/baz.cert")
 
 			generateTestsSimple("apiserver URL scheme is invalid",
@@ -1325,11 +1335,11 @@ mode=shared
 
 		BeforeEach(func() {
 			var err error
-			certFile, err = createTempFile("cert.crt")
+			certFile, _, err = createTempFile("cert.crt")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			keyFile, err = createTempFile("priv.key")
+			keyFile, _, err = createTempFile("priv.key")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			caFile, err = createTempFile("ca.crt")
+			caFile, _, err = createTempFile("ca.crt")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -52,7 +52,8 @@ func adjustNodeName() string {
 }
 
 // newKubernetesRestConfig create a Kubernetes rest config from either a kubeconfig,
-// TLS properties, or an apiserver URL
+// TLS properties, or an apiserver URL. If the CA certificate data is passed in the
+// CAData in the KubernetesConfig, the CACert path is ignored.
 func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error) {
 	var kconfig *rest.Config
 	var err error
@@ -61,19 +62,16 @@ func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error
 		// uses the current context in kubeconfig
 		kconfig, err = clientcmd.BuildConfigFromFlags("", conf.Kubeconfig)
 	} else if strings.HasPrefix(conf.APIServer, "https") {
-		// TODO: Looks like the check conf.APIServer is redundant and can be removed
-		if conf.APIServer == "" || conf.Token == "" {
+		if conf.Token == "" || len(conf.CAData) == 0 {
 			return nil, fmt.Errorf("TLS-secured apiservers require token and CA certificate")
 		}
-		kconfig = &rest.Config{
-			Host:        conf.APIServer,
-			BearerToken: conf.Token,
+		if _, err := cert.NewPoolFromBytes(conf.CAData); err != nil {
+			return nil, err
 		}
-		if conf.CACert != "" {
-			if _, err := cert.NewPool(conf.CACert); err != nil {
-				return nil, err
-			}
-			kconfig.TLSClientConfig = rest.TLSClientConfig{CAFile: conf.CACert}
+		kconfig = &rest.Config{
+			Host:            conf.APIServer,
+			BearerToken:     conf.Token,
+			TLSClientConfig: rest.TLSClientConfig{CAData: conf.CAData},
 		}
 	} else if strings.HasPrefix(conf.APIServer, "http") {
 		kconfig, err = clientcmd.BuildConfigFromFlags(conf.APIServer, "")

--- a/go-controller/pkg/util/kube_test.go
+++ b/go-controller/pkg/util/kube_test.go
@@ -17,6 +17,32 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 )
 
+// Go Daddy Class 2 CA
+const validCACert string = `-----BEGIN CERTIFICATE-----
+MIIEADCCAuigAwIBAgIBADANBgkqhkiG9w0BAQUFADBjMQswCQYDVQQGEwJVUzEh
+MB8GA1UEChMYVGhlIEdvIERhZGR5IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBE
+YWRkeSBDbGFzcyAyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTA0MDYyOTE3
+MDYyMFoXDTM0MDYyOTE3MDYyMFowYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRo
+ZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3Mg
+MiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASAwDQYJKoZIhvcNAQEBBQADggEN
+ADCCAQgCggEBAN6d1+pXGEmhW+vXX0iG6r7d/+TvZxz0ZWizV3GgXne77ZtJ6XCA
+PVYYYwhv2vLM0D9/AlQiVBDYsoHUwHU9S3/Hd8M+eKsaA7Ugay9qK7HFiH7Eux6w
+wdhFJ2+qN1j3hybX2C32qRe3H3I2TqYXP2WYktsqbl2i/ojgC95/5Y0V4evLOtXi
+EqITLdiOr18SPaAIBQi2XKVlOARFmR6jYGB0xUGlcmIbYsUfb18aQr4CUWWoriMY
+avx4A6lNf4DD+qta/KFApMoZFv6yyO9ecw3ud72a9nmYvLEHZ6IVDd2gWMZEewo+
+YihfukEHU1jPEX44dMX4/7VpkI+EdOqXG68CAQOjgcAwgb0wHQYDVR0OBBYEFNLE
+sNKR1EwRcbNhyz2h/t2oatTjMIGNBgNVHSMEgYUwgYKAFNLEsNKR1EwRcbNhyz2h
+/t2oatTjoWekZTBjMQswCQYDVQQGEwJVUzEhMB8GA1UEChMYVGhlIEdvIERhZGR5
+IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBEYWRkeSBDbGFzcyAyIENlcnRpZmlj
+YXRpb24gQXV0aG9yaXR5ggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQAD
+ggEBADJL87LKPpH8EsahB4yOd6AzBhRckB4Y9wimPQoZ+YeAEW5p5JYXMP80kWNy
+OO7MHAGjHZQopDH2esRU1/blMVgDoszOYtuURXO1v0XJJLXVggKtI3lpjbi2Tc7P
+TMozI+gciKqdi0FuFskg5YmezTvacPd+mSYgFFQlq25zheabIZ0KbIIOqPjCDPoQ
+HmyW74cNxA9hi63ugyuV+I6ShHI56yDqg+2DzZduCLzrTia2cyvk0/ZM/iZx4mER
+dEr/VxqHD3VILs9RaRegAhJhldXRQLIQTO7ErBBDpqWeCtWVYpoNz4iCxTIM5Cuf
+ReYNnyicsbkqWletNw+vHX/bvZ8=
+-----END CERTIFICATE-----`
+
 func TestNewClientset(t *testing.T) {
 	tests := []struct {
 		desc        string
@@ -38,9 +64,9 @@ func TestNewClientset(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			desc: "error: CACert invalid for https config",
+			desc: "error: CAData invalid for https config",
 			inpConfig: config.KubernetesConfig{
-				CACert:    "testCert",
+				CAData:    []byte("testCert"),
 				APIServer: "https",
 				Token:     "testToken",
 			},
@@ -51,6 +77,7 @@ func TestNewClientset(t *testing.T) {
 			inpConfig: config.KubernetesConfig{
 				APIServer: "https",
 				Token:     "testToken",
+				CAData:    []byte(validCACert),
 			},
 		},
 		{


### PR DESCRIPTION
    Passing the Kube API authentication data via the CNI config file
    has two problems:
    
    1) the CA file path might be different to the cniserver (because
    it's containerized) than it is to the cnishim running outside
    a container
    
    2) it's better not to leak authentication info into the host
    filesystem, even though the CNI config file should have restricted
    permissions
    
    To solve these two issues, pass the Kube API authentication data
    back from the cniserver (running in ovnkube-node) to the cnishim
    in the JSON response instead of writing it to a file on-disk.
    
    This commit reverts parts of:
    d39716645fe8bc7f021e7ea0b5f61bbcf421fe8a
    cni: cancel pod sandbox add requests if the pod's UID or MAC changes

@trozet @astoycos @squeed 