### PR TITLE
[WIP] Scale/Perf: LGW: LRP 1003: Reconstruct the policy using address sets

### DIFF
--- a/go-controller/pkg/ovn/address_set/mocks/AddressSet.go
+++ b/go-controller/pkg/ovn/address_set/mocks/AddressSet.go
@@ -76,6 +76,31 @@ func (_m *AddressSet) GetASHashNames() (string, string) {
 	return r0, r1
 }
 
+// GetIPs provides a mock function with given fields:
+func (_m *AddressSet) GetIPs() ([]net.IP, []net.IP) {
+	ret := _m.Called()
+
+	var r0 []net.IP
+	if rf, ok := ret.Get(0).(func() []net.IP); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]net.IP)
+		}
+	}
+
+	var r1 []net.IP
+	if rf, ok := ret.Get(1).(func() []net.IP); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]net.IP)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetName provides a mock function with given fields:
 func (_m *AddressSet) GetName() string {
 	ret := _m.Called()

--- a/go-controller/pkg/ovn/address_set/mocks/AddressSetFactory.go
+++ b/go-controller/pkg/ovn/address_set/mocks/AddressSetFactory.go
@@ -29,17 +29,26 @@ func (_m *AddressSetFactory) DestroyAddressSetInBackingStore(name string) error 
 }
 
 // EnsureAddressSet provides a mock function with given fields: name
-func (_m *AddressSetFactory) EnsureAddressSet(name string) error {
+func (_m *AddressSetFactory) EnsureAddressSet(name string) (addressset.AddressSet, error) {
 	ret := _m.Called(name)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
+	var r0 addressset.AddressSet
+	if rf, ok := ret.Get(0).(func(string) addressset.AddressSet); ok {
 		r0 = rf(name)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(addressset.AddressSet)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // NewAddressSet provides a mock function with given fields: name, ips

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -305,7 +305,7 @@ func (oc *Controller) addEgressFirewall(egressFirewall *egressfirewallapi.Egress
 	// EgressFirewall needs to make sure that the address_set for the namespace exists independently of the namespace object
 	// so that OVN doesn't get unresolved references to the address_set.
 	// TODO: This should go away once we do something like refcounting for address_sets.
-	err = oc.addressSetFactory.EnsureAddressSet(egressFirewall.Namespace)
+	_, err = oc.addressSetFactory.EnsureAddressSet(egressFirewall.Namespace)
 	if err != nil {
 		return fmt.Errorf("cannot Ensure that addressSet for namespace %s exists %v", egressFirewall.Namespace, err)
 	}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -206,7 +206,6 @@ func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace string) {
 			pod, namespace)
 		return
 	}
-
 	for _, gwIP := range foundGws.gws {
 		// check for previously configured pod routes
 		for podIP, gwInfo := range nsInfo.podExternalRoutes {
@@ -442,14 +441,34 @@ func (oc *Controller) addPerPodGRSNAT(pod *kapi.Pod, podIfAddrs []*net.IPNet) er
 // by ecmp routes
 func (oc *Controller) addHybridRoutePolicyForPod(podIP net.IP, node string) error {
 	if config.Gateway.Mode == config.GatewayModeLocal {
+		// handle deletion of legacy policies, makes it safe for upgrades
+		err := delLegacyHybridRoutePolicyForPod(podIP, node)
+		if err != nil {
+			klog.Errorf("Cannot remove legacy hybrid router policy for pod %s on node %s, err: %v", podIP.String(), node, err)
+		}
+		// Add podIP to the node's address_set.
+		as, err := oc.addressSetFactory.EnsureAddressSet("hybrid-route-pods-" + node)
+		if err != nil {
+			return fmt.Errorf("cannot Ensure that addressSet for node %s exists %v", node, err)
+		}
+		err = as.AddIPs([]net.IP{(podIP)})
+		if err != nil {
+			return fmt.Errorf("unable to add PodIP %s: to the address set %s, err: %v", podIP.String(), node, err)
+		}
+
 		// add allow policy to bypass lr-policy in GR
+		ipv4HashedAS, ipv6HashedAS := as.GetASHashNames()
 		var l3Prefix string
+		var matchSrcAS string
 		isIPv6 := utilnet.IsIPv6(podIP)
 		if isIPv6 {
 			l3Prefix = "ip6"
+			matchSrcAS = ipv6HashedAS
 		} else {
 			l3Prefix = "ip4"
+			matchSrcAS = ipv4HashedAS
 		}
+
 		// get the GR to join switch ip address
 		grJoinIfAddrs, err := util.GetLRPAddrs(types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + node)
 		if err != nil {
@@ -473,18 +492,15 @@ func (oc *Controller) addHybridRoutePolicyForPod(podIP net.IP, node string) erro
 			}
 			matchDst += fmt.Sprintf(" && %s.dst != %s", clusterL3Prefix, clusterSubnet.CIDR)
 		}
+
 		// traffic destined outside of cluster subnet go to GR
-		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.src == %s`, types.RouterToSwitchPrefix, node, l3Prefix, podIP)
+		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.src == $%s`, types.RouterToSwitchPrefix, node, l3Prefix, matchSrcAS)
 		matchStr += matchDst
-		_, stderr, err := util.RunOVNNbctl("lr-policy-add", types.OVNClusterRouter, types.HybridOverlayReroutePriority, matchStr, "reroute",
+		_, stderr, err := util.RunOVNNbctl("--may-exist", "lr-policy-add", types.OVNClusterRouter, types.HybridOverlayReroutePriority, matchStr, "reroute",
 			grJoinIfAddr.IP.String())
 		if err != nil {
-			// TODO: lr-policy-add doesn't support --may-exist, resort to this workaround for now.
-			// Have raised an issue against ovn repository (https://github.com/ovn-org/ovn/issues/49)
-			if !strings.Contains(stderr, "already existed") {
-				return fmt.Errorf("failed to add policy route '%s' to %s "+
-					"stderr: %s, error: %v", matchStr, types.OVNClusterRouter, stderr, err)
-			}
+			return fmt.Errorf("failed to add policy route '%s' to %s "+
+				"stderr: %s, error: %v", matchStr, types.OVNClusterRouter, stderr, err)
 		}
 	}
 	return nil
@@ -494,33 +510,98 @@ func (oc *Controller) addHybridRoutePolicyForPod(podIP net.IP, node string) erro
 // by ecmp routes
 func (oc *Controller) delHybridRoutePolicyForPod(podIP net.IP, node string) error {
 	if config.Gateway.Mode == config.GatewayModeLocal {
-		// delete allow policy to bypass lr-policy in GR
+		// Delete podIP from the node's address_set.
+		as, err := oc.addressSetFactory.EnsureAddressSet("hybrid-route-pods-" + node)
+		if err != nil {
+			return fmt.Errorf("cannot Ensure that addressSet for node %s exists %v", node, err)
+		}
+		err = as.DeleteIPs([]net.IP{(podIP)})
+		if err != nil {
+			return fmt.Errorf("unable to remove PodIP %s: to the address set %s, err: %v", podIP.String(), node, err)
+		}
+
+		// delete allow policy to bypass lr-policy in GR, only if there are zero pods on this node.
+		ipv4HashedAS, ipv6HashedAS := as.GetASHashNames()
+		ipv4PodIPs, ipv6PodIPs := as.GetIPs()
+		deletePolicy := false
 		var l3Prefix string
+		var matchSrcAS string
 		if utilnet.IsIPv6(podIP) {
 			l3Prefix = "ip6"
+			if len(ipv6PodIPs) == 0 {
+				deletePolicy = true
+			}
+			matchSrcAS = ipv6HashedAS
 		} else {
 			l3Prefix = "ip4"
-		}
-		var matchDst string
-		var clusterL3Prefix string
-		for _, clusterSubnet := range config.Default.ClusterSubnets {
-			if utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
-				clusterL3Prefix = "ip6"
-			} else {
-				clusterL3Prefix = "ip4"
+			if len(ipv4PodIPs) == 0 {
+				deletePolicy = true
 			}
-			if l3Prefix != clusterL3Prefix {
-				continue
+			matchSrcAS = ipv4HashedAS
+		}
+		if deletePolicy {
+			var matchDst string
+			var clusterL3Prefix string
+			for _, clusterSubnet := range config.Default.ClusterSubnets {
+				if utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
+					clusterL3Prefix = "ip6"
+				} else {
+					clusterL3Prefix = "ip4"
+				}
+				if l3Prefix != clusterL3Prefix {
+					continue
+				}
+				matchDst += fmt.Sprintf(" && %s.dst != %s", l3Prefix, clusterSubnet.CIDR)
 			}
-			matchDst += fmt.Sprintf(" && %s.dst != %s", l3Prefix, clusterSubnet.CIDR)
+			matchStr := fmt.Sprintf(`inport == "%s%s" && %s.src == $%s`, types.RouterToSwitchPrefix, node, l3Prefix, matchSrcAS)
+			matchStr += matchDst
+			_, stderr, err := util.RunOVNNbctl("--if-exists", "lr-policy-del", types.OVNClusterRouter, types.HybridOverlayReroutePriority, matchStr)
+			if err != nil {
+				klog.Errorf("Failed to remove policy: %s, on: %s, stderr: %s, err: %v",
+					matchStr, types.OVNClusterRouter, stderr, err)
+			}
 		}
-		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.src == %s`, types.RouterToSwitchPrefix, node, l3Prefix, podIP)
-		matchStr += matchDst
-		_, stderr, err := util.RunOVNNbctl("lr-policy-del", types.OVNClusterRouter, types.HybridOverlayReroutePriority, matchStr)
-		if err != nil {
-			klog.Errorf("Failed to remove policy: %s, on: %s, stderr: %s, err: %v",
-				matchStr, types.OVNClusterRouter, stderr, err)
+		if len(ipv4PodIPs) == 0 && len(ipv6PodIPs) == 0 {
+			// delete address set.
+			err := as.Destroy()
+			if err != nil {
+				klog.Errorf("Failed to remove address set: %s, on: %s, err: %v",
+					as.GetName(), node, err)
+			}
 		}
+	}
+	return nil
+}
+
+// delLegacyHybridRoutePolicyForPod handles deleting a higher priority allow policy to allow traffic to be routed normally
+// by ecmp routes
+func delLegacyHybridRoutePolicyForPod(podIP net.IP, node string) error {
+	// delete allow policy to bypass lr-policy in GR
+	var l3Prefix string
+	if utilnet.IsIPv6(podIP) {
+		l3Prefix = "ip6"
+	} else {
+		l3Prefix = "ip4"
+	}
+	var matchDst string
+	var clusterL3Prefix string
+	for _, clusterSubnet := range config.Default.ClusterSubnets {
+		if utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
+			clusterL3Prefix = "ip6"
+		} else {
+			clusterL3Prefix = "ip4"
+		}
+		if l3Prefix != clusterL3Prefix {
+			continue
+		}
+		matchDst += fmt.Sprintf(" && %s.dst != %s", l3Prefix, clusterSubnet.CIDR)
+	}
+	matchStr := fmt.Sprintf(`inport == "%s%s" && %s.src == %s`, types.RouterToSwitchPrefix, node, l3Prefix, podIP)
+	matchStr += matchDst
+	_, stderr, err := util.RunOVNNbctl("--if-exists", "lr-policy-del", types.OVNClusterRouter, types.HybridOverlayReroutePriority, matchStr)
+	if err != nil {
+		klog.Errorf("Failed to remove legacy policy: %s, on: %s, stderr: %s, err: %v",
+			matchStr, types.OVNClusterRouter, stderr, err)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"context"
 	"encoding/json"
+	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -858,6 +859,105 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+	})
+	ginkgo.Context("hybrid route policy operations in lgw mode", func() {
+		ginkgo.It("add hybrid route policy for pods", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.Gateway.Mode = config.GatewayModeLocal
+				namespaceT := *newNamespace("namespace1")
+				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1,9.0.0.2", "k8s.ovn.org/bfd-enabled": ""}
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					"namespace1",
+				)
+
+				fakeOvn.start(ctx,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
+						},
+					},
+				)
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists lr-policy-del ovn_cluster_router 501 inport == \"rtos-node1\" && ip4.src == 10.128.1.3 && ip4.dst != 10.128.0.0/14",
+					Output: "\n",
+				})
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exist get logical_router_port rtoj-GR_node1 networks",
+					Output: "100.64.0.4/16\n",
+				})
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --may-exist lr-policy-add ovn_cluster_router 501 inport == \"rtos-node1\" && ip4.src == $a17568862106095406051 && ip4.dst != 10.128.0.0/14 reroute 100.64.0.4",
+					Output: "\n",
+				})
+
+				injectNode(fakeOvn)
+				err := fakeOvn.controller.addHybridRoutePolicyForPod(net.ParseIP(t.podIP), t.nodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
+				fakeOvn.asf.ExpectAddressSetWithIPs("hybrid-route-pods-node1", []string{t.podIP})
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+		ginkgo.It("delete hybrid route policy for pods", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.Gateway.Mode = config.GatewayModeLocal
+				namespaceT := *newNamespace("namespace1")
+				namespaceT.Annotations = map[string]string{"k8s.ovn.org/routing-external-gws": "9.0.0.1,9.0.0.2", "k8s.ovn.org/bfd-enabled": ""}
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					"namespace1",
+				)
+
+				fakeOvn.start(ctx,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
+						},
+					},
+				)
+				fExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    "ovn-nbctl --timeout=15 --if-exists lr-policy-del ovn_cluster_router 501 inport == \"rtos-node1\" && ip4.src == $a17568862106095406051 && ip4.dst != 10.128.0.0/14",
+					Output: "\n",
+				})
+
+				injectNode(fakeOvn)
+				err := fakeOvn.controller.delHybridRoutePolicyForPod(net.ParseIP(t.podIP), t.nodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
+				fakeOvn.asf.ExpectEmptyAddressSet("hybrid-route-pods-node1")
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
 	})
 })
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -185,7 +185,7 @@ func (oc *Controller) upgradeToSingleSwitchOVNTopology(existingNodeList *kapi.No
 
 		// for all nodes include the ones that were deleted, delete its gateway entities.
 		// See comments above the multiJoinSwitchGatewayCleanup() function for details.
-		err = multiJoinSwitchGatewayCleanup(nodeName, upgradeOnly)
+		err = oc.multiJoinSwitchGatewayCleanup(nodeName, upgradeOnly)
 		if err != nil {
 			return err
 		}
@@ -210,7 +210,7 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 	}
 	// If version is less than Host -> Service with OpenFlow, we need to remove and cleanup DGP
 	if err == nil && ver < types.OvnHostToSvcOFTopoVersion && config.Gateway.Mode == config.GatewayModeShared {
-		err = cleanupDGP(existingNodes)
+		err = oc.cleanupDGP(existingNodes)
 	}
 	return err
 }
@@ -675,7 +675,7 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 		if err != nil && err != util.NoIPError {
 			return err
 		}
-		if err := addPolicyBasedRoutes(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
+		if err := oc.addPolicyBasedRoutes(node.Name, hostIfAddr.IP.String(), l3GatewayConfigIP, relevantHostIPs); err != nil {
 			return err
 		}
 
@@ -1163,7 +1163,7 @@ func (oc *Controller) deleteNode(nodeName string, hostSubnets []*net.IPNet, node
 		klog.Errorf("Error deleting node %s logical network: %v", nodeName, err)
 	}
 
-	if err := gatewayCleanup(nodeName); err != nil {
+	if err := oc.gatewayCleanup(nodeName); err != nil {
 		klog.Errorf("Failed to clean up node %s gateway: (%v)", nodeName, err)
 	}
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -898,7 +898,7 @@ func (oc *Controller) syncNodeGateway(node *kapi.Node, hostSubnets []*net.IPNet)
 		hostSubnets, _ = util.ParseNodeHostSubnetAnnotation(node)
 	}
 	if l3GatewayConfig.Mode == config.GatewayModeDisabled {
-		if err := gatewayCleanup(node.Name); err != nil {
+		if err := oc.gatewayCleanup(node.Name); err != nil {
 			return fmt.Errorf("error cleaning up gateway for node %s: %v", node.Name, err)
 		}
 		if err := oc.joinSwIPManager.releaseJoinLRPIPs(node.Name); err != nil {

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -37,6 +37,8 @@ const (
 	GWRouterToExtSwitchPrefix    = "rtoe-"
 	EgressGWSwitchPrefix         = "exgw-"
 
+	InterNodeTraffic = "inter-node-traffic"
+
 	NodeLocalSwitch = "node_local_switch"
 
 	// ACL directions

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -42,6 +43,19 @@ func GetWorkerFromGatewayRouter(gr string) string {
 // GetGatewayRouterFromNode determines a node's corresponding gateway router name
 func GetGatewayRouterFromNode(node string) string {
 	return types.GWRouterPrefix + node
+}
+
+func GetMgmtPortIPsFromNode(node *kapi.Node) []net.IP {
+	subnets, err := ParseNodeHostSubnetAnnotation(node)
+	if err != nil {
+		klog.Errorf("failed to get host subnets for %s: %v", node.Name, err)
+	}
+	var mgmtPortIPs []net.IP
+	for _, subnet := range subnets {
+		mgmtPortIP := GetNodeManagementIfAddr(subnet)
+		mgmtPortIPs = append(mgmtPortIPs, mgmtPortIP.IP)
+	}
+	return mgmtPortIPs
 }
 
 // GetNodeChassisID returns the machine's OVN chassis ID


### PR DESCRIPTION

**- What this PR does and why is it needed**
This PR modifies the way 1003 LRP flows for inter-node traffic in LGW mode are constructed. This flow has the != match per node which can cause a lot of flow generation. Idea is to use one global address-set that contains all the management port's IPs in it.

`policy`: We will have one policy in total instead of one policy per node.
`lflows`: We will have one flow in total instead of one per node.
`openflows`: A cluster having 500 nodes would have 10500 flows w/o the PR and 521 flows only with the PR.

**- Special notes for reviewers**
This PR only touches LGW mode since the 501 policy is not created or used in SGW mode. 


**- How to verify it**
Spin up a KIND cluster.

On a cluster without the PR:
```
1003 ip4.src == 10.244.0.2  && ip4.dst != 10.244.0.0/16 /* inter-ovn-worker */         reroute               169.254.0.1
1003 ip4.src == 10.244.1.2  && ip4.dst != 10.244.0.0/16 /* inter-ovn-control-plane */         reroute               169.254.0.1
1003 ip4.src == 10.244.2.2  && ip4.dst != 10.244.0.0/16 /* inter-ovn-worker2 */         reroute               169.254.0.1
```

On a cluster with the PR:
```
1003 ip4.src == $a6650847339905343653 && ip4.dst != 10.244.0.0/16 /* inter-node-traffic */         reroute               169.254.0.1

$ ovn-sbctl lflow-list | grep priority=1003
  table=12(lr_in_policy       ), priority=1003 , match=(ip4.src == $a6650847339905343653 && ip4.dst != 10.244.0.0/16 /* inter-node-traffic */), action=(reg0 = 169.254.0.1; reg1 = 169.254.0.2; eth.src = 0a:58:a9:fe:00:02; outport = "rtos-node_local_switch"; flags.loopback = 1; reg8[0..15] = 0; next;)

_uuid               : 2faf137b-b9d0-4972-90bb-b7adc2ee7e1e
addresses           : ["10.244.0.2", "10.244.1.2", "10.244.2.2"]
external_ids        : {name=ovn-k8s-mp0-ips_v4}
name                : a6650847339905343653

```

TODO: test upgrades. Also currently this depends on https://github.com/ovn-org/ovn-kubernetes/pull/2387. 

**- Description for the changelog**
Performance fix for LRP 1003 used in LGW mode.