### PR TITLE
Fixes skipping pods accidentally in retry

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"reflect"
 	"strconv"
 	"sync"
@@ -453,32 +452,34 @@ func (oc *Controller) iterateRetryPods(updateAll bool) {
 		if podEntry.ignore {
 			continue
 		}
+
 		pod := podEntry.pod
-		if !util.PodScheduled(pod) {
+		podDesc := fmt.Sprintf("[%s/%s/%s]", pod.UID, pod.Namespace, pod.Name)
+		// it could be that the Pod got deleted, but Pod's DeleteFunc has not been called yet, so don't retry
+		kPod, err := oc.watchFactory.GetPod(pod.Namespace, pod.Name)
+		if err != nil && errors.IsNotFound(err) {
+			klog.Infof("%s pod not found in the informers cache, not going to retry pod setup", podDesc)
+			delete(oc.retryPods, uid)
+			continue
+		}
+
+		if !util.PodScheduled(kPod) {
+			klog.V(5).Infof("retry: %s not scheduled", podDesc)
 			continue
 		}
 		podTimer := podEntry.timeStamp.Add(time.Minute)
 		if updateAll || now.After(podTimer) {
-			podDesc := fmt.Sprintf("[%s/%s/%s]", pod.UID, pod.Namespace, pod.Name)
-			// it could be that the Pod got deleted, but Pod's DeleteFunc has not been called yet, so don't retry
-			_, err := oc.watchFactory.GetPod(pod.Namespace, pod.Name)
-			if err != nil {
-				if e, ok := err.(*errors.StatusError); ok && e.ErrStatus.Code == http.StatusNotFound {
-					klog.Infof("%s pod not found in the informers cache, not going to retry pod setup", podDesc)
-					delete(oc.retryPods, uid)
-					continue
-				}
-			}
-
 			klog.Infof("%s retry pod setup", podDesc)
 
-			if oc.ensurePod(nil, pod, true) {
+			if oc.ensurePod(nil, kPod, true) {
 				klog.Infof("%s pod setup successful", podDesc)
 				delete(oc.retryPods, uid)
 			} else {
 				klog.Infof("%s setup retry failed; will try again later", podDesc)
 				oc.retryPods[uid] = &retryEntry{pod, time.Now(), false}
 			}
+		} else {
+			klog.V(5).Infof("%s retry pod not after timer yet, time: %s", podDesc, podTimer)
 		}
 	}
 }


### PR DESCRIPTION
The code was using the initially stored pod object to determine if the
pod was scheduled or not, rather than the current state of the pod.

Signed-off-by: Tim Rozet <trozet@redhat.com>

