### PR TITLE
Bug 1998515: ovn-kubernetes repeatedly updates host-addresses annotation on ipv6/dual-stack hosts

### DIFF
--- a/go-controller/pkg/kube/annotator.go
+++ b/go-controller/pkg/kube/annotator.go
@@ -32,6 +32,8 @@ type nodeAnnotator struct {
 }
 
 // NewNodeAnnotator returns a new annotator for Node objects
+// Node annotator compares current annotations found in the node(*kapi.Node) and only updates them if there is a change.
+// It does not sync the node(*kapi.Node) with the API server which means that in most cases it should be Run() once and discarded.
 func NewNodeAnnotator(kube Interface, node *kapi.Node) Annotator {
 	return &nodeAnnotator{
 		kube:    kube,

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -306,7 +306,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		gw, err = newLocalGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator, n.recorder, managementPortConfig)
 	case config.GatewayModeShared:
 		klog.Info("Preparing Shared Gateway")
-		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator,
+		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, n.Kube, nodeAnnotator,
 			managementPortConfig, n.watchFactory)
 	case config.GatewayModeDisabled:
 		var chassisID string
@@ -331,10 +331,6 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	// value is nil. so, you cannot directly set the value to an interface and later check if
 	// value was nil by comparing the interface to nil. this is because if the value is `nil`,
 	// then the interface will still hold the type of the value being set.
-
-	if config.Gateway.Mode == config.GatewayModeShared && config.OvnKubeNode.Mode == types.NodeModeFull {
-		gw.nodeIPManager = newAddressManager(nodeAnnotator, managementPortConfig)
-	}
 
 	if loadBalancerHealthChecker != nil {
 		gw.loadBalancerHealthChecker = loadBalancerHealthChecker

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -213,7 +213,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			defer GinkgoRecover()
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
-			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator,
+			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, k, nodeAnnotator,
 				&fakeMgmtPortConfig, nil)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)
@@ -479,7 +479,7 @@ func shareGatewayInterfaceSmartNICTest(app *cli.App, testNS ns.NetNS,
 			// provide host IP as GR IP
 			gwIPs := []*net.IPNet{ovntest.MustParseIPNet(hostCIDR)}
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops,
-				gatewayIntf, "", gwIPs, nodeAnnotator, &fakeMgmtPortConfig, nil)
+				gatewayIntf, "", gwIPs, k, nodeAnnotator, &fakeMgmtPortConfig, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1069,7 +1069,7 @@ func setBridgeOfPorts(bridge *bridgeConfiguration) error {
 }
 
 func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string,
-	gwIPs []*net.IPNet, nodeAnnotator kube.Annotator, cfg *managementPortConfig, watchFactory factory.NodeWatchFactory) (*gateway, error) {
+	gwIPs []*net.IPNet, kube kube.Interface, nodeAnnotator kube.Annotator, cfg *managementPortConfig, watchFactory factory.NodeWatchFactory) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
 
@@ -1124,7 +1124,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			return err
 		}
 
-		gw.nodeIPManager = newAddressManager(nodeAnnotator, cfg)
+		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg)
 
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Shared Gateway Node Port Watcher")


### PR DESCRIPTION
Node annotator does not synchronize annotations with the API, it only compares against the ones provided with `NewNodeAnnotator`. 
It caused the address manager to set the same `host-addresses` annotations every time there was a notification from `netlink.AddrSubscribe`

The proposed change creates a new node annotator each time there is a need to update `host-addresses`.