### PR TITLE
disabling iface-id-ver feature must happen on both master and node

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -376,6 +376,7 @@ ovn_image=${image} \
   ovn_multicast_enable=${ovn_multicast_enable} \
   ovn_egress_ip_enable=${ovn_egress_ip_enable} \
   ovn_egress_firewall_enable=${ovn_egress_firewall_enable} \
+  ovn_disable_ovn_iface_id_ver=${ovn_disable_ovn_iface_id_ver} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_master_count=${ovn_master_count} \
   ovn_gateway_mode=${ovn_gateway_mode} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -903,6 +903,11 @@ ovn-master() {
       ovn_acl_logging_rate_limit_flag="--acl-logging-rate-limit ${ovn_acl_logging_rate_limit}"
   fi
 
+  disable_ovn_iface_id_ver_flag=
+  if [[ ${ovn_disable_ovn_iface_id_ver} == "true" ]]; then
+      disable_ovn_iface_id_ver_flag="--disable-ovn-iface-id-ver"
+  fi
+
   multicast_enabled_flag=
   if [[ ${ovn_multicast_enable} == "true" ]]; then
       multicast_enabled_flag="--enable-multicast"
@@ -933,6 +938,7 @@ ovn-master() {
     --logfile-maxage=${ovnkube_logfile_maxage} \
     ${hybrid_overlay_flags} \
     ${disable_snat_multiple_gws_flag} \
+    ${disable_ovn_iface_id_ver_flag} \
     ${empty_lb_events_flag} \
     ${ovn_v4_join_subnet_opt} \
     ${ovn_v6_join_subnet_opt} \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -260,6 +260,8 @@ spec:
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_ACL_LOGGING_RATE_LIMIT
           value: "{{ ovn_acl_logging_rate_limit }}"
+        - name: OVN_DISABLE_OVN_IFACE_ID_VER
+          value: "{{ ovn_disable_ovn_iface_id_ver }}"
         - name: OVN_HOST_NETWORK_NAMESPACE
           valueFrom:
             configMapKeyRef:

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -57,15 +57,16 @@ var (
 
 	// Default holds parsed config file parameters and command-line overrides
 	Default = DefaultConfig{
-		MTU:               1400,
-		ConntrackZone:     64000,
-		EncapType:         "geneve",
-		EncapIP:           "",
-		EncapPort:         DefaultEncapPort,
-		InactivityProbe:   100000, // in Milliseconds
-		OpenFlowProbe:     180,    // in Seconds
-		LFlowCacheEnable:  true,
-		RawClusterSubnets: "10.128.0.0/14/23",
+		MTU:                  1400,
+		ConntrackZone:        64000,
+		EncapType:            "geneve",
+		EncapIP:              "",
+		EncapPort:            DefaultEncapPort,
+		InactivityProbe:      100000, // in Milliseconds
+		OpenFlowProbe:        180,    // in Seconds
+		LFlowCacheEnable:     true,
+		RawClusterSubnets:    "10.128.0.0/14/23",
+		DisableOVNIfaceIdVer: false,
 	}
 
 	// Logging holds logging-related parsed config file parameters and command-line overrides
@@ -196,6 +197,8 @@ type DefaultConfig struct {
 	// ClusterSubnets holds parsed cluster subnet entries and may be used
 	// outside the config module.
 	ClusterSubnets []CIDRNetworkEntry
+	// Option to disable the iface-id-ver feature in OVN
+	DisableOVNIfaceIdVer bool `gcfg:"disable-ovn-iface-id-ver"`
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides
@@ -351,9 +354,8 @@ type HybridOverlayConfig struct {
 
 // OvnKubeNodeConfig holds ovnkube-node configurations
 type OvnKubeNodeConfig struct {
-	Mode                 string `gcfg:"mode"`
-	MgmtPortNetdev       string `gcfg:"mgmt-port-netdev"`
-	DisableOVNIfaceIdVer bool   `gcfg:"disable-ovn-iface-id-ver"`
+	Mode           string `gcfg:"mode"`
+	MgmtPortNetdev string `gcfg:"mgmt-port-netdev"`
 }
 
 // OvnDBScheme describes the OVN database connection transport method
@@ -1077,8 +1079,8 @@ var OvnKubeNodeFlags = []cli.Flag{
 		Name: "disable-ovn-iface-id-ver",
 		Usage: "if iface-id-ver option is not enabled in ovn, set this flag to True " +
 			"(depends on ovn version, minimal required is 21.09)",
-		Value:       OvnKubeNode.DisableOVNIfaceIdVer,
-		Destination: &cliConfig.OvnKubeNode.DisableOVNIfaceIdVer,
+		Value:       Default.DisableOVNIfaceIdVer,
+		Destination: &cliConfig.Default.DisableOVNIfaceIdVer,
 	},
 }
 

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -282,7 +282,7 @@ func isOVNControllerReady(name string) (bool, error) {
 // OVS.Interface.external-id:ovn-installed can only be used correctly
 // in a combination with OVS.Interface.external-id:iface-id-ver
 func getOVNIfUpCheckMode() (bool, error) {
-	if config.OvnKubeNode.DisableOVNIfaceIdVer {
+	if config.Default.DisableOVNIfaceIdVer {
 		klog.Infof("'iface-id-ver' is manually disabled, ovn-installed feature can't be used")
 		return false, nil
 	}


### PR DESCRIPTION
currently, the iface-id-ver feature is disabled on the node alone. so on
the master side we create LSP with iface-id-ver set and on the node side
we are not setting external_ids:iface-id-ver on the OVS port. this results
in ovn-controller not claiming the logical port and performing the physical
binding.

@dcbw @JacobTanenbaum @npinaeva PTAL