### PR TITLE
Metrics: remove "_total" suffix from non-counter metrics

### DIFF
--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -377,7 +377,7 @@ func RegisterOvnControllerMetrics() {
 		prometheus.GaugeOpts{
 			Namespace: MetricOvnNamespace,
 			Subsystem: MetricOvnSubsystemController,
-			Name:      "integration_bridge_patch_ports_total",
+			Name:      "integration_bridge_patch_ports",
 			Help: "Captures the number of patch ports that connect br-int OVS " +
 				"bridge to physical OVS bridge and br-local OVS bridge.",
 		},
@@ -388,7 +388,7 @@ func RegisterOvnControllerMetrics() {
 		prometheus.GaugeOpts{
 			Namespace: MetricOvnNamespace,
 			Subsystem: MetricOvnSubsystemController,
-			Name:      "integration_bridge_geneve_ports_total",
+			Name:      "integration_bridge_geneve_ports",
 			Help:      "Captures the number of geneve ports that are on br-int OVS bridge.",
 		},
 		func() float64 {


### PR DESCRIPTION
Signed-off-by: Martin Kennelly <mkennell@redhat.com>

```
promtool check metrics < ovn.txt 
ovn_controller_integration_bridge_geneve_ports_total non-counter metrics should not have "_total" suffix
ovn_controller_integration_bridge_patch_ports_total non-counter metrics should not have "_total" suffix
```
If a metric is not counter based, it is recommended to not have _total suffix.