### PR TITLE
egressgw: only return unique elements from getRouteInfosForGateway()

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -101,25 +101,22 @@ func (oc *Controller) getRouteInfosForGateway(gatewayIP, namespace string) []*ex
 	oc.exGWCacheMutex.RLock()
 	defer oc.exGWCacheMutex.RUnlock()
 
-	routes := make([]*externalRouteInfo, 0)
+	routeInfos := make([]*externalRouteInfo, 0)
 	for namespacedName, routeInfo := range oc.externalGWCache {
 		if namespacedName.Namespace != namespace {
 			continue
 		}
 
-		routeFound := false
 		for _, route := range routeInfo.podExternalRoutes {
 			if _, ok := route[gatewayIP]; ok {
-				routes = append(routes, routeInfo)
-				routeFound = true
+				routeInfo.Lock()
+				routeInfos = append(routeInfos, routeInfo)
+				break
 			}
-		}
-		if routeFound {
-			routeInfo.Lock()
 		}
 	}
 
-	return routes
+	return routeInfos
 }
 
 // getRouteInfosForNamespace returns all routeInfos locked for a specific namespace


### PR DESCRIPTION
If a single routeInfo had multiple external routes that matched the
same gateway IP, that routeInfo could be added to the returned list
multiple times. It was only locked once, however.

But deletePodGWRoutesForNamespace() iterates over the list returned
by getRouteInfosForGateway() and calls Unlock() on each element in
the list, which can create an unbalanced locking situation (multiple
Unlocks for a single Lock) in the above situation where a routeInfo
has multiple external routes matching the same gatewayIP.

@trozet @alexanderConstantinescu 