### PR TITLE
Metric: Egress firewall count

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -183,6 +183,13 @@ var metricIPsecEnabled = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help:      "Specifies whether IPSec is enabled for this cluster(1) or not enabled for this cluster(0)",
 })
 
+var metricEgressFirewallCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "num_egress_firewalls",
+	Help:      "The number of egress firewall policies",
+})
+
 var registerMasterMetricsOnce sync.Once
 var startMasterMetricUpdaterOnce sync.Once
 
@@ -260,6 +267,7 @@ func RegisterMasterMetrics(nbClient, sbClient goovn.Client) {
 		prometheus.MustRegister(metricEgressIPCount)
 		prometheus.MustRegister(metricEgressFirewallRuleCount)
 		prometheus.MustRegister(metricIPsecEnabled)
+		prometheus.MustRegister(metricEgressFirewallCount)
 		registerWorkqueueMetrics(MetricOvnkubeNamespace, MetricOvnkubeSubsystemMaster)
 	})
 }
@@ -384,4 +392,14 @@ func ipsecMetricHandler(table string, model model.Model) {
 	} else {
 		metricIPsecEnabled.Set(0)
 	}
+}
+
+// IncrementEgressFirewallCount increments the number of Egress firewalls
+func IncrementEgressFirewallCount() {
+	metricEgressFirewallCount.Inc()
+}
+
+// DecrementEgressFirewallCount decrements the number of Egress firewalls
+func DecrementEgressFirewallCount() {
+	metricEgressFirewallCount.Dec()
 }

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -163,14 +163,14 @@ var metricV6AllocatedHostSubnetCount = prometheus.NewGauge(prometheus.GaugeOpts{
 })
 
 var metricEgressIPCount = prometheus.NewGauge(prometheus.GaugeOpts{
-	Namespace: MetricOvnNamespace,
+	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "num_egress_ips",
 	Help:      "The number of defined egress IP addresses",
 })
 
 var metricEgressFirewallRuleCount = prometheus.NewGauge(prometheus.GaugeOpts{
-	Namespace: MetricOvnNamespace,
+	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
 	Name:      "num_egress_firewall_rules",
 	Help:      "The number of egress firewall rules defined"},

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -761,6 +761,7 @@ func (oc *Controller) WatchEgressFirewall() *factory.Handler {
 				klog.Error(err)
 			}
 			metrics.UpdateEgressFirewallRuleCount(float64(len(egressFirewall.Spec.Egress)))
+			metrics.IncrementEgressFirewallCount()
 		},
 		UpdateFunc: func(old, newer interface{}) {
 			newEgressFirewall := newer.(*egressfirewall.EgressFirewall).DeepCopy()
@@ -801,6 +802,7 @@ func (oc *Controller) WatchEgressFirewall() *factory.Handler {
 				klog.Errorf("Failed to commit db changes for egressFirewall in namespace %s stdout: %q, stderr: %q, err: %+v", egressFirewall.Namespace, stdout, stderr, err)
 			}
 			metrics.UpdateEgressFirewallRuleCount(float64(-len(egressFirewall.Spec.Egress)))
+			metrics.DecrementEgressFirewallCount()
 		},
 	}, oc.syncEgressFirewall)
 }


### PR DESCRIPTION

**- What this PR does and why is it needed**
Even though we can have only one egress firewall per namespace, we would like to know what proportion of namespaces have an egress firewall.


**- How to verify it**
1. Configure a EgressFirewall CR:
```
apiVersion: k8s.ovn.org/v1
kind: EgressFirewall
metadata:
  name: default
spec:
  egress:
  - to:
      cidrSelector: 1.1.1.3
    type: Allow
  - to:
      cidrSelector: 0.0.0.0/2
    type: Allow
```
2. Curl the /metrics endpoint (:9409 w/ KinD) and grep for `egress_firewalls`. It should show an integer of one.
3. Delete the CR created in step one.
4. Curl the /metrics endpoint (:9409 w/ KinD) and grep for `egress_firewalls`. It should show an integer of 0. 


**- Description for the changelog**
<!--
None
-->