### PR TITLE
[libovsdb] Update test matcher for libovsdb

### DIFF
--- a/go-controller/pkg/testing/libovsdb/matchers.go
+++ b/go-controller/pkg/testing/libovsdb/matchers.go
@@ -229,7 +229,7 @@ func haveData(ignoreUUIDs, nameUUIDs bool, expected []TestData) gomegatypes.Gome
 		}
 		return actual
 	}
-	return gomega.WithTransform(transform, gomega.ContainElements(matchers))
+	return gomega.WithTransform(transform, gomega.ConsistOf(matchers))
 }
 
 func matchTestData(ignoreUUID bool, expected TestData) *testDataMatcher {


### PR DESCRIPTION
The previous gomega matching function `ContainsElement` doesn't
assert that objects which are deleted, are also not retrieved in the
final result. Ex: item1, item2 exists, item1 is deleted. With
`ContainsElement(item2)` we cannot fully assert that item1 is gone. With
`ConsistOf(item2)` we can.

/assign @jcaamano 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->