### PR TITLE
factory: remove duplicate include

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -19,7 +19,6 @@ import (
 	egressipinformerfactory "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions"
 
 	kapi "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -578,7 +577,7 @@ func (wf *WatchFactory) ServiceInformer() cache.SharedIndexInformer {
 // This matches the behavior of kube-proxy
 func noHeadlessServiceSelector() func(options *metav1.ListOptions) {
 	// if the service is headless, skip it
-	noHeadlessEndpoints, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
+	noHeadlessEndpoints, err := labels.NewRequirement(kapi.IsHeadlessService, selection.DoesNotExist, nil)
 	if err != nil {
 		// cannot occur
 		panic(err)


### PR DESCRIPTION
Found a downstream panic; I can't believe this is the reason but I don't know what else it would be, and it's silly to have two of the same include.

@trozet 

```
E0819 06:47:31.180307       1 handler.go:190] Object has no meta: cannot get ObjectMeta from type *v1.Pod
E0819 06:47:31.180430       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 130 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x19457e0, 0x292eef0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x95
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x86
panic(0x19457e0, 0x292eef0)
	/usr/lib/golang/src/runtime/panic.go:965 +0x1b9
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory.(*informer).newFederatedQueuedHandler.func3(0x19cd5e0, 0xc000ac47c0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/factory/handler.go:297 +0x1ce
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:245
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
```