### PR TITLE
Generate client with monitor for SB and NB DB

### DIFF
--- a/go-controller/pkg/util/libovsdb.go
+++ b/go-controller/pkg/util/libovsdb.go
@@ -73,8 +73,7 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 	if err != nil {
 		return nil, err
 	}
-
-	return newClient(cfg, dbModel, stopCh)
+	return newClientWithMonitor(cfg, stopCh, dbModel)
 }
 
 // NewNBClient creates a new OVN Northbound Database client
@@ -88,7 +87,10 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 	if err != nil {
 		return nil, err
 	}
+	return newClientWithMonitor(cfg, stopCh, dbModel)
+}
 
+func newClientWithMonitor(cfg config.OvnAuthConfig, stopCh <-chan struct{}, dbModel *model.DBModel) (client.Client, error) {
 	c, err := newClient(cfg, dbModel, stopCh)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously we only created a client and monitored the cache for the NB
DB, this resulted in an empty cache generation for the SB DB (which we
also need to perform operations against). This fixes that

/assign @flavio-fernandes @jcaamano 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->