### PR TITLE
fixes as it relates to node addition/update handling

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -610,15 +610,11 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 	// 	  - from the management port via the node_local_switch's localnet port
 	//    - from the hostsubnet via management port
 	// 2. a dnat_and_snat nat entry to SNAT the traffic from the management port
-	subnets, err := util.ParseNodeHostSubnetAnnotation(node)
-	if err != nil {
-		return fmt.Errorf("failed to get host subnets for %s: %v", node.Name, err)
-	}
 	mpMAC, err := util.ParseNodeManagementPortMACAddress(node)
 	if err != nil {
 		return err
 	}
-	for _, subnet := range subnets {
+	for _, subnet := range hostSubnets {
 		hostIfAddr := util.GetNodeManagementIfAddr(subnet)
 		l3GatewayConfigIP, err := util.MatchIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
 		if err != nil {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -922,7 +922,10 @@ func (oc *Controller) syncNodeGateway(node *kapi.Node, hostSubnets []*net.IPNet)
 	}
 
 	if hostSubnets == nil {
-		hostSubnets, _ = util.ParseNodeHostSubnetAnnotation(node)
+		hostSubnets, err = util.ParseNodeHostSubnetAnnotation(node)
+		if err != nil {
+			return err
+		}
 	}
 
 	if l3GatewayConfig.Mode == config.GatewayModeDisabled {


### PR DESCRIPTION
there are two commits:

1. return on error while parsing node's subnet annotation

  ```
  on node addition to a cluster, say we failed in performing gateway setup.
  the node is added to gatewayFailed store. on next node update,
  syncNodeGateway() is called and it could be that the node still doesn't have
  host-subnets node annotation set and we will return nil from that function
  and remove the node from the gatewayFailed store without setting up gateway.
  ```

2. no need to obtain node's host-subnets annotation instead use the passed arg

@dcbw @trozet PTAL
