### PR TITLE
Fixes unnecessary loadbalancer OVN transactions

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -3,7 +3,6 @@ package services
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -309,9 +308,10 @@ func (c *Controller) syncService(key string) error {
 	c.alreadyAppliedLock.Lock()
 	existingLBs, ok := c.alreadyApplied[key]
 	c.alreadyAppliedLock.Unlock()
-	if ok && reflect.DeepEqual(lbs, existingLBs) {
+	if ok && ovnlb.LoadBalancersEqualNoUUID(existingLBs, lbs) {
 		klog.V(3).Infof("Skipping no-op change for service %s", key)
 	} else {
+		klog.V(5).Infof("Services do not match, existing lbs: %#v, built lbs: %#v", existingLBs, lbs)
 		// Actually apply load-balancers to OVN.
 		//
 		// Note: this may fail if a node was deleted between listing nodes and applying.

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -2,6 +2,7 @@ package loadbalancer
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -150,6 +151,25 @@ func EnsureLBs(nbClient libovsdbclient.Client, externalIDs map[string]string, LB
 	klog.V(5).Infof("Deleted %d stale LBs for %#v", len(toDelete), externalIDs)
 
 	return nil
+}
+
+// LoadBalancersEqualNoUUID compares load balancer objects excluding uuid
+func LoadBalancersEqualNoUUID(lbs1, lbs2 []LB) bool {
+	if len(lbs1) != len(lbs2) {
+		return false
+	}
+	new1 := make([]LB, len(lbs1))
+	new2 := make([]LB, len(lbs2))
+	for _, lb := range lbs1 {
+		lb.UUID = ""
+		new1 = append(new1, lb)
+
+	}
+	for _, lb := range lbs2 {
+		lb.UUID = ""
+		new2 = append(new2, lb)
+	}
+	return reflect.DeepEqual(new1, new2)
 }
 
 func mapLBDifferenceByKey(keyMap map[string][]*nbdb.LoadBalancer, keyIn sets.String, keyNotIn sets.String, lb *nbdb.LoadBalancer) {


### PR DESCRIPTION
When deciding if a service needs updating, we do a reflect.DeepEqual on
the existing load balancers that are stored in a cache, vs the load
balancers that would be built by the operation. This comparison was
incorrect, because it was comparing the UUID field, which will never be
equal. The end result is potentially a lot more pressure on OVN for
transactions that essentially do nothing.

Signed-off-by: Tim Rozet <trozet@redhat.com>

