### PR TITLE
Fix ginkgo argument for unit test case specification

### DIFF
--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -11,7 +11,7 @@ cd "${OVN_KUBE_ROOT}"
 PKGS=$(go list -mod vendor -f '{{if len .TestGoFiles}} {{.ImportPath}} {{end}}' ${PKGS:-./cmd/... ./pkg/... ./hybrid-overlay/...} | xargs)
 
 if [[ "$1" == "focus" && "$2" != "" ]]; then
-    ginkgo_focus="-ginkgo.focus="${2}""
+    ginkgo_focus="-ginkgo.focus="$(echo ${2} | sed 's/ /\\s/g')""
 fi
 
 TEST_REPORT_DIR=${TEST_REPORT_DIR:="./_artifacts"}


### PR DESCRIPTION
Specifying (as an example)

```
PKGS="github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn" GINKGO_FOCUS="creates an address set for existing nodes when the host network traffic
 namespace is created" make check
```

currently is broken because the white space characters for the defined
test case are not replaced correctly. We need to do the same thing we do
for that argument in our E2E tests:

https://github.com/ovn-org/ovn-kubernetes/blob/8fc9298e56457f66b39415992d8ec7d838d4217e/test/scripts/e2e-cp.sh#L75

FYI: also doing:

```
PKGS="github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn" hack/test-go.sh focus "creates an address set for existing nodes when the host network traffic namespace is created"
```

will work, and run the tests without a container

/assign @flavio-fernandes 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->