### PR TITLE
Handle ICMP frag in OVN for packet sizes greater than pod MTU

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -42,6 +42,7 @@ usage() {
     echo "                 [-cl |--ovn-loglevel-controller <loglevel>] [-dl|--ovn-loglevel-nbctld <loglevel>]"
     echo "                 [-ep |--experimental-provider <name>] |"
     echo "                 [-eb |--egress-gw-separate-bridge]"
+    echo "                 [-dg |--disable-gateway-mtu]"
     echo "                 [-h]]"
     echo ""
     echo "-cf  | --config-file               Name of the KIND J2 configuration file."
@@ -77,6 +78,7 @@ usage() {
     echo "-dl  | --ovn-loglevel-nbctld       Log config for nbctl daemon DEFAULT: '-vconsole:info'."
     echo "-ep  | --experimental-provider     Use an experimental OCI provider such as podman, instead of docker. DEFAULT: Disabled."
     echo "-eb  | --egress-gw-separate-bridge The external gateway traffic uses a separate bridge."
+    echo "-dg  | --disable-gateway-mtu       Disable setting gateway_mtu option to rtoj gateway port. Default: Disabled"
     echo "--delete                      	   Delete current cluster"
     echo ""
 }
@@ -101,6 +103,8 @@ parse_args() {
             -ho | --hybrid-enabled )            OVN_HYBRID_OVERLAY_ENABLE=true
                                                 ;;
             -ds | --disable-snat-multiple-gws ) OVN_DISABLE_SNAT_MULTIPLE_GWS=true
+                                                ;;
+            -ds | --disable-gateway-mtu )       OVN_DISABLE_GATEWAY_MTU=true
                                                 ;;
             -ep | --experimental-provider )     shift
                                                 export KIND_EXPERIMENTAL_PROVIDER=$1
@@ -214,6 +218,7 @@ print_params() {
      echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
      echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
      echo "OVN_DISABLE_SNAT_MULTIPLE_GWS = $OVN_DISABLE_SNAT_MULTIPLE_GWS"
+     echo "OVN_DISABLE_GATEWAY_MTU = $OVN_DISABLE_GATEWAY_MTU"
      echo "OVN_NETFLOW_TARGETS = $OVN_NETFLOW_TARGETS"
      echo "OVN_SFLOW_TARGETS = $OVN_SFLOW_TARGETS"
      echo "OVN_IPFIX_TARGETS = $OVN_IPFIX_TARGETS"
@@ -274,6 +279,7 @@ set_default_params() {
   KIND_IPV6_SUPPORT=${KIND_IPV6_SUPPORT:-false}
   OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
   OVN_DISABLE_SNAT_MULTIPLE_GWS=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-false}
+  OVN_DISABLE_GATEWAY_MTU=${OVN_DISABLE_GATEWAY_MTU:-false}
   OVN_EMPTY_LB_EVENTS=${OVN_EMPTY_LB_EVENTS:-false}
   OVN_MULTICAST_ENABLE=${OVN_MULTICAST_ENABLE:-false}
   KIND_ALLOW_SYSTEM_WRITES=${KIND_ALLOW_SYSTEM_WRITES:-false}
@@ -499,6 +505,7 @@ create_ovn_kube_manifests() {
     --gateway-mode="${OVN_GATEWAY_MODE}" \
     --hybrid-enabled="${OVN_HYBRID_OVERLAY_ENABLE}" \
     --disable-snat-multiple-gws="${OVN_DISABLE_SNAT_MULTIPLE_GWS}" \
+    --disable-gateway-mtu="${OVN_DISABLE_GATEWAY_MTU}" \
     --ovn-empty-lb-events="${OVN_EMPTY_LB_EVENTS}" \
     --multicast-enabled="${OVN_MULTICAST_ENABLE}" \
     --k8s-apiserver="${API_URL}" \

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -34,7 +34,6 @@ usage() {
     echo "usage: kind.sh [[[-cf |--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]"
     echo "                 [-ho |--hybrid-enabled] [-ii|--install-ingress] [-n4|--no-ipv4]"
     echo "                 [-i6 |--ipv6] [-wk|--num-workers <num>] [-ds|--disable-snat-multiple-gws]"
-    echo "                 [-dp |--disable-pkt-mtu-check]"
     echo "                 [-nf |--netflow-targets <targets>] [sf|--sflow-targets <targets>] [-if|--ipfix-targets]"
     echo "                 [-sw |--allow-system-writes] [-gm|--gateway-mode <mode>]"
     echo "                 [-nl |--node-loglevel <num>] [-ml|--master-loglevel <num>]"
@@ -52,7 +51,6 @@ usage() {
     echo "-ha  | --ha-enabled                Enable high availability. DEFAULT: HA Disabled."
     echo "-ho  | --hybrid-enabled            Enable hybrid overlay. DEFAULT: Disabled."
     echo "-ds  | --disable-snat-multiple-gws Disable SNAT for multiple gws. DEFAULT: Disabled."
-    echo "-dp  | --disable-pkt-mtu-check     Disable checking packet size greater than MTU. Default: Disabled"
     echo "-nf  | --netflow-targets           Comma delimited list of ip:port netflow collectors. DEFAULT: Disabled."
     echo "-sf  | --sflow-targets             Comma delimited list of ip:port sflow collectors. DEFAULT: Disabled."
     echo "-if  | --ipfix-targets             Comma delimited list of ip:port ipfix collectors. DEFAULT: Disabled."
@@ -103,8 +101,6 @@ parse_args() {
             -ho | --hybrid-enabled )            OVN_HYBRID_OVERLAY_ENABLE=true
                                                 ;;
             -ds | --disable-snat-multiple-gws ) OVN_DISABLE_SNAT_MULTIPLE_GWS=true
-                                                ;;
-            -dp | --disable-pkt-mtu-check )     OVN_DISABLE_PKT_MTU_CHECK=true
                                                 ;;
             -ep | --experimental-provider )     shift
                                                 export KIND_EXPERIMENTAL_PROVIDER=$1
@@ -218,7 +214,6 @@ print_params() {
      echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
      echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
      echo "OVN_DISABLE_SNAT_MULTIPLE_GWS = $OVN_DISABLE_SNAT_MULTIPLE_GWS"
-     echo "OVN_DISABLE_PKT_MTU_CHECK = $OVN_DISABLE_PKT_MTU_CHECK"
      echo "OVN_NETFLOW_TARGETS = $OVN_NETFLOW_TARGETS"
      echo "OVN_SFLOW_TARGETS = $OVN_SFLOW_TARGETS"
      echo "OVN_IPFIX_TARGETS = $OVN_IPFIX_TARGETS"
@@ -279,7 +274,6 @@ set_default_params() {
   KIND_IPV6_SUPPORT=${KIND_IPV6_SUPPORT:-false}
   OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
   OVN_DISABLE_SNAT_MULTIPLE_GWS=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-false}
-  OVN_DISABLE_PKT_MTU_CHECK=${OVN_DISABLE_PKT_MTU_CHECK:-false}
   OVN_EMPTY_LB_EVENTS=${OVN_EMPTY_LB_EVENTS:-false}
   OVN_MULTICAST_ENABLE=${OVN_MULTICAST_ENABLE:-false}
   KIND_ALLOW_SYSTEM_WRITES=${KIND_ALLOW_SYSTEM_WRITES:-false}
@@ -505,7 +499,6 @@ create_ovn_kube_manifests() {
     --gateway-mode="${OVN_GATEWAY_MODE}" \
     --hybrid-enabled="${OVN_HYBRID_OVERLAY_ENABLE}" \
     --disable-snat-multiple-gws="${OVN_DISABLE_SNAT_MULTIPLE_GWS}" \
-    --disable-pkt-mtu-check="${OVN_DISABLE_PKT_MTU_CHECK}" \
     --ovn-empty-lb-events="${OVN_EMPTY_LB_EVENTS}" \
     --multicast-enabled="${OVN_MULTICAST_ENABLE}" \
     --k8s-apiserver="${API_URL}" \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -38,6 +38,7 @@ OVN_REMOTE_PROBE_INTERVAL=""
 OVN_MONITOR_ALL=""
 OVN_HYBRID_OVERLAY_ENABLE=""
 OVN_DISABLE_SNAT_MULTIPLE_GWS=""
+OVN_DISABLE_GATEWAY_MTU=""
 OVN_EMPTY_LB_EVENTS=""
 OVN_MULTICAST_ENABLE=""
 OVN_EGRESSIP_ENABLE=
@@ -153,6 +154,9 @@ while [ "$1" != "" ]; do
   --disable-snat-multiple-gws)
     OVN_DISABLE_SNAT_MULTIPLE_GWS=$VALUE
     ;;
+  --disable-gateway-mtu)
+    OVN_DISABLE_GATEWAY_MTU=$VALUE
+    ;;
   --ovn-empty-lb-events)
     OVN_EMPTY_LB_EVENTS=$VALUE
     ;;
@@ -255,6 +259,8 @@ ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR}
 echo "ovn_hybrid_overlay_net_cidr: ${ovn_hybrid_overlay_net_cidr}"
 ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS}
 echo "ovn_disable_snat_multiple_gws: ${ovn_disable_snat_multiple_gws}"
+ovn_disable_gateway_mtu=${OVN_DISABLE_GATEWAY_MTU}
+echo "ovn_disable_gateway_mtu: ${ovn_disable_gateway_mtu}"
 ovn_empty_lb_events=${OVN_EMPTY_LB_EVENTS}
 echo "ovn_empty_lb_events: ${ovn_empty_lb_events}"
 ovn_ssl_en=${OVN_SSL_ENABLE:-"no"}
@@ -309,6 +315,7 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_disable_gateway_mtu=${ovn_disable_gateway_mtu} \
   ovn_v4_join_subnet=${ovn_v4_join_subnet} \
   ovn_v6_join_subnet=${ovn_v6_join_subnet} \
   ovn_multicast_enable=${ovn_multicast_enable} \
@@ -340,6 +347,7 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_disable_gateway_mtu=${ovn_disable_gateway_mtu} \
   ovn_v4_join_subnet=${ovn_v4_join_subnet} \
   ovn_v6_join_subnet=${ovn_v6_join_subnet} \
   ovn_multicast_enable=${ovn_multicast_enable} \
@@ -366,6 +374,7 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_disable_gateway_mtu=${ovn_disable_gateway_mtu} \
   ovn_empty_lb_events=${ovn_empty_lb_events} \
   ovn_v4_join_subnet=${ovn_v4_join_subnet} \
   ovn_v6_join_subnet=${ovn_v6_join_subnet} \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -38,7 +38,6 @@ OVN_REMOTE_PROBE_INTERVAL=""
 OVN_MONITOR_ALL=""
 OVN_HYBRID_OVERLAY_ENABLE=""
 OVN_DISABLE_SNAT_MULTIPLE_GWS=""
-OVN_DISABLE_PKT_MTU_CHECK=""
 OVN_EMPTY_LB_EVENTS=""
 OVN_MULTICAST_ENABLE=""
 OVN_EGRESSIP_ENABLE=
@@ -154,9 +153,6 @@ while [ "$1" != "" ]; do
   --disable-snat-multiple-gws)
     OVN_DISABLE_SNAT_MULTIPLE_GWS=$VALUE
     ;;
-  --disable-pkt-mtu-check)
-    OVN_DISABLE_PKT_MTU_CHECK=$VALUE
-    ;;
   --ovn-empty-lb-events)
     OVN_EMPTY_LB_EVENTS=$VALUE
     ;;
@@ -259,8 +255,6 @@ ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR}
 echo "ovn_hybrid_overlay_net_cidr: ${ovn_hybrid_overlay_net_cidr}"
 ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS}
 echo "ovn_disable_snat_multiple_gws: ${ovn_disable_snat_multiple_gws}"
-ovn_disable_pkt_mtu_check=${OVN_DISABLE_PKT_MTU_CHECK}
-echo "ovn_disable_pkt_mtu_check: ${ovn_disable_pkt_mtu_check}"
 ovn_empty_lb_events=${OVN_EMPTY_LB_EVENTS}
 echo "ovn_empty_lb_events: ${ovn_empty_lb_events}"
 ovn_ssl_en=${OVN_SSL_ENABLE:-"no"}
@@ -315,7 +309,6 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
-  ovn_disable_pkt_mtu_check=${ovn_disable_pkt_mtu_check} \
   ovn_v4_join_subnet=${ovn_v4_join_subnet} \
   ovn_v6_join_subnet=${ovn_v6_join_subnet} \
   ovn_multicast_enable=${ovn_multicast_enable} \
@@ -347,7 +340,6 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
-  ovn_disable_pkt_mtu_check=${ovn_disable_pkt_mtu_check} \
   ovn_v4_join_subnet=${ovn_v4_join_subnet} \
   ovn_v6_join_subnet=${ovn_v6_join_subnet} \
   ovn_multicast_enable=${ovn_multicast_enable} \
@@ -374,7 +366,6 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
-  ovn_disable_pkt_mtu_check=${ovn_disable_pkt_mtu_check} \
   ovn_empty_lb_events=${ovn_empty_lb_events} \
   ovn_v4_join_subnet=${ovn_v4_join_subnet} \
   ovn_v6_join_subnet=${ovn_v6_join_subnet} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -189,6 +189,7 @@ ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE:-}
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR:-}
 ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-}
+ovn_disable_gateway_mtu=${OVN_DISABLE_GATEWAY_MTU:-}
 ovn_empty_lb_events=${OVN_EMPTY_LB_EVENTS:-}
 # OVN_V4_JOIN_SUBNET - v4 join subnet
 ovn_v4_join_subnet=${OVN_V4_JOIN_SUBNET:-}
@@ -866,6 +867,11 @@ ovn-master() {
       disable_snat_multiple_gws_flag="--disable-snat-multiple-gws"
   fi
 
+  disable_gateway_mtu_flag=
+  if [[ ${ovn_disable_gateway_mtu} == "true" ]]; then
+      disable_gateway_mtu_flag="--disable-gateway-mtu"
+  fi
+
   empty_lb_events_flag=
   if [[ ${ovn_empty_lb_events} == "true" ]]; then
       empty_lb_events_flag="--ovn-empty-lb-events"
@@ -930,6 +936,7 @@ ovn-master() {
     --logfile-maxage=${ovnkube_logfile_maxage} \
     ${hybrid_overlay_flags} \
     ${disable_snat_multiple_gws_flag} \
+    ${disable_gateway_mtu_flag} \
     ${empty_lb_events_flag} \
     ${ovn_v4_join_subnet_opt} \
     ${ovn_v6_join_subnet_opt} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -189,7 +189,6 @@ ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE:-}
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR:-}
 ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-}
-ovn_disable_pkt_mtu_check=${OVN_DISABLE_PKT_MTU_CHECK:-}
 ovn_empty_lb_events=${OVN_EMPTY_LB_EVENTS:-}
 # OVN_V4_JOIN_SUBNET - v4 join subnet
 ovn_v4_join_subnet=${OVN_V4_JOIN_SUBNET:-}
@@ -867,11 +866,6 @@ ovn-master() {
       disable_snat_multiple_gws_flag="--disable-snat-multiple-gws"
   fi
 
-  disable_pkt_mtu_check_flag=
-  if [[ ${ovn_disable_pkt_mtu_check} == "true" ]]; then
-      disable_pkt_mtu_check_flag="--disable-pkt-mtu-check"
-  fi
-
   empty_lb_events_flag=
   if [[ ${ovn_empty_lb_events} == "true" ]]; then
       empty_lb_events_flag="--ovn-empty-lb-events"
@@ -1032,11 +1026,6 @@ ovn-node() {
       disable_snat_multiple_gws_flag="--disable-snat-multiple-gws"
   fi
 
-  disable_pkt_mtu_check_flag=
-  if [[ ${ovn_disable_pkt_mtu_check} == "true" ]]; then
-      disable_pkt_mtu_check_flag="--disable-pkt-mtu-check"
-  fi
-
   multicast_enabled_flag=
   if [[ ${ovn_multicast_enable} == "true" ]]; then
       multicast_enabled_flag="--enable-multicast"
@@ -1140,7 +1129,6 @@ ovn-node() {
     --logfile-maxage=${ovnkube_logfile_maxage} \
     ${hybrid_overlay_flags} \
     ${disable_snat_multiple_gws_flag} \
-    ${disable_pkt_mtu_check_flag} \
     --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
     --gateway-router-subnet=${ovn_gateway_router_subnet} \
     --pidfile ${OVN_RUNDIR}/ovnkube.pid \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -246,6 +246,8 @@ spec:
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
           value: "{{ ovn_disable_snat_multiple_gws }}"
+        - name: OVN_DISABLE_GATEWAY_MTU
+          value: "{{ ovn_disable_gateway_mtu }}"
         - name: OVN_EMPTY_LB_EVENTS
           value: "{{ ovn_empty_lb_events }}"
         - name: OVN_V4_JOIN_SUBNET

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -151,8 +151,6 @@ spec:
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
           value: "{{ ovn_disable_snat_multiple_gws }}"
-        - name: OVN_DISABLE_PKT_MTU_CHECK
-          value: "{{ ovn_disable_pkt_mtu_check }}"
         - name: OVN_NETFLOW_TARGETS
           value: "{{ ovn_netflow_targets }}"
         - name: OVN_SFLOW_TARGETS

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -308,6 +308,8 @@ type GatewayConfig struct {
 	// RouterSubnet is the subnet to be used for the GR external port. auto-detected if not given.
 	// Must match the the kube node IP address. Currently valid for Smart-NICs only.
 	RouterSubnet string `gcfg:"router-subnet"`
+	// DisableGatewayMTU disables setting gateway_mtu option to rtoj- gateway port
+	DisableGatewayMTU bool `gcfg:"disable-gateway-mtu"`
 }
 
 // OvnAuthConfig holds client authentication and location details for
@@ -990,6 +992,11 @@ var OVNGatewayFlags = []cli.Flag{
 		Usage:       "The v6 join subnet used for assigning join switch IPv6 addresses",
 		Destination: &cliConfig.Gateway.V6JoinSubnet,
 		Value:       Gateway.V6JoinSubnet,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-gateway-mtu",
+		Usage:       "Disable setting gateway_mtu option for gateway port",
+		Destination: &cliConfig.Gateway.DisableGatewayMTU,
 	},
 	&cli.StringFlag{
 		Name: "gateway-router-subnet",

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -305,11 +305,6 @@ type GatewayConfig struct {
 	V4JoinSubnet string `gcfg:"v4-join-subnet"`
 	// V6JoinSubnet to be used in the cluster
 	V6JoinSubnet string `gcfg:"v6-join-subnet"`
-	// DisablePacketMTUCheck disables adding openflow flows to check packets too large to be
-	// delivered to OVN due to pod MTU being lower than NIC MTU. Disabling this check will result in southbound packets
-	// exceeding pod MTU to be dropped by OVN. With this check enabled, ICMP needs frag/packet too big will be sent
-	// back to the original client
-	DisablePacketMTUCheck bool `gcfg:"disable-pkt-mtu-check"`
 	// RouterSubnet is the subnet to be used for the GR external port. auto-detected if not given.
 	// Must match the the kube node IP address. Currently valid for Smart-NICs only.
 	RouterSubnet string `gcfg:"router-subnet"`
@@ -995,11 +990,6 @@ var OVNGatewayFlags = []cli.Flag{
 		Usage:       "The v6 join subnet used for assigning join switch IPv6 addresses",
 		Destination: &cliConfig.Gateway.V6JoinSubnet,
 		Value:       Gateway.V6JoinSubnet,
-	},
-	&cli.BoolFlag{
-		Name:        "disable-pkt-mtu-check",
-		Usage:       "Disable OpenFlow checks for if packet size is greater than pod MTU",
-		Destination: &cliConfig.Gateway.DisablePacketMTUCheck,
 	},
 	&cli.StringFlag{
 		Name: "gateway-router-subnet",

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -221,20 +221,6 @@ func gatewayInitInternal(nodeName, gwIntf, egressGatewayIntf string, subnets []*
 		return nil, nil, err
 	}
 
-	if !config.Gateway.DisablePacketMTUCheck {
-		chkPktLengthSupported, err := util.DetectCheckPktLengthSupport(gatewayBridge.bridgeName)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if !chkPktLengthSupported {
-			klog.Warningf("OVS on this node does not support check packet length action in kernel datapath. This "+
-				"will cause incoming packets destined to OVN and larger than pod MTU: %d to the node, being dropped "+
-				"without sending fragmentation needed", config.Default.MTU)
-			config.Gateway.DisablePacketMTUCheck = true
-		}
-	}
-
 	l3GwConfig := util.L3GatewayConfig{
 		Mode:           config.GatewayModeShared,
 		ChassisID:      chassisID,

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -255,11 +255,6 @@ func (g *gateway) GetGatewayBridgeIface() string {
 	return g.openflowManager.defaultBridge.bridgeName
 }
 
-// getMaxFrameLength returns the maximum frame size (ignoring VLAN header) that a gateway can handle
-func getMaxFrameLength() int {
-	return config.Default.MTU + 14
-}
-
 type bridgeConfiguration struct {
 	bridgeName  string
 	uplinkName  string

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -124,10 +124,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: systemID,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-appctl --timeout=15 dpif/show-dp-features breth0",
-			Output: "Check pkt length action: Yes",
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 get Interface patch-breth0_node1-to-br-int ofport",
 			Output: "5",
 		})

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package node
@@ -245,10 +246,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 
 		expectedTables := map[string]util.FakeTable{
 			"nat": {
-				"PREROUTING": []string{
-					"-j OVN-KUBE-EXTERNALIP",
-					"-j OVN-KUBE-NODEPORT",
-				},
 				"OUTPUT": []string{
 					"-j OVN-KUBE-EXTERNALIP",
 					"-j OVN-KUBE-NODEPORT",
@@ -349,11 +346,6 @@ func shareGatewayInterfaceSmartNICTest(app *cli.App, testNS ns.NetNS,
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:system-id",
 			Output: systemID,
-		})
-		// DetectCheckPktLengthSupport
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ovs-appctl --timeout=15 dpif/show-dp-features " + brphys,
-			Output: "Check pkt length action: Yes",
 		})
 		// GetSmartNICHostInterface
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -79,12 +79,6 @@ func getSharedGatewayInitRules(chain string, proto iptables.Protocol) []iptRule 
 	return []iptRule{
 		{
 			table:    "nat",
-			chain:    "PREROUTING",
-			args:     []string{"-j", chain},
-			protocol: proto,
-		},
-		{
-			table:    "nat",
 			chain:    "OUTPUT",
 			args:     []string{"-j", chain},
 			protocol: proto,
@@ -122,6 +116,12 @@ func getLegacyLocalGatewayInitRules(chain string, proto iptables.Protocol) []ipt
 
 func getLegacySharedGatewayInitRules(chain string, proto iptables.Protocol) []iptRule {
 	return []iptRule{
+		{
+			table:    "nat",
+			chain:    "PREROUTING",
+			args:     []string{"-j", chain},
+			protocol: proto,
+		},
 		{
 			table:    "filter",
 			chain:    "OUTPUT",

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -142,7 +142,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 					npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 				} else {
 					npw.ofm.updateFlowCacheEntry(key, []string{
-						fmt.Sprintf("cookie=%s, priority=100, in_port=%s, %s, tp_dst=%d, actions=%s",
+						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, actions=%s",
 							cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, npw.ofportPatch),
 						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_src=%d, actions=%s",
 							cookie, npw.ofportPatch, flowProtocol, svcPort.NodePort, npw.ofportPhys)})

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package node

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -115,10 +115,16 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 		gwLRPNetworks = append(gwLRPNetworks, gwLRPIfAddr.String())
 	}
 
+	var options map[string]string
+	if !config.Gateway.DisableGatewayMTU {
+		options = map[string]string{"gateway_mtu": fmt.Sprintf("%d", util.GetMaxFrameLength())}
+	}
+
 	logicalRouterPort := nbdb.LogicalRouterPort{
 		Name:     gwRouterPort,
 		MAC:      gwLRPMAC.String(),
 		Networks: gwLRPNetworks,
+		Options:  options,
 	}
 	opModels = []libovsdbops.OperationModel{
 		{
@@ -126,6 +132,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			OnModelUpdates: []interface{}{
 				&logicalRouterPort.MAC,
 				&logicalRouterPort.Networks,
+				&logicalRouterPort.Options,
 			},
 			DoAfter: func() {
 				logicalRouter.Ports = []string{logicalRouterPort.UUID}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -57,6 +57,9 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		Name:     gwRouterPort,
 		MAC:      util.IPAddrToHWAddr(joinLRPIPs[0].IP).String(),
 		Networks: networks,
+		Options: map[string]string{
+			"gateway_mtu": fmt.Sprintf("%d", util.GetMaxFrameLength()),
+		},
 	})
 	grStaticRoutes := []string{}
 	for i, subnet := range clusterIPSubnets {

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package util

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -950,23 +950,3 @@ func (t *NBTxn) AddOrCommit(args []string) (string, string, error) {
 	t.add(args...)
 	return "", "", nil
 }
-
-// DetectCheckPktLengthSupport checks if OVN supports check packet length action in OVS kernel datapath
-func DetectCheckPktLengthSupport(bridge string) (bool, error) {
-	stdout, stderr, err := RunOVSAppctl("dpif/show-dp-features", bridge)
-	if err != nil {
-		klog.Errorf("Failed to query OVS for check packet length support, "+
-			"stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
-		return false, err
-	}
-
-	re := regexp.MustCompile(`(?i)yes|(?i)true`)
-
-	for _, line := range strings.Split(strings.TrimSuffix(stdout, "\n"), "\n") {
-		if strings.Contains(line, "Check pkt length action") && re.MatchString(line) {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -17,6 +17,8 @@ import (
 	utilnet "k8s.io/utils/net"
 )
 
+const EtherHeaderLength = 14
+
 // StringArg gets the named command-line argument or returns an error if it is empty
 func StringArg(context *cli.Context, name string) (string, error) {
 	val := context.String(name)
@@ -32,6 +34,11 @@ func GetLegacyK8sMgmtIntfName(nodeName string) string {
 		return types.K8sPrefix + (nodeName[:11])
 	}
 	return types.K8sPrefix + nodeName
+}
+
+// GetMaxFrameLength returns the maximum frame size (ignoring VLAN header) that a gateway can handle
+func GetMaxFrameLength() int {
+	return config.Default.MTU + EtherHeaderLength
 }
 
 // GetWorkerFromGatewayRouter determines a node's corresponding worker switch name from a gateway router name


### PR DESCRIPTION
This PR reverts 7e832266167b518fdb9f6eba63623e7753e753f5 and 78cf7be68841456ac427d0e709280e4cd7e3883b commits,
and fixes the HWOL issue: https://bugzilla.redhat.com/show_bug.cgi?id=2000988
    
Note: it removes the --disable-pkt-mtu-check flag

Signed-off-by: Zenghui Shi <zshi@redhat.com>