### PR TITLE
HBO: Make GetPortAddresses return portMAC even if portIP is nil

### DIFF
--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -59,9 +59,6 @@ func GetPortAddresses(portName string, ovnNBClient goovn.Client) (net.HardwareAd
 		return nil, nil, nil
 	}
 
-	if len(addresses) < 2 {
-		return nil, nil, fmt.Errorf("error while obtaining addresses for %s: %v", portName, addresses)
-	}
 	mac, err := net.ParseMAC(addresses[0])
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse logical switch port %q MAC %q: %v", portName, addresses[0], err)

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -97,9 +97,8 @@ func TestGetPortAddresses(t *testing.T) {
 			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: "06:c6:d4:fb:fb:ba 10.244.2.2"}, nil}},
 		},
 		{
-			desc:                 "test code path where addresses list count is less than 2",
+			desc:                 "test code path where port has MAC but no IPs",
 			inpPort:              "TEST_PORT",
-			errMatch:             fmt.Errorf("error while obtaining addresses for"),
 			onRetArgsOvnNBClient: &ovntest.TestifyMockHelper{OnCallMethodName: "LSPGet", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{&goovn.LogicalSwitchPort{DynamicAddresses: "06:c6:d4:fb:fb:ba"}, nil}},
 		},
 		{


### PR DESCRIPTION
**- What this PR does and why is it needed**

In `GetPortAddresses`, we check if we have both PortMAC and IP for
the port. If not we return nil for both values. While this works
for normal ports, for the HBO ports which don't have IPs for
the `int-<node>` interface, we will always hit this condition and
return an empty PortMAC which in turn triggers the lsp-add even
if the portMAC already exists.

When we have an external entity updating the node object, the
watcher triggers `handleOverlayPort` and we keep hitting this
condition.

Let's remove the `len(addresses)<2` check since its not needed
for HBO and in normal pod port case, `pods.getPortAddresses` already
handles the case for empty podMac or podIPs. This way when portMAC
is set but not the IPs, we will still return the portMAC and the
respective code paths handle it as needed.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

**- How to verify it**
Spin up a KIND cluster. Before the PR we could see lots of:

```
I0803 09:04:26.498592      51 master.go:231] Creating / updating node ovn-control-plane hybrid overlay port with mac 0a:58:0a:f4:01:03
I0803 09:04:36.540287      51 master.go:231] Creating / updating node ovn-worker2 hybrid overlay port with mac 0a:58:0a:f4:00:03
I0803 09:04:36.540746      51 master.go:231] Creating / updating node ovn-worker hybrid overlay port with mac 0a:58:0a:f4:02:03
I0803 09:09:28.379210      51 master.go:231] Creating / updating node ovn-control-plane hybrid overlay port with mac 0a:58:0a:f4:01:03
I0803 09:09:38.413117      51 master.go:231] Creating / updating node ovn-worker2 hybrid overlay port with mac 0a:58:0a:f4:00:03
I0803 09:09:38.415934      51 master.go:231] Creating / updating node ovn-worker hybrid overlay port with mac 0a:58:0a:f4:02:03
I0803 09:14:30.025162      51 master.go:231] Creating / updating node ovn-control-plane hybrid overlay port with mac 0a:58:0a:f4:01:03
I0803 09:14:40.066693      51 master.go:231] Creating / updating node ovn-worker hybrid overlay port with mac 0a:58:0a:f4:02:03
I0803 09:14:40.068880      51 master.go:231] Creating / updating node ovn-worker2 hybrid overlay port with mac 0a:58:0a:f4:00:03
I0803 09:19:31.382330      51 master.go:231] Creating / updating node ovn-control-plane hybrid overlay port with mac 0a:58:0a:f4:01:03
I0803 09:19:41.438269      51 master.go:231] Creating / updating node ovn-worker hybrid overlay port with mac 0a:58:0a:f4:02:03
I0803 09:19:41.441319      51 master.go:231] Creating / updating node ovn-worker2 hybrid overlay port with mac 0a:58:0a:f4:00:03
I0803 09:24:32.765837      51 master.go:231] Creating / updating node ovn-control-plane hybrid overlay port with mac 0a:58:0a:f4:01:03
I0803 09:24:42.806418      51 master.go:231] Creating / updating node ovn-worker2 hybrid overlay port with mac 0a:58:0a:f4:00:03
I0803 09:24:42.810539      51 master.go:231] Creating / updating node ovn-worker hybrid overlay port with mac 0a:58:0a:f4:02:03
I0803 09:29:34.326222      51 master.go:231] Creating / updating node ovn-control-plane hybrid overlay port with mac 0a:58:0a:f4:01:03
I0803 09:29:44.396047      51 master.go:231] Creating / updating node ovn-worker hybrid overlay port with mac 0a:58:0a:f4:02:03
I0803 09:29:44.397670      51 master.go:231] Creating / updating node ovn-worker2 hybrid overlay port with mac 0a:58:0a:f4:00:03
I0803 09:34:35.842705      51 master.go:231] Creating / updating node ovn-control-plane hybrid overlay port with mac 0a:58:0a:f4:01:03
I0803 09:34:45.878037      51 master.go:231] Creating / updating node ovn-worker2 hybrid overlay port with mac 0a:58:0a:f4:00:03
I0803 09:34:45.881372      51 master.go:231] Creating / updating node ovn-worker hybrid overlay port with mac 0a:58:0a:f4:02:03
I0803 09:39:36.971651      51 master.go:231] Creating / updating node ovn-control-plane hybrid overlay port with mac 0a:58:0a:f4:01:03
I0803 09:39:47.023406      51 master.go:231] Creating / updating node ovn-worker2 hybrid overlay port with mac 0a:58:0a:f4:00:03
I0803 09:39:47.023452      51 master.go:231] Creating / updating node ovn-worker hybrid overlay port with mac 0a:58:0a:f4:02:03

```

With the PR, we handle this better for node updates since now `GetPortAddresses` will return the portMAC even if portIPs are nil.

```
I0803 09:52:38.487000      50 master.go:259] Processing add event for node ovn-control-plane
I0803 09:52:38.487011      50 master.go:259] Processing add event for node ovn-worker
I0803 09:52:38.487015      50 master.go:259] Processing add event for node ovn-worker2
I0803 09:52:38.487043      50 master.go:199] Allocating MAC 0a:58:0a:f4:01:03 to node ovn-control-plane
I0803 09:52:38.487047      50 master.go:199] Allocating MAC 0a:58:0a:f4:00:03 to node ovn-worker
I0803 09:52:38.487054      50 master.go:224] Creating / updating node ovn-control-plane hybrid overlay port with mac 0a:58:0a:f4:01:03
I0803 09:52:38.487060      50 master.go:224] Creating / updating node ovn-worker hybrid overlay port with mac 0a:58:0a:f4:00:03
I0803 09:52:38.487092      50 master.go:199] Allocating MAC 0a:58:0a:f4:02:03 to node ovn-worker2
I0803 09:52:38.487108      50 master.go:224] Creating / updating node ovn-worker2 hybrid overlay port with mac 0a:58:0a:f4:02:03

```