### PR TITLE
Bug 1985562: Deleting OVS transient ports to avoid issues during node reboot

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -505,7 +505,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 	mgmtPort.CheckManagementPortHealth(mgmtPortConfig, n.stopChan)
 
 	if config.OvnKubeNode.Mode != types.NodeModeSmartNICHost {
-		// start health check to ensure there are no stale OVS internal ports
+		// start health check to ensure there are no stale OVS internal or transient ports
 		go wait.Until(func() {
 			checkForStaleOVSInterfaces(n.name, n.watchFactory.(*factory.WatchFactory))
 		}, time.Minute, n.stopChan)


### PR DESCRIPTION
Added function to delete OVS transient ports to avoid errors after node reboot
this option was added via this OVS commit https://github.com/openvswitch/ovs/commit/54b21db723