### PR TITLE
move node subnet and local NAT IP allocation to syncNodes()

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -301,36 +301,10 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	nodeNames := []string{}
 	for _, node := range existingNodes.Items {
 		nodeNames = append(nodeNames, node.Name)
-		hostSubnets, _ := util.ParseNodeHostSubnetAnnotation(&node)
-		klog.V(5).Infof("Node %s contains subnets: %v", node.Name, hostSubnets)
-		for _, hostSubnet := range hostSubnets {
-			err := oc.masterSubnetAllocator.MarkAllocatedNetwork(hostSubnet)
-			if err != nil {
-				utilruntime.HandleError(err)
-			}
-			util.UpdateUsedHostSubnetsCount(hostSubnet, &oc.v4HostSubnetsUsed, &oc.v6HostSubnetsUsed, true)
-		}
-		if config.Gateway.Mode == config.GatewayModeLocal {
-			nodeLocalNatIPs, _ := util.ParseNodeLocalNatIPAnnotation(&node)
-			klog.V(5).Infof("Node %s contains local NAT IPs: %v", node.Name, nodeLocalNatIPs)
-			for _, nodeLocalNatIP := range nodeLocalNatIPs {
-				var err error
-				if utilnet.IsIPv6(nodeLocalNatIP) {
-					err = oc.nodeLocalNatIPv6Allocator.Allocate(nodeLocalNatIP)
-				} else {
-					err = oc.nodeLocalNatIPv4Allocator.Allocate(nodeLocalNatIP)
-				}
-				if err != nil {
-					utilruntime.HandleError(err)
-				}
-			}
-		}
 	}
 
 	// update metrics for host subnets
 	metrics.RecordSubnetCount(v4HostSubnetCount, v6HostSubnetCount)
-	metrics.RecordSubnetUsage(oc.v4HostSubnetsUsed, oc.v6HostSubnetsUsed)
-
 	if _, _, err := util.RunOVNNbctl("--columns=_uuid", "list", "port_group"); err != nil {
 		klog.Fatal("OVN version too old; does not support port groups")
 	}
@@ -1274,12 +1248,39 @@ func (oc *Controller) syncNodes(nodes []interface{}) {
 			continue
 		}
 		foundNodes[node.Name] = node
+
+		hostSubnets, _ := util.ParseNodeHostSubnetAnnotation(node)
+		klog.V(5).Infof("Node %s contains subnets: %v", node.Name, hostSubnets)
+		for _, hostSubnet := range hostSubnets {
+			err := oc.masterSubnetAllocator.MarkAllocatedNetwork(hostSubnet)
+			if err != nil {
+				utilruntime.HandleError(err)
+			}
+			util.UpdateUsedHostSubnetsCount(hostSubnet, &oc.v4HostSubnetsUsed, &oc.v6HostSubnetsUsed, true)
+		}
+		if config.Gateway.Mode == config.GatewayModeLocal {
+			nodeLocalNatIPs, _ := util.ParseNodeLocalNatIPAnnotation(node)
+			klog.V(5).Infof("Node %s contains local NAT IPs: %v", node.Name, nodeLocalNatIPs)
+			for _, nodeLocalNatIP := range nodeLocalNatIPs {
+				var err error
+				if utilnet.IsIPv6(nodeLocalNatIP) {
+					err = oc.nodeLocalNatIPv6Allocator.Allocate(nodeLocalNatIP)
+				} else {
+					err = oc.nodeLocalNatIPv4Allocator.Allocate(nodeLocalNatIP)
+				}
+				if err != nil {
+					utilruntime.HandleError(err)
+				}
+			}
+		}
+
 		// For each existing node, reserve its joinSwitch LRP IPs if they already exist.
 		_, err := oc.joinSwIPManager.EnsureJoinLRPIPs(node.Name)
 		if err != nil {
 			klog.Errorf("Failed to get join switch port IP address for node %s: %v", node.Name, err)
 		}
 	}
+	metrics.RecordSubnetUsage(oc.v4HostSubnetsUsed, oc.v6HostSubnetsUsed)
 
 	// We only deal with cleaning up nodes that shouldn't exist here, since
 	// watchNodes() will be called for all existing nodes at startup anyway.


### PR DESCRIPTION
Today, there is a potential chance that a node is deleted after
StartClusterMaster() but before syncNodes(). This would cause the leak
of the node subnets or local NAT IPs that are allocated in
StartClusterMaster(). Moving the allocation to syncNodes() would
address this issue.

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->