### PR TITLE
Scale fixes

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -179,7 +179,7 @@ func cniRequestToPodRequest(cr *Request, podLister corev1listers.PodLister, kcli
 
 	req.CNIConf = conf
 	req.timestamp = time.Now()
-	req.ctx, req.cancel = context.WithCancel(context.Background())
+	req.ctx, req.cancel = context.WithTimeout(context.Background(), time.Minute)
 	return req, nil
 }
 
@@ -195,6 +195,8 @@ func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer req.cancel()
+
 	if s.mode == types.NodeModeSmartNICHost {
 		req.IsSmartNIC = true
 	}

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -203,7 +203,14 @@ func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
 		result = response.Result
 	} else {
 		// Use the IPAM details from ovnkube-node to configure the pod interface
-		pr, _ := cniRequestToPodRequest(req, nil, kclient)
+		pr, err := cniRequestToPodRequest(req, nil, kclient)
+		if err != nil {
+			err = fmt.Errorf("failed to create pod request: %v", err)
+			klog.Error(err.Error())
+			return err
+		}
+		defer pr.cancel()
+
 		result, err = pr.getCNIResult(nil, kclient, response.PodIFInfo)
 		if err != nil {
 			err = fmt.Errorf("failed to get CNI Result from pod interface info %v: %v", response.PodIFInfo, err)

--- a/go-controller/pkg/cni/cnismartnic_test.go
+++ b/go-controller/pkg/cni/cnismartnic_test.go
@@ -34,8 +34,6 @@ var _ = Describe("cnismartnic tests", func() {
 				DeviceID: "",
 			},
 			timestamp:  time.Time{},
-			ctx:        nil,
-			cancel:     nil,
 			IsSmartNIC: true,
 		}
 	})

--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -294,13 +294,15 @@ func waitForPodInterface(ctx context.Context, mac string, ifAddrs []*net.IPNet,
 	} else {
 		queries = getLegacyFlowQueries(mac, ifAddrs, ofPort)
 	}
-	timeout := time.After(20 * time.Second)
+
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("canceled waiting for OVS port binding for %s %v", mac, ifAddrs)
-		case <-timeout:
-			return fmt.Errorf("timed out waiting for OVS port binding%s for %s %v", detail, mac, ifAddrs)
+			errDetail := "timed out"
+			if ctx.Err() == context.Canceled {
+				errDetail = "canceled while"
+			}
+			return fmt.Errorf("%s waiting for OVS port binding%s for %s %v", errDetail, detail, mac, ifAddrs)
 		default:
 			if err := isIfaceIDSet(ifaceName, ifaceID); err != nil {
 				return err

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -62,7 +62,9 @@ const (
 	resyncInterval        = 0
 	handlerAlive   uint32 = 0
 	handlerDead    uint32 = 1
-	numEventQueues int    = 15
+
+	// namespace, node, and pod handlers
+	defaultNumEventQueues uint32 = 15
 )
 
 var (
@@ -123,7 +125,8 @@ func NewMasterWatchFactory(ovnClientset *util.OVNClientset) (*WatchFactory, erro
 	})
 
 	// Create our informer-wrapper informer (and underlying shared informer) for types we need
-	wf.informers[podType], err = newQueuedInformer(podType, wf.iFactory.Core().V1().Pods().Informer(), wf.stopChan)
+	wf.informers[podType], err = newQueuedInformer(podType, wf.iFactory.Core().V1().Pods().Informer(), wf.stopChan,
+		defaultNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
@@ -140,11 +143,12 @@ func NewMasterWatchFactory(ovnClientset *util.OVNClientset) (*WatchFactory, erro
 		return nil, err
 	}
 	wf.informers[namespaceType], err = newQueuedInformer(namespaceType, wf.iFactory.Core().V1().Namespaces().Informer(),
-		wf.stopChan)
+		wf.stopChan, defaultNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
-	wf.informers[nodeType], err = newQueuedInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer(), wf.stopChan)
+	wf.informers[nodeType], err = newQueuedInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer(), wf.stopChan,
+		defaultNumEventQueues)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +223,8 @@ func NewNodeWatchFactory(ovnClientset *util.OVNClientset, nodeName string) (*Wat
 	})
 
 	var err error
-	wf.informers[podType], err = newQueuedInformer(podType, wf.iFactory.Core().V1().Pods().Informer(), wf.stopChan)
+	wf.informers[podType], err = newQueuedInformer(podType, wf.iFactory.Core().V1().Pods().Informer(), wf.stopChan,
+		defaultNumEventQueues)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -2,7 +2,7 @@ package factory
 
 import (
 	"fmt"
-	"hash/fnv"
+	"math/rand"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -14,6 +14,7 @@ import (
 
 	egressiplister "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/listers/egressip/v1"
 
+	ktypes "k8s.io/apimachinery/pkg/types"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -64,6 +65,11 @@ type listerInterface interface{}
 
 type initialAddFn func(*Handler, []interface{})
 
+type queueMapEntry struct {
+	queue    uint32
+	refcount int32
+}
+
 type informer struct {
 	sync.RWMutex
 	oType    reflect.Type
@@ -75,6 +81,8 @@ type informer struct {
 	// when a handler is added
 	initialAddFunc initialAddFn
 	shutdownWg     sync.WaitGroup
+	queueMap       map[ktypes.NamespacedName]*queueMapEntry
+	queueMapLock   sync.Mutex
 }
 
 func (i *informer) forEachQueuedHandler(f func(h *Handler)) {
@@ -160,28 +168,76 @@ func (i *informer) processEvents(events chan *event, stopChan <-chan struct{}) {
 	}
 }
 
-func getQueueNum(oType reflect.Type, obj interface{}, numEventQueues int) uint32 {
+func (i *informer) getNewQueueNum(numEventQueues uint32) uint32 {
+	var j, startIdx, queueIdx uint32
+	startIdx = uint32(rand.Intn(int(numEventQueues - 1)))
+	queueIdx = startIdx
+	lowestNum := len(i.events[startIdx])
+	for j = 0; j < numEventQueues; j++ {
+		tryQueue := (startIdx + j) % numEventQueues
+		num := len(i.events[tryQueue])
+		if num < lowestNum {
+			lowestNum = num
+			queueIdx = tryQueue
+		}
+	}
+	return queueIdx
+}
+
+func (i *informer) refQueueEntry(oType reflect.Type, obj interface{}, numEventQueues uint32) (ktypes.NamespacedName, *queueMapEntry) {
 	meta, err := getObjectMeta(oType, obj)
 	if err != nil {
 		klog.Errorf("Object has no meta: %v", err)
-		return 0
+		return ktypes.NamespacedName{}, nil
 	}
 
-	// Distribute the object to an event queue based on a hash of its
-	// namespaced name, so that all events for a given object are
-	// serialized in one queue.
-	h := fnv.New32()
-	if meta.Namespace != "" {
-		_, _ = h.Write([]byte(meta.Namespace))
-		_, _ = h.Write([]byte("/"))
+	namespacedName := ktypes.NamespacedName{Namespace: meta.Namespace, Name: meta.Name}
+
+	i.queueMapLock.Lock()
+	defer i.queueMapLock.Unlock()
+
+	entry, ok := i.queueMap[namespacedName]
+	if ok {
+		if atomic.AddInt32(&entry.refcount, 1) == 1 {
+			// Entry is unused because add/update operations completed
+			// but we haven't seen a delete yet. Assign new queue to
+			// ensure queue balance.
+			entry.queue = i.getNewQueueNum(numEventQueues)
+		}
+	} else {
+		// no entry found, assign new queue
+		entry = &queueMapEntry{
+			refcount: 1,
+			queue:    i.getNewQueueNum(numEventQueues),
+		}
+		i.queueMap[namespacedName] = entry
 	}
-	_, _ = h.Write([]byte(meta.Name))
-	return h.Sum32() % uint32(numEventQueues)
+	return namespacedName, entry
+}
+
+func (i *informer) unrefQueueEntry(key ktypes.NamespacedName, entry *queueMapEntry, del bool) {
+	if entry == nil {
+		return
+	}
+
+	// To reduce lock contention don't bother grabbing the lock for
+	// add/update operations which are quite frequent. We'll eventually
+	// get a delete for the object and remove it from the queue map.
+	if !del {
+		atomic.AddInt32(&entry.refcount, -1)
+		return
+	}
+
+	i.queueMapLock.Lock()
+	defer i.queueMapLock.Unlock()
+	if atomic.AddInt32(&entry.refcount, -1) <= 0 {
+		delete(i.queueMap, key)
+	}
 }
 
 // enqueueEvent adds an event to the appropriate queue for the object
-func (i *informer) enqueueEvent(oldObj, obj interface{}, numEventQueues int, processFunc func(*event)) {
-	i.events[getQueueNum(i.oType, obj, numEventQueues)] <- &event{
+func (i *informer) enqueueEvent(oldObj, obj interface{}, queueNum uint32, processFunc func(*event)) {
+	i.events[queueNum] <- &event{
 		obj:     obj,
 		oldObj:  oldObj,
 		process: processFunc,
@@ -204,27 +260,31 @@ func ensureObjectOnDelete(obj interface{}, expectedType reflect.Type) (interface
 	return obj, nil
 }
 
-func (i *informer) newFederatedQueuedHandler(numEventQueues int) cache.ResourceEventHandlerFuncs {
+func (i *informer) newFederatedQueuedHandler(numEventQueues uint32) cache.ResourceEventHandlerFuncs {
 	name := i.oType.Elem().Name()
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			i.enqueueEvent(nil, obj, numEventQueues, func(e *event) {
+			key, entry := i.refQueueEntry(i.oType, obj, numEventQueues)
+			i.enqueueEvent(nil, obj, entry.queue, func(e *event) {
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "add").Inc()
 				start := time.Now()
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnAdd(e.obj)
 				})
 				metrics.MetricResourceAddLatency.Observe(time.Since(start).Seconds())
+				i.unrefQueueEntry(key, entry, false)
 			})
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			i.enqueueEvent(oldObj, newObj, numEventQueues, func(e *event) {
+			key, entry := i.refQueueEntry(i.oType, newObj, numEventQueues)
+			i.enqueueEvent(oldObj, newObj, entry.queue, func(e *event) {
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "update").Inc()
 				start := time.Now()
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnUpdate(e.oldObj, e.obj)
 				})
 				metrics.MetricResourceUpdateLatency.Observe(time.Since(start).Seconds())
+				i.unrefQueueEntry(key, entry, false)
 			})
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -233,13 +293,15 @@ func (i *informer) newFederatedQueuedHandler(numEventQueues int) cache.ResourceE
 				klog.Errorf(err.Error())
 				return
 			}
-			i.enqueueEvent(nil, realObj, numEventQueues, func(e *event) {
+			key, entry := i.refQueueEntry(i.oType, obj, numEventQueues)
+			i.enqueueEvent(nil, realObj, entry.queue, func(e *event) {
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "delete").Inc()
 				start := time.Now()
 				i.forEachQueuedHandler(func(h *Handler) {
 					h.OnDelete(e.obj)
 				})
 				metrics.MetricResourceDeleteLatency.Observe(time.Since(start).Seconds())
+				i.unrefQueueEntry(key, entry, true)
 			})
 		},
 	}
@@ -326,11 +388,11 @@ func newBaseInformer(oType reflect.Type, sharedInformer cache.SharedIndexInforme
 	}
 
 	return &informer{
-		oType:      oType,
-		inf:        sharedInformer,
-		lister:     lister,
-		handlers:   make(map[uint64]*Handler),
-		shutdownWg: sync.WaitGroup{},
+		oType:    oType,
+		inf:      sharedInformer,
+		lister:   lister,
+		handlers: make(map[uint64]*Handler),
+		queueMap: make(map[ktypes.NamespacedName]*queueMapEntry),
 	}, nil
 }
 
@@ -349,7 +411,7 @@ func newInformer(oType reflect.Type, sharedInformer cache.SharedIndexInformer) (
 }
 
 func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInformer,
-	stopChan chan struct{}, numEventQueues int) (*informer, error) {
+	stopChan chan struct{}, numEventQueues uint32) (*informer, error) {
 	i, err := newBaseInformer(oType, sharedInformer)
 	if err != nil {
 		return nil, err
@@ -365,27 +427,37 @@ func newQueuedInformer(oType reflect.Type, sharedInformer cache.SharedIndexInfor
 		// initial add events will be distributed. When a new handler
 		// is added, only that handler should receive events for all
 		// existing objects.
-		adds := make([]chan interface{}, numEventQueues)
+		type initialAddEntry struct {
+			obj      interface{}
+			doneFunc func()
+		}
+		adds := make([]chan *initialAddEntry, numEventQueues)
 		queueWg := &sync.WaitGroup{}
 		queueWg.Add(len(adds))
 		for j := range adds {
-			adds[j] = make(chan interface{}, 10)
-			go func(addChan chan interface{}) {
+			adds[j] = make(chan *initialAddEntry, 10)
+			go func(addChan chan *initialAddEntry) {
 				defer queueWg.Done()
 				for {
-					obj, ok := <-addChan
+					entry, ok := <-addChan
 					if !ok {
 						return
 					}
-					h.OnAdd(obj)
+					h.OnAdd(entry.obj)
+					entry.doneFunc()
 				}
 			}(adds[j])
 		}
 		// Distribute the existing items into the handler-specific
 		// channel array.
 		for _, obj := range items {
-			queueIdx := getQueueNum(i.oType, obj, numEventQueues)
-			adds[queueIdx] <- obj
+			key, entry := i.refQueueEntry(i.oType, obj, numEventQueues)
+			adds[entry.queue] <- &initialAddEntry{
+				obj: obj,
+				doneFunc: func() {
+					i.unrefQueueEntry(key, entry, false)
+				},
+			}
 		}
 		// Close all the channels
 		for j := range adds {

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -315,7 +315,7 @@ func (oc *Controller) deleteGWRoutesForPod(namespace string, podIPNets []*net.IP
 }
 
 // addEgressGwRoutesForPod handles adding all routes to gateways for a pod on a specific GR
-func (oc *Controller) addGWRoutesForPod(gateways []gatewayInfo, podIfAddrs []*net.IPNet, namespace, node string) error {
+func (oc *Controller) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddrs []*net.IPNet, namespace, node string) error {
 	nsInfo := oc.getNamespaceLocked(namespace)
 	defer nsInfo.Unlock()
 	gr := util.GetGatewayRouterFromNode(node)

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -50,7 +50,8 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 	}
 }
 
-func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
+// adds pod to addr set and returns true if namespace supports multicast
+func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) error {
 	nsInfo := oc.ensureNamespaceLocked(ns)
 	defer nsInfo.Unlock()
 
@@ -58,21 +59,12 @@ func (oc *Controller) addPodToNamespace(ns string, portInfo *lpInfo) error {
 		var err error
 		nsInfo.addressSet, err = oc.createNamespaceAddrSetAllPods(ns)
 		if err != nil {
-			return fmt.Errorf("unable to add pod to namespace. Cannot create address set for namespace: %s,"+
-				"error: %v", ns, err)
+			return fmt.Errorf("unable to add pod to namespace %s; failed to create namespace address set: %v", ns, err)
 		}
 	}
 
-	if err := nsInfo.addressSet.AddIPs(createIPAddressSlice(portInfo.ips)); err != nil {
+	if err := nsInfo.addressSet.AddIPs(createIPAddressSlice(ips)); err != nil {
 		return err
-	}
-
-	// If multicast is allowed and enabled for the namespace, add the port
-	// to the allow policy.
-	if oc.multicastSupport && nsInfo.multicastEnabled {
-		if err := podAddAllowMulticastPolicy(oc.ovnNBClient, ns, portInfo); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -109,6 +101,10 @@ func createIPAddressSlice(ips []*net.IPNet) []net.IP {
 	return ipAddrs
 }
 
+func isNamespaceMulticastEnabled(annotations map[string]string) bool {
+	return annotations[nsMulticastAnnotation] == "true"
+}
+
 // Creates an explicit "allow" policy for multicast traffic within the
 // namespace if multicast is enabled. Otherwise, removes the "allow" policy.
 // Traffic will be dropped by the default multicast deny ACL.
@@ -117,9 +113,8 @@ func (oc *Controller) multicastUpdateNamespace(ns *kapi.Namespace, nsInfo *names
 		return
 	}
 
-	enabled := (ns.Annotations[nsMulticastAnnotation] == "true")
+	enabled := isNamespaceMulticastEnabled(ns.Annotations)
 	enabledOld := nsInfo.multicastEnabled
-
 	if enabledOld == enabled {
 		return
 	}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -225,13 +225,17 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 	return nil
 }
 
-func (oc *Controller) getRoutingExternalGWs(ns string) gatewayInfo {
-	res := gatewayInfo{}
+func (oc *Controller) getRoutingGWs(ns string) (gatewayInfo, map[string]gatewayInfo) {
 	nsInfo := oc.getNamespaceLocked(ns)
 	if nsInfo == nil {
-		return res
+		return gatewayInfo{}, nil
 	}
 	defer nsInfo.Unlock()
+	return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo)
+}
+
+func (oc *Controller) getRoutingExternalGWs(nsInfo *namespaceInfo) gatewayInfo {
+	res := gatewayInfo{}
 	// return a copy of the object so it can be handled without the
 	// namespace locked
 	res.bfdEnabled = nsInfo.routingExternalGWs.bfdEnabled
@@ -240,12 +244,7 @@ func (oc *Controller) getRoutingExternalGWs(ns string) gatewayInfo {
 	return res
 }
 
-func (oc *Controller) getRoutingPodGWs(ns string) map[string]gatewayInfo {
-	nsInfo := oc.getNamespaceLocked(ns)
-	if nsInfo == nil {
-		return nil
-	}
-	defer nsInfo.Unlock()
+func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]gatewayInfo {
 	// return a copy of the object so it can be handled without the
 	// namespace locked
 	res := make(map[string]gatewayInfo)
@@ -450,8 +449,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	// add src-ip routes to GR if external gw annotation is set
-	routingExternalGWs := oc.getRoutingExternalGWs(pod.Namespace)
-	routingPodGWs := oc.getRoutingPodGWs(pod.Namespace)
+	routingExternalGWs, routingPodGWs := oc.getRoutingGWs(pod.Namespace)
 
 	// if we have any external or pod Gateways, add routes
 	gateways := make([]gatewayInfo, 0)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -225,40 +225,6 @@ func (oc *Controller) addRoutesGatewayIP(pod *kapi.Pod, podAnnotation *util.PodA
 	return nil
 }
 
-func (oc *Controller) getRoutingGWs(ns string) (gatewayInfo, map[string]gatewayInfo) {
-	nsInfo := oc.getNamespaceLocked(ns)
-	if nsInfo == nil {
-		return gatewayInfo{}, nil
-	}
-	defer nsInfo.Unlock()
-	return oc.getRoutingExternalGWs(nsInfo), oc.getRoutingPodGWs(nsInfo)
-}
-
-func (oc *Controller) getRoutingExternalGWs(nsInfo *namespaceInfo) gatewayInfo {
-	res := gatewayInfo{}
-	// return a copy of the object so it can be handled without the
-	// namespace locked
-	res.bfdEnabled = nsInfo.routingExternalGWs.bfdEnabled
-	res.gws = make([]net.IP, len(nsInfo.routingExternalGWs.gws))
-	copy(res.gws, nsInfo.routingExternalGWs.gws)
-	return res
-}
-
-func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]gatewayInfo {
-	// return a copy of the object so it can be handled without the
-	// namespace locked
-	res := make(map[string]gatewayInfo)
-	for k, v := range nsInfo.routingExternalPodGWs {
-		item := gatewayInfo{
-			bfdEnabled: v.bfdEnabled,
-			gws:        make([]net.IP, len(v.gws)),
-		}
-		copy(item.gws, v.gws)
-		res[k] = item
-	}
-	return res
-}
-
 func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	// If a node does node have an assigned hostsubnet don't wait for the logical switch to appear
 	if oc.lsManager.IsNonHostSubnetSwitch(pod.Spec.NodeName) {
@@ -444,15 +410,13 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	// Ensure the namespace/nsInfo exists
-	if err := oc.addPodToNamespace(pod.Namespace, podIfAddrs); err != nil {
+	routingExternalGWs, routingPodGWs, err := oc.addPodToNamespace(pod.Namespace, podIfAddrs)
+	if err != nil {
 		return err
 	}
 
-	// add src-ip routes to GR if external gw annotation is set
-	routingExternalGWs, routingPodGWs := oc.getRoutingGWs(pod.Namespace)
-
 	// if we have any external or pod Gateways, add routes
-	gateways := make([]gatewayInfo, 0)
+	gateways := make([]*gatewayInfo, 0)
 
 	if len(routingExternalGWs.gws) > 0 {
 		gateways = append(gateways, routingExternalGWs)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -444,44 +444,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		releaseIPs = false
 	}
 
-	// set addresses on the port
-	addresses = make([]string, len(podIfAddrs)+1)
-	addresses[0] = podMac.String()
-	for idx, podIfAddr := range podIfAddrs {
-		addresses[idx+1] = podIfAddr.IP.String()
-	}
-	// LSP addresses in OVN are a single space-separated value
-	cmd, err = oc.ovnNBClient.LSPSetAddress(portName, strings.Join(addresses, " "))
-	if err != nil {
-		return fmt.Errorf("unable to create LSPSetAddress command for port: %s", portName)
-	}
-	cmds = append(cmds, cmd)
-
-	// add external ids
-	extIds := map[string]string{"namespace": pod.Namespace, "pod": "true"}
-	cmd, err = oc.ovnNBClient.LSPSetExternalIds(portName, extIds)
-	if err != nil {
-		return fmt.Errorf("unable to create LSPSetExternalIds command for port: %s", portName)
-	}
-	cmds = append(cmds, cmd)
-
-	// execute all the commands together.
-	err = oc.ovnNBClient.Execute(cmds...)
-	if err != nil {
-		return fmt.Errorf("error while creating logical port %s error: %v",
-			portName, err)
-	}
-
-	lsp, err = oc.ovnNBClient.LSPGet(portName)
-	if err != nil || lsp == nil {
-		return fmt.Errorf("failed to get the logical switch port: %s from the ovn client, error: %s", portName, err)
-	}
-
-	// Add the pod's logical switch port to the port cache
-	portInfo := oc.logicalPortCache.add(logicalSwitch, portName, lsp.UUID, podMac, podIfAddrs)
-
 	// Ensure the namespace/nsInfo exists
-	if err = oc.addPodToNamespace(pod.Namespace, portInfo); err != nil {
+	if err := oc.addPodToNamespace(pod.Namespace, podIfAddrs); err != nil {
 		return err
 	}
 
@@ -522,18 +486,63 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		return fmt.Errorf("failed to handle external GW check: %v", err)
 	}
 
+	// set addresses on the port
+	addresses = make([]string, len(podIfAddrs)+1)
+	addresses[0] = podMac.String()
+	for idx, podIfAddr := range podIfAddrs {
+		addresses[idx+1] = podIfAddr.IP.String()
+	}
+
+	// LSP addresses in OVN are a single space-separated value
+	cmd, err = oc.ovnNBClient.LSPSetAddress(portName, strings.Join(addresses, " "))
+	if err != nil {
+		return fmt.Errorf("unable to create LSPSetAddress command for port: %s", portName)
+	}
+	cmds = append(cmds, cmd)
+
+	// add external ids
+	extIds := map[string]string{"namespace": pod.Namespace, "pod": "true"}
+	cmd, err = oc.ovnNBClient.LSPSetExternalIds(portName, extIds)
+	if err != nil {
+		return fmt.Errorf("unable to create LSPSetExternalIds command for port: %s", portName)
+	}
+	cmds = append(cmds, cmd)
+
 	// CNI depends on the flows from port security, delay setting it until end
 	cmd, err = oc.ovnNBClient.LSPSetPortSecurity(portName, strings.Join(addresses, " "))
 	if err != nil {
 		return fmt.Errorf("unable to create LSPSetPortSecurity command for port: %s", portName)
 	}
 
-	err = oc.ovnNBClient.Execute(cmd)
+	cmds = append(cmds, cmd)
+
+	// execute all the commands together.
+	err = oc.ovnNBClient.Execute(cmds...)
 	if err != nil {
-		return fmt.Errorf("error while setting port security on port: %s error: %v",
+		return fmt.Errorf("error while creating logical port %s error: %v",
 			portName, err)
 	}
 
+	lsp, err = oc.ovnNBClient.LSPGet(portName)
+	if err != nil || lsp == nil {
+		return fmt.Errorf("failed to get the logical switch port: %s from the ovn client, error: %s", portName, err)
+	}
+
+	// Add the pod's logical switch port to the port cache
+	portInfo := oc.logicalPortCache.add(logicalSwitch, portName, lsp.UUID, podMac, podIfAddrs)
+
+	// If multicast is allowed and enabled for the namespace, add the port to the allow policy.
+	// FIXME: there's a race here with the Namespace multicastUpdateNamespace() handler, but
+	// it's rare and easily worked around for now.
+	ns, err := oc.watchFactory.GetNamespace(pod.Namespace)
+	if err != nil {
+		return err
+	}
+	if oc.multicastSupport && isNamespaceMulticastEnabled(ns.Annotations) {
+		if err := podAddAllowMulticastPolicy(oc.ovnNBClient, pod.Namespace, portInfo); err != nil {
+			return err
+		}
+	}
 	// observe the pod creation latency metric.
 	metrics.RecordPodCreated(pod)
 	return nil


### PR DESCRIPTION
Includes a handful of fixes from the outcome of downstream scale testing. Basically the tl;dr is:

1. Having many pod handlers doesnt fix our scale issues, because of lock contention with nsInfo, as well as single threaded ovsdb operations.
2. Having many pod handlers can result can cause average latency of a pod to bring up to be worse, because creation order of events coming from kapi can be spread over many handlers (all fighting for locks), and there is no guarantee a pod created at a given time is processed in a timely manner. Decreasing the number of queues helps this somewhat.

This PR includes fixes that:

1. Tune pod handlers to 15. Increasing the pod handlers to 50 or 150, does not give us any lower pod ready latency, even with full queues, because of contention between handlers. As we increase the efficiency of the pod handler itself, in the future we can increase number of handlers.
2. The enqueueEvent was not a fairly distributed queue, some queues were overloaded. Refactored it to be a round robin.
3. We were executing 2 ovsdb transactions (at least) for every addLogicalPort, reduce those 2 to 1.
4. We were waiting some time for annotations, and waiting another amount of time for flows. Just have a single timeout and wait for that.
