### PR TITLE
Metric: IPsec

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -6,11 +6,15 @@ import (
 	"sync"
 	"time"
 
-	goovn "github.com/ebay/go-ovn"
+	"github.com/ovn-org/libovsdb/cache"
+	"github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	goovn "github.com/ebay/go-ovn"
+	"github.com/prometheus/client_golang/prometheus"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -170,8 +174,15 @@ var metricEgressFirewallRuleCount = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help:      "The number of egress firewall rules defined"},
 )
 
+var metricIPsecEnabled = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "ipsec_enabled",
+	Help:      "Specifies whether IPSec is enabled for this cluster(1) or not enabled for this cluster(0)",
+})
+
 var registerMasterMetricsOnce sync.Once
-var startE2ETimeStampUpdaterOnce sync.Once
+var startMasterMetricUpdaterOnce sync.Once
 
 // RegisterMasterMetrics registers some ovnkube master metrics with the Prometheus
 // registry
@@ -246,37 +257,24 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 		prometheus.MustRegister(metricV6AllocatedHostSubnetCount)
 		prometheus.MustRegister(metricEgressIPCount)
 		prometheus.MustRegister(metricEgressFirewallRuleCount)
+		prometheus.MustRegister(metricIPsecEnabled)
 		registerWorkqueueMetrics(MetricOvnkubeNamespace, MetricOvnkubeSubsystemMaster)
 	})
 }
 
-// StartE2ETimeStampMetricUpdater adds a goroutine that updates a "timestamp" value in the
-// nbdb every 30 seconds. This is so we can determine freshness of the database
-func StartE2ETimeStampMetricUpdater(stopChan <-chan struct{}, ovnNBClient goovn.Client) {
-	startE2ETimeStampUpdaterOnce.Do(func() {
+// StartMasterMetricUpdater adds a goroutine that updates a "timestamp" value in the
+// nbdb every 30 seconds. This is so we can determine freshness of the database.
+// Also, update IPsec enabled or disable metric.
+func StartMasterMetricUpdater(stopChan <-chan struct{}, ovnNBClient goovn.Client, nbClient client.Client) {
+	startMasterMetricUpdaterOnce.Do(func() {
+		addIPSecMetricHandler(nbClient)
 		go func() {
-			tsUpdateTicker := time.NewTicker(30 * time.Second)
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
 			for {
 				select {
-				case <-tsUpdateTicker.C:
-					options, err := ovnNBClient.NBGlobalGetOptions()
-					if err != nil {
-						klog.Errorf("Can't get existing NB Global Options for updating timestamps")
-						continue
-					}
-					t := time.Now().Unix()
-					options["e2e_timestamp"] = fmt.Sprintf("%d", t)
-					cmd, err := ovnNBClient.NBGlobalSetOptions(options)
-					if err != nil {
-						klog.Errorf("Failed to bump timestamp: %v", err)
-					} else {
-						err = cmd.Execute()
-						if err != nil {
-							klog.Errorf("Failed to set timestamp: %v", err)
-						} else {
-							metricE2ETimestamp.Set(float64(t))
-						}
-					}
+				case <-ticker.C:
+					updateE2ETimestampMetric(nbClient)
 				case <-stopChan:
 					return
 				}
@@ -326,4 +324,51 @@ func RecordEgressIPCount(count float64) {
 // UpdateEgressFirewallRuleCount records the number of Egress firewall rules.
 func UpdateEgressFirewallRuleCount(count float64) {
 	metricEgressFirewallRuleCount.Add(count)
+}
+
+func updateE2ETimestampMetric(ovnNBClient goovn.Client) {
+	options, err := ovnNBClient.NBGlobalGetOptions()
+	if err != nil {
+		klog.Errorf("Can't get existing NB Global Options for updating timestamps")
+		return
+	}
+	t := time.Now().Unix()
+	options["e2e_timestamp"] = fmt.Sprintf("%d", t)
+	cmd, err := ovnNBClient.NBGlobalSetOptions(options)
+	if err != nil {
+		klog.Errorf("Failed to bump timestamp: %v", err)
+	} else {
+		err = cmd.Execute()
+		if err != nil {
+			klog.Errorf("Failed to set timestamp: %v", err)
+		} else {
+			metricE2ETimestamp.Set(float64(t))
+		}
+	}
+}
+
+func addIPSecMetricHandler(ovnNBClient client.Client) {
+	ovnNBClient.Cache().AddEventHandler(&cache.EventHandlerFuncs{
+		AddFunc: func(table string, model model.Model) {
+			ipsecMetricHandler(table, model)
+		},
+		UpdateFunc: func(table string, _, new model.Model) {
+			ipsecMetricHandler(table, new)
+		},
+		DeleteFunc: func(table string, model model.Model) {
+			ipsecMetricHandler(table, model)
+		},
+	})
+}
+
+func ipsecMetricHandler(table string, model model.Model) {
+	if table != "NB_Global" {
+		return
+	}
+	entry := model.(*nbdb.NBGlobal)
+	if entry.Ipsec {
+		metricIPsecEnabled.Set(1)
+	} else {
+		metricIPsecEnabled.Set(0)
+	}
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -93,9 +93,8 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup, ctx context.Con
 					end := time.Since(start)
 					metrics.MetricMasterReadyDuration.Set(end.Seconds())
 				}()
-				// run the End-to-end timestamp metric updater only on the
-				// active master node.
-				metrics.StartE2ETimeStampMetricUpdater(oc.stopChan, oc.ovnNBClient)
+				// run only on the active master node.
+				metrics.StartMasterMetricUpdater(oc.stopChan, oc.ovnNBClient, oc.nbClient)
 				if err := oc.StartClusterMaster(nodeName); err != nil {
 					panic(err.Error())
 				}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -94,7 +94,7 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup, ctx context.Con
 					metrics.MetricMasterReadyDuration.Set(end.Seconds())
 				}()
 				// run only on the active master node.
-				metrics.StartMasterMetricUpdater(oc.stopChan, oc.ovnNBClient, oc.nbClient)
+				metrics.StartMasterMetricUpdater(oc.stopChan, oc.nbClient)
 				if err := oc.StartClusterMaster(nodeName); err != nil {
 					panic(err.Error())
 				}


### PR DESCRIPTION
Hey,
This PR adds two things. It adds IPSec metric and also removed the need for go-ovn lib and using libovsdb instead.
The detection if IPSec is enabled or disabled is retrieved from OVN NB NB_Global table.

Apologies for bundling in the removal of go-ovn here but it simplified the PR for me because I needed libovsdb to access the IPSec boolean in OVN NBDB. This is not available with go-ovn API.

No changes to e2etimestamp metric functional output.

This IPSec metric gives us visibility into whether this feature is used.