### PR TITLE
Add routable-mtu config setting

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -162,6 +162,7 @@ ovn_gateway_router_subnet=${OVN_GATEWAY_ROUTER_SUBNET:-""}
 net_cidr=${OVN_NET_CIDR:-10.128.0.0/14/23}
 svc_cidr=${OVN_SVC_CIDR:-172.30.0.0/16}
 mtu=${OVN_MTU:-1400}
+routable_mtu=${OVN_ROUTABLE_MTU:-}
 
 # set metrics endpoint bind to K8S_NODE_IP.
 metrics_endpoint_ip=${K8S_NODE_IP:-0.0.0.0}
@@ -1025,6 +1026,11 @@ ovn-node() {
     wait_for_event process_ready ovn-controller
   fi
 
+  ovn_routable_mtu_flag=
+  if [[ -n "${routable_mtu}" ]]; then
+	  routable_mtu_flag="--routable-mtu ${routable_mtu}"
+  fi
+
   hybrid_overlay_flags=
   if [[ ${ovn_hybrid_overlay_enable} == "true" ]]; then
     hybrid_overlay_flags="--enable-hybrid-overlay"
@@ -1159,6 +1165,7 @@ ovn-node() {
     ${ovn_unprivileged_flag} \
     --nodeport \
     --mtu=${mtu} \
+    ${routable_mtu_flag} \
     ${ovn_encap_ip_flag} \
     --loglevel=${ovnkube_loglevel} \
     --logfile-maxsize=${ovnkube_logfile_maxsize} \

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -131,6 +131,12 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: mtu
+        - name: OVN_ROUTABLE_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: routable_mtu
+              optional: true
         - name: K8S_NODE
           valueFrom:
             fieldRef:

--- a/go-controller/pkg/cni/mocks/CNIPluginLibOps.go
+++ b/go-controller/pkg/cni/mocks/CNIPluginLibOps.go
@@ -18,7 +18,7 @@ type CNIPluginLibOps struct {
 }
 
 // AddRoute provides a mock function with given fields: ipn, gw, dev
-func (_m *CNIPluginLibOps) AddRoute(ipn *net.IPNet, gw net.IP, dev netlink.Link) error {
+func (_m *CNIPluginLibOps) AddRoute(ipn *net.IPNet, gw net.IP, dev netlink.Link, mtu int) error {
 	ret := _m.Called(ipn, gw, dev)
 
 	var r0 error

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -38,6 +38,7 @@ type PodInterfaceInfo struct {
 	util.PodAnnotation
 
 	MTU           int    `json:"mtu"`
+	RoutableMTU   int    `json:"routable-mtu"`
 	Ingress       int64  `json:"ingress"`
 	Egress        int64  `json:"egress"`
 	CheckExtIDs   bool   `json:"check-external-ids"`

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -121,6 +121,7 @@ func PodAnnotation2PodInfo(podAnnotation map[string]string, checkExtIDs bool, po
 	podInterfaceInfo := &PodInterfaceInfo{
 		PodAnnotation: *podAnnotSt,
 		MTU:           config.Default.MTU,
+		RoutableMTU:   config.Default.RoutableMTU,
 		Ingress:       ingress,
 		Egress:        egress,
 		CheckExtIDs:   checkExtIDs,

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -159,6 +159,10 @@ const (
 type DefaultConfig struct {
 	// MTU value used for the overlay networks.
 	MTU int `gcfg:"mtu"`
+	// RoutableMTU is the maximum routable MTU between nodes, used to facilitate
+	// an MTU migration procedure where different nodes might be using different
+	// MTU values
+	RoutableMTU int `gcfg:"routable-mtu"`
 	// ConntrackZone affects only the gateway nodes, This value is used to track connections
 	// that are initiated from the pods so that the reverse connections go back to the pods.
 	// This represents the conntrack zone used for the conntrack flow rules.
@@ -564,6 +568,11 @@ var CommonFlags = []cli.Flag{
 		Usage:       "MTU value used for the overlay networks (default: 1400)",
 		Destination: &cliConfig.Default.MTU,
 		Value:       Default.MTU,
+	},
+	&cli.IntFlag{
+		Name:        "routable-mtu",
+		Usage:       "Maximum routable MTU between nodes, used to facilitate an MTU migration procedure where different nodes might be using different MTU values",
+		Destination: &cliConfig.Default.RoutableMTU,
 	},
 	&cli.IntFlag{
 		Name:        "conntrack-zone",

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -243,16 +243,14 @@ func configureSvcRouteViaInterface(iface string, gwIPs []net.IP) error {
 			return fmt.Errorf("unable to find gateway IP for subnet: %v, found IPs: %v", subnet, gwIPs)
 		}
 
-		route, err := util.LinkRouteGet(link, gwIP[0], subnet)
-		if err != nil {
-			return fmt.Errorf("unable to get route[%s via %s dev %s]: %v", subnet, gwIP[0], iface, err)
+		mtu := config.Default.MTU
+		if config.Default.RoutableMTU != 0 {
+			mtu = config.Default.RoutableMTU
 		}
-		if route == nil || route.MTU != config.Default.MTU {
-			// Add or update the route
-			err = util.LinkRoutesReplace(link, gwIP[0], []*net.IPNet{subnet}, config.Default.MTU)
-			if err != nil {
-				return fmt.Errorf("unable to add/update route for service via %s, error: %v", iface, err)
-			}
+
+		err = util.LinkRoutesAddOrUpdateMTU(link, gwIP[0], []*net.IPNet{subnet}, mtu)
+		if err != nil {
+			return fmt.Errorf("unable to add/update route for service via %s, error: %v", iface, err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1222,7 +1222,7 @@ var _ = Describe("Gateway unit tests", func() {
 			netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
 			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
 			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-			netlinkMock.On("RouteReplace", expectedRoute).Return(nil)
+			netlinkMock.On("RouteAdd", expectedRoute).Return(nil)
 
 			err = configureSvcRouteViaInterface("ens1f0", gwIPs)
 			Expect(err).ToNot(HaveOccurred())
@@ -1285,6 +1285,28 @@ var _ = Describe("Gateway unit tests", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("Fails if link route add fails", func() {
+			_, ipnet, err := net.ParseCIDR("10.96.0.0/16")
+			Expect(err).ToNot(HaveOccurred())
+			config.Kubernetes.ServiceCIDRs = []*net.IPNet{ipnet}
+			gwIPs := []net.IP{net.ParseIP("10.0.0.11")}
+
+			lnk := &linkMock.Link{}
+			lnkAttr := &netlink.LinkAttrs{
+				Name:  "ens1f0",
+				Index: 5,
+			}
+
+			lnk.On("Attrs").Return(lnkAttr)
+			netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
+			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
+			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			netlinkMock.On("RouteAdd", mock.Anything).Return(fmt.Errorf("failed to replace route"))
+
+			err = configureSvcRouteViaInterface("ens1f0", gwIPs)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("Fails if link route replace fails", func() {
 			_, ipnet, err := net.ParseCIDR("10.96.0.0/16")
 			Expect(err).ToNot(HaveOccurred())
@@ -1296,10 +1318,18 @@ var _ = Describe("Gateway unit tests", func() {
 				Name:  "ens1f0",
 				Index: 5,
 			}
+			previousRoute := &netlink.Route{
+				Dst:       ipnet,
+				LinkIndex: 5,
+				Scope:     netlink.SCOPE_UNIVERSE,
+				Gw:        gwIPs[0],
+				MTU:       config.Default.MTU - 100,
+			}
+
 			lnk.On("Attrs").Return(lnkAttr)
 			netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
 			netlinkMock.On("LinkSetUp", mock.Anything).Return(nil)
-			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+			netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return([]netlink.Route{*previousRoute}, nil)
 			netlinkMock.On("RouteReplace", mock.Anything).Return(fmt.Errorf("failed to replace route"))
 
 			err = configureSvcRouteViaInterface("ens1f0", gwIPs)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -1272,19 +1271,7 @@ func addMasqueradeRoute(netIfaceName string, nextHops []net.IP) error {
 		return fmt.Errorf("no valid ipv4 next hop exists: %v", err)
 	}
 	_, masqIPNet, _ := net.ParseCIDR(types.V4MasqueradeSubnet)
-	exists, err := util.LinkRouteExists(netIfaceLink, v4nextHops[0], masqIPNet)
-	if err != nil {
-		return fmt.Errorf("failed to check if route exists for masquerade subnet, error: %v", err)
-	}
-	if exists {
-		return nil
-	}
-	err = util.LinkRoutesAdd(netIfaceLink, v4nextHops[0], []*net.IPNet{masqIPNet}, 0)
-	if os.IsExist(err) {
-		klog.V(5).Infof("Ignoring error %s from 'route add %s via %s'",
-			err.Error(), masqIPNet, v4nextHops[0])
-		return nil
-	}
+	err = util.LinkRoutesAddOrUpdateMTU(netIfaceLink, v4nextHops[0], []*net.IPNet{masqIPNet}, config.Default.RoutableMTU)
 	if err != nil {
 		return fmt.Errorf("unable to add OVN masquerade route to host, error: %v", err)
 	}

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -459,8 +459,8 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 					} else {
 						gwIP = mgmtPortConfig.ipv6.gwIP
 					}
-					err := util.LinkRoutesAdd(link, gwIP, []*net.IPNet{subnet}, 0)
-					if err != nil && !os.IsExist(err) {
+					err := util.LinkRoutesAddOrUpdateMTU(link, gwIP, []*net.IPNet{subnet}, config.Default.RoutableMTU)
+					if err != nil {
 						return fmt.Errorf("unable to add legacy route for services via mp0, error: %v", err)
 					}
 				}


### PR DESCRIPTION
routable-mtu setting is introduced to faciliate a procedure allowing to
change the MTU on a running cluster with minimum service disruption.

Given current and target mtu values:
1. Set `mtu` to the higher MTU value and `routable-mtu` to the lower
   MTU value.
2. Do a rolling reboot. As a node restarts, `routable-mtu` is set on
   all appropriate routes while interfaces have `mtu` configured.
   The node will effectively use the lower `routable-mtu` for outgoing
   traffic, but be able to handle incoming traffic up to the higher
   `mtu`.
3. Change the MTU on all interfaces not handled by ovn-k to the target
   MTU value. Since the MTU effectively used in the cluster is the lower
   one, this has no impact on traffic.
4. Set `mtu` to the target MTU value and unset `routable-mtu`.
5. Do a rolling reboot. As a node restarts, the target MTU value is set
   on the interfaces and the routes are reset to default MTU values.
   Since the MTU effectively used in other nodes of the cluster is the
   lower onei but able to handle the higher one, this has no impact on
   traffic.

`routable-mtu` is set as the MTU for the following routes:
* pod default route
* non link scoped management port route,
* services route


Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->