### PR TITLE
Remove redundant LRP removal in upgrade path

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -779,9 +779,6 @@ func (oc *Controller) addPolicyBasedRoutes(nodeName, mgmtPortIP string, hostIfAd
 		if err := oc.syncPolicyBasedRoutes(nodeName, sets.NewString(matchStr), types.InterNodePolicyPriority, natSubnetNextHop); err != nil {
 			return fmt.Errorf("unable to sync inter-node policies, err: %v", err)
 		}
-	} else if config.Gateway.Mode == config.GatewayModeShared {
-		// if we are upgrading from Local to Shared gateway mode, we need to ensure the inter-node LRP is removed
-		oc.removeLRPolicies(nodeName, []string{types.InterNodePolicyPriority})
 	}
 
 	return nil


### PR DESCRIPTION
Upon upgrade to new SGW, we already call delPbrAndNatRules
which is removing the 1003 & 1005 policies.

We don't need to do it again everytime in addPolicyBasedRoutes.

We are removing 1003 in two places to safe guard upgrades to new SGW mode.

1) https://github.com/ovn-org/ovn-kubernetes/blob/42639ad6e644dad0dd84cc3ba641b480156b4bc9/go-controller/pkg/ovn/gateway_cleanup.go#L116
2) https://github.com/ovn-org/ovn-kubernetes/blob/42639ad6e644dad0dd84cc3ba641b480156b4bc9/go-controller/pkg/ovn/gateway_init.go#L784

Let's just use the proper cleanup path for upgrades where we are removing 1005 & 1003. Anyhow doesn't make sense we are simply removing only 1003 (and not removing 1005) in `addPolicyBasedRoutes` path.