### PR TITLE
CI: Run full e2e tests on upgrade jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,9 +222,9 @@ jobs:
         export OVN_IMAGE="ovn-daemonset-f:pr"
         make -C test upgrade-ovn
 
-    - name: Run Single-Stack Tests
+    - name: Run E2E shard-conformance
       run: |
-        make -C test shard-test WHAT="Networking Granular Checks"
+        make -C test shard-conformance
 
     - name: Export logs
       if: always()


### PR DESCRIPTION
Run full e2e tests on upgrade jobs instead of only the Networking
Granular Checks.

Fixes #2641

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->