### PR TITLE
[libovsdb] Modify matchers to take into account optional field values

### DIFF
--- a/go-controller/pkg/testing/libovsdb/libovsdb.go
+++ b/go-controller/pkg/testing/libovsdb/libovsdb.go
@@ -262,6 +262,11 @@ func replaceUUIDs(data TestData, mapFrom func(string, int) string) {
 		switch f := f.(type) {
 		case string:
 			v.Field(i).Set(reflect.ValueOf(mapFrom(f, i)))
+		case *string:
+			if f != nil {
+				tmp := mapFrom(*f, i)
+				v.Field(i).Set(reflect.ValueOf(&tmp))
+			}
 		case []string:
 			for si, sv := range f {
 				f[si] = mapFrom(sv, i)

--- a/go-controller/pkg/testing/libovsdb/matchers.go
+++ b/go-controller/pkg/testing/libovsdb/matchers.go
@@ -143,6 +143,19 @@ func testDataEqual(x, y TestData, ignoreUUIDs bool) bool {
 		f1 := v1.Field(i)
 		f2 := v2.Field(i)
 		switch f1.Kind() {
+		case reflect.Ptr:
+			uv1 := reflect.Indirect(f1)
+			uv2 := reflect.Indirect(f2)
+			switch uv1.Kind() {
+			case reflect.String:
+				if ignoreUUIDs {
+					isF1UUID := validUUID.MatchString(uv1.String())
+					isF2UUID := validUUID.MatchString(uv2.String())
+					if isF1UUID || isF2UUID {
+						continue
+					}
+				}
+			}
 		case reflect.String:
 			if ignoreUUIDs {
 				isF1UUID := validUUID.MatchString(f1.String())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

When verifying if https://github.com/ovn-org/libovsdb/pull/220 works, I realized our testing framework needs to be modified to be able to handle optional field values (referenced by pointers). Explicitly for optional field values representing UUIDs (see: https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/nbdb/logical_router_static_route.go#L18) we need to compare the referenced pointer value and see if they match. 

I always get a bit nervous when using `reflect` and was a bit afraid that my changes in `matchers.go` will panic for non-string pointer values, but according to the doc for `String()`:

> func (reflect.Value).String() string
> (reflect.Value).String on pkg.go.dev

> String returns the string v's underlying value, as a string. String is a special case because of Go's String method convention. Unlike the other getters, it does not panic if v's Kind is not String. Instead, it returns a string of the form "<T value>" where T is v's type. The fmt package treats Values specially. It does not call their String method implicitly but instead prints the concrete values they hold.

So maybe we're fine? 

/assign @jcaamano @flavio-fernandes  

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->