### PR TITLE
Release VF and its representor on pod deletion

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -143,6 +143,13 @@ func (pr *PodRequest) cmdDel() error {
 		return nil
 	}
 
+	if pr.CNIConf.DeviceID != "" {
+		if err := pr.ReleaseVF(); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	if err := pr.PlatformSpecificCleanup(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Unlike veth interface, VFs shall be released from pod
netns to host netns on pod deletion, otherwise the next
pod creation using the same VF would fail with either
no such device or inactive VF representor device

Signed-off-by: Zenghui Shi <zshi@redhat.com>
