### PR TITLE
Fix lb delete during node deletion

### DIFF
--- a/go-controller/pkg/ovn/loadbalancer/lb_cache.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache.go
@@ -93,6 +93,24 @@ func (c *LBCache) removeVips(toRemove []DeleteVIPEntry) {
 	}
 }
 
+// RemoveSwitch removes the provided switchname from all the lb.Switches in the LBCache.
+func (c *LBCache) RemoveSwitch(switchname string) {
+	c.Lock()
+	defer c.Unlock()
+	for _, lbCache := range c.existing {
+		lbCache.Switches.Delete(switchname)
+	}
+}
+
+// RemoveRouter removes the provided routername from all the lb.Routers in the LBCache.
+func (c *LBCache) RemoveRouter(routername string) {
+	c.Lock()
+	defer c.Unlock()
+	for _, lbCache := range c.existing {
+		lbCache.Routers.Delete(routername)
+	}
+}
+
 // addNewLB is a shortcut when creating a load balancer; we know it won't have any switches or routers
 func (c *LBCache) addNewLB(lb *LB) {
 	c.Lock()

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
@@ -157,4 +157,22 @@ GR_ovn-control-plane,31bb6bff-93b9-4080-a1b9-9a1fa898b1f0 cb6ebcb0-c12d-4404-ada
 		"GR_ovn-control-plane": {"31bb6bff-93b9-4080-a1b9-9a1fa898b1f0", "cb6ebcb0-c12d-4404-ada7-5aa2b898f06b", "f0747ebb-71c2-4249-bdca-f33670ae544f"},
 	})
 
+	globalCache := &LBCache{}
+	globalCache.existing = make(map[string]*CachedLB, len(lbs))
+	for i := range lbs {
+		globalCache.existing[lbs[i].UUID] = &lbs[i]
+	}
+
+	globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Routers.Insert("GR_ovn-worker2", "GR_ovn-worker", "ovn_cluster_router", "GR_ovn-control-plane")
+	globalCache.RemoveRouter("GR_ovn-worker")
+	assert.Equal(t, globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Routers, sets.String{
+		"GR_ovn-control-plane": {}, "GR_ovn-worker2": {}, "ovn_cluster_router": {},
+	})
+
+	globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Switches.Insert("ovn-worker2", "ovn-worker", "ovn-control-plane")
+	globalCache.RemoveSwitch("ovn-worker")
+	assert.Equal(t, globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Switches, sets.String{
+		"ovn-control-plane": {}, "ovn-worker2": {},
+	})
+	assert.Equal(t, globalCache.existing["cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"].Switches, sets.String{}) // nothing changed
 }


### PR DESCRIPTION
**- What this PR does and why is it needed**

When a node gets deleted, the logical switch and
gateway router get removed first. However we do
not update the LBCache and this causes dependency
failures during deletion leaving behind wrong ip->vip
pairing in the lbs.

When the pods on this node go away, ensureLBs
gets triggered and it tries to update endpoints across
load balancers. This `set load_balancer` command is
batched with `ls-lb-del` & `lr-lb-del` commands to remove
association of the lbs from the removed switches and
routers. These commands fail together because the switches
and routers are not present in ovn.

This PR updates the LBcache as soon as we remove the
routers and switches.

**- How to verify it**

Before the PR:

```
I0827 08:52:51.185522      50 ovs.go:209] exec(172): /usr/bin/ovn-nbctl --timeout=15 set load_balancer 3b912b21-f0c4-4afb-8906-743f13727bbc external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=kube-system/kube-dns name=Service_kube-system/kube-dns_TCP_cluster options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53","10.96.0.10:9153"="10.244.2.3:9153,10.244.2.5:9153"} -- --if-exists ls-lb-del ovn-worker 3b912b21-f0c4-4afb-8906-743f13727bbc -- --if-exists lr-lb-del GR_ovn-worker 3b912b21-f0c4-4afb-8906-743f13727bbc -- set load_balancer 0d2bc5d2-3687-439a-9bd1-30426dfb43c2 external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=kube-system/kube-dns name=Service_kube-system/kube-dns_UDP_cluster options:event=false options:reject=true options:skip_snat=false protocol=udp selection_fields=[] vips={"10.96.0.10:53"="10.244.2.3:53,10.244.2.5:53"} -- --if-exists ls-lb-del ovn-worker 0d2bc5d2-3687-439a-9bd1-30426dfb43c2 -- --if-exists lr-lb-del GR_ovn-worker 0d2bc5d2-3687-439a-9bd1-30426dfb43c2
I0827 08:52:51.189255      50 ovs.go:212] exec(172): stdout: ""
I0827 08:52:51.189287      50 ovs.go:213] exec(172): stderr: "ovn-nbctl: ovn-worker: switch name not found\n"
I0827 08:52:51.189303      50 ovs.go:215] exec(172): err: exit status 1
I0827 08:52:51.189351      50 services_controller.go:244] Finished syncing service kube-dns on namespace kube-system : 4.434042ms
I0827 08:52:51.189425      50 services_controller.go:218] "Error syncing service, retrying" service="kube-system/kube-dns" err="failed to ensure service kube-system/kube-dns load balancers: failed to commit load balancer changes for map[string]string{\"k8s.ovn.org/kind\":\"Service\", \"k8s.ovn.org/owner\":\"kube-system/kube-dns\"}: OVN command '/usr/bin/ovn-nbctl --timeout=15 set load_balancer 3b912b21-f0c4-4afb-8906-743f13727bbc external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=kube-system/kube-dns name=Service_kube-system/kube-dns_TCP_cluster options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={\"10.96.0.10:53\"=\"10.244.2.3:53,10.244.2.5:53\",\"10.96.0.10:9153\"=\"10.244.2.3:9153,10.244.2.5:9153\"} -- --if-exists ls-lb-del ovn-worker 3b912b21-f0c4-4afb-8906-743f13727bbc -- --if-exists lr-lb-del GR_ovn-worker 3b912b21-f0c4-4afb-8906-743f13727bbc -- set load_balancer 0d2bc5d2-3687-439a-9bd1-30426dfb43c2 external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=kube-system/kube-dns name=Service_kube-system/kube-dns_UDP_cluster options:event=false options:reject=true options:skip_snat=false protocol=udp selection_fields=[] vips={\"10.96.0.10:53\"=\"10.244.2.3:53,10.244.2.5:53\"} -- --if-exists ls-lb-del ovn-worker 0d2bc5d2-3687-439a-9bd1-30426dfb43c2 -- --if-exists lr-lb-del GR_ovn-worker 0d2bc5d2-3687-439a-9bd1-30426dfb43c2' failed: exit status 1"
```
After the PR:
```
I0829 19:09:14.814415      49 pods.go:92] Deleting pod: default/server-on-ovn-worker2
I0829 19:09:14.814447      49 address_set.go:520] (1d8dfd3c-9aa5-44cf-bb0c-9306d86f4240/default_v4/a5154718082306775057) deleting IP [10.244.0.5] from address set
I0829 19:09:14.814662      49 services_controller.go:240] Processing sync for service default/service-backed-server-on-ovn-worker2
I0829 19:09:14.814700      49 kube.go:301] Getting endpoints for slice default/service-backed-server-on-ovn-worker2-s89tk
I0829 19:09:14.814718      49 kube.go:344] LB Endpoints for default/service-backed-server-on-ovn-worker2 are: [] / [] on port: 0
I0829 19:09:14.814732      49 services_controller.go:293] Built service default/service-backed-server-on-ovn-worker2 LB cluster-wide configs []services.lbConfig{services.lbConfig{vips:[]string{"10.96.225.76"}, protocol:"TCP", inport:80, eps:util.LbEndpoints{V4IPs:[]string{}, V6IPs:[]string{}, Port:0}, externalTrafficLocal:false}}
I0829 19:09:14.814753      49 services_controller.go:294] Built service default/service-backed-server-on-ovn-worker2 LB per-node configs []services.lbConfig{services.lbConfig{vips:[]string{"node"}, protocol:"TCP", inport:30764, eps:util.LbEndpoints{V4IPs:[]string{}, V6IPs:[]string{}, Port:0}, externalTrafficLocal:false}}
I0829 19:09:14.814802      49 services_controller.go:300] Service default/service-backed-server-on-ovn-worker2 has 1 cluster-wide and 1 per-node configs, making 1 and 2 load balancers
I0829 19:09:14.814956      49 ovs.go:209] exec(173): /usr/bin/ovn-nbctl --timeout=15 set load_balancer 090b2987-1e55-41af-b399-94cddc393e67 external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=default/service-backed-server-on-ovn-worker2 name=Service_default/service-backed-server-on-ovn-worker2_TCP_cluster options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"10.96.225.76:80"=""} -- set load_balancer 92909871-76b8-48ed-b486-063310f28fc9 external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=default/service-backed-server-on-ovn-worker2 name=Service_default/service-backed-server-on-ovn-worker2_TCP_node_router+switch_ovn-control-plane options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"172.18.0.3:30764"=""} -- set load_balancer 26cd29d6-2d1e-4597-b89c-9ddfad156912 external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=default/service-backed-server-on-ovn-worker2 name=Service_default/service-backed-server-on-ovn-worker2_TCP_node_router+switch_ovn-worker options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"172.18.0.4:30764"=""} -- --if-exists destroy Load_Balancer e398c76d-bf83-4e1f-9a70-f0e3d4358a78
E0829 19:09:14.826898      49 pods.go:130] node ovn-worker2 not found in the logical switch manager cache
I0829 19:09:14.826941      49 port_cache.go:69] port-cache(default_server-on-ovn-worker2): scheduling port for removal at 2021-08-29 19:10:14.826934816 +0000 UTC m=+355.004331930
I0829 19:09:14.827049      49 ovs.go:212] exec(173): stdout: ""
I0829 19:09:14.827080      49 ovs.go:213] exec(173): stderr: ""
I0829 19:09:14.827092      49 loadbalancer.go:80] Deleted 1 stale LBs for map[string]string{"k8s.ovn.org/kind":"Service", "k8s.ovn.org/owner":"default/service-backed-server-on-ovn-worker2"}
```

**- Description for the changelog**
`Fixes LBCache staleness`