### PR TITLE
Make egressIPs compatible with externalgws

### DIFF
--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -2124,7 +2124,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
 				_, fullMaskPodNet, _ := net.ParseCIDR("10.128.1.3/32")
-				fakeOvn.controller.addPerPodGRSNAT(&pod[0], []*net.IPNet{fullMaskPodNet})
+				addPerPodGRSNAT(fakeOvn.controller.nbClient, fakeOvn.controller.watchFactory, &pod[0], []*net.IPNet{fullMaskPodNet})
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				finalNB = []libovsdbtest.TestData{
 					&nbdb.LogicalRouter{
@@ -2138,7 +2138,8 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Networks: []string{"100.64.0.4/32"},
 					},
 				}
-				fakeOvn.controller.deletePerPodGRSNAT(nodeName, []*net.IPNet{fullMaskPodNet})
+				err := deletePerPodGRSNAT(fakeOvn.controller.nbClient, nodeName, []*net.IPNet{fullMaskPodNet})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -261,7 +261,9 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 					if err != nil {
 						klog.Warningf("Unable to get port %s in cache for SNAT rule removal", logicalPort)
 					} else {
-						oc.deletePerPodGRSNAT(pod.Spec.NodeName, portInfo.ips)
+						if err = deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, portInfo.ips); err != nil {
+							klog.Error(err.Error())
+						}
 					}
 				}
 			}
@@ -290,7 +292,7 @@ func (oc *Controller) updateNamespace(old, newer *kapi.Namespace) {
 				if err != nil {
 					klog.Error(err.Error())
 				} else {
-					if err = oc.addPerPodGRSNAT(pod, podAnnotation.IPs); err != nil {
+					if err = addPerPodGRSNAT(oc.nbClient, oc.watchFactory, pod, podAnnotation.IPs); err != nil {
 						klog.Error(err.Error())
 					}
 				}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -273,6 +273,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 			allocator:             allocator{&sync.Mutex{}, make(map[string]*egressNode)},
 			nbClient:              libovsdbOvnNBClient,
 			modelClient:           modelClient,
+			watchFactory:          wf,
 		},
 		loadbalancerClusterCache: make(map[kapi.Protocol]string),
 		multicastSupport:         config.EnableMulticast,

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -152,7 +152,9 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	}
 
 	if config.Gateway.DisableSNATMultipleGWs {
-		oc.deletePerPodGRSNAT(pod.Spec.NodeName, portInfo.ips)
+		if err := deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, portInfo.ips); err != nil {
+			klog.Errorf(err.Error())
+		}
 	}
 	podNsName := ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
 	oc.deleteGWRoutesForPod(podNsName, portInfo.ips)
@@ -477,7 +479,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	} else if config.Gateway.DisableSNATMultipleGWs {
 		// Add NAT rules to pods if disable SNAT is set and does not have
 		// namespace annotations to go through external egress router
-		if err = oc.addPerPodGRSNAT(pod, podIfAddrs); err != nil {
+		if err = addPerPodGRSNAT(oc.nbClient, oc.watchFactory, pod, podIfAddrs); err != nil {
 			return err
 		}
 	}

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -50,13 +50,6 @@ if [ "$KIND_IPV6_SUPPORT" == true ]; then
   SKIPPED_TESTS+=$IPV6_SKIPPED_TESTS
 fi
 
-if [ "$OVN_DISABLE_SNAT_MULTIPLE_GWS" == true ]; then
-  if [ "$SKIPPED_TESTS" != "" ]; then
-  	SKIPPED_TESTS+="|"
-  fi
-  SKIPPED_TESTS+="Should validate the egress IP functionality against remote hosts"
-fi
-
 if [ "$OVN_GATEWAY_MODE" == "local" ]; then
   if [ "$SKIPPED_TESTS" != "" ]; then
   	SKIPPED_TESTS+="|"


### PR DESCRIPTION
**- What this PR does and why is it needed**

Currently we use the disableSNATMultipleGWs option for externalgws feature to ensure we
do not SNAT podIPs to the nodeIP. This means we enable a per pod snat for the pods not
managed by externalgws.

EgressIPs feature can work only if the SNAT for an egressIP managed pod is to the egressIP
and not the nodeIP as is the case when disableSNATMultipleGWs is set.

So far we were declaring these features as mutually exclusive. Let's stop that and instead
add the logic to simply delete SNAT to nodeIP for an egressIP managed pod & add SNAT to nodeIP
for an egressIP un-managed pod.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

**- Note to reviewers**
e2e tests already exist for egressIPs, they were skipped when `disable-SNAT` was true, so un-skipping them in this PR. Currently all CI jobs are running in disable-SNAT=false mode, but I ran the e2e's locally with ds=true and they pass. There is also another PR to enable control-plane tests with disable-SNAT=true.

**- How to verify it**
Tested on KIND cluster setup with egressIPs:
```
initial state:
sh-5.1# ovn-nbctl lr-nat-list GR_ovn-worker
sh-5.1# ovn-nbctl lr-nat-list GR_ovn-worker2
TYPE             EXTERNAL_IP        EXTERNAL_PORT    LOGICAL_IP            EXTERNAL_MAC         LOGICAL_PORT
snat             172.18.0.4                          10.244.2.3


pod being egressip managed - ovn-worker is the managing node:
sh-5.1# ovn-nbctl lr-nat-list GR_ovn-worker2
sh-5.1# ovn-nbctl lr-nat-list GR_ovn-worker 
TYPE             EXTERNAL_IP        EXTERNAL_PORT    LOGICAL_IP            EXTERNAL_MAC         LOGICAL_PORT
snat             172.18.0.9                          10.244.2.3


pod removed from being egressIP managed:

sh-5.1# ovn-nbctl lr-nat-list GR_ovn-worker
sh-5.1# ovn-nbctl lr-nat-list GR_ovn-worker2
TYPE             EXTERNAL_IP        EXTERNAL_PORT    LOGICAL_IP            EXTERNAL_MAC         LOGICAL_PORT
snat             172.18.0.4                          10.244.2.3

```


**- Description for the changelog**
`Make egressIPs and externalgws compatible`