### PR TITLE
Scale: Don't trigger updateNode unless needed

### DIFF
--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -91,7 +91,12 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) *nodeTracker {
 				return
 			}
 
-			nt.updateNode(newObj)
+			// updateNode needs to be called only when hostSubnet annotation has changed or
+			// if L3Gateway annotation's ip addresses have changed or the name of the node (very rare)
+			// has changed. No need to trigger update for any other field change.
+			if util.NodeSubnetAnnotationChanged(oldObj, newObj) || util.NodeL3GatewayAnnotationChanged(oldObj, newObj) || oldObj.Name != newObj.Name {
+				nt.updateNode(newObj)
+			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			node, ok := obj.(*v1.Node)

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -277,6 +277,10 @@ func ParseNodeL3GatewayAnnotation(node *kapi.Node) (*L3GatewayConfig, error) {
 	return cfg, nil
 }
 
+func NodeL3GatewayAnnotationChanged(oldNode, newNode *kapi.Node) bool {
+	return oldNode.Annotations[ovnNodeL3GatewayConfig] != newNode.Annotations[ovnNodeL3GatewayConfig]
+}
+
 // ParseNodeChassisIDAnnotation returns the node's ovnNodeChassisID annotation
 func ParseNodeChassisIDAnnotation(node *kapi.Node) (string, error) {
 	chassisID, ok := node.Annotations[ovnNodeChassisID]

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -333,6 +333,74 @@ func TestParseNodeL3GatewayAnnotation(t *testing.T) {
 	}
 }
 
+func TestNodeL3GatewayAnnotationChanged(t *testing.T) {
+	tests := []struct {
+		desc    string
+		oldNode *v1.Node
+		newNode *v1.Node
+		result  bool
+	}{
+		{
+			desc: "true: annotation changed",
+			oldNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			newNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.254.33.2/24", "next-hop":"169.254.33.1"}}`,
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			desc: "true: annotation's node IP field changed",
+			newNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.254.33.3/24", "next-hop":"169.254.33.1"}}`,
+					},
+				},
+			},
+			oldNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.254.33.2/24", "next-hop":"169.254.33.1"}}`,
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			desc: "false: annotation didn't change",
+			newNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.254.33.2/24", "next-hop":"169.254.33.1"}}`,
+					},
+				},
+			},
+			oldNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"169.254.33.2/24", "next-hop":"169.254.33.1"}}`,
+					},
+				},
+			},
+			result: false,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			result := NodeL3GatewayAnnotationChanged(tc.oldNode, tc.newNode)
+			assert.Equal(t, tc.result, result)
+		})
+	}
+}
+
 func TestParseNodeManagementPortMACAddress(t *testing.T) {
 	tests := []struct {
 		desc        string

--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 )
@@ -109,6 +110,10 @@ func parseSubnetAnnotation(node *kapi.Node, annotationName string) ([]*net.IPNet
 	}
 
 	return ipnets, nil
+}
+
+func NodeSubnetAnnotationChanged(oldNode, newNode *v1.Node) bool {
+	return oldNode.Annotations[ovnNodeSubnets] != newNode.Annotations[ovnNodeSubnets]
 }
 
 // CreateNodeHostSubnetAnnotation creates a "k8s.ovn.org/node-subnets" annotation,

--- a/go-controller/pkg/util/subnet_annotations_unit_test.go
+++ b/go-controller/pkg/util/subnet_annotations_unit_test.go
@@ -177,6 +177,74 @@ func TestParseSubnetAnnotation(t *testing.T) {
 	}
 }
 
+func TestNodeSubnetAnnotationChanged(t *testing.T) {
+	tests := []struct {
+		desc    string
+		oldNode *v1.Node
+		newNode *v1.Node
+		result  bool
+	}{
+		{
+			desc: "true: annotation changed",
+			oldNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			newNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.0.0/24\"}",
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			desc: "true: annotation's value changed",
+			newNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.0.0/24\"}",
+					},
+				},
+			},
+			oldNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.2.0/24\"}",
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			desc: "false: annotation didn't change",
+			newNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.0.0/24\"}",
+					},
+				},
+			},
+			oldNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/node-subnets": "{\"default\":\"10.244.0.0/24\"}",
+					},
+				},
+			},
+			result: false,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			result := NodeSubnetAnnotationChanged(tc.oldNode, tc.newNode)
+			assert.Equal(t, tc.result, result)
+		})
+	}
+}
+
 func TestCreateNodeHostSubnetAnnotation(t *testing.T) {
 	tests := []struct {
 		desc            string


### PR DESCRIPTION
**- What this PR does and why is it needed**

Currently any update to any of the node fields triggers an `updateNode` from the `updateFunc` of
node watcher. For each node, every 5mins there is `updateNode` being triggered since something
seems to be updating the node object. In reality `updateNode` only needs to be called if node.Name
or switchName or gwRouterName or hostSubnet annotation or L3Gateway annotation change (which
are rare changes) and it has no effect on other unrelated field changes. Most of the times we
end up parsing annotations and computing ip address from the annotations only to realize the
actual node fields are the same as in the cache and we return without taking any action.

In large prod clusters, even if its event-triggered it will cause a lot of noise/unnecessary computations because a lot
of node fields might be getting updated that have no relation to what `updateNode` is actually doing.

So let's trip-off earlier on and call the function only when needed.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>


**- How to verify it**
Currently we can see updates triggered every 5 mins for each node in the cluster:
```
I1025 18:29:52.542370      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-control-plane
I1025 18:30:02.622199      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-worker
I1025 18:31:53.260599      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-worker4
I1025 18:32:13.362027      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-worker2
I1025 18:34:24.255786      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-worker3
I1025 18:34:54.466068      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-control-plane
I1025 18:35:04.529574      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-worker
I1025 18:36:55.269308      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-worker4
I1025 18:37:15.377136      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-worker2
I1025 18:39:26.163359      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-worker3
I1025 18:39:56.348335      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-control-plane
I1025 18:40:06.401712      51 node_tracker.go:162] Processing possible switch / router updates for node ovn-worker
```
However note that no actual change is getting processed in the cache (We don't hit https://github.com/ovn-org/ovn-kubernetes/blob/42639ad6e644dad0dd84cc3ba641b480156b4bc9/go-controller/pkg/ovn/controller/services/node_tracker.go#L143). The `updateNode` function was mostly designed for add and delete node events to syncServices LBs.

With the PR, we should trigger updates only when one of the necessary fields have changed in the object.