### PR TITLE
validate the MTU check against the interface that has OVN Encap IP

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -349,7 +349,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	waiter.AddWait(gw.readyFunc, initGw)
 	n.gateway = gw
 
-	return n.validateGatewayMTU(gatewayIntf)
+	return n.validateVTEPInterfaceMTU()
 }
 
 // interfaceForEXGW takes the interface requested to act as exgw bridge

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -594,16 +594,25 @@ func (n *OvnNode) WatchEndpoints() {
 	}, nil)
 }
 
-// validateGatewayMTU checks if the MTU of the given network interface is big
-// enough to carry the `config.Default.MTU` and the Geneve header. If the MTU
-// is not big enough, it will taint the node with the value of
-// `types.OvnK8sSmallMTUTaintKey`
-func (n *OvnNode) validateGatewayMTU(gatewayInterfaceName string) error {
+// validateVTEPInterfaceMTU checks if the MTU of the interface that has ovn-encap-ip is big
+// enough to carry the `config.Default.MTU` and the Geneve header. If the MTU is not big
+// enough, it will taint the node with the value of `types.OvnK8sSmallMTUTaintKey`
+func (n *OvnNode) validateVTEPInterfaceMTU() error {
 	tooSmallMTUTaint := &kapi.Taint{Key: types.OvnK8sSmallMTUTaintKey, Effect: kapi.TaintEffectNoSchedule}
 
-	mtu, err := util.GetNetworkInterfaceMTU(gatewayInterfaceName)
+	ovnEncapIPStr, stderr, err := util.RunOVSVsctl("--if-exists", "get",
+		"Open_vSwitch", ".", "external_ids:ovn-encap-ip")
 	if err != nil {
-		return fmt.Errorf("could not get MTU from gateway network interface %s: %w", gatewayInterfaceName, err)
+		return fmt.Errorf("failed to obtain the ovn-encap-ip from Open_vSwtich table. stderr: %s, %v",
+			stderr, err)
+	}
+	ovnEncapIP := net.ParseIP(ovnEncapIPStr)
+	if ovnEncapIP == nil {
+		return fmt.Errorf("the set OVN Encap IP is invalid: (%s)", ovnEncapIPStr)
+	}
+	interfaceName, mtu, err := util.GetIFNameAndMTUForAddress(ovnEncapIP)
+	if err != nil {
+		return fmt.Errorf("could not get MTU for the interface with address %s: %w", ovnEncapIP, err)
 	}
 
 	// calc required MTU
@@ -618,18 +627,20 @@ func (n *OvnNode) validateGatewayMTU(gatewayInterfaceName string) error {
 
 	// check if node needs to be tainted
 	if mtu < requiredMTU {
-		klog.V(2).Infof("MTU (%d) of gateway network interface %s is not big enough to deal with Geneve header overhead (sum %d). Tainting node with %v...", mtu, gatewayInterfaceName, requiredMTU, tooSmallMTUTaint)
+		klog.V(2).Infof("MTU (%d) of network interface %s is not big enough to deal with Geneve "+
+			"header overhead (sum %d). Tainting node with %v...", mtu, interfaceName,
+			requiredMTU, tooSmallMTUTaint)
 
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			return n.Kube.SetTaintOnNode(n.name, tooSmallMTUTaint)
 		})
-	} else {
-		klog.V(2).Infof("MTU (%d) of gateway network interface %s is big enough to deal with Geneve header overhead (sum %d). Making sure node is not tainted with %v...", mtu, gatewayInterfaceName, requiredMTU, tooSmallMTUTaint)
-
-		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			return n.Kube.RemoveTaintFromNode(n.name, tooSmallMTUTaint)
-		})
 	}
+	klog.V(2).Infof("MTU (%d) of network interface %s is big enough to deal with Geneve header overhead (sum %d). "+
+		"Making sure node is not tainted with %v...", mtu, interfaceName, requiredMTU, tooSmallMTUTaint)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return n.Kube.RemoveTaintFromNode(n.name, tooSmallMTUTaint)
+	})
 }
 
 type epAddressItem struct {

--- a/go-controller/pkg/util/mocks/NetLinkOps.go
+++ b/go-controller/pkg/util/mocks/NetLinkOps.go
@@ -87,6 +87,29 @@ func (_m *NetLinkOps) ConntrackDeleteFilter(table netlink.ConntrackTableType, fa
 	return r0, r1
 }
 
+// LinkByIndex provides a mock function with given fields: index
+func (_m *NetLinkOps) LinkByIndex(index int) (netlink.Link, error) {
+	ret := _m.Called(index)
+
+	var r0 netlink.Link
+	if rf, ok := ret.Get(0).(func(int) netlink.Link); ok {
+		r0 = rf(index)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(netlink.Link)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(index)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LinkByName provides a mock function with given fields: ifaceName
 func (_m *NetLinkOps) LinkByName(ifaceName string) (netlink.Link, error) {
 	ret := _m.Called(ifaceName)


### PR DESCRIPTION
whether the MTU is big enough to hold the GENEVE packets is being
erroneously checked against the gatewayInterface (aka bridge interface).
however, that might not be the case in some deployments. it could be that
a separate VTEP network could be used to carry GENEVE packets. so, the
right thing to do is to arrive at the interface from the ovn-encap-ip and
then check for that interface's MTU

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@dcbw @trozet @creydr PTAL