### PR TITLE
 kind.sh: Check for pod object creation

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -551,6 +551,24 @@ install_ingress() {
 }
 
 kubectl_wait_pods() {
+  echo "Waiting for k8s to create ovn-kubernetes pod resources..."
+  local PODS_CREATED=false
+  for i in {1..10}; do
+    local NUM_PODS=$(kubectl -n ovn-kubernetes get pods -o json 2> /dev/null | jq '.items | length')
+    if [[ "${NUM_PODS}" -ne 0 ]]; then
+      echo "ovn-kubernetes pods created."
+      PODS_CREATED=true
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "${PODS_CREATED}" == false ]]; then
+    echo "ovn-kubernetes pods were not created."
+    exit 1
+  fi
+  echo "ovn-kubernetes pods created."
+
   # Check that everything is fine and running. IPv6 cluster seems to take a little
   # longer to come up, so extend the wait time.
   OVN_TIMEOUT=300s


### PR DESCRIPTION
On some systems we may reach this point before
k8s gets the chance to actually create the pods

This causes the check for pod readiness in ovn-kubernetes
namespace to fail with "error: no matching resources found"
as no pods will be present.

Add an initial sleep to allow k8s controllers to create
the relevant (sub)resources

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->