### PR TITLE
exit 0 instead of 1

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -109,7 +109,7 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup, ctx context.Con
 				// the cache. It is better to exit for now.
 				// kube will restart and this will become a follower.
 				klog.Infof("No longer leader; exiting")
-				os.Exit(1)
+				os.Exit(0)
 			},
 			OnNewLeader: func(newLeaderName string) {
 				if newLeaderName != nodeName {


### PR DESCRIPTION
When we lose leadership we exit to trigger a restart of the container
to come back up as a follower. That is not an error condition so
exit(0) makes more sense. When we exit(1) it's noted in some
CI jobs that it was an error condition and indicative of some
problem. This will remove that scary report in our CI.

with exit(1) our monitor logs look like this:

Nov 19 20:25:14.241 E ns/openshift-ovn-kubernetes pod/ovnkube-master-bpq94 node/ip-10-0-165-169.us-east-2.compute.internal container/ovnkube-master reason/ContainerExit code/1 cause/Error -11-19T20:24:43.215Z|02253|reconnect|INFO|ssl:10.0.241.143:9641: connected\n2021-11-19T20:24:43.221Z|02254|fatal_signal|WARN|terminating with signal 15 (Terminated)\n2021-11-19T20:24:43.221Z|00002|daemon_unix(monitor)|INFO|pid 13 died, killed (Terminated), exiting\nI1119 20:24:43.232860       1 client.go:484] [OVN_Southbound] disconnected from ssl:10.0.165.169:9642; reconnecting ... \nI1119 20:24:43.241844       1 ovnkube.go:123] Received signal terminated. Shutting down\nI1119 20:24:43.242142       1 reflector.go:225] Stopping reflector *v1.Node (0s) from k8s.io/client-go/informers/factory.go:134\nI1119 20:24:43.242178       1 reflector.go:225] Stopping reflector *v1beta1.EndpointSlice (0s) from k8s.io/client-go/informers/factory.go:134\nI1119 20:24:43.242200       1 reflector.go:225] Stopping reflector *v1.Service (0s) from k8s.io/client-go/informers/factory.go:134\nI1119 20:24:43.242222       1 services_controller.go:173] Shutting down controller ovn-lb-controller\nI1119 20:24:43.242283       1 reflector.go:225] Stopping reflector *v1.Pod (0s) from k8s.io/client-go/informers/factory.go:134\nI1119 20:24:43.242310       1 reflector.go:225] Stopping reflector *v1.Node (0s) from k8s.io/client-go/informers/factory.go:134\nI1119 20:24:43.242338       1 reflector.go:225] Stopping reflector *v1.NetworkPolicy (0s) from k8s.io/client-go/informers/factory.go:134\nI1119 20:24:43.242361       1 reflector.go:225] Stopping reflector *v1.Service (0s) from k8s.io/client-go/informers/factory.go:134\nI1119 20:24:43.242383       1 reflector.go:225] Stopping reflector *v1.EgressIP (0s) from github.com/openshift/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/externalversions/factory.go:117\nI1119 20:24:43.242397       1 reflector.go:225] Stopping reflector *v1.Endpoints (0s) from k8s.io/client-go/informers/factory.go:134\nI1119 20:24:43.242418       1 reflector.go:225] Stopping reflector *v1.Namespace (0s) from k8s.io/client-go/informers/factory.go:134\nI1119 20:24:43.253048       1 master.go:107] No longer leader;\n

with exit(0) the monitor log is less alarming:

Nov 19 22:25:20.567 I ns/openshift-ovn-kubernetes pod/ovnkube-master-pz287 node/ip-10-0-129-41.us-west-1.compute.internal container/ovnkube-master reason/ContainerExit code/0 cause/Completed

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->