### PR TITLE
kind.sh: Ignore missing key when disabling ipv6

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -441,8 +441,8 @@ docker_disable_ipv6() {
   # is not very common.
   KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
   for n in $KIND_NODES; do
-    $OCI_BIN exec "$n" sysctl net.ipv6.conf.all.disable_ipv6=0
-    $OCI_BIN exec "$n" sysctl net.ipv6.conf.all.forwarding=1
+    $OCI_BIN exec "$n" sysctl --ignore net.ipv6.conf.all.disable_ipv6=0
+    $OCI_BIN exec "$n" sysctl --ignore net.ipv6.conf.all.forwarding=1
   done
 }
 


### PR DESCRIPTION
(This is my first pull request here, I followed the guidelines, but apologies if I missed something)

When deploying ovn with the kind.sh script on a system without ipv6 support, the deployment fails because sysctl can not find ipv6 key : 

> sysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_ipv6: No such file or directory

Adding the --ignore flag tell sysctl to ignore this error.

This should be safe to ignore it there, since the function wants to disable ipv6 anyway.

Signed-off-by: Olivier Cazade <ocazade@redhat.com>
