### PR TITLE
Ensure host veths are cleaned up properly

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -351,6 +351,7 @@ func (pr *PodRequest) ConfigureInterface(podLister corev1listers.PodLister, kcli
 		err = ConfigureOVS(pr.ctx, pr.PodNamespace, pr.PodName, hostIface.Name, ifInfo, pr.SandboxID,
 			podLister, kclient, pr.PodUID)
 		if err != nil {
+			pr.deletePorts()
 			return nil, err
 		}
 	}
@@ -409,15 +410,19 @@ func (pr *PodRequest) deletePodConntrack() {
 	}
 }
 
-// PlatformSpecificCleanup deletes the OVS port
-func (pr *PodRequest) PlatformSpecificCleanup() error {
+func (pr *PodRequest) deletePorts() {
 	ifaceName := pr.SandboxID[:15]
 	out, err := ovsExec("del-port", "br-int", ifaceName)
-	if err != nil && !strings.Contains(string(out), "no port named") {
+	_ = util.LinkDelete(ifaceName)
+	if err != nil && !strings.Contains(out, "no port named") {
 		// DEL should be idempotent; don't return an error just log it
 		klog.Warningf("Failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))
 	}
+}
 
+// PlatformSpecificCleanup deletes the OVS port
+func (pr *PodRequest) PlatformSpecificCleanup() error {
+	pr.deletePorts()
 	_ = clearPodBandwidth(pr.SandboxID)
 	pr.deletePodConntrack()
 

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -413,10 +412,7 @@ func (pr *PodRequest) deletePodConntrack() {
 // PlatformSpecificCleanup deletes the OVS port
 func (pr *PodRequest) PlatformSpecificCleanup() error {
 	ifaceName := pr.SandboxID[:15]
-	ovsArgs := []string{
-		"del-port", "br-int", ifaceName,
-	}
-	out, err := exec.Command("ovs-vsctl", ovsArgs...).CombinedOutput()
+	out, err := ovsExec("del-port", "br-int", ifaceName)
 	if err != nil && !strings.Contains(string(out), "no port named") {
 		// DEL should be idempotent; don't return an error just log it
 		klog.Warningf("Failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))


### PR DESCRIPTION
Due to https://bugzilla.redhat.com/show_bug.cgi?id=2003193 where crio is not cleaning up leftover veths/netns...overtime OVS CPU climbs to 100% and performance degrades in the node. This ensures OVN CNI cleans up the ports rather than relying on kublet/crio.

Signed-off-by: Tim Rozet <trozet@redhat.com>

