### PR TITLE
fix egressfirewall dns deletion

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -336,7 +336,10 @@ func (oc *Controller) deleteEgressFirewall(egressFirewallObj *egressfirewallapi.
 		return fmt.Errorf("there is no egressFirewall found in namespace %s", egressFirewallObj.Namespace)
 	}
 
-	ef, _ := obj.(egressFirewall)
+	ef, ok := obj.(*egressFirewall)
+	if !ok {
+		return fmt.Errorf("DeleteEgressFirewall failed: type assertion failed")
+	}
 
 	ef.Lock()
 	defer ef.Unlock()


### PR DESCRIPTION
in egressfirewall delete when doing type assertion on the object
returned from LoadAndStore() the assertion was the wrong type so
egressfirewall dns names are not being deleted

this patch changes

 ef, _ := obj.(egressFirewall)

To

 ef, ok := obj.(*egressFirewall)

so that the type assertion completes correctly

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->