### PR TITLE
NIT: miscellaneous fixes to log messages to aid debugging

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -66,7 +66,8 @@ func getFlagsByCategory() map[string][]cli.Flag {
 	m["OVN Southbound DB Options"] = config.OvnSBFlags
 	m["OVN Gateway Options"] = config.OVNGatewayFlags
 	m["Master HA Options"] = config.MasterHAFlags
-	m["OVN Kube Node flags"] = config.OvnKubeNodeFlags
+	m["OVN Kube Node Options"] = config.OvnKubeNodeFlags
+	m["Monitoring Options"] = config.MonitoringFlags
 
 	return m
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -59,7 +59,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	// get all the nodes from the watchFactory
 	nodes, err := oc.watchFactory.GetNodes()
 	if err != nil {
-		klog.Errorf("Failed to get nodes")
+		klog.Errorf("Failed to get nodes: %v", err)
 		return
 	}
 	for _, n := range nodes {

--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -52,7 +52,8 @@ func (c *portCache) add(logicalSwitch, logicalPort, uuid string, mac net.Hardwar
 		ips:           ips,
 		mac:           mac,
 	}
-	klog.V(5).Infof("port-cache(%s): added port %+v", logicalPort, portInfo)
+	klog.V(5).Infof("port-cache(%s): added port %+v with IP: %s and MAC: %s",
+		logicalPort, portInfo, portInfo.ips, portInfo.mac)
 	c.cache[logicalPort] = portInfo
 	return portInfo
 }

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -741,7 +741,8 @@ func RunRoute(args ...string) (string, string, error) {
 	return strings.TrimSpace(stdout.String()), stderr.String(), err
 }
 
-// AddOFFlowWithSpecificAction replaces flows in the bridge with a FLOOD action flow
+// AddOFFlowWithSpecificAction replaces flows in the bridge by a single flow with a
+// specified action
 func AddOFFlowWithSpecificAction(bridgeName, action string) (string, string, error) {
 	args := []string{"-O", "OpenFlow13", "replace-flows", bridgeName, "-"}
 


### PR DESCRIPTION
for example: currently we log

port-cache(namespace1_myPod): added port &{name:namespace1_myPod
uuid:8a86f6d8-7972-4253-b0bd-ddbef66e9303 logicalSwitch:node1
ips:[0xc01d14e570] mac:[17 34 51 68 85 102]

the 'ips' value is not readable.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>