### PR TITLE
Make container OVS interfaces Transient, Batch Periodic interface scrubbing

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -272,7 +272,8 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 	for i, ip := range ifInfo.IPs {
 		ipStrs[i] = ip.String()
 	}
-	// Add the new sandbox's OVS port
+	// Add the new sandbox's OVS port, tag the interface as transient so stale
+	// pod interfaces are scrubbed on hard reboot
 	ovsArgs := []string{
 		"add-port", "br-int", hostIfaceName, "--", "set",
 		"interface", hostIfaceName,
@@ -281,6 +282,7 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 		fmt.Sprintf("external_ids:iface-id-ver=%s", initialPodUID),
 		fmt.Sprintf("external_ids:ip_addresses=%s", strings.Join(ipStrs, ",")),
 		fmt.Sprintf("external_ids:sandbox=%s", sandboxID),
+		"other_config:transient=true",
 	}
 
 	if out, err := ovsExec(ovsArgs...); err != nil {

--- a/go-controller/pkg/node/node_dpu_test.go
+++ b/go-controller/pkg/node/node_dpu_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
@@ -26,7 +27,7 @@ func genOVSFindCmd(table, column, condition string) string {
 
 func genOVSAddPortCmd(hostIfaceName, ifaceID, mac, ip, sandboxID, podUID string) string {
 	return fmt.Sprintf("ovs-vsctl --timeout=30 add-port br-int %s -- set interface %s external_ids:attached_mac=%s "+
-		"external_ids:iface-id=%s external_ids:iface-id-ver=%s external_ids:ip_addresses=%s external_ids:sandbox=%s",
+		"external_ids:iface-id=%s external_ids:iface-id-ver=%s external_ids:ip_addresses=%s external_ids:sandbox=%s other_config:transient=true",
 		hostIfaceName, hostIfaceName, mac, ifaceID, podUID, ip, sandboxID)
 }
 


### PR DESCRIPTION
This will ensure stale pod OVS interfaces are purged by
the OVS service during a hard reboot for a node

This leaves the mechanism we have in ovnkube node to
periodically search for and remove stale interfaces, but improves 
the function by batching the interface deletion commands