### PR TITLE
Fix LGW Node `SyncServices`

### DIFF
--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -356,7 +356,7 @@ func recreateIPTRules(table, chain string, keepIPTRules []iptRule) {
 // only incoming traffic on that IP will be accepted for NodePort rules; otherwise incoming traffic on the NodePort
 // on all IPs will be accepted. If gatewayIP is "", then NodePort traffic will be DNAT'ed to the service port on
 // the service's ClusterIP. Otherwise, it will be DNAT'ed to the NodePort on the gatewayIP.
-func getGatewayIPTRules(service *kapi.Service, gatewayIPs []string, hasLocalHostEndpoint bool) []iptRule {
+func getGatewayIPTRules(service *kapi.Service, hasLocalHostEndpoint bool) []iptRule {
 	rules := make([]iptRule, 0)
 	clusterIPs := util.GetClusterIPs(service)
 	for _, svcPort := range service.Spec.Ports {
@@ -371,21 +371,14 @@ func getGatewayIPTRules(service *kapi.Service, gatewayIPs []string, hasLocalHost
 				klog.Errorf("Skipping service: %s, invalid service port %v", svcPort.Name, err)
 				continue
 			}
-			if gatewayIPs == nil {
-				if !hasLocalHostEndpoint {
-					for _, clusterIP := range clusterIPs {
-						rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port)...)
-					}
-				} else {
-					// Port redirect host -> Nodeport -> host traffic directly to endpoint
-					for _, clusterIP := range clusterIPs {
-						rules = append(rules, getNodePortLocalIPTRules(svcPort, clusterIP, int32(svcPort.TargetPort.IntValue()))...)
-					}
+			if !hasLocalHostEndpoint {
+				for _, clusterIP := range clusterIPs {
+					rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.Port)...)
 				}
-				// (astoycos) TODO remove me with LGW fix
 			} else {
-				for _, gatewayIP := range gatewayIPs {
-					rules = append(rules, getNodePortIPTRules(svcPort, gatewayIP, svcPort.Port)...)
+				// Port redirect host -> Nodeport -> host traffic directly to endpoint
+				for _, clusterIP := range clusterIPs {
+					rules = append(rules, getNodePortLocalIPTRules(svcPort, clusterIP, int32(svcPort.TargetPort.IntValue()))...)
 				}
 			}
 		}

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -259,7 +259,7 @@ func (l *localPortWatcher) SyncServices(serviceInterface []interface{}) {
 			klog.Errorf("Spurious object in syncServices: %v", serviceInterface)
 			continue
 		}
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, []string{l.gatewayIPv4, l.gatewayIPv6}, false)...)
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, false)...)
 	}
 	for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
 		recreateIPTRules("nat", chain, keepIPTRules)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -517,7 +517,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 		npw.updateServiceFlowCache(service, false, hasHostNet)
 		npw.updateServiceFlowCache(service, true, hasHostNet)
 		// Add correct iptables rules
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, hasHostNet)...)
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, hasHostNet)...)
 	}
 	// sync OF rules once
 	npw.ofm.requestFlowSync()
@@ -647,7 +647,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) {
 			continue
 		}
 		// Add correct iptables rules
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, false)...)
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, false)...)
 	}
 
 	// sync IPtables rules once

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -136,7 +136,7 @@ func deleteLocalNodeAccessBridge() error {
 // If A Service External Traffic Policy==Local and backend is a host-networked pod
 // we must steer traffic from host -> svc straight to the host instead of into OVN
 func addSharedGatewayIptRules(service *kapi.Service, hasLocalHostEndpoint bool) {
-	rules := getGatewayIPTRules(service, nil, hasLocalHostEndpoint)
+	rules := getGatewayIPTRules(service, hasLocalHostEndpoint)
 
 	if err := addIptRules(rules); err != nil {
 		klog.Errorf("Failed to add iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)
@@ -144,7 +144,7 @@ func addSharedGatewayIptRules(service *kapi.Service, hasLocalHostEndpoint bool) 
 }
 
 func delSharedGatewayIptRules(service *kapi.Service, hasLocalHostEndpoint bool) {
-	rules := getGatewayIPTRules(service, nil, hasLocalHostEndpoint)
+	rules := getGatewayIPTRules(service, hasLocalHostEndpoint)
 
 	if err := delIptRules(rules); err != nil {
 		klog.Errorf("Failed to delete iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)


### PR DESCRIPTION
So if I'm understanding correctly this 

```
keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, []string{l.gatewayIPv4, l.gatewayIPv6})...)
```
Is only called in the syncServices function for Local GW and it's broken , It was creating iptables rules like so 

```
for _, gatewayIP := range gatewayIPs {
					rules = append(rules, getNodePortIPTRules(svcPort, gatewayIP, svcPort.Port)...)
				}
```
So a rule for traffic Destined to the nodeport <svcPort> that DNATed  the traffic to the `<ovn-k8s-gw0 IP>:<servicePort>`, which Isn't a real endpoint. Also no where else in the LGW node code do we add iptables rules like this  

Instead on Service Add in the LGW Node code we use that same IP [here](https://github.com/ovn-org/ovn-kubernetes/blob/fae10ffecb1b79e3db4eec384d45aaaa88d09703/go-controller/pkg/node/gateway_localnet.go#L193) but then don't actually use that IP to make the relevant IPtables rules [here](https://github.com/ovn-org/ovn-kubernetes/blob/fae10ffecb1b79e3db4eec384d45aaaa88d09703/go-controller/pkg/node/gateway_localnet.go#L206) that DNAT traffic to the <clusterIP>:<SvcPort> for the service

```
if gatewayIP != "" {
					iptRules = append(iptRules, getNodePortIPTRules(port, ip, port.Port)...)
					klog.V(5).Infof("Will add iptables rule for NodePort: %v and "+
						"protocol: %v", port.NodePort, port.Protocol)
```



I will change [this](https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/node/gateway_localnet.go#L262) to 

```
keepIPTRules = append(keepIPTRules, getGatewayIPTRules(svc, false)...)

```

Which should accurately recreate all Iptables rules to DNAT traffic destined for the nodeport or external IP to the clusterIP of the service 

NOTE: Iptables to DNAT to `<ovn-k8s-gw0 IP>:<servicePort>` was initially implemented for ICNI 1.0 and is no longer used 