### PR TITLE
Converge to use one label for apps

### DIFF
--- a/contrib/kind-dual-stack-conversion.sh
+++ b/contrib/kind-dual-stack-conversion.sh
@@ -31,7 +31,7 @@ convert_cni() {
   # restart ovnkube-master
   # FIXME: kubectl rollout restart deployment leaves the old pod hanging 
   # as workaround we delete the master directly
-  kubectl -n ovn-kubernetes delete pod -l name=ovnkube-master
+  kubectl -n ovn-kubernetes delete pod -l app=ovnkube-master
   # restart ovnkube-node
   kubectl -n ovn-kubernetes rollout restart daemonset ovnkube-node
   kubectl -n ovn-kubernetes rollout status daemonset ovnkube-node

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -17,7 +17,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      name: ovnkube-master
+      app: ovnkube-master
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       labels:
-        name: ovnkube-master
+        app: ovnkube-master
         component: network
         type: infra
         kubernetes.io/os: "linux"
@@ -57,7 +57,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchExpressions:
-                  - key: name
+                  - key: app
                     operator: In
                     values:
                       - ovnkube-master

--- a/dist/templates/ovnkube-monitor.yaml.j2
+++ b/dist/templates/ovnkube-monitor.yaml.j2
@@ -31,7 +31,7 @@ metadata:
   namespace: ovn-kubernetes
 spec:
   selector:
-    name: ovnkube-master
+    app: ovnkube-master
   type: ClusterIP
   clusterIP: None
   publishNotReadyAddresses: true
@@ -80,7 +80,7 @@ metadata:
   namespace: ovn-kubernetes
 spec:
   selector:
-    name: ovnkube-node
+    app: ovnkube-node
   type: ClusterIP
   clusterIP: None
   publishNotReadyAddresses: true

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -91,7 +91,7 @@ var ovnNorthdStopwatchShowMetricsMap = map[string]*stopwatchMetricDetails{
 
 func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
-		return checkPodRunsOnGivenNode(clientset, "name=ovnkube-master", k8sNodeName, true)
+		return checkPodRunsOnGivenNode(clientset, "app=ovnkube-master", k8sNodeName, true)
 	})
 	if err != nil {
 		if err == wait.ErrWaitTimeout {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -413,7 +413,7 @@ func runCommand(cmd ...string) (string, error) {
 // restartOVNKubeNodePod restarts the ovnkube-node pod from namespace, running on nodeName
 func restartOVNKubeNodePod(clientset kubernetes.Interface, namespace string, nodeName string) error {
 	ovnKubeNodePods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: "name=ovnkube-node",
+		LabelSelector: "app=ovnkube-node",
 		FieldSelector: "spec.nodeName=" + nodeName,
 	})
 	if err != nil {
@@ -432,7 +432,7 @@ func restartOVNKubeNodePod(clientset kubernetes.Interface, namespace string, nod
 	framework.Logf("waiting for node %s to have running ovnkube-node pod", nodeName)
 	wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
 		ovnKubeNodePods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "name=ovnkube-node",
+			LabelSelector: "app=ovnkube-node",
 			FieldSelector: "spec.nodeName=" + nodeName,
 		})
 		if err != nil {
@@ -478,7 +478,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		}
 
 		masterPods, err := f.ClientSet.CoreV1().Pods("ovn-kubernetes").List(context.Background(), metav1.ListOptions{
-			LabelSelector: "name=ovnkube-master",
+			LabelSelector: "app=ovnkube-master",
 		})
 		framework.ExpectNoError(err)
 		numMasters = len(masterPods.Items)
@@ -528,7 +528,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		podClient := f.ClientSet.CoreV1().Pods("ovn-kubernetes")
 
 		podList, err := podClient.List(context.Background(), metav1.ListOptions{
-			LabelSelector: "name=ovnkube-master",
+			LabelSelector: "app=ovnkube-master",
 		})
 		framework.ExpectNoError(err)
 
@@ -2623,7 +2623,7 @@ var _ = ginkgo.Describe("e2e br-int NetFlow export validation", func() {
 		framework.ExpectNoError(err)
 
 		ovnKubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNs).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "name=ovnkube-node",
+			LabelSelector: "app=ovnkube-node",
 		})
 		if err != nil {
 			framework.Failf("could not get ovnkube-node pods: %v", err)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -565,7 +565,7 @@ func waitClusterHealthy(f *framework.Framework, numMasters int) error {
 		}
 
 		podList, err = podClient.List(context.Background(), metav1.ListOptions{
-			LabelSelector: "name=ovnkube-master",
+			LabelSelector: "app=ovnkube-master",
 		})
 		if err != nil {
 			return false, fmt.Errorf("failed to list ovn-kube node pods: %w", err)


### PR DESCRIPTION
Currently, there are two labels to describe ovn-k apps
master/node: name=ovnkube-* and app=ovnkube-*.

Converge to using label app=ovnkube-* only in order to allow code
which needs to search for an application to do so with one
label upstream and downstream namely: https://github.com/ovn-org/ovn-kubernetes/blob/0a7dda66ede4927c5b90be1046bfe886f60ea00d/go-controller/pkg/metrics/ovn_northd.go#L94

Signed-off-by: Martin Kennelly <mkennell@redhat.com>
