### PR TITLE
Change default OVN_BRANCH name to 'main'.

### DIFF
--- a/dist/images/Dockerfile.fedora.dev
+++ b/dist/images/Dockerfile.fedora.dev
@@ -31,7 +31,7 @@ ENV PYTHONDONTWRITEBYTECODE yes
 
 ARG KERNEL_VERSION
 ARG OVN_REPO=https://github.com/ovn-org/ovn.git
-ARG OVN_BRANCH=master
+ARG OVN_BRANCH=main
 ARG OVS_REPO=https://github.com/openvswitch/ovs.git
 ARG OVS_BRANCH=master
 

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -19,7 +19,7 @@ ifeq ($(ARCH),arm64)
 endif
 KERNEL_VERSION ?= `uname -r`
 OVS_BRANCH ?= master
-OVN_BRANCH ?= master
+OVN_BRANCH ?= main
 OCI_BIN ?= docker
 
 # The image of ovnkube/ovn-daemonset-u should be multi-arched before using it on arm64


### PR DESCRIPTION
OVN recently renamed its default branch.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>