### PR TITLE
Dockerfile.fedora: Update ovn build to ovn-21.06.0-15.fc33.

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-21.06.0-12.fc33
+ARG ovnver=ovn-21.06.0-15.fc33
 
 # install needed rpms - openvswitch must be 2.10.4 or higher
 RUN INSTALL_PKGS=" \


### PR DESCRIPTION
This new version includes support for multiple DGPs per router, which is
needed for an upcoming commit.

Signed-off-by: Han Zhou <hzhou@ovn.org>
