### PR TITLE
[WIP] Add the possibility to disable onvkube-masters leader election

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -293,8 +293,10 @@ set_default_params() {
   if [ "$OVN_HA" == true ]; then
     KIND_NUM_MASTER=3
     KIND_NUM_WORKER=${KIND_NUM_WORKER:-0}
+    OVN_DISABLE_LEADER_ELECTION=false
   else
     KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}
+    OVN_DISABLE_LEADER_ELECTION=true
   fi
   OVN_HOST_NETWORK_NAMESPACE=${OVN_HOST_NETWORK_NAMESPACE:-ovn-host-network}
   OCI_BIN=${KIND_EXPERIMENTAL_PROVIDER:-docker}
@@ -490,6 +492,7 @@ create_ovn_kube_manifests() {
     --multicast-enabled="${OVN_MULTICAST_ENABLE}" \
     --k8s-apiserver="${API_URL}" \
     --ovn-master-count="${KIND_NUM_MASTER}" \
+    --ovn-disable-leader-election="${OVN_DISABLE_LEADER_ELECTION}" \
     --ovn-unprivileged-mode=no \
     --master-loglevel="${MASTER_LOG_LEVEL}" \
     --node-loglevel="${NODE_LOG_LEVEL}" \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -50,6 +50,7 @@ OVN_IPFIX_TARGETS=""
 OVN_HOST_NETWORK_NAMESPACE=""
 OVN_EX_GW_NETWORK_INTERFACE=""
 OVNKUBE_NODE_MGMT_PORT_NETDEV=""
+OVN_DISABLE_LEADER_ELECTION=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -133,6 +134,9 @@ while [ "$1" != "" ]; do
     ;;
   --ovn-master-count)
     OVN_MASTER_COUNT=$VALUE
+    ;;
+  --ovn-disable-leader-election)
+    OVN_DISABLE_LEADER_ELECTION=$VALUE
     ;;
   --ovn-nb-port)
     OVN_NB_PORT=$VALUE
@@ -373,6 +377,7 @@ ovn_image=${image} \
   ovn_master_count=${ovn_master_count} \
   ovn_gateway_mode=${ovn_gateway_mode} \
   ovn_ex_gw_networking_interface=${ovn_ex_gw_networking_interface} \
+  ovn_disable_leader_election=${OVN_DISABLE_LEADER_ELECTION} \
   j2 ../templates/ovnkube-master.yaml.j2 -o ../yaml/ovnkube-master.yaml
 
 ovn_image=${image} \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -265,6 +265,8 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: host_network_namespace
+        - name: OVN_DISABLE_LEADER_ELECTION
+          value: "{{ ovn_disable_leader_election }}"
       # end of container
 
       volumes:

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -253,7 +253,7 @@ func runOvnKube(ctx *cli.Context) error {
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil,
 			ovnNBClient, ovnSBClient, libovsdbOvnNBClient, libovsdbOvnSBClient, util.EventRecorder(ovnClientset.KubeClient))
-		if err := ovnController.Start(master, wg, ctx.Context); err != nil {
+		if err := ovnController.Start(ctx.Context, master, wg); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -120,6 +120,7 @@ var (
 		ElectionLeaseDuration: 60,
 		ElectionRenewDeadline: 30,
 		ElectionRetryPeriod:   20,
+		DisableLeaderElection: false,
 	}
 
 	// HybridOverlay holds hybrid overlay feature config options.
@@ -329,9 +330,10 @@ type OvnAuthConfig struct {
 // MasterHAConfig holds configuration for master HA
 // configuration.
 type MasterHAConfig struct {
-	ElectionLeaseDuration int `gcfg:"election-lease-duration"`
-	ElectionRenewDeadline int `gcfg:"election-renew-deadline"`
-	ElectionRetryPeriod   int `gcfg:"election-retry-period"`
+	ElectionLeaseDuration int  `gcfg:"election-lease-duration"`
+	ElectionRenewDeadline int  `gcfg:"election-renew-deadline"`
+	ElectionRetryPeriod   int  `gcfg:"election-retry-period"`
+	DisableLeaderElection bool `gcfg:"disable-leader-election"`
 }
 
 // HybridOverlayConfig holds configuration for hybrid overlay
@@ -1018,6 +1020,12 @@ var MasterHAFlags = []cli.Flag{
 		Destination: &cliConfig.MasterHA.ElectionRetryPeriod,
 		Value:       MasterHA.ElectionRetryPeriod,
 	},
+	&cli.BoolFlag{
+		Name:        "ha-disable-leader-election",
+		Usage:       "Disable leader election (default: false). Must only be used in case of a single master.",
+		Destination: &cliConfig.MasterHA.DisableLeaderElection,
+		Value:       MasterHA.DisableLeaderElection,
+	},
 }
 
 // HybridOverlayFlats capture hybrid overlay feature options
@@ -1633,6 +1641,7 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 	klog.V(5).Infof("OVN South config: %+v", OvnSouth)
 	klog.V(5).Infof("Hybrid Overlay config: %+v", HybridOverlay)
 	klog.V(5).Infof("Ovnkube Node config: %+v", OvnKubeNode)
+	klog.V(5).Infof("MasterHA config: %+v", MasterHA)
 
 	return retConfigFile, nil
 }


### PR DESCRIPTION
**- What this PR does and why is it needed**

ovnkube-master uses leader election even in the case there is only one master and actually "nothing" to elect. This PR adds the possibility to disable the leader election by using the cli flag `ha-disable-leader-election`. 
So for example in case of a SNO during an api server rollout, the api server could be down long enough, so ovnkube decides it no longer has the lock and then exits. In this case you would get an ovn-kube outage on top of your apiserver outage.

**- Special notes for reviewers**

Changed `Controller.Start()` to check the new config parameter (`MasterHA.DisableLeaderElection`), if it should start with leader election, or without.

**- How to verify it**
* Option 1: 
  * since I updated the kind script to set the `--ha-disable-leader-election` flag in case of `OVN_HA=false` (which is default), you can simply start a kind cluster. 
  * The logs of ovnkube-master should log that it is running without leader election:
     ```
     ...
     I0727 10:37:03.002371      56 master.go:64] Start without leader election
     ...
     ```
  * If you start kind with `OVN_HA=true ./kind.sh`, it should bring up a kind cluster with ovn in ha mode and enabled leader election. This can be verified in the logs of one of the ovnkube-masters.
* Option 2:
  * Add the following to a configmap, mount it into the container and reference it as config:
    ```
    [masterha]
    disable-leader-election=true
    ```
**- Description for the changelog**
Allow to disable leader election of onvkube-master