### PR TITLE
libovsdb: matcher compare slices as sets

### DIFF
--- a/go-controller/pkg/testing/libovsdb/matchers.go
+++ b/go-controller/pkg/testing/libovsdb/matchers.go
@@ -3,7 +3,6 @@ package libovsdb
 import (
 	"fmt"
 	"reflect"
-	"sort"
 
 	"github.com/mitchellh/copystructure"
 	"github.com/onsi/gomega"
@@ -12,26 +11,14 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 )
 
-// isStringSetEqual compares a string slice as an unordered set
-func isStringSetEqual(x, y interface{}) bool {
-	xs, ok := x.([]string)
-	if !ok {
-		return false
+// isSetEqual compares a slice as an unordered set
+func isSetEqual(x, y interface{}) bool {
+	// used gomega for now
+	match, err := gomega.ConsistOf(x).Match(y)
+	if err != nil {
+		panic(err)
 	}
-	ys, ok := y.([]string)
-	if !ok {
-		return false
-	}
-	if len(xs) != len(ys) {
-		return false
-	}
-	xsc := make([]string, len(xs))
-	ysc := make([]string, len(ys))
-	copy(xsc, xs)
-	copy(ysc, ys)
-	sort.Strings(xsc)
-	sort.Strings(ysc)
-	return reflect.DeepEqual(xsc, ysc)
+	return match
 }
 
 // isUUIDSlice checks whether all values of the slice are uuids
@@ -127,7 +114,7 @@ func matchAndReplaceNamedUUIDs(actual, expected []TestData) {
 // - Expects input to be pointers to struct
 // - If ignoreUUIDs, strings, slices or maps that contain UUIDs are ignored. Slices
 //   and maps lengths are still checked to match.
-// - String slices are compared as an unordered set
+// - Slices are compared as an unordered set
 // - Otherwise reflect.DeepEqual is used.
 func testDataEqual(x, y TestData, ignoreUUIDs bool) bool {
 	if x == nil || y == nil {
@@ -175,7 +162,7 @@ func testDataEqual(x, y TestData, ignoreUUIDs bool) bool {
 					continue
 				}
 			}
-			if !isStringSetEqual(f1.Interface(), f2.Interface()) {
+			if !isSetEqual(f1.Interface(), f2.Interface()) {
 				return false
 			}
 			continue


### PR DESCRIPTION
**- What this PR does and why is it needed**

Now libovsdb matcher does not only compare string slices as string sets, it cmpares any slice as a set.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
