### PR TITLE
Fixup FindSBGlobal and monitor sb_global

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -97,6 +97,8 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 			client.WithTable(&sbdb.MACBinding{}),
 			// used by libovsdbops
 			client.WithTable(&sbdb.Chassis{}),
+			// used for metrics
+			client.WithTable(&sbdb.SBGlobal{}),
 		),
 	)
 	if err != nil {

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -205,7 +205,7 @@ func RegisterMasterMetrics(sbClient client.Client) {
 		scrapeOvnTimestamp := func() float64 {
 			sbGlobal, err := libovsdbops.FindSBGlobal(sbClient)
 			if err != nil {
-				klog.Errorf("Failed to get global options for the SB_Global table")
+				klog.Errorf("Failed to get global options for the SB_Global table err: %v", err)
 				return 0
 			}
 			if val, ok := sbGlobal.Options["e2e_timestamp"]; ok {

--- a/go-controller/pkg/ovn/libovsdbops/sb_global.go
+++ b/go-controller/pkg/ovn/libovsdbops/sb_global.go
@@ -10,22 +10,22 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
-// findSBGlobal returns the SBGlobal table entry
+// FindSBGlobal returns the SBGlobal table entry
 func FindSBGlobal(sbClient libovsdbclient.Client) (*sbdb.SBGlobal, error) {
 	sbGlobal := []sbdb.SBGlobal{}
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
 	err := sbClient.List(ctx, &sbGlobal)
 	if err != nil {
-		return nil, fmt.Errorf("failed listing nbGlobal table entires err: %v", err)
+		return nil, fmt.Errorf("failed listing sbGlobal table entry err: %v", err)
 	}
-	// We should error if the nbGlobal table entry does not exist
+	// We should error if the sbGlobal table entry does not exist
 	if len(sbGlobal) == 0 {
 		return nil, libovsdbclient.ErrNotFound
 	}
-	// The nbGlobal table should only have one row
+	// The sbGlobal table should only have one row
 	if len(sbGlobal) != 1 {
-		return nil, fmt.Errorf("multible NBGlobal rows found")
+		return nil, fmt.Errorf("multible SBGlobal rows found")
 	}
 
 	return &sbGlobal[0], nil


### PR DESCRIPTION
Some minor fixups, and ensure we return it's error if any
in RegisterMasterMetrics

Ensure we monitor the sbdb's sb_global table since
it is fetched for metrics purposes

fixes 

`2021-11-30T17:02:56.194213143Z E1130 17:02:56.194158       1 master.go:208] Failed to get global options for the SB_Global table err: object not found`