### PR TITLE
Restricting ovn service account to access configmaps in ovn-k8s namespace

### DIFF
--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -46,7 +46,6 @@ rules:
   - nodes
   - endpoints
   - services
-  - configmaps
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - extensions
@@ -105,6 +104,35 @@ subjects:
   namespace: ovn-kubernetes
 
 ---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: ovn-kubernetes
+  name: ovn-k8s-configmap
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: only-ovnk8s-configmaps
+  namespace: ovn-kubernetes
+roleRef:
+  name: ovn-k8s-configmap
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: ovn
+  namespace: ovn-kubernetes
+
+---
+
 # The network cidr and service cidr are set in the ovn-config configmap
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION

Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>
Currently, we can access all the configmaps in the whole cluster as `ovn` serviceaccount user,
but we want to restrict it out to the configmaps that are in ovn-kubernetes namespace
