### PR TITLE
Allow manual triggering of ovn-ci workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches: [ master ]
   schedule:
     - cron: '0 */12 * * *'
+  workflow_dispatch:
 
 env:
   GO_VERSION: "1.16.3"


### PR DESCRIPTION
**- What this PR does and why is it needed**
Currently Github runs workflows for a PR only on a push. If there are some flaky tests, the user has to force push, to retrigger a run of the ovn-ci workflow. 
This PR addresses it and allows to trigger a run of the ovn-ci workflow manually, e.g. in case a flaky test failed and the user wants to revalidate (https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).

**- How to verify it**
I cherry-picked this to the default branch of my fork. So you should see the "run workflow" button on the ovn-ci workflow: https://github.com/creydr/ovn-kubernetes/actions/workflows/test.yml