### PR TITLE
fix hybrid overlay communication through services

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -324,7 +324,7 @@ func (m *MasterController) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet,
 		}
 
 		drIP := util.GetNodeHybridOverlayIfAddr(nodeSubnet).IP
-		matchStr := fmt.Sprintf(`inport == \"%s%s\" && %s.dst == %s`,
+		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.dst == %s`,
 			ovntypes.RouterToSwitchPrefix, nodeName, L3Prefix, hybridCIDR)
 
 		intPriority, _ := strconv.Atoi(ovntypes.HybridOverlaySubnetPriority)

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 					},
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{nodeHOIP},
-					Match:    "inport == \\\"rtos-node1\\\" && ip4.dst == 11.1.0.0/16",
+					Match:    "inport == \"rtos-node1\" && ip4.dst == 11.1.0.0/16",
 					UUID:     "reroute-policy-UUID",
 				},
 				&nbdb.LogicalRouter{
@@ -315,7 +315,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 					},
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{nodeHOIP},
-					Match:    "inport == \\\"rtos-node1\\\" && ip4.dst == 11.1.0.0/16",
+					Match:    "inport == \"rtos-node1\" && ip4.dst == 11.1.0.0/16",
 					UUID:     "reroute-policy-UUID",
 				},
 				&nbdb.LogicalSwitchPort{
@@ -403,7 +403,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 					},
 					Action:   nbdb.LogicalRouterPolicyActionReroute,
 					Nexthops: []string{nodeHOIP},
-					Match:    "inport == \\\"rtos-node1\\\" && ip4.dst == 11.1.0.0/16",
+					Match:    "inport == \"rtos-node1\" && ip4.dst == 11.1.0.0/16",
 					UUID:     "reroute-policy-UUID",
 				},
 				&nbdb.LogicalRouter{


### PR DESCRIPTION
since implementing libovsdb the escape character in the matchStr is extra and goes
into the database as a backslash character instead of escape

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->