### PR TITLE
libovsdb: tweak timeout

### DIFF
--- a/go-controller/pkg/ovn/libovsdbops/util.go
+++ b/go-controller/pkg/ovn/libovsdbops/util.go
@@ -11,6 +11,7 @@ import (
 	libovsdbmodel "github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 const (
@@ -38,7 +39,10 @@ func TransactAndCheck(client client.Client, ops []ovsdb.Operation) ([]ovsdb.Oper
 		return []ovsdb.OperationResult{{}}, nil
 	}
 
-	results, err := client.Transact(context.TODO(), ops...)
+	ctx, cancel := context.WithTimeout(context.TODO(), util.OVSDBTimeout)
+	defer cancel()
+
+	results, err := client.Transact(ctx, ops...)
 	if err != nil {
 		return nil, fmt.Errorf("error in transact with ops %+v: %v", ops, err)
 	}

--- a/go-controller/pkg/util/libovsdb.go
+++ b/go-controller/pkg/util/libovsdb.go
@@ -20,12 +20,16 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	OVSDBTimeout = 10 * time.Second
+)
+
 // newClient creates a new client object given the provided config
 // the stopCh is required to ensure the goroutine for ssl cert
 // update is not leaked
 func newClient(cfg config.OvnAuthConfig, dbModel *model.DBModel, stopCh <-chan struct{}) (client.Client, error) {
 	options := []client.Option{
-		client.WithReconnect(500*time.Millisecond, &backoff.ZeroBackOff{}),
+		client.WithReconnect(OVSDBTimeout, &backoff.ZeroBackOff{}),
 		client.WithLeaderOnly(true),
 	}
 	for _, endpoint := range strings.Split(cfg.GetURL(), ",") {
@@ -49,7 +53,7 @@ func newClient(cfg config.OvnAuthConfig, dbModel *model.DBModel, stopCh <-chan s
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), OVSDBTimeout)
 	defer cancel()
 	err = client.Connect(ctx)
 	if err != nil {


### PR DESCRIPTION
Set libovsdb timeout to 10s due to observed delays of up to 5s in
scale testing. Once scale improvements are in this might be lowered.
Add timeout context for Transact.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
