### PR TITLE
hybrid-overlay: ensure that named networks are valid for Windows

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_windows.go
@@ -99,7 +99,7 @@ func ensureBaseNetwork() error {
 	_, fakeSubnetCIDR, _ := net.ParseCIDR("100.64.0.0/30")
 	fakeSubnetGateway := net.ParseIP("100.64.0.2")
 
-	baseNetwork := GetExistingNetwork(baseNetworkName, fakeSubnetCIDR.String(), fakeSubnetGateway.String())
+	baseNetwork := EnsureExistingNetworkIsValid(baseNetworkName, fakeSubnetCIDR.String(), fakeSubnetGateway.String())
 	if baseNetwork != nil {
 		// nothing to do
 		return nil
@@ -256,7 +256,7 @@ func (n *NodeController) initSelf(node *kapi.Node, nodeSubnet *net.IPNet) error 
 		return fmt.Errorf("the hybrid overlay VXLAN port cannot be greater than 65535. Current value: %v", config.HybridOverlay.VXLANPort)
 	}
 
-	network := GetExistingNetwork(networkName, nodeSubnet.String(), gatewayAddress.String())
+	network := EnsureExistingNetworkIsValid(networkName, nodeSubnet.String(), gatewayAddress.String())
 	if network == nil {
 		// Create the overlay network
 		networkInfo := NetworkInfo{

--- a/go-controller/hybrid-overlay/pkg/controller/overlay_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/overlay_windows.go
@@ -241,7 +241,9 @@ func GetGatewayAddress(subnet *hcn.Subnet) string {
 	return ""
 }
 
-func GetExistingNetwork(networkName string, expectedAddressPrefix string, expectedGW string) *hcn.HostComputeNetwork {
+//EnsureExistingNetworkIsValid returns the existing network defined by the given network name is valid, if there is a network with the
+// given name that is invalid the network is deleted
+func EnsureExistingNetworkIsValid(networkName string, expectedAddressPrefix string, expectedGW string) *hcn.HostComputeNetwork {
 	existingNetwork, err := hcn.GetNetworkByName(networkName)
 	if err != nil || existingNetwork.Type != hcn.Overlay {
 		return nil
@@ -254,6 +256,11 @@ func GetExistingNetwork(networkName string, expectedAddressPrefix string, expect
 				return existingNetwork
 			}
 		}
+	}
+
+	if existingNetwork != nil {
+		// the named network already exists but the nodes subnet or GW has changed
+		existingNetwork.Delete()
 	}
 
 	return nil


### PR DESCRIPTION
Ensure that if a windows overlay network exists on node start that it is
valid for the node.

currently if a windows node is deleted and there is an attempt to recreate the node with the same name the node overlay network will fail to be created. This patch fixes that 

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

Reported at https://bugzilla.redhat.com/show_bug.cgi?id=1984201

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->