### PR TITLE
add support for NetworkPolicyEndPort feature

### DIFF
--- a/go-controller/pkg/ovn/gress_policy_test.go
+++ b/go-controller/pkg/ovn/gress_policy_test.go
@@ -117,3 +117,52 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 		assert.Equal(t, tc.expected, output)
 	}
 }
+
+func TestGetL4Match(t *testing.T) {
+	testcases := []struct {
+		desc     string
+		protocol string
+		port     int32
+		endPort  int32
+		expected string
+	}{
+		{
+			"unsupported protocol",
+			"kube",
+			0,
+			0,
+			"",
+		},
+		{
+			"valid protocol with no endport specified",
+			"TCP",
+			300,
+			0,
+			"tcp && tcp.dst==300",
+		},
+		{
+			"valid protocol with endport specified",
+			"TCP",
+			300,
+			310,
+			"tcp && 300<=tcp.dst<=310",
+		},
+		{
+			"valid protocol with no ports specified",
+			"TCP",
+			0,
+			0,
+			"tcp",
+		},
+	}
+
+	for _, tc := range testcases {
+		pp := &portPolicy{
+			protocol: tc.protocol,
+			port:     tc.port,
+			endPort:  tc.endPort,
+		}
+		l4Match, _ := pp.getL4Match()
+		assert.Equal(t, tc.expected, l4Match)
+	}
+}


### PR DESCRIPTION
with the support for this feature(alpha in 1.21 and beta in 1.22), the
network policies can be authored with port range. OVN already supports
port range, so it is is just a matter of implementing the support for it
in OVN K8s.

we don't need to check for the validity of the endport as it relates to
port (it should be >=, endport can't exist without port, and so on) since
it is already checked for us by the k8s apiserver.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@astoycos @dcbw @trozet PTAL