### PR TITLE
Fix E2E IPv6 tests: adapt addresses and subnets

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -9,14 +9,10 @@ export KUBECONFIG=${HOME}/admin.conf
 # Skip tests which are not IPv6 ready yet (see description of https://github.com/ovn-org/ovn-kubernetes/pull/2276)
 IPV6_SKIPPED_TESTS="Should be allowed by externalip services|\
 should provide connection to external host by DNS name from a pod|\
-should provide Internet connection continuously when master is killed|\
-should provide Internet connection continuously when ovn-k8s pod is killed|\
 Should validate connectivity from a pod to a non-node host address on same node|\
 Should validate connectivity without vxlan before and after updating the namespace annotation to a new external gateway|\
 Should validate ingress connectivity from an external gateway|\
 Should validate NetFlow data of br-int is sent to an external gateway|\
-Should validate the egress firewall policy functionality against remote hosts|\
-Should validate the egress IP functionality against remote hosts|\
 recovering from deleting db files while maintain connectivity|\
 test tainting a node according to its defaults interface MTU size"
 


### PR DESCRIPTION
This commit fixes some previously skipped E2E tests by using an alternative set of addresses and subnets for IPv6 clusters.

It also enables the control-plane IPv6 tests in a separate commit.

Signed-off-by: Patryk Diak <pdiak@redhat.com>