### PR TITLE
Bug 1998515: ovn-kubernetes repeatedly updates host-addresses annotation on ipv6/dual-stack hosts

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -306,7 +306,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 		gw, err = newLocalGateway(n.name, subnets, gatewayNextHops, gatewayIntf, nodeAnnotator, n.recorder, managementPortConfig)
 	case config.GatewayModeShared:
 		klog.Info("Preparing Shared Gateway")
-		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator,
+		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator, n.Kube,
 			managementPortConfig, n.watchFactory)
 	case config.GatewayModeDisabled:
 		var chassisID string
@@ -331,10 +331,6 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	// value is nil. so, you cannot directly set the value to an interface and later check if
 	// value was nil by comparing the interface to nil. this is because if the value is `nil`,
 	// then the interface will still hold the type of the value being set.
-
-	if config.Gateway.Mode == config.GatewayModeShared && config.OvnKubeNode.Mode == types.NodeModeFull {
-		gw.nodeIPManager = newAddressManager(nodeAnnotator, managementPortConfig)
-	}
 
 	if loadBalancerHealthChecker != nil {
 		gw.loadBalancerHealthChecker = loadBalancerHealthChecker

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -213,7 +213,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			defer GinkgoRecover()
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
-			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator,
+			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator, k,
 				&fakeMgmtPortConfig, nil)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)
@@ -479,7 +479,7 @@ func shareGatewayInterfaceSmartNICTest(app *cli.App, testNS ns.NetNS,
 			// provide host IP as GR IP
 			gwIPs := []*net.IPNet{ovntest.MustParseIPNet(hostCIDR)}
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops,
-				gatewayIntf, "", gwIPs, nodeAnnotator, &fakeMgmtPortConfig, nil)
+				gatewayIntf, "", gwIPs, nodeAnnotator, k, &fakeMgmtPortConfig, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1069,7 +1069,7 @@ func setBridgeOfPorts(bridge *bridgeConfiguration) error {
 }
 
 func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string,
-	gwIPs []*net.IPNet, nodeAnnotator kube.Annotator, cfg *managementPortConfig, watchFactory factory.NodeWatchFactory) (*gateway, error) {
+	gwIPs []*net.IPNet, nodeAnnotator kube.Annotator, kube kube.Interface, cfg *managementPortConfig, watchFactory factory.NodeWatchFactory) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
 
@@ -1124,7 +1124,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			return err
 		}
 
-		gw.nodeIPManager = newAddressManager(nodeAnnotator, cfg)
+		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg)
 
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Shared Gateway Node Port Watcher")


### PR DESCRIPTION
Address manager needs to update host-addresses annotation only when there is an actual address change

1. Create `nodeAnnotator` in `newAddressManager` instead of using an existing one, this avoids sending annotations that were added by other components.
2. Modify `addressManager` so it will try to set the annotations only if there was an actual change, not on every netlink notification.
2. Remove redundant `nodeIPManager` creation from `gateway_init.go`, it is always created in `GatewayModeShared`: https://github.com/ovn-org/ovn-kubernetes/blob/12074303166c94bec47c21ffb90f97bd0863b66d/go-controller/pkg/node/gateway_shared_intf.go#L1127

PTAL: @dcbw @astoycos @flavio-fernandes 
