### PR TITLE
attempting to reduce cardinality in the interest of memory performance

### DIFF
--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -214,7 +214,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnAdd(e.obj)
 				})
-				metrics.MetricResourceUpdateLatency.WithLabelValues(name, "add").Observe(time.Since(start).Seconds())
+				metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -224,7 +224,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnUpdate(e.oldObj, e.obj)
 				})
-				metrics.MetricResourceUpdateLatency.WithLabelValues(name, "update").Observe(time.Since(start).Seconds())
+				metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 			})
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -239,7 +239,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnDelete(e.obj)
 				})
-				metrics.MetricResourceUpdateLatency.WithLabelValues(name, "delete").Observe(time.Since(start).Seconds())
+				metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 			})
 		},
 	}
@@ -254,7 +254,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			i.forEachHandler(obj, func(h *Handler) {
 				h.OnAdd(obj)
 			})
-			metrics.MetricResourceUpdateLatency.WithLabelValues(name, "add").Observe(time.Since(start).Seconds())
+			metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			metrics.MetricResourceUpdateCount.WithLabelValues(name, "update").Inc()
@@ -262,7 +262,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			i.forEachHandler(newObj, func(h *Handler) {
 				h.OnUpdate(oldObj, newObj)
 			})
-			metrics.MetricResourceUpdateLatency.WithLabelValues(name, "update").Observe(time.Since(start).Seconds())
+			metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 		},
 		DeleteFunc: func(obj interface{}) {
 			realObj, err := ensureObjectOnDelete(obj, i.oType)
@@ -275,7 +275,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			i.forEachHandler(realObj, func(h *Handler) {
 				h.OnDelete(realObj)
 			})
-			metrics.MetricResourceUpdateLatency.WithLabelValues(name, "delete").Observe(time.Since(start).Seconds())
+			metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 		},
 	}
 }

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -214,7 +214,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnAdd(e.obj)
 				})
-				metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
+				metrics.MetricResourceAddLatency.WithLabelValues(name, "add").Observe(time.Since(start).Seconds())
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -224,7 +224,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnUpdate(e.oldObj, e.obj)
 				})
-				metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
+				metrics.MetricResourceUpdateLatency.WithLabelValues(name, "update").Observe(time.Since(start).Seconds())
 			})
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -239,7 +239,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnDelete(e.obj)
 				})
-				metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
+				metrics.MetricResourceDeleteLatency.WithLabelValues(name, "delete").Observe(time.Since(start).Seconds())
 			})
 		},
 	}
@@ -254,7 +254,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			i.forEachHandler(obj, func(h *Handler) {
 				h.OnAdd(obj)
 			})
-			metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
+			metrics.MetricResourceAddLatency.WithLabelValues(name, "add").Observe(time.Since(start).Seconds())
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			metrics.MetricResourceUpdateCount.WithLabelValues(name, "update").Inc()
@@ -262,7 +262,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			i.forEachHandler(newObj, func(h *Handler) {
 				h.OnUpdate(oldObj, newObj)
 			})
-			metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
+			metrics.MetricResourceUpdateLatency.WithLabelValues(name, "update").Observe(time.Since(start).Seconds())
 		},
 		DeleteFunc: func(obj interface{}) {
 			realObj, err := ensureObjectOnDelete(obj, i.oType)
@@ -275,7 +275,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			i.forEachHandler(realObj, func(h *Handler) {
 				h.OnDelete(realObj)
 			})
-			metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
+			metrics.MetricResourceDeleteLatency.WithLabelValues(name, "delete").Observe(time.Since(start).Seconds())
 		},
 	}
 }

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -214,7 +214,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnAdd(e.obj)
 				})
-				metrics.MetricResourceAddLatency.WithLabelValues(name, "add").Observe(time.Since(start).Seconds())
+				metrics.MetricResourceAddLatency.Observe(time.Since(start).Seconds())
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -224,7 +224,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnUpdate(e.oldObj, e.obj)
 				})
-				metrics.MetricResourceUpdateLatency.WithLabelValues(name, "update").Observe(time.Since(start).Seconds())
+				metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 			})
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -239,7 +239,7 @@ func (i *informer) newFederatedQueuedHandler() cache.ResourceEventHandlerFuncs {
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnDelete(e.obj)
 				})
-				metrics.MetricResourceDeleteLatency.WithLabelValues(name, "delete").Observe(time.Since(start).Seconds())
+				metrics.MetricResourceDeleteLatency.Observe(time.Since(start).Seconds())
 			})
 		},
 	}
@@ -254,7 +254,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			i.forEachHandler(obj, func(h *Handler) {
 				h.OnAdd(obj)
 			})
-			metrics.MetricResourceAddLatency.WithLabelValues(name, "add").Observe(time.Since(start).Seconds())
+			metrics.MetricResourceAddLatency.Observe(time.Since(start).Seconds())
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			metrics.MetricResourceUpdateCount.WithLabelValues(name, "update").Inc()
@@ -262,7 +262,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			i.forEachHandler(newObj, func(h *Handler) {
 				h.OnUpdate(oldObj, newObj)
 			})
-			metrics.MetricResourceUpdateLatency.WithLabelValues(name, "update").Observe(time.Since(start).Seconds())
+			metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
 		},
 		DeleteFunc: func(obj interface{}) {
 			realObj, err := ensureObjectOnDelete(obj, i.oType)
@@ -275,7 +275,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			i.forEachHandler(realObj, func(h *Handler) {
 				h.OnDelete(realObj)
 			})
-			metrics.MetricResourceDeleteLatency.WithLabelValues(name, "delete").Observe(time.Since(start).Seconds())
+			metrics.MetricResourceDeleteLatency.Observe(time.Since(start).Seconds())
 		},
 	}
 }

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -60,44 +60,32 @@ var MetricResourceUpdateCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 
 // MetricResourceAddLatency is the time taken to complete resource update by an handler.
 // This measures the latency for all of the handlers for a given resource.
-var MetricResourceAddLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+var MetricResourceAddLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "resource_add_latency_seconds",
 	Help:      "The duration to process all handlers for a given resource event - add.",
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
-	[]string{
-		"name",
-		"event",
-	},
 )
 
 // MetricResourceUpdateLatency is the time taken to complete resource update by an handler.
 // This measures the latency for all of the handlers for a given resource.
-var MetricResourceUpdateLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+var MetricResourceUpdateLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "resource_update_latency_seconds",
 	Help:      "The duration to process all handlers for a given resource event - update.",
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
-	[]string{
-		"name",
-		"event",
-	},
 )
 
 // MetricResourceDeleteLatency is the time taken to complete resource update by an handler.
 // This measures the latency for all of the handlers for a given resource.
-var MetricResourceDeleteLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+var MetricResourceDeleteLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "resource_delete_latency_seconds",
 	Help:      "The duration to process all handlers for a given resource event - delete.",
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
-	[]string{
-		"name",
-		"event",
-	},
 )
 
 // MetricRequeueServiceCount is the number of times a particular service has been requeued.

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -60,16 +60,12 @@ var MetricResourceUpdateCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 
 // MetricResourceUpdateLatency is the time taken to complete resource update by an handler.
 // This measures the latency for all of the handlers for a given resource.
-var MetricResourceUpdateLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+var MetricResourceUpdateLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "resource_update_latency_seconds",
 	Help:      "The duration to process all handlers for a given resource event (add, update, or delete)",
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
-	[]string{
-		"name",
-		"event",
-	},
 )
 
 // MetricRequeueServiceCount is the number of times a particular service has been requeued.

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -58,14 +58,46 @@ var MetricResourceUpdateCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 	},
 )
 
+// MetricResourceAddLatency is the time taken to complete resource update by an handler.
+// This measures the latency for all of the handlers for a given resource.
+var MetricResourceAddLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "resource_add_latency_seconds",
+	Help:      "The duration to process all handlers for a given resource event - add.",
+	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
+	[]string{
+		"name",
+		"event",
+	},
+)
+
 // MetricResourceUpdateLatency is the time taken to complete resource update by an handler.
 // This measures the latency for all of the handlers for a given resource.
-var MetricResourceUpdateLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
+var MetricResourceUpdateLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "resource_update_latency_seconds",
-	Help:      "The duration to process all handlers for a given resource event (add, update, or delete)",
+	Help:      "The duration to process all handlers for a given resource event - update.",
 	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
+	[]string{
+		"name",
+		"event",
+	},
+)
+
+// MetricResourceDeleteLatency is the time taken to complete resource update by an handler.
+// This measures the latency for all of the handlers for a given resource.
+var MetricResourceDeleteLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "resource_delete_latency_seconds",
+	Help:      "The duration to process all handlers for a given resource event - delete.",
+	Buckets:   prometheus.ExponentialBuckets(.1, 2, 15)},
+	[]string{
+		"name",
+		"event",
+	},
 )
 
 // MetricRequeueServiceCount is the number of times a particular service has been requeued.

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -214,7 +214,9 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 		// this is to not to create circular import between metrics and util package
 		util.MetricOvnCliLatency = metricOvnCliLatency
 		prometheus.MustRegister(MetricResourceUpdateCount)
+		prometheus.MustRegister(MetricResourceAddLatency)
 		prometheus.MustRegister(MetricResourceUpdateLatency)
+		prometheus.MustRegister(MetricResourceDeleteLatency)
 		prometheus.MustRegister(MetricRequeueServiceCount)
 		prometheus.MustRegister(MetricSyncServiceCount)
 		prometheus.MustRegister(MetricSyncServiceLatency)


### PR DESCRIPTION

`resource_update_latency_seconds` metric creates hundreds of time series. We tested this against 120 worker cluster of OpenShift and in the spirit of trying to reduce cardinality as seen in #2279 from @aojea (and after consulting with him), this is a follow up PR along the similar lines.
![image](https://user-images.githubusercontent.com/8180469/127689587-360e59c1-f9e0-4a76-9ca1-81e1d8ebb0e4.png)


@girishmg @trozet  kindly review if this will be acceptable to change. Thank you.

xref:
https://blog.freshtracks.io/bomb-squad-automatic-detection-and-suppression-of-prometheus-cardinality-explosions-62ca8e02fa32

Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>
