### PR TITLE
Fix cleanExGwECMPRoutes on startup

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -1075,10 +1075,11 @@ func (oc *Controller) buildOVNECMPCache() map[string][]*ovnRoute {
 			router:  logicalRouterRes[0].Name,
 			outport: *logicalRouterStaticRoute.OutputPort,
 		}
-		if _, ok := ovnRouteCache[logicalRouterStaticRoute.IPPrefix]; !ok {
-			ovnRouteCache[logicalRouterStaticRoute.IPPrefix] = []*ovnRoute{route}
+		podIP, _, _ := net.ParseCIDR(logicalRouterStaticRoute.IPPrefix)
+		if _, ok := ovnRouteCache[podIP.String()]; !ok {
+			ovnRouteCache[podIP.String()] = []*ovnRoute{route}
 		} else {
-			ovnRouteCache[logicalRouterStaticRoute.IPPrefix] = append(ovnRouteCache[logicalRouterStaticRoute.IPPrefix], route)
+			ovnRouteCache[podIP.String()] = append(ovnRouteCache[podIP.String()], route)
 		}
 	}
 	return ovnRouteCache


### PR DESCRIPTION
**- What this PR does and why is it needed**

Currently we are always deleting and recreating all ECMP routes
BFD sessions and LRP 501 policies on startup because in https://github.com/ovn-org/ovn-kubernetes/commit/cde0a611c5710d34eb85fcbee943659b2d8f0262
we changed the key of the ovnRouteCache map to PodIP CIDR.
Let's change it back to PodIP, else it won't match with
the key in the clusterRouteCache.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>


**- How to verify it**
Before the PR:
```
I1011 14:52:02.651173      39 ovn.go:306] Starting all the Watchers...
I1011 14:52:02.651823      39 egressgw.go:873] OVN ECMP route cache is: map[10.244.1.4/32:[0xc0020ee500] 10.244.2.5/32:[0xc0020ee550]]
I1011 14:52:02.651946      39 egressgw.go:874] Cluster ECMP route cache is: map[10.244.1.4:[172.18.0.5] 10.244.2.5:[172.18.0.5]]
I1011 14:52:02.652002      39 egressgw.go:881] Found stale exgw ecmp route, podIP: 10.244.1.4/32, nexthop: 172.18.0.5, router: GR_ovn-worker2
I1011 14:52:02.652273      39 model_client.go:283] Mutate operations generated as: [{Op:mutate Table:Logical_Router Row:map[] Rows:[] Columns:[] Mutations:[{Column:static_routes Mutator:delete Value:{GoSet:[{GoUUID:cefbd62d-2b43-4842-bb7d-de754fe96205}]}}] Timeout:0 Where:[where column _uuid == {ba19d248-c2e5-4daf-a9d9-d8038e1d4135}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUIDName:}]
I1011 14:52:02.656060      39 model_client.go:292] Delete operations generated as: [{Op:delete Table:BFD Row:map[] Rows:[] Columns:[] Mutations:[] Timeout:0 Where:[where column _uuid == {d46f4539-582c-4be5-920d-e422e6dbb5dd}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUIDName:}]
I1011 14:52:02.661304      39 egressgw.go:881] Found stale exgw ecmp route, podIP: 10.244.2.5/32, nexthop: 172.18.0.5, router: GR_ovn-worker
I1011 14:52:02.661528      39 model_client.go:283] Mutate operations generated as: [{Op:mutate Table:Logical_Router Row:map[] Rows:[] Columns:[] Mutations:[{Column:static_routes Mutator:delete Value:{GoSet:[{GoUUID:4c65debc-f6e2-4e39-be27-6265fa8cb6f1}]}}] Timeout:0 Where:[where column _uuid == {09ec2891-d289-4240-8092-13e936fa3b22}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUIDName:}]
I1011 14:52:02.668173      39 model_client.go:292] Delete operations generated as: [{Op:delete Table:BFD Row:map[] Rows:[] Columns:[] Mutations:[] Timeout:0 Where:[where column _uuid == {2daa306a-a990-49c4-9be1-2b94c276bda0}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUIDName:}]
I1011 14:52:02.670439      39 egressgw.go:811] Syncing exgw routes took 19.194548ms

```
After the PR:
```
I1011 15:42:51.886203      38 egressgw.go:872] OVN ECMP route cache is: map[10.244.0.6:[0xc000285bd0] 10.244.2.3:[0xc000285b80]]
I1011 15:42:51.886258      38 egressgw.go:873] Cluster ECMP route cache is: map[10.244.0.6:[172.18.0.5] 10.244.2.3:[172.18.0.5]]
I1011 15:42:51.886517      38 egressgw.go:811] Syncing exgw routes took 1.024053ms

```

