### PR TITLE
CI/CD: Ajust e2e timeouts in github action workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,8 @@ jobs:
     name: e2e
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # 30 mins for kind, 150 mins for control-plane tests, 10 minutes for all other steps
+    timeout-minutes: 190
     strategy:
       fail-fast: false
       matrix:
@@ -328,10 +329,14 @@ jobs:
       run: |
         docker load --input image-pr.tar
     - name: kind setup
+      timeout-minutes: 30
       run: |
         export OVN_IMAGE="ovn-daemonset-f:pr"
         make -C test install-kind
     - name: Run Tests
+      # e2e tests take less than 30 minutes normally, 60 should be more than enough
+      # set 2 1/2 hours for control-plane tests as these might take a while
+      timeout-minutes: ${{ matrix.target == 'control-plane' && 150 || 60 }}
       run: |
         make -C test ${{ matrix.target }}
     - name: Upload Junit Reports


### PR DESCRIPTION
Adjust the timeouts for e2e tests. Cap kind deployment and kubernetes e2e
tests to 30 and 60 minutes respectively. Allow control-plane tests to
run for up to 150 minutes. Add some buffer for all other steps.

Fixes #2607

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->