### PR TITLE
Create a Controller holder to allow multiple OVN controllers per network

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -251,9 +251,14 @@ func runOvnKube(ctx *cli.Context) error {
 		// since we capture some metrics in Start()
 		metrics.RegisterMasterMetrics(ovnNBClient, ovnSBClient)
 
-		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil,
-			ovnNBClient, ovnSBClient, libovsdbOvnNBClient, libovsdbOvnSBClient, util.EventRecorder(ovnClientset.KubeClient))
-		if err := ovnController.Start(master, wg, ctx.Context); err != nil {
+		ovnMHController, err := ovn.NewOvnMHController(ovnClientset, master, masterWatchFactory,
+			stopChan, nil, ovnNBClient, ovnSBClient, libovsdbOvnNBClient, libovsdbOvnSBClient,
+			util.EventRecorder(ovnClientset.KubeClient), wg)
+		if err != nil {
+			return err
+		}
+		err = ovnMHController.Start(ctx.Context)
+		if err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -111,7 +111,7 @@ func (oc *Controller) syncEgressFirewall(egressFirwalls []interface{}) {
 			return
 		}
 		if egressFirewallACLIDs != "" {
-			nodes, err := oc.watchFactory.GetNodes()
+			nodes, err := oc.mc.watchFactory.GetNodes()
 			if err != nil {
 				klog.Errorf("Unable to cleanup egress firewall ACLs remaining from local gateway mode, cannot list nodes, err: %v", err)
 				return
@@ -238,7 +238,7 @@ func (oc *Controller) syncEgressFirewall(egressFirwalls []interface{}) {
 	}
 
 	// get all the k8s EgressFirewall Objects
-	egressFirewallList, err := oc.kube.GetEgressFirewalls()
+	egressFirewallList, err := oc.mc.kube.GetEgressFirewalls()
 	if err != nil {
 		klog.Errorf("Cannot reconcile the state of egressfirewalls in ovn database and k8s. err: %v", err)
 	}
@@ -361,7 +361,7 @@ func (oc *Controller) deleteEgressFirewall(egressFirewallObj *egressfirewallapi.
 
 func (oc *Controller) updateEgressFirewallWithRetry(egressfirewall *egressfirewallapi.EgressFirewall) error {
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		return oc.kube.UpdateEgressFirewall(egressfirewall)
+		return oc.mc.kube.UpdateEgressFirewall(egressfirewall)
 	})
 	if retryErr != nil {
 		return fmt.Errorf("error in updating status on EgressFirewall %s/%s: %v",
@@ -413,7 +413,7 @@ func (oc *Controller) addEgressFirewallRules(ef *egressFirewall, hashedAddressSe
 func (oc *Controller) createEgressFirewallRules(priority int, match, action, externalID string, txn *util.NBTxn) error {
 	logicalSwitches := []string{}
 	if config.Gateway.Mode == config.GatewayModeLocal {
-		nodes, err := oc.watchFactory.GetNodes()
+		nodes, err := oc.mc.watchFactory.GetNodes()
 		if err != nil {
 			return fmt.Errorf("unable to setup egress firewall ACLs on cluster nodes, err: %v", err)
 		}
@@ -460,7 +460,7 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 func (oc *Controller) deleteEgressFirewallRules(externalID string, txn *util.NBTxn) error {
 	logicalSwitches := []string{}
 	if config.Gateway.Mode == config.GatewayModeLocal {
-		nodes, err := oc.watchFactory.GetNodes()
+		nodes, err := oc.mc.watchFactory.GetNodes()
 		if err != nil {
 			return fmt.Errorf("unable to setup egress firewall ACLs on cluster nodes, err: %v", err)
 		}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -229,7 +229,7 @@ func (oc *Controller) addExternalGWsForNamespace(egress gatewayInfo, nsInfo *nam
 
 // addGWRoutesForNamespace handles adding routes for all existing pods in namespace
 func (oc *Controller) addGWRoutesForNamespace(namespace string, egress gatewayInfo) error {
-	existingPods, err := oc.watchFactory.GetPods(namespace)
+	existingPods, err := oc.mc.watchFactory.GetPods(namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get all the pods (%v)", err)
 	}
@@ -507,7 +507,7 @@ func (oc *Controller) deletePerPodGRSNAT(node string, podIPNets []*net.IPNet) {
 
 func (oc *Controller) addPerPodGRSNAT(pod *kapi.Pod, podIfAddrs []*net.IPNet) error {
 	nodeName := pod.Spec.NodeName
-	node, err := oc.watchFactory.GetNode(nodeName)
+	node, err := oc.mc.watchFactory.GetNode(nodeName)
 	if err != nil {
 		return fmt.Errorf("failed to get node %s: %v", nodeName, err)
 	}
@@ -669,7 +669,7 @@ func cleanUpBFDEntry(gatewayIP, gatewayRouter, prefix string) {
 // external gateway routes. In case no second bridge is configured, we
 // use the default one and the prefix is empty.
 func (oc *Controller) extSwitchPrefix(nodeName string) (string, error) {
-	node, err := oc.watchFactory.GetNode(nodeName)
+	node, err := oc.mc.watchFactory.GetNode(nodeName)
 	if err != nil {
 		return "", errors.Wrapf(err, "extSwitchPrefix: failed to find node %s", nodeName)
 	}
@@ -832,7 +832,7 @@ func getExGwPodIPs(gatewayPod *kapi.Pod) ([]net.IP, error) {
 }
 
 func (oc *Controller) buildClusterECMPCacheFromNamespaces(clusterRouteCache map[string][]string) {
-	namespaces, err := oc.watchFactory.GetNamespaces()
+	namespaces, err := oc.mc.watchFactory.GetNamespaces()
 	if err != nil {
 		klog.Errorf("Error getting all namespaces for exgw ecmp route sync: %v", err)
 		return
@@ -848,7 +848,7 @@ func (oc *Controller) buildClusterECMPCacheFromNamespaces(clusterRouteCache map[
 			continue
 		}
 		// get all pods in the namespace
-		nsPods, err := oc.watchFactory.GetPods(namespace.Name)
+		nsPods, err := oc.mc.watchFactory.GetPods(namespace.Name)
 		if err != nil {
 			klog.Errorf("Unable to clean ExGw ECMP routes for namespace: %s, %v",
 				namespace, err)
@@ -883,7 +883,7 @@ func (oc *Controller) buildClusterECMPCacheFromNamespaces(clusterRouteCache map[
 
 func (oc *Controller) buildClusterECMPCacheFromPods(clusterRouteCache map[string][]string) {
 	// Get all Pods serving as exgws
-	pods, err := oc.watchFactory.GetAllPods()
+	pods, err := oc.mc.watchFactory.GetAllPods()
 	if err != nil {
 		klog.Error("Error getting all pods for exgw ecmp route sync: %v", err)
 		return
@@ -894,7 +894,7 @@ func (oc *Controller) buildClusterECMPCacheFromPods(clusterRouteCache map[string
 			continue
 		}
 		// get all pods in the namespace
-		nsPods, err := oc.watchFactory.GetPods(podRoutingNamespaceAnno)
+		nsPods, err := oc.mc.watchFactory.GetPods(podRoutingNamespaceAnno)
 		if err != nil {
 			klog.Errorf("Unable to clean ExGw ECMP routes for exgw: %s, serving namespace: %s, %v",
 				pod.Name, podRoutingNamespaceAnno, err)

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -952,5 +952,5 @@ func injectNode(fakeOvn *FakeOVN) {
 			},
 		},
 	}
-	fakeOvn.controller.watchFactory.NodeInformer().GetStore().Add(node)
+	fakeOvn.controller.mc.watchFactory.NodeInformer().GetStore().Add(node)
 }

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -50,7 +50,7 @@ func (oc *Controller) addEgressIP(eIP *egressipv1.EgressIP) error {
 	if err != nil {
 		return fmt.Errorf("invalid namespaceSelector on EgressIP %s: %v", eIP.Name, err)
 	}
-	h := oc.watchFactory.AddFilteredNamespaceHandler("", sel,
+	h := oc.mc.watchFactory.AddFilteredNamespaceHandler("", sel,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				namespace := obj.(*kapi.Namespace)
@@ -78,18 +78,18 @@ func (oc *Controller) deleteEgressIP(eIP *egressipv1.EgressIP) error {
 	oc.eIPC.namespaceHandlerMutex.Lock()
 	defer oc.eIPC.namespaceHandlerMutex.Unlock()
 	if nH, exists := oc.eIPC.namespaceHandlerCache[getEgressIPKey(eIP)]; exists {
-		oc.watchFactory.RemoveNamespaceHandler(&nH)
+		oc.mc.watchFactory.RemoveNamespaceHandler(&nH)
 		delete(oc.eIPC.namespaceHandlerCache, getEgressIPKey(eIP))
 	}
 
 	oc.eIPC.podHandlerMutex.Lock()
 	defer oc.eIPC.podHandlerMutex.Unlock()
 	if pH, exists := oc.eIPC.podHandlerCache[getEgressIPKey(eIP)]; exists {
-		oc.watchFactory.RemovePodHandler(&pH)
+		oc.mc.watchFactory.RemovePodHandler(&pH)
 		delete(oc.eIPC.podHandlerCache, getEgressIPKey(eIP))
 	}
 
-	namespaces, err := oc.kube.GetNamespaces(eIP.Spec.NamespaceSelector)
+	namespaces, err := oc.mc.kube.GetNamespaces(eIP.Spec.NamespaceSelector)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (oc *Controller) syncEgressIPs(eIPs []interface{}) {
 		// In the unlikely event that any status has been misallocated previously:
 		// unassign that by updating the entire status and re-allocate properly in addEgressIP
 		if !validAssignment {
-			namespaces, err := oc.kube.GetNamespaces(eIP.Spec.NamespaceSelector)
+			namespaces, err := oc.mc.kube.GetNamespaces(eIP.Spec.NamespaceSelector)
 			if err != nil {
 				klog.Errorf("Unable to list namespaces matched by EgressIP: %s, err: %v", getEgressIPKey(eIP), err)
 				continue
@@ -358,13 +358,13 @@ func (oc *Controller) generatePodIPCacheForEgressIP(eIPs []interface{}) (map[str
 			continue
 		}
 		egressIPToPodIPCache[egressIP.Name] = sets.NewString()
-		namespaces, err := oc.watchFactory.GetNamespacesBySelector(egressIP.Spec.NamespaceSelector)
+		namespaces, err := oc.mc.watchFactory.GetNamespacesBySelector(egressIP.Spec.NamespaceSelector)
 		if err != nil {
 			klog.Errorf("Error building egress IP sync cache, cannot retrieve namespaces for EgressIP: %s, err: %v", egressIP.Name, err)
 			continue
 		}
 		for _, namespace := range namespaces {
-			pods, err := oc.watchFactory.GetPodsBySelector(namespace.Name, egressIP.Spec.PodSelector)
+			pods, err := oc.mc.watchFactory.GetPodsBySelector(namespace.Name, egressIP.Spec.PodSelector)
 			if err != nil {
 				klog.Errorf("Error building egress IP sync cache, cannot retrieve pods for namespace: %s and egress IP: %s, err: %v", namespace.Name, egressIP.Name, err)
 				continue
@@ -391,7 +391,7 @@ func (oc *Controller) isAnyClusterNodeIP(ip net.IP) *egressNode {
 
 func (oc *Controller) updateEgressIPWithRetry(eIP *egressipv1.EgressIP) error {
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		return oc.kube.UpdateEgressIP(eIP)
+		return oc.mc.kube.UpdateEgressIP(eIP)
 	})
 	if retryErr != nil {
 		return fmt.Errorf("error in updating status on EgressIP %s: %v", eIP.Name, retryErr)
@@ -406,7 +406,7 @@ func (oc *Controller) addNamespaceEgressIP(eIP *egressipv1.EgressIP, namespace *
 	if err != nil {
 		return fmt.Errorf("invalid podSelector on EgressIP %s: %v", eIP.Name, err)
 	}
-	h := oc.watchFactory.AddFilteredPodHandler(namespace.Name, sel,
+	h := oc.mc.watchFactory.AddFilteredPodHandler(namespace.Name, sel,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				pod := obj.(*kapi.Pod)
@@ -448,7 +448,7 @@ func (oc *Controller) deleteNamespaceEgressIP(eIP *egressipv1.EgressIP, namespac
 	oc.eIPC.podHandlerMutex.Lock()
 	defer oc.eIPC.podHandlerMutex.Unlock()
 	if pH, exists := oc.eIPC.podHandlerCache[getEgressIPKey(eIP)]; exists {
-		oc.watchFactory.RemovePodHandler(&pH)
+		oc.mc.watchFactory.RemovePodHandler(&pH)
 		delete(oc.eIPC.podHandlerCache, getEgressIPKey(eIP))
 	}
 	if err := oc.deleteNamespacePodsEgressIP(eIP, namespace); err != nil {
@@ -458,7 +458,7 @@ func (oc *Controller) deleteNamespaceEgressIP(eIP *egressipv1.EgressIP, namespac
 }
 
 func (oc *Controller) deleteNamespacePodsEgressIP(eIP *egressipv1.EgressIP, namespace *kapi.Namespace) error {
-	pods, err := oc.kube.GetPods(namespace.Name, eIP.Spec.PodSelector)
+	pods, err := oc.mc.kube.GetPods(namespace.Name, eIP.Spec.PodSelector)
 	if err != nil {
 		return err
 	}
@@ -486,7 +486,7 @@ func (oc *Controller) assignEgressIPs(eIP *egressipv1.EgressIP) error {
 			Kind: "EgressIP",
 			Name: eIP.Name,
 		}
-		oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "NoMatchingNodeFound", "no assignable nodes for EgressIP: %s, please tag at least one node with label: %s", eIP.Name, util.GetNodeEgressLabel())
+		oc.mc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "NoMatchingNodeFound", "no assignable nodes for EgressIP: %s, please tag at least one node with label: %s", eIP.Name, util.GetNodeEgressLabel())
 		return fmt.Errorf("no assignable nodes")
 	}
 	klog.V(5).Infof("Current assignments are: %+v", existingAllocations)
@@ -498,7 +498,7 @@ func (oc *Controller) assignEgressIPs(eIP *egressipv1.EgressIP) error {
 				Kind: "EgressIP",
 				Name: eIP.Name,
 			}
-			oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "InvalidEgressIP", "egress IP: %s for object EgressIP: %s is not a valid IP address", egressIP, eIP.Name)
+			oc.mc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "InvalidEgressIP", "egress IP: %s for object EgressIP: %s is not a valid IP address", egressIP, eIP.Name)
 			return fmt.Errorf("unable to parse provided EgressIP: %s, invalid", egressIP)
 		}
 		if node := oc.isAnyClusterNodeIP(eIPC); node != nil {
@@ -506,7 +506,7 @@ func (oc *Controller) assignEgressIPs(eIP *egressipv1.EgressIP) error {
 				Kind: "EgressIP",
 				Name: eIP.Name,
 			}
-			oc.recorder.Eventf(
+			oc.mc.recorder.Eventf(
 				&eIPRef,
 				kapi.EventTypeWarning,
 				"UnsupportedRequest",
@@ -542,7 +542,7 @@ func (oc *Controller) assignEgressIPs(eIP *egressipv1.EgressIP) error {
 			Kind: "EgressIP",
 			Name: eIP.Name,
 		}
-		oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "NoMatchingNodeFound", "No matching nodes found, which can host any of the egress IPs: %v for object EgressIP: %s", eIP.Spec.EgressIPs, eIP.Name)
+		oc.mc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "NoMatchingNodeFound", "No matching nodes found, which can host any of the egress IPs: %v for object EgressIP: %s", eIP.Spec.EgressIPs, eIP.Name)
 		return fmt.Errorf("no matching host found")
 	}
 	if len(assignments) < len(eIP.Spec.EgressIPs) {
@@ -551,7 +551,7 @@ func (oc *Controller) assignEgressIPs(eIP *egressipv1.EgressIP) error {
 			Kind: "EgressIP",
 			Name: eIP.Name,
 		}
-		oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "UnassignedRequest", "Not all egress IPs for EgressIP: %s could be assigned, please tag more nodes", eIP.Name)
+		oc.mc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "UnassignedRequest", "Not all egress IPs for EgressIP: %s could be assigned, please tag more nodes", eIP.Name)
 	}
 	return nil
 }
@@ -624,7 +624,7 @@ func (oc *Controller) addEgressNode(egressNode *kapi.Node) error {
 	defer oc.eIPC.assignmentRetryMutex.Unlock()
 	for eIPName := range oc.eIPC.assignmentRetry {
 		klog.V(5).Infof("Re-assignment for EgressIP: %s attempted by new node: %s", eIPName, egressNode.Name)
-		eIP, err := oc.kube.GetEgressIP(eIPName)
+		eIP, err := oc.mc.kube.GetEgressIP(eIPName)
 		if errors.IsNotFound(err) {
 			klog.Errorf("Re-assignment for EgressIP: EgressIP: %s not found in the api-server, err: %v", eIPName, err)
 			delete(oc.eIPC.assignmentRetry, eIP.Name)
@@ -657,7 +657,7 @@ func (oc *Controller) deleteEgressNode(egressNode *kapi.Node) error {
 	); err != nil {
 		klog.Errorf("Unable to remove GARP configuration on external logical switch port for egress node: %s, stdout: %s, stderr: %s, err: %v", egressNode.Name, stdout, stderr, err)
 	}
-	egressIPs, err := oc.kube.GetEgressIPs()
+	egressIPs, err := oc.mc.kube.GetEgressIPs()
 	if err != nil {
 		return fmt.Errorf("unable to list egressIPs, err: %v", err)
 	}
@@ -1062,7 +1062,7 @@ func (oc *Controller) checkEgressNodesReachability() {
 		}
 		oc.eIPC.allocatorMutex.Unlock()
 		for nodeName, shouldDelete := range reAddOrDelete {
-			node, err := oc.kube.GetNode(nodeName)
+			node, err := oc.mc.kube.GetNode(nodeName)
 			if err != nil {
 				klog.Errorf("Node: %s reachability changed, but could not retrieve node from API server, err: %v", node.Name, err)
 			}

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -690,7 +690,7 @@ func (oc *Controller) addNodeLocalNatEntries(node *kapi.Node, mgmtPortMAC string
 		return fmt.Errorf("failed to marshal node %q annotation for node local NAT IP %s",
 			node.Name, externalIP.String())
 	}
-	err = oc.kube.SetAnnotationsOnNode(node.Name, nodeAnnotations)
+	err = oc.mc.kube.SetAnnotationsOnNode(node.Name, nodeAnnotations)
 	if err != nil {
 		return fmt.Errorf("failed to set node local NAT IP annotation on node %s: %v",
 			node.Name, err)

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -270,10 +270,10 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 				// clusterController.WatchNodes() needs to following two port groups to have been created.
 				pg := libovsdbops.BuildPortGroup(ovntypes.ClusterPortGroupName, ovntypes.ClusterPortGroupName, nil, nil)
-				err = libovsdbops.CreateOrUpdatePortGroups(fakeOvn.controller.nbClient, pg)
+				err = libovsdbops.CreateOrUpdatePortGroups(fakeOvn.controller.mc.nbClient, pg)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				pg = libovsdbops.BuildPortGroup(ovntypes.ClusterRtrPortGroupName, ovntypes.ClusterRtrPortGroupName, nil, nil)
-				err = libovsdbops.CreateOrUpdatePortGroups(fakeOvn.controller.nbClient, pg)
+				err = libovsdbops.CreateOrUpdatePortGroups(fakeOvn.controller.mc.nbClient, pg)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				fakeOvn.controller.WatchNamespaces()


### PR DESCRIPTION
This commit is to Prepare for the upcoming multi-network OVN CNI
support, we are adding a new OvnMHController structure which can hold
multiple OVN controllers (one per network).

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->