### PR TITLE
bump libovsdb

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
-	github.com/ovn-org/libovsdb v0.6.1-0.20210803142447-94fe2cdc514e
+	github.com/ovn-org/libovsdb v0.6.1-0.20210820090057-e418ed547c02
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/procfs v0.2.0 // indirect

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -327,6 +327,8 @@ github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/ory/dockertest/v3 v3.7.0/go.mod h1:PvCCgnP7AfBZeVrzwiUTjZx/IUXlGLC1zQlUQrLIlUE=
 github.com/ovn-org/libovsdb v0.6.1-0.20210803142447-94fe2cdc514e h1:qlUkF5zLGDhOiwYMzdFOZAZqGhbXRVMihQhGuLufg/s=
 github.com/ovn-org/libovsdb v0.6.1-0.20210803142447-94fe2cdc514e/go.mod h1:z8nnwUG5G+D4bzoUm6qbg5fC4q9pphb5VwO0AS473Ks=
+github.com/ovn-org/libovsdb v0.6.1-0.20210820090057-e418ed547c02 h1:sR2jFzB7fd/s//b3g7zBragDxTfrmCZvET6ANmrK4v4=
+github.com/ovn-org/libovsdb v0.6.1-0.20210820090057-e418ed547c02/go.mod h1:z8nnwUG5G+D4bzoUm6qbg5fC4q9pphb5VwO0AS473Ks=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
@@ -145,6 +145,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 		// FIXME: This only emits the error from the last attempted connection
 		return fmt.Errorf("failed to connect to endpoints %q: %v", o.options.endpoints, err)
 	}
+
 	if err := o.createRPC2Client(c); err != nil {
 		return err
 	}
@@ -152,6 +153,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 	dbs, err := o.listDbs(ctx)
 	if err != nil {
 		o.rpcClient.Close()
+		o.rpcClient = nil
 		return err
 	}
 
@@ -164,6 +166,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 	}
 	if !found {
 		o.rpcClient.Close()
+		o.rpcClient = nil
 		return fmt.Errorf("target database not found")
 	}
 
@@ -180,8 +183,10 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 
 	if err != nil {
 		o.rpcClient.Close()
+		o.rpcClient = nil
 		return err
 	}
+
 	o.schemaMutex.Lock()
 	o.schema = schema
 	o.schemaMutex.Unlock()
@@ -192,6 +197,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 			o.api = newAPI(o.cache)
 		} else {
 			o.rpcClient.Close()
+			o.rpcClient = nil
 			return err
 		}
 		o.cacheMutex.Unlock()
@@ -208,6 +214,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 			err = o.monitor(ctx, id, reconnect, request...)
 			if err != nil {
 				o.rpcClient.Close()
+				o.rpcClient = nil
 				return err
 			}
 		}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -169,7 +169,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/ovn-org/libovsdb v0.6.1-0.20210803142447-94fe2cdc514e
+# github.com/ovn-org/libovsdb v0.6.1-0.20210820090057-e418ed547c02
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
 github.com/ovn-org/libovsdb/mapper


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This pulls in https://github.com/ovn-org/libovsdb/pull/218 which fixes a bug that @dcbw noticed with the reconnect logic.

TL;DR libovsdb would immediately try to reconnect and would not get "connection refused" (even though ovsdb-server had shut down). the reconnect logic would get stuck in a half-connected state (established and rpc connection, but can't perform rpcs) and subsequent calls to `connect` would not error out, because we had an rpc connection, even if it wasn't working.... This ensures that state is cleaned up during failure in `connect`. I've tested this and it now works as expected on container restart and forced stop + delay of 2 minutes to reconnect, so I'm confident this should fix any issues seen here in CI.

/cc @dcbw 


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
None

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->