### PR TITLE
[WIP] remove useless ovn command in config

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1798,22 +1798,6 @@ func (a *OvnAuthConfig) ensureCACert() error {
 		return nil
 	}
 
-	// Client can bootstrap the CA from the OVN API.  Use nbctl for both
-	// SB and NB since ovn-sbctl only supports --bootstrap-ca-cert from
-	// 2.9.90+.
-	// FIXME: change back to a.ctlCmd when sbctl supports --bootstrap-ca-cert
-	// https://github.com/openvswitch/ovs/pull/226
-	args := []string{
-		"--db=" + a.GetURL(),
-		"--timeout=5",
-	}
-	if a.Scheme == OvnDBSchemeSSL {
-		args = append(args, "--private-key="+a.PrivKey)
-		args = append(args, "--certificate="+a.Cert)
-		args = append(args, "--bootstrap-ca-cert="+a.CACert)
-	}
-	args = append(args, "list", "nb_global")
-	_, _ = rawExec(a.exec, "ovn-nbctl", args...)
 	if _, err := os.Stat(a.CACert); os.IsNotExist(err) {
 		klog.Warningf("Bootstrapping %s CA certificate failed", a.CACert)
 	}

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -1191,9 +1191,6 @@ mode=shared
 
 		It("configures client northbound SSL correctly", func() {
 			fexec := ovntest.NewFakeExec()
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --db=" + nbURL + " --timeout=5 --private-key=" + keyFile + " --certificate=" + certFile + " --bootstrap-ca-cert=" + caFile + " list nb_global",
-			})
 
 			cliConfig := &OvnAuthConfig{
 				Address:        nbURL,
@@ -1221,7 +1218,6 @@ mode=shared
 		It("configures client southbound SSL correctly", func() {
 			fexec := ovntest.NewFakeExec()
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovn-nbctl --db=" + sbURL + " --timeout=5 --private-key=" + keyFile + " --certificate=" + certFile + " --bootstrap-ca-cert=" + caFile + " list nb_global",
 				"ovs-vsctl --timeout=15 del-ssl",
 				"ovs-vsctl --timeout=15 set-ssl " + keyFile + " " + certFile + " " + caFile,
 				"ovs-vsctl --timeout=15 set Open_vSwitch . external_ids:ovn-remote=\"" + sbURL + "\"",


### PR DESCRIPTION
there is a useless call to ovn that does nothing in config, it follows
an old style of calling ovn-nbctl so I removed it. The call was not
checked in any way so it was not replaced

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->