### PR TITLE
Fix sbdb.MacBinding model

### DIFF
--- a/go-controller/pkg/ovn/libovsdbops/model.go
+++ b/go-controller/pkg/ovn/libovsdbops/model.go
@@ -190,7 +190,7 @@ func getListFromModel(model model.Model) interface{} {
 	case *sbdb.Chassis:
 		return &[]sbdb.Chassis{}
 	case *sbdb.MACBinding:
-		return t.UUID
+		return &[]sbdb.MACBinding{}
 	default:
 		panic(fmt.Sprintf("getModelList: unknown model %T", t))
 	}


### PR DESCRIPTION
In https://github.com/ovn-org/ovn-kubernetes/pull/2631 there was a rebase disaster and this resulted in incorrectly returning the uuid of sbdb.MACBinding instead of the model object list.