### PR TITLE
release DPU VF assigned to the Pod back to the host network namespace

### DIFF
--- a/go-controller/pkg/cni/cni_dpu.go
+++ b/go-controller/pkg/cni/cni_dpu.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-func (pr *PodRequest) addDPUConnectionDetailsAnnot(k kube.Interface) error {
+func (pr *PodRequest) addDPUConnectionDetailsAnnot(k kube.Interface, vfNetdevName string) error {
 	// 1. Verify there is a device id
 	if pr.CNIConf.DeviceID == "" {
 		return fmt.Errorf("DeviceID must be set for Pod request with DPU")
@@ -35,9 +35,10 @@ func (pr *PodRequest) addDPUConnectionDetailsAnnot(k kube.Interface) error {
 	}
 
 	dpuConnDetails := util.DPUConnectionDetails{
-		PfId:      fmt.Sprint(fn),
-		VfId:      fmt.Sprint(vfindex),
-		SandboxId: pr.SandboxID,
+		PfId:         fmt.Sprint(fn),
+		VfId:         fmt.Sprint(vfindex),
+		SandboxId:    pr.SandboxID,
+		VfNetdevName: vfNetdevName,
 	}
 
 	podAnnot := kube.NewPodAnnotator(k, pr.PodName, pr.PodNamespace)

--- a/go-controller/pkg/cni/cni_dpu_test.go
+++ b/go-controller/pkg/cni/cni_dpu_test.go
@@ -53,13 +53,13 @@ var _ = Describe("cni_dpu tests", func() {
 			}
 			Expect(err).ToNot(HaveOccurred())
 			fakeKubeInterface.On("SetAnnotationsOnPod", pr.PodNamespace, pr.PodName, annnot).Return(nil)
-			err = pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface)
+			err = pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface, "")
 			Expect(err).ToNot(HaveOccurred())
 
 		})
 
 		It("Fails if DeviceID is not present in CNI config", func() {
-			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface)
+			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface, "")
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -67,7 +67,7 @@ var _ = Describe("cni_dpu tests", func() {
 			pr.CNIConf.DeviceID = "0000:05:00.4"
 			fakeSriovnetOps.On("GetPfPciFromVfPci", pr.CNIConf.DeviceID).Return(
 				"", fmt.Errorf("failed to get PF address"))
-			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface)
+			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface, "")
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -76,7 +76,7 @@ var _ = Describe("cni_dpu tests", func() {
 			fakeSriovnetOps.On("GetPfPciFromVfPci", pr.CNIConf.DeviceID).Return("0000:05:00.0", nil)
 			fakeSriovnetOps.On("GetVfIndexByPciAddress", pr.CNIConf.DeviceID).Return(
 				-1, fmt.Errorf("failed to get VF index"))
-			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface)
+			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface, "")
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -84,7 +84,7 @@ var _ = Describe("cni_dpu tests", func() {
 			pr.CNIConf.DeviceID = "0000:05:00.4"
 			fakeSriovnetOps.On("GetPfPciFromVfPci", pr.CNIConf.DeviceID).Return("05:00.0", nil)
 			fakeSriovnetOps.On("GetVfIndexByPciAddress", pr.CNIConf.DeviceID).Return(2, nil)
-			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface)
+			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface, "")
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -93,7 +93,7 @@ var _ = Describe("cni_dpu tests", func() {
 			fakeSriovnetOps.On("GetPfPciFromVfPci", pr.CNIConf.DeviceID).Return("0000:05:00.0", nil)
 			fakeSriovnetOps.On("GetVfIndexByPciAddress", pr.CNIConf.DeviceID).Return(2, nil)
 			fakeKubeInterface.On("SetAnnotationsOnPod", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("failed to set annotation"))
-			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface)
+			err := pr.addDPUConnectionDetailsAnnot(&fakeKubeInterface, "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to set annotation"))
 		})

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -168,18 +168,8 @@ func setupSriovInterface(netns ns.NetNS, containerID, ifName string, ifInfo *Pod
 	hostIface := &current.Interface{}
 	contIface := &current.Interface{}
 
-	// 1. get VF netdevice from PCI
-	vfNetdevices, err := util.GetSriovnetOps().GetNetDevicesFromPci(pciAddrs)
-	if err != nil {
-		return nil, nil, err
-
-	}
-
-	// Make sure we have 1 netdevice per pci address
-	if len(vfNetdevices) != 1 {
-		return nil, nil, fmt.Errorf("failed to get one netdevice interface per %s", pciAddrs)
-	}
-	vfNetdevice := vfNetdevices[0]
+	// 1. get the VF's netdevName that was stashed early on
+	vfNetdevice := ifInfo.VfNetdevName
 
 	if !ifInfo.IsDPUHostMode {
 		// 2. get Uplink netdevice
@@ -219,7 +209,7 @@ func setupSriovInterface(netns ns.NetNS, containerID, ifName string, ifInfo *Pod
 	}
 
 	// 7. Move VF to Container namespace
-	err = moveIfToNetns(vfNetdevice, netns)
+	err := moveIfToNetns(vfNetdevice, netns)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -294,6 +284,9 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 		"other_config:transient=true",
 	}
 
+	if len(ifInfo.VfNetdevName) != 0 {
+		ovsArgs = append(ovsArgs, "external_ids:vf-netdev-name=%s", ifInfo.VfNetdevName)
+	}
 	if out, err := ovsExec(ovsArgs...); err != nil {
 		return fmt.Errorf("failure in plugging pod interface: %v\n  %q", err, out)
 	}
@@ -363,7 +356,7 @@ func (pr *PodRequest) ConfigureInterface(podLister corev1listers.PodLister, kcli
 		err = ConfigureOVS(pr.ctx, pr.PodNamespace, pr.PodName, hostIface.Name, ifInfo, pr.SandboxID,
 			podLister, kclient)
 		if err != nil {
-			pr.deletePorts()
+			pr.deletePorts(hostIface.Name)
 			return nil, err
 		}
 	}
@@ -395,6 +388,84 @@ func (pr *PodRequest) ConfigureInterface(podLister corev1listers.PodLister, kcli
 	return []*current.Interface{hostIface, contIface}, nil
 }
 
+func (pr *PodRequest) UnconfigureInterface(ifInfo *PodInterfaceInfo) error {
+	podDesc := fmt.Sprintf("for pod %s/%s", pr.PodNamespace, pr.PodName)
+	klog.V(5).Infof("Tear down interface (%+v) %s", *pr, podDesc)
+	if pr.CNIConf.DeviceID == "" {
+		if ifInfo.IsDPUHostMode {
+			klog.Warningf("Unexpected configuration %s, Device ID must be present for pod request on smart-nic host",
+				podDesc)
+			return nil
+		}
+	} else {
+		// For SRIOV case, we'd need to move the VF from container namespace back to the host namespace
+		netns, err := ns.GetNS(pr.Netns)
+		if err != nil {
+			return fmt.Errorf("failed to get container namespace %s: %v", podDesc, err)
+		}
+		defer netns.Close()
+
+		hostNS, err := ns.GetCurrentNS()
+		if err != nil {
+			return fmt.Errorf("failed to get host namespace %s: %v", podDesc, err)
+		}
+		defer hostNS.Close()
+
+		err = netns.Do(func(_ ns.NetNS) error {
+			// container side interface deletion
+			link, err := util.GetNetLinkOps().LinkByName(pr.IfName)
+			if err != nil {
+				return fmt.Errorf("failed to get container interface %s %s: %v", pr.IfName, podDesc, err)
+			}
+			err = util.GetNetLinkOps().LinkSetDown(link)
+			if err != nil {
+				return fmt.Errorf("failed to bring down container interface %s %s: %v", pr.IfName, podDesc, err)
+			}
+			// rename VF device back to its original name in the host namespace:
+			err = util.GetNetLinkOps().LinkSetName(link, ifInfo.VfNetdevName)
+			if err != nil {
+				return fmt.Errorf("failed to rename container interface %s to %s %s: %v",
+					pr.IfName, ifInfo.VfNetdevName, podDesc, err)
+			}
+			// move VF device to host netns
+			err = util.GetNetLinkOps().LinkSetNsFd(link, int(hostNS.Fd()))
+			if err != nil {
+				return fmt.Errorf("failed to move container interface %s back to host namespace %s: %v",
+					pr.IfName, podDesc, err)
+			}
+			return nil
+		})
+		if err != nil {
+			klog.Errorf(err.Error())
+		}
+	}
+
+	if ifInfo.IsDPUHostMode {
+		// there is nothing else to do in the DPU-Host mode
+		return nil
+	}
+
+	// host side interface deletion
+	ifName := pr.SandboxID[:15]
+	out, err := ovsExec("del-port", "br-int", ifName)
+	if err != nil && !strings.Contains(out, "no port named") {
+		// DEL should be idempotent; don't return an error just log it
+		klog.Warningf("Failed to delete OVS port %s %s from br-int: %v\n %q", ifName, podDesc, err, string(out))
+	}
+	err = clearPodBandwidth(pr.SandboxID)
+	if err != nil {
+		klog.Warningf("Failed to clearPodBandwidth sandbox %v %s: %v", pr.SandboxID, podDesc, err)
+	}
+	// In SmartNic (CX5) case, there is no point in deleting the representor port
+	if pr.CNIConf.DeviceID == "" {
+		if err = util.LinkDelete(ifName); err != nil {
+			klog.Warningf("Failed to delete interface %s %s: %v", ifName, podDesc, err)
+		}
+	}
+	pr.deletePodConntrack()
+	return nil
+}
+
 func (pr *PodRequest) deletePodConntrack() {
 	if pr.CNIConf.PrevResult == nil {
 		return
@@ -422,21 +493,14 @@ func (pr *PodRequest) deletePodConntrack() {
 	}
 }
 
-func (pr *PodRequest) deletePorts() {
-	ifaceName := pr.SandboxID[:15]
+func (pr *PodRequest) deletePorts(ifaceName string) {
 	out, err := ovsExec("del-port", "br-int", ifaceName)
-	_ = util.LinkDelete(ifaceName)
 	if err != nil && !strings.Contains(out, "no port named") {
 		// DEL should be idempotent; don't return an error just log it
 		klog.Warningf("Failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))
 	}
-}
-
-// PlatformSpecificCleanup deletes the OVS port
-func (pr *PodRequest) PlatformSpecificCleanup() error {
-	pr.deletePorts()
-	_ = clearPodBandwidth(pr.SandboxID)
-	pr.deletePodConntrack()
-
-	return nil
+	// skip deleting representor ports
+	if pr.CNIConf.DeviceID == "" {
+		_ = util.LinkDelete(ifaceName)
+	}
 }

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -460,37 +460,6 @@ func TestSetupSriovInterface(t *testing.T) {
 		linkMockHelper       []ovntest.TestifyMockHelper
 	}{
 		{
-			desc:         "test code path when GetNetDevicesFromPci() returns error",
-			inpNetNS:     mockNS,
-			inpContID:    "35b82dbe2c39768d9874861aee38cf569766d4855b525ae02bff2bfbda73392a",
-			inpIfaceName: "eth0",
-			inpPodIfaceInfo: &PodInterfaceInfo{
-				PodAnnotation: util.PodAnnotation{},
-				MTU:           1500,
-			},
-			inpPCIAddrs: "0000:03:00.1",
-			errExp:      true,
-			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
-			},
-		},
-		{
-			desc:         "test code path when netdevice per pci address does not equal one",
-			inpNetNS:     mockNS,
-			inpContID:    "35b82dbe2c39768d9874861aee38cf569766d4855b525ae02bff2bfbda73392a",
-			inpIfaceName: "eth0",
-			inpPodIfaceInfo: &PodInterfaceInfo{
-				PodAnnotation: util.PodAnnotation{},
-				MTU:           1500,
-			},
-			inpPCIAddrs: "0000:03:00.1",
-			errMatch:    fmt.Errorf("failed to get one netdevice interface per"),
-			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				// e.g; `ls -l /sys/bus/pci/devices/0000:01:00.0/net/` is the equivalent command line to get devices info
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01", "eno2"}, nil}},
-			},
-		},
-		{
 			desc:         "test code path when GetUplinkRepresentor() returns error",
 			inpNetNS:     mockNS,
 			inpContID:    "35b82dbe2c39768d9874861aee38cf569766d4855b525ae02bff2bfbda73392a",
@@ -498,11 +467,11 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPodIfaceInfo: &PodInterfaceInfo{
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
+				VfNetdevName:  "en01",
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf("mock error")}},
 			},
 		},
@@ -514,11 +483,11 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPodIfaceInfo: &PodInterfaceInfo{
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
+				VfNetdevName:  "en01",
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{-1, fmt.Errorf("mock error")}},
 			},
@@ -531,11 +500,11 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPodIfaceInfo: &PodInterfaceInfo{
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
+				VfNetdevName:  "en01",
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"", fmt.Errorf("mock error")}},
@@ -549,11 +518,11 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPodIfaceInfo: &PodInterfaceInfo{
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
+				VfNetdevName:  "en01",
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errMatch:    fmt.Errorf("failed to rename"),
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
@@ -571,11 +540,11 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPodIfaceInfo: &PodInterfaceInfo{
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
+				VfNetdevName:  "en01",
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
@@ -598,11 +567,11 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPodIfaceInfo: &PodInterfaceInfo{
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
+				VfNetdevName:  "en01",
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errMatch:    fmt.Errorf("failed to set MTU on"),
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
@@ -631,11 +600,11 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPodIfaceInfo: &PodInterfaceInfo{
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
+				VfNetdevName:  "en01",
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
@@ -666,11 +635,11 @@ func TestSetupSriovInterface(t *testing.T) {
 			inpPodIfaceInfo: &PodInterfaceInfo{
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
+				VfNetdevName:  "en01",
 			},
 			inpPCIAddrs: "0000:03:00.1",
 			errExp:      true,
 			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
 				{OnCallMethodName: "GetUplinkRepresentor", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"testlinkrepresentor", nil}},
 				{OnCallMethodName: "GetVfIndexByPciAddress", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{0, nil}},
 				{OnCallMethodName: "GetVfRepresentor", OnCallMethodArgType: []string{"string", "int"}, RetArgList: []interface{}{"VFRepresentor", nil}},
@@ -708,12 +677,11 @@ func TestSetupSriovInterface(t *testing.T) {
 				PodAnnotation: util.PodAnnotation{},
 				MTU:           1500,
 				IsDPUHostMode: true,
+				VfNetdevName:  "en01",
 			},
-			inpPCIAddrs: "0000:03:00.1",
-			errExp:      false,
-			sriovOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "GetNetDevicesFromPci", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{[]string{"en01"}, nil}},
-			},
+			inpPCIAddrs:        "0000:03:00.1",
+			errExp:             false,
+			sriovOpsMockHelper: []ovntest.TestifyMockHelper{},
 			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
 				// The below two mock calls are needed for the moveIfToNetns() call that internally invokes them
 				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{mockLink, nil}},
@@ -842,44 +810,6 @@ func TestPodRequest_deletePodConntrack(t *testing.T) {
 			}
 			tc.inpPodRequest.deletePodConntrack()
 			mockTypeResult.AssertExpectations(t)
-		})
-	}
-}
-
-func TestPodRequest_PlatformSpecificCleanup(t *testing.T) {
-	// Skipping the test for now as this test passes when individually run but fails as part of suite run
-	t.SkipNow()
-	tests := []struct {
-		desc          string
-		inpPodRequest PodRequest
-		errExp        bool
-	}{
-		{
-			desc: "tests entire function coverage",
-			inpPodRequest: PodRequest{
-				SandboxID: "35b82dbe2c39768d9874861aee38cf569766d4855b525ae02bff2bfbda73392a",
-				CNIConf: &types.NetConf{
-					NetConf: cnitypes.NetConf{},
-				},
-			},
-		},
-		// TODO: Below test causes nil pointer exception when `pr.CNIConf.PrevResult == nil` is encountered in deletePodConntrack() method as pr.CNIConf is nil.
-		// The code may need to be updated to check that pr.CNIConf is not nil?
-		//{
-		//	desc: "tests code path when CNIConf is not provided",
-		//	inpPodRequest: PodRequest{
-		//		SandboxID: "35b82dbe2c39768d9874861aee38cf569766d4855b525ae02bff2bfbda73392a",
-		//	},
-		//},
-	}
-	for i, tc := range tests {
-		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			err := tc.inpPodRequest.PlatformSpecificCleanup()
-			if tc.errExp {
-				assert.Error(t, err)
-			} else {
-				assert.Nil(t, err)
-			}
 		})
 	}
 }

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -44,6 +44,7 @@ type PodInterfaceInfo struct {
 	CheckExtIDs   bool   `json:"check-external-ids"`
 	IsDPUHostMode bool   `json:"is-dpu-host-mode"`
 	PodUID        string `json:"pod-uid"`
+	VfNetdevName  string `json:"vf-netdev-name"`
 }
 
 // Explicit type for CNI commands the server handles
@@ -97,7 +98,7 @@ func (response *Response) MarshalForLogging() ([]byte, error) {
 		return nil, nil
 	}
 
-	// Only one of Result and PodIFInfo is ever set by cmdAdd
+	// Only one of Result and PodIFInfo is ever set by cmdAdd/cmdDel
 	if response.Result != nil {
 		noAuth = response.Result
 	} else {

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -103,7 +103,7 @@ func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, k
 }
 
 // PodAnnotation2PodInfo creates PodInterfaceInfo from Pod annotations and additional attributes
-func PodAnnotation2PodInfo(podAnnotation map[string]string, checkExtIDs bool, podUID string) (
+func PodAnnotation2PodInfo(podAnnotation map[string]string, checkExtIDs bool, podUID, vfNetdevname string) (
 	*PodInterfaceInfo, error) {
 	podAnnotSt, err := util.UnmarshalPodAnnotation(podAnnotation)
 	if err != nil {
@@ -127,6 +127,7 @@ func PodAnnotation2PodInfo(podAnnotation map[string]string, checkExtIDs bool, po
 		CheckExtIDs:   checkExtIDs,
 		IsDPUHostMode: config.OvnKubeNode.Mode == types.NodeModeDPUHost,
 		PodUID:        podUID,
+		VfNetdevName:  vfNetdevname,
 	}
 	return podInterfaceInfo, nil
 }

--- a/go-controller/pkg/cni/utils_test.go
+++ b/go-controller/pkg/cni/utils_test.go
@@ -220,26 +220,26 @@ var _ = Describe("CNI Utils tests", func() {
 		podUID := "4d06bae8-9c38-41f6-945c-f92320e782e4"
 		It("Creates PodInterfaceInfo in NodeModeFull mode", func() {
 			config.OvnKubeNode.Mode = ovntypes.NodeModeFull
-			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID)
+			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID, "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.IsDPUHostMode).To(BeFalse())
 		})
 
 		It("Creates PodInterfaceInfo in NodeModeDPUHost mode", func() {
 			config.OvnKubeNode.Mode = ovntypes.NodeModeDPUHost
-			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID)
+			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID, "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.IsDPUHostMode).To(BeTrue())
 		})
 
 		It("Creates PodInterfaceInfo with checkExtIDs false", func() {
-			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID)
+			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID, "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.CheckExtIDs).To(BeFalse())
 		})
 
 		It("Creates PodInterfaceInfo with checkExtIDs true", func() {
-			pif, err := PodAnnotation2PodInfo(podAnnot, true, podUID)
+			pif, err := PodAnnotation2PodInfo(podAnnot, true, podUID, "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.CheckExtIDs).To(BeTrue())
 		})

--- a/go-controller/pkg/node/node_dpu.go
+++ b/go-controller/pkg/node/node_dpu.go
@@ -46,7 +46,7 @@ func (n *OvnNode) watchPodsDPU(isOvnUpEnabled bool) {
 					retryPods.Store(pod.UID, true)
 					return
 				}
-				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, isOvnUpEnabled, string(pod.UID))
+				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, isOvnUpEnabled, string(pod.UID), "")
 				if err != nil {
 					retryPods.Store(pod.UID, true)
 					return
@@ -82,7 +82,7 @@ func (n *OvnNode) watchPodsDPU(isOvnUpEnabled bool) {
 					klog.Infof("Failed to get rep name, %s. retrying", err)
 					return
 				}
-				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, isOvnUpEnabled, string(pod.UID))
+				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, isOvnUpEnabled, string(pod.UID), "")
 				if err != nil {
 					return
 				}

--- a/go-controller/pkg/util/dpu_annotations.go
+++ b/go-controller/pkg/util/dpu_annotations.go
@@ -45,9 +45,10 @@ const (
 )
 
 type DPUConnectionDetails struct {
-	PfId      string `json:"pfId"`
-	VfId      string `json:"vfId"`
-	SandboxId string `json:"sandboxId"`
+	PfId         string `json:"pfId"`
+	VfId         string `json:"vfId"`
+	SandboxId    string `json:"sandboxId"`
+	VfNetdevName string `json:"vfNetdevName,omitempty"`
 }
 
 type DPUConnectionStatus struct {


### PR DESCRIPTION
on pod deletion we need to `rename` the VF device assigned to the Pod
to its original name and then move it to the host network namespace. we
were not doing the same and were hitting the following race:

t0: pod is deleted
t1: cmdDel returned immediately without releasing the VF
t2: kubelet released the DEVICE_ID
t3: udev kicks in and renames the VF device from `net1` to its original
    name

Now between t2 and t3 a new Pod can come up and consume that DEVICE_ID
and cmdAdd`setupSRIOVInterface() will end up not finding that VF
