### PR TITLE
Fix deadlock in exgw pod del/add

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -86,8 +86,8 @@ func (oc *Controller) ensureRouteInfoLocked(podName ktypes.NamespacedName) (*ext
 	if routeInfoExisted {
 		// Check that the routeInfo wasn't altered in the cache while we were waiting for the lock
 		// and that routeInfo that we locked is not stale.
-		oc.exGWCacheMutex.RLock()
-		defer oc.exGWCacheMutex.RUnlock()
+		oc.exGWCacheMutex.Lock()
+		defer oc.exGWCacheMutex.Unlock()
 		if routeInfo != oc.externalGWCache[podName] {
 			routeInfo.Unlock()
 			return nil, fmt.Errorf("routeInfo for pod %s, was altered during ensure route info", podName)
@@ -99,8 +99,8 @@ func (oc *Controller) ensureRouteInfoLocked(podName ktypes.NamespacedName) (*ext
 
 // getRouteInfosForGateway returns all routeInfos locked for a specific namespace and gateway IP
 func (oc *Controller) getRouteInfosForGateway(gatewayIP, namespace string) []*externalRouteInfo {
-	oc.exGWCacheMutex.RLock()
-	defer oc.exGWCacheMutex.RUnlock()
+	oc.exGWCacheMutex.Lock()
+	defer oc.exGWCacheMutex.Unlock()
 
 	routeInfos := make([]*externalRouteInfo, 0)
 	for namespacedName, routeInfo := range oc.externalGWCache {
@@ -122,8 +122,8 @@ func (oc *Controller) getRouteInfosForGateway(gatewayIP, namespace string) []*ex
 
 // getRouteInfosForNamespace returns all routeInfos locked for a specific namespace
 func (oc *Controller) getRouteInfosForNamespace(namespace string) []*externalRouteInfo {
-	oc.exGWCacheMutex.RLock()
-	defer oc.exGWCacheMutex.RUnlock()
+	oc.exGWCacheMutex.Lock()
+	defer oc.exGWCacheMutex.Unlock()
 
 	routes := make([]*externalRouteInfo, 0)
 	for namespacedName, routeInfo := range oc.externalGWCache {
@@ -141,9 +141,9 @@ func (oc *Controller) getRouteInfosForNamespace(namespace string) []*externalRou
 func (oc *Controller) deleteRouteInfoLocked(name ktypes.NamespacedName) *externalRouteInfo {
 	// Attempt to find the routeInfo in the cache, release the cache lock while
 	// we try to lock the routeInfo to avoid any deadlock
-	oc.exGWCacheMutex.RLock()
+	oc.exGWCacheMutex.Lock()
 	routeInfo := oc.externalGWCache[name]
-	oc.exGWCacheMutex.RUnlock()
+	oc.exGWCacheMutex.Unlock()
 
 	if routeInfo == nil {
 		return nil

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -137,7 +137,7 @@ type Controller struct {
 	namespacesMutex sync.Mutex
 
 	externalGWCache map[ktypes.NamespacedName]*externalRouteInfo
-	exGWCacheMutex  sync.RWMutex
+	exGWCacheMutex  sync.Mutex
 
 	// egressFirewalls is a map of namespaces and the egressFirewall attached to it
 	egressFirewalls sync.Map
@@ -265,7 +265,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		namespaces:                make(map[string]*namespaceInfo),
 		namespacesMutex:           sync.Mutex{},
 		externalGWCache:           make(map[ktypes.NamespacedName]*externalRouteInfo),
-		exGWCacheMutex:            sync.RWMutex{},
+		exGWCacheMutex:            sync.Mutex{},
 		addressSetFactory:         addressSetFactory,
 		lspIngressDenyCache:       make(map[string]int),
 		lspEgressDenyCache:        make(map[string]int),


### PR DESCRIPTION
**- What this PR does and why is it needed**

Fix deadlock in exgw pod del/add
    
The exGWCacheMutex RW Mutex is tricky in its workings and
is causing deadlock between ensureRouteInfoLocked
and getRouteInfosForGateway.
    
Let's change exGWCacheMutex to ordinary Mutex like we do for nsInfo.
    
Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
Co-Authored-By: Dan Williams <dcbw@redhat.com>
Co-Authored-By: Tim Rozet <trozet@redhat.com>


**- Special notes for reviewers**

See @dcbw 's awesome deadlock steps on comment https://github.com/ovn-org/ovn-kubernetes/pull/2655#issuecomment-970349042