### PR TITLE
Support migrations between LGW  and SGW

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -122,6 +122,11 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					Name: node1Name,
 					ACLs: []string{purgeACL.UUID, keepACL.UUID},
 				}
+				InitialJoinSwitch := &nbdb.LogicalSwitch{
+					UUID: libovsdbops.BuildNamedUUID(),
+					Name: "join",
+					ACLs: []string{purgeACL.UUID, keepACL.UUID},
+				}
 
 				dbSetup := libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
@@ -129,6 +134,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 						purgeACL,
 						keepACL,
 						InitialNodeSwitch,
+						InitialJoinSwitch,
 					},
 				}
 
@@ -150,7 +156,13 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 
 				fakeOVN.controller.WatchEgressFirewall()
 
-				// stale ACL will be removed from the switch
+				// Both ACLS will be removed from the join switch
+				finalJoinSwitch := &nbdb.LogicalSwitch{
+					UUID: InitialJoinSwitch.UUID,
+					Name: "join",
+				}
+
+				// stale ACL will be removed from the node switch
 				finalNodeSwitch := &nbdb.LogicalSwitch{
 					UUID: InitialNodeSwitch.UUID,
 					Name: node1Name,
@@ -164,6 +176,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					otherACL,
 					keepACL,
 					finalNodeSwitch,
+					finalJoinSwitch,
 				}
 
 				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))

--- a/go-controller/pkg/ovn/libovsdbops/switch.go
+++ b/go-controller/pkg/ovn/libovsdbops/switch.go
@@ -227,7 +227,28 @@ func RemoveACLsFromNodeSwitches(nbClient libovsdbclient.Client, acls []nbdb.ACL)
 	return nil
 }
 
-// RemoveACLsFromAllSwitches removes the ACL uuid entry from Logical Switch acl's list.
+// RemoveACLsFromJoinSwitch removes the specified ACLs from the distributed join switch
+func RemoveACLsFromJoinSwitch(nbClient libovsdbclient.Client, acls []nbdb.ACL) error {
+	// Find join switch
+	joinSwichLookupFcn := func(item *nbdb.LogicalSwitch) bool {
+		// Return only join switch (the per node ones if its old topology & distributed one if its new topology)
+		return (strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == "join")
+	}
+
+	switches, err := findSwitchesByPredicate(nbClient, joinSwichLookupFcn)
+	if err != nil {
+		return err
+	}
+
+	err = removeACLsFromSwitches(nbClient, switches, acls)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RemoveACLFromSwitches removes the ACL uuid entry from Logical Switch acl's list.
 func RemoveACLsFromAllSwitches(nbClient libovsdbclient.Client, acls []nbdb.ACL) error {
 	// Find all switches
 	switches, err := findSwitches(nbClient)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->


We are adding handling the logic behind local and shared gateway migrations. Specifically we handle two things:
- delete the static route towards management port when moving to shared and delete the static route towards join subnet when moving to local wrt to the hostSubnet source prefix routes on ovn_cluster_router.
- similar to how we were already deleting acls from node switches when moving to shared, we will now start deleting acls from join switches when moving to local.

Apart from these two differences and a few others like 501 hybrid policy (which is already migration ready), we really shouldn't have any differences between the two gateway modes as long as users properly upgraded it using the `topology-version` for older clusters. New clusters should have the latest codebase, which means the topologies will be identical for both modes.

**- Special Note to Reviewers**
Depends on https://github.com/ovn-org/ovn-kubernetes/pull/2663

**- How to verify it**
Related unit testing has been incorporated and migration has been tested on a KIND cluster.