### PR TITLE
install-kind.sh: Compare kind binary against hardcoded checksum

### DIFF
--- a/test/scripts/install-kind.sh
+++ b/test/scripts/install-kind.sh
@@ -2,6 +2,42 @@
 
 set -ex
 
+KIND_URL=https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+KIND_SHA=949f81b3c30ca03a3d4effdecda04f100fa3edc07a28b19400f72ede7c5f0491
+KIND_DOWNLOAD_RETRIES=5
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TMP_DIR="$(mktemp -d)"
+
+install_kind() {
+	set +e
+
+	local download_successful=false
+
+	for retry in $(seq 1 ${KIND_DOWNLOAD_RETRIES}); do
+		curl -Lo ./kind ${KIND_URL}
+		echo "${KIND_SHA} kind" | sha256sum --check
+		if [ $? -eq 0 ]; then
+			download_successful=true
+			break
+		else
+			echo "Check sum '${KIND_SHA}' does not match file ./kind"
+		fi
+
+		sleep 5
+	done
+
+	if ! ${download_successful}; then
+		echo "Could not download kind binary"
+		exit 1
+	fi
+
+	chmod +x ./kind
+	sudo mv ./kind /usr/local/bin/
+	set -e
+}
+
+pushd $TMP_DIR
 # Install latest stable kubectl
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 chmod +x ./kubectl
@@ -14,10 +50,9 @@ sudo mv ./e2e.test /usr/local/bin/e2e.test
 sudo mv ./ginkgo /usr/local/bin/ginkgo
 rm kubernetes-test-linux-amd64.tar.gz
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-chmod +x ./kind
-sudo mv ./kind /usr/local/bin/
+install_kind
+popd # go out of $TMP_DIR
 
-pushd ../contrib
+pushd $SCRIPT_DIR/../../contrib
 ./kind.sh
-popd
+popd # go our of $SCRIPT_DIR/../../contrib


### PR DESCRIPTION
Verify that the downloaded kind binary matches the SHA256 checksum
specified in the script. If it does not match, retry.
This should take care of failed downloads from the kind website.

Fixes #2584

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->