### PR TITLE
Fix panic on node object deletion

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1190,9 +1190,11 @@ func (oc *Controller) deleteNodeLogicalNetwork(nodeName string) error {
 	logicalRouterName := types.RouterToSwitchPrefix + nodeName
 	opModels := []libovsdbops.OperationModel{
 		{
+			Model:          &nbdb.LogicalSwitch{},
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 		},
 		{
+			Model:          &nbdb.LogicalRouter{},
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == logicalRouterName },
 		},
 	}


### PR DESCRIPTION
Deleting a node currently causes ovnkube-master to panic. The reason is: `OperationModel` requires `Model` to be specified as to automatically generate `ExistingResults` when performing a `Delete`, see: https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/ovn/libovsdbops/model_client.go#L190-L198

A better solution might be to use `reflect` and infer the type of `ExistingResult` from the function argument specified in `ModelPredicate`. But that might be a task for later, in the mean time this will fix the panic. 

/assign @jcaamano 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->