### PR TITLE
Recreate existing service routes on startup to allow for MTU changes

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1145,13 +1145,71 @@ var _ = Describe("Gateway unit tests", func() {
 			lnk.On("Attrs").Return(lnkAttr)
 			netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
 			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
-			netlinkMock.On("RouteAdd", expectedRoute).Return(nil)
+			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			netlinkMock.On("RouteReplace", expectedRoute).Return(nil)
 
 			err = configureSvcRouteViaInterface("ens1f0", gwIPs)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("Fails if link route add fails", func() {
+		It("Replaces previous kubernetes service routes on interface when MTU changes", func() {
+			_, ipnet, err := net.ParseCIDR("10.96.0.0/16")
+			Expect(err).ToNot(HaveOccurred())
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{ipnet}
+			gwIPs := []net.IP{net.ParseIP("10.0.0.11")}
+			lnk := &linkMock.Link{}
+			lnkAttr := &netlink.LinkAttrs{
+				Name:  "ens1f0",
+				Index: 5,
+			}
+			previousRoute := &netlink.Route{
+				Dst:       ipnet,
+				LinkIndex: 5,
+				Scope:     netlink.SCOPE_UNIVERSE,
+				Gw:        gwIPs[0],
+				MTU:       config.Default.MTU - 100,
+			}
+
+			expectedRoute := &netlink.Route{
+				Dst:       ipnet,
+				LinkIndex: 5,
+				Scope:     netlink.SCOPE_UNIVERSE,
+				Gw:        gwIPs[0],
+				MTU:       config.Default.MTU,
+			}
+
+			lnk.On("Attrs").Return(lnkAttr)
+			netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
+			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
+			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return([]netlink.Route{*previousRoute}, nil)
+			netlinkMock.On("RouteReplace", expectedRoute).Return(nil)
+
+			err = configureSvcRouteViaInterface("ens1f0", gwIPs)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Fails if link route list fails", func() {
+			_, ipnet, err := net.ParseCIDR("10.96.0.0/16")
+			Expect(err).ToNot(HaveOccurred())
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{ipnet}
+			gwIPs := []net.IP{net.ParseIP("10.0.0.11")}
+
+			lnk := &linkMock.Link{}
+			lnkAttr := &netlink.LinkAttrs{
+				Name:  "ens1f0",
+				Index: 5,
+			}
+			lnk.On("Attrs").Return(lnkAttr)
+
+			netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
+			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
+			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed to list routes"))
+
+			err = configureSvcRouteViaInterface("ens1f0", gwIPs)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Fails if link route replace fails", func() {
 			_, ipnet, err := net.ParseCIDR("10.96.0.0/16")
 			Expect(err).ToNot(HaveOccurred())
 			config.Kubernetes.ServiceCIDRs = []*net.IPNet{ipnet}
@@ -1165,7 +1223,8 @@ var _ = Describe("Gateway unit tests", func() {
 			lnk.On("Attrs").Return(lnkAttr)
 			netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
 			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
-			netlinkMock.On("RouteAdd", mock.Anything).Return(fmt.Errorf("failed to add route"))
+			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			netlinkMock.On("RouteReplace", mock.Anything).Return(fmt.Errorf("failed to replace route"))
 
 			err = configureSvcRouteViaInterface("ens1f0", gwIPs)
 			Expect(err).To(HaveOccurred())

--- a/go-controller/pkg/util/mocks/NetLinkOps.go
+++ b/go-controller/pkg/util/mocks/NetLinkOps.go
@@ -319,6 +319,20 @@ func (_m *NetLinkOps) RouteAdd(route *netlink.Route) error {
 	return r0
 }
 
+// RouteReplace provides a mock function with given fields: route
+func (_m *NetLinkOps) RouteReplace(route *netlink.Route) error {
+	ret := _m.Called(route)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*netlink.Route) error); ok {
+		r0 = rf(route)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RouteDel provides a mock function with given fields: route
 func (_m *NetLinkOps) RouteDel(route *netlink.Route) error {
 	ret := _m.Called(route)

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -401,6 +401,28 @@ func TestLinkRoutesDel(t *testing.T) {
 					OnCallMethodArgType: []string{"*mocks.Link", "int"},
 					RetArgList: []interface{}{
 						[]netlink.Route{
+							{Dst: nil},
+							{Dst: ovntest.MustParseIPNet("192.168.1.0/24")},
+						},
+						nil,
+					},
+				},
+				{
+					OnCallMethodName: "RouteDel", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil},
+				},
+			},
+		},
+		{
+			desc:         "default route delete succeeds",
+			inputLink:    mockLink,
+			inputSubnets: []*net.IPNet{nil},
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{
+					OnCallMethodName:    "RouteList",
+					OnCallMethodArgType: []string{"*mocks.Link", "int"},
+					RetArgList: []interface{}{
+						[]netlink.Route{
+							{Dst: nil},
 							{Dst: ovntest.MustParseIPNet("192.168.1.0/24")},
 						},
 						nil,


### PR DESCRIPTION
This PR introduces the following changes:
 - Recreate existing service routes on startup to allow for MTU changes
 - Fix `util.LinkRoutesDel` to work with links that have a default route defined