### PR TITLE
Don't return the error when annotation cannot be unmarshalled

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -182,7 +182,9 @@ func (oc *Controller) addPodExternalGW(pod *kapi.Pod) error {
 
 	foundGws, err := getExGwPodIPs(pod)
 	if err != nil {
-		return err
+		klog.Errorf("Error getting exgw IPs for pod: %s, error: %v", pod.Name, err)
+		oc.recordPodEvent(err, pod)
+		return nil
 	}
 
 	// if we found any gateways then we need to update current pods routing in the relevant namespace
@@ -955,10 +957,9 @@ func getExGwPodIPs(gatewayPod *kapi.Pod) ([]net.IP, error) {
 			}
 		}
 	} else {
-		klog.Errorf("Ignoring pod %s as an external gateway candidate. Invalid combination "+
+		return nil, fmt.Errorf("ignoring pod %s as an external gateway candidate. Invalid combination "+
 			"of host network: %t and routing-network annotation: %s", gatewayPod.Name, gatewayPod.Spec.HostNetwork,
 			gatewayPod.Annotations[routingNetworkAnnotation])
-		return nil, nil
 	}
 	return foundGws, nil
 }


### PR DESCRIPTION

**- What this PR does and why is it needed**

While creating an exgw pod, we try to unmarshall the `network-status`
annotation that is set by the multus CNI plugin. Since multus only
sets the annotation after it calls the SRIOV plugin this means
ovn-k must return a successful CNI_ADD result.

Currently we return the error to the top and fail to create the pod,
this blocking the pod creation. Let's just log an error instead.

**- How to verify it**
Before the PR:
```
I1007 19:17:30.532046      38 egressgw.go:177] External gateway pod: e2e-gateway-pod, detected for namespace(s) bar
I1007 19:17:30.532099      38 pods.go:262] [default/e2e-gateway-pod] addLogicalPort took 42.449531ms
E1007 19:17:30.532136      38 ovn.go:567] failed to handle external GW check: unable to unmarshall annotation k8s.v1.cni.cncf.io/network-status on pod e2e-gateway-pod: unexpected end of JSON input
I1007 19:17:30.532230      38 ovn.go:429] Posting a Warning event for Pod default/e2e-gateway-pod
I1007 19:17:30.532304      38 ovn.go:473] [688f0576-51a8-419a-9ec2-fe9970cdfa94/default/e2e-gateway-pod] setup retry failed; will try again later
I1007 19:17:30.532381      38 event.go:282] Event(v1.ObjectReference{Kind:"Pod", Namespace:"default", Name:"e2e-gateway-pod", UID:"688f0576-51a8-419a-9ec2-fe9970cdfa94", APIVersion:"v1", ResourceVersion:"269216", FieldPath:""}): type: 'Warning' reason: 'ErrorAddingLogicalPort' failed to handle external GW check: unable to unmarshall annotation k8s.v1.cni.cncf.io/network-status on pod e2e-gateway-pod: unexpected end of JSON input
I1007 19:17:38.044311      38 leaderelection.go:278] successfully renewed lease ovn-kubernetes/ovn-kubernetes-master
I1007 19:17:50.441269      38 reflector.go:535] k8s.io/client-go/informers/factory.go:134: Watch close - *v1beta1.EndpointSlice total 0 items received
I1007 19:17:58.057559      38 leaderelection.go:278] successfully renewed lease ovn-kubernetes/ovn-kubernetes-master
I1007 19:18:00.532592      38 ovn.go:467] [688f0576-51a8-419a-9ec2-fe9970cdfa94/default/e2e-gateway-pod] retry pod setup
I1007 19:18:00.532850      38 pods.go:272] [default/e2e-gateway-pod] creating logical port for pod on switch ovn-worker2
I1007 19:18:00.533115      38 address_set.go:454] (11a92d35-951c-44bf-a262-4220ecd6ba7f/default_v4/a5154718082306775057) adding IPs ([10.244.0.4]) to address set
I1007 19:18:00.535643      38 ovs.go:209] exec(252): /usr/bin/ovn-nbctl --timeout=15 --columns _uuid --format=csv --no-headings find nat external_ip="172.18.0.2" type=snat logical_ip="10.244.0.4"
I1007 19:18:00.545575      38 ovs.go:212] exec(252): stdout: "1e8de9a5-f965-417b-9ec0-ab69f3b5d120\n"
I1007 19:18:00.545674      38 ovs.go:213] exec(252): stderr: ""
I1007 19:18:00.545852      38 ovs.go:209] exec(253): /usr/bin/ovn-nbctl --timeout=15 --columns _uuid --no-headings find logical_router name=GR_ovn-worker2 nat{>=}1e8de9a5-f965-417b-9ec0-ab69f3b5d120
I1007 19:18:00.556142      38 ovs.go:212] exec(253): stdout: "df17496b-69b8-46a1-bece-97a252279c06\n"
I1007 19:18:00.556242      38 ovs.go:213] exec(253): stderr: ""
I1007 19:18:00.556289      38 egressgw.go:177] External gateway pod: e2e-gateway-pod, detected for namespace(s) bar
I1007 19:18:00.556331      38 pods.go:262] [default/e2e-gateway-pod] addLogicalPort took 23.617639ms
E1007 19:18:00.556446      38 ovn.go:567] failed to handle external GW check: unable to unmarshall annotation k8s.v1.cni.cncf.io/network-status on pod e2e-gateway-pod: unexpected end of JSON input
I1007 19:18:00.556494      38 ovn.go:429] Posting a Warning event for Pod default/e2e-gateway-pod
I1007 19:18:00.556563      38 ovn.go:473] [688f0576-51a8-419a-9ec2-fe9970cdfa94/default/e2e-gateway-pod] setup retry failed; will try again later
I1007 19:18:00.556641      38 event.go:282] Event(v1.ObjectReference{Kind:"Pod", Namespace:"default", Name:"e2e-gateway-pod", UID:"688f0576-51a8-419a-9ec2-fe9970cdfa94", APIVersion:"v1", ResourceVersion:"269216", FieldPath:""}): type: 'Warning' reason: 'ErrorAddingLogicalPort' failed to handle external GW check: unable to unmarshall annotation k8s.v1.cni.cncf.io/network-status on pod e2e-gateway-pod: unexpected end of JSON input
```
With this PR:
```
I1007 20:04:47.563744      50 pods.go:428] Annotation values: ip=[10.244.2.5/24] ; mac=0a:58:0a:f4:02:05 ; gw=[10.244.2.1]
Annotation=map[k8s.ovn.org/pod-networks:{"default":{"ip_addresses":["10.244.2.5/24"],"mac_address":"0a:58:0a:f4:02:05","gateway_ips":["10.244.2.1"],"ip_address":"10.244.2.5/24","gateway_ip":"10.244.2.1"}}]
I1007 20:04:47.563771      50 kube.go:67] Setting annotations map[k8s.ovn.org/pod-networks:{"default":{"ip_addresses":["10.244.2.5/24"],"mac_address":"0a:58:0a:f4:02:05","gateway_ips":["10.244.2.1"],"ip_address":"10.244.2.5/24","gateway_ip":"10.244.2.1"}}] on pod default/e2e-gateway-pod
I1007 20:04:47.569893      50 address_set.go:454] (79430473-e164-4acb-b00d-2437bf59d185/default_v4/a5154718082306775057) adding IPs ([10.244.2.5]) to address set
I1007 20:04:47.570412      50 egressgw.go:181] External gateway pod: e2e-gateway-pod, detected for namespace(s) bar
E1007 20:04:47.570440      50 egressgw.go:185] Error getting exgw IPs for pod: e2e-gateway-pod, error: unable to unmarshall annotation k8s.v1.cni.cncf.io/network-status on pod e2e-gateway-pod: unexpected end of JSON input
I1007 20:04:47.571333      50 port_cache.go:55] port-cache(default_e2e-gateway-pod): added port &{name:default_e2e-gateway-pod uuid:30b76e2a-5362-45eb-8766-db904cf8c0bb logicalSwitch:ovn-worker2 ips:[0xc002d30f30] mac:[10 88 10 244 2 5] expires:{wall:0 ext:0 loc:<nil>}} with IP: [10.244.2.5/24] and MAC: 0a:58:0a:f4:02:05
I1007 20:04:47.571393      50 pods.go:262] [default/e2e-gateway-pod] addLogicalPort took 7.810357ms
```

