### PR TITLE
Add "iface-id-ver=${POD_UID}" tuple to the external-ids of logical and OVS ports

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -278,6 +278,7 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 		"interface", hostIfaceName,
 		fmt.Sprintf("external_ids:attached_mac=%s", ifInfo.MAC),
 		fmt.Sprintf("external_ids:iface-id=%s", ifaceID),
+		fmt.Sprintf("external_ids:iface-id-ver=%s", initialPodUID),
 		fmt.Sprintf("external_ids:ip_addresses=%s", strings.Join(ipStrs, ",")),
 		fmt.Sprintf("external_ids:sandbox=%s", sandboxID),
 	}

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -257,7 +257,7 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 	ifInfo *PodInterfaceInfo, sandboxID string, podLister corev1listers.PodLister,
 	kclient kubernetes.Interface, initialPodUID string) error {
 	klog.Infof("ConfigureOVS: namespace: %s, podName: %s", namespace, podName)
-	ifaceID := fmt.Sprintf("%s_%s", namespace, podName)
+	ifaceID := util.GetIfaceId(namespace, podName)
 
 	// Find and remove any existing OVS port with this iface-id. Pods can
 	// have multiple sandboxes if some are waiting for garbage collection,

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -351,8 +351,9 @@ type HybridOverlayConfig struct {
 
 // OvnKubeNodeConfig holds ovnkube-node configurations
 type OvnKubeNodeConfig struct {
-	Mode           string `gcfg:"mode"`
-	MgmtPortNetdev string `gcfg:"mgmt-port-netdev"`
+	Mode                 string `gcfg:"mode"`
+	MgmtPortNetdev       string `gcfg:"mgmt-port-netdev"`
+	DisableOVNIfaceIdVer bool   `gcfg:"disable-ovn-iface-id-ver"`
 }
 
 // OvnDBScheme describes the OVN database connection transport method
@@ -1071,6 +1072,13 @@ var OvnKubeNodeFlags = []cli.Flag{
 			"and used to allow host network services and pods to access k8s pod and service networks. ",
 		Value:       OvnKubeNode.MgmtPortNetdev,
 		Destination: &cliConfig.OvnKubeNode.MgmtPortNetdev,
+	},
+	&cli.BoolFlag{
+		Name: "disable-ovn-iface-id-ver",
+		Usage: "if iface-id-ver option is not enabled in ovn, set this flag to True " +
+			"(depends on ovn version, minimal required is 21.09)",
+		Value:       OvnKubeNode.DisableOVNIfaceIdVer,
+		Destination: &cliConfig.OvnKubeNode.DisableOVNIfaceIdVer,
 	},
 }
 

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -192,7 +192,7 @@ func checkForStaleOVSRepresentorInterfaces(nodeName string, wf factory.ObjectCac
 			// Note: wf (WatchFactory) *usually* returns pods assigned to this node, however we dont rely on it
 			// and add this check to filter out pods assigned to other nodes. (e.g when ovnkube master and node
 			// share the same process)
-			expectedIfaceIds[strings.Join([]string{pod.Namespace, pod.Name}, "_")] = true
+			expectedIfaceIds[util.GetIfaceId(pod.Namespace, pod.Name)] = true
 		}
 	}
 

--- a/go-controller/pkg/node/node_smartnic_test.go
+++ b/go-controller/pkg/node/node_smartnic_test.go
@@ -24,10 +24,10 @@ func genOVSFindCmd(table, column, condition string) string {
 		column, table, condition)
 }
 
-func genOVSAddPortCmd(hostIfaceName, ifaceID, mac, ip, sandboxID string) string {
+func genOVSAddPortCmd(hostIfaceName, ifaceID, mac, ip, sandboxID, podUID string) string {
 	return fmt.Sprintf("ovs-vsctl --timeout=30 add-port br-int %s -- set interface %s external_ids:attached_mac=%s "+
-		"external_ids:iface-id=%s external_ids:ip_addresses=%s external_ids:sandbox=%s",
-		hostIfaceName, hostIfaceName, mac, ifaceID, ip, sandboxID)
+		"external_ids:iface-id=%s external_ids:iface-id-ver=%s external_ids:ip_addresses=%s external_ids:sandbox=%s",
+		hostIfaceName, hostIfaceName, mac, ifaceID, podUID, ip, sandboxID)
 }
 
 func genOVSDelPortCmd(portName string) string {
@@ -157,7 +157,7 @@ var _ = Describe("Node Smart NIC tests", func() {
 					"external-ids:iface-id="+genIfaceID(pod.Namespace, pod.Name)),
 			})
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: genOVSAddPortCmd(vfRep, genIfaceID(pod.Namespace, pod.Name), "", "", "a8d09931"),
+				Cmd: genOVSAddPortCmd(vfRep, genIfaceID(pod.Namespace, pod.Name), "", "", "a8d09931", string(pod.UID)),
 				Err: fmt.Errorf("failed to run ovs command"),
 			})
 			// Mock netlink/ovs calls for cleanup
@@ -185,7 +185,7 @@ var _ = Describe("Node Smart NIC tests", func() {
 						"external-ids:iface-id="+genIfaceID(pod.Namespace, pod.Name)),
 				})
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: genOVSAddPortCmd(vfRep, genIfaceID(pod.Namespace, pod.Name), "", "", "a8d09931"),
+					Cmd: genOVSAddPortCmd(vfRep, genIfaceID(pod.Namespace, pod.Name), "", "", "a8d09931", string(pod.UID)),
 				})
 				// clearPodBandwidth
 				execMock.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -113,7 +113,7 @@ func (oc *Controller) addGWRoutesForNamespace(namespace string, egress gatewayIn
 	// TODO (trozet): use the go bindings here and batch commands
 	for _, pod := range existingPods {
 		if config.Gateway.DisableSNATMultipleGWs {
-			logicalPort := podLogicalPortName(pod)
+			logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
 			portInfo, err := oc.logicalPortCache.get(logicalPort)
 			if err != nil {
 				klog.Warningf("Unable to get port %s in cache for SNAT rule removal", logicalPort)

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -279,7 +279,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 					klog.Errorf("Failed to get all the pods (%v)", err)
 				}
 				for _, pod := range existingPods {
-					logicalPort := podLogicalPortName(pod)
+					logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
 					portInfo, err := oc.logicalPortCache.get(logicalPort)
 					if err != nil {
 						klog.Warningf("Unable to get port %s in cache for SNAT rule removal", logicalPort)

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -114,7 +114,7 @@ func newTPod(nodeName, nodeSubnet, nodeMgtIP, nodeGWIP, podName, podIP, podMAC, 
 		podIP:      podIP,
 		podMAC:     podMAC,
 		namespace:  namespace,
-		portName:   namespace + "_" + podName,
+		portName:   util.GetLogicalPortName(namespace, podName),
 	}
 	return
 }
@@ -224,7 +224,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				// Assign it and perform the update
 				t.nodeName = "node1"
-				t.portName = t.namespace + "_" + t.podName
+				t.portName = util.GetLogicalPortName(t.namespace, t.podName)
 				t.populateLogicalSwitchCache(fakeOvn)
 
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Update(context.TODO(), newPod(t.namespace, t.podName, t.nodeName, t.podIP), metav1.UpdateOptions{})
@@ -435,7 +435,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Eventually(fExec.CalledMatchesExpected).Should(gomega.BeTrue(), fExec.ErrorDesc)
 				gomega.Expect(getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)).Should(gomega.MatchJSON(podJSON))
 
-				lsp, err := fakeOvn.ovnNBClient.LSPGet(t.namespace + "_" + t.podName)
+				lsp, err := fakeOvn.ovnNBClient.LSPGet(t.portName)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(lsp.Addresses).To(gomega.HaveLen(1))
 				gomega.Expect(lsp.Addresses[0]).To(gomega.ContainSubstring(t.podIP))

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -452,7 +452,7 @@ func (oc *Controller) createMulticastAllowPolicy(ns string, nsInfo *namespaceInf
 		klog.Warningf("Failed to get pods for namespace %q: %v", ns, err)
 	}
 	for _, pod := range pods {
-		portName := podLogicalPortName(pod)
+		portName := util.GetLogicalPortName(pod.Namespace, pod.Name)
 		if portInfo, err := oc.logicalPortCache.get(portName); err != nil {
 			klog.Errorf(err.Error())
 		} else if err := podAddAllowMulticastPolicy(oc.ovnNBClient, ns, portInfo); err != nil {
@@ -727,7 +727,7 @@ func (oc *Controller) handleLocalPodSelectorAddFunc(
 	}
 
 	// Get the logical port info
-	logicalPort := podLogicalPortName(pod)
+	logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
 	portInfo, err := oc.logicalPortCache.get(logicalPort)
 	if err != nil {
 		klog.Errorf(err.Error())
@@ -791,7 +791,7 @@ func (oc *Controller) handleLocalPodSelectorSetPods(
 			continue
 		}
 
-		portInfo, err := oc.logicalPortCache.get(podLogicalPortName(pod))
+		portInfo, err := oc.logicalPortCache.get(util.GetLogicalPortName(pod.Namespace, pod.Name))
 		// pod is not yet handled
 		// no big deal, we'll get the update when it is.
 		if err != nil {
@@ -837,7 +837,7 @@ func (oc *Controller) handleLocalPodSelectorDelFunc(
 	}
 
 	// Get the logical port info
-	logicalPort := podLogicalPortName(pod)
+	logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
 	portInfo, err := oc.logicalPortCache.get(logicalPort)
 	if err != nil {
 		klog.Errorf(err.Error())

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -261,3 +261,21 @@ ipLoop:
 
 	return out
 }
+
+func GetLogicalPortName(podNamespace, podName string) string {
+	return composePortName(podNamespace, podName)
+}
+
+func GetIfaceId(podNamespace, podName string) string {
+	return composePortName(podNamespace, podName)
+}
+
+// composePortName should be called both for LogicalPortName and iface-id
+// because ovn-nb man says:
+// Logical_Switch_Port.name must match external_ids:iface-id
+// in the Open_vSwitch database’s Interface table,
+// because hypervisors use external_ids:iface-id as a lookup key to
+// identify the network interface of that entity.
+func composePortName(podNamespace, podName string) string {
+	return podNamespace + "_" + podName
+}


### PR DESCRIPTION
Newly added option [1] allows to distinguish new vs old logical
ports for recreated pod with the same name, thus making "ovn-installed"
option reliable again [2].

1. Add "iface-id-ver" option to logical and OVS ports
[Upgrade][master] add iface-id-ver only for newly created Ports,
no ovn version check, since if iface-id-ver is not enabled in ovn, it will be just ignored
[Upgrade][node] no additional actions are needed, because existing Interfaces don't need
iface-id-set since it won't be set in master. Ovn support for iface-id-ver will be checked
during cni server creation
2. Add OvnKubeNodeConfig option "ovn-iface-id-ver-disabled" to manually
   disable this feature for older ovn versions
3. Change test mock that checks ovs add-port command
4. Add common function to compose LogicalPort name = iface-id
5. Enable OVNPortUp support after upgrade based on OVNTopo version and getOVNIfUpCheckMode check
6. revert [2]
[1] ovn-org/ovn@922c45f
[2] 22bed6a

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>