### PR TITLE
Metrics: convert metrics to base prometheus units

### DIFF
--- a/go-controller/pkg/metrics/ovn.go
+++ b/go-controller/pkg/metrics/ovn.go
@@ -15,17 +15,16 @@ import (
 var metricRemoteProbeInterval = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
 	Subsystem: MetricOvnSubsystemController,
-	Name:      "remote_probe_interval",
-	Help: "The maximum number of milliseconds of idle time on connection to " +
-		"the OVN SB DB before sending an inactivity probe message.",
+	Name:      "remote_probe_interval_seconds",
+	Help:      "The inactivity probe interval of the connection to the OVN SB DB.",
 })
 
 var metricOpenFlowProbeInterval = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
 	Subsystem: MetricOvnSubsystemController,
-	Name:      "openflow_probe_interval",
-	Help: "The maximum number of milliseconds of idle time on OpenFlow connection " +
-		"to the OVS bridge before sending an inactivity probe message.",
+	Name:      "openflow_probe_interval_seconds",
+	Help: "The inactivity probe interval of the OpenFlow connection to the " +
+		"OpenvSwitch integration bridge.",
 })
 
 var metricMonitorAll = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -275,7 +274,7 @@ func setOvnControllerConfigurationMetrics() (err error) {
 			metricOpenFlowProbeInterval.Set(metricValue)
 		case "ovn-remote-probe-interval":
 			metricValue := parseMetricToFloat(MetricOvnSubsystemController, "ovn-remote-probe-interval", fieldValue)
-			metricRemoteProbeInterval.Set(metricValue)
+			metricRemoteProbeInterval.Set(metricValue / 1000)
 		case "ovn-monitor-all":
 			var ovnMonitorValue float64
 			if fieldValue == "true" {

--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -37,7 +37,7 @@ var metricOVNDBMonitor = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 var metricDBSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: MetricOvnNamespace,
 	Subsystem: MetricOvnSubsystemDB,
-	Name:      "db_size",
+	Name:      "db_size_bytes",
 	Help:      "The size of the database file associated with the OVN DB component."},
 	[]string{
 		"db_name",


### PR DESCRIPTION
Prometheus recommends to only use base units (seconds/
bytes) [1].

Also, corrected openflow probe interval that was in
consumed in seconds [2] but the `HELP` field said milliseconds.

[1] https://prometheus.io/docs/practices/naming/#base-units
[2] https://www.ovn.org/support/dist-docs/ovn-controller.8.html

Signed-off-by: Martin Kennelly <mkennell@redhat.com>