### PR TITLE
Metrics: Add additional label to refer to ovnkube master

### DIFF
--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -351,7 +351,7 @@ func getOvnDbVersionInfo() {
 
 func RegisterOvnDBMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
-		return checkPodRunsOnGivenNode(clientset, "ovn-db-pod=true", k8sNodeName, false)
+		return checkPodRunsOnGivenNode(clientset, []string{"ovn-db-pod=true"}, k8sNodeName, false)
 	})
 	if err != nil {
 		if err == wait.ErrWaitTimeout {

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -91,7 +91,7 @@ var ovnNorthdStopwatchShowMetricsMap = map[string]*stopwatchMetricDetails{
 
 func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string) {
 	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
-		return checkPodRunsOnGivenNode(clientset, "name=ovnkube-master", k8sNodeName, true)
+		return checkPodRunsOnGivenNode(clientset, []string{"app=ovnkube-master", "name=ovnkube-master"}, k8sNodeName, true)
 	})
 	if err != nil {
 		if err == wait.ErrWaitTimeout {


### PR DESCRIPTION
Our downstream distribution refers to ovn-kubernetes master
with label app=ovnkube-master intead of name=ovnkube-master.
This PR uses both to search for ovnkube master.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>
