### PR TITLE
kind.sh: Use absolute paths instead of relative paths

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 export KUBECONFIG=${HOME}/admin.conf
 
 run_kubectl() {
@@ -290,7 +292,7 @@ set_default_params() {
   OVN_GATEWAY_MODE=${OVN_GATEWAY_MODE:-shared}
   KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS:-false}
   OVN_HA=${OVN_HA:-false}
-  KIND_CONFIG=${KIND_CONFIG:-./kind.yaml.j2}
+  KIND_CONFIG=${KIND_CONFIG:-${DIR}/kind.yaml.j2}
   KIND_REMOVE_TAINT=${KIND_REMOVE_TAINT:-true}
   KIND_IPV4_SUPPORT=${KIND_IPV4_SUPPORT:-true}
   KIND_IPV6_SUPPORT=${KIND_IPV6_SUPPORT:-false}
@@ -428,7 +430,7 @@ set_cluster_cidr_ip_families() {
 
 create_kind_cluster() {
   # Output of the j2 command
-  KIND_CONFIG_LCL=./kind.yaml
+  KIND_CONFIG_LCL=${DIR}/kind.yaml
 
   ovn_apiServerAddress=${API_IP} \
     ovn_ip_family=${IP_FAMILY} \
@@ -498,12 +500,12 @@ coredns_patch() {
 build_ovn_image() {
   if [ "$OVN_IMAGE" == local ]; then
     # Build ovn docker image
-    pushd ../go-controller
+    pushd ${DIR}/../go-controller
     make
     popd
 
     # Build ovn kube image
-    pushd ../dist/images
+    pushd ${DIR}/../dist/images
     # Find all built executables, but ignore the 'windows' directory if it exists
     find ../../go-controller/_output/go/bin/ -maxdepth 1 -type f -exec cp -f {} . \;
     echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
@@ -514,7 +516,7 @@ build_ovn_image() {
 }
 
 create_ovn_kube_manifests() {
-  pushd ../dist/images
+  pushd ${DIR}/../dist/images
   ./daemonset.sh \
     --image="${OVN_IMAGE}" \
     --net-cidr="${NET_CIDR}" \
@@ -556,7 +558,7 @@ install_ovn_image() {
 }
 
 install_ovn() {
-  pushd ../dist/yaml
+  pushd ${DIR}/../dist/yaml
   run_kubectl apply -f k8s.ovn.org_egressfirewalls.yaml
   run_kubectl apply -f k8s.ovn.org_egressips.yaml
   run_kubectl apply -f ovn-setup.yaml


### PR DESCRIPTION
Use absolute paths instead of relative paths so that kind.sh can be
run from any directory.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->