### PR TITLE
Fix ensurePod to call addPodExternalGW only for annotation updates

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -566,10 +566,13 @@ func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) bool {
 			return false
 		}
 	} else {
-		if err := oc.addPodExternalGW(pod); err != nil {
-			klog.Errorf(err.Error())
-			oc.recordPodEvent(err, pod)
-			return false
+		// either pod is host-networked or its an update for a normal pod (addPort=false case)
+		if oldPod == nil || exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod) {
+			if err := oc.addPodExternalGW(pod); err != nil {
+				klog.Errorf(err.Error())
+				oc.recordPodEvent(err, pod)
+				return false
+			}
 		}
 	}
 


### PR DESCRIPTION
**- What this PR does and why is it needed**

Currently we call `addPodExternalGW` from both `ensurePod` and
`addLogicalPort`. If `ensurePod` is called with `addPort=false`
from the `UpdatePodHandler`, it will keep trying to call
`addPodExternalGW` to add routes and policies repeatedly
for the same pod. During exgw pod creation, we see same routes
and policies getting added 3 times in a row for the same pod.

**- Special notes for reviewers**

Note that https://github.com/ovn-org/ovn-kubernetes/pull/2337 fixed this by adding a check into `addGWRoutesForNamespace` 
to return if routes already exist for the pod:

https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/ovn/egressgw.go#L138-L140

but this comes later in the code flow. Its better to not call
`addPodExternalGW` at all unless needed. This would save
time and help with pod latency issues specially at scale.



**- How to verify it**
Before the PR (older versions):

```
I0825 16:54:18.129719       1 kube.go:63] Setting annotations map[k8s.ovn.org/pod-networks:{"default":{"ip_addresses":["10.128.6.52/23"],"mac_address":"0a:58:0a:80:06:34","gateway_ips":["10.128.6.1"],"ip_address":"10.128.6.52/23","gateway_ip":"10.128.6.1"}}] on pod default/route2jump
2021-08-25T16:54:18.152Z|01330|nbctl|INFO|Running command run -- add address_set d2c97191-3ad1-43da-9ba3-081ff5440b8e addresses "\"10.128.6.52\""
I0825 16:54:18.157901       1 egressgw.go:38] External gateway pod: route2jump, detected for namespace(s) bar
2021-08-25T16:54:18.162Z|01331|nbctl|INFO|Running command run --may-exist --policy=src-ip --ecmp-symmetric-reply -- lr-route-add GR_ci-ln-0ytq3yb-f76d1-fjzln-worker-c-lq4vv 10.128.6.49/32 192.168.216.1
2021-08-25T16:54:18.178Z|01332|nbctl|INFO|Running command run -- lr-policy-add ovn_cluster_router 501 "inport == \"rtos-ci-ln-0ytq3yb-f76d1-fjzln-worker-c-lq4vv\" && ip4.src == 10.128.6.49 && ip4.dst != 10.128.0.0/16" reroute 100.64.0.5
I0825 16:54:18.195632       1 pods.go:302] [default/route2jump] addLogicalPort took 66.521317ms
I0825 16:54:18.195987       1 egressgw.go:38] External gateway pod: route2jump, detected for namespace(s) bar
2021-08-25T16:54:18.204Z|01333|nbctl|INFO|Running command run --may-exist --policy=src-ip --ecmp-symmetric-reply -- lr-route-add GR_ci-ln-0ytq3yb-f76d1-fjzln-worker-c-lq4vv 10.128.6.49/32 192.168.216.1
2021-08-25T16:54:18.214Z|01334|nbctl|INFO|Running command run -- lr-policy-add ovn_cluster_router 501 "inport == \"rtos-ci-ln-0ytq3yb-f76d1-fjzln-worker-c-lq4vv\" && ip4.src == 10.128.6.49 && ip4.dst != 10.128.0.0/16" reroute 100.64.0.5
I0825 16:54:18.215649       1 egressgw.go:38] External gateway pod: route2jump, detected for namespace(s) bar
2021-08-25T16:54:18.219Z|01335|nbctl|INFO|Running command run --may-exist --policy=src-ip --ecmp-symmetric-reply -- lr-route-add GR_ci-ln-0ytq3yb-f76d1-fjzln-worker-c-lq4vv 10.128.6.49/32 192.168.216.1
2021-08-25T16:54:18.228Z|01336|nbctl|INFO|Running command run -- lr-policy-add ovn_cluster_router 501 "inport == \"rtos-ci-ln-0ytq3yb-f76d1-fjzln-worker-c-lq4vv\" && ip4.src == 10.128.6.49 && ip4.dst != 10.128.0.0/16" reroute 100.64.0.5
```

After the PR:
```
I0825 18:27:54.452985       1 kube.go:63] Setting annotations map[k8s.ovn.org/pod-networks:{"default":{"ip_addresses":["10.128.6.32/23"],"mac_address":"0a:58:0a:80:06:20","gateway_ips":["10.128.6.1"],"ip_address":"10.128.6.32/23","gateway_ip":"10.128.6.1"}}] on pod default/route2jump
2021-08-25T18:27:54.480Z|00565|nbctl|INFO|Running command run -- add address_set d2c97191-3ad1-43da-9ba3-081ff5440b8e addresses "\"10.128.6.32\""
I0825 18:27:54.487330       1 egressgw.go:38] External gateway pod: route2jump, detected for namespace(s) bar
2021-08-25T18:27:54.504Z|00566|nbctl|INFO|Running command run --may-exist --policy=src-ip --ecmp-symmetric-reply -- lr-route-add GR_ci-ln-0ytq3yb-f76d1-fjzln-worker-c-lq4vv 10.128.6.28/32 192.168.216.1
2021-08-25T18:27:54.535Z|00567|nbctl|INFO|Running command run -- lr-policy-add ovn_cluster_router 501 "inport == \"rtos-ci-ln-0ytq3yb-f76d1-fjzln-worker-c-lq4vv\" && ip4.src == 10.128.6.28 && ip4.dst != 10.128.0.0/16" reroute 100.64.0.5
I0825 18:27:54.552509       1 pods.go:302] [default/route2jump] addLogicalPort took 100.007739ms
```

**- Description for the changelog**
`Stop ensurePod from calling addPodExternalGW multiple times for the same pod.`

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
