### PR TITLE
libovsdb: Use libovsdb for load balancer operations

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
-	github.com/ovn-org/libovsdb v0.6.1-0.20210910072853-ca80b79a451e
+	github.com/ovn-org/libovsdb v0.6.1-0.20210914134040-e4215434d1ba
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/procfs v0.2.0 // indirect

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -325,10 +325,8 @@ github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5X
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/ory/dockertest/v3 v3.7.0/go.mod h1:PvCCgnP7AfBZeVrzwiUTjZx/IUXlGLC1zQlUQrLIlUE=
-github.com/ovn-org/libovsdb v0.6.1-0.20210831170920-b98d0617096a h1:rdrTSKy6raqfv5XE0orKWkx3NteCBI1sTxHHAOATlzU=
-github.com/ovn-org/libovsdb v0.6.1-0.20210831170920-b98d0617096a/go.mod h1:z8nnwUG5G+D4bzoUm6qbg5fC4q9pphb5VwO0AS473Ks=
-github.com/ovn-org/libovsdb v0.6.1-0.20210910072853-ca80b79a451e h1:fRPeYVHnDtmSZPcfVmWSu/51/ftfYotM3AtbQIFDSBQ=
-github.com/ovn-org/libovsdb v0.6.1-0.20210910072853-ca80b79a451e/go.mod h1:z8nnwUG5G+D4bzoUm6qbg5fC4q9pphb5VwO0AS473Ks=
+github.com/ovn-org/libovsdb v0.6.1-0.20210914134040-e4215434d1ba h1:qg9T+cndpTgpHzNsq78nTlHp2LCHTdf+BawC7M9B/B4=
+github.com/ovn-org/libovsdb v0.6.1-0.20210914134040-e4215434d1ba/go.mod h1:z8nnwUG5G+D4bzoUm6qbg5fC4q9pphb5VwO0AS473Ks=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -83,7 +83,7 @@ func (r *repair) runBeforeSync() {
 	}
 
 	// Find all load-balancers associated with Services
-	lbCache, err := ovnlb.GetLBCache()
+	lbCache, err := ovnlb.GetLBCache(r.nbClient)
 	if err != nil {
 		klog.Errorf("Failed to get load_balancer cache: %v", err)
 	}
@@ -108,7 +108,7 @@ func (r *repair) runBeforeSync() {
 	}
 
 	// Delete those stale load balancers
-	if err := ovnlb.DeleteLBs(nil, staleLBs); err != nil {
+	if err := ovnlb.DeleteLBs(r.nbClient, staleLBs); err != nil {
 		klog.Errorf("Failed to delete stale LBs: %v", err)
 	}
 	klog.V(2).Infof("Deleted %d stale service LBs", len(staleLBs))
@@ -153,7 +153,7 @@ func (r *repair) runAfterSync() {
 
 func (r *repair) deleteLegacyLBs() error {
 	// Find all load-balancers associated with Services
-	legacyLBs, err := findLegacyLBs()
+	legacyLBs, err := findLegacyLBs(r.nbClient)
 	if err != nil {
 		klog.Errorf("Failed to list existing load balancers: %v", err)
 		return err

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -5,11 +5,11 @@ import (
 	"net"
 	"testing"
 
+	"github.com/onsi/gomega"
 	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
-	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
@@ -104,7 +104,8 @@ func TestSyncServices(t *testing.T) {
 		name        string
 		slice       *discovery.EndpointSlice
 		service     *v1.Service
-		ovnCmd      []ovntest.ExpectedCmd
+		initialDb   []libovsdbtest.TestData
+		expectedDb  []libovsdbtest.TestData
 		gatewayMode string
 	}{
 
@@ -134,23 +135,61 @@ func TestSyncServices(t *testing.T) {
 					}},
 				},
 			},
-			ovnCmd: []ovntest.ExpectedCmd{
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --format=json --data=json --columns=name,_uuid,protocol,external_ids,vips find load_balancer`,
-					Output: `{"data": []}`,
+			initialDb: []libovsdbtest.TestData{
+				&nbdb.LogicalSwitch{
+					UUID: "switch-node-a",
+					Name: "switch-node-a",
 				},
-				{
-					Cmd: `ovn-nbctl --timeout=15 --no-heading --format=csv --data=bare --columns=name,load_balancer find logical_switch`,
+				&nbdb.LogicalSwitch{
+					UUID: "switch-node-b",
+					Name: "switch-node-b",
 				},
-				{
-					Cmd: `ovn-nbctl --timeout=15 --no-heading --format=csv --data=bare --columns=name,load_balancer find logical_router`,
+				&nbdb.LogicalRouter{
+					UUID: "gr-node-a",
+					Name: "gr-node-a",
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 create load_balancer external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_cluster options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"192.168.1.1:80"=""}`,
-					Output: "uuid-1",
+				&nbdb.LogicalRouter{
+					UUID: "gr-node-b",
+					Name: "gr-node-b",
 				},
-				{
-					Cmd: `ovn-nbctl --timeout=15 --may-exist ls-lb-add switch-node-a uuid-1 -- --may-exist ls-lb-add switch-node-b uuid-1 -- --may-exist lr-lb-add gr-node-a uuid-1 -- --may-exist lr-lb-add gr-node-b uuid-1`,
+			},
+			expectedDb: []libovsdbtest.TestData{
+				&nbdb.LoadBalancer{
+					UUID: "Service_testns/foo_TCP_cluster",
+					Name: "Service_testns/foo_TCP_cluster",
+					Options: map[string]string{
+						"event":     "false",
+						"reject":    "true",
+						"skip_snat": "false",
+					},
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.1.1:80": "",
+					},
+					ExternalIDs: map[string]string{
+						"k8s.ovn.org/kind":  "Service",
+						"k8s.ovn.org/owner": "testns/foo",
+					},
+				},
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-a",
+					Name:         "switch-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-b",
+					Name:         "switch-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-a",
+					Name:         "gr-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-b",
+					Name:         "gr-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
 				},
 			},
 		},
@@ -180,22 +219,97 @@ func TestSyncServices(t *testing.T) {
 					}},
 				},
 			},
-			ovnCmd: []ovntest.ExpectedCmd{
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --format=json --data=json --columns=name,_uuid,protocol,external_ids,vips find load_balancer`,
-					Output: `{"data":[["Service_testns/foo_TCP_cluster",["uuid","uuid-1"],"tcp",["map",[["k8s.ovn.org/kind","Service"],["k8s.ovn.org/owner","testns/foo"]]],["map",[["192.168.0.1:6443",""]]]]]}`,
+			initialDb: []libovsdbtest.TestData{
+				&nbdb.LoadBalancer{
+					UUID: "Service_testns/foo_TCP_cluster",
+					Name: "Service_testns/foo_TCP_cluster",
+					Options: map[string]string{
+						"event":     "false",
+						"reject":    "true",
+						"skip_snat": "false",
+					},
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.0.1:6443": "",
+					},
+					ExternalIDs: map[string]string{
+						"k8s.ovn.org/kind":  "Service",
+						"k8s.ovn.org/owner": "testns/foo",
+					},
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --no-heading --format=csv --data=bare --columns=name,load_balancer find logical_switch`,
-					Output: `wrong-switch,uuid-1`,
+				&nbdb.LogicalSwitch{
+					UUID: "switch-node-a",
+					Name: "switch-node-a",
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --no-heading --format=csv --data=bare --columns=name,load_balancer find logical_router`,
-					Output: "gr-node-a,uuid-1\ngr-node-c,uuid-1",
+				&nbdb.LogicalSwitch{
+					UUID: "switch-node-b",
+					Name: "switch-node-b",
 				},
-				{
-					Cmd: `ovn-nbctl --timeout=15 set load_balancer uuid-1 external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_cluster options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"192.168.1.1:80"=""} ` +
-						`-- --may-exist ls-lb-add switch-node-a uuid-1 -- --may-exist ls-lb-add switch-node-b uuid-1 -- --if-exists ls-lb-del wrong-switch uuid-1 -- --may-exist lr-lb-add gr-node-b uuid-1 -- --if-exists lr-lb-del gr-node-c uuid-1`,
+				&nbdb.LogicalSwitch{
+					UUID:         "wrong-switch",
+					Name:         "wrong-switch",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-a",
+					Name:         "gr-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalRouter{
+					UUID: "gr-node-b",
+					Name: "gr-node-b",
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-c",
+					Name:         "gr-node-c",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+			},
+			expectedDb: []libovsdbtest.TestData{
+				&nbdb.LoadBalancer{
+					UUID: "Service_testns/foo_TCP_cluster",
+					Name: "Service_testns/foo_TCP_cluster",
+					Options: map[string]string{
+						"event":     "false",
+						"reject":    "true",
+						"skip_snat": "false",
+					},
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.1.1:80": "",
+					},
+					ExternalIDs: map[string]string{
+						"k8s.ovn.org/kind":  "Service",
+						"k8s.ovn.org/owner": "testns/foo",
+					},
+				},
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-a",
+					Name:         "switch-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-b",
+					Name:         "switch-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "wrong-switch",
+					Name: "wrong-switch",
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-a",
+					Name:         "gr-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-b",
+					Name:         "gr-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalRouter{
+					UUID: "gr-node-c",
+					Name: "gr-node-c",
 				},
 			},
 		},
@@ -225,24 +339,99 @@ func TestSyncServices(t *testing.T) {
 					}},
 				},
 			},
-			ovnCmd: []ovntest.ExpectedCmd{
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --format=json --data=json --columns=name,_uuid,protocol,external_ids,vips find load_balancer`,
-					Output: `{"data":[["Service_testns/foo_TCP_cluster",["uuid","uuid-1"],"tcp",["map",[["k8s.ovn.org/kind","Service"],["k8s.ovn.org/owner","testns/foo"]]],["map",[["192.168.0.1:6443",""]]]],["",["uuid","uuid-legacy"],"tcp",["map",[["TCP_lb_gateway_router",""]]],["map",[["192.168.1.1:80",""]]]]]}`,
+			initialDb: []libovsdbtest.TestData{
+				&nbdb.LoadBalancer{
+					UUID: "Service_testns/foo_TCP_cluster",
+					Name: "Service_testns/foo_TCP_cluster",
+					Options: map[string]string{
+						"event":     "false",
+						"reject":    "true",
+						"skip_snat": "false",
+					},
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.0.1:6443": "",
+					},
+					ExternalIDs: map[string]string{
+						"k8s.ovn.org/kind":  "Service",
+						"k8s.ovn.org/owner": "testns/foo",
+					},
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --no-heading --format=csv --data=bare --columns=name,load_balancer find logical_switch`,
-					Output: "switch-node-a,uuid-1\nswitch-node-b,uuid-1",
+				&nbdb.LoadBalancer{
+					UUID:     "TCP_lb_gateway_router",
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.1.1:80": "",
+					},
+					ExternalIDs: map[string]string{
+						"TCP_lb_gateway_router": "",
+					},
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --no-heading --format=csv --data=bare --columns=name,load_balancer find logical_router`,
-					Output: "gr-node-a,uuid-1\ngr-node-b,uuid-1",
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-a",
+					Name:         "switch-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
 				},
-				{
-					Cmd: `ovn-nbctl --timeout=15 set load_balancer uuid-1 external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_cluster options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"192.168.1.1:80"=""}`,
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-b",
+					Name:         "switch-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
 				},
-				{
-					Cmd: `ovn-nbctl --timeout=15 --if-exists remove load_balancer uuid-legacy vips  "192.168.1.1:80"`,
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-a",
+					Name:         "gr-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-b",
+					Name:         "gr-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+			},
+			expectedDb: []libovsdbtest.TestData{
+				&nbdb.LoadBalancer{
+					UUID: "Service_testns/foo_TCP_cluster",
+					Name: "Service_testns/foo_TCP_cluster",
+					Options: map[string]string{
+						"event":     "false",
+						"reject":    "true",
+						"skip_snat": "false",
+					},
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.1.1:80": "",
+					},
+					ExternalIDs: map[string]string{
+						"k8s.ovn.org/kind":  "Service",
+						"k8s.ovn.org/owner": "testns/foo",
+					},
+				},
+				&nbdb.LoadBalancer{
+					UUID:     "TCP_lb_gateway_router",
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					ExternalIDs: map[string]string{
+						"TCP_lb_gateway_router": "",
+					},
+				},
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-a",
+					Name:         "switch-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-b",
+					Name:         "switch-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-a",
+					Name:         "gr-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
+				},
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-b",
+					Name:         "gr-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
 				},
 			},
 		},
@@ -285,31 +474,128 @@ func TestSyncServices(t *testing.T) {
 					}},
 				},
 			},
-			ovnCmd: []ovntest.ExpectedCmd{
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --format=json --data=json --columns=name,_uuid,protocol,external_ids,vips find load_balancer`,
-					Output: `{"data":[["Service_testns/foo_TCP_cluster",["uuid","uuid-1"],"tcp",["map",[["k8s.ovn.org/kind","Service"],["k8s.ovn.org/owner","testns/foo"]]],["map",[["192.168.0.1:6443",""]]]]]}`,
+			initialDb: []libovsdbtest.TestData{
+				&nbdb.LoadBalancer{
+					UUID: "Service_testns/foo_TCP_cluster",
+					Name: "Service_testns/foo_TCP_cluster",
+					Options: map[string]string{
+						"event":     "false",
+						"reject":    "true",
+						"skip_snat": "false",
+					},
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.0.1:6443": "",
+					},
+					ExternalIDs: map[string]string{
+						"k8s.ovn.org/kind":  "Service",
+						"k8s.ovn.org/owner": "testns/foo",
+					},
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --no-heading --format=csv --data=bare --columns=name,load_balancer find logical_switch`,
-					Output: "switch-node-a,uuid-1\nswitch-node-b,uuid-1",
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-a",
+					Name:         "switch-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 --no-heading --format=csv --data=bare --columns=name,load_balancer find logical_router`,
-					Output: "gr-node-a,uuid-1\ngr-node-b,uuid-1",
+				&nbdb.LogicalSwitch{
+					UUID:         "switch-node-b",
+					Name:         "switch-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 create load_balancer external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_node_router+switch_node-a options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"10.0.0.1:8989"="10.128.0.2:3456,10.128.1.2:3456"}`,
-					Output: "uuid-rs-nodea",
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-a",
+					Name:         "gr-node-a",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
 				},
-				{
-					Cmd:    `ovn-nbctl --timeout=15 create load_balancer external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_node_router+switch_node-b options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"10.0.0.2:8989"="10.128.0.2:3456,10.128.1.2:3456"}`,
-					Output: "uuid-rs-nodeb",
+				&nbdb.LogicalRouter{
+					UUID:         "gr-node-b",
+					Name:         "gr-node-b",
+					LoadBalancer: []string{"Service_testns/foo_TCP_cluster"},
 				},
-				{
-					Cmd: `ovn-nbctl --timeout=15 set load_balancer uuid-1 external_ids:k8s.ovn.org/kind=Service external_ids:k8s.ovn.org/owner=testns/foo name=Service_testns/foo_TCP_cluster options:event=false options:reject=true options:skip_snat=false protocol=tcp selection_fields=[] vips={"192.168.1.1:80"="10.128.0.2:3456,10.128.1.2:3456"}` +
-						` -- --may-exist ls-lb-add switch-node-a uuid-rs-nodea -- --may-exist lr-lb-add gr-node-a uuid-rs-nodea` +
-						` -- --may-exist ls-lb-add switch-node-b uuid-rs-nodeb -- --may-exist lr-lb-add gr-node-b uuid-rs-nodeb`,
+			},
+			expectedDb: []libovsdbtest.TestData{
+				&nbdb.LoadBalancer{
+					UUID: "Service_testns/foo_TCP_cluster",
+					Name: "Service_testns/foo_TCP_cluster",
+					Options: map[string]string{
+						"event":     "false",
+						"reject":    "true",
+						"skip_snat": "false",
+					},
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"192.168.1.1:80": "10.128.0.2:3456,10.128.1.2:3456",
+					},
+					ExternalIDs: map[string]string{
+						"k8s.ovn.org/kind":  "Service",
+						"k8s.ovn.org/owner": "testns/foo",
+					},
+				},
+				&nbdb.LoadBalancer{
+					UUID: "Service_testns/foo_TCP_node_router+switch_node-a",
+					Name: "Service_testns/foo_TCP_node_router+switch_node-a",
+					Options: map[string]string{
+						"event":     "false",
+						"reject":    "true",
+						"skip_snat": "false",
+					},
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"10.0.0.1:8989": "10.128.0.2:3456,10.128.1.2:3456",
+					},
+					ExternalIDs: map[string]string{
+						"k8s.ovn.org/kind":  "Service",
+						"k8s.ovn.org/owner": "testns/foo",
+					},
+				},
+				&nbdb.LoadBalancer{
+					UUID: "Service_testns/foo_TCP_node_router+switch_node-b",
+					Name: "Service_testns/foo_TCP_node_router+switch_node-b",
+					Options: map[string]string{
+						"event":     "false",
+						"reject":    "true",
+						"skip_snat": "false",
+					},
+					Protocol: &nbdb.LoadBalancerProtocolTCP,
+					Vips: map[string]string{
+						"10.0.0.2:8989": "10.128.0.2:3456,10.128.1.2:3456",
+					},
+					ExternalIDs: map[string]string{
+						"k8s.ovn.org/kind":  "Service",
+						"k8s.ovn.org/owner": "testns/foo",
+					},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "switch-node-a",
+					Name: "switch-node-a",
+					LoadBalancer: []string{
+						"Service_testns/foo_TCP_cluster",
+						"Service_testns/foo_TCP_node_router+switch_node-a",
+					},
+				},
+				&nbdb.LogicalSwitch{
+					UUID: "switch-node-b",
+					Name: "switch-node-b",
+					LoadBalancer: []string{
+						"Service_testns/foo_TCP_cluster",
+						"Service_testns/foo_TCP_node_router+switch_node-b",
+					},
+				},
+				&nbdb.LogicalRouter{
+					UUID: "gr-node-a",
+					Name: "gr-node-a",
+					LoadBalancer: []string{
+						"Service_testns/foo_TCP_cluster",
+						"Service_testns/foo_TCP_node_router+switch_node-a",
+					},
+				},
+				&nbdb.LogicalRouter{
+					UUID: "gr-node-b",
+					Name: "gr-node-b",
+					LoadBalancer: []string{
+						"Service_testns/foo_TCP_cluster",
+						"Service_testns/foo_TCP_node_router+switch_node-b",
+					},
 				},
 			},
 		},
@@ -317,6 +603,8 @@ func TestSyncServices(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d_%s", i, tt.name), func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+
 			if tt.gatewayMode != "" {
 				globalconfig.Gateway.Mode = globalconfig.GatewayMode(tt.gatewayMode)
 			} else {
@@ -324,7 +612,7 @@ func TestSyncServices(t *testing.T) {
 			}
 
 			ovnlb.TestOnlySetCache(nil)
-			controller, err := newController()
+			controller, err := newControllerWithDBSetup(libovsdbtest.TestSetup{NBData: tt.initialDb})
 			if err != nil {
 				t.Fatalf("Error creating controller: %v", err)
 			}
@@ -334,24 +622,13 @@ func TestSyncServices(t *testing.T) {
 			controller.serviceStore.Add(tt.service)
 
 			controller.nodeTracker.nodes = defaultNodes
-			// Expected OVN commands
-			fexec := ovntest.NewLooseCompareFakeExec()
-			for _, cmd := range tt.ovnCmd {
-				cmd := cmd
-				fexec.AddFakeCmd(&cmd)
-			}
-			err = util.SetExec(fexec)
-			if err != nil {
-				t.Errorf("fexec error: %v", err)
-			}
+
 			err = controller.syncService(ns + "/" + serviceName)
 			if err != nil {
 				t.Errorf("syncServices error: %v", err)
 			}
 
-			if !fexec.CalledMatchesExpected() {
-				t.Error(fexec.ErrorDesc())
-			}
+			g.Eventually(controller.nbClient).Should(libovsdbtest.HaveData(tt.expectedDb))
 		})
 	}
 }

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -14,7 +15,7 @@ import (
 )
 
 // gatewayCleanup removes all the NB DB objects created for a node's gateway
-func gatewayCleanup(nodeName string) error {
+func gatewayCleanup(nbClient libovsdbclient.Client, nodeName string) error {
 	gatewayRouter := types.GWRouterPrefix + nodeName
 
 	// Get the gateway router port's IP address (connected to join switch)
@@ -38,7 +39,7 @@ func gatewayCleanup(nodeName string) error {
 	}
 
 	// Remove router to lb associations from the LBCache before removing the router
-	lbCache, err := ovnlb.GetLBCache()
+	lbCache, err := ovnlb.GetLBCache(nbClient)
 	if err != nil {
 		return fmt.Errorf("failed to get load_balancer cache for router %s: %v", gatewayRouter, err)
 	}
@@ -138,7 +139,7 @@ func staticRouteCleanup(nextHops []net.IP) {
 // the single join switch versions; this is to cleanup the logical entities for the
 // specified node if the node was deleted when the ovnkube-master pod was brought down
 // to do the version upgrade.
-func multiJoinSwitchGatewayCleanup(nodeName string, upgradeOnly bool) error {
+func multiJoinSwitchGatewayCleanup(nbClient libovsdbclient.Client, nodeName string, upgradeOnly bool) error {
 	gatewayRouter := types.GWRouterPrefix + nodeName
 
 	// Get the gateway router port's IP address (connected to join switch)
@@ -197,7 +198,7 @@ func multiJoinSwitchGatewayCleanup(nodeName string, upgradeOnly bool) error {
 	}
 
 	// Remove router to lb associations from the LBCache before removing the router
-	lbCache, err := ovnlb.GetLBCache()
+	lbCache, err := ovnlb.GetLBCache(nbClient)
 	if err != nil {
 		return fmt.Errorf("failed to get load_balancer cache for router %s: %v", gatewayRouter, err)
 	}

--- a/go-controller/pkg/ovn/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/ovn/libovsdbops/loadbalancer.go
@@ -1,0 +1,239 @@
+package libovsdbops
+
+import (
+	"fmt"
+
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/model"
+	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+)
+
+// findLoadBalancer looks up the load balancer in the cache and sets the UUID
+func findLoadBalancer(nbClient libovsdbclient.Client, lb *nbdb.LoadBalancer) error {
+	if lb.UUID != "" && !IsNamedUUID(lb.UUID) {
+		return nil
+	}
+
+	lbs := []nbdb.LoadBalancer{}
+	err := nbClient.WhereCache(func(item *nbdb.LoadBalancer) bool {
+		return item.Name == lb.Name
+	}).List(&lbs)
+	if err != nil {
+		return fmt.Errorf("can't find load balancer %+v: %v", *lb, err)
+	}
+
+	if len(lbs) > 1 {
+		return fmt.Errorf("unexpectedly found multiple load balancers: %+v", lbs)
+	}
+
+	if len(lbs) == 0 {
+		return libovsdbclient.ErrNotFound
+	}
+
+	lb.UUID = lbs[0].UUID
+	return nil
+}
+
+// getNonZeroLoadBalancerMutableFields builds a list of load balancer
+// mutable fields with non zero values to be used as the list of fields to
+// Update.
+// The purpose is to prevent libovsdb interpreting non-nil empty maps/slices
+// as default and thus being filtered out of the update. The intention is to
+// use non-nil empty maps/slices to clear them out in the update.
+// See: https://github.com/ovn-org/libovsdb/issues/226
+func getNonZeroLoadBalancerMutableFields(lb *nbdb.LoadBalancer) []interface{} {
+	fields := []interface{}{}
+	if lb.Name != "" {
+		fields = append(fields, &lb.Name)
+	}
+	if lb.ExternalIDs != nil {
+		fields = append(fields, &lb.ExternalIDs)
+	}
+	if lb.HealthCheck != nil {
+		fields = append(fields, &lb.HealthCheck)
+	}
+	if lb.IPPortMappings != nil {
+		fields = append(fields, &lb.IPPortMappings)
+	}
+	if lb.Options != nil {
+		fields = append(fields, &lb.Options)
+	}
+	if lb.Protocol != nil {
+		fields = append(fields, &lb.Protocol)
+	}
+	if lb.SelectionFields != nil {
+		fields = append(fields, &lb.SelectionFields)
+	}
+	if lb.Vips != nil {
+		fields = append(fields, &lb.Vips)
+	}
+	return fields
+}
+
+func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, selectionFields []nbdb.LoadBalancerSelectionFields, vips, options, externalIds map[string]string) *nbdb.LoadBalancer {
+	return &nbdb.LoadBalancer{
+		Name:            name,
+		Protocol:        &protocol,
+		SelectionFields: selectionFields,
+		Vips:            vips,
+		Options:         options,
+		ExternalIDs:     externalIds,
+	}
+}
+
+func ensureLoadBalancerUUID(lb *nbdb.LoadBalancer) {
+	if lb.UUID == "" {
+		lb.UUID = BuildNamedUUID()
+	}
+}
+
+func createOrUpdateLoadBalancerOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lb *nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	if ops == nil {
+		ops = []libovsdb.Operation{}
+	}
+
+	err := findLoadBalancer(nbClient, lb)
+	if err != nil && err != libovsdbclient.ErrNotFound {
+		return nil, err
+	}
+
+	// If LoadBalancer does not exist, create it
+	if err == libovsdbclient.ErrNotFound {
+		ensureLoadBalancerUUID(lb)
+		op, err := nbClient.Create(lb)
+		if err != nil {
+			return nil, err
+		}
+		ops = append(ops, op...)
+		return ops, nil
+	}
+
+	fields := getNonZeroLoadBalancerMutableFields(lb)
+	op, err := nbClient.Where(lb).Update(lb, fields...)
+	if err != nil {
+		return nil, err
+	}
+	ops = append(ops, op...)
+
+	return ops, nil
+}
+
+func CreateOrUpdateLoadBalancersOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	if ops == nil {
+		ops = []libovsdb.Operation{}
+	}
+	for _, lb := range lbs {
+		var err error
+		ops, err = createOrUpdateLoadBalancerOps(nbClient, ops, lb)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ops, nil
+}
+
+func CreateOrUpdateLoadBalancers(nbClient libovsdbclient.Client, lbs ...*nbdb.LoadBalancer) error {
+	ops, err := CreateOrUpdateLoadBalancersOps(nbClient, nil, lbs...)
+	if err != nil {
+		return err
+	}
+
+	_, err = TransactAndCheck(nbClient, ops)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func RemoveLoadBalancerVipsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lb *nbdb.LoadBalancer, vips ...string) ([]libovsdb.Operation, error) {
+	if ops == nil {
+		ops = []libovsdb.Operation{}
+	}
+
+	err := findLoadBalancer(nbClient, lb)
+	if err != nil {
+		return nil, err
+	}
+
+	op, err := nbClient.Where(lb).Mutate(lb, model.Mutation{
+		Field:   &lb.Vips,
+		Mutator: libovsdb.MutateOperationDelete,
+		Value:   vips,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ops = append(ops, op...)
+
+	return ops, nil
+}
+
+func RemoveLoadBalancerVips(nbClient libovsdbclient.Client, lb *nbdb.LoadBalancer, vips ...string) error {
+	ops, err := RemoveLoadBalancerVipsOps(nbClient, nil, lb, vips...)
+	if err != nil {
+		return err
+	}
+
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
+}
+
+func deleteLoadBalancerOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lb *nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	if ops == nil {
+		ops = []libovsdb.Operation{}
+	}
+
+	err := findLoadBalancer(nbClient, lb)
+	if err == libovsdbclient.ErrNotFound {
+		// noop
+		return ops, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	op, err := nbClient.Where(lb).Delete()
+	if err != nil {
+		return nil, err
+	}
+	ops = append(ops, op...)
+
+	return ops, nil
+}
+
+func DeleteLoadBalancersOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	if ops == nil {
+		ops = []libovsdb.Operation{}
+	}
+	var err error
+	for _, lb := range lbs {
+		ops, err = deleteLoadBalancerOps(nbClient, ops, lb)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ops, nil
+}
+
+func DeleteLoadBalancers(nbClient libovsdbclient.Client, lbs []*nbdb.LoadBalancer) error {
+	ops, err := DeleteLoadBalancersOps(nbClient, nil, lbs...)
+	if err != nil {
+		return err
+	}
+
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
+}
+
+func ListLoadBalancers(nbClient libovsdbclient.Client) ([]nbdb.LoadBalancer, error) {
+	lbs := &[]nbdb.LoadBalancer{}
+	err := nbClient.List(lbs)
+	if err != nil {
+		return nil, err
+	}
+	return *lbs, nil
+}

--- a/go-controller/pkg/ovn/libovsdbops/router.go
+++ b/go-controller/pkg/ovn/libovsdbops/router.go
@@ -1,0 +1,107 @@
+package libovsdbops
+
+import (
+	"fmt"
+
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/model"
+	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+)
+
+// findRouter looks up the router in the cache and sets the UUID
+func findRouter(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) error {
+	if router.UUID != "" && !IsNamedUUID(router.UUID) {
+		return nil
+	}
+
+	routers := []nbdb.LogicalRouter{}
+	err := nbClient.WhereCache(func(item *nbdb.LogicalRouter) bool {
+		return item.Name == router.Name
+	}).List(&routers)
+	if err != nil {
+		return fmt.Errorf("can't find router %+v: %v", *router, err)
+	}
+
+	if len(routers) > 1 {
+		return fmt.Errorf("unexpectedly found multiple routers: %+v", routers)
+	}
+
+	if len(routers) == 0 {
+		return libovsdbclient.ErrNotFound
+	}
+
+	router.UUID = routers[0].UUID
+	return nil
+}
+
+func AddLoadBalancersToRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	if ops == nil {
+		ops = []libovsdb.Operation{}
+	}
+	if len(lbs) == 0 {
+		return ops, nil
+	}
+
+	err := findRouter(nbClient, router)
+	if err != nil {
+		return nil, err
+	}
+
+	lbUUIDs := make([]string, 0, len(lbs))
+	for _, lb := range lbs {
+		lbUUIDs = append(lbUUIDs, lb.UUID)
+	}
+
+	op, err := nbClient.Where(router).Mutate(router, model.Mutation{
+		Field:   &router.LoadBalancer,
+		Mutator: libovsdb.MutateOperationInsert,
+		Value:   lbUUIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ops = append(ops, op...)
+
+	return ops, nil
+}
+
+func RemoveLoadBalancersFromRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	if ops == nil {
+		ops = []libovsdb.Operation{}
+	}
+	if len(lbs) == 0 {
+		return ops, nil
+	}
+
+	err := findRouter(nbClient, router)
+	if err != nil {
+		return nil, err
+	}
+
+	lbUUIDs := make([]string, 0, len(lbs))
+	for _, lb := range lbs {
+		lbUUIDs = append(lbUUIDs, lb.UUID)
+	}
+
+	op, err := nbClient.Where(router).Mutate(router, model.Mutation{
+		Field:   &router.LoadBalancer,
+		Mutator: libovsdb.MutateOperationDelete,
+		Value:   lbUUIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ops = append(ops, op...)
+
+	return ops, nil
+}
+
+func ListRoutersWithLoadBalancers(nbClient libovsdbclient.Client) ([]nbdb.LogicalRouter, error) {
+	routers := &[]nbdb.LogicalRouter{}
+	err := nbClient.WhereCache(func(item *nbdb.LogicalRouter) bool {
+		return item.LoadBalancer != nil
+	}).List(routers)
+	return *routers, err
+}

--- a/go-controller/pkg/ovn/libovsdbops/switch.go
+++ b/go-controller/pkg/ovn/libovsdbops/switch.go
@@ -1,0 +1,106 @@
+package libovsdbops
+
+import (
+	"fmt"
+
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/model"
+	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+)
+
+// findSwitch looks up the switch in the cache and sets the UUID
+func findSwitch(nbClient libovsdbclient.Client, lswitch *nbdb.LogicalSwitch) error {
+	if lswitch.UUID != "" && !IsNamedUUID(lswitch.UUID) {
+		return nil
+	}
+
+	switches := []nbdb.LogicalSwitch{}
+	err := nbClient.WhereCache(func(item *nbdb.LogicalSwitch) bool {
+		return item.Name == lswitch.Name
+	}).List(&switches)
+	if err != nil {
+		return fmt.Errorf("can't find router %+v: %v", *lswitch, err)
+	}
+
+	if len(switches) > 1 {
+		return fmt.Errorf("unexpectedly found multiple switches: %+v", switches)
+	}
+
+	if len(switches) == 0 {
+		return libovsdbclient.ErrNotFound
+	}
+
+	lswitch.UUID = switches[0].UUID
+	return nil
+}
+
+func AddLoadBalancersToSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lswitch *nbdb.LogicalSwitch, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	if ops == nil {
+		ops = []libovsdb.Operation{}
+	}
+	if len(lbs) == 0 {
+		return ops, nil
+	}
+
+	err := findSwitch(nbClient, lswitch)
+	if err != nil {
+		return nil, err
+	}
+
+	lbUUIDs := make([]string, 0, len(lbs))
+	for _, lb := range lbs {
+		lbUUIDs = append(lbUUIDs, lb.UUID)
+	}
+
+	op, err := nbClient.Where(lswitch).Mutate(lswitch, model.Mutation{
+		Field:   &lswitch.LoadBalancer,
+		Mutator: libovsdb.MutateOperationInsert,
+		Value:   lbUUIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ops = append(ops, op...)
+	return ops, nil
+}
+
+func RemoveLoadBalancersFromSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lswitch *nbdb.LogicalSwitch, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	if ops == nil {
+		ops = []libovsdb.Operation{}
+	}
+	if len(lbs) == 0 {
+		return ops, nil
+	}
+
+	err := findSwitch(nbClient, lswitch)
+	if err != nil {
+		return nil, err
+	}
+
+	lbUUIDs := make([]string, 0, len(lbs))
+	for _, lb := range lbs {
+		lbUUIDs = append(lbUUIDs, lb.UUID)
+	}
+
+	op, err := nbClient.Where(lswitch).Mutate(lswitch, model.Mutation{
+		Field:   &lswitch.LoadBalancer,
+		Mutator: libovsdb.MutateOperationDelete,
+		Value:   lbUUIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ops = append(ops, op...)
+
+	return ops, nil
+}
+
+func ListSwitchesWithLoadBalancers(nbClient libovsdbclient.Client) ([]nbdb.LogicalSwitch, error) {
+	switches := &[]nbdb.LogicalSwitch{}
+	err := nbClient.WhereCache(func(item *nbdb.LogicalSwitch) bool {
+		return item.LoadBalancer != nil
+	}).List(switches)
+	return *switches, err
+}

--- a/go-controller/pkg/ovn/libovsdbops/util.go
+++ b/go-controller/pkg/ovn/libovsdbops/util.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"sync/atomic"
 
 	"github.com/ovn-org/libovsdb/client"
+	libovsdbmodel "github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 )
 
 const (
@@ -29,7 +32,7 @@ func BuildNamedUUID() string {
 }
 
 // TransactAndCheck transacts the given ops againts client and returns
-// results of no error ocurred or an error otherwise.
+// results if no error ocurred or an error otherwise.
 func TransactAndCheck(client client.Client, ops []ovsdb.Operation) ([]ovsdb.OperationResult, error) {
 	if len(ops) <= 0 {
 		return []ovsdb.OperationResult{{}}, nil
@@ -42,8 +45,71 @@ func TransactAndCheck(client client.Client, ops []ovsdb.Operation) ([]ovsdb.Oper
 
 	opErrors, err := ovsdb.CheckOperationResults(results, ops)
 	if err != nil {
-		return nil, fmt.Errorf("error in transact with results %+v and errors %+v: %v", results, opErrors, err)
+		return nil, fmt.Errorf("error in transact with ops %+v results %+v and errors %+v: %v", ops, results, opErrors, err)
 	}
 
 	return results, nil
+}
+
+// TransactAndCheckAndSetUUIDs transacts the given ops againts client and returns
+// results if no error ocurred or an error otherwise. It sets the real uuids for
+// the passed models if they were inserted and have a named-uuid (as built by
+// BuildNamedUUID)
+func TransactAndCheckAndSetUUIDs(client client.Client, models interface{}, ops []ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+	results, err := TransactAndCheck(client, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	s := reflect.ValueOf(models)
+	if s.Kind() != reflect.Slice {
+		panic("models given a non-slice type")
+	}
+
+	if s.IsNil() {
+		return results, nil
+	}
+
+	namedModelMap := map[string]libovsdbmodel.Model{}
+	for i := 0; i < s.Len(); i++ {
+		model := s.Index(i).Interface()
+		uuid := getUUID(model)
+		if IsNamedUUID(uuid) {
+			namedModelMap[uuid] = model
+		}
+	}
+
+	for i, op := range ops {
+		if op.Op != ovsdb.OperationInsert {
+			continue
+		}
+
+		if !IsNamedUUID(op.UUIDName) {
+			continue
+		}
+
+		if model, ok := namedModelMap[op.UUIDName]; ok {
+			setUUID(model, results[i].UUID.GoUUID)
+		}
+	}
+
+	return results, nil
+}
+
+func getUUID(model libovsdbmodel.Model) string {
+	switch t := model.(type) {
+	case *nbdb.LoadBalancer:
+		return t.UUID
+	default:
+		panic("getUUID: unknown model")
+	}
+}
+
+func setUUID(model libovsdbmodel.Model, uuid string) {
+	switch t := model.(type) {
+	case *nbdb.LoadBalancer:
+		t.UUID = uuid
+	default:
+		panic("setUUID: unknown model")
+	}
 }

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
@@ -6,119 +6,81 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 )
 
 func TestNewCache(t *testing.T) {
 
-	data := `
-{
-  "data": [
-    [
-      "Service_default/kubernetes_TCP_node_router_ovn-control-plane",
-      [
-        "uuid",
-        "cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"
-      ],
-      "tcp",
-      [
-        "map",
-        [
-          [
-            "k8s.ovn.org/kind",
-            "Service"
-          ],
-          [
-            "k8s.ovn.org/owner",
-            "default/kubernetes"
-          ]
-        ]
-      ],
-      [
-        "map",
-        [
-          [
-            "192.168.0.1:6443",
-            "1.1.1.1:1,2.2.2.2:2"
-          ],
-          [
-            "[fe::1]:1",
-            "[fe::2]:1,[fe::2]:2" 
-          ]
-        ]
-      ]
-    ],
-    [
-      "Service_default/kubernetes_TCP_node_switch_ovn-control-plane_merged",
-      [
-        "uuid",
-        "7dc190c4-c615-467f-af83-9856d832c9a0"
-      ],
-      "tcp",
-      [
-        "map",
-        [
-          [
-            "k8s.ovn.org/kind",
-            "Service"
-          ],
-          [
-            "k8s.ovn.org/owner",
-            "default/kubernetes"
-          ]
-        ]
-      ],
-      [
-        "map",
-        [
-          [
-            "192.168.0.1:6443",
-            "1.1.1.1:1,2.2.2.2:2"
-          ],
-          [
-            "[ff::1]:1",
-            "[fe::2]:1,[fe::2]:2" 
-          ]
-        ]
-      ]
-    ]
-  ],
-  "headings": [
-    "name",
-    "_uuid",
-    "external_ids",
-	"protocol"
-  ]
-}
-`
+	initialDb := []libovsdb.TestData{
+		&nbdb.LoadBalancer{
+			UUID:     "cb6ebcb0-c12d-4404-ada7-5aa2b898f06b",
+			Name:     "Service_default/kubernetes_TCP_node_router_ovn-control-plane",
+			Protocol: &nbdb.LoadBalancerProtocolTCP,
+			ExternalIDs: map[string]string{
+				"k8s.ovn.org/kind":  "Service",
+				"k8s.ovn.org/owner": "default/kubernetes",
+			},
+			Vips: map[string]string{
+				"192.168.0.1:6443": "1.1.1.1:1,2.2.2.2:2",
+				"[fe::1]:1":        "[fe::2]:1,[fe::2]:2",
+			},
+		},
+		&nbdb.LoadBalancer{
+			UUID:     "7dc190c4-c615-467f-af83-9856d832c9a0",
+			Name:     "Service_default/kubernetes_TCP_node_switch_ovn-control-plane_merged",
+			Protocol: &nbdb.LoadBalancerProtocolTCP,
+			ExternalIDs: map[string]string{
+				"k8s.ovn.org/kind":  "Service",
+				"k8s.ovn.org/owner": "default/kubernetes",
+			},
+			Vips: map[string]string{
+				"192.168.0.1:6443": "1.1.1.1:1,2.2.2.2:2",
+				"[ff::1]:1":        "[fe::2]:1,[fe::2]:2",
+			},
+		},
+		&nbdb.LogicalRouter{
+			Name:         "GR_ovn-worker2",
+			LoadBalancer: []string{"7dc190c4-c615-467f-af83-9856d832c9a0"},
+		},
+		&nbdb.LogicalRouter{
+			Name:         "GR_ovn-worker",
+			LoadBalancer: []string{"7dc190c4-c615-467f-af83-9856d832c9a0"},
+		},
+		&nbdb.LogicalRouter{
+			Name: "ovn_cluster_router",
+		},
+		&nbdb.LogicalRouter{
+			Name:         "GR_ovn-control-plane",
+			LoadBalancer: []string{"cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"},
+		},
+		&nbdb.LogicalSwitch{
+			Name:         "ovn-worker",
+			LoadBalancer: []string{"7dc190c4-c615-467f-af83-9856d832c9a0"},
+		},
+		&nbdb.LogicalSwitch{
+			Name:         "ovn-worker2",
+			LoadBalancer: []string{"cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"},
+		},
+		&nbdb.LogicalSwitch{
+			Name:         "ovn-control-plane",
+			LoadBalancer: []string{"7dc190c4-c615-467f-af83-9856d832c9a0"},
+		},
+	}
 
-	fexec := ovntest.NewFakeExec()
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 --format=json --data=json --columns=name,_uuid,protocol,external_ids,vips find load_balancer",
-		Output: data,
-	})
-
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd: `ovn-nbctl --timeout=15 --no-heading --format=csv --data=bare --columns=name,load_balancer find logical_router`,
-		Output: `GR_ovn-worker2,31bb6bff-93b9-4080-a1b9-9a1fa898b1f0 7dc190c4-c615-467f-af83-9856d832c9a0 f0747ebb-71c2-4249-bdca-f33670ae544f
-GR_ovn-worker,31bb6bff-93b9-4080-a1b9-9a1fa898b1f0 7dc190c4-c615-467f-af83-9856d832c9a0 f0747ebb-71c2-4249-bdca-f33670ae544f
-ovn_cluster_router,
-GR_ovn-control-plane,31bb6bff-93b9-4080-a1b9-9a1fa898b1f0 cb6ebcb0-c12d-4404-ada7-5aa2b898f06b f0747ebb-71c2-4249-bdca-f33670ae544f
-`,
-	})
-	err := util.SetExec(fexec)
+	stopChan := make(chan struct{})
+	nbClient, err := libovsdb.NewNBTestHarness(libovsdb.TestSetup{NBData: initialDb}, stopChan)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	lbs, err := listLBs()
+	c, err := newCache(nbClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, []CachedLB{
-		{
+	assert.Equal(t, map[string]*CachedLB{
+		"cb6ebcb0-c12d-4404-ada7-5aa2b898f06b": {
 			UUID:     "cb6ebcb0-c12d-4404-ada7-5aa2b898f06b",
 			Name:     "Service_default/kubernetes_TCP_node_router_ovn-control-plane",
 			Protocol: "tcp",
@@ -127,11 +89,14 @@ GR_ovn-control-plane,31bb6bff-93b9-4080-a1b9-9a1fa898b1f0 cb6ebcb0-c12d-4404-ada
 				"k8s.ovn.org/owner": "default/kubernetes",
 			},
 			VIPs: sets.NewString("192.168.0.1:6443", "[fe::1]:1"),
-
-			Switches: sets.String{},
-			Routers:  sets.String{},
+			Switches: sets.String{
+				"ovn-worker2": {},
+			},
+			Routers: sets.String{
+				"GR_ovn-control-plane": {},
+			},
 		},
-		{
+		"7dc190c4-c615-467f-af83-9856d832c9a0": {
 			UUID:     "7dc190c4-c615-467f-af83-9856d832c9a0",
 			Name:     "Service_default/kubernetes_TCP_node_switch_ovn-control-plane_merged",
 			Protocol: "tcp",
@@ -140,39 +105,31 @@ GR_ovn-control-plane,31bb6bff-93b9-4080-a1b9-9a1fa898b1f0 cb6ebcb0-c12d-4404-ada
 				"k8s.ovn.org/owner": "default/kubernetes",
 			},
 			VIPs: sets.NewString("192.168.0.1:6443", "[ff::1]:1"),
-
-			Switches: sets.String{},
-			Routers:  sets.String{},
+			Switches: sets.String{
+				"ovn-worker":        {},
+				"ovn-control-plane": {},
+			},
+			Routers: sets.String{
+				"GR_ovn-worker":  {},
+				"GR_ovn-worker2": {},
+			},
 		},
-	}, lbs)
+	}, c.existing)
 
-	routerLBs, err := findTableLBs("logical_router")
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, routerLBs, map[string][]string{
-		"GR_ovn-worker2":       {"31bb6bff-93b9-4080-a1b9-9a1fa898b1f0", "7dc190c4-c615-467f-af83-9856d832c9a0", "f0747ebb-71c2-4249-bdca-f33670ae544f"},
-		"GR_ovn-worker":        {"31bb6bff-93b9-4080-a1b9-9a1fa898b1f0", "7dc190c4-c615-467f-af83-9856d832c9a0", "f0747ebb-71c2-4249-bdca-f33670ae544f"},
-		"ovn_cluster_router":   {},
-		"GR_ovn-control-plane": {"31bb6bff-93b9-4080-a1b9-9a1fa898b1f0", "cb6ebcb0-c12d-4404-ada7-5aa2b898f06b", "f0747ebb-71c2-4249-bdca-f33670ae544f"},
+	c.RemoveRouter("GR_ovn-worker")
+	assert.Equal(t, c.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Routers, sets.String{
+		"GR_ovn-worker2": {},
 	})
 
-	globalCache := &LBCache{}
-	globalCache.existing = make(map[string]*CachedLB, len(lbs))
-	for i := range lbs {
-		globalCache.existing[lbs[i].UUID] = &lbs[i]
-	}
-
-	globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Routers.Insert("GR_ovn-worker2", "GR_ovn-worker", "ovn_cluster_router", "GR_ovn-control-plane")
-	globalCache.RemoveRouter("GR_ovn-worker")
-	assert.Equal(t, globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Routers, sets.String{
-		"GR_ovn-control-plane": {}, "GR_ovn-worker2": {}, "ovn_cluster_router": {},
+	c.RemoveSwitch("ovn-worker")
+	assert.Equal(t, c.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Switches, sets.String{
+		"ovn-control-plane": {},
+	})
+	// nothing changed
+	assert.Equal(t, c.existing["cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"].Switches, sets.String{
+		"ovn-worker2": {},
 	})
 
-	globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Switches.Insert("ovn-worker2", "ovn-worker", "ovn-control-plane")
-	globalCache.RemoveSwitch("ovn-worker")
-	assert.Equal(t, globalCache.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Switches, sets.String{
-		"ovn-control-plane": {}, "ovn-worker2": {},
-	})
-	assert.Equal(t, globalCache.existing["cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"].Switches, sets.String{}) // nothing changed
+	nbClient.Close()
+	close(stopChan)
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -185,7 +185,7 @@ func (oc *Controller) upgradeToSingleSwitchOVNTopology(existingNodeList *kapi.No
 
 		// for all nodes include the ones that were deleted, delete its gateway entities.
 		// See comments above the multiJoinSwitchGatewayCleanup() function for details.
-		err = multiJoinSwitchGatewayCleanup(nodeName, upgradeOnly)
+		err = multiJoinSwitchGatewayCleanup(oc.nbClient, nodeName, upgradeOnly)
 		if err != nil {
 			return err
 		}
@@ -1080,7 +1080,7 @@ func (oc *Controller) deleteNodeHostSubnet(nodeName string, subnet *net.IPNet) e
 
 func (oc *Controller) deleteNodeLogicalNetwork(nodeName string) error {
 	// Remove switch to lb associations from the LBCache before removing the switch
-	lbCache, err := ovnlb.GetLBCache()
+	lbCache, err := ovnlb.GetLBCache(oc.nbClient)
 	if err != nil {
 		return fmt.Errorf("failed to get load_balancer cache for node %s: %v", nodeName, err)
 	}
@@ -1130,7 +1130,7 @@ func (oc *Controller) deleteNode(nodeName string, hostSubnets []*net.IPNet, node
 		klog.Errorf("Error deleting node %s logical network: %v", nodeName, err)
 	}
 
-	if err := gatewayCleanup(nodeName); err != nil {
+	if err := gatewayCleanup(oc.nbClient, nodeName); err != nil {
 		klog.Errorf("Failed to clean up node %s gateway: (%v)", nodeName, err)
 	}
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -916,7 +916,7 @@ func (oc *Controller) syncNodeGateway(node *kapi.Node, hostSubnets []*net.IPNet)
 	}
 
 	if l3GatewayConfig.Mode == config.GatewayModeDisabled {
-		if err := gatewayCleanup(node.Name); err != nil {
+		if err := gatewayCleanup(oc.nbClient, node.Name); err != nil {
 			return fmt.Errorf("error cleaning up gateway for node %s: %v", node.Name, err)
 		}
 		if err := oc.joinSwIPManager.ReleaseJoinLRPIPs(node.Name); err != nil {

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/mapper/mapper.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/mapper/mapper.go
@@ -315,7 +315,10 @@ func (m Mapper) NewMutation(tableName string, data interface{}, column string, m
 	}
 
 	var ovsValue interface{}
-	if mutator == "delete" && columnSchema.Type == ovsdb.TypeMap {
+	// Usually a mutation value is of the same type of the value being mutated
+	// except for delete mutation of maps where it can also be a list of same type of
+	// keys (rfc7047 5.1). Handle this special case here.
+	if mutator == "delete" && columnSchema.Type == ovsdb.TypeMap && reflect.TypeOf(value).Kind() != reflect.Map {
 		// It's OK to cast the value to a list of elements because validation has passed
 		ovsSet, err := ovsdb.NewOvsSet(value)
 		if err != nil {

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -169,7 +169,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/ovn-org/libovsdb v0.6.1-0.20210910072853-ca80b79a451e
+# github.com/ovn-org/libovsdb v0.6.1-0.20210914134040-e4215434d1ba
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
 github.com/ovn-org/libovsdb/mapper


### PR DESCRIPTION
Moves all LB operations over to libovsdb. Worth mentioning:

- libovsdb low level operations have been aggregated in ovn/libovsdbops package to avoid cluttering main bussiness logic. Every operation has two versions, one that returns libovsdb operations for batching and another that directly transacts that operation.
- Aggregated all ops in a single transaction where reasonable.
