### PR TITLE
cni: match default kubelet CRI operation timeout for CNI operations

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -179,7 +179,8 @@ func cniRequestToPodRequest(cr *Request, podLister corev1listers.PodLister, kcli
 
 	req.CNIConf = conf
 	req.timestamp = time.Now()
-	req.ctx, req.cancel = context.WithTimeout(context.Background(), time.Minute)
+	// Match the Kubelet default CRI operation timeout of 2m
+	req.ctx, req.cancel = context.WithTimeout(context.Background(), 2*time.Minute)
 	return req, nil
 }
 


### PR DESCRIPTION
There's no point in limiting the timeout to something lower than the
CRI timeout; it just causes pods in large-scale clusters to hit the
kubelet retry backoffs and take even longer to bring up. Continued
improvements to OVN will reduce the need for longer timeouts in
the near future.

@trozet @girishmg @flavio-fernandes @jcaamano 