### PR TITLE
Move Geneve header length constants into types package

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -527,9 +527,6 @@ func (n *OvnNode) WatchEndpoints() {
 // is not big enough, it will taint the node with the value of
 // `types.OvnK8sSmallMTUTaintKey`
 func (n *OvnNode) validateGatewayMTU(gatewayInterfaceName string) error {
-	// TODO: find a better place for these constants
-	const geneveHeaderLengthIPv4 = 58 // https://github.com/openshift/cluster-network-operator/pull/720#issuecomment-664020823
-	const geneveHeaderLengthIPv6 = geneveHeaderLengthIPv4 + 20
 	tooSmallMTUTaint := &kapi.Taint{Key: types.OvnK8sSmallMTUTaintKey, Effect: kapi.TaintEffectNoSchedule}
 
 	mtu, err := util.GetNetworkInterfaceMTU(gatewayInterfaceName)
@@ -541,10 +538,10 @@ func (n *OvnNode) validateGatewayMTU(gatewayInterfaceName string) error {
 	var requiredMTU int
 	if config.IPv4Mode && !config.IPv6Mode {
 		// we run in single-stack IPv4 only
-		requiredMTU = config.Default.MTU + geneveHeaderLengthIPv4
+		requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv4
 	} else {
 		// we run in single-stack IPv6 or dual-stack mode
-		requiredMTU = config.Default.MTU + geneveHeaderLengthIPv6
+		requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv6
 	}
 
 	// check if node needs to be tainted

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	netlink_mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	utilMocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
 	kapi "k8s.io/api/core/v1"
@@ -35,14 +36,10 @@ var _ = Describe("Node", func() {
 			nodeName = "my-node"
 			linkName = "breth0"
 
-			// TODO take constants from node.go
-			geneveHeaderLengthIPv4 = 58
-			geneveHeaderLengthIPv6 = geneveHeaderLengthIPv4 + 20
-
 			configDefaultMTU               = 1500 //value for config.Default.MTU
-			mtuTooSmallForIPv4AndIPv6      = configDefaultMTU + geneveHeaderLengthIPv4 - 1
-			mtuOkForIPv4ButTooSmallForIPv6 = configDefaultMTU + geneveHeaderLengthIPv4
-			mtuOkForIPv4AndIPv6            = configDefaultMTU + geneveHeaderLengthIPv6
+			mtuTooSmallForIPv4AndIPv6      = configDefaultMTU + types.GeneveHeaderLengthIPv4 - 1
+			mtuOkForIPv4ButTooSmallForIPv6 = configDefaultMTU + types.GeneveHeaderLengthIPv4
+			mtuOkForIPv4AndIPv6            = configDefaultMTU + types.GeneveHeaderLengthIPv6
 		)
 
 		BeforeEach(func() {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -121,4 +121,9 @@ const (
 	NodeModeFull         = "full"
 	NodeModeSmartNIC     = "smart-nic"
 	NodeModeSmartNICHost = "smart-nic-host"
+
+	// Geneve header length for IPv4 (https://github.com/openshift/cluster-network-operator/pull/720#issuecomment-664020823)
+	GeneveHeaderLengthIPv4 = 58
+	// Geneve header length for IPv6 (https://github.com/openshift/cluster-network-operator/pull/720#issuecomment-664020823)
+	GeneveHeaderLengthIPv6 = GeneveHeaderLengthIPv4 + 20
 )


### PR DESCRIPTION
**- What this PR does and why is it needed**
Moves Geneve header length constants into `types` package

**- Special notes for reviewers**
Only a small cleanup

**- How to verify it**
No functional change so unit tests should pass

**- Description for the changelog**
none