### PR TITLE
libovsdb: fill in uuid of matched row

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -381,21 +381,13 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 		}...)
 	}
 
-	foundACLs := []nbdb.ACL{}
 	opModels = append([]libovsdbops.OperationModel{
 		{
 			Model:          egressFirewallACL,
 			ModelPredicate: func(acl *nbdb.ACL) bool { return libovsdbops.IsEquivalentACL(acl, egressFirewallACL) },
-			ExistingResult: &foundACLs,
 			DoAfter: func() {
-				var uuid string
-				if len(foundACLs) == 1 {
-					uuid = foundACLs[0].UUID
-				} else {
-					uuid = egressFirewallACL.UUID
-				}
 				for _, lsw := range switches {
-					lsw.ACLs = []string{uuid}
+					lsw.ACLs = []string{egressFirewallACL.UUID}
 				}
 			},
 		},

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -371,6 +371,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 					DoAfter: func() {
 						logicalRouter.StaticRoutes = libovsdbops.ExtractUUIDsFromModels(&logicalRouterStaticRouteRes)
 					},
+					BulkOp: true,
 				},
 				{
 					Model:          &logicalRouter,

--- a/go-controller/pkg/ovn/libovsdbops/model.go
+++ b/go-controller/pkg/ovn/libovsdbops/model.go
@@ -120,6 +120,7 @@ func copyIndexes(model model.Model) model.Model {
 	case *nbdb.LoadBalancerGroup:
 		return &nbdb.LoadBalancerGroup{
 			UUID: t.UUID,
+			Name: t.Name,
 		}
 	case *nbdb.LogicalRouter:
 		return &nbdb.LogicalRouter{

--- a/go-controller/pkg/ovn/libovsdbops/model_client.go
+++ b/go-controller/pkg/ovn/libovsdbops/model_client.go
@@ -207,8 +207,6 @@ type opModelToOpMapper func(model interface{}, opModel *OperationModel) (o []ovs
 func (m *ModelClient) buildOps(doWhenFound opModelToOpMapper, doWhenNotFound opModelToOpMapper, opModels ...OperationModel) (interface{}, []ovsdb.Operation, error) {
 	ops := []ovsdb.Operation{}
 	notfound := []interface{}{}
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
-	defer cancel()
 	for _, opModel := range opModels {
 		if opModel.ExistingResult == nil && opModel.Model != nil {
 			opModel.ExistingResult = getListFromModel(opModel.Model)
@@ -216,7 +214,7 @@ func (m *ModelClient) buildOps(doWhenFound opModelToOpMapper, doWhenNotFound opM
 
 		// lookup
 		if opModel.ModelPredicate != nil {
-			if err := m.client.WhereCache(opModel.ModelPredicate).List(ctx, opModel.ExistingResult); err != nil {
+			if err := m.whereCache(&opModel); err != nil {
 				return nil, nil, fmt.Errorf("unable to list items for model, err: %v", err)
 			}
 		} else if opModel.Model != nil {
@@ -336,6 +334,27 @@ func (m *ModelClient) get(opModel *OperationModel) (interface{}, error) {
 	}
 	addToExistingResult(copy, opModel.ExistingResult)
 	return copy, nil
+}
+
+func (m *ModelClient) whereCache(opModel *OperationModel) error {
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	var err error
+	if err = m.client.WhereCache(opModel.ModelPredicate).List(ctx, opModel.ExistingResult); err != nil {
+		return err
+	}
+
+	if opModel.Model == nil || opModel.BulkOp {
+		return nil
+	}
+
+	// for non-bulk op cases, copy (the one) uuid found to model provided, for convenience
+	err = onModels(opModel.ExistingResult, func(model interface{}) error {
+		uuid := getUUID(model)
+		setUUID(opModel.Model, uuid)
+		return nil
+	})
+	return err
 }
 
 func addToExistingResult(model interface{}, existingResult interface{}) {

--- a/go-controller/pkg/ovn/libovsdbops/model_client_test.go
+++ b/go-controller/pkg/ovn/libovsdbops/model_client_test.go
@@ -199,6 +199,42 @@ func TestCreateOrUpdateForRootObjects(t *testing.T) {
 				},
 			},
 		},
+		{
+			"Test setting of uuid of existing item to model when using model predicate",
+			func() []OperationModel {
+				notTheUUIDWanted := BuildNamedUUID()
+				model := nbdb.AddressSet{
+					UUID: notTheUUIDWanted,
+					Name: adressSetTestName,
+				}
+				return []OperationModel{
+					{
+						Model:          &model,
+						ModelPredicate: func(a *nbdb.AddressSet) bool { return a.Name == adressSetTestName },
+						BulkOp:         false,
+						ErrNotFound:    true,
+						DoAfter: func() {
+							if model.UUID == notTheUUIDWanted {
+								t.Fatalf("Test setting of uuid of existing item to model: should have UUID %s modified to match %s",
+									notTheUUIDWanted, adressSetTestUUID)
+							}
+						},
+					},
+				}
+			},
+			[]libovsdbtest.TestData{
+				&nbdb.AddressSet{
+					Name: adressSetTestName,
+					UUID: adressSetTestUUID,
+				},
+			},
+			[]libovsdbtest.TestData{
+				&nbdb.AddressSet{
+					Name: adressSetTestName,
+					UUID: adressSetTestUUID,
+				},
+			},
+		},
 	}
 
 	for _, tCase := range tt {

--- a/go-controller/pkg/ovn/libovsdbops/switch.go
+++ b/go-controller/pkg/ovn/libovsdbops/switch.go
@@ -270,23 +270,14 @@ func AddACLToNodeSwitch(nbClient libovsdbclient.Client, nodeName string, nodeACL
 		Name: nodeName,
 	}
 
-	existingACLres := []nbdb.ACL{}
-
 	// Here we either need to create the ACL and add to the LS or simply add to the LS
 	opModels := []OperationModel{
 		{
 			Model:          nodeACL,
 			ModelPredicate: func(acl *nbdb.ACL) bool { return IsEquivalentACL(acl, nodeACL) },
-			ExistingResult: &existingACLres,
 			DoAfter: func() {
 				// Bulkop is false, we should fail early if we get more than one result
-				// If ACL exists It's UUID will be in opModel.ExistingResult
-				// If it does not, it will be added to the model
-				if len(existingACLres) == 1 {
-					nodeSwitch.ACLs = []string{existingACLres[0].UUID}
-				} else {
-					nodeSwitch.ACLs = []string{nodeACL.UUID}
-				}
+				nodeSwitch.ACLs = []string{nodeACL.UUID}
 			},
 		},
 		{

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -295,21 +295,11 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		loadBalancerGroup := nbdb.LoadBalancerGroup{
 			Name: types.ClusterLBGroupName,
 		}
-		loadBalancerGroupRes := []nbdb.LoadBalancerGroup{}
+		// Create loadBalancerGroup if needed. Since this table is indexed by name, there is no need to
+		// mention that field in OnModelUpdates or ModelPredicate.
 		opModels := []libovsdbops.OperationModel{
 			{
-				Model:          &loadBalancerGroup,
-				ModelPredicate: func(lbg *nbdb.LoadBalancerGroup) bool { return lbg.Name == types.ClusterLBGroupName },
-				OnModelUpdates: []interface{}{
-					&loadBalancerGroup.Name,
-				},
-				ExistingResult: &loadBalancerGroupRes,
-				DoAfter: func() {
-					if len(loadBalancerGroupRes) > 0 {
-						loadBalancerGroup.UUID = loadBalancerGroupRes[0].UUID
-					}
-				},
-				ErrNotFound: false,
+				Model: &loadBalancerGroup,
 			},
 		}
 		if _, err = oc.modelClient.CreateOrUpdate(opModels...); err != nil {


### PR DESCRIPTION
When matching for rows is done via a predicate function, there is
a flag called BulkOp. When that is `false`, it means that up to one row
should be found. In such cases, the changes proposed here will fill in
the uuid of row.

This saves caller from having to grab the uuid from the results
slice, normally done via the DoAfter attribute, like in the example below:

```
 1 loadBalancerGroup := nbdb.LoadBalancerGroup{ Name: types.ClusterLBGroupName, }
 2 loadBalancerGroupRes := []nbdb.LoadBalancerGroup{}
 3 opModels := []libovsdbops.OperationModel{
 4    {
 5      Model:          &loadBalancerGroup,
 6      ModelPredicate: func(lbg *nbdb.LoadBalancerGroup) bool { return lbg.Name == types.ClusterLBGroupName },
...
 7      ExistingResult: &loadBalancerGroupRes,
 8      DoAfter:        func() {
 9                          if len(loadBalancerGroupRes) > 0 {
10                              loadBalancerGroup.UUID = loadBalancerGroupRes[0].UUID
11                      }
12    },
```

Note that OperationModel.BulkOp is omitted because that is False by default. In this case,
lines 7 and below would no longer be needed because 'loadBalancerGroup.UUID' will already
have the wanted value populated.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
