### PR TITLE
master: give leader election an event recorder

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -67,7 +67,10 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup, ctx context.Con
 		"ovn-kubernetes-master",
 		oc.client.CoreV1(),
 		nil,
-		resourcelock.ResourceLockConfig{Identity: nodeName},
+		resourcelock.ResourceLockConfig{
+			Identity:      nodeName,
+			EventRecorder: oc.recorder,
+		},
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Lets us watch leader election events between ovnkube masters
and debug leader election problems.