### PR TITLE
Metrics: Add OVN-Controller liveness metric

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -101,6 +101,8 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 			client.WithTable(&sbdb.SBGlobal{}),
 			// used for metrics
 			client.WithTable(&sbdb.PortBinding{}),
+			// used for metrics
+			client.WithTable(&sbdb.ChassisPrivate{}),
 		),
 	)
 	if err != nil {

--- a/go-controller/pkg/libovsdbops/chassis_private.go
+++ b/go-controller/pkg/libovsdbops/chassis_private.go
@@ -1,0 +1,23 @@
+package libovsdbops
+
+import (
+	"context"
+	"fmt"
+
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+)
+
+// FindChassisPrivate returns a list of ChassisPrivate from cache. Returned objects are read-only
+// because getUUID and setUUID are not configured for ChassisPrivate table in model.go.
+func FindChassisPrivate(sbClient libovsdbclient.Client) ([]sbdb.ChassisPrivate, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	searchedChassisPrivate := []sbdb.ChassisPrivate{}
+	err := sbClient.List(ctx, &searchedChassisPrivate)
+	if err != nil {
+		return nil, fmt.Errorf("failed listing chassis private err: %v", err)
+	}
+	return searchedChassisPrivate, nil
+}

--- a/go-controller/pkg/libovsdbops/nb_global.go
+++ b/go-controller/pkg/libovsdbops/nb_global.go
@@ -60,3 +60,26 @@ func UpdateNBGlobalOptions(nbClient libovsdbclient.Client, options map[string]st
 
 	return nil
 }
+
+// UpdateNBGlobalNbCfg updates the nb_cfg field for the single row in the NBGlobal table
+func UpdateNBGlobalNbCfg(nbClient libovsdbclient.Client, nbCfg int) error {
+	nbGlobal, err := FindNBGlobal(nbClient)
+	if err != nil {
+		return err
+	}
+	nbGlobal.NbCfg = nbCfg
+
+	opModel := OperationModel{
+		Model: nbGlobal,
+		OnModelUpdates: []interface{}{
+			&nbGlobal.NbCfg,
+		},
+		ErrNotFound: true,
+	}
+
+	m := NewModelClient(nbClient)
+	if _, err := m.CreateOrUpdate(opModel); err != nil {
+		return fmt.Errorf("error while updating NBGlobal nb_cfg: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
By updating NBDBs NB_Global field nb_cfg with an
arbitary value periodically, northd replicates this
value in SBDBs SB_Global nb_cfg field. All
nodes OVN-Controllers react by populating their
respective Chassis_Private nb_cfg field with this value
and also a timestamp in nb_cfg timestamp field.

We scape the nb_cfg field from Chassis_Private table and
this allows us to determine if OVN-Controller is alive
and any OVN-Controllers that are behind.

This commit exposes 3 metrics.
* ..nb_cfg_nbdb - value written to NBDB
* ..nb_cfg_sbdb - value replicated by northd
* ..nb_cfg_chassis - value written by OVN-Controller

Co-authored-by: Casey Callendrello <cdc@redhat.com>
Co-authored-by: Martin Kennelly <mkennell@redhat.com>

Reworked/rebased from Caseys original PR: https://github.com/ovn-org/ovn-kubernetes/pull/2414
Concerns about metric cardinality creating a label per node and also overhead of watching chassis_private table... Getting input from @girishmg here would be great and also from others.
/cc
@bpickard22
@trozet 