### PR TITLE
Ensure node host address annotations are in sync with api server

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -247,11 +247,9 @@ func NewNodeWatchFactory(ovnClientset *util.OVNClientset, nodeName string) (*Wat
 		return nil, err
 	}
 
-	if config.HybridOverlay.Enabled {
-		wf.informers[nodeType], err = newInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer())
-		if err != nil {
-			return nil, err
-		}
+	wf.informers[nodeType], err = newInformer(nodeType, wf.iFactory.Core().V1().Nodes().Informer())
+	if err != nil {
+		return nil, err
 	}
 
 	return wf, nil

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -45,6 +45,8 @@ type NodeWatchFactory interface {
 	NodeInformer() cache.SharedIndexInformer
 	LocalPodInformer() cache.SharedIndexInformer
 
+	GetNode(name string) (*kapi.Node, error)
+
 	GetService(namespace, name string) (*kapi.Service, error)
 	GetEndpoint(namespace, name string) (*kapi.Endpoints, error)
 }

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -214,7 +214,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator, k,
-				&fakeMgmtPortConfig, nil)
+				&fakeMgmtPortConfig, wf)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)
 			Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1124,7 +1124,7 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 			return err
 		}
 
-		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg)
+		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory)
 
 		if config.Gateway.NodeportEnable {
 			klog.Info("Creating Shared Gateway Node Port Watcher")


### PR DESCRIPTION
Node annotator address changes may fail updates to Kube api.
To handle such cases, make sure they are in sync by comparing the
annotator value against kapi.Node.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
Co-Authored-By: Tim Rozet <trozet@redhat.com>
