### PR TITLE
DBChecker: reconcile the election timeouts when specified

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -314,8 +314,8 @@ type OvnAuthConfig struct {
 	CACert         string `gcfg:"client-cacert"`
 	CertCommonName string `gcfg:"cert-common-name"`
 	Scheme         OvnDBScheme
-
-	northbound bool
+	ElectionTimer  uint `gcfg:"election-timer"`
+	northbound     bool
 
 	exec kexec.Interface
 }
@@ -868,6 +868,11 @@ var OvnNBFlags = []cli.Flag{
 			"SAN extension, this parameter should match one of the SAN fields.",
 		Destination: &cliConfig.OvnNorth.CertCommonName,
 	},
+	&cli.UintFlag{
+		Name:        "nb-raft-election-timer",
+		Usage:       "The desired northbound database election timer.",
+		Destination: &cliConfig.OvnNorth.ElectionTimer,
+	},
 }
 
 //OvnSBFlags capture OVN southbound database options
@@ -904,6 +909,11 @@ var OvnSBFlags = []cli.Flag{
 			"should match the DNS(hostname) of the server. In case the certificate has a " +
 			"SAN extension, this parameter should match one of the SAN fields.",
 		Destination: &cliConfig.OvnSouth.CertCommonName,
+	},
+	&cli.UintFlag{
+		Name:        "sb-raft-election-timer",
+		Usage:       "The desired southbound database election timer.",
+		Destination: &cliConfig.OvnSouth.ElectionTimer,
 	},
 }
 

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -25,6 +26,13 @@ import (
 var nbClusterStatusRetryCnt, sbClusterStatusRetryCnt int32
 
 const maxClusterStatusRetry = 10
+
+type dbProperties struct {
+	appCtl                func(args ...string) (string, string, error)
+	dbName                string
+	electionTimer         int
+	clusterStatusRetryCnt *int32
+}
 
 func RunDBChecker(kclient kube.Interface, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
@@ -65,6 +73,7 @@ func ensureOvnDBState(db string, kclient kube.Interface, stopCh <-chan struct{})
 			}
 		}
 	}
+	properties := propertiesForDB(db)
 
 	for {
 		select {
@@ -72,6 +81,9 @@ func ensureOvnDBState(db string, kclient kube.Interface, stopCh <-chan struct{})
 			klog.V(5).Infof("Ensure routines for Raft db: %s kicked off by ticker", db)
 			ensureLocalRaftServerID(db)
 			ensureClusterRaftMembership(db, kclient)
+			if properties.electionTimer != 0 {
+				ensureElectionTimeout(properties)
+			}
 		case <-stopCh:
 			ticker.Stop()
 			return
@@ -243,6 +255,56 @@ func ensureClusterRaftMembership(db string, kclient kube.Interface) {
 	}
 }
 
+// ensureClusterRaftMembership ensures there are no unknown members in the current Raft cluster
+func ensureElectionTimeout(db *dbProperties) {
+	out, stderr, err := db.appCtl("cluster/status", db.dbName)
+	if err != nil {
+		klog.Warningf("Unable to get cluster status for: %s, stderr: %v, err: %v", db, stderr, err)
+		if atomic.LoadInt32(db.clusterStatusRetryCnt) > maxClusterStatusRetry {
+			//delete the db file and start master
+			atomic.StoreInt32(db.clusterStatusRetryCnt, 0)
+		} else {
+			atomic.AddInt32(db.clusterStatusRetryCnt, 1)
+			klog.Infof("Failed to get cluster status for: %s, number of retries: %d", db, *db.clusterStatusRetryCnt)
+		}
+		return
+	}
+	// on retrieving cluster/status successfully reset the retry counter.
+	atomic.StoreInt32(db.clusterStatusRetryCnt, 0)
+
+	if !strings.Contains(out, "Role: leader") { // we only update on the leader
+		return
+	}
+
+	r, _ := regexp.Compile(`Election timer: (\d+)`)
+	match := r.FindStringSubmatch(out)
+	if len(match) < 2 {
+		klog.Infof("Failed to get current election timer for %s from status", db.dbName)
+		return
+	}
+	currentElectionTimer, err := strconv.Atoi(match[1])
+	if err != nil {
+		klog.Infof("Failed to convert election timer %v for %s", match[2], db.dbName)
+		return
+	}
+	if currentElectionTimer == db.electionTimer {
+		return
+	}
+
+	max_election_timer := currentElectionTimer * 2
+	if db.electionTimer <= max_election_timer {
+		_, stderr, err := db.appCtl("cluster/change-election-timer", db.dbName, fmt.Sprint(db.electionTimer))
+		if err != nil {
+			klog.Infof("Failed to change election timer for %s %v %v", db.dbName, err, stderr)
+		}
+		return
+	}
+	_, stderr, err = db.appCtl("cluster/change-election-timer", db.dbName, fmt.Sprint(max_election_timer))
+	if err != nil {
+		klog.Infof("Failed to change election timer for %s %v %v", db.dbName, err, stderr)
+	}
+}
+
 func resetRaftDB(db string) {
 	// backup the db by renaming it and then stop the nb/sb ovsdb process.
 	dbFile := filepath.Base(db)
@@ -293,4 +355,21 @@ func EnableDBMemTrimming() error {
 		return fmt.Errorf("unable to turn on memory trimming for SB DB, stderr: %s, error: %v", stderr, err)
 	}
 	return nil
+}
+
+func propertiesForDB(db string) *dbProperties {
+	if strings.Contains(db, "ovnsb") {
+		return &dbProperties{
+			electionTimer:         int(config.OvnNorth.ElectionTimer) * 1000,
+			appCtl:                util.RunOVNNBAppCtl,
+			dbName:                "OVN_Northbound",
+			clusterStatusRetryCnt: &nbClusterStatusRetryCnt,
+		}
+	}
+	return &dbProperties{
+		electionTimer:         int(config.OvnSouth.ElectionTimer) * 1000,
+		appCtl:                util.RunOVNSBAppCtl,
+		dbName:                "OVN_Southbound",
+		clusterStatusRetryCnt: &sbClusterStatusRetryCnt,
+	}
 }

--- a/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
@@ -1,0 +1,135 @@
+package ovndbmanager
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type mockRes struct {
+	res    string
+	stderr string
+	err    error
+	called bool
+}
+
+const status_template = `87f0
+Name: OVN_Northbound
+Cluster ID: f832 (f832bbff-e28c-4656-83f0-075e91a7ab8f)
+Server ID: 87f0 (87f0d686-8a8d-4585-9513-45efac449101)
+Address: ssl:10.1.1.185:9643
+Status: cluster member
+Role: %s
+Term: 4
+Leader: bbf6
+Vote: unknown
+
+Election timer: %s
+Log: [19418, 26772]
+Entries not yet committed: 0
+Entries not yet applied: 0
+Connections: ->bbf6 ->ad31 <-bbf6 <-ad31
+Disconnections: 1
+Servers:
+    87f0 (87f0 at ssl:10.1.1.185:9643) (self)
+    bbf6 (bbf6 at ssl:10.1.1.218:9643) last msg 2757 ms ago
+    ad31 (ad31 at ssl:10.1.1.211:9643) last msg 153868958 ms ago`
+
+func TestElectionTimer(t *testing.T) {
+	var mockCalls map[string]*mockRes
+	var unexpectedKeys []string
+	mock := func(args ...string) (string, string, error) {
+		key := keyForArgs(args...)
+		res, ok := mockCalls[key]
+		if !ok {
+			unexpectedKeys = append(unexpectedKeys, key)
+			return "", "key not found", fmt.Errorf("key not found")
+		}
+		res.called = true
+		return res.res, res.stderr, res.err
+	}
+
+	db := &dbProperties{
+		appCtl:                mock,
+		dbName:                "OVN_Northbound",
+		clusterStatusRetryCnt: &nbClusterStatusRetryCnt,
+	}
+	tests := []struct {
+		desc         string
+		mockCalls    map[string]*mockRes
+		timeout      int
+		role         string
+		currentTimer string
+	}{
+		{
+			"Follower, not trying to change",
+			map[string]*mockRes{},
+			1000,
+			"follower",
+			"10000",
+		},
+		{
+			"leader, timer doesn't change",
+			map[string]*mockRes{},
+			1000,
+			"leader",
+			"1000",
+		},
+		{
+			"leader, timer must change",
+			map[string]*mockRes{
+				keyForArgs("cluster/change-election-timer", "OVN_Northbound", "2000"): {
+					res:    "change of election timer initiated",
+					stderr: "",
+					err:    nil,
+				},
+			},
+			2000,
+			"leader",
+			"1500",
+		},
+		{
+			"leader, timer must change but desired is more than double",
+			map[string]*mockRes{
+				keyForArgs("cluster/change-election-timer", "OVN_Northbound", "3000"): {
+					res:    "change of election timer initiated",
+					stderr: "",
+					err:    nil,
+				},
+			},
+			5000,
+			"leader",
+			"1500",
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			mockCalls = map[string]*mockRes{
+				keyForArgs("cluster/status", "OVN_Northbound"): {
+					res:    fmt.Sprintf(status_template, tc.role, tc.currentTimer),
+					stderr: "",
+					err:    nil,
+				},
+			}
+			for k, v := range tc.mockCalls {
+				mockCalls[k] = v
+			}
+
+			unexpectedKeys = make([]string, 0)
+			db.electionTimer = tc.timeout
+			ensureElectionTimeout(db)
+			for k, c := range tc.mockCalls {
+				if !c.called {
+					t.Errorf("Expecting call with args %s", k)
+				}
+			}
+			if len(unexpectedKeys) > 0 {
+				t.Errorf("Received unexpected calls %v", unexpectedKeys)
+			}
+		})
+	}
+}
+
+func keyForArgs(args ...string) string {
+	return strings.Join(args, "-")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

We may want to update the ovn election timers, and in order to do that
we need to act asynchronously because the election must be completed and
the change must be performed on the leader node. So, we add two optional
parameters for the desired election timer and we change that as part of
the db checker timer.


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->