### PR TITLE
Reactive acl logging

### DIFF
--- a/go-controller/pkg/ovn/libovsdbops/acl.go
+++ b/go-controller/pkg/ovn/libovsdbops/acl.go
@@ -147,30 +147,32 @@ func CreateOrUpdateACLs(nbClient libovsdbclient.Client, acls ...*nbdb.ACL) error
 	return err
 }
 
-func UpdateACLLoggingOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, acl *nbdb.ACL) ([]libovsdb.Operation, error) {
+func UpdateACLsLoggingOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, acls ...*nbdb.ACL) ([]libovsdb.Operation, error) {
 	if ops == nil {
 		ops = []libovsdb.Operation{}
 	}
 
-	err := findACL(nbClient, acl)
-	if err != nil {
-		return nil, err
-	}
+	for _, acl := range acls {
+		err := findACL(nbClient, acl)
+		if err != nil {
+			return nil, err
+		}
 
-	uuid := acl.UUID
-	acl.UUID = ""
-	op, err := nbClient.Where(&nbdb.ACL{UUID: uuid}).Update(acl, &acl.Severity, &acl.Log)
-	if err != nil {
-		return nil, err
+		uuid := acl.UUID
+		acl.UUID = ""
+		op, err := nbClient.Where(&nbdb.ACL{UUID: uuid}).Update(acl, &acl.Severity, &acl.Log)
+		if err != nil {
+			return nil, err
+		}
+		ops = append(ops, op...)
+		acl.UUID = uuid
 	}
-	ops = append(ops, op...)
-	acl.UUID = uuid
 
 	return ops, nil
 }
 
 func UpdateACLLogging(nbClient libovsdbclient.Client, acl *nbdb.ACL) error {
-	ops, err := UpdateACLLoggingOps(nbClient, nil, acl)
+	ops, err := UpdateACLsLoggingOps(nbClient, nil, acl)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -298,7 +298,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 	if aclAnnotation != oldACLAnnotation && (oc.aclLoggingCanEnable(aclAnnotation, nsInfo) || aclAnnotation == "") &&
 		len(nsInfo.networkPolicies) > 0 {
 		// deny rules are all one per namespace
-		if err := oc.setACLDenyLogging(old.Name, nsInfo, nsInfo.aclLogging.Deny); err != nil {
+		if err := oc.setACLLoggingForNamespace(old.Name, nsInfo, nsInfo.aclLogging); err != nil {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Namespace %s: ACL logging setting updated to deny=%s allow=%s",

--- a/test/e2e/acl_logging.go
+++ b/test/e2e/acl_logging.go
@@ -1,0 +1,164 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	knet "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	logSeverityNamespaceAnnotation = "k8s.ovn.org/acl-logging"
+	maxPokeRetries                 = 15
+	ovnControllerLogPath           = "/var/log/openvswitch/ovn-controller.log"
+	pokeInterval                   = 1 * time.Second
+)
+
+var _ = Describe("ACL Logging", func() {
+	const (
+		denyAllPolicyName       = "default-deny-all"
+		initialDenyACLSeverity  = "alert"
+		initialAllowACLSeverity = "notice"
+		namespacePrefix         = "acl-logging"
+		pokerPodIndex           = 0
+		pokedPodIndex           = 1
+	)
+
+	fr := framework.NewDefaultFramework(namespacePrefix)
+
+	var (
+		nsName string
+		pods   []v1.Pod
+	)
+
+	setNamespaceACLLogSeverity := func(namespaceToUpdate *v1.Namespace, desiredDenyLogLevel string, desiredAllowLogLevel string) error {
+		if namespaceToUpdate.ObjectMeta.Annotations == nil {
+			namespaceToUpdate.ObjectMeta.Annotations = map[string]string{}
+		}
+		By("updating the namespace's ACL logging severity")
+		updatedLogSeverity := fmt.Sprintf(`{ "deny": "%s", "allow": "%s" }`, desiredDenyLogLevel, desiredAllowLogLevel)
+		namespaceToUpdate.Annotations[logSeverityNamespaceAnnotation] = updatedLogSeverity
+
+		_, err := fr.ClientSet.CoreV1().Namespaces().Update(context.TODO(), namespaceToUpdate, metav1.UpdateOptions{})
+		return err
+	}
+
+	BeforeEach(func() {
+		By("configuring the ACL logging level within the namespace")
+		nsName = fr.Namespace.Name
+		namespace, err := fr.ClientSet.CoreV1().Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), "failed to retrieve the namespace")
+		Expect(setNamespaceACLLogSeverity(namespace, initialDenyACLSeverity, initialAllowACLSeverity)).To(Succeed())
+
+		By("creating a \"default deny\" network policy")
+		_, err = makeDenyAllPolicy(fr, nsName, denyAllPolicyName)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating pods")
+		cmd := []string{"/bin/bash", "-c", "/agnhost netexec --http-port 8000"}
+		for i := 0; i < 2; i++ {
+			pod := newAgnhostPod(fmt.Sprintf("pod%d", i+1), cmd...)
+			pod = fr.PodClient().CreateSync(pod)
+			Expect(waitForACLLoggingPod(fr, nsName, pod.GetName())).To(Succeed())
+			pods = append(pods, *pod)
+		}
+
+		By("sending traffic between acl-logging test pods we trigger ACL logging")
+		clientPod := pods[pokerPodIndex]
+		pokedPod := pods[pokedPodIndex]
+		framework.Logf(
+			"Poke pod %s (on node %s) from pod %s (on node %s)",
+			pokedPod.GetName(),
+			pokedPod.Spec.NodeName,
+			clientPod.GetName(),
+			clientPod.Spec.NodeName)
+		Expect(
+			pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
+			"traffic should be blocked since we only use a deny all traffic policy")
+	})
+
+	AfterEach(func() {
+		pods = nil
+	})
+
+	It("the logs have the expected log level", func() {
+		clientPodScheduledPodName := pods[pokerPodIndex].Spec.NodeName
+		// Retry here in the case where OVN acls have not been programmed yet
+		Eventually(func() (bool, error) {
+			return assertDenyLogs(
+				clientPodScheduledPodName,
+				nsName,
+				denyAllPolicyName,
+				initialDenyACLSeverity)
+		}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+	})
+
+	When("the namespace's ACL logging annotation is updated", func() {
+		const updatedAllowACLLogSeverity = "debug"
+
+		BeforeEach(func() {
+			By(fmt.Sprintf("updating the namespace's ACL logging level to %s", updatedAllowACLLogSeverity))
+
+			namespace, err := fr.ClientSet.CoreV1().Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to retrieve the namespace")
+			Expect(setNamespaceACLLogSeverity(namespace, updatedAllowACLLogSeverity, updatedAllowACLLogSeverity)).To(Succeed())
+			namespace, err = fr.ClientSet.CoreV1().Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
+		})
+
+		BeforeEach(func() {
+			By("poking some more...")
+			clientPod := pods[pokerPodIndex]
+			pokedPod := pods[pokedPodIndex]
+
+			framework.Logf(
+				"Poke pod %s (on node %s) from pod %s (on node %s)",
+				pokedPod.GetName(),
+				pokedPod.Spec.NodeName,
+				clientPod.GetName(),
+				clientPod.Spec.NodeName)
+			Expect(
+				pokePod(fr, clientPod.GetName(), pokedPod.Status.PodIP)).To(HaveOccurred(),
+				"traffic should be blocked since we only use a deny all traffic policy")
+		})
+
+		It("the ACL logs are updated accordingly", func() {
+			clientPodScheduledPodName := pods[pokerPodIndex].Spec.NodeName
+			Eventually(func() (bool, error) {
+				return assertDenyLogs(
+					clientPodScheduledPodName,
+					nsName,
+					denyAllPolicyName,
+					updatedAllowACLLogSeverity)
+			}, maxPokeRetries*pokeInterval, pokeInterval).Should(BeTrue())
+		})
+	})
+})
+
+func makeDenyAllPolicy(f *framework.Framework, ns string, policyName string) (*knet.NetworkPolicy, error) {
+	policy := &knet.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Spec: knet.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []knet.PolicyType{knet.PolicyTypeEgress, knet.PolicyTypeIngress},
+			Ingress:     []knet.NetworkPolicyIngressRule{},
+			Egress:      []knet.NetworkPolicyEgressRule{},
+		},
+	}
+	return f.ClientSet.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), policy, metav1.CreateOptions{})
+}
+
+func waitForACLLoggingPod(f *framework.Framework, namespace string, podName string) error {
+	return e2epod.WaitForPodCondition(f.ClientSet, namespace, podName, "running", 5*time.Second, func(pod *v1.Pod) (bool, error) {
+		podIP := pod.Status.PodIP
+		return podIP != "" && pod.Status.Phase != v1.PodPending, nil
+	})
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR updates the ACL logging configuration as a reaction to namespace updates.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
closes #2340

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

Provision the following yaml:
```yaml
---
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    k8s.ovn.org/acl-logging: '{ "deny": "alert", "allow": "notice" }'
  name: tenantA
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: cidr-block
  namespace: tenantA
spec:
  podSelector: {}
  policyTypes:
  - Ingress
  - Egress
  ingress:
  - from:
    - ipBlock:
        cidr: 172.17.0.0/16

```
Update the ACL log levels in the namespace annotation:
```
cat <<EOF | kubectl create -f -
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    k8s.ovn.org/acl-logging: '{ "deny": "debug", "allow": "debug" }'
  name: tenantA
EOF
```
Check the namespace's logging level (it should feature `debug`):
```
kubectl get namespace tenantA -o jsonpath="{.metadata.annotations.k8s\.ovn\.org/acl-logging}"
{ "deny": "debug", "allow": "debug" } # expected
```

Check the OVN ACLs `severity` column value:
```
kubectl exec -n ovn-kubernetes <ovn kube master pod name> -- \
    /usr/bin/ovn-nbctl --columns=name,log,severity list ACL tenantA_only-from-default-ns_0 tenantA_cidr-block_0
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Dynamically update the ACL logging configuration per individual namespaces, for provisioned network policies.
