### PR TITLE
Make config parsing more resilient for unknown config fields

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1552,7 +1552,11 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 
 		// Parse ovn-k8s config file.
 		if err = gcfg.ReadInto(&cfg, f); err != nil {
-			return "", fmt.Errorf("failed to parse config file %s: %v", f.Name(), err)
+			if gcfg.FatalOnly(err) != nil {
+				return "", fmt.Errorf("failed to parse config file %s: %v", f.Name(), err)
+			}
+			// error is only a warning -> log it but continue
+			klog.Warningf("Warning on parsing config file: %s", err)
 		}
 		klog.Infof("Parsed config file %s", f.Name())
 		klog.Infof("Parsed config: %+v", cfg)


### PR DESCRIPTION
**- What this PR does and why is it needed**
Currently ovnkube-node & -master pods fail to start, when the config files contain an unknown field or unknown section. This can lead during updates to problems in the following scenario:

1. ConfigMap is updated
2. ovnkube-node rollout starts
3. somehow an ovnkube-master pod needs to be (re-)started (be it through eviction from a node or something else)
4. the newly started ovnkube-master pod isn't aware of the new config structure and fails to parse the config, resulting in a crashloop of the newly ovnkube-master. This can result in a stucking rollout.

Fixes [BZ 1988440](https://bugzilla.redhat.com/show_bug.cgi?id=1988440)

This PR addresses this and makes the config parsing more resilient against unknown fields or sections. 

**- How to verify it**
I added two new unit tests, which parses a config with an unknown field and section and one with an syntax issue.

**- Description for the changelog**
```
Allow unknown fields and sections in config file
```