### PR TITLE
Add the default cluster name to upgrade.sh

### DIFF
--- a/test/scripts/upgrade-ovn.sh
+++ b/test/scripts/upgrade-ovn.sh
@@ -117,6 +117,7 @@ kubectl_wait_for_upgrade(){
 }
 
 ## This script is responsible to upgrade ovn daemonsets to run new pods with image built from a PR
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn} # Set default values
 install_ovn_image
 run_kubectl set image daemonsets.apps ovnkube-node ovnkube-node="${OVN_IMAGE}" ovs-metrics-exporter="${OVN_IMAGE}"  ovn-controller="${OVN_IMAGE}" -n ovn-kubernetes
 kubectl_wait_daemonset ovnkube-node


### PR DESCRIPTION
The script works fine when run from the makefile
for tests, since the cluster name is set in install-kind
script. For running it standalone, let's add "ovn"
as the default cluster-name.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

Helps solve:

```
./upgrade-ovn.sh 
+ export KUBECONFIG=/home/<name>/admin.conf
+ KUBECONFIG=/home/<name>/admin.conf
+ export OVN_IMAGE=ovn-daemonset-f:dev
+ OVN_IMAGE=ovn-daemonset-f:dev
+ install_ovn_image
+ kind load docker-image ovn-daemonset-f:dev --name ''
ERROR: no nodes found for cluster ""
```