### PR TITLE
Fix errors during delete for get object meta

### DIFF
--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -293,7 +293,7 @@ func (i *informer) newFederatedQueuedHandler(numEventQueues uint32) cache.Resour
 				klog.Errorf(err.Error())
 				return
 			}
-			key, entry := i.refQueueEntry(i.oType, obj, numEventQueues)
+			key, entry := i.refQueueEntry(i.oType, realObj, numEventQueues)
 			i.enqueueEvent(nil, realObj, entry.queue, func(e *event) {
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "delete").Inc()
 				start := time.Now()


### PR DESCRIPTION
EnsureObjectOnDelete checks the expected type of the object, if it
doesn't match it gets the the object from the tombstone and returns the
real object. After this, we were still using the old object to get meta
from during refQueueEntry.

Not 100% sure this fixes the issue, but it seems plausible since EnsureObjectOnDelete can not match the expected type.

Signed-off-by: Tim Rozet <trozet@redhat.com>
