### PR TITLE
Fixes race with namespace acl logging updates

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -303,7 +303,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 	if aclAnnotation != oldACLAnnotation && (oc.aclLoggingCanEnable(aclAnnotation, nsInfo) || aclAnnotation == "") &&
 		len(nsInfo.networkPolicies) > 0 {
 		// deny rules are all one per namespace
-		if err := oc.setACLLoggingForNamespace(old.Name, nsInfo.networkPolicies, nsInfo.portGroupIngressDenyName, nsInfo.portGroupEgressDenyName, nsInfo.aclLogging); err != nil {
+		if err := oc.setACLLoggingForNamespace(old.Name, nsInfo); err != nil {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Namespace %s: ACL logging setting updated to deny=%s allow=%s",


### PR DESCRIPTION
policies created after namespace logging level updates inherit updated
logging level test was failing. This is due to a race between np and
namespace handlers. The test updates the namespace and creates the
network policy around the same time.

In the network policy handler, we update nsInfo to hold the network
policy, and then proceed to start creating the network policy. We no
longer hold the nsInfo lock at this point, so the namespace handler can
continue. Also, in the network policy handler we have to release the
lock on the network policy itself while adding handlers to the factory.
In addition, the namespace handler was attempting to update ACLs for a
network policy without holding the network policy lock.

This can lead to several race conditions like:
1. network policy gets nsInfo lock first, adds its network policy to
   nsInfo and releases the lock
2. network policy starts to create its ACL, but at the same time
   namespace handler sees the namespace update and tries to update the
   ACL as well

To fix this problem this patch does a few things:
1. make namespace handler lock network policies to update them
2. since we lock/unlock network policy several times during create, we
   cannot rely just on the np lock, so add an np.created field to the
   network policy to signal to the namespace handler that the np can be
   updated
3. namespace handler checks if the np was finished initial creation, and
   if it is not, then retries several times...waiting on network policy
   handler to finish

Signed-off-by: Tim Rozet <trozet@redhat.com>

