### PR TITLE
remove go-ovn southbound client from hybrid overlay

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -28,7 +28,6 @@ type MasterController struct {
 	allocator        *subnetallocator.SubnetAllocator
 	nodeEventHandler informer.EventHandler
 	ovnNBClient      goovn.Client
-	ovnSBClient      goovn.Client
 }
 
 // NewMaster a new master controller that listens for node events
@@ -37,7 +36,6 @@ func NewMaster(kube kube.Interface,
 	namespaceInformer cache.SharedIndexInformer,
 	podInformer cache.SharedIndexInformer,
 	ovnNBClient goovn.Client,
-	ovnSBClient goovn.Client,
 	eventHandlerCreateFunction informer.EventHandlerCreateFunction,
 ) (*MasterController, error) {
 
@@ -45,7 +43,6 @@ func NewMaster(kube kube.Interface,
 		kube:        kube,
 		allocator:   subnetallocator.NewSubnetAllocator(),
 		ovnNBClient: ovnNBClient,
-		ovnSBClient: ovnSBClient,
 	}
 
 	m.nodeEventHandler = eventHandlerCreateFunction("node", nodeInformer,

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -111,7 +111,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
-			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 
 			m, err := NewMaster(
 				&kube.Kube{KClient: fakeClient},
@@ -119,7 +118,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
 				mockOVNNBClient,
-				mockOVNSBClient,
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -182,7 +180,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
-			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 			m, err := NewMaster(
@@ -191,7 +188,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
 				mockOVNNBClient,
-				mockOVNSBClient,
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -265,7 +261,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
-			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 
 			populatePortAddresses(nodeName, nodeHOMAC, nodeHOIP, mockOVNNBClient)
 
@@ -279,7 +274,6 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
 				mockOVNNBClient,
-				mockOVNSBClient,
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -332,14 +326,12 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 			mockOVNNBClient := ovntest.NewMockOVNClient(goovn.DBNB)
-			mockOVNSBClient := ovntest.NewMockOVNClient(goovn.DBSB)
 			m, err := NewMaster(
 				&kube.Kube{KClient: fakeClient},
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
 				mockOVNNBClient,
-				mockOVNSBClient,
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -378,7 +378,6 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 			oc.watchFactory.NamespaceInformer(),
 			oc.watchFactory.PodInformer(),
 			oc.ovnNBClient,
-			oc.ovnSBClient,
 			informer.NewDefaultEventHandler,
 		)
 		if err != nil {


### PR DESCRIPTION
with the effort to remove the go-ovn bindings from ovn-kube there remove
the go-ovn SB client from hybrid overlay. Nothing is using it at this
point.

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->