### PR TITLE
vendor: bump libovsdb

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
-	github.com/ovn-org/libovsdb v0.6.1-0.20210728143211-5f41f6da59f7
+	github.com/ovn-org/libovsdb v0.6.1-0.20210803142447-94fe2cdc514e
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/procfs v0.2.0 // indirect

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -73,8 +73,8 @@ github.com/cenkalti/hub v1.0.1-0.20160527103212-11382a9960d3/go.mod h1:tcYwtS3a2
 github.com/cenkalti/hub v1.0.1 h1:UMtjc6dHSaOQTO15SVA50MBIR9zQwvsukQupDrkIRtg=
 github.com/cenkalti/hub v1.0.1/go.mod h1:tcYwtS3a2d9NO/0xDXVJWx3IedurUjYCqFCmpi0lpHs=
 github.com/cenkalti/rpc2 v0.0.0-20170726070524-c51a77e5f664/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
-github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1 h1:aT9Ez2drLmrviqTnVnH87AeXLXLgUrXACJ2g90cTT2w=
-github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
+github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984 h1:CNwZyGS6KpfaOWbh2yLkSy3rSTUh3jub9CzpFpP6PVQ=
+github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -323,8 +323,8 @@ github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5X
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/ory/dockertest/v3 v3.7.0/go.mod h1:PvCCgnP7AfBZeVrzwiUTjZx/IUXlGLC1zQlUQrLIlUE=
-github.com/ovn-org/libovsdb v0.6.1-0.20210728143211-5f41f6da59f7 h1:DwufVXaK6fowTYe/S8lFSx8w7T+dLkNDeEV/tceZDJo=
-github.com/ovn-org/libovsdb v0.6.1-0.20210728143211-5f41f6da59f7/go.mod h1:5Ld4X+oWvMlbPAGvbJyE/wp8TAWdydI67jatQ3qbsVc=
+github.com/ovn-org/libovsdb v0.6.1-0.20210803142447-94fe2cdc514e h1:qlUkF5zLGDhOiwYMzdFOZAZqGhbXRVMihQhGuLufg/s=
+github.com/ovn-org/libovsdb v0.6.1-0.20210803142447-94fe2cdc514e/go.mod h1:z8nnwUG5G+D4bzoUm6qbg5fC4q9pphb5VwO0AS473Ks=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/pkg/nbdb/acl.go
+++ b/go-controller/pkg/nbdb/acl.go
@@ -9,7 +9,7 @@ type (
 	ACLSeverity  = string
 )
 
-const (
+var (
 	ACLActionAllow          ACLAction    = "allow"
 	ACLActionAllowRelated   ACLAction    = "allow-related"
 	ACLActionAllowStateless ACLAction    = "allow-stateless"
@@ -18,10 +18,10 @@ const (
 	ACLDirectionFromLport   ACLDirection = "from-lport"
 	ACLDirectionToLport     ACLDirection = "to-lport"
 	ACLSeverityAlert        ACLSeverity  = "alert"
-	ACLSeverityWarning      ACLSeverity  = "warning"
-	ACLSeverityNotice       ACLSeverity  = "notice"
-	ACLSeverityInfo         ACLSeverity  = "info"
 	ACLSeverityDebug        ACLSeverity  = "debug"
+	ACLSeverityInfo         ACLSeverity  = "info"
+	ACLSeverityNotice       ACLSeverity  = "notice"
+	ACLSeverityWarning      ACLSeverity  = "warning"
 )
 
 // ACL defines an object in ACL table
@@ -32,8 +32,8 @@ type ACL struct {
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Log         bool              `ovsdb:"log"`
 	Match       string            `ovsdb:"match"`
-	Meter       []string          `ovsdb:"meter"`
-	Name        []string          `ovsdb:"name"`
+	Meter       *string           `ovsdb:"meter"`
+	Name        *string           `ovsdb:"name"`
 	Priority    int               `ovsdb:"priority"`
-	Severity    []ACLSeverity     `ovsdb:"severity"`
+	Severity    *ACLSeverity      `ovsdb:"severity"`
 }

--- a/go-controller/pkg/nbdb/bfd.go
+++ b/go-controller/pkg/nbdb/bfd.go
@@ -7,22 +7,22 @@ type (
 	BFDStatus = string
 )
 
-const (
+var (
+	BFDStatusAdminDown BFDStatus = "admin_down"
 	BFDStatusDown      BFDStatus = "down"
 	BFDStatusInit      BFDStatus = "init"
 	BFDStatusUp        BFDStatus = "up"
-	BFDStatusAdminDown BFDStatus = "admin_down"
 )
 
 // BFD defines an object in BFD table
 type BFD struct {
 	UUID        string            `ovsdb:"_uuid"`
-	DetectMult  []int             `ovsdb:"detect_mult"`
+	DetectMult  *int              `ovsdb:"detect_mult"`
 	DstIP       string            `ovsdb:"dst_ip"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	LogicalPort string            `ovsdb:"logical_port"`
-	MinRx       []int             `ovsdb:"min_rx"`
-	MinTx       []int             `ovsdb:"min_tx"`
+	MinRx       *int              `ovsdb:"min_rx"`
+	MinTx       *int              `ovsdb:"min_tx"`
 	Options     map[string]string `ovsdb:"options"`
-	Status      []BFDStatus       `ovsdb:"status"`
+	Status      *BFDStatus        `ovsdb:"status"`
 }

--- a/go-controller/pkg/nbdb/connection.go
+++ b/go-controller/pkg/nbdb/connection.go
@@ -7,9 +7,9 @@ package nbdb
 type Connection struct {
 	UUID            string            `ovsdb:"_uuid"`
 	ExternalIDs     map[string]string `ovsdb:"external_ids"`
-	InactivityProbe []int             `ovsdb:"inactivity_probe"`
+	InactivityProbe *int              `ovsdb:"inactivity_probe"`
 	IsConnected     bool              `ovsdb:"is_connected"`
-	MaxBackoff      []int             `ovsdb:"max_backoff"`
+	MaxBackoff      *int              `ovsdb:"max_backoff"`
 	OtherConfig     map[string]string `ovsdb:"other_config"`
 	Status          map[string]string `ovsdb:"status"`
 	Target          string            `ovsdb:"target"`

--- a/go-controller/pkg/nbdb/load_balancer.go
+++ b/go-controller/pkg/nbdb/load_balancer.go
@@ -8,16 +8,16 @@ type (
 	LoadBalancerSelectionFields = string
 )
 
-const (
+var (
+	LoadBalancerProtocolSCTP          LoadBalancerProtocol        = "sctp"
 	LoadBalancerProtocolTCP           LoadBalancerProtocol        = "tcp"
 	LoadBalancerProtocolUDP           LoadBalancerProtocol        = "udp"
-	LoadBalancerProtocolSCTP          LoadBalancerProtocol        = "sctp"
-	LoadBalancerSelectionFieldsEthSrc LoadBalancerSelectionFields = "eth_src"
 	LoadBalancerSelectionFieldsEthDst LoadBalancerSelectionFields = "eth_dst"
-	LoadBalancerSelectionFieldsIPSrc  LoadBalancerSelectionFields = "ip_src"
+	LoadBalancerSelectionFieldsEthSrc LoadBalancerSelectionFields = "eth_src"
 	LoadBalancerSelectionFieldsIPDst  LoadBalancerSelectionFields = "ip_dst"
-	LoadBalancerSelectionFieldsTpSrc  LoadBalancerSelectionFields = "tp_src"
+	LoadBalancerSelectionFieldsIPSrc  LoadBalancerSelectionFields = "ip_src"
 	LoadBalancerSelectionFieldsTpDst  LoadBalancerSelectionFields = "tp_dst"
+	LoadBalancerSelectionFieldsTpSrc  LoadBalancerSelectionFields = "tp_src"
 )
 
 // LoadBalancer defines an object in Load_Balancer table
@@ -28,7 +28,7 @@ type LoadBalancer struct {
 	IPPortMappings  map[string]string             `ovsdb:"ip_port_mappings"`
 	Name            string                        `ovsdb:"name"`
 	Options         map[string]string             `ovsdb:"options"`
-	Protocol        []LoadBalancerProtocol        `ovsdb:"protocol"`
+	Protocol        *LoadBalancerProtocol         `ovsdb:"protocol"`
 	SelectionFields []LoadBalancerSelectionFields `ovsdb:"selection_fields"`
 	Vips            map[string]string             `ovsdb:"vips"`
 }

--- a/go-controller/pkg/nbdb/logical_router.go
+++ b/go-controller/pkg/nbdb/logical_router.go
@@ -6,7 +6,7 @@ package nbdb
 // LogicalRouter defines an object in Logical_Router table
 type LogicalRouter struct {
 	UUID         string            `ovsdb:"_uuid"`
-	Enabled      []bool            `ovsdb:"enabled"`
+	Enabled      *bool             `ovsdb:"enabled"`
 	ExternalIDs  map[string]string `ovsdb:"external_ids"`
 	LoadBalancer []string          `ovsdb:"load_balancer"`
 	Name         string            `ovsdb:"name"`

--- a/go-controller/pkg/nbdb/logical_router_policy.go
+++ b/go-controller/pkg/nbdb/logical_router_policy.go
@@ -7,7 +7,7 @@ type (
 	LogicalRouterPolicyAction = string
 )
 
-const (
+var (
 	LogicalRouterPolicyActionAllow   LogicalRouterPolicyAction = "allow"
 	LogicalRouterPolicyActionDrop    LogicalRouterPolicyAction = "drop"
 	LogicalRouterPolicyActionReroute LogicalRouterPolicyAction = "reroute"
@@ -19,7 +19,7 @@ type LogicalRouterPolicy struct {
 	Action      LogicalRouterPolicyAction `ovsdb:"action"`
 	ExternalIDs map[string]string         `ovsdb:"external_ids"`
 	Match       string                    `ovsdb:"match"`
-	Nexthop     []string                  `ovsdb:"nexthop"`
+	Nexthop     *string                   `ovsdb:"nexthop"`
 	Nexthops    []string                  `ovsdb:"nexthops"`
 	Options     map[string]string         `ovsdb:"options"`
 	Priority    int                       `ovsdb:"priority"`

--- a/go-controller/pkg/nbdb/logical_router_port.go
+++ b/go-controller/pkg/nbdb/logical_router_port.go
@@ -6,15 +6,15 @@ package nbdb
 // LogicalRouterPort defines an object in Logical_Router_Port table
 type LogicalRouterPort struct {
 	UUID           string            `ovsdb:"_uuid"`
-	Enabled        []bool            `ovsdb:"enabled"`
+	Enabled        *bool             `ovsdb:"enabled"`
 	ExternalIDs    map[string]string `ovsdb:"external_ids"`
 	GatewayChassis []string          `ovsdb:"gateway_chassis"`
-	HaChassisGroup []string          `ovsdb:"ha_chassis_group"`
+	HaChassisGroup *string           `ovsdb:"ha_chassis_group"`
 	Ipv6Prefix     []string          `ovsdb:"ipv6_prefix"`
 	Ipv6RaConfigs  map[string]string `ovsdb:"ipv6_ra_configs"`
 	MAC            string            `ovsdb:"mac"`
 	Name           string            `ovsdb:"name"`
 	Networks       []string          `ovsdb:"networks"`
 	Options        map[string]string `ovsdb:"options"`
-	Peer           []string          `ovsdb:"peer"`
+	Peer           *string           `ovsdb:"peer"`
 }

--- a/go-controller/pkg/nbdb/logical_router_static_route.go
+++ b/go-controller/pkg/nbdb/logical_router_static_route.go
@@ -7,19 +7,19 @@ type (
 	LogicalRouterStaticRoutePolicy = string
 )
 
-const (
-	LogicalRouterStaticRoutePolicySrcIP LogicalRouterStaticRoutePolicy = "src-ip"
+var (
 	LogicalRouterStaticRoutePolicyDstIP LogicalRouterStaticRoutePolicy = "dst-ip"
+	LogicalRouterStaticRoutePolicySrcIP LogicalRouterStaticRoutePolicy = "src-ip"
 )
 
 // LogicalRouterStaticRoute defines an object in Logical_Router_Static_Route table
 type LogicalRouterStaticRoute struct {
-	UUID        string                           `ovsdb:"_uuid"`
-	BFD         []string                         `ovsdb:"bfd"`
-	ExternalIDs map[string]string                `ovsdb:"external_ids"`
-	IPPrefix    string                           `ovsdb:"ip_prefix"`
-	Nexthop     string                           `ovsdb:"nexthop"`
-	Options     map[string]string                `ovsdb:"options"`
-	OutputPort  []string                         `ovsdb:"output_port"`
-	Policy      []LogicalRouterStaticRoutePolicy `ovsdb:"policy"`
+	UUID        string                          `ovsdb:"_uuid"`
+	BFD         *string                         `ovsdb:"bfd"`
+	ExternalIDs map[string]string               `ovsdb:"external_ids"`
+	IPPrefix    string                          `ovsdb:"ip_prefix"`
+	Nexthop     string                          `ovsdb:"nexthop"`
+	Options     map[string]string               `ovsdb:"options"`
+	OutputPort  *string                         `ovsdb:"output_port"`
+	Policy      *LogicalRouterStaticRoutePolicy `ovsdb:"policy"`
 }

--- a/go-controller/pkg/nbdb/logical_switch_port.go
+++ b/go-controller/pkg/nbdb/logical_switch_port.go
@@ -7,18 +7,18 @@ package nbdb
 type LogicalSwitchPort struct {
 	UUID             string            `ovsdb:"_uuid"`
 	Addresses        []string          `ovsdb:"addresses"`
-	Dhcpv4Options    []string          `ovsdb:"dhcpv4_options"`
-	Dhcpv6Options    []string          `ovsdb:"dhcpv6_options"`
-	DynamicAddresses []string          `ovsdb:"dynamic_addresses"`
-	Enabled          []bool            `ovsdb:"enabled"`
+	Dhcpv4Options    *string           `ovsdb:"dhcpv4_options"`
+	Dhcpv6Options    *string           `ovsdb:"dhcpv6_options"`
+	DynamicAddresses *string           `ovsdb:"dynamic_addresses"`
+	Enabled          *bool             `ovsdb:"enabled"`
 	ExternalIDs      map[string]string `ovsdb:"external_ids"`
-	HaChassisGroup   []string          `ovsdb:"ha_chassis_group"`
+	HaChassisGroup   *string           `ovsdb:"ha_chassis_group"`
 	Name             string            `ovsdb:"name"`
 	Options          map[string]string `ovsdb:"options"`
-	ParentName       []string          `ovsdb:"parent_name"`
+	ParentName       *string           `ovsdb:"parent_name"`
 	PortSecurity     []string          `ovsdb:"port_security"`
-	Tag              []int             `ovsdb:"tag"`
-	TagRequest       []int             `ovsdb:"tag_request"`
+	Tag              *int              `ovsdb:"tag"`
+	TagRequest       *int              `ovsdb:"tag_request"`
 	Type             string            `ovsdb:"type"`
-	Up               []bool            `ovsdb:"up"`
+	Up               *bool             `ovsdb:"up"`
 }

--- a/go-controller/pkg/nbdb/meter.go
+++ b/go-controller/pkg/nbdb/meter.go
@@ -7,7 +7,7 @@ type (
 	MeterUnit = string
 )
 
-const (
+var (
 	MeterUnitKbps  MeterUnit = "kbps"
 	MeterUnitPktps MeterUnit = "pktps"
 )
@@ -17,7 +17,7 @@ type Meter struct {
 	UUID        string            `ovsdb:"_uuid"`
 	Bands       []string          `ovsdb:"bands"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
-	Fair        []bool            `ovsdb:"fair"`
+	Fair        *bool             `ovsdb:"fair"`
 	Name        string            `ovsdb:"name"`
 	Unit        MeterUnit         `ovsdb:"unit"`
 }

--- a/go-controller/pkg/nbdb/meter_band.go
+++ b/go-controller/pkg/nbdb/meter_band.go
@@ -7,7 +7,7 @@ type (
 	MeterBandAction = string
 )
 
-const (
+var (
 	MeterBandActionDrop MeterBandAction = "drop"
 )
 

--- a/go-controller/pkg/nbdb/model.go
+++ b/go-controller/pkg/nbdb/model.go
@@ -101,8 +101,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "name": {
@@ -112,8 +111,7 @@ var schema = `{
               "minLength": 63,
               "maxLength": 63
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "priority": {
@@ -133,15 +131,14 @@ var schema = `{
                 "set",
                 [
                   "alert",
-                  "warning",
-                  "notice",
+                  "debug",
                   "info",
-                  "debug"
+                  "notice",
+                  "warning"
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       }
@@ -187,8 +184,7 @@ var schema = `{
               "type": "integer",
               "minInteger": 1
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "dst_ip": {
@@ -214,8 +210,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "min_tx": {
@@ -224,8 +219,7 @@ var schema = `{
               "type": "integer",
               "minInteger": 1
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "options": {
@@ -247,15 +241,14 @@ var schema = `{
               "enum": [
                 "set",
                 [
+                  "admin_down",
                   "down",
                   "init",
-                  "up",
-                  "admin_down"
+                  "up"
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       },
@@ -285,8 +278,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "is_connected": {
@@ -299,8 +291,7 @@ var schema = `{
               "type": "integer",
               "minInteger": 1000
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "other_config": {
@@ -404,7 +395,6 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 1,
             "max": "unlimited"
           }
         },
@@ -528,8 +518,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "HA_Chassis",
-              "refType": "strong"
+              "refTable": "HA_Chassis"
             },
             "min": 0,
             "max": "unlimited"
@@ -563,8 +552,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Load_Balancer_Health_Check",
-              "refType": "strong"
+              "refTable": "Load_Balancer_Health_Check"
             },
             "min": 0,
             "max": "unlimited"
@@ -604,14 +592,13 @@ var schema = `{
               "enum": [
                 "set",
                 [
+                  "sctp",
                   "tcp",
-                  "udp",
-                  "sctp"
+                  "udp"
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "selection_fields": {
@@ -621,12 +608,12 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "eth_src",
                   "eth_dst",
-                  "ip_src",
+                  "eth_src",
                   "ip_dst",
-                  "tp_src",
-                  "tp_dst"
+                  "ip_src",
+                  "tp_dst",
+                  "tp_src"
                 ]
               ]
             },
@@ -686,8 +673,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -720,8 +706,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "NAT",
-              "refType": "strong"
+              "refTable": "NAT"
             },
             "min": 0,
             "max": "unlimited"
@@ -743,8 +728,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Logical_Router_Policy",
-              "refType": "strong"
+              "refTable": "Logical_Router_Policy"
             },
             "min": 0,
             "max": "unlimited"
@@ -754,8 +738,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Logical_Router_Port",
-              "refType": "strong"
+              "refTable": "Logical_Router_Port"
             },
             "min": 0,
             "max": "unlimited"
@@ -765,8 +748,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Logical_Router_Static_Route",
-              "refType": "strong"
+              "refTable": "Logical_Router_Static_Route"
             },
             "min": 0,
             "max": "unlimited"
@@ -811,8 +793,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "nexthops": {
@@ -854,8 +835,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -874,8 +854,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Gateway_Chassis",
-              "refType": "strong"
+              "refTable": "Gateway_Chassis"
             },
             "min": 0,
             "max": "unlimited"
@@ -885,11 +864,9 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "HA_Chassis_Group",
-              "refType": "strong"
+              "refTable": "HA_Chassis_Group"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "ipv6_prefix": {
@@ -924,7 +901,6 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 1,
             "max": "unlimited"
           }
         },
@@ -945,8 +921,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       },
@@ -965,8 +940,7 @@ var schema = `{
               "refTable": "BFD",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -1004,8 +978,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "policy": {
@@ -1015,13 +988,12 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "src-ip",
-                  "dst-ip"
+                  "dst-ip",
+                  "src-ip"
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       }
@@ -1032,8 +1004,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "ACL",
-              "refType": "strong"
+              "refTable": "ACL"
             },
             "min": 0,
             "max": "unlimited"
@@ -1066,8 +1037,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Forwarding_Group",
-              "refType": "strong"
+              "refTable": "Forwarding_Group"
             },
             "min": 0,
             "max": "unlimited"
@@ -1103,8 +1073,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Logical_Switch_Port",
-              "refType": "strong"
+              "refTable": "Logical_Switch_Port"
             },
             "min": 0,
             "max": "unlimited"
@@ -1114,8 +1083,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "QoS",
-              "refType": "strong"
+              "refTable": "QoS"
             },
             "min": 0,
             "max": "unlimited"
@@ -1141,8 +1109,7 @@ var schema = `{
               "refTable": "DHCP_Options",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "dhcpv6_options": {
@@ -1152,8 +1119,7 @@ var schema = `{
               "refTable": "DHCP_Options",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "dynamic_addresses": {
@@ -1161,8 +1127,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "enabled": {
@@ -1170,8 +1135,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -1190,11 +1154,9 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "HA_Chassis_Group",
-              "refType": "strong"
+              "refTable": "HA_Chassis_Group"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "name": {
@@ -1217,8 +1179,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "port_security": {
@@ -1237,8 +1198,7 @@ var schema = `{
               "minInteger": 1,
               "maxInteger": 4095
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "tag_request": {
@@ -1248,8 +1208,7 @@ var schema = `{
               "minInteger": 0,
               "maxInteger": 4095
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "type": {
@@ -1260,8 +1219,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       },
@@ -1277,10 +1235,8 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Meter_Band",
-              "refType": "strong"
+              "refTable": "Meter_Band"
             },
-            "min": 1,
             "max": "unlimited"
           }
         },
@@ -1301,8 +1257,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "name": {
@@ -1377,22 +1332,18 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Address_Set",
-              "refType": "strong"
+              "refTable": "Address_Set"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "exempted_ext_ips": {
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Address_Set",
-              "refType": "strong"
+              "refTable": "Address_Set"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -1415,8 +1366,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_port_range": {
@@ -1430,8 +1380,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "options": {
@@ -1454,8 +1403,8 @@ var schema = `{
                 "set",
                 [
                   "dnat",
-                  "snat",
-                  "dnat_and_snat"
+                  "dnat_and_snat",
+                  "snat"
                 ]
               ]
             }
@@ -1529,8 +1478,7 @@ var schema = `{
               "type": "uuid",
               "refTable": "SSL"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       }
@@ -1541,8 +1489,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "ACL",
-              "refType": "strong"
+              "refTable": "ACL"
             },
             "min": 0,
             "max": "unlimited"
@@ -1605,8 +1552,8 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "rate",
-                  "burst"
+                  "burst",
+                  "rate"
                 ]
               ]
             },

--- a/go-controller/pkg/nbdb/nat.go
+++ b/go-controller/pkg/nbdb/nat.go
@@ -7,23 +7,23 @@ type (
 	NATType = string
 )
 
-const (
+var (
 	NATTypeDNAT        NATType = "dnat"
-	NATTypeSNAT        NATType = "snat"
 	NATTypeDNATAndSNAT NATType = "dnat_and_snat"
+	NATTypeSNAT        NATType = "snat"
 )
 
 // NAT defines an object in NAT table
 type NAT struct {
 	UUID              string            `ovsdb:"_uuid"`
-	AllowedExtIPs     []string          `ovsdb:"allowed_ext_ips"`
-	ExemptedExtIPs    []string          `ovsdb:"exempted_ext_ips"`
+	AllowedExtIPs     *string           `ovsdb:"allowed_ext_ips"`
+	ExemptedExtIPs    *string           `ovsdb:"exempted_ext_ips"`
 	ExternalIDs       map[string]string `ovsdb:"external_ids"`
 	ExternalIP        string            `ovsdb:"external_ip"`
-	ExternalMAC       []string          `ovsdb:"external_mac"`
+	ExternalMAC       *string           `ovsdb:"external_mac"`
 	ExternalPortRange string            `ovsdb:"external_port_range"`
 	LogicalIP         string            `ovsdb:"logical_ip"`
-	LogicalPort       []string          `ovsdb:"logical_port"`
+	LogicalPort       *string           `ovsdb:"logical_port"`
 	Options           map[string]string `ovsdb:"options"`
 	Type              NATType           `ovsdb:"type"`
 }

--- a/go-controller/pkg/nbdb/nb_global.go
+++ b/go-controller/pkg/nbdb/nb_global.go
@@ -17,5 +17,5 @@ type NBGlobal struct {
 	Options        map[string]string `ovsdb:"options"`
 	SbCfg          int               `ovsdb:"sb_cfg"`
 	SbCfgTimestamp int               `ovsdb:"sb_cfg_timestamp"`
-	SSL            []string          `ovsdb:"ssl"`
+	SSL            *string           `ovsdb:"ssl"`
 }

--- a/go-controller/pkg/nbdb/qos.go
+++ b/go-controller/pkg/nbdb/qos.go
@@ -9,10 +9,10 @@ type (
 	QoSDirection = string
 )
 
-const (
+var (
 	QoSActionDSCP         QoSAction    = "dscp"
-	QoSBandwidthRate      QoSBandwidth = "rate"
 	QoSBandwidthBurst     QoSBandwidth = "burst"
+	QoSBandwidthRate      QoSBandwidth = "rate"
 	QoSDirectionFromLport QoSDirection = "from-lport"
 	QoSDirectionToLport   QoSDirection = "to-lport"
 )

--- a/go-controller/pkg/ovn/libovsdbops/util.go
+++ b/go-controller/pkg/ovn/libovsdbops/util.go
@@ -1,6 +1,7 @@
 package libovsdbops
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ovn-org/libovsdb/client"
@@ -12,7 +13,7 @@ func TransactAndCheck(client client.Client, ops []ovsdb.Operation) ([]ovsdb.Oper
 		return []ovsdb.OperationResult{{}}, nil
 	}
 
-	results, err := client.Transact(ops...)
+	results, err := client.Transact(context.TODO(), ops...)
 	if err != nil {
 		return nil, fmt.Errorf("error in transact with ops %+v: %v", ops, err)
 	}

--- a/go-controller/pkg/sbdb/bfd.go
+++ b/go-controller/pkg/sbdb/bfd.go
@@ -7,11 +7,11 @@ type (
 	BFDStatus = string
 )
 
-const (
+var (
+	BFDStatusAdminDown BFDStatus = "admin_down"
 	BFDStatusDown      BFDStatus = "down"
 	BFDStatusInit      BFDStatus = "init"
 	BFDStatusUp        BFDStatus = "up"
-	BFDStatusAdminDown BFDStatus = "admin_down"
 )
 
 // BFD defines an object in BFD table

--- a/go-controller/pkg/sbdb/chassis_private.go
+++ b/go-controller/pkg/sbdb/chassis_private.go
@@ -6,7 +6,7 @@ package sbdb
 // ChassisPrivate defines an object in Chassis_Private table
 type ChassisPrivate struct {
 	UUID           string            `ovsdb:"_uuid"`
-	Chassis        []string          `ovsdb:"chassis"`
+	Chassis        *string           `ovsdb:"chassis"`
 	ExternalIDs    map[string]string `ovsdb:"external_ids"`
 	Name           string            `ovsdb:"name"`
 	NbCfg          int               `ovsdb:"nb_cfg"`

--- a/go-controller/pkg/sbdb/connection.go
+++ b/go-controller/pkg/sbdb/connection.go
@@ -7,9 +7,9 @@ package sbdb
 type Connection struct {
 	UUID            string            `ovsdb:"_uuid"`
 	ExternalIDs     map[string]string `ovsdb:"external_ids"`
-	InactivityProbe []int             `ovsdb:"inactivity_probe"`
+	InactivityProbe *int              `ovsdb:"inactivity_probe"`
 	IsConnected     bool              `ovsdb:"is_connected"`
-	MaxBackoff      []int             `ovsdb:"max_backoff"`
+	MaxBackoff      *int              `ovsdb:"max_backoff"`
 	OtherConfig     map[string]string `ovsdb:"other_config"`
 	ReadOnly        bool              `ovsdb:"read_only"`
 	Role            string            `ovsdb:"role"`

--- a/go-controller/pkg/sbdb/controller_event.go
+++ b/go-controller/pkg/sbdb/controller_event.go
@@ -7,14 +7,14 @@ type (
 	ControllerEventEventType = string
 )
 
-const (
+var (
 	ControllerEventEventTypeEmptyLbBackends ControllerEventEventType = "empty_lb_backends"
 )
 
 // ControllerEvent defines an object in Controller_Event table
 type ControllerEvent struct {
 	UUID      string                   `ovsdb:"_uuid"`
-	Chassis   []string                 `ovsdb:"chassis"`
+	Chassis   *string                  `ovsdb:"chassis"`
 	EventInfo map[string]string        `ovsdb:"event_info"`
 	EventType ControllerEventEventType `ovsdb:"event_type"`
 	SeqNum    int                      `ovsdb:"seq_num"`

--- a/go-controller/pkg/sbdb/dhcp_options.go
+++ b/go-controller/pkg/sbdb/dhcp_options.go
@@ -7,16 +7,16 @@ type (
 	DHCPOptionsType = string
 )
 
-const (
+var (
 	DHCPOptionsTypeBool         DHCPOptionsType = "bool"
-	DHCPOptionsTypeUint8        DHCPOptionsType = "uint8"
-	DHCPOptionsTypeUint16       DHCPOptionsType = "uint16"
-	DHCPOptionsTypeUint32       DHCPOptionsType = "uint32"
+	DHCPOptionsTypeDomains      DHCPOptionsType = "domains"
+	DHCPOptionsTypeHostID       DHCPOptionsType = "host_id"
 	DHCPOptionsTypeIpv4         DHCPOptionsType = "ipv4"
 	DHCPOptionsTypeStaticRoutes DHCPOptionsType = "static_routes"
 	DHCPOptionsTypeStr          DHCPOptionsType = "str"
-	DHCPOptionsTypeHostID       DHCPOptionsType = "host_id"
-	DHCPOptionsTypeDomains      DHCPOptionsType = "domains"
+	DHCPOptionsTypeUint16       DHCPOptionsType = "uint16"
+	DHCPOptionsTypeUint32       DHCPOptionsType = "uint32"
+	DHCPOptionsTypeUint8        DHCPOptionsType = "uint8"
 )
 
 // DHCPOptions defines an object in DHCP_Options table

--- a/go-controller/pkg/sbdb/dhcpv6_options.go
+++ b/go-controller/pkg/sbdb/dhcpv6_options.go
@@ -7,10 +7,10 @@ type (
 	DHCPv6OptionsType = string
 )
 
-const (
+var (
 	DHCPv6OptionsTypeIpv6 DHCPv6OptionsType = "ipv6"
-	DHCPv6OptionsTypeStr  DHCPv6OptionsType = "str"
 	DHCPv6OptionsTypeMAC  DHCPv6OptionsType = "mac"
+	DHCPv6OptionsTypeStr  DHCPv6OptionsType = "str"
 )
 
 // DHCPv6Options defines an object in DHCPv6_Options table

--- a/go-controller/pkg/sbdb/encap.go
+++ b/go-controller/pkg/sbdb/encap.go
@@ -7,7 +7,7 @@ type (
 	EncapType = string
 )
 
-const (
+var (
 	EncapTypeGeneve EncapType = "geneve"
 	EncapTypeSTT    EncapType = "stt"
 	EncapTypeVxlan  EncapType = "vxlan"

--- a/go-controller/pkg/sbdb/gateway_chassis.go
+++ b/go-controller/pkg/sbdb/gateway_chassis.go
@@ -6,7 +6,7 @@ package sbdb
 // GatewayChassis defines an object in Gateway_Chassis table
 type GatewayChassis struct {
 	UUID        string            `ovsdb:"_uuid"`
-	Chassis     []string          `ovsdb:"chassis"`
+	Chassis     *string           `ovsdb:"chassis"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Name        string            `ovsdb:"name"`
 	Options     map[string]string `ovsdb:"options"`

--- a/go-controller/pkg/sbdb/ha_chassis.go
+++ b/go-controller/pkg/sbdb/ha_chassis.go
@@ -6,7 +6,7 @@ package sbdb
 // HAChassis defines an object in HA_Chassis table
 type HAChassis struct {
 	UUID        string            `ovsdb:"_uuid"`
-	Chassis     []string          `ovsdb:"chassis"`
+	Chassis     *string           `ovsdb:"chassis"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Priority    int               `ovsdb:"priority"`
 }

--- a/go-controller/pkg/sbdb/igmp_group.go
+++ b/go-controller/pkg/sbdb/igmp_group.go
@@ -7,7 +7,7 @@ package sbdb
 type IGMPGroup struct {
 	UUID     string   `ovsdb:"_uuid"`
 	Address  string   `ovsdb:"address"`
-	Chassis  []string `ovsdb:"chassis"`
-	Datapath []string `ovsdb:"datapath"`
+	Chassis  *string  `ovsdb:"chassis"`
+	Datapath *string  `ovsdb:"datapath"`
 	Ports    []string `ovsdb:"ports"`
 }

--- a/go-controller/pkg/sbdb/ip_multicast.go
+++ b/go-controller/pkg/sbdb/ip_multicast.go
@@ -7,14 +7,14 @@ package sbdb
 type IPMulticast struct {
 	UUID          string `ovsdb:"_uuid"`
 	Datapath      string `ovsdb:"datapath"`
-	Enabled       []bool `ovsdb:"enabled"`
+	Enabled       *bool  `ovsdb:"enabled"`
 	EthSrc        string `ovsdb:"eth_src"`
-	IdleTimeout   []int  `ovsdb:"idle_timeout"`
+	IdleTimeout   *int   `ovsdb:"idle_timeout"`
 	Ip4Src        string `ovsdb:"ip4_src"`
 	Ip6Src        string `ovsdb:"ip6_src"`
-	Querier       []bool `ovsdb:"querier"`
-	QueryInterval []int  `ovsdb:"query_interval"`
-	QueryMaxResp  []int  `ovsdb:"query_max_resp"`
+	Querier       *bool  `ovsdb:"querier"`
+	QueryInterval *int   `ovsdb:"query_interval"`
+	QueryMaxResp  *int   `ovsdb:"query_max_resp"`
 	SeqNo         int    `ovsdb:"seq_no"`
-	TableSize     []int  `ovsdb:"table_size"`
+	TableSize     *int   `ovsdb:"table_size"`
 }

--- a/go-controller/pkg/sbdb/load_balancer.go
+++ b/go-controller/pkg/sbdb/load_balancer.go
@@ -7,19 +7,19 @@ type (
 	LoadBalancerProtocol = string
 )
 
-const (
+var (
+	LoadBalancerProtocolSCTP LoadBalancerProtocol = "sctp"
 	LoadBalancerProtocolTCP  LoadBalancerProtocol = "tcp"
 	LoadBalancerProtocolUDP  LoadBalancerProtocol = "udp"
-	LoadBalancerProtocolSCTP LoadBalancerProtocol = "sctp"
 )
 
 // LoadBalancer defines an object in Load_Balancer table
 type LoadBalancer struct {
-	UUID        string                 `ovsdb:"_uuid"`
-	Datapaths   []string               `ovsdb:"datapaths"`
-	ExternalIDs map[string]string      `ovsdb:"external_ids"`
-	Name        string                 `ovsdb:"name"`
-	Options     map[string]string      `ovsdb:"options"`
-	Protocol    []LoadBalancerProtocol `ovsdb:"protocol"`
-	Vips        map[string]string      `ovsdb:"vips"`
+	UUID        string                `ovsdb:"_uuid"`
+	Datapaths   []string              `ovsdb:"datapaths"`
+	ExternalIDs map[string]string     `ovsdb:"external_ids"`
+	Name        string                `ovsdb:"name"`
+	Options     map[string]string     `ovsdb:"options"`
+	Protocol    *LoadBalancerProtocol `ovsdb:"protocol"`
+	Vips        map[string]string     `ovsdb:"vips"`
 }

--- a/go-controller/pkg/sbdb/logical_flow.go
+++ b/go-controller/pkg/sbdb/logical_flow.go
@@ -7,9 +7,9 @@ type (
 	LogicalFlowPipeline = string
 )
 
-const (
-	LogicalFlowPipelineIngress LogicalFlowPipeline = "ingress"
+var (
 	LogicalFlowPipelineEgress  LogicalFlowPipeline = "egress"
+	LogicalFlowPipelineIngress LogicalFlowPipeline = "ingress"
 )
 
 // LogicalFlow defines an object in Logical_Flow table
@@ -17,8 +17,8 @@ type LogicalFlow struct {
 	UUID            string              `ovsdb:"_uuid"`
 	Actions         string              `ovsdb:"actions"`
 	ExternalIDs     map[string]string   `ovsdb:"external_ids"`
-	LogicalDatapath []string            `ovsdb:"logical_datapath"`
-	LogicalDpGroup  []string            `ovsdb:"logical_dp_group"`
+	LogicalDatapath *string             `ovsdb:"logical_datapath"`
+	LogicalDpGroup  *string             `ovsdb:"logical_dp_group"`
 	Match           string              `ovsdb:"match"`
 	Pipeline        LogicalFlowPipeline `ovsdb:"pipeline"`
 	Priority        int                 `ovsdb:"priority"`

--- a/go-controller/pkg/sbdb/meter.go
+++ b/go-controller/pkg/sbdb/meter.go
@@ -7,7 +7,7 @@ type (
 	MeterUnit = string
 )
 
-const (
+var (
 	MeterUnitKbps  MeterUnit = "kbps"
 	MeterUnitPktps MeterUnit = "pktps"
 )

--- a/go-controller/pkg/sbdb/meter_band.go
+++ b/go-controller/pkg/sbdb/meter_band.go
@@ -7,7 +7,7 @@ type (
 	MeterBandAction = string
 )
 
-const (
+var (
 	MeterBandActionDrop MeterBandAction = "drop"
 )
 

--- a/go-controller/pkg/sbdb/model.go
+++ b/go-controller/pkg/sbdb/model.go
@@ -132,10 +132,10 @@ var schema = `{
               "enum": [
                 "set",
                 [
+                  "admin_down",
                   "down",
                   "init",
-                  "up",
-                  "admin_down"
+                  "up"
                 ]
               ]
             }
@@ -159,7 +159,6 @@ var schema = `{
               "type": "uuid",
               "refTable": "Encap"
             },
-            "min": 1,
             "max": "unlimited"
           }
         },
@@ -230,8 +229,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -281,8 +279,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "is_connected": {
@@ -295,8 +292,7 @@ var schema = `{
               "type": "integer",
               "minInteger": 1000
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "other_config": {
@@ -349,8 +345,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "event_info": {
@@ -400,14 +395,14 @@ var schema = `{
                 "set",
                 [
                   "bool",
-                  "uint8",
-                  "uint16",
-                  "uint32",
+                  "domains",
+                  "host_id",
                   "ipv4",
                   "static_routes",
                   "str",
-                  "host_id",
-                  "domains"
+                  "uint16",
+                  "uint32",
+                  "uint8"
                 ]
               ]
             }
@@ -437,8 +432,8 @@ var schema = `{
                 "set",
                 [
                   "ipv6",
-                  "str",
-                  "mac"
+                  "mac",
+                  "str"
                 ]
               ]
             }
@@ -454,7 +449,6 @@ var schema = `{
               "type": "uuid",
               "refTable": "Datapath_Binding"
             },
-            "min": 1,
             "max": "unlimited"
           }
         },
@@ -608,8 +602,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -664,8 +657,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -709,8 +701,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "HA_Chassis",
-              "refType": "strong"
+              "refTable": "HA_Chassis"
             },
             "min": 0,
             "max": "unlimited"
@@ -749,8 +740,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "datapath": {
@@ -760,8 +750,7 @@ var schema = `{
               "refTable": "Datapath_Binding",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "ports": {
@@ -800,8 +789,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "eth_src": {
@@ -812,8 +800,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "ip4_src": {
@@ -827,8 +814,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "query_interval": {
@@ -836,8 +822,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "query_max_resp": {
@@ -845,8 +830,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "seq_no": {
@@ -857,8 +841,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       },
@@ -914,14 +897,13 @@ var schema = `{
               "enum": [
                 "set",
                 [
+                  "sctp",
                   "tcp",
-                  "udp",
-                  "sctp"
+                  "udp"
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "vips": {
@@ -976,8 +958,7 @@ var schema = `{
               "type": "uuid",
               "refTable": "Datapath_Binding"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "logical_dp_group": {
@@ -986,8 +967,7 @@ var schema = `{
               "type": "uuid",
               "refTable": "Logical_DP_Group"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "match": {
@@ -1000,8 +980,8 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "ingress",
-                  "egress"
+                  "egress",
+                  "ingress"
                 ]
               ]
             }
@@ -1060,10 +1040,8 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Meter_Band",
-              "refType": "strong"
+              "refTable": "Meter_Band"
             },
-            "min": 1,
             "max": "unlimited"
           }
         },
@@ -1175,8 +1153,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "datapath": {
@@ -1194,8 +1171,7 @@ var schema = `{
               "refTable": "Encap",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -1214,8 +1190,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Gateway_Chassis",
-              "refType": "strong"
+              "refTable": "Gateway_Chassis"
             },
             "min": 0,
             "max": "unlimited"
@@ -1225,11 +1200,9 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "HA_Chassis_Group",
-              "refType": "strong"
+              "refTable": "HA_Chassis_Group"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "logical_port": {
@@ -1270,8 +1243,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "tag": {
@@ -1281,8 +1253,7 @@ var schema = `{
               "minInteger": 1,
               "maxInteger": 4095
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "tunnel_key": {
@@ -1302,8 +1273,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "virtual_parent": {
@@ -1311,8 +1281,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       },
@@ -1444,8 +1413,7 @@ var schema = `{
               "type": "uuid",
               "refTable": "SSL"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       }
@@ -1537,8 +1505,7 @@ var schema = `{
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "src_ip": {
@@ -1554,14 +1521,13 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "online",
+                  "error",
                   "offline",
-                  "error"
+                  "online"
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       },

--- a/go-controller/pkg/sbdb/port_binding.go
+++ b/go-controller/pkg/sbdb/port_binding.go
@@ -6,20 +6,20 @@ package sbdb
 // PortBinding defines an object in Port_Binding table
 type PortBinding struct {
 	UUID           string            `ovsdb:"_uuid"`
-	Chassis        []string          `ovsdb:"chassis"`
+	Chassis        *string           `ovsdb:"chassis"`
 	Datapath       string            `ovsdb:"datapath"`
-	Encap          []string          `ovsdb:"encap"`
+	Encap          *string           `ovsdb:"encap"`
 	ExternalIDs    map[string]string `ovsdb:"external_ids"`
 	GatewayChassis []string          `ovsdb:"gateway_chassis"`
-	HaChassisGroup []string          `ovsdb:"ha_chassis_group"`
+	HaChassisGroup *string           `ovsdb:"ha_chassis_group"`
 	LogicalPort    string            `ovsdb:"logical_port"`
 	MAC            []string          `ovsdb:"mac"`
 	NatAddresses   []string          `ovsdb:"nat_addresses"`
 	Options        map[string]string `ovsdb:"options"`
-	ParentPort     []string          `ovsdb:"parent_port"`
-	Tag            []int             `ovsdb:"tag"`
+	ParentPort     *string           `ovsdb:"parent_port"`
+	Tag            *int              `ovsdb:"tag"`
 	TunnelKey      int               `ovsdb:"tunnel_key"`
 	Type           string            `ovsdb:"type"`
-	Up             []bool            `ovsdb:"up"`
-	VirtualParent  []string          `ovsdb:"virtual_parent"`
+	Up             *bool             `ovsdb:"up"`
+	VirtualParent  *string           `ovsdb:"virtual_parent"`
 }

--- a/go-controller/pkg/sbdb/sb_global.go
+++ b/go-controller/pkg/sbdb/sb_global.go
@@ -11,5 +11,5 @@ type SBGlobal struct {
 	Ipsec       bool              `ovsdb:"ipsec"`
 	NbCfg       int               `ovsdb:"nb_cfg"`
 	Options     map[string]string `ovsdb:"options"`
-	SSL         []string          `ovsdb:"ssl"`
+	SSL         *string           `ovsdb:"ssl"`
 }

--- a/go-controller/pkg/sbdb/service_monitor.go
+++ b/go-controller/pkg/sbdb/service_monitor.go
@@ -8,24 +8,24 @@ type (
 	ServiceMonitorStatus   = string
 )
 
-const (
+var (
 	ServiceMonitorProtocolTCP   ServiceMonitorProtocol = "tcp"
 	ServiceMonitorProtocolUDP   ServiceMonitorProtocol = "udp"
-	ServiceMonitorStatusOnline  ServiceMonitorStatus   = "online"
-	ServiceMonitorStatusOffline ServiceMonitorStatus   = "offline"
 	ServiceMonitorStatusError   ServiceMonitorStatus   = "error"
+	ServiceMonitorStatusOffline ServiceMonitorStatus   = "offline"
+	ServiceMonitorStatusOnline  ServiceMonitorStatus   = "online"
 )
 
 // ServiceMonitor defines an object in Service_Monitor table
 type ServiceMonitor struct {
-	UUID        string                   `ovsdb:"_uuid"`
-	ExternalIDs map[string]string        `ovsdb:"external_ids"`
-	IP          string                   `ovsdb:"ip"`
-	LogicalPort string                   `ovsdb:"logical_port"`
-	Options     map[string]string        `ovsdb:"options"`
-	Port        int                      `ovsdb:"port"`
-	Protocol    []ServiceMonitorProtocol `ovsdb:"protocol"`
-	SrcIP       string                   `ovsdb:"src_ip"`
-	SrcMAC      string                   `ovsdb:"src_mac"`
-	Status      []ServiceMonitorStatus   `ovsdb:"status"`
+	UUID        string                  `ovsdb:"_uuid"`
+	ExternalIDs map[string]string       `ovsdb:"external_ids"`
+	IP          string                  `ovsdb:"ip"`
+	LogicalPort string                  `ovsdb:"logical_port"`
+	Options     map[string]string       `ovsdb:"options"`
+	Port        int                     `ovsdb:"port"`
+	Protocol    *ServiceMonitorProtocol `ovsdb:"protocol"`
+	SrcIP       string                  `ovsdb:"src_ip"`
+	SrcMAC      string                  `ovsdb:"src_mac"`
+	Status      *ServiceMonitorStatus   `ovsdb:"status"`
 }

--- a/go-controller/pkg/util/libovsdb.go
+++ b/go-controller/pkg/util/libovsdb.go
@@ -94,7 +94,15 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 		return nil, err
 	}
 
-	_, err = c.MonitorAll()
+	// TODO(flaviof): whenever we get around to passing a context down from the caller, we will
+	// replace the TODO with that one.
+	ctx, cancel := context.WithCancel(context.TODO())
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	_, err = c.MonitorAll(ctx)
 	if err != nil {
 		c.Close()
 		return nil, err

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/api_test_model.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/api_test_model.go
@@ -131,21 +131,21 @@ func (*testLogicalSwitch) Table() string {
 //LogicalSwitchPort struct defines an object in Logical_Switch_Port table
 type testLogicalSwitchPort struct {
 	UUID             string            `ovsdb:"_uuid"`
-	Up               []bool            `ovsdb:"up"`
-	Dhcpv4Options    []string          `ovsdb:"dhcpv4_options"`
+	Up               *bool             `ovsdb:"up"`
+	Dhcpv4Options    *string           `ovsdb:"dhcpv4_options"`
 	Name             string            `ovsdb:"name"`
-	DynamicAddresses []string          `ovsdb:"dynamic_addresses"`
-	HaChassisGroup   []string          `ovsdb:"ha_chassis_group"`
+	DynamicAddresses *string           `ovsdb:"dynamic_addresses"`
+	HaChassisGroup   *string           `ovsdb:"ha_chassis_group"`
 	Options          map[string]string `ovsdb:"options"`
-	Enabled          []bool            `ovsdb:"enabled"`
+	Enabled          *bool             `ovsdb:"enabled"`
 	Addresses        []string          `ovsdb:"addresses"`
-	Dhcpv6Options    []string          `ovsdb:"dhcpv6_options"`
-	TagRequest       []int             `ovsdb:"tag_request"`
-	Tag              []int             `ovsdb:"tag"`
+	Dhcpv6Options    *string           `ovsdb:"dhcpv6_options"`
+	TagRequest       *int              `ovsdb:"tag_request"`
+	Tag              *int              `ovsdb:"tag"`
 	PortSecurity     []string          `ovsdb:"port_security"`
 	ExternalIds      map[string]string `ovsdb:"external_ids"`
 	Type             string            `ovsdb:"type"`
-	ParentName       []string          `ovsdb:"parent_name"`
+	ParentName       *string           `ovsdb:"parent_name"`
 }
 
 // Table returns the table name. It's part of the Model interface

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
@@ -46,11 +46,11 @@ type Client interface {
 	SetOption(Option) error
 	Connected() bool
 	DisconnectNotify() chan struct{}
-	Echo() error
-	Transact(...ovsdb.Operation) ([]ovsdb.OperationResult, error)
-	Monitor(...TableMonitor) (string, error)
-	MonitorAll() (string, error)
-	MonitorCancel(id string) error
+	Echo(context.Context) error
+	Transact(context.Context, ...ovsdb.Operation) ([]ovsdb.OperationResult, error)
+	Monitor(context.Context, ...TableMonitor) (string, error)
+	MonitorAll(context.Context) (string, error)
+	MonitorCancel(ctx context.Context, id string) error
 	NewTableMonitor(m model.Model, fields ...interface{}) TableMonitor
 	API
 }
@@ -149,7 +149,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 		return err
 	}
 
-	dbs, err := o.listDbs()
+	dbs, err := o.listDbs(ctx)
 	if err != nil {
 		o.rpcClient.Close()
 		return err
@@ -167,7 +167,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 		return fmt.Errorf("target database not found")
 	}
 
-	schema, err := o.getSchema(o.dbModel.Name())
+	schema, err := o.getSchema(ctx, o.dbModel.Name())
 	errors := o.dbModel.Validate(schema)
 	if len(errors) > 0 {
 		var combined []string
@@ -205,7 +205,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 		o.monitorsMutex.Lock()
 		defer o.monitorsMutex.Unlock()
 		for id, request := range o.monitors {
-			err = o.monitor(id, reconnect, request...)
+			err = o.monitor(ctx, id, reconnect, request...)
 			if err != nil {
 				o.rpcClient.Close()
 				return err
@@ -312,10 +312,10 @@ func (o *ovsdbClient) update(args []json.RawMessage, reply *[]interface{}) error
 // getSchema returns the schema in use for the provided database name
 // RFC 7047 : get_schema
 // Should only be called when mutex is held
-func (o *ovsdbClient) getSchema(dbName string) (*ovsdb.DatabaseSchema, error) {
+func (o *ovsdbClient) getSchema(ctx context.Context, dbName string) (*ovsdb.DatabaseSchema, error) {
 	args := ovsdb.NewGetSchemaArgs(dbName)
 	var reply ovsdb.DatabaseSchema
-	err := o.rpcClient.Call("get_schema", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "get_schema", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return nil, ErrNotConnected
@@ -328,9 +328,9 @@ func (o *ovsdbClient) getSchema(dbName string) (*ovsdb.DatabaseSchema, error) {
 // listDbs returns the list of databases on the server
 // RFC 7047 : list_dbs
 // Should only be called when mutex is held
-func (o *ovsdbClient) listDbs() ([]string, error) {
+func (o *ovsdbClient) listDbs(ctx context.Context) ([]string, error) {
 	var dbs []string
-	err := o.rpcClient.Call("list_dbs", nil, &dbs)
+	err := o.rpcClient.CallWithContext(ctx, "list_dbs", nil, &dbs)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return nil, ErrNotConnected
@@ -342,7 +342,7 @@ func (o *ovsdbClient) listDbs() ([]string, error) {
 
 // Transact performs the provided Operations on the database
 // RFC 7047 : transact
-func (o *ovsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+func (o *ovsdbClient) Transact(ctx context.Context, operation ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
 	var reply []ovsdb.OperationResult
 	if ok := o.Schema().ValidateOperations(operation...); !ok {
 		return nil, fmt.Errorf("validation failed for the operation")
@@ -354,7 +354,7 @@ func (o *ovsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.OperationR
 		o.rpcMutex.Unlock()
 		return nil, ErrNotConnected
 	}
-	err := o.rpcClient.Call("transact", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "transact", args, &reply)
 	o.rpcMutex.Unlock()
 	if err != nil {
 		if err == rpc2.ErrShutdown {
@@ -366,17 +366,17 @@ func (o *ovsdbClient) Transact(operation ...ovsdb.Operation) ([]ovsdb.OperationR
 }
 
 // MonitorAll is a convenience method to monitor every table/column
-func (o *ovsdbClient) MonitorAll() (string, error) {
+func (o *ovsdbClient) MonitorAll(ctx context.Context) (string, error) {
 	var options []TableMonitor
 	for name := range o.dbModel.Types() {
 		options = append(options, TableMonitor{Table: name})
 	}
-	return o.Monitor(options...)
+	return o.Monitor(ctx, options...)
 }
 
 // MonitorCancel will request cancel a previously issued monitor request
 // RFC 7047 : monitor_cancel
-func (o *ovsdbClient) MonitorCancel(id string) error {
+func (o *ovsdbClient) MonitorCancel(ctx context.Context, id string) error {
 	var reply ovsdb.OperationResult
 	args := ovsdb.NewMonitorCancelArgs(id)
 	o.rpcMutex.Lock()
@@ -384,7 +384,7 @@ func (o *ovsdbClient) MonitorCancel(id string) error {
 	if o.rpcClient == nil {
 		return ErrNotConnected
 	}
-	err := o.rpcClient.Call("monitor_cancel", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "monitor_cancel", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return ErrNotConnected
@@ -428,12 +428,12 @@ func (o *ovsdbClient) NewTableMonitor(m model.Model, fields ...interface{}) Tabl
 // and populate the cache with them. Subsequent updates will be processed
 // by the Update Notifications
 // RFC 7047 : monitor
-func (o *ovsdbClient) Monitor(options ...TableMonitor) (string, error) {
+func (o *ovsdbClient) Monitor(ctx context.Context, options ...TableMonitor) (string, error) {
 	id := uuid.NewString()
-	return id, o.monitor(id, false, options...)
+	return id, o.monitor(ctx, id, false, options...)
 }
 
-func (o *ovsdbClient) monitor(id string, reconnect bool, options ...TableMonitor) error {
+func (o *ovsdbClient) monitor(ctx context.Context, id string, reconnect bool, options ...TableMonitor) error {
 	if len(options) == 0 {
 		return fmt.Errorf("no monitor options provided")
 	}
@@ -463,7 +463,7 @@ func (o *ovsdbClient) monitor(id string, reconnect bool, options ...TableMonitor
 	if o.rpcClient == nil {
 		return ErrNotConnected
 	}
-	err := o.rpcClient.Call("monitor", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "monitor", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return ErrNotConnected
@@ -480,7 +480,7 @@ func (o *ovsdbClient) monitor(id string, reconnect bool, options ...TableMonitor
 }
 
 // Echo tests the liveness of the OVSDB connetion
-func (o *ovsdbClient) Echo() error {
+func (o *ovsdbClient) Echo(ctx context.Context) error {
 	args := ovsdb.NewEchoArgs()
 	var reply []interface{}
 	o.rpcMutex.RLock()
@@ -488,7 +488,7 @@ func (o *ovsdbClient) Echo() error {
 	if o.rpcClient == nil {
 		return ErrNotConnected
 	}
-	err := o.rpcClient.Call("echo", args, &reply)
+	err := o.rpcClient.CallWithContext(ctx, "echo", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {
 			return ErrNotConnected

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/bindings.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/bindings.go
@@ -20,7 +20,7 @@ type ErrWrongType struct {
 }
 
 func (e *ErrWrongType) Error() string {
-	return fmt.Sprintf("Wrong Type (%s): expected %s but got %s (%s)",
+	return fmt.Sprintf("Wrong Type (%s): expected %s but got %+v (%s)",
 		e.from, e.expected, e.got, reflect.TypeOf(e.got))
 }
 
@@ -54,7 +54,7 @@ func NativeTypeFromAtomic(basicType string) reflect.Type {
 
 //NativeType returns the reflect.Type that can hold the value of a column
 //OVS Type to Native Type convertions:
-// OVS sets -> go slices
+// OVS sets -> go slices, arrays or a go native type depending on the key
 // OVS uuid -> go strings
 // OVS map  -> go map
 // OVS enum -> go native type depending on the type of the enum key
@@ -70,6 +70,18 @@ func NativeType(column *ColumnSchema) reflect.Type {
 		return reflect.MapOf(keyType, valueType)
 	case TypeSet:
 		keyType := NativeTypeFromAtomic(column.TypeObj.Key.Type)
+		// optional type
+		if column.TypeObj.Min() == 0 && column.TypeObj.Max() == 1 {
+			return reflect.PtrTo(keyType)
+		}
+		// non-optional type with max 1
+		if column.TypeObj.Min() == 1 && column.TypeObj.Max() == 1 {
+			return keyType
+		}
+		// max is > 1, use an array
+		if column.TypeObj.Max() > 1 {
+			return reflect.ArrayOf(column.TypeObj.Max(), keyType)
+		}
 		return reflect.SliceOf(keyType)
 	default:
 		panic(fmt.Errorf("unknown extended type %s", column.Type))
@@ -114,31 +126,77 @@ func OvsToNative(column *ColumnSchema, ovsElem interface{}) (interface{}, error)
 		naType := NativeType(column)
 		// The inner slice is []interface{}
 		// We need to convert it to the real type os slice
-		var nativeSet reflect.Value
-
-		// RFC says that for a set of exactly one, an atomic type an be sent
-		switch ovsSet := ovsElem.(type) {
-		case OvsSet:
-			nativeSet = reflect.MakeSlice(naType, 0, len(ovsSet.GoSet))
-			for _, v := range ovsSet.GoSet {
-				nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, v)
+		switch naType.Kind() {
+		case reflect.Ptr:
+			switch ovsSet := ovsElem.(type) {
+			case OvsSet:
+				if len(ovsSet.GoSet) > 1 {
+					return nil, fmt.Errorf("expected a slice of len =< 1, but got a slice with %d elements", len(ovsSet.GoSet))
+				}
+				if len(ovsSet.GoSet) == 0 {
+					return reflect.Zero(naType).Interface(), nil
+				}
+				native, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsSet.GoSet[0])
 				if err != nil {
 					return nil, err
 				}
+				pv := reflect.New(naType.Elem())
+				pv.Elem().Set(reflect.ValueOf(native))
+				return pv.Interface(), nil
+			default:
+				native, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
+				if err != nil {
+					return nil, err
+				}
+				pv := reflect.New(naType.Elem())
+				pv.Elem().Set(reflect.ValueOf(native))
+				return pv.Interface(), nil
+			}
+		case reflect.Array:
+			array := reflect.New(reflect.ArrayOf(column.TypeObj.Max(), naType.Elem())).Elem()
+			switch ovsSet := ovsElem.(type) {
+			case OvsSet:
+				for i, v := range ovsSet.GoSet {
+					nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, v)
+					if err != nil {
+						return nil, err
+					}
+					array.Index(i).Set(reflect.ValueOf(nv))
+				}
+			default:
+				nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
+				if err != nil {
+					return nil, err
+				}
+				array.Index(0).Set(reflect.ValueOf(nv))
+			}
+			return array.Interface(), nil
+		case reflect.Slice:
+			var nativeSet reflect.Value
+			switch ovsSet := ovsElem.(type) {
+			case OvsSet:
+				nativeSet = reflect.MakeSlice(naType, 0, len(ovsSet.GoSet))
+				for _, v := range ovsSet.GoSet {
+					nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, v)
+					if err != nil {
+						return nil, err
+					}
+					nativeSet = reflect.Append(nativeSet, reflect.ValueOf(nv))
+				}
+
+			default:
+				nativeSet = reflect.MakeSlice(naType, 0, 1)
+				nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
+				if err != nil {
+					return nil, err
+				}
+
 				nativeSet = reflect.Append(nativeSet, reflect.ValueOf(nv))
 			}
-
+			return nativeSet.Interface(), nil
 		default:
-			nativeSet = reflect.MakeSlice(naType, 0, 1)
-			nv, err := OvsToNativeAtomic(column.TypeObj.Key.Type, ovsElem)
-			if err != nil {
-				return nil, err
-			}
-
-			nativeSet = reflect.Append(nativeSet, reflect.ValueOf(nv))
+			return nil, fmt.Errorf("native type was not slice, array or pointer. got %d", naType.Kind())
 		}
-		return nativeSet.Interface(), nil
-
 	case TypeMap:
 		naType := NativeType(column)
 		ovsMap, ok := ovsElem.(OvsMap)
@@ -354,11 +412,16 @@ func isDefaultBaseValue(elem interface{}, etype ExtendedType) bool {
 	if !value.IsValid() {
 		return true
 	}
-
+	if reflect.TypeOf(elem).Kind() == reflect.Ptr {
+		return reflect.ValueOf(elem).IsZero()
+	}
 	switch etype {
 	case TypeUUID:
 		return elem.(string) == "00000000-0000-0000-0000-000000000000" || elem.(string) == "" || isNamed(elem.(string))
 	case TypeMap, TypeSet:
+		if value.Kind() == reflect.Array {
+			return value.Len() == 0
+		}
 		return value.IsNil() || value.Len() == 0
 	case TypeString:
 		return elem.(string) == ""

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/bhendo/go-powershell/utils
 github.com/cenkalti/backoff/v4
 # github.com/cenkalti/hub v1.0.1
 github.com/cenkalti/hub
-# github.com/cenkalti/rpc2 v0.0.0-20210220005819-4a29bc83afe1
+# github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984
 github.com/cenkalti/rpc2
 github.com/cenkalti/rpc2/jsonrpc
 # github.com/cespare/xxhash/v2 v2.1.1
@@ -171,7 +171,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/ovn-org/libovsdb v0.6.1-0.20210728143211-5f41f6da59f7
+# github.com/ovn-org/libovsdb v0.6.1-0.20210803142447-94fe2cdc514e
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
 github.com/ovn-org/libovsdb/mapper


### PR DESCRIPTION
This picks up Dave's change to use pointers for optional datatypes.
It also includes Dan's changes to client to pass Context to functions
that call rpc2's Call().

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>

**- Special notes for reviewers**

@dcbw : your input may be needed on this PR, where I currently added context.TODO() in 2 places
that now require the context parameter. Quite possibly they are `context.Background()`

@jcaamano @alexanderConstantinescu : Let's rebase the libovsdb work to use this PR, so we have
the proper generated types from libovsdb.