### PR TITLE
port missing in the network policy port_groups

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -674,6 +674,13 @@ func (oc *Controller) processLocalPodSelectorSetPods(policy *knet.NetworkPolicy,
 			continue
 		}
 
+		// this is portInfo of the previous deleted Pod of the same name
+		// wait for the next Pod update event
+		if !portInfo.expires.IsZero() {
+			klog.Warningf("Port %s is already marked for removal", logicalPort)
+			continue
+		}
+
 		// this pod is somehow already added to this policy, then skip
 		if _, ok := np.localPods.LoadOrStore(portInfo.name, portInfo); ok {
 			continue


### PR DESCRIPTION
when Pod add/update event is handled for selected Pods of a given
policy, the portInfo in the cache may still be that of the staled Pod.
In order not to add the stale port into the portGroup, stop processing
and wait for the next Pod update event.

Signed-off-by: Yun Zhou yunz@nvidia.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->