### PR TITLE
Log all nbdb txns via libovsdb

### DIFF
--- a/go-controller/pkg/ovn/libovsdbops/transact.go
+++ b/go-controller/pkg/ovn/libovsdbops/transact.go
@@ -38,6 +38,8 @@ func TransactAndCheck(c client.Client, ops []ovsdb.Operation) ([]ovsdb.Operation
 		return []ovsdb.OperationResult{{}}, nil
 	}
 
+	klog.Infof("Configuring OVN: %+v", ops)
+
 	ctx, cancel := context.WithTimeout(context.TODO(), types.OVSDBTimeout)
 	defer cancel()
 


### PR DESCRIPTION
We used to log all nbctl commands via the daemon, and it was incredibly
useful for debugging. We need the same logging at least for the short
term with libovsdb, otherwise we cannot tell what is being
configured...especially in level driven scenarios like services
controller.

Signed-off-by: Tim Rozet <trozet@redhat.com>

