### PR TITLE
Tests: fix ipv6 conversion flake

### DIFF
--- a/contrib/kind-dual-stack-conversion.sh
+++ b/contrib/kind-dual-stack-conversion.sh
@@ -159,7 +159,7 @@ spec:
       targetPort: 80
 EOF
 
-if ! kubectl wait --for=condition=ready pods --all --timeout=100s ; then
+if ! kubectl rollout status deployment server-deployment -w --timeout=100s ; then
   echo "deployment is not running"
   kubectl get pods -o wide -A || true
   exit 1


### PR DESCRIPTION
It waits for all pods to be ready, but fails early if the deployment hasn't created any pods yet.

Instead, just wait for the deployment to roll out.

Signed-off-by: Casey Callendrello <cdc@redhat.com>