### PR TITLE
Scale/Perf: LGW: LRP 501: Reconstruct the policy using address sets

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -24,6 +24,8 @@ const (
 	addrsetName = "foobar"
 	ipAddress1  = "1.2.3.4"
 	ipAddress2  = "5.6.7.8"
+	ipAddress3  = "fd00:10:244::"
+	ipAddress4  = "fc00:f853:ccd:e793::4"
 	fakeUUID    = "8a86f6d8-7972-4253-b0bd-ddbef66e9303"
 	fakeUUIDv6  = "8a86f6d8-7972-4253-b0bd-ddbef66e9304"
 )
@@ -216,6 +218,176 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("ensures an address set exists and returns it", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.AddressSet{
+							UUID:        fakeUUID,
+							Name:        hashedAddressSet(addrsetName + ipv4AddressSetSuffix),
+							ExternalIDs: map[string]string{"name": addrsetName + ipv4AddressSetSuffix},
+							Addresses:   []string{ipAddress1},
+						},
+					},
+				}
+				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
+
+				_, err = config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				as, err := asFactory.EnsureAddressSet("foobar")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectedDatabaseState := []libovsdbtest.TestData{
+					&nbdb.AddressSet{
+						UUID:        fakeUUID,
+						Name:        hashedAddressSet(addrsetName + ipv4AddressSetSuffix),
+						Addresses:   []string{ipAddress1},
+						ExternalIDs: map[string]string{"name": addrsetName + ipv4AddressSetSuffix},
+					},
+				}
+				gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				original_v4, original_v6 := as.GetASHashNames()
+				expected_v4, _ := MakeAddressSetHashNames("foobar")
+				gomega.Expect(original_v4).To(gomega.Equal(expected_v4))
+				gomega.Expect(original_v6).To(gomega.Equal(""))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("ensures an address set exists and returns it, both ip4 and ipv6", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.AddressSet{
+							UUID:        fakeUUID,
+							Name:        hashedAddressSet(addrsetName + ipv4AddressSetSuffix),
+							ExternalIDs: map[string]string{"name": addrsetName + ipv4AddressSetSuffix},
+							Addresses:   []string{ipAddress1, ipAddress2},
+						},
+						&nbdb.AddressSet{
+							UUID:        fakeUUIDv6,
+							Name:        hashedAddressSet(addrsetName + ipv6AddressSetSuffix),
+							ExternalIDs: map[string]string{"name": addrsetName + ipv6AddressSetSuffix},
+							Addresses:   []string{ipAddress3, ipAddress4},
+						},
+					},
+				}
+				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
+				_, err = config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				config.IPv6Mode = true
+				config.IPv4Mode = true
+
+				expectedDatabaseState := []libovsdbtest.TestData{
+					&nbdb.AddressSet{
+						UUID:        fakeUUID,
+						Name:        hashedAddressSet(addrsetName + ipv4AddressSetSuffix),
+						Addresses:   []string{ipAddress1, ipAddress2},
+						ExternalIDs: map[string]string{"name": addrsetName + ipv4AddressSetSuffix},
+					},
+					&nbdb.AddressSet{
+						UUID:        fakeUUIDv6,
+						Name:        hashedAddressSet(addrsetName + ipv6AddressSetSuffix),
+						Addresses:   []string{ipAddress3, ipAddress4},
+						ExternalIDs: map[string]string{"name": addrsetName + ipv6AddressSetSuffix},
+					},
+				}
+
+				as, err := asFactory.EnsureAddressSet("foobar")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				original_v4, original_v6 := as.GetASHashNames()
+				expected_v4, expected_v6 := MakeAddressSetHashNames("foobar")
+				gomega.Expect(original_v4).To(gomega.Equal(expected_v4))
+				gomega.Expect(original_v6).To(gomega.Equal(expected_v6))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("ensures an empty address set exists and returns it", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.AddressSet{
+							UUID:        fakeUUID,
+							Name:        hashedAddressSet(addrsetName + ipv4AddressSetSuffix),
+							ExternalIDs: map[string]string{"name": addrsetName + ipv4AddressSetSuffix},
+							Addresses:   []string{},
+						},
+					},
+				}
+				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
+				_, err = config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				as, err := asFactory.EnsureAddressSet("foobar")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				expectedDatabaseState := []libovsdbtest.TestData{
+					&nbdb.AddressSet{
+						UUID:        fakeUUID,
+						Name:        hashedAddressSet(addrsetName + ipv4AddressSetSuffix),
+						Addresses:   []string{},
+						ExternalIDs: map[string]string{"name": addrsetName + ipv4AddressSetSuffix},
+					},
+				}
+
+				gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				original_v4, original_v6 := as.GetASHashNames()
+				expected_v4, _ := MakeAddressSetHashNames("foobar")
+				gomega.Expect(original_v4).To(gomega.Equal(expected_v4))
+				gomega.Expect(original_v6).To(gomega.Equal(""))
+				ipsv4, ipsv6 := as.GetIPs()
+				gomega.Expect(ipsv4).To(gomega.Equal([]string{}))
+				gomega.Expect(ipsv6).To(gomega.BeNil())
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("ensures an address set exists and if not creates a new one", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{}
+				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
+
+				_, err = config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				expectedDatabaseState := &nbdb.AddressSet{
+					Name:        hashedAddressSet(addrsetName + ipv4AddressSetSuffix),
+					Addresses:   []string{},
+					ExternalIDs: map[string]string{"name": addrsetName + ipv4AddressSetSuffix},
+				}
+
+				as, err := asFactory.EnsureAddressSet("foobar")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+				v4ips, v6ips := as.GetIPs()
+				gomega.Expect(v4ips).To(gomega.Equal([]string{}))
+				gomega.Expect(v6ips).To(gomega.BeNil())
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.It("destroys an address set", func() {
@@ -267,6 +439,39 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 					ExternalIDs: map[string]string{"name": addrsetName + ipv4AddressSetSuffix},
 				}
 				gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("gets all IPs from an address set", func() {
+			app.Action = func(ctx *cli.Context) error {
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.AddressSet{
+							UUID:        fakeUUID,
+							Name:        hashedAddressSet(addrsetName + ipv4AddressSetSuffix),
+							ExternalIDs: map[string]string{"name": addrsetName + ipv4AddressSetSuffix},
+							Addresses:   []string{ipAddress1, ipAddress2},
+						},
+					},
+				}
+				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
+				_, err = config.InitConfig(ctx, nil, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				config.IPv4Mode = true
+
+				as, err := asFactory.EnsureAddressSet("foobar")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ipsv4, ipsv6 := as.GetIPs()
+
+				gomega.Expect(ipsv4).To(gomega.Equal([]string{ipAddress1, ipAddress2}))
+				gomega.Expect(ipsv6).To(gomega.BeNil())
 				return nil
 			}
 

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -49,9 +49,24 @@ func (f *FakeAddressSetFactory) NewAddressSet(name string, ips []net.IP) (Addres
 	return set, nil
 }
 
-// EnsureAddressSet returns nil
-func (f *FakeAddressSetFactory) EnsureAddressSet(name string) error {
-	return nil
+// EnsureAddressSet returns set object
+func (f *FakeAddressSetFactory) EnsureAddressSet(name string) (AddressSet, error) {
+	f.Lock()
+	defer f.Unlock()
+	_, ok := f.sets[name]
+	gomega.Expect(ok).To(gomega.BeFalse())
+	set, err := newFakeAddressSets(name, []net.IP{}, f.removeAddressSet)
+	if err != nil {
+		return nil, err
+	}
+	ip4ASName, ip6ASName := MakeAddressSetName(name)
+	if set.ipv4 != nil {
+		f.sets[ip4ASName] = set.ipv4
+	}
+	if set.ipv6 != nil {
+		f.sets[ip6ASName] = set.ipv6
+	}
+	return set, nil
 }
 
 func (f *FakeAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIterFunc) error {
@@ -250,6 +265,23 @@ func (as *fakeAddressSets) AddIPs(ips []net.IP) error {
 	return nil
 }
 
+func (as *fakeAddressSets) GetIPs() ([]string, []string) {
+	as.Lock()
+	defer as.Unlock()
+
+	var v4ips []string
+	var v6ips []string
+
+	if as.ipv6 != nil {
+		v6ips = as.ipv6.allIPs()
+	}
+	if as.ipv4 != nil {
+		v4ips = as.ipv4.allIPs()
+	}
+
+	return v4ips, v6ips
+}
+
 func (as *fakeAddressSets) SetIPs(ips []net.IP) error {
 	// NOOP
 	return nil
@@ -323,4 +355,13 @@ func (as *fakeAddressSet) destroy() error {
 	atomic.StoreUint32(&as.destroyed, 1)
 	as.removeFn(as.name)
 	return nil
+}
+
+func (as *fakeAddressSet) allIPs() []string {
+	// my kingdom for a ".values()" function
+	out := make([]string, 0, len(as.ips))
+	for _, ip := range as.ips {
+		out = append(out, ip.String())
+	}
+	return out
 }

--- a/go-controller/pkg/ovn/address_set/mocks/AddressSet.go
+++ b/go-controller/pkg/ovn/address_set/mocks/AddressSet.go
@@ -76,6 +76,31 @@ func (_m *AddressSet) GetASHashNames() (string, string) {
 	return r0, r1
 }
 
+// GetIPs provides a mock function with given fields:
+func (_m *AddressSet) GetIPs() ([]string, []string) {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 []string
+	if rf, ok := ret.Get(1).(func() []string); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]string)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetName provides a mock function with given fields:
 func (_m *AddressSet) GetName() string {
 	ret := _m.Called()

--- a/go-controller/pkg/ovn/address_set/mocks/AddressSetFactory.go
+++ b/go-controller/pkg/ovn/address_set/mocks/AddressSetFactory.go
@@ -29,17 +29,26 @@ func (_m *AddressSetFactory) DestroyAddressSetInBackingStore(name string) error 
 }
 
 // EnsureAddressSet provides a mock function with given fields: name
-func (_m *AddressSetFactory) EnsureAddressSet(name string) error {
+func (_m *AddressSetFactory) EnsureAddressSet(name string) (addressset.AddressSet, error) {
 	ret := _m.Called(name)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
+	var r0 addressset.AddressSet
+	if rf, ok := ret.Get(0).(func(string) addressset.AddressSet); ok {
 		r0 = rf(name)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(addressset.AddressSet)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // NewAddressSet provides a mock function with given fields: name, ips

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -305,7 +305,7 @@ func (oc *Controller) addEgressFirewall(egressFirewall *egressfirewallapi.Egress
 	// EgressFirewall needs to make sure that the address_set for the namespace exists independently of the namespace object
 	// so that OVN doesn't get unresolved references to the address_set.
 	// TODO: This should go away once we do something like refcounting for address_sets.
-	err = oc.addressSetFactory.EnsureAddressSet(egressFirewall.Namespace)
+	_, err = oc.addressSetFactory.EnsureAddressSet(egressFirewall.Namespace)
 	if err != nil {
 		return fmt.Errorf("cannot Ensure that addressSet for namespace %s exists %v", egressFirewall.Namespace, err)
 	}

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"context"
 	"encoding/json"
+	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -858,6 +859,101 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+	})
+	ginkgo.Context("hybrid route policy operations in lgw mode", func() {
+		ginkgo.It("add hybrid route policy for pods", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.Gateway.Mode = config.GatewayModeLocal
+				namespaceT := *newNamespace("namespace1")
+				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1,9.0.0.2", "k8s.ovn.org/bfd-enabled": ""}
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					"namespace1",
+				)
+
+				fakeOvn.start(ctx,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
+						},
+					},
+				)
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_node1 networks",
+					Output: "100.64.0.4/16\n",
+				})
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --may-exist lr-policy-add ovn_cluster_router 501 inport == \"rtos-node1\" && ip4.src == $a17568862106095406051 && ip4.dst != 10.128.0.0/14 reroute 100.64.0.4",
+					Output: "\n",
+				})
+
+				injectNode(fakeOvn)
+				err := fakeOvn.controller.addHybridRoutePolicyForPod(net.ParseIP(t.podIP), t.nodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
+				fakeOvn.asf.ExpectAddressSetWithIPs("hybrid-route-pods-node1", []string{t.podIP})
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+		ginkgo.It("delete hybrid route policy for pods", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.Gateway.Mode = config.GatewayModeLocal
+				namespaceT := *newNamespace("namespace1")
+				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1,9.0.0.2", "k8s.ovn.org/bfd-enabled": ""}
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					"namespace1",
+				)
+
+				fakeOvn.start(ctx,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
+						},
+					},
+				)
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists lr-policy-del ovn_cluster_router 501 inport == \"rtos-node1\" && ip4.src == $a17568862106095406051 && ip4.dst != 10.128.0.0/14",
+					Output: "\n",
+				})
+
+				injectNode(fakeOvn)
+				err := fakeOvn.controller.delHybridRoutePolicyForPod(net.ParseIP(t.podIP), t.nodeName, false)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
+				fakeOvn.asf.ExpectEmptyAddressSet("hybrid-route-pods-node1")
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 	})
 })
 

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -89,6 +89,9 @@ const (
 
 	OvnACLLoggingMeter = "acl-logging"
 
+	// OVN-K8S Address Sets Names
+	HybridRoutePolicyPrefix = "hybrid-route-pods-"
+
 	// OVN-K8S Topology Versions
 	OvnSingleJoinSwitchTopoVersion = 1
 	OvnNamespacedDenyPGTopoVersion = 2


### PR DESCRIPTION
**- What this PR does and why is it needed**
This PR modifies the way 501 LRP flows for external gw mode are constructed. This flow has the `!=` match per enabled pod which can cause a lot of flow generation. Idea is to use address-sets per node and store the podIPs in them.

`policy`: We will have one policy per node instead of one per pod.
`lflows`: We will have one flow per node instead of one per pod.
`openflows`: A cluster having 2800 pods would have 60,000 flows w/o the PR and 5000 with the PR.

**- Special notes for reviewers**
This PR only touches LGW mode since the 501 policy is not created or used in SGW mode. `e2e` tests already exist for external gateways and we can see the new method of policy getting added through CI logs.


**- How to verify it**
Spin up a KIND cluster, add the necessary annotations.
On a cluster without the PR:
```
501 inport == "rtos-ovn-worker2" && ip4.src == 10.244.2.5 && ip4.dst != 10.244.0.0/16         reroute                100.64.0.4
501 inport == "rtos-ovn-worker2" && ip4.src == 10.244.2.6 && ip4.dst != 10.244.0.0/16         reroute                100.64.0.4
```
On a cluster with the PR:
```
501 inport == "rtos-ovn-worker2" && ip4.src == $a6646986056643900426 && ip4.dst != 10.244.0.0/16         reroute                100.64.0.4
```
It is safe for upgrades, there is a `delLegacyHybridRoutePolicyForPod` function which is the delete function for the old LRP. This is preserved and called from `addHybridRoutePolicyForPod` upon master restart with the new image. Since we don't have a versioning system to make incremental updates, its unfortunate we have to carry the del's legacy code. However, this is not a reason for concern since when LGW goes away (will happen in the recent future), we can completely get rid of the 501 code.

**- Description for the changelog**
Performance fix for LRP 501 used in LGW mode.