### PR TITLE
Libovsdb fixes for lgw upgrades

### DIFF
--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -351,6 +351,7 @@ func (oc *Controller) cleanupDGP(nodes *kapi.NodeList) error {
 	opModels := []libovsdbops.OperationModel{
 		{
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.NodeLocalSwitch },
+			ExistingResult: &[]nbdb.LogicalSwitch{},
 		},
 	}
 	if err := oc.modelClient.Delete(opModels...); err != nil {

--- a/go-controller/pkg/ovn/libovsdbops/model.go
+++ b/go-controller/pkg/ovn/libovsdbops/model.go
@@ -39,6 +39,8 @@ func getUUID(model model.Model) string {
 		return t.UUID
 	case *sbdb.Chassis:
 		return t.UUID
+	case *sbdb.MACBinding:
+		return t.UUID
 	default:
 		panic(fmt.Sprintf("getUUID: unknown model %T", t))
 	}
@@ -73,6 +75,8 @@ func setUUID(model model.Model, uuid string) {
 	case *nbdb.PortGroup:
 		t.UUID = uuid
 	case *sbdb.Chassis:
+		t.UUID = uuid
+	case *sbdb.MACBinding:
 		t.UUID = uuid
 	default:
 		panic(fmt.Sprintf("setUUID: unknown model %T", t))
@@ -145,6 +149,11 @@ func copyIndexes(model model.Model) model.Model {
 			UUID: t.UUID,
 			Name: t.Name,
 		}
+	case *sbdb.MACBinding:
+		return &sbdb.MACBinding{
+			UUID: t.UUID,
+			IP:   t.IP,
+		}
 	default:
 		panic(fmt.Sprintf("copyIndexes: unknown model %T", t))
 	}
@@ -180,6 +189,8 @@ func getListFromModel(model model.Model) interface{} {
 		return &[]nbdb.PortGroup{}
 	case *sbdb.Chassis:
 		return &[]sbdb.Chassis{}
+	case *sbdb.MACBinding:
+		return t.UUID
 	default:
 		panic(fmt.Sprintf("getModelList: unknown model %T", t))
 	}

--- a/go-controller/pkg/ovn/libovsdbops/router.go
+++ b/go-controller/pkg/ovn/libovsdbops/router.go
@@ -200,9 +200,8 @@ func isEquivalentNAT(existing *nbdb.NAT, searched *nbdb.NAT) bool {
 		return false
 	}
 
-	// Allow externalIP to be empty if type is SNAT.
-	if (searched.ExternalIP != "" || searched.Type != nbdb.NATTypeSNAT) &&
-		searched.ExternalIP != existing.ExternalIP {
+	// Compre externalIP if its not empty.
+	if searched.ExternalIP != "" && searched.ExternalIP != existing.ExternalIP {
 		return false
 	}
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
This PR addresses three things that were broken in LGW upgrade path:

1. cleanupDGP: Add sbdb.MACBinding table to `getListfromModel`. If not, we will hit:
```
panic: getModelList: unknown model *sbdb.MACBinding

goroutine 106 [running]:
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops.getListFromModel(0x1a57c00, 0xc000abecd0, 0x1e05144, 0x0)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops/model.go:184 +0x5f7
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops.(*ModelClient).buildOps(0xc000b05430, 0xc000b05330, 0x0, 0xc000b05500, 0x1, 0x1, 0xc000abecd0, 0x50, 0x50, 0x1ce6b40, ...)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops/model_client.go:210 +0x8bb
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops.(*ModelClient).DeleteOps(0xc000b05430, 0xc000b05500, 0x1, 0x1, 0xc000b053a0, 0x40ff98, 0x50, 0x1ce6b40, 0x1aa0e01)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops/model_client.go:199 +0x85
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops.(*ModelClient).Delete(0xc000b05430, 0xc000b05500, 0x1, 0x1, 0x2, 0x2)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops/model_client.go:183 +0x4d
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).cleanupDGP(0xc000386c80, 0xc000272540, 0x0, 0x0)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway_cleanup.go:346 +0x288
```
2. cleanupDGP: Add `ExistingResult` to opModel during `node_local_switch` delete. If not, we will hit:
```
panic: reflect: call of reflect.Value.Type on zero Value

goroutine 117 [running]:
reflect.Value.Type(0x0, 0x0, 0x0, 0x8, 0xc00095b038)
	/usr/local/go/src/reflect/value.go:1908 +0x189
github.com/ovn-org/libovsdb/client.api.List(0xc0002d63c0, 0x2099f08, 0xc0009a0900, 0xc000d080f0, 0x0, 0x0, 0x20a8ef8, 0xc00007c900)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/vendor/github.com/ovn-org/libovsdb/client/api.go:101 +0x213
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops.(*ModelClient).buildOps(0xc000386ea0, 0xc00095b318, 0x0, 0xc00095b490, 0x1, 0x1, 0x1a87c20, 0xc000460f90, 0x2dd20e0, 0x0, ...)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops/model_client.go:216 +0x879
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops.(*ModelClient).DeleteOps(0xc000386ea0, 0xc00095b490, 0x1, 0x1, 0x0, 0xc0003fc820, 0x1, 0x1, 0x0)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops/model_client.go:199 +0x85
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops.(*ModelClient).Delete(0xc000386ea0, 0xc00095b490, 0x1, 0x1, 0x0, 0x0)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops/model_client.go:183 +0x4d
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).cleanupDGP(0xc000386c80, 0xc00020e000, 0x0, 0x0)
	/home/surya/go/src/github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway_cleanup.go:357 +0x38c
```
3. NAT: `isEquivalentNAT`: Allow EIP to be empty for DNAT_and_SNAT case. The conditional match is wrong, due to which the dnat_and_snat entries on ovn_cluster_router don't get removed.

4. Changing `k8s-ovn-topo-version` on `ovn_cluster_router`. Use `OnModelUpdate` instead of `OnModelMutate` since the latter doesn't change existing fields.

**- Special notes for reviewers**
These are mostly nit-fixes but do have upgrade impact and are blocking https://github.com/ovn-org/ovn-kubernetes/pull/2609. We don't detect these in CI since we are already past topology ver 3.


**- How to verify it**
Tested on KIND cluster.
