### PR TITLE
Add quotes around nexthop and dst-ip fields

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -520,7 +520,7 @@ func cleanUpBFDEntry(gatewayIP, gatewayRouter, prefix string) {
 	portName := prefix + types.GWRouterToExtSwitchPrefix + gatewayRouter
 
 	output, stderr, err := util.RunOVNNbctl(
-		"--format=csv", "--data=bare", "--no-heading", "--columns=bfd", "find", "Logical_Router_Static_Route", "output_port="+portName, "nexthop="+gatewayIP, "bfd!=[]")
+		"--format=csv", "--data=bare", "--no-heading", "--columns=bfd", "find", "Logical_Router_Static_Route", "output_port="+portName, "nexthop=\""+gatewayIP+"\"", "bfd!=[]")
 
 	if err != nil {
 		klog.Errorf("cleanUpBFDEntry: failed to list routes for %s, stderr: %q, (%v)", portName, gatewayIP, err, stderr)
@@ -532,7 +532,7 @@ func cleanUpBFDEntry(gatewayIP, gatewayRouter, prefix string) {
 		return
 	}
 	uuids, stderr, err := util.RunOVNNbctl(
-		"--format=csv", "--data=bare", "--no-heading", "--columns=_uuid", "find", "BFD", "logical_port="+portName, "dst_ip="+gatewayIP)
+		"--format=csv", "--data=bare", "--no-heading", "--columns=_uuid", "find", "BFD", "logical_port="+portName, "dst_ip=\""+gatewayIP+"\"")
 	if err != nil {
 		klog.Errorf("Failed to list routes for %s, stderr: %q, (%v)", gatewayRouter, err, stderr)
 		return


### PR DESCRIPTION
**- What this PR does and why is it needed**

While providing ipv6 addresses in `nexthop` and `dst-ip` fields into the
nbctl calls, it fails with the error `unexpected ":" parsing string`
during hbo pod deletion. This leads to stale bfd entries that don't
get cleaned up.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>


**- How to verify it**
Without the PR:

```
I0820 10:59:13.626354      48 pods.go:94] Deleting pod: t1/client-on-ovn-worker
I0820 10:59:13.626393      48 address_set.go:481] (d79acab8-7d39-47cc-8682-ab7bf0d80bb4/t1_v6/a3345265888189311907) deleting IP "fd00:10:244:1::7" from address set
I0820 10:59:13.626492      48 ovs.go:207] exec(188): /usr/bin/ovn-nbctl --timeout=15 remove address_set d79acab8-7d39-47cc-8682-ab7bf0d80bb4 addresses "fd00:10:244:1::7"
I0820 10:59:13.630174      48 ovs.go:210] exec(188): stdout: ""
I0820 10:59:13.630206      48 ovs.go:211] exec(188): stderr: ""
I0820 10:59:13.631453      48 ovs.go:207] exec(189): /usr/bin/ovn-nbctl --timeout=15 --if-exists --policy=src-ip lr-route-del GR_ovn-control-plane fd00:10:244:1::7/128 fd2e:6f44:5dd8::89
I0820 10:59:13.635284      48 ovs.go:210] exec(189): stdout: ""
I0820 10:59:13.635316      48 ovs.go:211] exec(189): stderr: ""
I0820 10:59:13.635384      48 ovs.go:207] exec(190): /usr/bin/ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=bfd find Logical_Router_Static_Route output_port=rtoe-GR_ovn-control-plane nexthop=fd2e:6f44:5dd8::89 bfd!=[]
I0820 10:59:13.638725      48 ovs.go:210] exec(190): stdout: ""
I0820 10:59:13.638761      48 ovs.go:211] exec(190): stderr: "ovn-nbctl: fd2e:6f44:5dd8::89: unexpected \":\" parsing string\n"
I0820 10:59:13.638773      48 ovs.go:213] exec(190): err: exit status 1
E0820 10:59:13.638801      48 egressgw.go:540] cleanUpBFDEntry: failed to list routes for rtoe-GR_ovn-control-plane, stderr: "fd2e:6f44:5dd8::89", (OVN command '/usr/bin/ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=bfd find Logical_Router_Static_Route output_port=rtoe-GR_ovn-control-plane nexthop=fd2e:6f44:5dd8::89 bfd!=[]' failed: exit status 1)%!(EXTRA string=ovn-nbctl: fd2e:6f44:5dd8::89: unexpected ":" parsing string
)
```
and

```
I0820 11:14:13.773141      50 pods.go:92] Deleting pod: t1/client-on-ovn-worker
I0820 11:14:13.773179      50 address_set.go:523] (e1da2d4e-0a64-473d-91a1-4849694f19f3/t1_v6/a3345265888189311907) deleting IP [fd00:10:244:1::7] from address set
I0820 11:14:13.774855      50 ovs.go:209] exec(86): /usr/bin/ovn-nbctl --timeout=15 --if-exists --policy=src-ip lr-route-del GR_ovn-control-plane fd00:10:244:1::7/128 fd2e:6f44:5dd8::89
I0820 11:14:13.780303      50 ovs.go:212] exec(86): stdout: ""
I0820 11:14:13.781026      50 ovs.go:213] exec(86): stderr: ""
I0820 11:14:13.781179      50 ovs.go:209] exec(87): /usr/bin/ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=bfd find Logical_Router_Static_Route output_port=rtoe-GR_ovn-control-plane nexthop="fd2e:6f44:5dd8::89" bfd!=[]
I0820 11:14:13.786979      50 ovs.go:212] exec(87): stdout: ""
I0820 11:14:13.787009      50 ovs.go:213] exec(87): stderr: ""
I0820 11:14:13.787069      50 ovs.go:209] exec(88): /usr/bin/ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find BFD logical_port=rtoe-GR_ovn-control-plane dst_ip=fd2e:6f44:5dd8::89
I0820 11:14:13.790103      50 ovs.go:212] exec(88): stdout: ""
I0820 11:14:13.790190      50 ovs.go:213] exec(88): stderr: "ovn-nbctl: fd2e:6f44:5dd8::89: unexpected \":\" parsing string\n"
I0820 11:14:13.790222      50 ovs.go:215] exec(88): err: exit status 1
E0820 11:14:13.790336      50 egressgw.go:537] Failed to list routes for GR_ovn-control-plane, stderr: "OVN command '/usr/bin/ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find BFD logical_port=rtoe-GR_ovn-control-plane dst_ip=fd2e:6f44:5dd8::89' failed: exit status 1", (ovn-nbctl: fd2e:6f44:5dd8::89: unexpected ":" parsing string
)
```

With the PR:
```
I0820 11:39:25.337712      52 pods.go:92] Deleting pod: t1/client-on-ovn-worker
I0820 11:39:25.337807      52 address_set.go:523] (07240eec-45c1-487a-9708-4a9bf72d6739/t1_v6/a3345265888189311907) deleting IP [fd00:10:244:2::8] from address set
I0820 11:39:25.341663      52 ovs.go:209] exec(97): /usr/bin/ovn-nbctl --timeout=15 --if-exists --policy=src-ip lr-route-del GR_ovn-control-plane fd00:10:244:2::8/128 fd2e:6f44:5dd8::89
I0820 11:39:25.345647      52 ovs.go:212] exec(97): stdout: ""
I0820 11:39:25.346212      52 ovs.go:213] exec(97): stderr: ""
I0820 11:39:25.346359      52 ovs.go:209] exec(98): /usr/bin/ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=bfd find Logical_Router_Static_Route output_port=rtoe-GR_ovn-control-plane nexthop="fd2e:6f44:5dd8::89" bfd!=[]
I0820 11:39:25.349843      52 ovs.go:212] exec(98): stdout: ""
I0820 11:39:25.349896      52 ovs.go:213] exec(98): stderr: ""
I0820 11:39:25.350032      52 ovs.go:209] exec(99): /usr/bin/ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find BFD logical_port=rtoe-GR_ovn-control-plane dst_ip="fd2e:6f44:5dd8::89"
I0820 11:39:25.353364      52 ovs.go:212] exec(99): stdout: "92f421a6-30f7-49aa-914c-3056a30bed47\n"
I0820 11:39:25.353401      52 ovs.go:213] exec(99): stderr: ""
I0820 11:39:25.353464      52 ovs.go:209] exec(100): /usr/bin/ovn-nbctl --timeout=15 --if-exists destroy BFD 92f421a6-30f7-49aa-914c-3056a30bed47
I0820 11:39:25.356819      52 ovs.go:212] exec(100): stdout: ""
I0820 11:39:25.356844      52 ovs.go:213] exec(100): stderr: ""
I0820 11:39:25.356936      52 ovs.go:209] exec(101): /usr/bin/ovn-nbctl --timeout=15 --if-exists --policy=src-ip lr-route-del GR_ovn-control-plane fd00:10:244:2::8/128 fd2e:6f44:5dd8::76
I0820 11:39:25.360766      52 ovs.go:212] exec(101): stdout: ""
I0820 11:39:25.361056      52 ovs.go:213] exec(101): stderr: ""
I0820 11:39:25.361374      52 ovs.go:209] exec(102): /usr/bin/ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=bfd find Logical_Router_Static_Route output_port=rtoe-GR_ovn-control-plane nexthop="fd2e:6f44:5dd8::76" bfd!=[]
I0820 11:39:25.366050      52 ovs.go:212] exec(102): stdout: ""
I0820 11:39:25.366081      52 ovs.go:213] exec(102): stderr: ""
I0820 11:39:25.366163      52 ovs.go:209] exec(103): /usr/bin/ovn-nbctl --timeout=15 --format=csv --data=bare --no-heading --columns=_uuid find BFD logical_port=rtoe-GR_ovn-control-plane dst_ip="fd2e:6f44:5dd8::76"
I0820 11:39:25.369571      52 ovs.go:212] exec(103): stdout: "46fdae8c-abe3-4853-b48a-f972be776744\n"
I0820 11:39:25.369603      52 ovs.go:213] exec(103): stderr: ""
I0820 11:39:25.369657      52 ovs.go:209] exec(104): /usr/bin/ovn-nbctl --timeout=15 --if-exists destroy BFD 46fdae8c-abe3-4853-b48a-f972be776744
I0820 11:39:25.373585      52 ovs.go:212] exec(104): stdout: ""
I0820 11:39:25.373616      52 ovs.go:213] exec(104): stderr: ""
```

**- Description for the changelog**
`Fixes bfd entry deletion in ipv6 mode`