### PR TITLE
Re-enable CI with `disable-snat-multiple-gws` enabled. 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,7 +279,6 @@ jobs:
          - {"second-bridge": "2br", "disable-snat-multiple-gws": "snatGW"}
          - {"second-bridge": "2br", "ha": "HA"}
          - {"second-bridge": "2br", "target": "control-plane"}
-         - {"second-bridge": "1br", "disable-snat-multiple-gws": "noSnatGW"}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}"


### PR DESCRIPTION
PR #2376 removed a bunch of CI runs, overlooking the fact that it
happened to remove the CI run where `disable-snat-multiple-gws`
is enabled. Egress IP and disable-snat.. are mutually
exclusive, but since both options are supported by ovnkube, both need to
be validated in CI!

/assign @dcbw @trozet 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->