### PR TITLE
Nit-Fix: Remove debug statements from LSPDel

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -631,7 +631,7 @@ func ovnNBLSPDel(client libovsdbclient.Client, logicalPort, logicalSwitch string
 	if err != nil {
 		return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
 	}
-	klog.Errorf("KEYWORD: POD DELETED?")
+
 	return nil
 }
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -524,7 +524,6 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations with IP Address Family", f
 					for _, tPod := range tPods {
 						pods = append(pods, *newPod(tPod.namespace, tPod.podName, tPod.nodeName, tPod.podIP))
 					}
-					fmt.Printf("KEYWORD: pods %+v\n", pods)
 
 					fakeOvn.startWithDBSetup(ctx, initialDB,
 						&v1.NamespaceList{


### PR DESCRIPTION
Deleting a pod leaves:

```
E1006 08:16:21.482432      50 pods.go:634] KEYWORD: POD DELETED?

```
if deletion was a success, because a debug statement snuck in.

/assign @JacobTanenbaum 