### PR TITLE
PodRequest`IsDPU field is confusing and must reflect a mode type

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/containernetworking/cni/pkg/types/current"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
 var (
@@ -101,7 +102,7 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, podLister corev1listers.PodL
 	kubecli := &kube.Kube{KClient: kclient}
 	annotCondFn := isOvnReady
 
-	if pr.IsDPU {
+	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
 		// Add DPU connection-details annotation so ovnkube-node running on DPU
 		// performs the needed network plumbing.
 		if err := pr.addDPUConnectionDetailsAnnot(kubecli); err != nil {
@@ -119,7 +120,7 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, podLister corev1listers.PodL
 		return nil, err
 	}
 
-	podInterfaceInfo, err := PodAnnotation2PodInfo(annotations, useOVSExternalIDs, pr.IsDPU, pr.PodUID)
+	podInterfaceInfo, err := PodAnnotation2PodInfo(annotations, useOVSExternalIDs, pr.PodUID)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +139,7 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, podLister corev1listers.PodL
 }
 
 func (pr *PodRequest) cmdDel() error {
-	if pr.IsDPU {
+	if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
 		// nothing to do
 		return nil
 	}

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -180,7 +180,7 @@ func HandleCNIRequest(request *PodRequest, podLister corev1listers.PodLister, us
 	if response != nil {
 		if result, err1 = response.Marshal(); err1 != nil {
 			return nil, fmt.Errorf("%s %s CNI request %+v failed to marshal result: %v",
-				request, request.Command, request, err)
+				request, request.Command, request, err1)
 		}
 		if resultForLogging, err1 = response.MarshalForLogging(); err1 != nil {
 			klog.Errorf("%s %s CNI request %+v, %v", request, request.Command, request, err1)

--- a/go-controller/pkg/cni/cni_dpu_test.go
+++ b/go-controller/pkg/cni/cni_dpu_test.go
@@ -34,7 +34,6 @@ var _ = Describe("cni_dpu tests", func() {
 				DeviceID: "",
 			},
 			timestamp: time.Time{},
-			IsDPU:     true,
 		}
 	})
 	Context("addDPUConnectionDetailsAnnot", func() {

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -72,7 +72,6 @@ func NewCNIServer(rundir string, useOVSExternalIDs bool, factory factory.NodeWat
 		useOVSExternalIDs: ovnPortBinding,
 		podLister:         corev1listers.NewPodLister(factory.LocalPodInformer().GetIndexer()),
 		kclient:           kclient,
-		mode:              config.OvnKubeNode.Mode,
 		kubeAuth: &KubeAPIAuth{
 			Kubeconfig:    config.Kubernetes.Kubeconfig,
 			KubeAPIServer: config.Kubernetes.APIServer,
@@ -196,10 +195,6 @@ func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 		return nil, err
 	}
 	defer req.cancel()
-
-	if s.mode == types.NodeModeDPUHost {
-		req.IsDPU = true
-	}
 
 	useOVSExternalIDs := false
 	if atomic.LoadInt32(&s.useOVSExternalIDs) > 0 {

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -173,7 +173,7 @@ func setupSriovInterface(netns ns.NetNS, containerID, ifName string, ifInfo *Pod
 	}
 	vfNetdevice := vfNetdevices[0]
 
-	if !ifInfo.IsDPU {
+	if !ifInfo.IsDPUHostMode {
 		// 2. get Uplink netdevice
 		uplink, err := util.GetSriovnetOps().GetUplinkRepresentor(pciAddrs)
 		if err != nil {
@@ -340,7 +340,7 @@ func (pr *PodRequest) ConfigureInterface(podLister corev1listers.PodLister, kcli
 		// SR-IOV Case
 		hostIface, contIface, err = setupSriovInterface(netns, pr.SandboxID, pr.IfName, ifInfo, pr.CNIConf.DeviceID)
 	} else {
-		if pr.IsDPU {
+		if ifInfo.IsDPUHostMode {
 			return nil, fmt.Errorf("unexpected configuration, pod request on dpu host. " +
 				"device ID must be provided")
 		}
@@ -351,7 +351,7 @@ func (pr *PodRequest) ConfigureInterface(podLister corev1listers.PodLister, kcli
 		return nil, err
 	}
 
-	if !ifInfo.IsDPU {
+	if !ifInfo.IsDPUHostMode {
 		err = ConfigureOVS(pr.ctx, pr.PodNamespace, pr.PodName, hostIface.Name, ifInfo, pr.SandboxID,
 			podLister, kclient)
 		if err != nil {

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -700,14 +700,14 @@ func TestSetupSriovInterface(t *testing.T) {
 			},
 		},
 		{
-			desc:         "test code path when IsDPU set to true",
+			desc:         "test code path when working in DPUHost mode",
 			inpNetNS:     mockNS,
 			inpContID:    "35b82dbe2c39768d9874861aee38cf569766d4855b525ae02bff2bfbda73392a",
 			inpIfaceName: "eth0",
 			inpPodIfaceInfo: &PodInterfaceInfo{
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
-				IsDPU:         true,
+				IsDPUHostMode: true,
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      false,

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -37,12 +37,12 @@ type KubeAPIAuth struct {
 type PodInterfaceInfo struct {
 	util.PodAnnotation
 
-	MTU         int    `json:"mtu"`
-	Ingress     int64  `json:"ingress"`
-	Egress      int64  `json:"egress"`
-	CheckExtIDs bool   `json:"check-external-ids"`
-	IsDPU       bool   `json:"dpu"`
-	PodUID      string `json:"pod-uid"`
+	MTU           int    `json:"mtu"`
+	Ingress       int64  `json:"ingress"`
+	Egress        int64  `json:"egress"`
+	CheckExtIDs   bool   `json:"check-external-ids"`
+	IsDPUHostMode bool   `json:"is-dpu-host-mode"`
+	PodUID        string `json:"pod-uid"`
 }
 
 // Explicit type for CNI commands the server handles
@@ -136,8 +136,6 @@ type PodRequest struct {
 	ctx context.Context
 	// cancel should be called to cancel this request
 	cancel context.CancelFunc
-	// Interface to pod is a DPU interface
-	IsDPU bool
 }
 
 type cniRequestFunc func(request *PodRequest, podLister corev1listers.PodLister, useOVSExternalIDs bool, kclient kubernetes.Interface, kubeAuth *KubeAPIAuth) ([]byte, error)
@@ -152,7 +150,4 @@ type Server struct {
 	kclient           kubernetes.Interface
 	podLister         corev1listers.PodLister
 	kubeAuth          *KubeAPIAuth
-
-	// CNI Server mode
-	mode string
 }

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
@@ -102,7 +103,7 @@ func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, k
 }
 
 // PodAnnotation2PodInfo creates PodInterfaceInfo from Pod annotations and additional attributes
-func PodAnnotation2PodInfo(podAnnotation map[string]string, checkExtIDs bool, isDPU bool, podUID string) (
+func PodAnnotation2PodInfo(podAnnotation map[string]string, checkExtIDs bool, podUID string) (
 	*PodInterfaceInfo, error) {
 	podAnnotSt, err := util.UnmarshalPodAnnotation(podAnnotation)
 	if err != nil {
@@ -123,7 +124,7 @@ func PodAnnotation2PodInfo(podAnnotation map[string]string, checkExtIDs bool, is
 		Ingress:       ingress,
 		Egress:        egress,
 		CheckExtIDs:   checkExtIDs,
-		IsDPU:         isDPU,
+		IsDPUHostMode: config.OvnKubeNode.Mode == types.NodeModeDPUHost,
 		PodUID:        podUID,
 	}
 	return podInterfaceInfo, nil

--- a/go-controller/pkg/cni/utils_test.go
+++ b/go-controller/pkg/cni/utils_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/k8s.io/client-go/listers/core/v1"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
@@ -216,26 +218,28 @@ var _ = Describe("CNI Utils tests", func() {
 "gateway_ip":"192.168.2.1"}}`,
 		}
 		podUID := "4d06bae8-9c38-41f6-945c-f92320e782e4"
-		It("Creates PodInterfaceInfo with IsDPU false", func() {
-			pif, err := PodAnnotation2PodInfo(podAnnot, false, false, podUID)
+		It("Creates PodInterfaceInfo in NodeModeFull mode", func() {
+			config.OvnKubeNode.Mode = ovntypes.NodeModeFull
+			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pif.IsDPU).To(BeFalse())
+			Expect(pif.IsDPUHostMode).To(BeFalse())
 		})
 
-		It("Creates PodInterfaceInfo with IsDPU true", func() {
-			pif, err := PodAnnotation2PodInfo(podAnnot, false, true, podUID)
+		It("Creates PodInterfaceInfo in NodeModeDPUHost mode", func() {
+			config.OvnKubeNode.Mode = ovntypes.NodeModeDPUHost
+			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pif.IsDPU).To(BeTrue())
+			Expect(pif.IsDPUHostMode).To(BeTrue())
 		})
 
 		It("Creates PodInterfaceInfo with checkExtIDs false", func() {
-			pif, err := PodAnnotation2PodInfo(podAnnot, false, false, podUID)
+			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.CheckExtIDs).To(BeFalse())
 		})
 
 		It("Creates PodInterfaceInfo with checkExtIDs true", func() {
-			pif, err := PodAnnotation2PodInfo(podAnnot, true, false, podUID)
+			pif, err := PodAnnotation2PodInfo(podAnnot, true, podUID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.CheckExtIDs).To(BeTrue())
 		})

--- a/go-controller/pkg/node/node_dpu.go
+++ b/go-controller/pkg/node/node_dpu.go
@@ -46,7 +46,7 @@ func (n *OvnNode) watchPodsDPU(isOvnUpEnabled bool) {
 					retryPods.Store(pod.UID, true)
 					return
 				}
-				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, isOvnUpEnabled, true, string(pod.UID))
+				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, isOvnUpEnabled, string(pod.UID))
 				if err != nil {
 					retryPods.Store(pod.UID, true)
 					return
@@ -82,7 +82,7 @@ func (n *OvnNode) watchPodsDPU(isOvnUpEnabled bool) {
 					klog.Infof("Failed to get rep name, %s. retrying", err)
 					return
 				}
-				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, isOvnUpEnabled, true, string(pod.UID))
+				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, isOvnUpEnabled, string(pod.UID))
 				if err != nil {
 					return
 				}

--- a/go-controller/pkg/node/node_dpu_test.go
+++ b/go-controller/pkg/node/node_dpu_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Node DPU tests", func() {
 				MTU:           1500,
 				Ingress:       -1,
 				Egress:        -1,
-				IsDPU:         true,
+				IsDPUHostMode: true,
 				PodUID:        "a-pod",
 			}
 


### PR DESCRIPTION
PodRequest`IsDPU is currently being used to capture whether ovnkube node
is running in DPUHostMode or not. However, IsDPU could mean two things:
-- DPU Host or DPU itself. Since IsDPU here is meant to track
DPUHostMode lets change the name to mean DPUHost mode.

Also, there is no need for Server`mode field, so remove it as well.

@adrianchiris PTAL