### PR TITLE
fix golangci-lint related issues

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -61,10 +61,7 @@ clean:
 	rm -f ./pkg/nbdb/ovn-nb.ovsschema
 	rm -f ./pkg/sbdb/ovn-sb.ovsschema
 
-.PHONY: install.tools lint gofmt
-
-install.tools:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin
+.PHONY: lint gofmt
 
 lint:
 ifeq ($(CONTAINER_RUNNABLE), 0)

--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# pin golangci-lint version to 1.33.2
-VERSION=v1.33.2
+# pin golangci-lint version to 1.42.0
+VERSION=v1.42.0
 if [ "$#" -ne 1 ]; then
     echo "Expected command line argument - container runtime (docker/podman) got $# arguments: $@"
     exit 1


### PR DESCRIPTION
This PR has two commits:

- remove install.tools target since it is not being used

    ```
    make lint only works within the container, so there is on point in
    installing golangci-lint tools on the build machine.
  ```
    
- move golangci-lint to version 1.42.0
  ```
  the 1.33.2 golangci-lint container uses go version 1.15.6 and that causes
  following error:
  
   cannot find package \".\" in:\n\t/app/vendor/io/fs
  
  so move to 1.42.0 version of golangci-lint that contains go version 1.16.7
  and doesn't have the issue of not finding `io/fs` package.
  ```


@dcbw @trozet PTAL