### PR TITLE
WIP: Update from core.Event to events.Events

### DIFF
--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -65,6 +65,7 @@ rules:
   - watch
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   - endpoints

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -243,7 +243,8 @@ func runOvnKube(ctx *cli.Context) error {
 		metrics.RegisterMasterBase()
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil,
-			libovsdbOvnNBClient, libovsdbOvnSBClient, util.EventRecorder(ovnClientset.KubeClient))
+			libovsdbOvnNBClient, libovsdbOvnSBClient, util.EventRecorder(ovnClientset.KubeClient,
+				"ovnkube-master", stopChan))
 		if err := ovnController.Start(master, wg, ctx.Context); err != nil {
 			return err
 		}
@@ -268,7 +269,8 @@ func runOvnKube(ctx *cli.Context) error {
 		// register ovnkube node specific prometheus metrics exported by the node
 		metrics.RegisterNodeMetrics()
 		start := time.Now()
-		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, stopChan, util.EventRecorder(ovnClientset.KubeClient))
+		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, stopChan, util.EventRecorder(ovnClientset.KubeClient,
+			"ovnkube-node", stopChan))
 		if err := n.Start(ctx.Context, wg); err != nil {
 			return err
 		}

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -400,8 +400,6 @@ github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mo
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366 h1:/llKlbXC7F6rqTkAl2GE//9GDR0iDsqJEFvvJ1kLJXg=
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366/go.mod h1:HJeHsH6mPyrrOVS/2j1zcztGAJG9ETKbqtlyohs84yY=
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
-github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4 h1:atUIOA34Cg9GVFn/8rmIsmnOIbi0D82x+xfhV2UuF1Q=
-github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/ovn-org/libovsdb v0.6.1-0.20220513144310-50ec17900991 h1:EsMLPWOIRgB9WFTt5+L99LaX4H1Nm6yL2S6zsx4TSzY=
 github.com/ovn-org/libovsdb v0.6.1-0.20220513144310-50ec17900991/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/go-controller/pkg/kube/healthcheck/healthcheck.go
+++ b/go-controller/pkg/kube/healthcheck/healthcheck.go
@@ -26,7 +26,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 // Server serves HTTP endpoints for each service name, with results
@@ -70,7 +70,7 @@ type HTTPServer interface {
 
 // NewServer allocates a new healthcheck server manager.  If either
 // of the injected arguments are nil, defaults will be used.
-func NewServer(hostname string, recorder record.EventRecorder, listener Listener, httpServerFactory HTTPServerFactory) Server {
+func NewServer(hostname string, recorder events.EventRecorder, listener Listener, httpServerFactory HTTPServerFactory) Server {
 	if listener == nil {
 		listener = stdNetListener{}
 	}
@@ -109,7 +109,7 @@ var _ HTTPServerFactory = stdHTTPServerFactory{}
 
 type server struct {
 	hostname    string
-	recorder    record.EventRecorder // can be nil
+	recorder    events.EventRecorder // can be nil
 	listener    Listener
 	httpFactory HTTPServerFactory
 
@@ -155,7 +155,7 @@ func (hcs *server) SyncServices(newServices map[types.NamespacedName]uint16) err
 						Namespace: nsn.Namespace,
 						Name:      nsn.Name,
 						UID:       types.UID(nsn.String()),
-					}, v1.EventTypeWarning, "FailedToStartServiceHealthcheck", msg)
+					}, nil, v1.EventTypeWarning, "FailedToStartServiceHealthcheck", "SyncService", msg)
 			}
 			klog.Error(msg)
 			continue

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -41,12 +41,12 @@ type OvnNode struct {
 	Kube         kube.Interface
 	watchFactory factory.NodeWatchFactory
 	stopChan     chan struct{}
-	recorder     record.EventRecorder
+	recorder     events.EventRecorder
 	gateway      Gateway
 }
 
 // NewNode creates a new controller for node management
-func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name string, stopChan chan struct{}, eventRecorder record.EventRecorder) *OvnNode {
+func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name string, stopChan chan struct{}, eventRecorder events.EventRecorder) *OvnNode {
 	return &OvnNode{
 		name:         name,
 		client:       kubeClient,

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 var fakeNodeName = "node"
@@ -21,7 +21,7 @@ type FakeOVNNode struct {
 	node       *OvnNode
 	watcher    factory.NodeWatchFactory
 	stopChan   chan struct{}
-	recorder   *record.FakeRecorder
+	recorder   *events.FakeRecorder
 	fakeClient *util.OVNClientset
 	fakeExec   *ovntest.FakeExec
 	wg         *sync.WaitGroup
@@ -33,7 +33,7 @@ func NewFakeOVNNode(fexec *ovntest.FakeExec) *FakeOVNNode {
 
 	return &FakeOVNNode{
 		fakeExec: fexec,
-		recorder: record.NewFakeRecorder(1),
+		recorder: events.NewFakeRecorder(1),
 		wg:       &sync.WaitGroup{},
 	}
 }

--- a/go-controller/pkg/node/port_claim_test.go
+++ b/go-controller/pkg/node/port_claim_test.go
@@ -9,9 +9,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
+
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -594,7 +595,7 @@ var _ = Describe("Node Operations", func() {
 				localAddrSet, err := getLocalAddrs()
 				Expect(err).ShouldNot(HaveOccurred())
 				lpm := localPortManager{
-					recorder:          record.NewFakeRecorder(10),
+					recorder:          events.NewFakeRecorder(10),
 					activeSocketsLock: sync.Mutex{},
 					localAddrSet:      localAddrSet,
 					portsMap:          make(map[utilnet.LocalPort]utilnet.Closeable),

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -47,6 +47,7 @@ func newControllerWithDBSetup(dbSetup libovsdbtest.TestSetup) (*serviceControlle
 		informerFactory.Core().V1().Services(),
 		informerFactory.Discovery().V1().EndpointSlices(),
 		informerFactory.Core().V1().Nodes(),
+		make(chan struct{}),
 	)
 	controller.servicesSynced = alwaysReady
 	controller.endpointSlicesSynced = alwaysReady

--- a/go-controller/pkg/ovn/controller/unidling/unidle_test.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle_test.go
@@ -13,7 +13,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,7 +40,7 @@ var _ = Describe("Unidling Controller", func() {
 
 	It("should respond to a controller event", func() {
 		client := fake.NewSimpleClientset()
-		recorder := record.NewFakeRecorder(10)
+		recorder := events.NewFakeRecorder(10)
 		informerFactory := informers.NewSharedInformerFactory(client, 0)
 		testSetup := libovsdbtest.TestSetup{
 			SBData: []libovsdbtest.TestData{

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -797,7 +797,8 @@ func (oc *Controller) executeCloudPrivateIPConfigOps(egressIPName string, ops ma
 					Kind: "EgressIP",
 					Name: egressIPName,
 				}
-				oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "CloudUpdateFailed", "egress IP: %s for object EgressIP: %s could not be updated, err: %v", egressIP, egressIPName, err)
+				oc.recorder.Eventf(&eIPRef, nil, kapi.EventTypeWarning, "CloudUpdateFailed", "ReconcileEgressIP",
+					"egress IP: %s for object EgressIP: %s could not be updated, err: %v", egressIP, egressIPName, err)
 				return fmt.Errorf("cloud update request failed for CloudPrivateIPConfig: %s, err: %v", cloudPrivateIPConfigName, err)
 			}
 			// toAdd is non-empty, this indicates an ADD
@@ -827,7 +828,8 @@ func (oc *Controller) executeCloudPrivateIPConfigOps(egressIPName string, ops ma
 					Kind: "EgressIP",
 					Name: egressIPName,
 				}
-				oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "CloudAssignmentFailed", "egress IP: %s for object EgressIP: %s could not be created, err: %v", egressIP, egressIPName, err)
+				oc.recorder.Eventf(&eIPRef, nil, kapi.EventTypeWarning, "CloudAssignmentFailed", "ReconcileEgressIP",
+					"egress IP: %s for object EgressIP: %s could not be created, err: %v", egressIP, egressIPName, err)
 				return fmt.Errorf("cloud add request failed for CloudPrivateIPConfig: %s, err: %v", cloudPrivateIPConfigName, err)
 			}
 			// toDelete is non-empty, this indicates an DELETE for which
@@ -841,7 +843,8 @@ func (oc *Controller) executeCloudPrivateIPConfigOps(egressIPName string, ops ma
 					Kind: "EgressIP",
 					Name: egressIPName,
 				}
-				oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "CloudDeletionFailed", "egress IP: %s for object EgressIP: %s could not be deleted, err: %v", egressIP, egressIPName, err)
+				oc.recorder.Eventf(&eIPRef, nil, kapi.EventTypeWarning, "CloudDeletionFailed", "ReconcileEgressIP",
+					"egress IP: %s for object EgressIP: %s could not be deleted, err: %v", egressIP, egressIPName, err)
 				return fmt.Errorf("cloud deletion request failed for CloudPrivateIPConfig: %s, err: %v", cloudPrivateIPConfigName, err)
 			}
 		}
@@ -858,7 +861,8 @@ func (oc *Controller) validateEgressIPSpec(name string, egressIPs []string) (set
 				Kind: "EgressIP",
 				Name: name,
 			}
-			oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "InvalidEgressIP", "egress IP: %s for object EgressIP: %s is not a valid IP address", egressIP, name)
+			oc.recorder.Eventf(&eIPRef, nil, kapi.EventTypeWarning, "InvalidEgressIP", "ReconcileEgressIP",
+				"egress IP: %s for object EgressIP: %s is not a valid IP address", egressIP, name)
 			return nil, fmt.Errorf("unable to parse provided EgressIP: %s, invalid", egressIP)
 		}
 		validatedEgressIPs.Insert(ip.String())
@@ -1413,7 +1417,8 @@ func (oc *Controller) assignEgressIPs(name string, egressIPs []string) []egressi
 			Kind: "EgressIP",
 			Name: name,
 		}
-		oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "NoMatchingNodeFound", "no assignable nodes for EgressIP: %s, please tag at least one node with label: %s", name, util.GetNodeEgressLabel())
+		oc.recorder.Eventf(&eIPRef, nil, kapi.EventTypeWarning, "NoMatchingNodeFound", "ReconcileEgressIP",
+			"no assignable nodes for EgressIP: %s, please tag at least one node with label: %s", name, util.GetNodeEgressLabel())
 		klog.Errorf("No assignable nodes found for EgressIP: %s and requested IPs: %v", name, egressIPs)
 		return assignments
 	}
@@ -1451,8 +1456,10 @@ func (oc *Controller) assignEgressIPs(name string, egressIPs []string) []egressi
 			}
 			oc.recorder.Eventf(
 				&eIPRef,
+				nil,
 				kapi.EventTypeWarning,
 				"UnsupportedRequest",
+				"ReconcileEgressIP",
 				"Egress IP: %v for object EgressIP: %s is the IP address of node: %s, this is unsupported", eIPC, name, node.name,
 			)
 			klog.Errorf("Egress IP: %v is the IP address of node: %s", eIPC, node.name)
@@ -1499,7 +1506,8 @@ func (oc *Controller) assignEgressIPs(name string, egressIPs []string) []egressi
 			Kind: "EgressIP",
 			Name: name,
 		}
-		oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "NoMatchingNodeFound", "No matching nodes found, which can host any of the egress IPs: %v for object EgressIP: %s", egressIPs, name)
+		oc.recorder.Eventf(&eIPRef, nil, kapi.EventTypeWarning, "NoMatchingNodeFound", "ReconcileEgressIP",
+			"No matching nodes found, which can host any of the egress IPs: %v for object EgressIP: %s", egressIPs, name)
 		klog.Errorf("No matching host found for EgressIP: %s", name)
 		return assignments
 	}
@@ -1508,7 +1516,8 @@ func (oc *Controller) assignEgressIPs(name string, egressIPs []string) []egressi
 			Kind: "EgressIP",
 			Name: name,
 		}
-		oc.recorder.Eventf(&eIPRef, kapi.EventTypeWarning, "UnassignedRequest", "Not all egress IPs for EgressIP: %s could be assigned, please tag more nodes", name)
+		oc.recorder.Eventf(&eIPRef, nil, kapi.EventTypeWarning, "UnassignedRequest", "ReconcileEgressIP",
+			"Not all egress IPs for EgressIP: %s could be assigned, please tag more nodes", name)
 	}
 	return assignments
 }

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -18,6 +18,7 @@ import (
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	utilnet "k8s.io/utils/net"
 )
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -70,8 +70,10 @@ func (oc *Controller) Start(identity string, wg *sync.WaitGroup, ctx context.Con
 		oc.client.CoreV1(),
 		nil,
 		resourcelock.ResourceLockConfig{
-			Identity:      identity,
-			EventRecorder: oc.recorder,
+			Identity: identity,
+			//ToDo: (martinkennelly) add back EventRecorder if EventRecorder interface is updated to events.Event
+			// from core.Event.
+			//EventRecorder: oc.recorder,
 		},
 	)
 	if err != nil {
@@ -1018,7 +1020,7 @@ func (oc *Controller) deleteStaleNodeChassis(node *kapi.Node) error {
 		}
 		if err = libovsdbops.DeleteChassisWithPredicate(oc.sbClient, p); err != nil {
 			// Send an event and Log on failure
-			oc.recorder.Eventf(node, kapi.EventTypeWarning, "ErrorMismatchChassis",
+			oc.recorder.Eventf(node, nil, kapi.EventTypeWarning, "ErrorMismatchChassis", "DeleteStaleNodeChassis",
 				"Node %s is now with a new chassis ID. Its stale chassis entry is still in the SBDB",
 				node.Name)
 			return fmt.Errorf("node %s is now with a new chassis ID. Its stale chassis entry is still in the SBDB", node.Name)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 // Please use following subnets for various networks that we have
@@ -982,7 +982,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
 				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+				events.NewFakeRecorder(0))
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 			clusterController.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
@@ -1183,7 +1183,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
 				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+				events.NewFakeRecorder(0))
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 			clusterController.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
@@ -1365,7 +1365,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
 				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+				events.NewFakeRecorder(0))
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 			clusterController.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
@@ -1599,7 +1599,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
 				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+				events.NewFakeRecorder(0))
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 
@@ -1898,7 +1898,7 @@ func TestController_allocateNodeSubnets(t *testing.T) {
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
 				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+				events.NewFakeRecorder(0))
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 
 			// configure the cluster allocators
@@ -1996,7 +1996,7 @@ func TestController_syncNodesRetriable(t *testing.T) {
 				addressset.NewFakeAddressSetFactory(),
 				nbClient,
 				sbClient,
-				record.NewFakeRecorder(0))
+				events.NewFakeRecorder(0))
 
 			controller.joinSwIPManager, err = lsm.NewJoinLogicalSwitchIPManager(nbClient, "", []string{})
 			if err != nil {

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -20,7 +20,7 @@ import (
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 const (
@@ -42,7 +42,7 @@ type FakeOVN struct {
 	controller   *Controller
 	stopChan     chan struct{}
 	asf          *addressset.FakeAddressSetFactory
-	fakeRecorder *record.FakeRecorder
+	fakeRecorder *events.FakeRecorder
 	nbClient     libovsdbclient.Client
 	sbClient     libovsdbclient.Client
 	dbSetup      libovsdbtest.TestSetup
@@ -53,7 +53,7 @@ type FakeOVN struct {
 func NewFakeOVN() *FakeOVN {
 	return &FakeOVN{
 		asf:          addressset.NewFakeAddressSetFactory(),
-		fakeRecorder: record.NewFakeRecorder(10),
+		fakeRecorder: events.NewFakeRecorder(10),
 		egressQoSWg:  &sync.WaitGroup{},
 	}
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -15,11 +15,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 
@@ -260,17 +259,11 @@ func PodScheduled(pod *kapi.Pod) bool {
 
 // EventRecorder returns an EventRecorder type that can be
 // used to post Events to different object's lifecycles.
-func EventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(klog.Infof)
-	eventBroadcaster.StartRecordingToSink(
-		&typedcorev1.EventSinkImpl{
-			Interface: kubeClient.CoreV1().Events(""),
-		})
-	recorder := eventBroadcaster.NewRecorder(
-		scheme.Scheme,
-		kapi.EventSource{Component: "controlplane"})
-	return recorder
+func EventRecorder(kubeClient kubernetes.Interface, reportingControllerName string, stopCh <-chan struct{}) events.EventRecorder {
+	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: kubeClient.EventsV1()})
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(stopCh)
+	return eventBroadcaster.NewRecorder(scheme.Scheme, reportingControllerName)
 }
 
 // UseEndpointSlices detect if Endpoints Slices are enabled in the cluster

--- a/go-controller/vendor/k8s.io/client-go/tools/events/OWNERS
+++ b/go-controller/vendor/k8s.io/client-go/tools/events/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-instrumentation-approvers
+- yastij
+- wojtek-t
+reviewers:
+- sig-instrumentation-reviewers
+- yastij
+- wojtek-t

--- a/go-controller/vendor/k8s.io/client-go/tools/events/doc.go
+++ b/go-controller/vendor/k8s.io/client-go/tools/events/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package events has all client logic for recording and reporting
+// "k8s.io/api/events/v1".Event events.
+package events // import "k8s.io/client-go/tools/events"

--- a/go-controller/vendor/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/go-controller/vendor/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -1,0 +1,398 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedv1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	typedeventsv1 "k8s.io/client-go/kubernetes/typed/events/v1"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/record/util"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+const (
+	maxTriesPerEvent = 12
+	finishTime       = 6 * time.Minute
+	refreshTime      = 30 * time.Minute
+	maxQueuedEvents  = 1000
+)
+
+var defaultSleepDuration = 10 * time.Second
+
+// TODO: validate impact of copying and investigate hashing
+type eventKey struct {
+	action              string
+	reason              string
+	reportingController string
+	regarding           corev1.ObjectReference
+	related             corev1.ObjectReference
+}
+
+type eventBroadcasterImpl struct {
+	*watch.Broadcaster
+	mu            sync.Mutex
+	eventCache    map[eventKey]*eventsv1.Event
+	sleepDuration time.Duration
+	sink          EventSink
+}
+
+// EventSinkImpl wraps EventsV1Interface to implement EventSink.
+// TODO: this makes it easier for testing purpose and masks the logic of performing API calls.
+// Note that rollbacking to raw clientset should also be transparent.
+type EventSinkImpl struct {
+	Interface typedeventsv1.EventsV1Interface
+}
+
+// Create takes the representation of a event and creates it. Returns the server's representation of the event, and an error, if there is any.
+func (e *EventSinkImpl) Create(event *eventsv1.Event) (*eventsv1.Event, error) {
+	if event.Namespace == "" {
+		return nil, fmt.Errorf("can't create an event with empty namespace")
+	}
+	return e.Interface.Events(event.Namespace).Create(context.TODO(), event, metav1.CreateOptions{})
+}
+
+// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+func (e *EventSinkImpl) Update(event *eventsv1.Event) (*eventsv1.Event, error) {
+	if event.Namespace == "" {
+		return nil, fmt.Errorf("can't update an event with empty namespace")
+	}
+	return e.Interface.Events(event.Namespace).Update(context.TODO(), event, metav1.UpdateOptions{})
+}
+
+// Patch applies the patch and returns the patched event, and an error, if there is any.
+func (e *EventSinkImpl) Patch(event *eventsv1.Event, data []byte) (*eventsv1.Event, error) {
+	if event.Namespace == "" {
+		return nil, fmt.Errorf("can't patch an event with empty namespace")
+	}
+	return e.Interface.Events(event.Namespace).Patch(context.TODO(), event.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+}
+
+// NewBroadcaster Creates a new event broadcaster.
+func NewBroadcaster(sink EventSink) EventBroadcaster {
+	return newBroadcaster(sink, defaultSleepDuration, map[eventKey]*eventsv1.Event{})
+}
+
+// NewBroadcasterForTest Creates a new event broadcaster for test purposes.
+func newBroadcaster(sink EventSink, sleepDuration time.Duration, eventCache map[eventKey]*eventsv1.Event) EventBroadcaster {
+	return &eventBroadcasterImpl{
+		Broadcaster:   watch.NewBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
+		eventCache:    eventCache,
+		sleepDuration: sleepDuration,
+		sink:          sink,
+	}
+}
+
+func (e *eventBroadcasterImpl) Shutdown() {
+	e.Broadcaster.Shutdown()
+}
+
+// refreshExistingEventSeries refresh events TTL
+func (e *eventBroadcasterImpl) refreshExistingEventSeries() {
+	// TODO: Investigate whether lock contention won't be a problem
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for isomorphicKey, event := range e.eventCache {
+		if event.Series != nil {
+			if recordedEvent, retry := recordEvent(e.sink, event); !retry {
+				if recordedEvent != nil {
+					e.eventCache[isomorphicKey] = recordedEvent
+				}
+			}
+		}
+	}
+}
+
+// finishSeries checks if a series has ended and either:
+// - write final count to the apiserver
+// - delete a singleton event (i.e. series field is nil) from the cache
+func (e *eventBroadcasterImpl) finishSeries() {
+	// TODO: Investigate whether lock contention won't be a problem
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for isomorphicKey, event := range e.eventCache {
+		eventSerie := event.Series
+		if eventSerie != nil {
+			if eventSerie.LastObservedTime.Time.Before(time.Now().Add(-finishTime)) {
+				if _, retry := recordEvent(e.sink, event); !retry {
+					delete(e.eventCache, isomorphicKey)
+				}
+			}
+		} else if event.EventTime.Time.Before(time.Now().Add(-finishTime)) {
+			delete(e.eventCache, isomorphicKey)
+		}
+	}
+}
+
+// NewRecorder returns an EventRecorder that records events with the given event source.
+func (e *eventBroadcasterImpl) NewRecorder(scheme *runtime.Scheme, reportingController string) EventRecorder {
+	hostname, _ := os.Hostname()
+	reportingInstance := reportingController + "-" + hostname
+	return &recorderImpl{scheme, reportingController, reportingInstance, e.Broadcaster, clock.RealClock{}}
+}
+
+func (e *eventBroadcasterImpl) recordToSink(event *eventsv1.Event, clock clock.Clock) {
+	// Make a copy before modification, because there could be multiple listeners.
+	eventCopy := event.DeepCopy()
+	go func() {
+		evToRecord := func() *eventsv1.Event {
+			e.mu.Lock()
+			defer e.mu.Unlock()
+			eventKey := getKey(eventCopy)
+			isomorphicEvent, isIsomorphic := e.eventCache[eventKey]
+			if isIsomorphic {
+				if isomorphicEvent.Series != nil {
+					isomorphicEvent.Series.Count++
+					isomorphicEvent.Series.LastObservedTime = metav1.MicroTime{Time: clock.Now()}
+					return nil
+				}
+				isomorphicEvent.Series = &eventsv1.EventSeries{
+					Count:            1,
+					LastObservedTime: metav1.MicroTime{Time: clock.Now()},
+				}
+				return isomorphicEvent
+			}
+			e.eventCache[eventKey] = eventCopy
+			return eventCopy
+		}()
+		if evToRecord != nil {
+			recordedEvent := e.attemptRecording(evToRecord)
+			if recordedEvent != nil {
+				recordedEventKey := getKey(recordedEvent)
+				e.mu.Lock()
+				defer e.mu.Unlock()
+				e.eventCache[recordedEventKey] = recordedEvent
+			}
+		}
+	}()
+}
+
+func (e *eventBroadcasterImpl) attemptRecording(event *eventsv1.Event) *eventsv1.Event {
+	tries := 0
+	for {
+		if recordedEvent, retry := recordEvent(e.sink, event); !retry {
+			return recordedEvent
+		}
+		tries++
+		if tries >= maxTriesPerEvent {
+			klog.Errorf("Unable to write event '%#v' (retry limit exceeded!)", event)
+			return nil
+		}
+		// Randomize sleep so that various clients won't all be
+		// synced up if the master goes down.
+		time.Sleep(wait.Jitter(e.sleepDuration, 0.25))
+	}
+}
+
+func recordEvent(sink EventSink, event *eventsv1.Event) (*eventsv1.Event, bool) {
+	var newEvent *eventsv1.Event
+	var err error
+	isEventSeries := event.Series != nil
+	if isEventSeries {
+		patch, patchBytesErr := createPatchBytesForSeries(event)
+		if patchBytesErr != nil {
+			klog.Errorf("Unable to calculate diff, no merge is possible: %v", patchBytesErr)
+			return nil, false
+		}
+		newEvent, err = sink.Patch(event, patch)
+	}
+	// Update can fail because the event may have been removed and it no longer exists.
+	if !isEventSeries || (isEventSeries && util.IsKeyNotFoundError(err)) {
+		// Making sure that ResourceVersion is empty on creation
+		event.ResourceVersion = ""
+		newEvent, err = sink.Create(event)
+	}
+	if err == nil {
+		return newEvent, false
+	}
+	// If we can't contact the server, then hold everything while we keep trying.
+	// Otherwise, something about the event is malformed and we should abandon it.
+	switch err.(type) {
+	case *restclient.RequestConstructionError:
+		// We will construct the request the same next time, so don't keep trying.
+		klog.Errorf("Unable to construct event '%#v': '%v' (will not retry!)", event, err)
+		return nil, false
+	case *errors.StatusError:
+		if errors.IsAlreadyExists(err) {
+			klog.V(5).Infof("Server rejected event '%#v': '%v' (will not retry!)", event, err)
+		} else {
+			klog.Errorf("Server rejected event '%#v': '%v' (will not retry!)", event, err)
+		}
+		return nil, false
+	case *errors.UnexpectedObjectError:
+		// We don't expect this; it implies the server's response didn't match a
+		// known pattern. Go ahead and retry.
+	default:
+		// This case includes actual http transport errors. Go ahead and retry.
+	}
+	klog.Errorf("Unable to write event: '%v' (may retry after sleeping)", err)
+	return nil, true
+}
+
+func createPatchBytesForSeries(event *eventsv1.Event) ([]byte, error) {
+	oldEvent := event.DeepCopy()
+	oldEvent.Series = nil
+	oldData, err := json.Marshal(oldEvent)
+	if err != nil {
+		return nil, err
+	}
+	newData, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+	return strategicpatch.CreateTwoWayMergePatch(oldData, newData, eventsv1.Event{})
+}
+
+func getKey(event *eventsv1.Event) eventKey {
+	key := eventKey{
+		action:              event.Action,
+		reason:              event.Reason,
+		reportingController: event.ReportingController,
+		regarding:           event.Regarding,
+	}
+	if event.Related != nil {
+		key.related = *event.Related
+	}
+	return key
+}
+
+// StartStructuredLogging starts sending events received from this EventBroadcaster to the structured logging function.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartStructuredLogging(verbosity klog.Level) func() {
+	return e.StartEventWatcher(
+		func(obj runtime.Object) {
+			event, ok := obj.(*eventsv1.Event)
+			if !ok {
+				klog.Errorf("unexpected type, expected eventsv1.Event")
+				return
+			}
+			klog.V(verbosity).InfoS("Event occurred", "object", klog.KRef(event.Regarding.Namespace, event.Regarding.Name), "kind", event.Regarding.Kind, "apiVersion", event.Regarding.APIVersion, "type", event.Type, "reason", event.Reason, "action", event.Action, "note", event.Note)
+		})
+}
+
+// StartEventWatcher starts sending events received from this EventBroadcaster to the given event handler function.
+// The return value is used to stop recording
+func (e *eventBroadcasterImpl) StartEventWatcher(eventHandler func(event runtime.Object)) func() {
+	watcher := e.Watch()
+	go func() {
+		defer utilruntime.HandleCrash()
+		for {
+			watchEvent, ok := <-watcher.ResultChan()
+			if !ok {
+				return
+			}
+			eventHandler(watchEvent.Object)
+		}
+	}()
+	return watcher.Stop
+}
+
+func (e *eventBroadcasterImpl) startRecordingEvents(stopCh <-chan struct{}) {
+	eventHandler := func(obj runtime.Object) {
+		event, ok := obj.(*eventsv1.Event)
+		if !ok {
+			klog.Errorf("unexpected type, expected eventsv1.Event")
+			return
+		}
+		e.recordToSink(event, clock.RealClock{})
+	}
+	stopWatcher := e.StartEventWatcher(eventHandler)
+	go func() {
+		<-stopCh
+		stopWatcher()
+	}()
+}
+
+// StartRecordingToSink starts sending events received from the specified eventBroadcaster to the given sink.
+func (e *eventBroadcasterImpl) StartRecordingToSink(stopCh <-chan struct{}) {
+	go wait.Until(e.refreshExistingEventSeries, refreshTime, stopCh)
+	go wait.Until(e.finishSeries, finishTime, stopCh)
+	e.startRecordingEvents(stopCh)
+}
+
+type eventBroadcasterAdapterImpl struct {
+	coreClient          typedv1core.EventsGetter
+	coreBroadcaster     record.EventBroadcaster
+	eventsv1Client      typedeventsv1.EventsV1Interface
+	eventsv1Broadcaster EventBroadcaster
+}
+
+// NewEventBroadcasterAdapter creates a wrapper around new and legacy broadcasters to simplify
+// migration of individual components to the new Event API.
+func NewEventBroadcasterAdapter(client clientset.Interface) EventBroadcasterAdapter {
+	eventClient := &eventBroadcasterAdapterImpl{}
+	if _, err := client.Discovery().ServerResourcesForGroupVersion(eventsv1.SchemeGroupVersion.String()); err == nil {
+		eventClient.eventsv1Client = client.EventsV1()
+		eventClient.eventsv1Broadcaster = NewBroadcaster(&EventSinkImpl{Interface: eventClient.eventsv1Client})
+	}
+	// Even though there can soon exist cases when coreBroadcaster won't really be needed,
+	// we create it unconditionally because its overhead is minor and will simplify using usage
+	// patterns of this library in all components.
+	eventClient.coreClient = client.CoreV1()
+	eventClient.coreBroadcaster = record.NewBroadcaster()
+	return eventClient
+}
+
+// StartRecordingToSink starts sending events received from the specified eventBroadcaster to the given sink.
+func (e *eventBroadcasterAdapterImpl) StartRecordingToSink(stopCh <-chan struct{}) {
+	if e.eventsv1Broadcaster != nil && e.eventsv1Client != nil {
+		e.eventsv1Broadcaster.StartRecordingToSink(stopCh)
+	}
+	if e.coreBroadcaster != nil && e.coreClient != nil {
+		e.coreBroadcaster.StartRecordingToSink(&typedv1core.EventSinkImpl{Interface: e.coreClient.Events("")})
+	}
+}
+
+func (e *eventBroadcasterAdapterImpl) NewRecorder(name string) EventRecorder {
+	if e.eventsv1Broadcaster != nil && e.eventsv1Client != nil {
+		return e.eventsv1Broadcaster.NewRecorder(scheme.Scheme, name)
+	}
+	return record.NewEventRecorderAdapter(e.DeprecatedNewLegacyRecorder(name))
+}
+
+func (e *eventBroadcasterAdapterImpl) DeprecatedNewLegacyRecorder(name string) record.EventRecorder {
+	return e.coreBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: name})
+}
+
+func (e *eventBroadcasterAdapterImpl) Shutdown() {
+	if e.coreBroadcaster != nil {
+		e.coreBroadcaster.Shutdown()
+	}
+	if e.eventsv1Broadcaster != nil {
+		e.eventsv1Broadcaster.Shutdown()
+	}
+}

--- a/go-controller/vendor/k8s.io/client-go/tools/events/event_recorder.go
+++ b/go-controller/vendor/k8s.io/client-go/tools/events/event_recorder.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/record/util"
+	"k8s.io/client-go/tools/reference"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+type recorderImpl struct {
+	scheme              *runtime.Scheme
+	reportingController string
+	reportingInstance   string
+	*watch.Broadcaster
+	clock clock.Clock
+}
+
+func (recorder *recorderImpl) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+	timestamp := metav1.MicroTime{time.Now()}
+	message := fmt.Sprintf(note, args...)
+	refRegarding, err := reference.GetReference(recorder.scheme, regarding)
+	if err != nil {
+		klog.Errorf("Could not construct reference to: '%#v' due to: '%v'. Will not report event: '%v' '%v' '%v'", regarding, err, eventtype, reason, message)
+		return
+	}
+
+	var refRelated *v1.ObjectReference
+	if related != nil {
+		refRelated, err = reference.GetReference(recorder.scheme, related)
+		if err != nil {
+			klog.V(9).Infof("Could not construct reference to: '%#v' due to: '%v'.", related, err)
+		}
+	}
+	if !util.ValidateEventType(eventtype) {
+		klog.Errorf("Unsupported event type: '%v'", eventtype)
+		return
+	}
+	event := recorder.makeEvent(refRegarding, refRelated, timestamp, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
+	go func() {
+		defer utilruntime.HandleCrash()
+		recorder.Action(watch.Added, event)
+	}()
+}
+
+func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRelated *v1.ObjectReference, timestamp metav1.MicroTime, eventtype, reason, message string, reportingController string, reportingInstance string, action string) *eventsv1.Event {
+	t := metav1.Time{Time: recorder.clock.Now()}
+	namespace := refRegarding.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+	return &eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", refRegarding.Name, t.UnixNano()),
+			Namespace: namespace,
+		},
+		EventTime:           timestamp,
+		Series:              nil,
+		ReportingController: reportingController,
+		ReportingInstance:   reportingInstance,
+		Action:              action,
+		Reason:              reason,
+		Regarding:           *refRegarding,
+		Related:             refRelated,
+		Note:                message,
+		Type:                eventtype,
+	}
+}

--- a/go-controller/vendor/k8s.io/client-go/tools/events/fake.go
+++ b/go-controller/vendor/k8s.io/client-go/tools/events/fake.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FakeRecorder is used as a fake during tests. It is thread safe. It is usable
+// when created manually and not by NewFakeRecorder, however all events may be
+// thrown away in this case.
+type FakeRecorder struct {
+	Events chan string
+}
+
+// Eventf emits an event
+func (f *FakeRecorder) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+	if f.Events != nil {
+		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+note, args...)
+	}
+}
+
+// NewFakeRecorder creates new fake event recorder with event channel with
+// buffer of given size.
+func NewFakeRecorder(bufferSize int) *FakeRecorder {
+	return &FakeRecorder{
+		Events: make(chan string, bufferSize),
+	}
+}

--- a/go-controller/vendor/k8s.io/client-go/tools/events/helper.go
+++ b/go-controller/vendor/k8s.io/client-go/tools/events/helper.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	eventsv1beta1 "k8s.io/api/events/v1beta1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var mapping = map[schema.GroupVersion]string{
+	eventsv1.SchemeGroupVersion:      "regarding",
+	eventsv1beta1.SchemeGroupVersion: "regarding",
+	corev1.SchemeGroupVersion:        "involvedObject",
+}
+
+// GetFieldSelector returns the appropriate field selector based on the API version being used to communicate with the server.
+// The returned field selector can be used with List and Watch to filter desired events.
+func GetFieldSelector(eventsGroupVersion schema.GroupVersion, regardingGroupVersionKind schema.GroupVersionKind, regardingName string, regardingUID types.UID) (fields.Selector, error) {
+	field := fields.Set{}
+
+	if _, ok := mapping[eventsGroupVersion]; !ok {
+		return nil, fmt.Errorf("unknown version %v", eventsGroupVersion)
+	}
+	prefix := mapping[eventsGroupVersion]
+
+	if len(regardingName) > 0 {
+		field[prefix+".name"] = regardingName
+	}
+
+	if len(regardingGroupVersionKind.Kind) > 0 {
+		field[prefix+".kind"] = regardingGroupVersionKind.Kind
+	}
+
+	regardingGroupVersion := regardingGroupVersionKind.GroupVersion()
+	if !regardingGroupVersion.Empty() {
+		field[prefix+".apiVersion"] = regardingGroupVersion.String()
+	}
+
+	if len(regardingUID) > 0 {
+		field[prefix+".uid"] = string(regardingUID)
+	}
+
+	return field.AsSelector(), nil
+}

--- a/go-controller/vendor/k8s.io/client-go/tools/events/interfaces.go
+++ b/go-controller/vendor/k8s.io/client-go/tools/events/interfaces.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	eventsv1 "k8s.io/api/events/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+)
+
+// EventRecorder knows how to record events on behalf of an EventSource.
+type EventRecorder interface {
+	// Eventf constructs an event from the given information and puts it in the queue for sending.
+	// 'regarding' is the object this event is about. Event will make a reference-- or you may also
+	// pass a reference to the object directly.
+	// 'related' is the secondary object for more complex actions. E.g. when regarding object triggers
+	// a creation or deletion of related object.
+	// 'type' of this event, and can be one of Normal, Warning. New types could be added in future
+	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it
+	// should be in UpperCamelCase format (starting with a capital letter). "reason" will be used
+	// to automate handling of events, so imagine people writing switch statements to handle them.
+	// You want to make that easy.
+	// 'action' explains what happened with regarding/what action did the ReportingController
+	// (ReportingController is a type of a Controller reporting an Event, e.g. k8s.io/node-controller, k8s.io/kubelet.)
+	// take in regarding's name; it should be in UpperCamelCase format (starting with a capital letter).
+	// 'note' is intended to be human readable.
+	Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{})
+}
+
+// EventBroadcaster knows how to receive events and send them to any EventSink, watcher, or log.
+type EventBroadcaster interface {
+	// StartRecordingToSink starts sending events received from the specified eventBroadcaster.
+	StartRecordingToSink(stopCh <-chan struct{})
+
+	// NewRecorder returns an EventRecorder that can be used to send events to this EventBroadcaster
+	// with the event source set to the given event source.
+	NewRecorder(scheme *runtime.Scheme, reportingController string) EventRecorder
+
+	// StartEventWatcher enables you to watch for emitted events without usage
+	// of StartRecordingToSink. This lets you also process events in a custom way (e.g. in tests).
+	// NOTE: events received on your eventHandler should be copied before being used.
+	// TODO: figure out if this can be removed.
+	StartEventWatcher(eventHandler func(event runtime.Object)) func()
+
+	// StartStructuredLogging starts sending events received from this EventBroadcaster to the structured
+	// logging function. The return value can be ignored or used to stop recording, if desired.
+	StartStructuredLogging(verbosity klog.Level) func()
+
+	// Shutdown shuts down the broadcaster
+	Shutdown()
+}
+
+// EventSink knows how to store events (client-go implements it.)
+// EventSink must respect the namespace that will be embedded in 'event'.
+// It is assumed that EventSink will return the same sorts of errors as
+// client-go's REST client.
+type EventSink interface {
+	Create(event *eventsv1.Event) (*eventsv1.Event, error)
+	Update(event *eventsv1.Event) (*eventsv1.Event, error)
+	Patch(oldEvent *eventsv1.Event, data []byte) (*eventsv1.Event, error)
+}
+
+// EventBroadcasterAdapter is a auxiliary interface to simplify migration to
+// the new events API. It is a wrapper around new and legacy broadcasters
+// that smartly chooses which one to use.
+//
+// Deprecated: This interface will be removed once migration is completed.
+type EventBroadcasterAdapter interface {
+	// StartRecordingToSink starts sending events received from the specified eventBroadcaster.
+	StartRecordingToSink(stopCh <-chan struct{})
+
+	// NewRecorder creates a new Event Recorder with specified name.
+	NewRecorder(name string) EventRecorder
+
+	// DeprecatedNewLegacyRecorder creates a legacy Event Recorder with specific name.
+	DeprecatedNewLegacyRecorder(name string) record.EventRecorder
+
+	// Shutdown shuts down the broadcaster.
+	Shutdown()
+}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -791,6 +791,7 @@ k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/tools/clientcmd/api/v1
+k8s.io/client-go/tools/events
 k8s.io/client-go/tools/leaderelection
 k8s.io/client-go/tools/leaderelection/resourcelock
 k8s.io/client-go/tools/metrics


### PR DESCRIPTION
Core Events is being replaced with k8s.io Events
and eventually the client-go API tools will be removed.

A consequence of updating to the new Events API
means we can no longer log events as well as emit
an event.

Another consequence is the new API requires us to define
an 'action' for each event.

There was an issue for cluster scoped objects,
where, if Eventf's 'regarding' parameter does not have a
namespace set, it is set by client-go tools to 'default'
namespace. The validation within the API server rejects
an event if the 'regarding' objects namespace is not
equal to the event object namespace.
This is fixed in kubernetes PR #100125 but for this
PR to work, we will need that fix.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

**- What this PR does and why is it needed**
See commit message.

**- Special notes for reviewers**
Core Events V1 reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#event-v1-core
events.k8s.io Events V1: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#event-v1-events-k8s-io
Client-go eventf description: https://github.com/kubernetes/client-go/blob/9b0b23a8ade2b5323d6624146cea2ad7b8928f25/tools/events/interfaces.go#L42


**- How to verify it**
WIP

**- Description for the changelog**
<!--
None
-->