### PR TITLE
ci: fix running e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -333,7 +333,7 @@ jobs:
         make -C test install-kind
     - name: Run Tests
       run: |
-        make -C test ${{ matrix.target.shard }}
+        make -C test ${{ matrix.target }}
     - name: Upload Junit Reports
       if: always()
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
@andreaskaris I think now that matrix.target no longer has 'shards', the e2e tests weren't running because there wasn't a target in the Makefile to hit :(