### PR TITLE
Remove generating test report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -346,20 +346,6 @@ jobs:
         name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: './test/_artifacts/*.xml'
 
-    - name: Generate Test Report
-      id: xunit-viewer
-      if: always()
-      uses: AutoModality/action-xunit-viewer@v1
-      with:
-        results: ./test/_artifacts/
-
-    - name: Upload Test Report
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-report-${{ env.JOB_NAME }}-${{ github.run_id }}
-        path: './test/_artifacts/index.html'
-
     - name: Export logs
       if: always()
       run: |
@@ -440,20 +426,6 @@ jobs:
         name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: './test/_artifacts/*.xml'
 
-    - name: Generate Test Report
-      id: xunit-viewer
-      if: always()
-      uses: AutoModality/action-xunit-viewer@v1
-      with:
-        results: ./test/_artifacts/
-
-    - name: Upload Test Report
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-report-${{ env.JOB_NAME }}-${{ github.run_id }}
-        path: './test/_artifacts/index.html'
-
     - name: Export logs
       if: always()
       run: |
@@ -529,20 +501,6 @@ jobs:
         with:
           name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: './test/_artifacts/*.xml'
-
-      - name: Generate Test Report
-        id: xunit-viewer
-        if: always()
-        uses: AutoModality/action-xunit-viewer@v1
-        with:
-          results: ./test/_artifacts/
-
-      - name: Upload Test Report
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-report-${{ env.JOB_NAME }}-${{ github.run_id }}
-          path: './test/_artifacts/index.html'
 
       - name: Export logs
         if: always()

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -147,20 +147,6 @@ jobs:
         name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: './test/_artifacts/*.xml'
 
-    - name: Generate Test Report
-      id: xunit-viewer
-      if: always()
-      uses: AutoModality/action-xunit-viewer@v1
-      with:
-        results: ./test/_artifacts/
-
-    - name: Upload Test Report
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-report-${{ env.JOB_NAME }}-${{ github.run_id }}
-        path: './test/_artifacts/index.html'
-
     - name: Export logs
       if: always()
       run: |


### PR DESCRIPTION
It is currently failing our CI, and I don't think anyone uses it anyway.

Signed-off-by: Tim Rozet <trozet@redhat.com>

