### PR TITLE
Implement ETP=local on LGW

### DIFF
--- a/docs/design/external_traffic_policy.md
+++ b/docs/design/external_traffic_policy.md
@@ -36,14 +36,14 @@ to that node.
 
 ## Handling Flows between the overlay and underlay
 
-In this section I will explain some relevant traffic flows when a service's `externalTrafficPolicy` is `local`.  For
+In this section we will look at some relevant traffic flows when a service's `externalTrafficPolicy` is `local`.  For
 these examples we will be using a Nodeport service, but the flow is generally the same for ExternalIP and Loadbalancer
 type services.
 
 ## Ingress Traffic
 
 This section will cover the networking entities hit when traffic ingresses a cluster via a service to either host
-networked pods or cluster networked pods
+networked pods or cluster networked pods. If its host networked pods, then the traffic flow is the same on both gateway modes. If its cluster networked pods, they will be different for each mode.
 
 ### External Source -> Service -> OVN pod
 
@@ -57,6 +57,108 @@ client is preserved  by the time it gets to the destination Pod.
 eth0--->|breth0| -----> 172.18.0.3 OVN GR 100.64.0.4 --> join switch --> ovn_cluster_router --> 10.244.1.3 pod
 
 ```
+
+#### **Local Gateway Mode**
+
+The implementation of this case differs for local gateway from that for shared gateway. In local gateway if the above path is used, response traffic would be assymmetric since the default route for pod egress traffic is via `ovn-k8s-mp0`.
+
+In local gateway mode, rather than sending the traffic from breth0 into OVN via gateway router, we use flows on breth0 to send it into the host.
+
+```text
+          host (ovn-worker, 172.18.0.3) ---- 172.18.0.3 LOCAL(host) -- iptables -- ovn-k8s-mp0 -- node-local-switch -- 10.244.1.3 pod
+           ^
+           ^
+           |
+eth0--->|breth0|
+
+```
+
+1. Match on the incoming traffic via it's nodePort, send it to `table=6`:
+
+```
+ cookie=0xb4e7084fbba8bb8a, duration=100.388s, table=0, n_packets=6, n_bytes=484, idle_age=9, priority=110,tcp,in_port=1,tp_dst=30820 actions=ct(commit,table=6,zone=64003)
+```
+
+2. Send it out to LOCAL ovs port on breth0 and traffic is delivered to the host:
+
+```
+ cookie=0xe745ecf105, duration=119.391s, table=6, n_packets=6, n_bytes=484, idle_age=28, priority=110 actions=LOCAL
+```
+
+3. In the host, we have an IPtable rule in the PREROUTING chain that DNATs this packet matched on nodePort to a masqueradeIP (169.254.169.3) used specially for this traffic flow.
+
+```
+[1:60] -A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 31787 -j DNAT --to-destination 169.254.169.3:31787
+```
+
+4. The special masquerade route in the host sends this packet into OVN via the management port.
+
+```
+169.254.169.3 via 10.244.0.1 dev ovn-k8s-mp0 
+```
+
+5. Since by default, all traffic into `ovn-k8s-mp0` gets SNAT-ed, we add an IPtable rule to `OVN-KUBE-SNAT-MGMTPORT` chain to ensure it doesn't get SNAT-ed to preserve its source-ip.
+
+```
+[1:60] -A OVN-KUBE-SNAT-MGMTPORT -p tcp -m tcp --dport 31787 -j RETURN
+```
+
+6. Traffic enters the node local switch on the worker node and hits the load-balancer where we add a new vip for this masqueradeIP to DNAT it correctly to the local backends. Note that this vip will translate only to the backends that are local to that worker node and hence traffic will be rejected if there is no local endpoint thus respecting ETP=local type traffic rules.
+
+The switch load-balancer on a node with local endpoints will look like this:
+
+```
+_uuid               : b3201caf-3089-4462-b96e-1406fd7c4256
+external_ids        : {"k8s.ovn.org/kind"=Service, "k8s.ovn.org/owner"="default/example-service-1"}
+health_check        : []
+ip_port_mappings    : {}
+name                : "Service_default/example-service-1_TCP_node_switch_ovn-worker2"
+options             : {event="false", reject="true", skip_snat="false"}
+protocol            : tcp
+selection_fields    : []
+vips                : {"169.254.169.3:30820"="10.244.1.4:8080,10.244.1.5:8080", "172.18.0.4:30820"="10.244.1.4:8080,10.244.1.5:8080"}
+```
+
+The switch load-balancer on a node without local endpoints will look like this:
+```
+_uuid               : 42d75e10-5598-4197-a6f2-1a37094bee13
+external_ids        : {"k8s.ovn.org/kind"=Service, "k8s.ovn.org/owner"="default/example-service-1"}
+health_check        : []
+ip_port_mappings    : {}
+name                : "Service_default/example-service-1_TCP_node_switch_ovn-worker"
+options             : {event="false", reject="true", skip_snat="false"}
+protocol            : tcp
+selection_fields    : []
+vips                : {"169.254.169.3:30820"="", "172.18.0.3:30820"="10.244.1.4:8080,10.244.1.5:8080"}
+```
+
+Response traffic will follow the same path (backend->node switch->mp0->host->breth0).
+
+7. Return traffic gets matched on src port being that of the nodePort and is sent to `table=7`
+
+```
+ cookie=0xb4e7084fbba8bb8a, duration=190.099s, table=0, n_packets=4, n_bytes=408, idle_age=99, priority=110,tcp,in_port=LOCAL,tp_src=30820 actions=ct(table=7,zone=64003)
+```
+
+8. Send the traffic back out breth0 back to the external source in `table=7`
+
+```
+ cookie=0xe745ecf105, duration=210.560s, table=7, n_packets=4, n_bytes=408, priority=110 actions=output:eth0
+```
+
+The conntrack state looks like this:
+```
+[NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 [UNREPLIED] src=172.18.0.4 dst=172.18.0.1 sport=30820 dport=30366 zone=64003
+[NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 [UNREPLIED] src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366
+[NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=169.254.169.3 sport=30366 dport=30820 [UNREPLIED] src=10.244.1.4 dst=172.18.0.1 sport=8080 dport=30366 zone=9
+[NEW] tcp      6 120 SYN_SENT src=172.18.0.1 dst=10.244.1.4 sport=30366 dport=8080 [UNREPLIED] src=10.244.1.4 dst=172.18.0.1 sport=8080 dport=30366 zone=14
+[UPDATE] tcp   6 60 SYN_RECV src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366
+[UPDATE] tcp   6 432000 ESTABLISHED src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366 [ASSURED]
+[UPDATE] tcp   6 120 FIN_WAIT src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366 [ASSURED]
+[UPDATE] tcp   6 30 LAST_ACK src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366 [ASSURED]
+[UPDATE] tcp   6 120 TIME_WAIT src=172.18.0.1 dst=172.18.0.4 sport=30366 dport=30820 src=169.254.169.3 dst=172.18.0.1 sport=30820 dport=30366 [ASSURED]
+```
+
 
 ### External Source -> Service -> Host Networked pod
 
@@ -106,8 +208,13 @@ networked pods or cluster networked pods
 
 ### Host -> Service -> OVN Pod
 
-This case is similar to normal host -> Service -> OVN Pod except the SRC address of the Traffic will be that of the
-management port `ovn-k8s-mp0` rather than the main address attatched to `eth0` on the host.
+#### **Shared Gateway Mode**
+
+Documentation will be updated after https://bugzilla.redhat.com/show_bug.cgi?id=2025467 is fixed.
+
+#### **Local Gateway Mode**
+
+This case is similar to steps 3-6 on `External -> Service -> OVN Pod` traffic senario we saw above for local gateway.
 
 ### Host -> Service -> Host
 
@@ -115,12 +222,12 @@ Again when the backend is a host networked pod we shortcircuit OVN to avoid SNAT
 to DNAT directly to the correct host endpoint.
 
 ```
--A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 32126 -j DNAT --to-destination <nodeIP>:<targetIP>
+[0:0] -A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 30940 -j REDIRECT --to-ports 8080
 ```
 
 ## Intra Cluster traffic
 
-For all service traffic that stays in the overlay the flows will remain the same for `externaltrafficpolicy:local`.
+For all service traffic that stays in the overlay the flows will remain the same for `externaltrafficpolicy:local`. If the traffic crosses over to the underlay then its not guaranteed to be the same. See https://bugzilla.redhat.com/show_bug.cgi?id=2027270.
 
 ## Sources
 - https://www.asykim.com/blog/deep-dive-into-kubernetes-external-traffic-policies

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -231,8 +231,9 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 					"-j OVN-KUBE-EXTERNALIP",
 					"-j OVN-KUBE-NODEPORT",
 				},
-				"OVN-KUBE-NODEPORT":   []string{},
-				"OVN-KUBE-EXTERNALIP": []string{},
+				"OVN-KUBE-NODEPORT":      []string{},
+				"OVN-KUBE-EXTERNALIP":    []string{},
+				"OVN-KUBE-SNAT-MGMTPORT": []string{},
 			},
 			"filter": {},
 		}
@@ -700,8 +701,9 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 			v1.ServiceTypeClusterIP,
 			[]string{externalIP},
 			v1.ServiceStatus{},
+			false,
 		)
-		endpoints := *newEndpoints("service1", "namespace1")
+		endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{})
 
 		_, nodeNet, err := net.ParseCIDR(nodeSubnet)
 		Expect(err).NotTo(HaveOccurred())
@@ -812,6 +814,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 				"POSTROUTING": []string{
 					"-s 10.1.1.0/24 -j MASQUERADE",
 				},
+				"OVN-KUBE-SNAT-MGMTPORT": []string{},
 			},
 			"filter": {
 				"FORWARD": []string{

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -24,6 +24,10 @@ const (
 	// defaultOpenFlowCookie identifies default open flow rules added to the host OVS bridge.
 	// The hex number 0xdeff105, aka defflos, is meant to sound like default flows.
 	defaultOpenFlowCookie = "0xdeff105"
+	// etpSvcOpenFlowCookie identifies constant open flow rules added to the host OVS
+	// bridge to move packets between host and external for etp=local traffic.
+	// The hex number 0xe745ecf105, represents etp(e74)-service(5ec)-flows which makes it easier for debugging.
+	etpSvcOpenFlowCookie = "0xe745ecf105"
 	// ovsLocalPort is the name of the OVS bridge local port
 	ovsLocalPort = "LOCAL"
 	// ctMarkOVN is the conntrack mark value for OVN traffic
@@ -67,23 +71,67 @@ type nodePortWatcher struct {
 type serviceConfig struct {
 	// Contains the current service
 	service *kapi.Service
-	// Were those rules etp:local + Host Networked rules
-	etpHostRules bool
+	// hasLocalHostNetworkEp will be true for a service if it has at least one endpoint which is "hostnetworked&local-to-this-node".
+	hasLocalHostNetworkEp bool
 }
 
-// updateServiceFlowCache handles managing shared gateway flows for ingress traffic towards kubernetes services
-// (nodeport, external, ingress). By default incoming traffic into the node is steered directly into OVN.
-// If a service has externalTrafficPolicy local, and has host-networked endpoints, traffic instead will be steered directly
-// into the host.
-// add parameter indicates if the flows should exist or be removed from the cache
-// epHostLocal indicates if a host networked endpoint exists for this
-// service func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bool, epHostLocal bool) {
-func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bool, epHostLocal bool) {
+// createFlowsForNonLocalHostNetEp adds the necessary openflows for a service when its backed by non-local-host-networked endpoints
+// This function is currently used only in LGW mode and when ETP=local for the service
+// cookie is the hash value of openflow cookie, svcPort is the nodePort of the service, flowProtocol is tcp/udp/sctp in v4 or v6 modes,
+// externalIPOrLBIngressIP is either externalIP or LB.status.ingress, nwDst&nwSrc are constants used to match on the destinations based on the flowprotocol
+func (npw *nodePortWatcher) createFlowsForNonLocalHostNetEp(cookie string, svcPort int32, flowProtocol string, externalIPOrLBIngressIP, nwDst, nwSrc string) []string {
+	var nodeportFlowsResult []string
+	if len(externalIPOrLBIngressIP) != 0 {
+		// if externalIPOrLBIngressIP is set then this service is of type LB/EIP
+		nodeportFlowsResult = append(nodeportFlowsResult,
+			fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,table=6)",
+				cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort, HostNodePortCTZone),
+			fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, %s=%s, tp_src=%d, actions=ct(zone=%d,table=7)",
+				cookie, flowProtocol, nwSrc, externalIPOrLBIngressIP, svcPort, HostNodePortCTZone))
+	} else {
+		// if externalIPOrLBIngressIP is not set then this service is of type NP
+		nodeportFlowsResult = append(nodeportFlowsResult,
+			// Traffic destined for ETP=local backed by OVN-K pod in LGW mode is matched on the svcNP and sent to table6.
+			fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, actions=ct(commit,zone=%d,table=6)",
+				cookie, npw.ofportPhys, flowProtocol, svcPort, HostNodePortCTZone),
+			// Return traffic is matched on the svcNP as the sourcePort and gets un-DNATed back to nodeIP.
+			fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%d, actions=ct(zone=%d,table=7)",
+				cookie, flowProtocol, svcPort, HostNodePortCTZone))
+	}
+	nodeportFlowsResult = append(nodeportFlowsResult,
+		// table 6, Sends the packet to Host. Note that the constant etp svc cookie is used since this flow would be
+		// same for all such services.
+		fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
+			etpSvcOpenFlowCookie),
+		// table 7, Sends the reply packet back out eth0 to the external client. Note that the constant etp svc
+		// cookie is used since this would be same for all such services.
+		fmt.Sprintf("cookie=%s, priority=110, table=7, actions=output:%s",
+			etpSvcOpenFlowCookie, npw.ofportPhys))
+	return nodeportFlowsResult
+}
+
+// updateServiceFlowCache handles managing breth0 gateway flows for ingress traffic towards kubernetes services
+// (nodeport, external, ingress). By default incoming traffic into the node is steered directly into OVN (case3 below).
+//
+// case1: If a service has externalTrafficPolicy=local, and has host-networked endpoints local to the node (hasLocalHostNetworkEp),
+// traffic instead will be steered directly into the host and DNAT-ed to the targetPort on the host.
+//
+// case2: Only applicable for LGW mode: If a service has externalTrafficPolicy=local, and it doesn't have host-networked
+// endpoints local to the node (!hasLocalHostNetworkEp - including empty endpoint.Subset), traffic will be steered into LOCAL
+// preserving sourceIP and IPTables will steer this traffic into OVN via ovn-k8s-mp0.
+//
+// case3: All other types of services i.e:
+//        case3a: if externalTrafficPolicy=cluster, irrespective of gateway modes, traffic will be steered into OVN via GR.
+//        case3b: if externalTrafficPolicy=local+!hasLocalHostNetworkEp+SGW mode, traffic will be steered into OVN via GR.
+// `add` parameter indicates if the flows should exist or be removed from the cache
+// `hasLocalHostNetworkEp` indicates if at least one host networked endpoint exists for this service which is local to this node.
+func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, hasLocalHostNetworkEp bool) {
 	var cookie, key string
 	var err error
 
 	// 14 bytes of overhead for ethernet header (does not include VLAN)
 	maxPktLength := getMaxFrameLength()
+	isServiceTypeETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
 
 	var actions string
 	if config.Gateway.DisablePacketMTUCheck {
@@ -123,7 +171,8 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 				// set to Local, and the backend pod is HostNetworked. We need to add
 				// Flows that will DNAT all traffic coming into nodeport to the nodeIP:Port and
 				// ensure that the return traffic is UnDNATed to correct the nodeIP:Nodeport
-				if epHostLocal {
+				if isServiceTypeETPLocal && hasLocalHostNetworkEp {
+					// case1 (see function description for details)
 					var nodeportFlows []string
 					klog.V(5).Infof("Adding flows on breth0 for Nodeport Service %s in Namespace: %s since ExternalTrafficPolicy=local", service.Name, service.Namespace)
 					// table 0, This rule matches on all traffic with dst port == NodePort, DNAT's it to the correct NodeIP
@@ -138,18 +187,27 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 								cookie, npw.ofportPhys, flowProtocol, svcPort.NodePort, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
 					}
 					nodeportFlows = append(nodeportFlows,
-						// table 6, Sends the packet to the host
+						// table 6, Sends the packet to the host. Note that the constant etp svc cookie is used since this flow would be
+						// same for all such services.
 						fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
-							cookie),
+							etpSvcOpenFlowCookie),
 						// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
 						fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(zone=%d nat,table=7)",
 							cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
-						// table 7, Sends the packet back out eth0 to the external client
+						// table 7, Sends the packet back out eth0 to the external client. Note that the constant etp svc
+						// cookie is used since this would be same for all such services.
 						fmt.Sprintf("cookie=%s, priority=110, table=7, "+
-							"actions=output:%s", cookie, npw.ofportPhys))
+							"actions=output:%s", etpSvcOpenFlowCookie, npw.ofportPhys))
 
 					npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
+				} else if isServiceTypeETPLocal && !hasLocalHostNetworkEp && config.Gateway.Mode == config.GatewayModeLocal {
+					// case2 (see function description for details)
+					var nodeportFlows []string
+					klog.V(5).Infof("Adding flows on breth0 for Nodeport Service %s in Namespace: %s since ExternalTrafficPolicy=local", service.Name, service.Namespace)
+					nodeportFlows = npw.createFlowsForNonLocalHostNetEp(cookie, svcPort.NodePort, flowProtocol, "", "", "")
+					npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 				} else {
+					// case3 (see function description for details)
 					npw.ofm.updateFlowCacheEntry(key, []string{
 						fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, tp_dst=%d, "+
 							"actions=%s",
@@ -166,7 +224,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 		// NodePort/Ingress access in the OVS bridge will only ever come from outside of the host
 		for _, ing := range service.Status.LoadBalancer.Ingress {
 			if len(ing.IP) > 0 {
-				err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, epHostLocal, protocol, actions, ing.IP, "Ingress")
+				err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, ing.IP, "Ingress")
 				if err != nil {
 					klog.Errorf(err.Error())
 				}
@@ -174,7 +232,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 		}
 		// flows for externalIPs
 		for _, externalIP := range service.Spec.ExternalIPs {
-			err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, epHostLocal, protocol, actions, externalIP, "External")
+			err = npw.createLbAndExternalSvcFlows(service, &svcPort, add, hasLocalHostNetworkEp, protocol, actions, externalIP, "External")
 			if err != nil {
 				klog.Errorf(err.Error())
 			}
@@ -182,27 +240,44 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add bo
 	}
 }
 
-// flow generation for LB and ExternalIP flow is essentially the same, so avoid code duplication with
-// this method
-func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, svcPort *kapi.ServicePort, add bool, epHostLocal bool, protocol string, actions string, ipAddress string, ipType string) error {
-	if net.ParseIP(ipAddress) == nil {
-		return fmt.Errorf("failed to parse %s IP: %q", ipType, ipAddress)
+// createLbAndExternalSvcFlows handles managing breth0 gateway flows for ingress traffic towards kubernetes services
+// (externalIP and LoadBalancer types). By default incoming traffic into the node is steered directly into OVN (case3 below).
+//
+// case1: If a service has externalTrafficPolicy=local, and has host-networked endpoints local to the node (hasLocalHostNetworkEp),
+// traffic instead will be steered directly into the host and DNAT-ed to the targetPort on the host.
+//
+// case2: Only applicable for LGW mode: If a service has externalTrafficPolicy=local, and it doesn't have host-networked
+// endpoints local to the node (!hasLocalHostNetworkEp - including empty endpoint.Subset), traffic will be steered into LOCAL
+// preserving sourceIP and IPTables will steer this traffic into OVN via ovn-k8s-mp0.
+//
+// case3: All other types of services i.e:
+//        case3a: if externalTrafficPolicy=cluster, irrespective of gateway modes, traffic will be steered into OVN via GR.
+//        case3b: if externalTrafficPolicy=local+!hasLocalHostNetworkEp+SGW mode, traffic will be steered into OVN via GR.
+// `add` parameter indicates if the flows should exist or be removed from the cache
+// `hasLocalHostNetworkEp` indicates if at least one host networked endpoint exists for this service which is local to this node.
+// `protocol` is TCP/UDP/SCTP as set in the svc.Port
+// `actions`: based on config.Gateway.DisablePacketMTUCheck, this will either be "send to patchport" or "send to table11 for checking if it needs to go to kernel for ICMP needs frag"
+// `externalIPOrLBIngressIP` is either externalIP.IP or LB.status.ingress.IP
+// `ipType` is either "External" or "Ingress"
+func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, svcPort *kapi.ServicePort, add bool, hasLocalHostNetworkEp bool, protocol string, actions string, externalIPOrLBIngressIP string, ipType string) error {
+	if net.ParseIP(externalIPOrLBIngressIP) == nil {
+		return fmt.Errorf("failed to parse %s IP: %q", ipType, externalIPOrLBIngressIP)
 	}
 	flowProtocol := protocol
 	nwDst := "nw_dst"
 	nwSrc := "nw_src"
-	if utilnet.IsIPv6String(ipAddress) {
+	if utilnet.IsIPv6String(externalIPOrLBIngressIP) {
 		flowProtocol = protocol + "6"
 		nwDst = "ipv6_dst"
 		nwSrc = "ipv6_src"
 	}
-	cookie, err := svcToCookie(service.Namespace, service.Name, ipAddress, svcPort.Port)
+	cookie, err := svcToCookie(service.Namespace, service.Name, externalIPOrLBIngressIP, svcPort.Port)
 	if err != nil {
 		klog.Warningf("Unable to generate cookie for %s svc: %s, %s, %s, %d, error: %v",
-			ipType, service.Namespace, service.Name, ipAddress, svcPort.Port, err)
+			ipType, service.Namespace, service.Name, externalIPOrLBIngressIP, svcPort.Port, err)
 		cookie = "0"
 	}
-	key := strings.Join([]string{ipType, service.Namespace, service.Name, ipAddress, fmt.Sprintf("%d", svcPort.Port)}, "_")
+	key := strings.Join([]string{ipType, service.Namespace, service.Name, externalIPOrLBIngressIP, fmt.Sprintf("%d", svcPort.Port)}, "_")
 	// Delete if needed and skip to next protocol
 	if !add {
 		npw.ofm.deleteFlowsByKey(key)
@@ -214,42 +289,51 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, s
 	// to the nodeIP / nodeIP:port of the host networked backend.
 	// And then ensure that return traffic is UnDNATed correctly back
 	// to the ingress / external IP
-	if epHostLocal {
+	isServiceTypeETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
+	if isServiceTypeETPLocal && hasLocalHostNetworkEp {
+		// case1 (see function description for details)
 		var nodeportFlows []string
 		klog.V(5).Infof("Adding flows on breth0 for %s Service %s in Namespace: %s since ExternalTrafficPolicy=local", ipType, service.Name, service.Namespace)
-		// table 0, This rule matches on all traffic with dst ip == LoadbalancerIP / extenalIP, DNAT's it to the correct NodeIP
+		// table 0, This rule matches on all traffic with dst ip == LoadbalancerIP / externalIP, DNAT's it to the correct NodeIP
 		// If ipv6 make sure to choose the ipv6 node address for rule
 		if strings.Contains(flowProtocol, "6") {
 			nodeportFlows = append(nodeportFlows,
 				fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=[%s]:%s),table=6)",
-					cookie, npw.ofportPhys, flowProtocol, nwDst, ipAddress, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
+					cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv6, svcPort.TargetPort.String()))
 		} else {
 			nodeportFlows = append(nodeportFlows,
 				fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, actions=ct(commit,zone=%d,nat(dst=%s:%s),table=6)",
-					cookie, npw.ofportPhys, flowProtocol, nwDst, ipAddress, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
+					cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, HostNodePortCTZone, npw.gatewayIPv4, svcPort.TargetPort.String()))
 		}
 		nodeportFlows = append(nodeportFlows,
 			// table 6, Sends the packet to the host
 			fmt.Sprintf("cookie=%s, priority=110, table=6, actions=output:LOCAL",
-				cookie),
+				etpSvcOpenFlowCookie),
 			// table 0, Matches on return traffic, i.e traffic coming from the host networked pod's port, and unDNATs
 			fmt.Sprintf("cookie=%s, priority=110, in_port=LOCAL, %s, tp_src=%s, actions=ct(commit,zone=%d nat,table=7)",
 				cookie, flowProtocol, svcPort.TargetPort.String(), HostNodePortCTZone),
 			// table 7, the packet back out eth0 to the external client
 			fmt.Sprintf("cookie=%s, priority=110, table=7, "+
-				"actions=output:%s", cookie, npw.ofportPhys))
+				"actions=output:%s", etpSvcOpenFlowCookie, npw.ofportPhys))
 
 		npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 
+	} else if isServiceTypeETPLocal && !hasLocalHostNetworkEp && config.Gateway.Mode == config.GatewayModeLocal {
+		// case2 (see function description for details)
+		var nodeportFlows []string
+		klog.V(5).Infof("Adding flows on breth0 for %s Service %s in Namespace: %s since ExternalTrafficPolicy=local", ipType, service.Name, service.Namespace)
+		nodeportFlows = npw.createFlowsForNonLocalHostNetEp(cookie, svcPort.Port, flowProtocol, externalIPOrLBIngressIP, nwDst, nwSrc)
+		npw.ofm.updateFlowCacheEntry(key, nodeportFlows)
 	} else {
+		// case3 (see function description for details)
 		npw.ofm.updateFlowCacheEntry(key, []string{
 			fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
 				"actions=%s",
-				cookie, npw.ofportPhys, flowProtocol, nwDst, ipAddress, svcPort.Port, actions),
+				cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, actions),
 			fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_src=%d, "+
 				"actions=output:%s",
-				cookie, npw.ofportPatch, flowProtocol, nwSrc, ipAddress, svcPort.Port, npw.ofportPhys),
-			npw.generateArpBypassFlow(protocol, ipAddress, cookie)})
+				cookie, npw.ofportPatch, flowProtocol, nwSrc, externalIPOrLBIngressIP, svcPort.Port, npw.ofportPhys),
+			npw.generateArpBypassFlow(protocol, externalIPOrLBIngressIP, cookie)})
 	}
 
 	return nil
@@ -314,23 +398,23 @@ func (npw *nodePortWatcher) getServiceInfo(index ktypes.NamespacedName) (out *se
 }
 
 // getAndSetServiceInfo creates and sets the serviceConfig, returns if it existed and whatever was there
-func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, etpHostRules bool) (old *serviceConfig, exists bool) {
+func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool) (old *serviceConfig, exists bool) {
 	npw.serviceInfoLock.Lock()
 	defer npw.serviceInfoLock.Unlock()
 
 	old, exists = npw.serviceInfo[index]
-	npw.serviceInfo[index] = &serviceConfig{service: service, etpHostRules: etpHostRules}
+	npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp}
 	return old, exists
 }
 
 // addOrSetServiceInfo creates and sets the serviceConfig if it doesn't exist
-func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, etpHostRules bool) (exists bool) {
+func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool) (exists bool) {
 	npw.serviceInfoLock.Lock()
 	defer npw.serviceInfoLock.Unlock()
 
 	if _, exists := npw.serviceInfo[index]; !exists {
 		// Only set this if it doesn't exist
-		npw.serviceInfo[index] = &serviceConfig{service: service, etpHostRules: etpHostRules}
+		npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp}
 		return false
 	}
 	return true
@@ -339,7 +423,7 @@ func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, ser
 
 // updateServiceInfo sets the serviceConfig for a service and returns the existing serviceConfig, if inputs are nil
 // do not update those fields, if it does not exist return nil.
-func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, service *kapi.Service, etpHostRules *bool) (old *serviceConfig, exists bool) {
+func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp *bool) (old *serviceConfig, exists bool) {
 
 	npw.serviceInfoLock.Lock()
 	defer npw.serviceInfoLock.Unlock()
@@ -353,62 +437,75 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 		npw.serviceInfo[index].service = service
 	}
 
-	if etpHostRules != nil {
-		npw.serviceInfo[index].etpHostRules = *etpHostRules
+	if hasLocalHostNetworkEp != nil {
+		npw.serviceInfo[index].hasLocalHostNetworkEp = *hasLocalHostNetworkEp
 	}
 
 	return old, exists
 }
 
 // addServiceRules ensures the correct iptables rules and OpenFlow physical
-// flows are programmed for a given service and hostNetwork endpoint configuration
-func addServiceRules(service *kapi.Service, hasHostNet bool, npw *nodePortWatcher) {
-	if util.ServiceExternalTrafficPolicyLocal(service) && hasHostNet {
-		klog.V(5).Infof("Adding externalTrafficPolicy:local and hostNetworked rules for %v", service)
-		// For dpu or Full mode
-		if npw != nil {
-			npw.updateServiceFlowCache(service, true, true)
-			npw.ofm.requestFlowSync()
-			// Dont touch iptables if in dpuMode
-			if !npw.dpuMode {
-				addSharedGatewayIptRules(service, true)
-			}
-			return
+// flows are programmed for a given service and endpoint configuration
+func addServiceRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, npw *nodePortWatcher) {
+	// For dpu or Full mode
+	if npw != nil {
+		npw.updateServiceFlowCache(service, true, svcHasLocalHostNetEndPnt)
+		npw.ofm.requestFlowSync()
+		if !npw.dpuMode {
+			// add iptable rules only in full mode
+			addGatewayIptRules(service, svcHasLocalHostNetEndPnt)
 		}
-		// For Host Only Mode
-		addSharedGatewayIptRules(service, true)
-	} else {
-		// For dpu or Full mode
-		if npw != nil {
-			npw.updateServiceFlowCache(service, true, false)
-			npw.ofm.requestFlowSync()
-			if !npw.dpuMode {
-				addSharedGatewayIptRules(service, false)
-			}
-			return
-		}
-		// For Host Only Mode
-		addSharedGatewayIptRules(service, false)
+		return
 	}
+	// For Host Only Mode
+	addGatewayIptRules(service, svcHasLocalHostNetEndPnt)
 }
 
 // delServiceRules deletes all possible iptables rules and OpenFlow physical
 // flows for a service
 func delServiceRules(service *kapi.Service, npw *nodePortWatcher) {
+	// full mode || dpu mode
 	if npw != nil {
 		npw.updateServiceFlowCache(service, false, false)
 		npw.ofm.requestFlowSync()
 		if !npw.dpuMode {
-			// Always try and delete all rules here
-			delSharedGatewayIptRules(service, true)
-			delSharedGatewayIptRules(service, false)
+			// Always try and delete all rules here in full mode & in host only mode. We don't touch iptables in dpu mode.
+			// +--------------------------+-----------------------+--------------+--------------------------------+
+			// | svcHasLocalHostNetEndPnt | ExternalTrafficPolicy | GatewayMode  |     Scenario for deletion      |
+			// |--------------------------|-----------------------|--------------|--------------------------------|
+			// |                          |                       |              |      deletes the REDIRECT      |
+			// |         true             |          local        | shared/local |      rules for etp=local +     |
+			// |                          |                       |              |      host-networked eps        |
+			// |--------------------------|-----------------------|--------------|--------------------------------|
+			// |                          |                       |              | deletes the DNAT rules for     |
+			// |         false            |          local        |   local      | etp=local + non-local-host-net |
+			// |                          |                       |              | eps towards masqueradeIP       |
+			// |--------------------------|-----------------------|--------------|--------------------------------|
+			// |                          |                       |              |                                |
+			// |         false            |          cluster      | shared/local |   	deletes the DNAT rules    |
+			// |         false            |           local       |   shared     |         towards clusterIP      |
+			// |                          |                       |              |       for the default case     |
+			// +--------------------------+-----------------------+--------------+--------------------------------+
+
+			// case1: deletes the REDIRECT rules for etp=local + host-networked pods in both gw modes
+			delGatewayIptRules(service, true)
+			// case2 Or case3a/3b:
+			// deletes the DNAT rules towards masqueradeIP for etp=local + ovn-k pods in LGW mode OR
+			// deletes the DNAT rules towards clusterIP for etp=local + ovn-k pods in SGW mode OR
+			// deletes the DNAT rules towards clusterIP for etp=cluster in both gw modes
+			delGatewayIptRules(service, false)
 		}
 		return
 	}
 
-	// For host only node always try and delete rules here
-	// externalTrafficPolicy is not implemented for dpu mode
-	delSharedGatewayIptRules(service, false)
+	// For host only mode always try and delete all rules here
+	// case1: deletes the REDIRECT rules for etp=local + host-networked pods in both gw modes
+	delGatewayIptRules(service, true)
+	// case2 Or case3a/3b:
+	// deletes the DNAT rules towards masqueradeIP for etp=local + ovn-k pods in LGW mode OR
+	// deletes the DNAT rules towards clusterIP for etp=local + ovn-k pods in SGW mode OR
+	// deletes the DNAT rules towards clusterIP for etp=cluster in both gw modes
+	delGatewayIptRules(service, false)
 }
 
 func serviceUpdateNeeded(old, new *kapi.Service) bool {
@@ -422,7 +519,7 @@ func serviceUpdateNeeded(old, new *kapi.Service) bool {
 
 // AddService handles configuring shared gateway bridge flows to steer External IP, Node Port, Ingress LB traffic into OVN
 func (npw *nodePortWatcher) AddService(service *kapi.Service) {
-	var etpHostRules bool
+	var hasLocalHostNetworkEp bool
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return
 	}
@@ -432,16 +529,16 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) {
 	ep, err := npw.watchFactory.GetEndpoint(service.Namespace, service.Name)
 	if err != nil {
 		klog.V(5).Infof("No endpoint found for service %s in namespace %s during service Add", service.Name, service.Namespace)
-		// No endpoints exist yet so default to false
-		etpHostRules = false
+		// No endpoint object exists yet so default to false
+		hasLocalHostNetworkEp = false
 	} else {
-		etpHostRules = hasHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
 	}
 
 	// If something didn't already do it add correct Service rules
-	if exists := npw.addOrSetServiceInfo(name, service, etpHostRules); !exists {
+	if exists := npw.addOrSetServiceInfo(name, service, hasLocalHostNetworkEp); !exists {
 		klog.V(5).Infof("Service Add %s event in namespace %s came before endpoint event setting svcConfig", service.Name, service.Namespace)
-		addServiceRules(service, etpHostRules, npw)
+		addServiceRules(service, hasLocalHostNetworkEp, npw)
 	} else {
 		klog.V(5).Infof("Rules already programmed for %s in namespace %s", service.Name, service.Namespace)
 	}
@@ -452,12 +549,11 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
 
 	if serviceUpdateNeeded(old, new) {
 		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
-			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress", new.Name)
+			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.Type, .Status.LoadBalancer.Ingress, .Spec.ExternalTrafficPolicy", new.Name)
 		return
 	}
-
 	// Update the service in svcConfig if we need to so that other handler
-	// threads do the correct thing, leave etpHostRules alone in the cache
+	// threads do the correct thing, leave hasLocalHostNetworkEp alone in the cache
 	svcConfig, exists := npw.updateServiceInfo(name, new, nil)
 	if !exists {
 		klog.V(5).Infof("Service %s in namespace %s was deleted during service Update", old.Name, old.Namespace)
@@ -473,7 +569,7 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
 		klog.V(5).Infof("Adding new service rules for: %v", new)
-		addServiceRules(new, svcConfig.etpHostRules, npw)
+		addServiceRules(new, svcConfig.hasLocalHostNetworkEp, npw)
 	}
 }
 
@@ -509,29 +605,27 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 			klog.V(5).Infof("No endpoint found for service %s in namespace %s during sync", service.Name, service.Namespace)
 			continue
 		}
-
-		hasHostNet := hasHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
-		npw.getAndSetServiceInfo(name, service, hasHostNet)
+		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp)
 		// Delete OF rules for service if they exist
-		npw.updateServiceFlowCache(service, false, hasHostNet)
-		npw.updateServiceFlowCache(service, true, hasHostNet)
+		npw.updateServiceFlowCache(service, false, hasLocalHostNetworkEp)
+		npw.updateServiceFlowCache(service, true, hasLocalHostNetworkEp)
 		// Add correct iptables rules only for Full mode
 		if !npw.dpuMode {
-			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, hasHostNet)...)
+			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, hasLocalHostNetworkEp)...)
 		}
 	}
 	// sync OF rules once
 	npw.ofm.requestFlowSync()
 	// sync IPtables rules once only for Full mode
 	if !npw.dpuMode {
-		for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain} {
+		for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain, iptableMgmPortChain} {
 			recreateIPTRules("nat", chain, keepIPTRules)
 		}
 	}
 }
 
 func (npw *nodePortWatcher) AddEndpoints(ep *kapi.Endpoints) {
-	var etpHostRules bool
 	name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
 
 	svc, err := npw.watchFactory.GetService(ep.Namespace, ep.Name)
@@ -547,40 +641,40 @@ func (npw *nodePortWatcher) AddEndpoints(ep *kapi.Endpoints) {
 	}
 
 	klog.V(5).Infof("Adding endpoints %s in namespace %s", ep.Name, ep.Namespace)
-	etpHostRules = hasHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
 
 	// Here we make sure the correct rules are programmed whenever an AddEndpoint
 	// event is received, only alter flows if we need to, i.e if cache wasn't
-	// set or if it was and etpHostRules state changed, to prevent flow churn
-	out, exists := npw.getAndSetServiceInfo(name, svc, etpHostRules)
+	// set or if it was and hasLocalHostNetworkEp state changed, to prevent flow churn
+	out, exists := npw.getAndSetServiceInfo(name, svc, hasLocalHostNetworkEp)
 	if !exists {
 		klog.V(5).Infof("Endpoint %s ADD event in namespace %s is creating rules", ep.Name, ep.Namespace)
-		addServiceRules(svc, etpHostRules, npw)
+		addServiceRules(svc, hasLocalHostNetworkEp, npw)
 		return
 	}
 
-	if out.etpHostRules != etpHostRules {
+	if out.hasLocalHostNetworkEp != hasLocalHostNetworkEp {
 		klog.V(5).Infof("Endpoint %s ADD event in namespace %s is updating rules", ep.Name, ep.Namespace)
 		delServiceRules(svc, npw)
-		addServiceRules(svc, etpHostRules, npw)
+		addServiceRules(svc, hasLocalHostNetworkEp, npw)
 	}
 
 }
 
 func (npw *nodePortWatcher) DeleteEndpoints(ep *kapi.Endpoints) {
-	var etpHostRules = false
+	var hasLocalHostNetworkEp = false
 
 	klog.V(5).Infof("Deleting endpoints %s in namespace %s", ep.Name, ep.Namespace)
 	// remove rules for endpoints and add back normal ones
 	name := ktypes.NamespacedName{Namespace: ep.Namespace, Name: ep.Name}
-	if svcConfig, exists := npw.updateServiceInfo(name, nil, &etpHostRules); exists {
+	if svcConfig, exists := npw.updateServiceInfo(name, nil, &hasLocalHostNetworkEp); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
 		// we have to do this because deleting and adding iptables rules is slow.
 		npw.serviceInfoLock.Lock()
 		defer npw.serviceInfoLock.Unlock()
 
 		delServiceRules(svcConfig.service, npw)
-		addServiceRules(svcConfig.service, etpHostRules, npw)
+		addServiceRules(svcConfig.service, hasLocalHostNetworkEp, npw)
 	}
 }
 
@@ -600,9 +694,10 @@ func (npw *nodePortWatcher) UpdateEndpoints(old *kapi.Endpoints, new *kapi.Endpo
 		}
 	}
 
-	// Update rules if hasHostNetworkEndpoints status changed
-	etpHostRulesNew := hasHostNetworkEndpoints(new, &npw.nodeIPManager.addresses)
-	if hasHostNetworkEndpoints(old, &npw.nodeIPManager.addresses) != etpHostRulesNew {
+	// Update rules if hasLocalHostNetworkEpNew status changed.
+	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints(old, &npw.nodeIPManager.addresses)
+	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints(new, &npw.nodeIPManager.addresses)
+	if hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew {
 		npw.DeleteEndpoints(old)
 		npw.AddEndpoints(new)
 	}
@@ -649,7 +744,8 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) {
 				serviceInterface)
 			continue
 		}
-		// Add correct iptables rules
+		// Add correct iptables rules.
+		// TODO: ETP is not implemented for smart NIC mode.
 		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, false)...)
 	}
 

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -54,18 +54,18 @@ func deleteLocalNodeAccessBridge() error {
 	return nil
 }
 
-// If A Service External Traffic Policy==Local and backend is a host-networked pod
-// we must steer traffic from host -> svc straight to the host instead of into OVN
-func addSharedGatewayIptRules(service *kapi.Service, hasLocalHostEndpoint bool) {
-	rules := getGatewayIPTRules(service, hasLocalHostEndpoint)
+// addGatewayIptRules adds the necessary iptable rules for a service on the node
+func addGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) {
+	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt)
 
 	if err := addIptRules(rules); err != nil {
 		klog.Errorf("Failed to add iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)
 	}
 }
 
-func delSharedGatewayIptRules(service *kapi.Service, hasLocalHostEndpoint bool) {
-	rules := getGatewayIPTRules(service, hasLocalHostEndpoint)
+// delGatewayIptRules removes the iptable rules for a service from the node
+func delGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) {
+	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt)
 
 	if err := delIptRules(rules); err != nil {
 		klog.Errorf("Failed to delete iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -96,7 +96,10 @@ func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {
 	return num
 }
 
-func hasHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses *sets.String) bool {
+// hasLocalHostNetworkEndpoints returns true if there is at least one host-networked endpoint
+// in the provided list that is local to this node.
+// It returns false if none of the endpoints are local host-networked endpoints or if ep.Subsets is nil.
+func hasLocalHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses *sets.String) bool {
 	for i := range ep.Subsets {
 		ss := &ep.Subsets[i]
 		for i := range ss.Addresses {

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -52,6 +52,21 @@ func newManagementPortIPFamilyConfig(hostSubnet *net.IPNet, isIPv6 bool) (*manag
 			cfg.allSubnets = append(cfg.allSubnets, subnet.CIDR)
 		}
 	}
+	// add the .3 masqueradeIP to add the route via mp0 for ETP=local case
+	// used only in LGW but we create it in SGW as well to maintain parity.
+	if isIPv6 {
+		_, masqueradeSubnet, err := net.ParseCIDR(types.V6HostETPLocalMasqueradeIP + "/128")
+		if err != nil {
+			return nil, err
+		}
+		cfg.allSubnets = append(cfg.allSubnets, masqueradeSubnet)
+	} else {
+		_, masqueradeSubnet, err := net.ParseCIDR(types.V4HostETPLocalMasqueradeIP + "/32")
+		if err != nil {
+			return nil, err
+		}
+		cfg.allSubnets = append(cfg.allSubnets, masqueradeSubnet)
+	}
 
 	if utilnet.IsIPv6CIDR(cfg.ifAddr) {
 		cfg.ipt, err = util.GetIPTablesHelper(iptables.ProtocolIPv6)

--- a/go-controller/pkg/node/port_claim_test.go
+++ b/go-controller/pkg/node/port_claim_test.go
@@ -135,6 +135,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				pcw.AddService(service)
@@ -171,6 +172,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				pcw.AddService(service)
@@ -209,6 +211,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				pcw.AddService(service)
@@ -247,6 +250,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				pcw.AddService(service)
@@ -278,6 +282,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				pcw.AddService(service)
@@ -314,6 +319,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{},
 					v1.ServiceStatus{},
+					false,
 				)
 				newService := newService("service7", "namespace1", "10.129.0.2",
 					[]kapi.ServicePort{
@@ -329,6 +335,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				pcw.UpdateService(oldService, newService)
@@ -358,6 +365,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
+					false,
 				)
 				newService := newService("service9", "namespace1", "10.129.0.2",
 					[]kapi.ServicePort{
@@ -373,6 +381,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				portMap := make(map[utilnet.LocalPort]bool)
@@ -418,6 +427,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{"8.8.8.8", "10.10.10.10"},
 					v1.ServiceStatus{},
+					false,
 				)
 				portMap := make(map[utilnet.LocalPort]bool)
 				lp, _ := utilnet.NewLocalPort(getDescription("", service, false), "8.8.8.8", "", 8088, utilnet.TCP)
@@ -462,6 +472,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				portMap := make(map[utilnet.LocalPort]bool)
@@ -508,6 +519,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				portMap := make(map[utilnet.LocalPort]bool)
@@ -552,6 +564,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				portMap := make(map[utilnet.LocalPort]bool)
@@ -604,6 +617,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"127.0.0.1", "8.8.8.8"},
 					v1.ServiceStatus{},
+					false,
 				)
 
 				errors := handleService(service, lpm.open)

--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"strings"
 
-	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -32,6 +31,8 @@ type lbConfig struct {
 	// that means, skipSNAT, and remove any non-local endpoints.
 	// (see below)
 	externalTrafficLocal bool
+	// indicates if this LB is configuring service of type NodePort.
+	hasNodePort bool
 }
 
 // just used for consistent ordering
@@ -53,7 +54,7 @@ var protos = []v1.Protocol{
 //
 // Per-node LBs will be created for
 // - services with NodePort set
-// - services with host-network endpoints (for shared gateway mode)
+// - services with host-network endpoints
 // - services with ExternalTrafficPolicy=Local
 func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice) (perNodeConfigs []lbConfig, clusterConfigs []lbConfig) {
 	// For each svcPort, determine if it will be applied per-node or cluster-wide
@@ -61,8 +62,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 		eps := util.GetLbEndpoints(endpointSlices, svcPort)
 
 		// if ExternalTrafficPolicy is local, then we need to do things a bit differently
-		externalTrafficLocal := globalconfig.Gateway.Mode == globalconfig.GatewayModeShared &&
-			service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal
+		externalTrafficLocal := (service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal)
 
 		// NodePort services get a per-node load balancer, but with the node's physical IP as the vip
 		// Thus, the vip "node" will be expanded later.
@@ -73,6 +73,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 				vips:                 []string{placeholderNodeIPs}, // shortcut for all-physical-ips
 				eps:                  eps,
 				externalTrafficLocal: externalTrafficLocal,
+				hasNodePort:          true,
 			}
 			perNodeConfigs = append(perNodeConfigs, nodePortLBConfig)
 		}
@@ -102,6 +103,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 				vips:                 externalVips,
 				eps:                  eps,
 				externalTrafficLocal: true,
+				hasNodePort:          false,
 			}
 			perNodeConfigs = append(perNodeConfigs, externalIPConfig)
 		} else {
@@ -116,12 +118,13 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 			vips:                 vips,
 			eps:                  eps,
 			externalTrafficLocal: false, // always false for ClusterIPs
+			hasNodePort:          false,
 		}
 
 		// Normally, the ClusterIP LB is global (on all node switches and routers),
-		// unless both of the following are true:
-		// - We're in shared gateway mode, and
+		// unless any of the following are true:
 		// - Any of the endpoints are host-network
+		// - ETP=local service backed by non-local-host-networked endpoints
 		//
 		// In that case, we need to create per-node LBs.
 		if hasHostEndpoints(eps.V4IPs) || hasHostEndpoints(eps.V6IPs) {
@@ -242,14 +245,10 @@ func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeIn
 }
 
 // buildPerNodeLBs takes a list of lbConfigs and expands them to one LB per protocol per node
-// This works differently based on whether or not we're in shared or local gateway mode.
 //
-// For local gateway, per-node lbs are created for:
-// - nodePort services, attached to each node's switch, vips are node's physical IPs
-//
-// For shared gateway, per-node lbs are created for
+// Per-node lbs are created for
 // - clusterip services with host-network endpoints are attached to each node's gateway router + switch
-// - nodeport services are attached to each node's gateway router + switch, vips are node's physical IPs
+// - nodeport services are attached to each node's gateway router + switch, vips are node's physical IPs (except if etp=local+ovnk backend pods)
 // - any services with host-network endpoints
 // - services with external IPs / LoadBalancer Status IPs
 //
@@ -260,7 +259,8 @@ func buildClusterLBs(service *v1.Service, configs []lbConfig, nodeInfos []nodeIn
 // For ExternalTrafficPolicy, all "External" IPs (NodePort, ExternalIPs, Loadbalancer Status) have:
 // - targets filtered to only local targets
 // - SkipSNAT enabled
-// This results in the creation of an additional load balancer on the GatewayRouters.
+// - NP LB on the switch will have masqueradeIP as the vip to handle etp=local for LGW case.
+// This results in the creation of an additional load balancer on the GatewayRouters and NodeSwitches.
 func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) []ovnlb.LB {
 	cbp := configsByProto(configs)
 	eids := util.ExternalIDsForObject(service)
@@ -276,8 +276,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 				continue
 			}
 
-			// local gateway mode - attach to switch only
-			// shared gateway mode - attach to router & switch,
+			// attach to router & switch,
 			// rules may or may not be different
 			// localRouterRules are rules with no snat
 			routerRules := make([]ovnlb.LBRule, 0, len(configs))
@@ -289,12 +288,15 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 
 				routerV4targetips := config.eps.V4IPs
 				routerV6targetips := config.eps.V6IPs
+				switchV4targetips := config.eps.V4IPs
+				switchV6targetips := config.eps.V6IPs
 
-				// shared gateway needs to "massage" some of the targets
-				if globalconfig.Gateway.Mode == "shared" && config.externalTrafficLocal {
-					// for ExternalTrafficPolicy=Local, then remove non-local endpoints from the router targets
+				if config.externalTrafficLocal {
+					// for ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
 					routerV4targetips = util.FilterIPsSlice(routerV4targetips, node.nodeSubnets(), true)
 					routerV6targetips = util.FilterIPsSlice(routerV6targetips, node.nodeSubnets(), true)
+					switchV4targetips = util.FilterIPsSlice(switchV4targetips, node.nodeSubnets(), true)
+					switchV6targetips = util.FilterIPsSlice(switchV6targetips, node.nodeSubnets(), true)
 				}
 				// at this point, the targets may be empty
 
@@ -328,6 +330,19 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 						targets = switchV6Targets
 					}
 
+					if config.externalTrafficLocal && config.hasNodePort {
+						// add special masqueradeIP as a vip if its nodePort svc with ETP=local
+						mvip := types.V4HostETPLocalMasqueradeIP
+						targetsETP := ovnlb.JoinHostsPort(switchV4targetips, config.eps.Port)
+						if isv6 {
+							mvip = types.V6HostETPLocalMasqueradeIP
+							targetsETP = ovnlb.JoinHostsPort(switchV6targetips, config.eps.Port)
+						}
+						switchRules = append(switchRules, ovnlb.LBRule{
+							Source:  ovnlb.Addr{IP: mvip, Port: config.inport},
+							Targets: targetsETP,
+						})
+					}
 					switchRules = append(switchRules, ovnlb.LBRule{
 						Source:  ovnlb.Addr{IP: vip, Port: config.inport},
 						Targets: targets,
@@ -347,7 +362,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 					// in other words, is this ExternalTrafficPolicy=local?
 					// if so, this gets a separate load balancer with SNAT disabled
 					// (but there's no need to do this if the list of targets is empty)
-					if globalconfig.Gateway.Mode == "shared" && config.externalTrafficLocal && len(targets) > 0 {
+					if config.externalTrafficLocal && len(targets) > 0 {
 						noSNATRouterRules = append(noSNATRouterRules, rule)
 					} else {
 						routerRules = append(routerRules, rule)

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -81,11 +81,13 @@ const (
 	V4NodeLocalNATSubnetNextHop    = "169.254.0.1"
 	V4NodeLocalDistributedGWPortIP = "169.254.0.2"
 
-	V4MasqueradeSubnet = "169.254.169.0/30"
-	V4HostMasqueradeIP = "169.254.169.2"
-	V6HostMasqueradeIP = "fd69::2"
-	V4OVNMasqueradeIP  = "169.254.169.1"
-	V6OVNMasqueradeIP  = "fd69::1"
+	V4MasqueradeSubnet         = "169.254.169.0/30"
+	V4HostMasqueradeIP         = "169.254.169.2"
+	V6HostMasqueradeIP         = "fd69::2"
+	V4OVNMasqueradeIP          = "169.254.169.1"
+	V6OVNMasqueradeIP          = "fd69::1"
+	V4HostETPLocalMasqueradeIP = "169.254.169.3"
+	V6HostETPLocalMasqueradeIP = "fd69::3"
 
 	// OpenFlow and Networking constants
 	RouteAdvertisementICMPType    = 134

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -51,15 +51,6 @@ if [ "$KIND_IPV6_SUPPORT" == true ]; then
   SKIPPED_TESTS+=$IPV6_SKIPPED_TESTS
 fi
 
-if [ "$OVN_GATEWAY_MODE" == "local" ]; then
-  if [ "$SKIPPED_TESTS" != "" ]; then
-  	SKIPPED_TESTS+="|"
-  fi
-  SKIPPED_TESTS+="Should be allowed to node local cluster-networked endpoints by nodeport services with externalTrafficPolicy=local|\
-e2e ingress to host-networked pods traffic validation|\
-host to host-networked pods traffic validation"
-fi
-
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote
 export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
**- What this PR does and why is it needed**
This PR implements `ExternalTrafficPolicy=Local` type traffic flow on local gateway mode. The path would be `external->host->ovn-k8s-mp0->OVN->node-local-switch->load-balancer-DNATs->endpoint`

**- Special notes for reviewers**
Depends on https://github.com/ovn-org/ovn-kubernetes/pull/2663 getting in first.

**- How to verify it**
Tried and tested on KIND cluster. Docs have been written detailing the process: https://github.com/ovn-org/ovn-kubernetes/pull/2651/commits/6272b0c26f70fe8e9db1e77dbd524b7aaf231a2a

**- Description for the changelog**
`Implement ETP=local for ovn clustered pods in LGW mode`