### PR TITLE
Fix logging invalid errors on ingress IP

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -166,9 +166,11 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 		// Established traffic is handled by default conntrack rules
 		// NodePort/Ingress access in the OVS bridge will only ever come from outside of the host
 		for _, ing := range service.Status.LoadBalancer.Ingress {
-			err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, epHostLocal, protocol, actions, ing.IP, "Ingress")
-			if err != nil {
-				klog.Errorf(err.Error())
+			if len(ing.IP) > 0 {
+				err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, epHostLocal, protocol, actions, ing.IP, "Ingress")
+				if err != nil {
+					klog.Errorf(err.Error())
+				}
 			}
 		}
 		// flows for externalIPs
@@ -184,11 +186,8 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 // flow generation for LB and ExternalIP flow is essentially the same, so avoid code duplication with
 // this method
 func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, svcPort *kapi.ServicePort, add bool, epHostLocal bool, protocol string, actions string, ipAddress string, ipType string) error {
-	if ipAddress == "" {
-		return fmt.Errorf("failed to parse %s IP. IP is empty.", ipType)
-	}
 	if net.ParseIP(ipAddress) == nil {
-		return fmt.Errorf("failed to parse %s IP: %s", ipType, ipAddress)
+		return fmt.Errorf("failed to parse %s IP: %q", ipType, ipAddress)
 	}
 	flowProtocol := protocol
 	nwDst := "nw_dst"


### PR DESCRIPTION
In downstream CI there are many occurrences of:
E1109 13:20:02.794662    3252 gateway_shared_intf.go:172] failed to parse Ingress IP. IP is empty.

Ingress can use either IP or hostname, and in the past we skipped trying
to create flows for services where the IP was empty. Somehow during
libovsdb migration we are now producing errors.

Previous code was like this:
https://github.com/openshift/ovn-kubernetes/blob/release-4.8/go-controller/pkg/node/gateway_shared_intf.go#L89

Signed-off-by: Tim Rozet <trozet@redhat.com>

