### PR TITLE
Bump libovsdb

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
-	github.com/ovn-org/libovsdb v0.6.1-0.20211029162056-8b93f8d269af
+	github.com/ovn-org/libovsdb v0.6.1-0.20211108195133-7e2b490befcf
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/afero v1.4.1

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -347,8 +347,10 @@ github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
-github.com/ovn-org/libovsdb v0.6.1-0.20211029162056-8b93f8d269af h1:Ig1d6eEfbAWP22Ec+J2OaPxMrG6OD/8xzGvCJnsGk44=
-github.com/ovn-org/libovsdb v0.6.1-0.20211029162056-8b93f8d269af/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
+github.com/ovn-org/libovsdb v0.6.1-0.20211106093420-bd92edf0e1d3 h1:gmaXMES+2xSyj1FTG82KWxf9SktQsGagufSR2lN1YIE=
+github.com/ovn-org/libovsdb v0.6.1-0.20211106093420-bd92edf0e1d3/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
+github.com/ovn-org/libovsdb v0.6.1-0.20211108195133-7e2b490befcf h1:8PzxLqSpuMPvspjoGbwlkxa9DYd32HHPJEcl2WirFBk=
+github.com/ovn-org/libovsdb v0.6.1-0.20211108195133-7e2b490befcf/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -301,7 +301,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(isEgressAssignableNode(node2.Name)).Should(gomega.BeFalse())
 
 				lsp := &nbdb.LogicalSwitchPort{Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name}
-				fakeOvn.controller.nbClient.Get(lsp)
+				fakeOvn.controller.nbClient.Get(context.Background(), lsp)
 				gomega.Eventually(lsp.Options["nat-addresses"]).Should(gomega.Equal("router"))
 
 				fakeOvn.controller.WatchEgressIP()
@@ -538,7 +538,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(isEgressAssignableNode(node2.Name)).Should(gomega.BeFalse())
 
 				lsp := &nbdb.LogicalSwitchPort{Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name}
-				fakeOvn.controller.nbClient.Get(lsp)
+				fakeOvn.controller.nbClient.Get(context.Background(), lsp)
 				gomega.Eventually(lsp.Options["nat-addresses"]).Should(gomega.Equal("router"))
 
 				fakeOvn.controller.WatchEgressIP()

--- a/go-controller/pkg/ovn/gateway/gateway.go
+++ b/go-controller/pkg/ovn/gateway/gateway.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"context"
 	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"strings"
 
 	"github.com/ovn-org/libovsdb/client"
@@ -23,9 +25,11 @@ var (
 // GetOvnGateways return all created gateways.
 func GetOvnGateways(nbClient client.Client) ([]string, error) {
 	logicalRouterRes := []nbdb.LogicalRouter{}
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
 	if err := nbClient.WhereCache(func(lr *nbdb.LogicalRouter) bool {
 		return lr.Options["chassis"] != "null"
-	}).List(&logicalRouterRes); err != nil {
+	}).List(ctx, &logicalRouterRes); err != nil {
 		return nil, err
 	}
 	result := []string{}
@@ -38,10 +42,12 @@ func GetOvnGateways(nbClient client.Client) ([]string, error) {
 // GetGatewayPhysicalIP return gateway physical IP
 func GetGatewayPhysicalIP(nbClient client.Client, gatewayRouter string) (string, error) {
 	logicalRouterRes := []nbdb.LogicalRouter{}
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
 	if err := nbClient.WhereCache(func(lr *nbdb.LogicalRouter) bool {
 		physicalIP, exists := lr.ExternalIDs["physical_ip"]
 		return lr.Name == gatewayRouter && exists && physicalIP != ""
-	}).List(&logicalRouterRes); err != nil {
+	}).List(ctx, &logicalRouterRes); err != nil {
 		return "", errors.Wrapf(err, "error to obtain physical IP on router %s, err: %v", gatewayRouter, err)
 	}
 	if len(logicalRouterRes) == 0 {
@@ -53,10 +59,12 @@ func GetGatewayPhysicalIP(nbClient client.Client, gatewayRouter string) (string,
 // GetGatewayPhysicalIPs return gateway physical IPs
 func GetGatewayPhysicalIPs(nbClient client.Client, gatewayRouter string) ([]string, error) {
 	logicalRouterRes := []nbdb.LogicalRouter{}
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
 	if err := nbClient.WhereCache(func(lr *nbdb.LogicalRouter) bool {
 		physicalIPs, exists := lr.ExternalIDs["physical_ips"]
 		return lr.Name == gatewayRouter && exists && physicalIPs != ""
-	}).List(&logicalRouterRes); err != nil {
+	}).List(ctx, &logicalRouterRes); err != nil {
 		return nil, errors.Wrapf(err, "error to obtain physical IP on router %s, err: %v", gatewayRouter, err)
 	}
 	if len(logicalRouterRes) == 1 {

--- a/go-controller/pkg/ovn/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/ovn/libovsdbops/loadbalancer.go
@@ -1,7 +1,9 @@
 package libovsdbops
 
 import (
+	"context"
 	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
@@ -16,10 +18,12 @@ func findLoadBalancer(nbClient libovsdbclient.Client, lb *nbdb.LoadBalancer) err
 		return nil
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
 	lbs := []nbdb.LoadBalancer{}
 	err := nbClient.WhereCache(func(item *nbdb.LoadBalancer) bool {
 		return item.Name == lb.Name
-	}).List(&lbs)
+	}).List(ctx, &lbs)
 	if err != nil {
 		return fmt.Errorf("can't find load balancer %+v: %v", *lb, err)
 	}
@@ -231,7 +235,9 @@ func DeleteLoadBalancers(nbClient libovsdbclient.Client, lbs []*nbdb.LoadBalance
 
 func ListLoadBalancers(nbClient libovsdbclient.Client) ([]nbdb.LoadBalancer, error) {
 	lbs := &[]nbdb.LoadBalancer{}
-	err := nbClient.List(lbs)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	err := nbClient.List(ctx, lbs)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/ovn/libovsdbops/portgroup.go
+++ b/go-controller/pkg/ovn/libovsdbops/portgroup.go
@@ -1,9 +1,11 @@
 package libovsdbops
 
 import (
+	"context"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 )
@@ -17,8 +19,9 @@ func findPortGroup(nbClient libovsdbclient.Client, pg *nbdb.PortGroup) error {
 	searched := &nbdb.PortGroup{
 		Name: pg.Name,
 	}
-
-	err := nbClient.Get(searched)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	err := nbClient.Get(ctx, searched)
 	if err != nil {
 		pg.UUID = searched.UUID
 	}

--- a/go-controller/pkg/ovn/libovsdbops/switch.go
+++ b/go-controller/pkg/ovn/libovsdbops/switch.go
@@ -1,6 +1,7 @@
 package libovsdbops
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -18,10 +19,12 @@ func findSwitch(nbClient libovsdbclient.Client, lswitch *nbdb.LogicalSwitch) err
 		return nil
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
 	switches := []nbdb.LogicalSwitch{}
 	err := nbClient.WhereCache(func(item *nbdb.LogicalSwitch) bool {
 		return item.Name == lswitch.Name
-	}).List(&switches)
+	}).List(ctx, &switches)
 	if err != nil {
 		return fmt.Errorf("can't find switch %+v: %v", *lswitch, err)
 	}
@@ -41,7 +44,9 @@ func findSwitch(nbClient libovsdbclient.Client, lswitch *nbdb.LogicalSwitch) err
 // findSwitches returns all the current logicalSwitches
 func findSwitches(nbClient libovsdbclient.Client) ([]nbdb.LogicalSwitch, error) {
 	switches := []nbdb.LogicalSwitch{}
-	err := nbClient.List(&switches)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	err := nbClient.List(ctx, &switches)
 	if err != nil {
 		return nil, fmt.Errorf("can't find Locial Switches err: %v", err)
 	}
@@ -56,7 +61,9 @@ func findSwitches(nbClient libovsdbclient.Client) ([]nbdb.LogicalSwitch, error) 
 // findSwitchesByPredicate Looks up switches in the cache based on the lookup function
 func findSwitchesByPredicate(nbClient libovsdbclient.Client, lookupFunction func(item *nbdb.LogicalSwitch) bool) ([]nbdb.LogicalSwitch, error) {
 	switches := []nbdb.LogicalSwitch{}
-	err := nbClient.WhereCache(lookupFunction).List(&switches)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	err := nbClient.WhereCache(lookupFunction).List(ctx, &switches)
 	if err != nil {
 		return nil, fmt.Errorf("can't find switches: %v", err)
 	}
@@ -160,9 +167,11 @@ func RemoveLoadBalancersFromSwitchOps(nbClient libovsdbclient.Client, ops []libo
 
 func ListSwitchesWithLoadBalancers(nbClient libovsdbclient.Client) ([]nbdb.LogicalSwitch, error) {
 	switches := &[]nbdb.LogicalSwitch{}
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
 	err := nbClient.WhereCache(func(item *nbdb.LogicalSwitch) bool {
 		return item.LoadBalancer != nil
-	}).List(switches)
+	}).List(ctx, switches)
 	return *switches, err
 }
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -434,9 +434,11 @@ func (oc *Controller) ovnTopologyCleanup() error {
 func (oc *Controller) determineOVNTopoVersionFromOVN() (int, error) {
 	ver := 0
 	logicalRouterRes := []nbdb.LogicalRouter{}
+	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+	defer cancel()
 	if err := oc.nbClient.WhereCache(func(lr *nbdb.LogicalRouter) bool {
 		return lr.Name == ovntypes.OVNClusterRouter
-	}).List(&logicalRouterRes); err != nil {
+	}).List(ctx, &logicalRouterRes); err != nil {
 		return ver, fmt.Errorf("failed in retrieving %s to determine the current version of OVN logical topology: "+
 			"error: %v", ovntypes.OVNClusterRouter, err)
 	}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -1,7 +1,9 @@
 package ovn
 
 import (
+	"context"
 	"fmt"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"net"
 	"time"
 
@@ -48,7 +50,9 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	// in order to minimize the number of database transactions build a map of all ports keyed by UUID
 	portCache := make(map[string]nbdb.LogicalSwitchPort)
 	lspList := []nbdb.LogicalSwitchPort{}
-	err := oc.nbClient.List(&lspList)
+	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+	defer cancel()
+	err := oc.nbClient.List(ctx, &lspList)
 	if err != nil {
 		klog.Errorf("Cannot sync pods, cannot retrieve list of logical switch ports (%+v)", err)
 		return
@@ -279,12 +283,14 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	lspExist := false
 	needsIP := true
 
+	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+	defer cancel()
 	// Check if the pod's logical switch port already exists. If it
 	// does don't re-add the port to OVN as this will change its
 	// UUID and and the port cache, address sets, and port groups
 	// will still have the old UUID.
 	getLSP := &nbdb.LogicalSwitchPort{Name: portName}
-	err = oc.nbClient.Get(getLSP)
+	err = oc.nbClient.Get(ctx, getLSP)
 	if err != nil && err != libovsdbclient.ErrNotFound {
 		return fmt.Errorf("unable to get the lsp: %s from the nbdb: %s", portName, err)
 	}
@@ -605,7 +611,9 @@ func ovnNBLSPDel(client libovsdbclient.Client, logicalPort, logicalSwitch string
 	}
 
 	lsp := &nbdb.LogicalSwitchPort{Name: logicalPort}
-	err = client.Get(lsp)
+	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+	defer cancel()
+	err = client.Get(ctx, lsp)
 	if err != nil {
 		return fmt.Errorf("cannot delete logical switch port %s failed retrieving the object %v", logicalPort, err)
 	}
@@ -634,10 +642,12 @@ func ovnNBLSPDel(client libovsdbclient.Client, logicalPort, logicalSwitch string
 
 func findLogicalSwitch(nbClient libovsdbclient.Client, logicalSwitchName string) (*nbdb.LogicalSwitch, error) {
 	logicalSwitches := []nbdb.LogicalSwitch{}
+	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+	defer cancel()
 	err := nbClient.WhereCache(
 		func(ls *nbdb.LogicalSwitch) bool {
 			return ls.Name == logicalSwitchName
-		}).List(&logicalSwitches)
+		}).List(ctx, &logicalSwitches)
 
 	if err != nil {
 		return nil, fmt.Errorf("error finding logical switch %s: %v", logicalSwitchName, err)

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -1,9 +1,11 @@
 package util
 
 import (
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"math/big"
 	"net"
 	"strconv"
@@ -36,7 +38,9 @@ func intToIP(i *big.Int) net.IP {
 // GetPortAddresses returns the MAC and IPs of the given logical switch port
 func GetPortAddresses(portName string, nbClient client.Client) (net.HardwareAddr, []net.IP, error) {
 	lsp := &nbdb.LogicalSwitchPort{Name: portName}
-	err := nbClient.Get(lsp)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	err := nbClient.Get(ctx, lsp)
 	if err != nil {
 		if err == client.ErrNotFound {
 			return nil, nil, nil
@@ -78,7 +82,9 @@ func GetPortAddresses(portName string, nbClient client.Client) (net.HardwareAddr
 // GetLRPAddrs returns the addresses for the given logical router port
 func GetLRPAddrs(nbClient client.Client, portName string) ([]*net.IPNet, error) {
 	lrp := nbdb.LogicalRouterPort{Name: portName}
-	err := nbClient.Get(&lrp)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	err := nbClient.Get(ctx, &lrp)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find router port: %s, err: %v", portName, err)
 	}

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"hash/fnv"
 	"net"
@@ -247,7 +248,9 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 	haveManagementPort := true
 	haveHybridOverlayPort := true
 	// Only Query The cache for mp0 and HO LSPs
-	if err := nbClient.Get(managmentPort); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	if err := nbClient.Get(ctx, managmentPort); err != nil {
 		if err != libovsdbclient.ErrNotFound {
 			return fmt.Errorf("failed to get management port for node %s error: %v", nodeName, err)
 		}
@@ -255,7 +258,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 		haveManagementPort = false
 	}
 
-	if err := nbClient.Get(HOPort); err != nil {
+	if err := nbClient.Get(ctx, HOPort); err != nil {
 		if err != libovsdbclient.ErrNotFound {
 			return fmt.Errorf("failed to get hybrid overlay port for node %s error: %v", nodeName, err)
 		}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
@@ -285,7 +285,12 @@ func (r *RowCache) Delete(uuid string) error {
 		if err != nil {
 			return err
 		}
-		delete(r.indexes[index], oldVal)
+		// only remove the index if it is pointing to this uuid
+		// otherwise we can cause a consistency issue if we've processed
+		// updates out of order
+		if r.indexes[index][oldVal] == uuid {
+			delete(r.indexes[index], oldVal)
+		}
 	}
 	delete(r.cache, uuid)
 	return nil

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/options.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/options.go
@@ -96,8 +96,10 @@ func WithLeaderOnly(leaderOnly bool) Option {
 
 // WithReconnect tells the client to automatically reconnect when
 // disconnected. The timeout is used to construct the context on
-// each call to Connect, while backoff dicates the backoff
-// algorithm to use
+// each call to Connect, while backoff dictates the backoff
+// algorithm to use. Using WithReconnect implies that
+// requested transactions will block until the client has fully reconnected,
+// rather than immediately returning an error if there is no connection.
 func WithReconnect(timeout time.Duration, backoff backoff.BackOff) Option {
 	return func(o *options) error {
 		o.reconnect = true

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -170,7 +170,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/ovn-org/libovsdb v0.6.1-0.20211029162056-8b93f8d269af
+# github.com/ovn-org/libovsdb v0.6.1-0.20211108195133-7e2b490befcf
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
 github.com/ovn-org/libovsdb/mapper


### PR DESCRIPTION
Includes fixes for upgrade issues found downstream. List and Get
operations now require a context to be passed. If the libovsdb client is
disconnected, it will attempt to reconnect and refresh the cache before
reporting the result back to the user.

Signed-off-by: Tim Rozet <trozet@redhat.com>

