### PR TITLE
Fix collector

### DIFF
--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -218,7 +218,13 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-enable-lflow-cache=true",
 						nodeIP, interval, ofintval, nodeName),
 				})
-
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-vsctl --timeout=15 -- clear bridge br-int netflow" +
+						" -- " +
+						"clear bridge br-int sflow" +
+						" -- " +
+						"clear bridge br-int ipfix",
+				})
 				err := util.SetExec(fexec)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -286,6 +292,13 @@ var _ = Describe("Node", func() {
 					Cmd: fmt.Sprintf("ovn-sbctl --timeout=15 set encap "+
 						"%s options:dst_port=%d", encapUUID, encapPort),
 				})
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-vsctl --timeout=15 -- clear bridge br-int netflow" +
+						" -- " +
+						"clear bridge br-int sflow" +
+						" -- " +
+						"clear bridge br-int ipfix",
+				})
 
 				err := util.SetExec(fexec)
 				Expect(err).NotTo(HaveOccurred())
@@ -340,7 +353,13 @@ var _ = Describe("Node", func() {
 						"external_ids:ovn-limit-lflow-cache-kb=100000",
 						nodeIP, interval, ofintval, nodeName),
 				})
-
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ovs-vsctl --timeout=15 -- clear bridge br-int netflow" +
+						" -- " +
+						"clear bridge br-int sflow" +
+						" -- " +
+						"clear bridge br-int ipfix",
+				})
 				err := util.SetExec(fexec)
 				Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1985838

Specifically when `OVN_NETFLOW_TARGETS` is set and eventually unset it does not clear the existing OVS collector targets. 

This PR also add's more e2e coverage and fixes a flake in the netflow export test which has been laying around. 