### PR TITLE
Fixes getPortAddresses being space separated value

### DIFF
--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -52,7 +52,7 @@ func GetPortAddresses(portName string, nbClient client.Client) (net.HardwareAddr
 
 	if lsp.DynamicAddresses == nil {
 		if len(lsp.Addresses) > 0 {
-			addresses = lsp.Addresses
+			addresses = strings.Split(lsp.Addresses[0], " ")
 		}
 	} else {
 		// dynamic addresses have format "0a:00:00:00:00:01 192.168.1.3"

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -139,7 +139,7 @@ func TestGetPortAddresses(t *testing.T) {
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitchPort{
 						Name:      portName,
-						Addresses: []string{hwAddr, badIPAddr},
+						Addresses: []string{fmt.Sprintf("%s %s", hwAddr, badIPAddr)},
 					},
 				},
 			},
@@ -151,7 +151,7 @@ func TestGetPortAddresses(t *testing.T) {
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitchPort{
 						Name:      portName,
-						Addresses: []string{hwAddr, ipAddr},
+						Addresses: []string{fmt.Sprintf("%s %s", hwAddr, ipAddr)},
 					},
 				},
 			},


### PR DESCRIPTION
Addresses on LSP are a space separated value of mac and ip addresses.
This was fixed for setting the address on an LSP in:
https://github.com/ovn-org/ovn-kubernetes/commit/c7cad83baf4fd756ee7bb9a018453f8a20ef9295

However, the logic was never fixed in getPortAddresses to split the
string into mac and ip values. This leads to errors like:
failed to parse logical switch port "openshift-multus_network-metrics-daemon-qzmg7"
MAC "0a:58:0a:80:02:04 10.128.2.4": address 0a:58:0a:80:02:04 10.128.2.4: invalid MAC address

Signed-off-by: Tim Rozet <trozet@redhat.com>

