### PR TITLE
CI: controlplane tests timing out

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -335,8 +335,8 @@ jobs:
         make -C test install-kind
     - name: Run Tests
       # e2e tests take less than 30 minutes normally, 60 should be more than enough
-      # set 2 1/2 hours for control-plane tests as these might take a while
-      timeout-minutes: ${{ matrix.target == 'control-plane' && 150 || 60 }}
+      # set 3 1/2 hours for control-plane tests as these might take a while
+      timeout-minutes: ${{ matrix.target == 'control-plane' && 210 || 60 }}
       run: |
         make -C test ${{ matrix.target }}
     - name: Upload Junit Reports


### PR DESCRIPTION
We had set the timeout to 150mins for
control plane tests and that is not
enough. We are seeing the tests timing
out. Let's bump this to 210mins.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

sample runs of time out:
https://github.com/ovn-org/ovn-kubernetes/runs/4233431908?check_suite_focus=true#step:10:3904
https://github.com/ovn-org/ovn-kubernetes/runs/4235721029?check_suite_focus=true#step:10:1848