### PR TITLE
lsm: remove duplicate wording in error message

### DIFF
--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -466,7 +466,7 @@ func (jsIPManager *JoinSwitchIPManager) getJoinLRPAddresses(nodeName string) []*
 			errStr = "Failed to get IPs"
 		} else {
 			errStr = fmt.Sprintf("Invalid IPs %s (possibly not in the range of subnet %s)",
-				util.JoinIPNetIPs(gwLRPIPs, " "), util.JoinIPNetIPs(joinSubnets, " "))
+				util.JoinIPNets(gwLRPIPs, " "), util.JoinIPNets(joinSubnets, " "))
 		}
 		klog.Warningf("%s for logical router port %s", errStr, gwLrpName)
 		return []*net.IPNet{}

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -463,7 +463,7 @@ func (jsIPManager *JoinSwitchIPManager) getJoinLRPAddresses(nodeName string) []*
 	if len(gwLRPIPs) != len(joinSubnets) {
 		var errStr string
 		if len(gwLRPIPs) == 0 {
-			errStr = fmt.Sprintf("Failed to get IPs for logical router port %s", gwLrpName)
+			errStr = "Failed to get IPs"
 		} else {
 			errStr = fmt.Sprintf("Invalid IPs %s (possibly not in the range of subnet %s)",
 				util.JoinIPNetIPs(gwLRPIPs, " "), util.JoinIPNetIPs(joinSubnets, " "))


### PR DESCRIPTION
`Failed to get IPs for logical router port rtoj-GR_ip-10-0-245-226.us-west-2.compute.internal for logical router port rtoj-GR_ip-10-0-245-226.us-west-2.compute.internal`

to

`Failed to get IPs for logical router port rtoj-GR_ip-10-0-245-226.us-west-2.compute.internal`
