### PR TITLE
Fix sync for logical static routes for egress gateway routes

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -607,7 +607,7 @@ func (oc *Controller) cleanECMPRoutes() {
 		out, stderr, err := util.RunOVNNbctl(
 			"--format=csv", "--data=bare", "--no-heading", "--columns=_uuid,name", "find", "Logical_Router", fmt.Sprintf("static_routes{>=}[%s]", uuid))
 		if err != nil || out == "" {
-			klog.Errorf("cleanECMPRoutes: failed to find logical router for %s", uuid, err, stderr)
+			klog.Errorf("cleanECMPRoutes: failed to find logical router for %s, err: %v, stderr: %s", uuid, err, stderr)
 			continue
 		}
 		values = strings.Split(out, ",")
@@ -616,11 +616,10 @@ func (oc *Controller) cleanECMPRoutes() {
 		node := util.GetWorkerFromGatewayRouter(gr)
 		prefix, err := oc.extSwitchPrefix(node)
 		if err != nil {
-			klog.Errorf("cleanECMPRoutes: failed to find logical router for %s", uuid, err, stderr)
+			klog.Errorf("cleanECMPRoutes: failed to find logical router for %s, err: %v", uuid, err)
 			continue
 		}
-		if (prefix != "" && !strings.Contains(port, prefix)) ||
-			(prefix == "" && strings.Contains(port, prefix)) {
+		if prefix != "" && !strings.Contains(port, prefix) {
 			klog.Infof("Found legacy ecmp route, output_port=%s, extSwitchPrefix=%s", port, prefix)
 			_, stderr, err = util.RunOVNNbctl("--if-exists", "remove", "Logical_Router", strings.TrimSuffix(lruuid, "\n"), "static_routes", uuid)
 			if err != nil {


### PR DESCRIPTION
Due to a bug in `cleanECMPRoutes` all logical router static routes get
deleted when ovnkube-master restarts. This fixes that and adds a
dedicated test case ensuring that we only clean up "legacy routes" on
restart. "Legacy routes" in this case being routes that were created
before a dedicated external gateway interface was specified by the user,
by annotating the node object.

/assign @trozet @fedepaol 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->