### PR TITLE
Add support for adding stateless OVN acls for network policies

### DIFF
--- a/go-controller/pkg/ovn/gress_policy_test.go
+++ b/go-controller/pkg/ovn/gress_policy_test.go
@@ -109,7 +109,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		gressPolicy := newGressPolicy(knet.PolicyTypeIngress, 5, "testing", "test")
+		gressPolicy := newGressPolicy(knet.PolicyTypeIngress, 5, "testing", "test", false)
 		for _, ipBlock := range tc.ipBlocks {
 			gressPolicy.addIPBlock(ipBlock)
 		}

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -2075,7 +2075,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 			},
 		}
 
-		gp := newGressPolicy(knet.PolicyTypeIngress, 0, policy.Namespace, policy.Name)
+		gp := newGressPolicy(knet.PolicyTypeIngress, 0, policy.Namespace, policy.Name, false)
 		err := gp.ensurePeerAddressSet(asFactory)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		asName := gp.peerAddressSet.GetName()


### PR DESCRIPTION
Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>

There is a requirement that certain OVN ACLs need to be created as `stateless` since ACLs on certain traffic, for example RoCE, cannot be offloaded with stateful firewall.

One of the simplest way to implement this would be to define a new annotation

**k8s.ovn.org/acl_stateless: "true"**
and require our tenants to annotate the K8s Network Policy with this annotation. With that all the ingress/egress rules in that ACL will be created with just `allow-stateless` action.