### PR TITLE
Two unrelated CI cleanups

### DIFF
--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -222,13 +222,13 @@ var _ = Describe("Config Operations", func() {
 
 	BeforeEach(func() {
 		// Restore global default values before each testcase
-		PrepareTestConfig()
+		err := PrepareTestConfig()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = Flags
 
-		var err error
 		cfgFile, err = ioutil.TempFile("", "conftest-")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -41,24 +42,24 @@ func (asn *testAddressSetName) makeNames() string {
 
 var _ = ginkgo.Describe("OVN Address Set operations", func() {
 	var (
-		app       *cli.App
-		asFactory AddressSetFactory
-		stopChan  chan struct{}
+		app             *cli.App
+		asFactory       AddressSetFactory
+		libovsdbCleanup *libovsdbtest.Cleanup
 	)
 
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
-		stopChan = make(chan struct{})
 
 		app = cli.NewApp()
 		app.Name = "test"
 		app.Flags = config.Flags
 
+		libovsdbCleanup = nil
 	})
 
 	ginkgo.AfterEach(func() {
-		close(stopChan)
+		libovsdbCleanup.Cleanup()
 	})
 
 	ginkgo.Context("when iterating address sets", func() {
@@ -81,7 +82,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -139,7 +142,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -173,7 +178,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				_, err = config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -196,7 +203,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 		ginkgo.It("creates a new address set and sets IPs", func() {
 			app.Action = func(ctx *cli.Context) error {
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -231,7 +240,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -278,7 +289,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -327,7 +340,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -363,7 +378,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 		ginkgo.It("ensures an address set exists and if not creates a new one", func() {
 			app.Action = func(ctx *cli.Context) error {
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -393,7 +410,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 	ginkgo.It("destroys an address set", func() {
 		app.Action = func(ctx *cli.Context) error {
 			dbSetup := libovsdbtest.TestSetup{}
-			libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+			var libovsdbOvnNBClient libovsdbclient.Client
+			var err error
+			libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -420,7 +439,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				const addr1 string = "1.2.3.4"
 
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -458,7 +479,9 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				var err error
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -487,7 +510,8 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1)})
@@ -522,7 +546,8 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1)})
@@ -563,7 +588,8 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -603,7 +629,8 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -646,7 +673,8 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -687,7 +715,8 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 			config.IPv6Mode = true
 
 			dbSetup := libovsdbtest.TestSetup{}
-			libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+			var libovsdbOvnNBClient libovsdbclient.Client
+			libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -730,7 +759,8 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
@@ -787,7 +817,8 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
@@ -916,7 +947,8 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				config.IPv6Mode = true
 
-				libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, stopChan)
+				var libovsdbOvnNBClient libovsdbclient.Client
+				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 

--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -24,8 +24,10 @@ import (
 func TestNewEgressDNS(t *testing.T) {
 	testCh := make(chan struct{})
 	dbSetup := libovsdbtest.TestSetup{}
-	libovsdbOvnNBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup, make(chan struct{}))
+
+	libovsdbOvnNBClient, _, libovsdbCleanup, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
 	assert.Nil(t, err)
+	t.Cleanup(libovsdbCleanup.Cleanup)
 
 	testOvnAddFtry := addressset.NewOvnAddressSetFactory(libovsdbOvnNBClient)
 	mockDnsOps := new(util_mocks.DNSOps)

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -46,7 +46,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN(nil)
+		fakeOvn = NewFakeOVN()
 	})
 
 	ginkgo.AfterEach(func() {
@@ -74,7 +74,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					namespaceT.Name,
 				)
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalSwitch{
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					namespaceT.Name,
 				)
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalSwitch{
@@ -344,7 +344,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					namespaceT.Name,
 				)
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalSwitch{
@@ -511,7 +511,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						namespaceT.Name,
 					)
 
-					fakeOvn.startWithDBSetup(ctx,
+					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: initNB,
 						},
@@ -665,7 +665,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						namespaceT.Name,
 					)
 
-					fakeOvn.startWithDBSetup(ctx,
+					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: initNB,
 						},
@@ -775,7 +775,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						namespaceT.Name,
 					)
 
-					fakeOvn.startWithDBSetup(ctx,
+					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: initNB,
 						},
@@ -961,7 +961,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					gwPod.Annotations["k8s.ovn.org/bfd-enabled"] = ""
 				}
 				gwPod.Spec.HostNetwork = true
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalSwitch{
@@ -1099,7 +1099,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					gwPod.Annotations["k8s.ovn.org/bfd-enabled"] = ""
 				}
 				gwPod.Spec.HostNetwork = true
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalSwitch{
@@ -1244,7 +1244,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					gwPod.Annotations["k8s.ovn.org/bfd-enabled"] = ""
 				}
 				gwPod.Spec.HostNetwork = true
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalSwitch{
@@ -1385,7 +1385,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						gwPod.Annotations["k8s.ovn.org/bfd-enabled"] = ""
 					}
 					gwPod.Spec.HostNetwork = true
-					fakeOvn.startWithDBSetup(ctx,
+					fakeOvn.startWithDBSetup(
 						libovsdbtest.TestSetup{
 							NBData: []libovsdbtest.TestData{
 								&nbdb.LogicalSwitch{
@@ -1584,7 +1584,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				gwPod := *newPod(namespaceX.Name, "gwPod", "node2", "10.0.0.1")
 				gwPod.Annotations = map[string]string{"k8s.ovn.org/routing-namespaces": namespaceT.Name}
 				gwPod.Spec.HostNetwork = true
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalSwitch{
@@ -1697,7 +1697,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				gwPod.Annotations["k8s.ovn.org/bfd-enabled"] = ""
 
 				gwPod.Spec.HostNetwork = true
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalSwitch{
@@ -1805,7 +1805,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					namespaceT.Name,
 				)
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.BFD{
@@ -1881,7 +1881,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -1932,7 +1932,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeLocal
 				intPriority, _ := strconv.Atoi(types.HybridOverlayReroutePriority)
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPolicy{
@@ -1991,7 +1991,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				intPriority, _ := strconv.Atoi(types.HybridOverlayReroutePriority)
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPolicy{
@@ -2077,7 +2077,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					*newPod(t.namespace, t.podName, t.nodeName, t.podIP),
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -60,11 +60,7 @@ func newEgressIPMeta(name string) metav1.ObjectMeta {
 	}
 }
 
-var (
-	egressPodLabel = map[string]string{"egress": "needed"}
-	node1Name      = "node1"
-	node2Name      = "node2"
-)
+var egressPodLabel = map[string]string{"egress": "needed"}
 
 func setupNode(nodeName string, ipNets []string, mockAllocationIPs []string) egressNode {
 	var v4IP, v6IP net.IP
@@ -103,6 +99,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 	var (
 		app     *cli.App
 		fakeOvn *FakeOVN
+	)
+	const (
+		node1Name = "node1"
+		node2Name = "node2"
 	)
 
 	dialer = fakeEgressIPDialer{}
@@ -161,8 +161,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN(nil)
-
+		fakeOvn = NewFakeOVN()
 	})
 
 	ginkgo.AfterEach(func() {
@@ -240,7 +239,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -484,7 +483,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -673,7 +672,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e32", "0:0:0:0:0:feff:c0a8:8e1e"})
 				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e23"})
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -833,7 +832,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e32", "0:0:0:0:0:feff:c0a8:8e1e"})
 				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e23"})
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -970,7 +969,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e32", "0:0:0:0:0:feff:c0a8:8e1e"})
 				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e23"})
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -1101,7 +1100,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				egressPod := *newPodWithLabels(namespace, podName, node1Name, "", egressPodLabel)
 				egressNamespace := newNamespace(namespace)
-				fakeOvn.start(ctx,
+				fakeOvn.start(
 					&v1.NamespaceList{
 						Items: []v1.Namespace{*egressNamespace},
 					},
@@ -1170,7 +1169,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e32", "0:0:0:0:0:feff:c0a8:8e1e"})
 				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e23"})
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -1318,7 +1317,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				egressPod := *newPodWithLabels(namespace, podName, node1Name, "", egressPodLabel)
 				egressNamespace := newNamespaceWithLabels(namespace, egressPodLabel)
-				fakeOvn.start(ctx,
+				fakeOvn.start(
 					&v1.NamespaceList{
 						Items: []v1.Namespace{*egressNamespace},
 					},
@@ -1389,7 +1388,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e32", "0:0:0:0:0:feff:c0a8:8e1e"})
 				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e23"})
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -1541,7 +1540,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e32", "0:0:0:0:0:feff:c0a8:8e1e"})
 				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e23"})
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPort{
@@ -1723,7 +1722,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				fakeOvn.startWithDBSetup(ctx, libovsdbtest.TestSetup{
+				fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
 						&nbdb.LogicalRouter{
 							Name: ovntypes.OVNClusterRouter,
@@ -1861,7 +1860,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				fakeOvn.start(ctx, &v1.NodeList{
+				fakeOvn.start(&v1.NodeList{
 					Items: []v1.Node{node},
 				})
 
@@ -1926,7 +1925,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouter{
@@ -2115,7 +2114,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouter{
@@ -2275,7 +2274,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouter{
@@ -2505,7 +2504,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouter{
@@ -2676,7 +2675,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				}
 
 				expectedNatLogicalPort := "k8s-node1"
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouterPolicy{
@@ -2866,7 +2865,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouter{
@@ -3144,7 +3143,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouter{
@@ -3418,7 +3417,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.startWithDBSetup(ctx,
+				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
 							&nbdb.LogicalRouter{
@@ -3646,7 +3645,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should be able to allocate non-conflicting IPv4 on node which can host it, even if it happens to be the node with more assignments", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 				egressIP := "192.168.126.99"
 
 				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e23"})
@@ -3681,7 +3680,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("Should not be able to assign egress IP defined in CIDR notation", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIPs := []string{"192.168.126.99/32"}
 
@@ -3716,7 +3715,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should be able to allocate non-conflicting IP on node with lowest amount of allocations", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP := "0:0:0:0:0:feff:c0a8:8e0f"
 				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, []string{"0:0:0:0:0:feff:c0a8:8e32", "0:0:0:0:0:feff:c0a8:8e1e"})
@@ -3747,7 +3746,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should be able to allocate several EgressIPs and avoid the same node", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP1 := "0:0:0:0:0:feff:c0a8:8e0d"
 				egressIP2 := "0:0:0:0:0:feff:c0a8:8e0f"
@@ -3780,7 +3779,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should be able to allocate several EgressIPs and avoid the same node and leave one un-assigned without error", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP1 := "0:0:0:0:0:feff:c0a8:8e0d"
 				egressIP2 := "0:0:0:0:0:feff:c0a8:8e0e"
@@ -3816,7 +3815,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should not be able to allocate already allocated IP", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP := "0:0:0:0:0:feff:c0a8:8e32"
 
@@ -3848,7 +3847,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should not be able to allocate node IP", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP := "0:0:0:0:0:feff:c0a8:8e0c"
 
@@ -3878,7 +3877,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should not be able to allocate conflicting compressed IP", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP := "::feff:c0a8:8e32"
 
@@ -3911,7 +3910,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should not be able to allocate IPv4 IP on nodes which can only host IPv6", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP := "192.168.126.16"
 
@@ -3943,7 +3942,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should be able to allocate non-conflicting compressed uppercase IP", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP := "::FEFF:C0A8:8D32"
 
@@ -3974,7 +3973,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should not be able to allocate conflicting compressed uppercase IP", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP := "::FEFF:C0A8:8E32"
 
@@ -4006,7 +4005,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		ginkgo.It("should not be able to allocate invalid IP", func() {
 			app.Action = func(ctx *cli.Context) error {
 
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIPs := []string{"0:0:0:0:0:feff:c0a8:8e32:5"}
 
@@ -4039,7 +4038,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 		ginkgo.It("should update status correctly for single-stack IPv4", func() {
 			app.Action = func(ctx *cli.Context) error {
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP := "192.168.126.10"
 				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, []string{"192.168.126.102", "192.168.126.111"})
@@ -4079,7 +4078,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 		ginkgo.It("should update status correctly for single-stack IPv6", func() {
 			app.Action = func(ctx *cli.Context) error {
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIP := "0:0:0:0:0:feff:c0a8:8e0d"
 
@@ -4115,7 +4114,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 		ginkgo.It("should update status correctly for dual-stack", func() {
 			app.Action = func(ctx *cli.Context) error {
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				egressIPv4 := "192.168.126.101"
 				egressIPv6 := "0:0:0:0:0:feff:c0a8:8e0d"
@@ -4183,10 +4182,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.start(ctx,
-					&egressipv1.EgressIPList{
-						Items: []egressipv1.EgressIP{eIP},
-					})
+				fakeOvn.start(&egressipv1.EgressIPList{
+					Items: []egressipv1.EgressIP{eIP},
+				})
 
 				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
 				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
@@ -4235,10 +4233,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.start(ctx,
-					&egressipv1.EgressIPList{
-						Items: []egressipv1.EgressIP{eIP},
-					})
+				fakeOvn.start(&egressipv1.EgressIPList{
+					Items: []egressipv1.EgressIP{eIP},
+				})
 
 				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
 				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
@@ -4282,10 +4279,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.start(ctx,
-					&egressipv1.EgressIPList{
-						Items: []egressipv1.EgressIP{eIP},
-					})
+				fakeOvn.start(&egressipv1.EgressIPList{
+					Items: []egressipv1.EgressIP{eIP},
+				})
 
 				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
 				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
@@ -4335,10 +4331,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.start(ctx,
-					&egressipv1.EgressIPList{
-						Items: []egressipv1.EgressIP{eIP},
-					})
+				fakeOvn.start(&egressipv1.EgressIPList{
+					Items: []egressipv1.EgressIP{eIP},
+				})
 
 				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
 				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
@@ -4383,10 +4378,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.start(ctx,
-					&egressipv1.EgressIPList{
-						Items: []egressipv1.EgressIP{eIP},
-					})
+				fakeOvn.start(&egressipv1.EgressIPList{
+					Items: []egressipv1.EgressIP{eIP},
+				})
 
 				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
 				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
@@ -4429,10 +4423,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.start(ctx,
-					&egressipv1.EgressIPList{
-						Items: []egressipv1.EgressIP{eIP},
-					})
+				fakeOvn.start(&egressipv1.EgressIPList{
+					Items: []egressipv1.EgressIP{eIP},
+				})
 
 				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
 				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
@@ -4474,10 +4467,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				fakeOvn.start(ctx,
-					&egressipv1.EgressIPList{
-						Items: []egressipv1.EgressIP{eIP},
-					})
+				fakeOvn.start(&egressipv1.EgressIPList{
+					Items: []egressipv1.EgressIP{eIP},
+				})
 
 				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
 				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
@@ -4518,7 +4510,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						EgressIPs: []string{egressIP1},
 					},
 				}
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
 				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2
@@ -4564,7 +4556,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						EgressIPs: []string{egressIP},
 					},
 				}
-				fakeOvn.start(ctx)
+				fakeOvn.start()
 
 				fakeOvn.controller.eIPC.allocator.cache[node1.name] = &node1
 				fakeOvn.controller.eIPC.allocator.cache[node2.name] = &node2

--- a/go-controller/pkg/ovn/gateway/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway/gateway_test.go
@@ -59,19 +59,19 @@ func TestGetOvnGateways(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stopChan := make(chan struct{})
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: tt.ovnInitState,
 			}
-			libovsdbOvnNBClient, err := libovsdbtest.NewNBTestHarness(dbSetup, stopChan)
+			libovsdbOvnNBClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
 			if err != nil {
 				t.Errorf("libovsdb client error: %v", err)
 			}
+			t.Cleanup(cleanup.Cleanup)
+
 			got, err := GetOvnGateways(libovsdbOvnNBClient)
 			if !sets.NewString(got...).HasAll(tt.want...) {
 				t.Errorf("GetOvnGateways() got = %v, want %v", got, tt.want)
 			}
-			close(stopChan)
 		})
 	}
 }
@@ -138,14 +138,15 @@ func TestGetGatewayPhysicalIPs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stopChan := make(chan struct{})
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: tt.ovnInitState,
 			}
-			libovsdbOvnNBClient, err := libovsdbtest.NewNBTestHarness(dbSetup, stopChan)
+			libovsdbOvnNBClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
 			if err != nil {
 				t.Errorf("libovsdb client error: %v", err)
 			}
+			t.Cleanup(cleanup.Cleanup)
+
 			got, err := GetGatewayPhysicalIPs(libovsdbOvnNBClient, "GR_ovn-control-plane")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetGatewayPhysicalIPs() error = %v, wantErr %v", err, tt.wantErr)
@@ -154,7 +155,6 @@ func TestGetGatewayPhysicalIPs(t *testing.T) {
 			if !sets.NewString(got...).HasAll(tt.want...) {
 				t.Errorf("GetOvnGateways() got = %v, want %v", got, tt.want)
 			}
-			close(stopChan)
 		})
 	}
 }

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -9,13 +9,8 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
-	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/libovsdbops"
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -23,8 +18,6 @@ import (
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/record"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -217,16 +210,10 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 
 var _ = ginkgo.Describe("Gateway Init Operations", func() {
 	var (
-		fexec           *ovntest.FakeExec
-		fakeClient      *util.OVNClientset
-		f               *factory.WatchFactory
-		stopChan        chan struct{}
-		libovsdbCleanup *libovsdbtest.Cleanup
+		fakeOvn *FakeOVN
 	)
 
 	ginkgo.BeforeEach(func() {
-		libovsdbCleanup = nil
-
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
 		// TODO make contexts here for shared gw mode and local gw mode, right now this only tests shared gw
@@ -234,52 +221,14 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		// Create new LBCache
 		ovnlb.TestOnlySetCache(nil)
 
-		fexec = ovntest.NewFakeExec()
-		err := util.SetExec(fexec)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		fakeClient = &util.OVNClientset{
-			KubeClient:           fake.NewSimpleClientset(),
-			EgressIPClient:       &egressipfake.Clientset{},
-			EgressFirewallClient: &egressfirewallfake.Clientset{},
-		}
-
-		stopChan = make(chan struct{})
-		f, err = factory.NewMasterWatchFactory(fakeClient)
+		fakeOvn = NewFakeOVN()
 	})
 
 	ginkgo.AfterEach(func() {
-		close(stopChan)
-		if libovsdbCleanup != nil {
-			libovsdbCleanup.Cleanup()
-		}
-	})
-
-	ginkgo.It("correctly sorts gateway routers", func() {
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
-			Output: `node5      chassis=842fdade-747a-43b8-b40a-d8e8e26379fa lb_force_snat_ip=100.64.0.5
-node2 chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=100.64.0.2
-node1 chassis=d17ddb5a-050d-42ab-ab50-7c6ce79a8f2e lb_force_snat_ip=100.64.0.1
-node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
-		})
-
-	})
-
-	ginkgo.It("ignores malformatted gateway router entires", func() {
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd: "ovn-nbctl --timeout=15 --data=bare --format=table --no-heading --columns=name,options find logical_router options:lb_force_snat_ip!=-",
-			Output: `node5      chassis=842fdade-747a-43b8-b40a-d8e8e26379fa lb_force_snat_ip=100.64.0.5
-node2 chassis=6a47b33b-89d3-4d65-ac31-b19b549326c7 lb_force_snat_ip=asdfsadf
-node1 chassis=d17ddb5a-050d-42ab-ab50-7c6ce79a8f2e lb_force_xxxxxxx=100.64.0.1
-node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
-		})
+		fakeOvn.shutdown()
 	})
 
 	ginkgo.It("creates an IPv4 gateway in OVN", func() {
-
-		f, err := factory.NewMasterWatchFactory(fakeClient)
-
 		expectedOVNClusterRouter := &nbdb.LogicalRouter{
 			UUID: types.OVNClusterRouter + "-UUID",
 			Name: types.OVNClusterRouter,
@@ -288,7 +237,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			UUID: nodeName + "-UUID",
 			Name: nodeName,
 		}
-		dbSetup := libovsdbtest.TestSetup{
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{
 				&nbdb.LogicalSwitch{
 					UUID: types.OVNJoinSwitch + "-UUID",
@@ -297,14 +246,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 				expectedOVNClusterRouter,
 				expectedNodeSwitch,
 			},
-		}
-		var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
-		libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-			libovsdbOvnNBClient, libovsdbOvnSBClient,
-			record.NewFakeRecorder(0))
+		})
 
 		clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")
 		hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23")
@@ -321,7 +263,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		}
 		sctpSupport := false
 
-		err = clusterController.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
+		err := fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		testData := []libovsdb.TestData{}
@@ -329,8 +271,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		// We don't set up the Allow from mgmt port ACL here
 		mgmtPortIP := ""
 		expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch, nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP)
-		gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-		gomega.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue())
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 	})
 
 	ginkgo.It("creates an IPv6 gateway in OVN", func() {
@@ -342,7 +283,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			UUID: nodeName + "-UUID",
 			Name: nodeName,
 		}
-		dbSetup := libovsdbtest.TestSetup{
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{
 				&nbdb.LogicalSwitch{
 					UUID: types.OVNJoinSwitch + "-UUID",
@@ -351,15 +292,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 				expectedOVNClusterRouter,
 				expectedNodeSwitch,
 			},
-		}
-		var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
-		var err error
-		libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-			libovsdbOvnNBClient, libovsdbOvnSBClient,
-			record.NewFakeRecorder(0))
+		})
 
 		clusterIPSubnets := ovntest.MustParseIPNets("fd01::/48")
 		hostSubnets := ovntest.MustParseIPNets("fd01:0:0:2::/64")
@@ -377,7 +310,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		}
 		sctpSupport := false
 
-		err = clusterController.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
+		err := fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		testData := []libovsdb.TestData{}
@@ -385,8 +318,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		// We don't set up the Allow from mgmt port ACL here
 		mgmtPortIP := ""
 		expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch, nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP)
-		gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-		gomega.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue())
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 	})
 
 	ginkgo.It("creates a dual-stack gateway in OVN", func() {
@@ -398,7 +330,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			UUID: nodeName + "-UUID",
 			Name: nodeName,
 		}
-		dbSetup := libovsdbtest.TestSetup{
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{
 				&nbdb.LogicalSwitch{
 					UUID: types.OVNJoinSwitch + "-UUID",
@@ -407,15 +339,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 				expectedOVNClusterRouter,
 				expectedNodeSwitch,
 			},
-		}
-		var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
-		var err error
-		libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-			libovsdbOvnNBClient, libovsdbOvnSBClient,
-			record.NewFakeRecorder(0))
+		})
 
 		clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14", "fd01::/48")
 		hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23", "fd01:0:0:2::/64")
@@ -433,7 +357,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		}
 		sctpSupport := false
 
-		err = clusterController.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
+		err := fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		testData := []libovsdb.TestData{}
@@ -441,8 +365,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		// We don't set up the Allow from mgmt port ACL here
 		mgmtPortIP := ""
 		expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch, nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP)
-		gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-		gomega.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue())
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 	})
 
 	ginkgo.It("cleans up a single-stack gateway in OVN", func() {
@@ -462,7 +385,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		matchstr5 := fmt.Sprintf(`ip4.src == 10.244.0.2  && ip4.dst != 10.244.0.0/16 /* inter-%s */`, nodeName)
 		matchstr6 := fmt.Sprintf("ip4.src == NO DELETE && ip4.dst == nodePhysicalIP /* %s-no */", nodeName)
 
-		dbSetup := libovsdbtest.TestSetup{
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{
 				&nbdb.LogicalRouterPort{
 					Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName,
@@ -542,19 +465,10 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 					UUID: types.ExternalSwitchPrefix + types.ExternalSwitchPrefix + nodeName + "-UUID",
 				},
 			},
-		}
-		var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
-		var err error
-		libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 
-		clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-			libovsdbOvnNBClient, libovsdbOvnSBClient,
-			record.NewFakeRecorder(0))
-
-		err = clusterController.gatewayCleanup(nodeName)
+		err := fakeOvn.controller.gatewayCleanup(nodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Eventually(fexec.CalledMatchesExpected()).Should(gomega.BeTrue(), fexec.ErrorDesc)
 
 		expectedDatabaseState := []libovsdbtest.TestData{
 			&nbdb.LogicalRouterPort{
@@ -596,7 +510,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 				Policies: []string{"match3-UUID", "match4-UUID", "match6-UUID"},
 			},
 		}
-		gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 	})
 
 	ginkgo.It("cleans up a dual-stack gateway in OVN", func() {
@@ -617,7 +531,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		matchstr5 := fmt.Sprintf(`ip4.src == 10.244.0.2  && ip4.dst != 10.244.0.0/16 /* inter-%s */`, nodeName)
 		matchstr6 := fmt.Sprintf("ip4.src == NO DELETE && ip4.dst == nodePhysicalIP /* %s-no */", nodeName)
 
-		dbSetup := libovsdbtest.TestSetup{
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{
 				&nbdb.LogicalRouterPort{
 					Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName,
@@ -701,19 +615,10 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 					UUID: types.ExternalSwitchPrefix + types.ExternalSwitchPrefix + nodeName + "-UUID",
 				},
 			},
-		}
-		var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
-		var err error
-		libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 
-		clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-			libovsdbOvnNBClient, libovsdbOvnSBClient,
-			record.NewFakeRecorder(0))
-
-		err = clusterController.gatewayCleanup(nodeName)
+		err := fakeOvn.controller.gatewayCleanup(nodeName)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Eventually(fexec.CalledMatchesExpected()).Should(gomega.BeTrue(), fexec.ErrorDesc)
 
 		expectedDatabaseState := []libovsdbtest.TestData{
 			&nbdb.LogicalRouterPort{
@@ -755,7 +660,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 				Policies: []string{"match3-UUID", "match4-UUID", "match6-UUID"},
 			},
 		}
-		gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 	})
 
 	ginkgo.It("removes leftover SNAT entries during init", func() {
@@ -767,7 +672,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 			UUID: nodeName + "-UUID",
 			Name: nodeName,
 		}
-		dbSetup := libovsdbtest.TestSetup{
+		fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{
 				&nbdb.LogicalSwitch{
 					UUID: types.OVNJoinSwitch + "-UUID",
@@ -776,15 +681,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 				expectedOVNClusterRouter,
 				expectedNodeSwitch,
 			},
-		}
-		var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
-		var err error
-		libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-			libovsdbOvnNBClient, libovsdbOvnSBClient,
-			record.NewFakeRecorder(0))
+		})
 
 		clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")
 		hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23")
@@ -803,7 +700,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		sctpSupport := false
 		config.Gateway.DisableSNATMultipleGWs = true
 
-		err = clusterController.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
+		err := fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		testData := []libovsdb.TestData{}
@@ -811,8 +708,6 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 		// We don't set up the Allow from mgmt port ACL here
 		mgmtPortIP := ""
 		expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch, nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP)
-		gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-		gomega.Eventually(fexec.CalledMatchesExpected()).Should(gomega.BeTrue(), fexec.ErrorDesc)
-
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 	})
 })

--- a/go-controller/pkg/ovn/libovsdbops/switch_test.go
+++ b/go-controller/pkg/ovn/libovsdbops/switch_test.go
@@ -83,9 +83,11 @@ func TestRemoveACLsFromSwitches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			stopChan := make(chan struct{})
-
-			nbClient, _ := libovsdbtest.NewNBTestHarness(tt.initialNbdb, stopChan)
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tt.initialNbdb, nil)
+			if err != nil {
+				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
+			}
+			t.Cleanup(cleanup.Cleanup)
 
 			fakeSwitches := []nbdb.LogicalSwitch{
 				*fakeSwitch1,
@@ -98,7 +100,7 @@ func TestRemoveACLsFromSwitches(t *testing.T) {
 				*fakeACL2,
 			}
 
-			err := removeACLsFromSwitches(nbClient, fakeSwitches, ACLs)
+			err = removeACLsFromSwitches(nbClient, fakeSwitches, ACLs)
 			if err != nil && !tt.expectErr {
 				t.Fatal(fmt.Errorf("RemoveACLFromNodeSwitches() error = %v", err))
 			}
@@ -112,8 +114,6 @@ func TestRemoveACLsFromSwitches(t *testing.T) {
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tt.desc, err))
 			}
-
-			close(stopChan)
 		})
 	}
 }

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
@@ -68,11 +68,11 @@ func TestNewCache(t *testing.T) {
 		},
 	}
 
-	stopChan := make(chan struct{})
-	nbClient, err := libovsdb.NewNBTestHarness(libovsdb.TestSetup{NBData: initialDb}, stopChan)
+	nbClient, cleanup, err := libovsdb.NewNBTestHarness(libovsdb.TestSetup{NBData: initialDb}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(cleanup.Cleanup)
 
 	c, err := newCache(nbClient)
 	if err != nil {
@@ -129,7 +129,4 @@ func TestNewCache(t *testing.T) {
 	assert.Equal(t, c.existing["cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"].Switches, sets.String{
 		"ovn-worker2": {},
 	})
-
-	nbClient.Close()
-	close(stopChan)
 }

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -241,7 +241,7 @@ func addNodeportLBs(fexec *ovntest.FakeExec, nodeName, tcpLBUUID, udpLBUUID, sct
 }
 */
 
-func addNodeLogicalFlows(testData []libovsdb.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter, expectedNodeSwitch *nbdb.LogicalSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup *nbdb.PortGroup, fexec *ovntest.FakeExec, node *tNode, clusterCIDR string, enableIPv6 bool) []libovsdb.TestData {
+func addNodeLogicalFlows(testData []libovsdb.TestData, expectedOVNClusterRouter *nbdb.LogicalRouter, expectedNodeSwitch *nbdb.LogicalSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup *nbdb.PortGroup, node *tNode, clusterCIDR string, enableIPv6 bool) []libovsdb.TestData {
 
 	lrpName := types.RouterToSwitchPrefix + node.Name
 	chassisName := node.SystemID
@@ -1174,7 +1174,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			expectedDatabaseState := []libovsdb.TestData{}
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, fexec, &node1, clusterCIDR, config.IPv6Mode)
+			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, clusterCIDR, config.IPv6Mode)
 
 			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
 				libovsdbOvnNBClient, libovsdbOvnSBClient,
@@ -1216,9 +1216,6 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config, []*net.IPNet{joinLRPIPs}, []*net.IPNet{dLRPIPs}, skipSnat, node1.NodeMgmtPortIP)
 			gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-			// Make sure remaining fexec calls are still correct
-			gomega.Expect(fexec.CalledMatchesExpected()).To(gomega.BeTrue(), fexec.ErrorDesc)
 
 			return nil
 		}

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -1,8 +1,6 @@
 package ovn
 
 import (
-	"sync"
-
 	"github.com/onsi/gomega"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -47,7 +45,6 @@ type FakeOVN struct {
 	nbClient     libovsdbclient.Client
 	sbClient     libovsdbclient.Client
 	dbSetup      libovsdbtest.TestSetup
-	wg           *sync.WaitGroup
 	nbsbCleanup  *libovsdbtest.Cleanup
 }
 
@@ -58,7 +55,6 @@ func NewFakeOVN(fexec *ovntest.FakeExec) *FakeOVN {
 		fakeExec:     fexec,
 		asf:          addressset.NewFakeAddressSetFactory(),
 		fakeRecorder: record.NewFakeRecorder(10),
-		wg:           &sync.WaitGroup{},
 	}
 }
 
@@ -94,7 +90,6 @@ func (o *FakeOVN) shutdown() {
 	o.watcher.Shutdown()
 	close(o.stopChan)
 	o.nbsbCleanup.Cleanup()
-	o.wg.Wait()
 }
 
 func (o *FakeOVN) init() {

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -3,14 +3,12 @@ package ovn
 import (
 	"github.com/onsi/gomega"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	"github.com/urfave/cli/v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
@@ -39,7 +37,6 @@ type FakeOVN struct {
 	watcher      *factory.WatchFactory
 	controller   *Controller
 	stopChan     chan struct{}
-	fakeExec     *ovntest.FakeExec
 	asf          *addressset.FakeAddressSetFactory
 	fakeRecorder *record.FakeRecorder
 	nbClient     libovsdbclient.Client
@@ -48,17 +45,18 @@ type FakeOVN struct {
 	nbsbCleanup  *libovsdbtest.Cleanup
 }
 
-func NewFakeOVN(fexec *ovntest.FakeExec) *FakeOVN {
-	err := util.SetExec(fexec)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+func NewFakeOVN() *FakeOVN {
 	return &FakeOVN{
-		fakeExec:     fexec,
 		asf:          addressset.NewFakeAddressSetFactory(),
 		fakeRecorder: record.NewFakeRecorder(10),
 	}
 }
 
-func (o *FakeOVN) start(ctx *cli.Context, objects ...runtime.Object) {
+func (o *FakeOVN) start(objects ...runtime.Object) {
+	fexec := ovntest.NewFakeExec()
+	err := util.SetExec(fexec)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 	egressIPObjects := []runtime.Object{}
 	egressFirewallObjects := []runtime.Object{}
 	v1Objects := []runtime.Object{}
@@ -71,8 +69,6 @@ func (o *FakeOVN) start(ctx *cli.Context, objects ...runtime.Object) {
 			v1Objects = append(v1Objects, object)
 		}
 	}
-	_, err := config.InitConfig(ctx, o.fakeExec, nil)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	o.fakeClient = &util.OVNClientset{
 		KubeClient:           fake.NewSimpleClientset(v1Objects...),
 		EgressIPClient:       egressipfake.NewSimpleClientset(egressIPObjects...),
@@ -81,9 +77,9 @@ func (o *FakeOVN) start(ctx *cli.Context, objects ...runtime.Object) {
 	o.init()
 }
 
-func (o *FakeOVN) startWithDBSetup(ctx *cli.Context, dbSetup libovsdbtest.TestSetup, objects ...runtime.Object) {
+func (o *FakeOVN) startWithDBSetup(dbSetup libovsdbtest.TestSetup, objects ...runtime.Object) {
 	o.dbSetup = dbSetup
-	o.start(ctx, objects...)
+	o.start(objects...)
 }
 
 func (o *FakeOVN) shutdown() {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -208,7 +208,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN(nil)
+		fakeOvn = NewFakeOVN()
 		initialDB = libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{
 				&nbdb.LogicalSwitch{
@@ -241,7 +241,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					namespaceT.Name,
 				)
 
-				fakeOvn.startWithDBSetup(ctx, initialDB,
+				fakeOvn.startWithDBSetup(initialDB,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespaceT,
@@ -297,7 +297,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					namespaceT.Name,
 				)
 
-				fakeOvn.startWithDBSetup(ctx, initialDB,
+				fakeOvn.startWithDBSetup(initialDB,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespaceT,
@@ -346,7 +346,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					namespaceT.Name,
 				)
 
-				fakeOvn.startWithDBSetup(ctx, initialDB,
+				fakeOvn.startWithDBSetup(initialDB,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespaceT,
@@ -398,7 +398,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					namespaceT.Name,
 				)
 
-				fakeOvn.startWithDBSetup(ctx, initialDB,
+				fakeOvn.startWithDBSetup(initialDB,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespaceT,
@@ -456,7 +456,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 				podJSON := t.getAnnotationsJson()
 
-				fakeOvn.startWithDBSetup(ctx, initialDB)
+				fakeOvn.startWithDBSetup(initialDB)
 				t.populateLogicalSwitchCache(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
@@ -497,7 +497,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					namespaceT.Name,
 				)
 
-				fakeOvn.startWithDBSetup(ctx, initialDB,
+				fakeOvn.startWithDBSetup(initialDB,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespaceT,
@@ -549,7 +549,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				)
 				pod := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
 				setPodAnnotations(pod, t)
-				fakeOvn.startWithDBSetup(ctx, initialDB,
+				fakeOvn.startWithDBSetup(initialDB,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespaceT,
@@ -658,7 +658,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				setPodAnnotations(pod1, t1)
 				pod2 := newPod(t2.namespace, t2.podName, t2.nodeName, t2.podIP)
 				setPodAnnotations(pod2, t2)
-				fakeOvn.startWithDBSetup(ctx, initialDB,
+				fakeOvn.startWithDBSetup(initialDB,
 					&v1.NamespaceList{
 						Items: []v1.Namespace{
 							namespaceT,

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -160,8 +160,12 @@ func TestGetPortAddresses(t *testing.T) {
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			stopChan := make(chan struct{})
-			nbClient, _, _ := libovsdbtest.NewNBSBTestHarness(tc.dbSetup, stopChan)
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tc.dbSetup, nil)
+			if err != nil {
+				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
+			}
+			t.Cleanup(cleanup.Cleanup)
+
 			hardwareAddr, ips, err := GetPortAddresses(portName, nbClient)
 			if tc.isNotFound {
 				assert.Nil(t, hardwareAddr)
@@ -178,8 +182,6 @@ func TestGetPortAddresses(t *testing.T) {
 				assert.Equal(t, len(ips), 1)
 				assert.Equal(t, ips[0].String(), ipAddr)
 			}
-
-			close(stopChan)
 		})
 	}
 }

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -418,9 +418,11 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			stopChan := make(chan struct{})
-
-			nbClient, _ := libovsdbtest.NewNBTestHarness(tc.initialNbdb, stopChan)
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tc.initialNbdb, nil)
+			if err != nil {
+				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
+			}
+			t.Cleanup(cleanup.Cleanup)
 
 			_, ipnet, err := net.ParseCIDR(tc.inpSubnetStr)
 			if err != nil {
@@ -448,8 +450,6 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tc.desc, err))
 			}
-
-			close(stopChan)
 		})
 	}
 }


### PR DESCRIPTION
Two unrelated things:

1) the libovsdb test server was being shut down concurrently with the client, which could trigger the client's reconnect handling and un-necessarily block tests for a while. Split the shutdown logic for client and server so that callers can shut them down in the right order (client first, then server) and prevent that. As a bonus actually clean things up rather than piling up tons of goroutines that we aren't properly terminating.

2) It turns out most tests don't change the config options and don't need to have the urfave/cli/v2 App object wrapping the testcase since they just use the defaults. But FakeOVN currently needs it... so remove that from FakeOVN and let the few tests that change the config do it directly rather than with CLI options pass to the App object.