### PR TITLE
Use DGP to connect logical switches to the cluster router.

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-21.06.0-12.fc33
+ARG ovnver=ovn-21.06.0-15.fc33
 
 # install needed rpms - openvswitch must be 2.10.4 or higher
 RUN INSTALL_PKGS=" \

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -219,7 +219,6 @@ func addNodeLogicalFlows(fexec *ovntest.FakeExec, node *tNode, clusterCIDR strin
 	})
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists lrp-del " + types.RouterToSwitchPrefix + node.Name + " -- lrp-add ovn_cluster_router " + types.RouterToSwitchPrefix + node.Name + " " + node.NodeLRPMAC + " " + node.NodeGWIP,
 		"ovn-nbctl --timeout=15 --may-exist ls-add " + node.Name + " -- set logical_switch " + node.Name + " other-config:subnet=" + node.NodeSubnet + " other-config:exclude_ips=" + node.NodeMgmtPortIP,
 		"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + node.Name + " " + types.SwitchToRouterPrefix + node.Name + " -- lsp-set-type " + types.SwitchToRouterPrefix + node.Name + " router -- lsp-set-options " + types.SwitchToRouterPrefix + node.Name + " router-port=" + types.RouterToSwitchPrefix + node.Name + " -- lsp-set-addresses " + types.SwitchToRouterPrefix + node.Name + " " + node.NodeLRPMAC,
 	})
@@ -249,6 +248,7 @@ func addNodeLogicalFlows(fexec *ovntest.FakeExec, node *tNode, clusterCIDR strin
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 -- --if-exists remove logical_switch " + node.Name + " other-config exclude_ips",
+		"ovn-nbctl --timeout=15 --if-exists lrp-del " + types.RouterToSwitchPrefix + node.Name + " -- lrp-add ovn_cluster_router " + types.RouterToSwitchPrefix + node.Name + " " + node.NodeLRPMAC + " " + node.NodeGWIP + " -- lrp-set-gateway-chassis " + types.RouterToSwitchPrefix + node.Name + " " + node.SystemID + " 1",
 		"ovn-nbctl --timeout=15 -- --may-exist lr-add " + node.GWRouter + " -- set logical_router " + node.GWRouter + " options:chassis=" + node.SystemID + " external_ids:physical_ip=" + node.GatewayRouterIP + " external_ids:physical_ips=" + node.GatewayRouterIP,
 		"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + types.OVNJoinSwitch + " " + types.JoinSwitchToGWRouterPrefix + node.GWRouter + " -- set logical_switch_port " + types.JoinSwitchToGWRouterPrefix + node.GWRouter + " type=router options:router-port=" + types.GWRouterToJoinSwitchPrefix + node.GWRouter + " addresses=router",
 		"ovn-nbctl --timeout=15 -- --if-exists lrp-del " + types.GWRouterToJoinSwitchPrefix + node.GWRouter + " -- lrp-add " + node.GWRouter + " " + types.GWRouterToJoinSwitchPrefix + node.GWRouter + " " + node.LrpMAC + " " + node.LrpIP + "/16" + addLRPForV6,

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -900,6 +900,7 @@ func (oc *Controller) syncNodeGateway(node *kapi.Node, hostSubnets []*net.IPNet)
 	if hostSubnets == nil {
 		hostSubnets, _ = util.ParseNodeHostSubnetAnnotation(node)
 	}
+
 	if l3GatewayConfig.Mode == config.GatewayModeDisabled {
 		if err := gatewayCleanup(node.Name); err != nil {
 			return fmt.Errorf("error cleaning up gateway for node %s: %v", node.Name, err)
@@ -928,6 +929,7 @@ func (oc *Controller) WatchNodes() {
 	var gatewaysFailed sync.Map
 	var mgmtPortFailed sync.Map
 	var addNodeFailed sync.Map
+	var nodeClusterRouterPortFailed sync.Map
 
 	start := time.Now()
 	oc.watchFactory.AddNodeHandler(cache.ResourceEventHandlerFuncs{
@@ -949,6 +951,13 @@ func (oc *Controller) WatchNodes() {
 				mgmtPortFailed.Store(node.Name, true)
 				gatewaysFailed.Store(node.Name, true)
 				return
+			}
+
+			if err = oc.syncNodeClusterRouterPort(node, hostSubnets); err != nil {
+				if !util.IsAnnotationNotSetError(err) {
+					klog.Warningf(err.Error())
+				}
+				nodeClusterRouterPortFailed.Store(node.Name, true)
 			}
 
 			err = oc.syncNodeManagementPort(node, hostSubnets)
@@ -1001,6 +1010,18 @@ func (oc *Controller) WatchNodes() {
 				addNodeFailed.Delete(node.Name)
 			}
 
+			_, failed = nodeClusterRouterPortFailed.Load(node.Name)
+			if failed || nodeChassisChanged(oldNode, node) || nodeSubnetChanged(oldNode, node) {
+				if err = oc.syncNodeClusterRouterPort(node, nil); err != nil {
+					if !util.IsAnnotationNotSetError(err) {
+						klog.Warningf(err.Error())
+					}
+					nodeClusterRouterPortFailed.Store(node.Name, true)
+				} else {
+					nodeClusterRouterPortFailed.Delete(node.Name)
+				}
+			}
+
 			_, failed = mgmtPortFailed.Load(node.Name)
 			if failed || macAddressChanged(oldNode, node) || nodeSubnetChanged(oldNode, node) {
 				err := oc.syncNodeManagementPort(node, hostSubnets)
@@ -1046,6 +1067,7 @@ func (oc *Controller) WatchNodes() {
 			addNodeFailed.Delete(node.Name)
 			mgmtPortFailed.Delete(node.Name)
 			gatewaysFailed.Delete(node.Name)
+			nodeClusterRouterPortFailed.Delete(node.Name)
 		},
 	}, oc.syncNodes)
 	klog.Infof("Bootstrapping existing nodes and cleaning stale nodes took %v", time.Since(start))


### PR DESCRIPTION
This patch sets gateway-chassis to the node itself for each logical
router port that connects node level switch to the cluster router. This
makes use of the OVN optimization [0] that avoids flooding-filling
unrelated datapaths by ovn-controller on each node, which perfectly
fits the ovn-kubernetes deployments where each logical switch is bound
to a chassis, significantly improving scalability of ovn-controller (10
times faster for recompute and 70-80% memory savings for ovn-controller
\+ OVS combined. See more details in [0]).

[0] https://github.com/ovn-org/ovn/commit/22298fd3790825f45680508bde821bb9a2d525d2

Signed-off-by: Han Zhou <hzhou@ovn.org>