### PR TITLE
[DNM] Test CI Flakes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,13 +274,12 @@ jobs:
          # in agnhost images. Disable them for now.
          - {"ipfamily": "dualstack", "target": "control-plane"}
          - {"ipfamily": "ipv6", "target": "control-plane"}
-         # No need to run disable-snat-multiple-gws with local GW mode
-         - {"disable-snat-multiple-gws": "noSnatGW", "gateway-mode": "local"}
+         # No need to run disable-snat-multiple-gws with shard conformance
+         - {"disable-snat-multiple-gws": "noSnatGW", "target": "shard-conformance"}
          - {"second-bridge": "2br", "gateway-mode": "local"}
          - {"second-bridge": "2br", "disable-snat-multiple-gws": "snatGW"}
          - {"second-bridge": "2br", "ha": "HA"}
          - {"second-bridge": "2br", "target": "control-plane"}
-         - {"second-bridge": "1br", "disable-snat-multiple-gws": "noSnatGW"}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}"

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -66,6 +66,14 @@ e2e ingress to host-networked pods traffic validation|\
 host to host-networked pods traffic validation"
 fi
 
+if [ "$OVN_DISABLE_SNAT_MULTIPLE_GWS" == false ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+    SKIPPED_TESTS+="|"
+  fi
+  SKIPPED_TESTS+="Should validate TCP/UDP connectivity to an external gateway's loopback address via a pod with external gateway annotations enabled|\
+Should validate TCP/UDP connectivity to multiple external gateways for a UDP / TCP scenario"
+fi
+
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote
 export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
**- What this PR does and why is it needed**
In CI, almost all lanes are using disable-snat.
When SNAT isn't disabled icni traffic will not
work expected. Disable those e2e tests in that
case.

We also need to re-enable at least one of the control-plane
tests with `disableSNAT=true` since none of the CI
matrices are currently doing this. It doesn't matter if its
the one with SGW or LGW since both these modes are practically
the same post https://github.com/ovn-org/ovn-kubernetes/pull/2663.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
