### PR TITLE
Kind: Make SGW as default

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -67,7 +67,7 @@ usage() {
     echo "                                   github CI to be updated with IPv6 settings."
     echo "                                   DEFAULT: Don't allow."
     echo "-gm  | --gateway-mode              Enable 'shared' or 'local' gateway mode."
-    echo "                                   DEFAULT: local."
+    echo "                                   DEFAULT: shared."
     echo "-ov  | --ovn-image            	   Use the specified docker image instead of building locally. DEFAULT: local build."
     echo "-ml  | --master-loglevel           Log level for ovnkube (master), DEFAULT: 5."
     echo "-nl  | --node-loglevel             Log level for ovnkube (node), DEFAULT: 5"
@@ -250,7 +250,7 @@ set_default_params() {
   # Set default values
   KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
   K8S_VERSION=${K8S_VERSION:-v1.20.0}
-  OVN_GATEWAY_MODE=${OVN_GATEWAY_MODE:-local}
+  OVN_GATEWAY_MODE=${OVN_GATEWAY_MODE:-shared}
   KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS:-false}
   OVN_HA=${OVN_HA:-false}
   KIND_CONFIG=${KIND_CONFIG:-./kind.yaml.j2}

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -89,7 +89,9 @@ usage: kind.sh [[[-cf |--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]
                  [-nl |--node-loglevel <num>] [-ml|--master-loglevel <num>]
                  [-dbl|--dbchecker-loglevel <num>] [-ndl|--ovn-loglevel-northd <loglevel>]
                  [-nbl|--ovn-loglevel-nb <loglevel>] [-sbl|--ovn-loglevel-sb <loglevel>]
-                 [-cl |--ovn-loglevel-controller <loglevel>] [-dl|--ovn-loglevel-nbctld <loglevel>] |
+                 [-cl |--ovn-loglevel-controller <loglevel>] [-dl|--ovn-loglevel-nbctld <loglevel>]
+                 [-ep |--experimental-provider <name>] |
+                 [-eb |--egress-gw-separate-bridge]
                  [-h]]
 
 -cf  | --config-file               Name of the KIND J2 configuration file.
@@ -114,7 +116,7 @@ usage: kind.sh [[[-cf |--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]
                                    github CI to be updated with IPv6 settings.
                                    DEFAULT: Don't allow.
 -gm  | --gateway-mode              Enable 'shared' or 'local' gateway mode.
-                                   DEFAULT: local.
+                                   DEFAULT: shared.
 -ov  | --ovn-image            	   Use the specified docker image instead of building locally. DEFAULT: local build.
 -ml  | --master-loglevel           Log level for ovnkube (master), DEFAULT: 5.
 -nl  | --node-loglevel             Log level for ovnkube (node), DEFAULT: 5
@@ -124,8 +126,9 @@ usage: kind.sh [[[-cf |--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]
 -sbl | --ovn-loglevel-sb           Log config for southboudn DB DEFAULT: '-vconsole:info -vfile:info'.
 -cl  | --ovn-loglevel-controller   Log config for ovn-controller DEFAULT: '-vconsole:info'.
 -dl  | --ovn-loglevel-nbctld       Log config for nbctl daemon DEFAULT: '-vconsole:info'.
+-ep  | --experimental-provider     Use an experimental OCI provider such as podman, instead of docker. DEFAULT: Disabled.
+-eb  | --egress-gw-separate-bridge The external gateway traffic uses a separate bridge.
 --delete                      	   Delete current cluster
-
 ```
 
 As seen above, if you do not specify any options the script will assume the default values.


### PR DESCRIPTION
Since the future is SGW, let's make this the default when creating KIND clusters.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>