### PR TITLE
Dont print pod retries if not scheduled

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -435,6 +435,9 @@ func (oc *Controller) iterateRetryPods() {
 	now := time.Now()
 	for uid, podEntry := range oc.retryPods {
 		pod := podEntry.pod
+		if !util.PodScheduled(pod) {
+			return
+		}
 		podTimer := podEntry.timeStamp.Add(time.Minute)
 		if now.After(podTimer) {
 			podDesc := fmt.Sprintf("[%s/%s/%s]", pod.UID, pod.Namespace, pod.Name)


### PR DESCRIPTION
We see at scale when a lot of pods are in pending state and not
scheduled to a node that we print useless logging that overflows the
ovnkube-master log:

I0720 21:10:45.781776       1 ovn.go:411] [54fbd32c-ea9d-4c8d-8ece-79f38d05024c/cluster-density-40bc6f73-be12-47be-a9ab-35dfe59adbe8-469/cluster-density-2-1-build] retry pod setup
I0720 21:10:45.781796       1 ovn.go:417] [54fbd32c-ea9d-4c8d-8ece-79f38d05024c/cluster-density-40bc6f73-be12-47be-a9ab-35dfe59adbe8-469/cluster-density-2-1-build] setup retry failed; will try again later
I0720 21:10:45.781802       1 ovn.go:411] [fa4d74f7-6504-4c0b-97c6-75ccddcb2bb9/cluster-density-40bc6f73-be12-47be-a9ab-35dfe59adbe8-119/deployment-2pod-1-7c7b46d4f4-kk4dv] retry pod setup
I0720 21:10:45.781806       1 ovn.go:417] [fa4d74f7-6504-4c0b-97c6-75ccddcb2bb9/cluster-density-40bc6f73-be12-47be-a9ab-35dfe59adbe8-119/deployment-2pod-1-7c7b46d4f4-kk4dv] setup retry failed; will try again later

Signed-off-by: Tim Rozet <trozet@redhat.com>

