### PR TITLE
ovn: only start ovsdb clients when leader

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -16,7 +16,6 @@ import (
 
 	"k8s.io/klog/v2"
 
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/urfave/cli/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -229,7 +228,7 @@ func runOvnKube(ctx *cli.Context) error {
 			return err
 		}
 		watchFactory = masterWatchFactory
-		var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
+		var libovsdbOvnNBClient, libovsdbOvnSBClient *libovsdb.Client
 
 		if libovsdbOvnNBClient, err = libovsdb.NewNBClient(stopChan); err != nil {
 			return fmt.Errorf("error when trying to initialize libovsdb NB client: %v", err)

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20211201215911-5a82bae32e46
 	github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366
-	github.com/ovn-org/libovsdb v0.6.1-0.20211216134718-ab69150b65ee
+	github.com/ovn-org/libovsdb v0.6.1-0.20220105115935-66dba396bab5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/afero v1.4.1

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -354,6 +354,8 @@ github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366/go.mod h1:HJeH
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
 github.com/ovn-org/libovsdb v0.6.1-0.20211216134718-ab69150b65ee h1:QccSNi42WX6zICnX1R5s/5Zv1M8nZz8AsAA+ZlP/TyQ=
 github.com/ovn-org/libovsdb v0.6.1-0.20211216134718-ab69150b65ee/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
+github.com/ovn-org/libovsdb v0.6.1-0.20220105115935-66dba396bab5 h1:gYJlVEknNdJF6SyVjy1nrYPGhpJC1lIl6nqeIs9HmqY=
+github.com/ovn-org/libovsdb v0.6.1-0.20220105115935-66dba396bab5/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -74,15 +74,14 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 		err := util.SetExec(fexec)
 		Expect(err).NotTo(HaveOccurred())
 
-		testHarness = nil
+		testHarness, err = libovsdbtest.NewNBSBTestHarness()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		close(stopChan)
 		wg.Wait()
-		if testHarness != nil {
-			testHarness.Cleanup()
-		}
+		testHarness.Cleanup()
 	})
 
 	const hybridOverlayClusterCIDR string = "11.1.0.0/16/24"
@@ -105,9 +104,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
 			dbSetup := libovsdbtest.TestSetup{}
-			testHarness, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-			Expect(err).NotTo(HaveOccurred())
-			err = testHarness.Run()
+			err = testHarness.Run(dbSetup)
 			Expect(err).NotTo(HaveOccurred())
 
 			m, err := NewMaster(
@@ -214,9 +211,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				NBData: initialNBDB,
 				SBData: initialSBDB,
 			}
-			testHarness, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-			Expect(err).NotTo(HaveOccurred())
-			err = testHarness.Run()
+			err = testHarness.Run(dbSetup)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -416,9 +411,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			// nothing will occur in the SBDB or NBDB in this instance because the HO lrp already exists
-			testHarness, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-			Expect(err).NotTo(HaveOccurred())
-			err = testHarness.Run()
+			err = testHarness.Run(dbSetup)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -522,9 +515,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			// nothing will occur in the SBDB in this instance because we don't explicitly clean up any created
 			// mac bindings
-			testHarness, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-			Expect(err).NotTo(HaveOccurred())
-			err = testHarness.Run()
+			err = testHarness.Run(dbSetup)
 			Expect(err).NotTo(HaveOccurred())
 
 			m, err := NewMaster(

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -11,11 +11,11 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
@@ -106,10 +106,12 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
 			dbSetup := libovsdbtest.TestSetup{}
-			var libovsdbOvnNBClient libovsdbclient.Client
-			var libovsdbOvnSBClient libovsdbclient.Client
-
+			var libovsdbOvnNBClient, libovsdbOvnSBClient *libovsdb.Client
 			libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
+			err = libovsdbOvnNBClient.Run()
+			Expect(err).NotTo(HaveOccurred())
+			err = libovsdbOvnSBClient.Run()
 			Expect(err).NotTo(HaveOccurred())
 
 			m, err := NewMaster(
@@ -216,11 +218,12 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				NBData: initialNBDB,
 				SBData: initialSBDB,
 			}
-
-			var libovsdbOvnNBClient libovsdbclient.Client
-			var libovsdbOvnSBClient libovsdbclient.Client
-
+			var libovsdbOvnNBClient, libovsdbOvnSBClient *libovsdb.Client
 			libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
+			err = libovsdbOvnNBClient.Run()
+			Expect(err).NotTo(HaveOccurred())
+			err = libovsdbOvnSBClient.Run()
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -418,12 +421,14 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				NBData: initialNBDB,
 				SBData: initialSBDB,
 			}
-
-			var libovsdbOvnNBClient libovsdbclient.Client
-			var libovsdbOvnSBClient libovsdbclient.Client
+			var libovsdbOvnNBClient, libovsdbOvnSBClient *libovsdb.Client
 
 			// nothing will occur in the SBDB or NBDB in this instance because the HO lrp already exists
 			libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
+			err = libovsdbOvnNBClient.Run()
+			Expect(err).NotTo(HaveOccurred())
+			err = libovsdbOvnSBClient.Run()
 			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -524,12 +529,15 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				NBData: initialDatabaseState,
 				SBData: nil,
 			}
-			var libovsdbOvnNBClient libovsdbclient.Client
-			var libovsdbOvnSBClient libovsdbclient.Client
+			var libovsdbOvnNBClient, libovsdbOvnSBClient *libovsdb.Client
 
 			// nothing will occur in the SBDB in this instance because we don't explicitly clean up any created
 			// mac bindings
 			libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
+			err = libovsdbOvnNBClient.Run()
+			Expect(err).NotTo(HaveOccurred())
+			err = libovsdbOvnSBClient.Run()
 			Expect(err).NotTo(HaveOccurred())
 
 			m, err := NewMaster(

--- a/go-controller/pkg/libovsdbops/model_client_test.go
+++ b/go-controller/pkg/libovsdbops/model_client_test.go
@@ -35,12 +35,12 @@ func runTestCase(t *testing.T, tCase OperationModelTestCase, shouldDelete bool) 
 		NBData: tCase.initialDB,
 	}
 
-	th, err := libovsdbtest.NewNBTestHarness(dbSetup)
+	th, err := libovsdbtest.NewNBTestHarness()
 	if err != nil {
 		return err
 	}
 	t.Cleanup(th.Cleanup)
-	if err := th.Run(); err != nil {
+	if err := th.Run(dbSetup); err != nil {
 		return fmt.Errorf("test: \"%s\" couldn't to start NB client: %v", tCase.name, err)
 	}
 
@@ -1038,12 +1038,12 @@ func TestCreateWithAdHocClient(t *testing.T) {
 			SBData: tCase.initialDB,
 		}
 
-		th, err := libovsdbtest.NewSBTestHarness(dbSetup)
+		th, err := libovsdbtest.NewSBTestHarness()
 		if err != nil {
 			t.Fatalf("test: \"%s\" failed to set up test harness: %v", tCase.name, err)
 		}
 		t.Cleanup(th.Cleanup)
-		if err := th.Run(); err != nil {
+		if err := th.Run(dbSetup); err != nil {
 			t.Fatalf("test: \"%s\" couldn't to start test harness: %v", tCase.name, err)
 		}
 

--- a/go-controller/pkg/libovsdbops/model_client_test.go
+++ b/go-controller/pkg/libovsdbops/model_client_test.go
@@ -40,6 +40,9 @@ func runTestCase(t *testing.T, tCase OperationModelTestCase, shouldDelete bool) 
 		return err
 	}
 	t.Cleanup(cleanup.Cleanup)
+	if err := nbClient.Run(); err != nil {
+		return fmt.Errorf("test: \"%s\" couldn't to start NB client: %v", tCase.name, err)
+	}
 
 	modelClient := NewModelClient(nbClient)
 
@@ -1040,6 +1043,12 @@ func TestCreateWithAdHocClient(t *testing.T) {
 			t.Fatalf("test: \"%s\" failed to set up test harness: %v", tCase.name, err)
 		}
 		t.Cleanup(cleanup.Cleanup)
+		if err := nbClient.Run(); err != nil {
+			t.Fatalf("test: \"%s\" couldn't to start NB client: %v", tCase.name, err)
+		}
+		if err := sbClient.Run(); err != nil {
+			t.Fatalf("test: \"%s\" couldn't to start SB client: %v", tCase.name, err)
+		}
 
 		modelClient := NewModelClient(nbClient)
 

--- a/go-controller/pkg/libovsdbops/model_client_test.go
+++ b/go-controller/pkg/libovsdbops/model_client_test.go
@@ -35,7 +35,7 @@ func runTestCase(t *testing.T, tCase OperationModelTestCase, shouldDelete bool) 
 		NBData: tCase.initialDB,
 	}
 
-	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/libovsdbops/switch_test.go
+++ b/go-controller/pkg/libovsdbops/switch_test.go
@@ -83,12 +83,12 @@ func TestRemoveACLsFromSwitches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			th, err := libovsdbtest.NewNBTestHarness(tt.initialNbdb)
+			th, err := libovsdbtest.NewNBTestHarness()
 			if err != nil {
 				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
 			}
 			t.Cleanup(th.Cleanup)
-			if err := th.Run(); err != nil {
+			if err := th.Run(tt.initialNbdb); err != nil {
 				t.Fatalf("test: \"%s\" couldn't to start the test harness: %v", tt.desc, err)
 			}
 

--- a/go-controller/pkg/libovsdbops/switch_test.go
+++ b/go-controller/pkg/libovsdbops/switch_test.go
@@ -88,6 +88,9 @@ func TestRemoveACLsFromSwitches(t *testing.T) {
 				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
 			}
 			t.Cleanup(cleanup.Cleanup)
+			if err := nbClient.Run(); err != nil {
+				t.Fatalf("test: \"%s\" couldn't to start NB client: %v", tt.desc, err)
+			}
 
 			fakeSwitches := []nbdb.LogicalSwitch{
 				*fakeSwitch1,

--- a/go-controller/pkg/libovsdbops/switch_test.go
+++ b/go-controller/pkg/libovsdbops/switch_test.go
@@ -83,13 +83,13 @@ func TestRemoveACLsFromSwitches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tt.initialNbdb)
+			th, err := libovsdbtest.NewNBTestHarness(tt.initialNbdb)
 			if err != nil {
 				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
 			}
-			t.Cleanup(cleanup.Cleanup)
-			if err := nbClient.Run(); err != nil {
-				t.Fatalf("test: \"%s\" couldn't to start NB client: %v", tt.desc, err)
+			t.Cleanup(th.Cleanup)
+			if err := th.Run(); err != nil {
+				t.Fatalf("test: \"%s\" couldn't to start the test harness: %v", tt.desc, err)
 			}
 
 			fakeSwitches := []nbdb.LogicalSwitch{
@@ -103,16 +103,16 @@ func TestRemoveACLsFromSwitches(t *testing.T) {
 				*fakeACL2,
 			}
 
-			err = removeACLsFromSwitches(nbClient, fakeSwitches, ACLs)
+			err = removeACLsFromSwitches(th.NBClient, fakeSwitches, ACLs)
 			if err != nil && !tt.expectErr {
 				t.Fatal(fmt.Errorf("RemoveACLFromNodeSwitches() error = %v", err))
 			}
 
 			matcher := libovsdbtest.HaveData(tt.expectedNbdb.NBData)
-			success, err := matcher.Match(nbClient)
+			success, err := matcher.Match(th.NBClient)
 
 			if !success {
-				t.Fatal(fmt.Errorf("test: \"%s\" didn't match expected with actual, err: %v", tt.desc, matcher.FailureMessage(nbClient)))
+				t.Fatal(fmt.Errorf("test: \"%s\" didn't match expected with actual, err: %v", tt.desc, matcher.FailureMessage(th.NBClient)))
 			}
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tt.desc, err))

--- a/go-controller/pkg/libovsdbops/switch_test.go
+++ b/go-controller/pkg/libovsdbops/switch_test.go
@@ -83,7 +83,7 @@ func TestRemoveACLsFromSwitches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tt.initialNbdb, nil)
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tt.initialNbdb)
 			if err != nil {
 				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
 			}

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -54,13 +54,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		testHarness = nil
+		var err error
+		testHarness, err = libovsdbtest.NewNBTestHarness()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
 	ginkgo.AfterEach(func() {
-		if testHarness != nil {
-			testHarness.Cleanup()
-		}
+		testHarness.Cleanup()
 	})
 
 	ginkgo.Context("when iterating address sets", func() {
@@ -83,10 +83,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -145,10 +142,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -183,10 +177,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -211,10 +202,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 		ginkgo.It("creates a new address set and sets IPs", func() {
 			app.Action = func(ctx *cli.Context) error {
 				dbSetup := libovsdbtest.TestSetup{}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -250,10 +238,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -301,10 +286,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -354,10 +336,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -394,10 +373,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 		ginkgo.It("ensures an address set exists and if not creates a new one", func() {
 			app.Action = func(ctx *cli.Context) error {
 				dbSetup := libovsdbtest.TestSetup{}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -428,10 +404,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 	ginkgo.It("destroys an address set", func() {
 		app.Action = func(ctx *cli.Context) error {
 			dbSetup := libovsdbtest.TestSetup{}
-			var err error
-			testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = testHarness.Run()
+			err := testHarness.Run(dbSetup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -459,10 +432,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				const addr1 string = "1.2.3.4"
 
 				dbSetup := libovsdbtest.TestSetup{}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -501,10 +471,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var err error
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err := testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -534,9 +501,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				dbSetup := libovsdbtest.TestSetup{}
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err = testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -572,9 +537,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				dbSetup := libovsdbtest.TestSetup{}
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err = testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -616,9 +579,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err = testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -659,9 +620,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err = testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -705,9 +664,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err = testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -749,9 +706,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 			config.IPv6Mode = true
 
 			dbSetup := libovsdbtest.TestSetup{}
-			testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = testHarness.Run()
+			err = testHarness.Run(dbSetup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -795,9 +750,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err = testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -855,9 +808,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err = testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)
@@ -906,9 +857,6 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 	})
 
 	ginkgo.Context("Dual Stack : when cleaning up old address sets", func() {
-		ginkgo.BeforeEach(func() {
-		})
-
 		ginkgo.It("destroys address sets in old non dual stack format", func() {
 			app.Action = func(ctx *cli.Context) error {
 				namespaces := []testAddressSetName{
@@ -986,9 +934,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				config.IPv6Mode = true
 
-				testHarness, err = libovsdbtest.NewNBTestHarness(dbSetup)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				err = testHarness.Run()
+				err = testHarness.Run(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(testHarness.NBClient)

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -186,7 +186,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -215,7 +215,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				dbSetup := libovsdbtest.TestSetup{}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -255,7 +255,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -307,7 +307,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -361,7 +361,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -402,7 +402,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				dbSetup := libovsdbtest.TestSetup{}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -437,7 +437,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 			dbSetup := libovsdbtest.TestSetup{}
 			var err error
 			var libovsdbOvnNBClient *libovsdb.Client
-			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = libovsdbOvnNBClient.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -469,7 +469,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				dbSetup := libovsdbtest.TestSetup{}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -512,7 +512,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				}
 				var err error
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -545,7 +545,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 				dbSetup := libovsdbtest.TestSetup{}
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -584,7 +584,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 				dbSetup := libovsdbtest.TestSetup{}
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -629,7 +629,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 				dbSetup := libovsdbtest.TestSetup{}
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -673,7 +673,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 				dbSetup := libovsdbtest.TestSetup{}
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -720,7 +720,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 				dbSetup := libovsdbtest.TestSetup{}
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -765,7 +765,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 			dbSetup := libovsdbtest.TestSetup{}
 			var libovsdbOvnNBClient *libovsdb.Client
-			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = libovsdbOvnNBClient.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -812,7 +812,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 				dbSetup := libovsdbtest.TestSetup{}
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -873,7 +873,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 				dbSetup := libovsdbtest.TestSetup{}
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1005,7 +1005,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				var libovsdbOvnNBClient *libovsdb.Client
-				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 
@@ -82,10 +82,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -142,10 +145,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -178,9 +184,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				_, err = config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -203,10 +213,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 		ginkgo.It("creates a new address set and sets IPs", func() {
 			app.Action = func(ctx *cli.Context) error {
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -240,10 +253,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -289,10 +305,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				_, err = config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -340,10 +359,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				_, err = config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -378,10 +400,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 		ginkgo.It("ensures an address set exists and if not creates a new one", func() {
 			app.Action = func(ctx *cli.Context) error {
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -410,10 +435,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 	ginkgo.It("destroys an address set", func() {
 		app.Action = func(ctx *cli.Context) error {
 			dbSetup := libovsdbtest.TestSetup{}
-			var libovsdbOvnNBClient libovsdbclient.Client
 			var err error
-			libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			var libovsdbOvnNBClient *libovsdb.Client
+			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = libovsdbOvnNBClient.Run()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 			_, err = config.InitConfig(ctx, nil, nil)
@@ -439,10 +467,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				const addr1 string = "1.2.3.4"
 
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				_, err = config.InitConfig(ctx, nil, nil)
@@ -479,10 +510,13 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						},
 					},
 				}
-				var libovsdbOvnNBClient libovsdbclient.Client
 				var err error
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				_, err = config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -510,9 +544,12 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1)})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -546,9 +583,12 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 				as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1)})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -588,9 +628,12 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2),
@@ -629,9 +672,12 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2),
@@ -673,9 +719,12 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				_, err = asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2),
@@ -715,9 +764,12 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 			config.IPv6Mode = true
 
 			dbSetup := libovsdbtest.TestSetup{}
-			var libovsdbOvnNBClient libovsdbclient.Client
-			libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			var libovsdbOvnNBClient *libovsdb.Client
+			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = libovsdbOvnNBClient.Run()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 			as, err := asFactory.NewAddressSet("foobar", []net.IP{net.ParseIP(addr1), net.ParseIP(addr2),
@@ -759,9 +811,12 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				as, err := asFactory.NewAddressSet("foobar", nil)
@@ -817,8 +872,10 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				config.IPv6Mode = true
 
 				dbSetup := libovsdbtest.TestSetup{}
-				var libovsdbOvnNBClient libovsdbclient.Client
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
@@ -947,9 +1004,12 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				config.IPv6Mode = true
 
-				var libovsdbOvnNBClient libovsdbclient.Client
-				libovsdbOvnNBClient, _, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+				var libovsdbOvnNBClient *libovsdb.Client
+				libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = libovsdbOvnNBClient.Run()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				asFactory = NewOvnAddressSetFactory(libovsdbOvnNBClient)
 
 				err = NonDualStackAddressSetCleanup(libovsdbOvnNBClient)

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -31,8 +31,8 @@ type serviceController struct {
 	testHarness        *libovsdbtest.Harness
 }
 
-func newControllerWithDBSetup(dbSetup libovsdbtest.TestSetup) (*serviceController, error) {
-	testHarness, err := libovsdbtest.NewNBTestHarness(dbSetup)
+func newControllerWithDBSetup() (*serviceController, error) {
+	testHarness, err := libovsdbtest.NewNBTestHarness()
 	if err != nil {
 		return nil, err
 	}
@@ -607,12 +607,12 @@ func TestSyncServices(t *testing.T) {
 			}
 
 			ovnlb.TestOnlySetCache(nil)
-			controller, err := newControllerWithDBSetup(libovsdbtest.TestSetup{NBData: tt.initialDb})
+			controller, err := newControllerWithDBSetup()
 			if err != nil {
 				t.Fatalf("Error creating controller: %v", err)
 			}
 			t.Cleanup(controller.close)
-			if err := controller.testHarness.Run(); err != nil {
+			if err := controller.testHarness.Run(libovsdbtest.TestSetup{NBData: tt.initialDb}); err != nil {
 				t.Fatalf("Error starting OVN NB client: %v", err)
 			}
 

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -32,7 +32,7 @@ type serviceController struct {
 }
 
 func newControllerWithDBSetup(dbSetup libovsdbtest.TestSetup) (*serviceController, error) {
-	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/ovn/controller/unidling/unidle_test.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle_test.go
@@ -26,15 +26,19 @@ func TestUnidlingContoller(t *testing.T) {
 
 var _ = Describe("Unidling Controller", func() {
 	var testHarness *libovsdbtest.Harness
+	var stopCh chan struct{}
 
 	BeforeEach(func() {
-		testHarness = nil
+		var err error
+		testHarness, err = libovsdbtest.NewSBTestHarness()
+		Expect(err).NotTo(HaveOccurred())
+
+		stopCh = make(chan struct{})
 	})
 
 	AfterEach(func() {
-		if testHarness != nil {
-			testHarness.Cleanup()
-		}
+		close(stopCh)
+		testHarness.Cleanup()
 	})
 
 	It("should respond to a controller event", func() {
@@ -53,13 +57,7 @@ var _ = Describe("Unidling Controller", func() {
 				},
 			},
 		}
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-
-		var err error
-		testHarness, err = libovsdbtest.NewSBTestHarness(testSetup)
-		Expect(err).NotTo(HaveOccurred())
-		err = testHarness.Run()
+		err := testHarness.Run(testSetup)
 		Expect(err).NotTo(HaveOccurred())
 
 		config.OvnSouth.Scheme = config.OvnDBSchemeTCP

--- a/go-controller/pkg/ovn/controller/unidling/unidle_test.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Unidling Controller", func() {
 
 		var sbClient *libovsdb.Client
 		var err error
-		sbClient, cleanup, err = libovsdbtest.NewSBTestHarness(testSetup, nil)
+		sbClient, cleanup, err = libovsdbtest.NewSBTestHarness(testSetup)
 		Expect(err).NotTo(HaveOccurred())
 		err = sbClient.Run()
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/ovn/controller/unidling/unidle_test.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -57,9 +57,11 @@ var _ = Describe("Unidling Controller", func() {
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
-		var sbClient libovsdbclient.Client
+		var sbClient *libovsdb.Client
 		var err error
 		sbClient, cleanup, err = libovsdbtest.NewSBTestHarness(testSetup, nil)
+		Expect(err).NotTo(HaveOccurred())
+		err = sbClient.Run()
 		Expect(err).NotTo(HaveOccurred())
 
 		config.OvnSouth.Scheme = config.OvnDBSchemeTCP

--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -25,7 +25,7 @@ func TestNewEgressDNS(t *testing.T) {
 	testCh := make(chan struct{})
 	dbSetup := libovsdbtest.TestSetup{}
 
-	libovsdbOvnNBClient, libovsdbCleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
+	libovsdbOvnNBClient, libovsdbCleanup, err := libovsdbtest.NewNBTestHarness(dbSetup)
 	assert.Nil(t, err)
 	t.Cleanup(libovsdbCleanup.Cleanup)
 	err = libovsdbOvnNBClient.Run()

--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -24,12 +24,11 @@ import (
 func TestNewEgressDNS(t *testing.T) {
 	testCh := make(chan struct{})
 	t.Cleanup(func() { close(testCh) })
-	dbSetup := libovsdbtest.TestSetup{}
 
-	th, err := libovsdbtest.NewNBTestHarness(dbSetup)
+	th, err := libovsdbtest.NewNBTestHarness()
 	assert.Nil(t, err)
 	t.Cleanup(th.Cleanup)
-	err = th.Run()
+	err = th.Run(libovsdbtest.TestSetup{})
 	assert.Nil(t, err)
 
 	testOvnAddFtry := addressset.NewOvnAddressSetFactory(th.NBClient)

--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -23,15 +23,16 @@ import (
 
 func TestNewEgressDNS(t *testing.T) {
 	testCh := make(chan struct{})
+	t.Cleanup(func() { close(testCh) })
 	dbSetup := libovsdbtest.TestSetup{}
 
-	libovsdbOvnNBClient, libovsdbCleanup, err := libovsdbtest.NewNBTestHarness(dbSetup)
+	th, err := libovsdbtest.NewNBTestHarness(dbSetup)
 	assert.Nil(t, err)
-	t.Cleanup(libovsdbCleanup.Cleanup)
-	err = libovsdbOvnNBClient.Run()
+	t.Cleanup(th.Cleanup)
+	err = th.Run()
 	assert.Nil(t, err)
 
-	testOvnAddFtry := addressset.NewOvnAddressSetFactory(libovsdbOvnNBClient)
+	testOvnAddFtry := addressset.NewOvnAddressSetFactory(th.NBClient)
 	mockDnsOps := new(util_mocks.DNSOps)
 	util.SetDNSLibOpsMockInst(mockDnsOps)
 	tests := []struct {

--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -25,9 +25,11 @@ func TestNewEgressDNS(t *testing.T) {
 	testCh := make(chan struct{})
 	dbSetup := libovsdbtest.TestSetup{}
 
-	libovsdbOvnNBClient, _, libovsdbCleanup, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
+	libovsdbOvnNBClient, libovsdbCleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
 	assert.Nil(t, err)
 	t.Cleanup(libovsdbCleanup.Cleanup)
+	err = libovsdbOvnNBClient.Run()
+	assert.Nil(t, err)
 
 	testOvnAddFtry := addressset.NewOvnAddressSetFactory(libovsdbOvnNBClient)
 	mockDnsOps := new(util_mocks.DNSOps)

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -180,7 +180,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					finalJoinSwitch,
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -263,7 +263,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					finalNodeSwitch,
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -351,7 +351,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					finalNodeSwitch,
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -448,7 +448,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					finalNodeSwitch,
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -542,7 +542,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					nodeSwitch2,
 				}
 
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Expect(fakeOVN.testHarness.NBClient).To(libovsdbtest.HaveData(expectedDatabaseState))
 
 				err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -555,7 +555,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					nodeSwitch2,
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -649,7 +649,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					finalNodeSwitch,
 				}
 
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Expect(fakeOVN.testHarness.NBClient).To(libovsdbtest.HaveData(expectedDatabaseState))
 
 				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -658,7 +658,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 
 				ipv4ACL.Action = nbdb.ACLActionDrop
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -804,7 +804,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					finalJoinSwitch,
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -882,7 +882,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					finalJoinSwitch,
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -965,7 +965,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					finalJoinSwitch,
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -1059,7 +1059,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					finalJoinSwitch,
 				}
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -1139,13 +1139,13 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					finalJoinSwitch,
 				}
 
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Expect(fakeOVN.testHarness.NBClient).To(libovsdbtest.HaveData(expectedDatabaseState))
 
 				err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// join switch should return to orignal state, egfw was deleted
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(fakeOVN.dbSetup.NBData))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(fakeOVN.dbSetup.NBData))
 
 				return nil
 			}
@@ -1227,7 +1227,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					finalJoinSwitch,
 				}
 
-				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Expect(fakeOVN.testHarness.NBClient).To(libovsdbtest.HaveData(expectedDatabaseState))
 
 				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1236,7 +1236,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 
 				ipv4ACL.Action = nbdb.ACLActionDrop
 
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOVN.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -107,7 +107,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				fakeOvn.controller.WatchPods()
 
 				gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -240,7 +240,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -376,7 +376,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				fakeOvn.controller.WatchPods()
 
 				gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -537,7 +537,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 					err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Delete(context.TODO(), t.podName, *metav1.NewDeleteOptions(0))
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+					gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 					return nil
 				}
 				err := app.Run([]string{app.Name})
@@ -691,7 +691,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 					err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Delete(context.TODO(), t.podName, *metav1.NewDeleteOptions(0))
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB...))
+					gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB...))
 					return nil
 				}
 				err := app.Run([]string{app.Name})
@@ -801,7 +801,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 					err := fakeOvn.fakeClient.KubeClient.CoreV1().Namespaces().Delete(context.TODO(), t.namespace, *metav1.NewDeleteOptions(0))
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+					gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 					return nil
 				}
 
@@ -994,7 +994,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(), newPod(t.namespace, t.podName, t.nodeName, t.podIP), metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -1131,7 +1131,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 				_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespaceX.Name).Create(context.TODO(), &gwPod, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -1277,7 +1277,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Create(context.TODO(), newPod(t.namespace, t.podName, t.nodeName, t.podIP), metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(func() string { return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName) }, 2).Should(gomega.MatchJSON(`{"default": {"ip_addresses":["` + t.podIP + `/24"], "mac_address":"` + t.podMAC + `", "gateway_ips": ["` + t.nodeGWIP + `"], "ip_address":"` + t.podIP + `/24", "gateway_ip": "` + t.nodeGWIP + `"}}`))
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -1417,11 +1417,11 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 					_, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespaceX.Name).Create(context.TODO(), &gwPod, metav1.CreateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(beforeDeleteNB))
+					gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(beforeDeleteNB))
 
 					err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespaceX.Name).Delete(context.TODO(), gwPod.Name, *metav1.NewDeleteOptions(0))
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(afterDeleteNB))
+					gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(afterDeleteNB))
 					return nil
 				}
 
@@ -1669,7 +1669,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						StaticRoutes: []string{"static-route-1-UUID", "static-route-2-UUID"},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -1782,7 +1782,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						StaticRoutes: []string{"static-route-1-UUID", "static-route-2-UUID"},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -1869,7 +1869,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						StaticRoutes: []string{"static-route-1-UUID"},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -1920,7 +1920,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 				err := fakeOvn.controller.addHybridRoutePolicyForPod(net.ParseIP("10.128.1.3"), "node1")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				// check if the address-set was created with the podIP
 				fakeOvn.asf.ExpectAddressSetWithIPs("hybrid-route-pods-node1", []string{"10.128.1.3"})
 				return nil
@@ -1980,7 +1980,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				injectNode(fakeOvn)
 				err := fakeOvn.controller.delHybridRoutePolicyForPod(net.ParseIP("10.128.1.3"), "node1")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				fakeOvn.asf.ExpectEmptyAddressSet("hybrid-route-pods-node1")
 				return nil
 			}
@@ -2045,7 +2045,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 				err := fakeOvn.controller.delAllHybridRoutePolicies()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				fakeOvn.asf.ExpectEmptyAddressSet("hybrid-route-pods-node1")
 				return nil
 			}
@@ -2124,7 +2124,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 
 				err := fakeOvn.controller.delAllLegacyHybridRoutePolicies()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 
@@ -2203,7 +2203,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				fakeOvn.controller.WatchPods()
 				_, fullMaskPodNet, _ := net.ParseCIDR("10.128.1.3/32")
 				addPerPodGRSNAT(fakeOvn.controller.nbClient, fakeOvn.controller.watchFactory, &pod[0], []*net.IPNet{fullMaskPodNet})
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				finalNB = []libovsdbtest.TestData{
 					&nbdb.LogicalRouter{
 						Name: types.GWRouterPrefix + nodeName,
@@ -2218,7 +2218,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				}
 				err := deletePerPodGRSNAT(fakeOvn.controller.nbClient, nodeName, []*net.IPNet{fullMaskPodNet})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil
 			}
 

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -430,7 +430,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -665,7 +665,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -795,7 +795,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				egressIPs, nodes := getEgressIPStatus(eIP.Name)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
@@ -842,7 +842,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -966,7 +966,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Nat:  []string{"egressip-nat-UUID"},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				egressIPs, nodes := getEgressIPStatus(eIP.Name)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
@@ -981,7 +981,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Eventually(getEgressIPStatusLen(eIP.Name)).Should(gomega.Equal(1))
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -1117,7 +1117,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Nat:  []string{"egressip-nat-UUID"},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -1302,7 +1302,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Nat:  []string{"egressip-nat-UUID"},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				egressIPs, nodes := getEgressIPStatus(eIP.Name)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
@@ -1347,7 +1347,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Nat:  nil,
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -1534,7 +1534,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Nat:  []string{"egressip-nat-UUID"},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				egressIPs, nodes := getEgressIPStatus(eIP.Name)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
@@ -1557,7 +1557,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				_, err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Update(context.TODO(), eIPUpdate, metav1.UpdateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(func() string {
 					egressIPs, _ := getEgressIPStatus(eIP.Name)
@@ -1686,7 +1686,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Nat:  []string{"egressip-nat-UUID"},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				egressIPs, nodes := getEgressIPStatus(eIP.Name)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
@@ -1709,7 +1709,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 
 				_, err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Update(context.TODO(), eIPUpdate, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				gomega.Eventually(getEgressIPStatusLen(eIP.Name)).Should(gomega.Equal(1))
 
 				egressIPs, nodes = getEgressIPStatus(eIP.Name)
@@ -1875,7 +1875,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -2032,7 +2032,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(1))
 				gomega.Eventually(isEgressAssignableNode(node.Name)).Should(gomega.BeFalse())
@@ -2092,7 +2092,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -2247,7 +2247,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
 				gomega.Expect(fakeOvn.controller.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
@@ -2405,7 +2405,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
@@ -2467,7 +2467,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -2658,7 +2658,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					},
 				}
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -2848,7 +2848,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -2999,7 +2999,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
 				gomega.Expect(fakeOvn.controller.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
@@ -3061,7 +3061,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(0))
 				gomega.Eventually(isEgressAssignableNode(node1.Name)).Should(gomega.BeTrue())
@@ -3125,7 +3125,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				return nil
 			}
@@ -3273,7 +3273,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
 				gomega.Expect(fakeOvn.controller.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
@@ -3330,7 +3330,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				egressIPs, nodes := getEgressIPStatus(egressIPName)
@@ -3394,7 +3394,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 
@@ -3548,7 +3548,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(1))
 				gomega.Expect(fakeOvn.controller.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
@@ -3604,7 +3604,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				egressIPs, nodes = getEgressIPStatus(egressIPName)
@@ -3677,7 +3677,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						},
 					},
 				}
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				return nil
 			}
 

--- a/go-controller/pkg/ovn/gateway/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway/gateway_test.go
@@ -62,13 +62,13 @@ func TestGetOvnGateways(t *testing.T) {
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: tt.ovnInitState,
 			}
-			testHarness, err := libovsdbtest.NewNBTestHarness(dbSetup)
+			testHarness, err := libovsdbtest.NewNBTestHarness()
 			if err != nil {
 				t.Errorf("libovsdb client error: %v", err)
 			}
 			t.Cleanup(testHarness.Cleanup)
-			if err := testHarness.Run(); err != nil {
-				t.Errorf("couldn't to start NB client: %v", err)
+			if err := testHarness.Run(dbSetup); err != nil {
+				t.Errorf("couldn't to start test harness: %v", err)
 			}
 
 			got, err := GetOvnGateways(testHarness.NBClient)
@@ -144,13 +144,13 @@ func TestGetGatewayPhysicalIPs(t *testing.T) {
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: tt.ovnInitState,
 			}
-			testHarness, err := libovsdbtest.NewNBTestHarness(dbSetup)
+			testHarness, err := libovsdbtest.NewNBTestHarness()
 			if err != nil {
 				t.Errorf("libovsdb client error: %v", err)
 			}
 			t.Cleanup(testHarness.Cleanup)
-			if err := testHarness.Run(); err != nil {
-				t.Errorf("couldn't to start NB client: %v", err)
+			if err := testHarness.Run(dbSetup); err != nil {
+				t.Errorf("couldn't to start test harness: %v", err)
 			}
 
 			got, err := GetGatewayPhysicalIPs(testHarness.NBClient, "GR_ovn-control-plane")

--- a/go-controller/pkg/ovn/gateway/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway/gateway_test.go
@@ -62,7 +62,7 @@ func TestGetOvnGateways(t *testing.T) {
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: tt.ovnInitState,
 			}
-			libovsdbOvnNBClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
+			libovsdbOvnNBClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup)
 			if err != nil {
 				t.Errorf("libovsdb client error: %v", err)
 			}
@@ -144,7 +144,7 @@ func TestGetGatewayPhysicalIPs(t *testing.T) {
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: tt.ovnInitState,
 			}
-			libovsdbOvnNBClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup, nil)
+			libovsdbOvnNBClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup)
 			if err != nil {
 				t.Errorf("libovsdb client error: %v", err)
 			}

--- a/go-controller/pkg/ovn/gateway/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway/gateway_test.go
@@ -62,16 +62,16 @@ func TestGetOvnGateways(t *testing.T) {
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: tt.ovnInitState,
 			}
-			libovsdbOvnNBClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup)
+			testHarness, err := libovsdbtest.NewNBTestHarness(dbSetup)
 			if err != nil {
 				t.Errorf("libovsdb client error: %v", err)
 			}
-			t.Cleanup(cleanup.Cleanup)
-			if err := libovsdbOvnNBClient.Run(); err != nil {
+			t.Cleanup(testHarness.Cleanup)
+			if err := testHarness.Run(); err != nil {
 				t.Errorf("couldn't to start NB client: %v", err)
 			}
 
-			got, err := GetOvnGateways(libovsdbOvnNBClient)
+			got, err := GetOvnGateways(testHarness.NBClient)
 			if !sets.NewString(got...).HasAll(tt.want...) {
 				t.Errorf("GetOvnGateways() got = %v, want %v", got, tt.want)
 			}
@@ -144,16 +144,16 @@ func TestGetGatewayPhysicalIPs(t *testing.T) {
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: tt.ovnInitState,
 			}
-			libovsdbOvnNBClient, cleanup, err := libovsdbtest.NewNBTestHarness(dbSetup)
+			testHarness, err := libovsdbtest.NewNBTestHarness(dbSetup)
 			if err != nil {
 				t.Errorf("libovsdb client error: %v", err)
 			}
-			t.Cleanup(cleanup.Cleanup)
-			if err := libovsdbOvnNBClient.Run(); err != nil {
+			t.Cleanup(testHarness.Cleanup)
+			if err := testHarness.Run(); err != nil {
 				t.Errorf("couldn't to start NB client: %v", err)
 			}
 
-			got, err := GetGatewayPhysicalIPs(libovsdbOvnNBClient, "GR_ovn-control-plane")
+			got, err := GetGatewayPhysicalIPs(testHarness.NBClient, "GR_ovn-control-plane")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetGatewayPhysicalIPs() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/go-controller/pkg/ovn/gateway/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway/gateway_test.go
@@ -67,6 +67,9 @@ func TestGetOvnGateways(t *testing.T) {
 				t.Errorf("libovsdb client error: %v", err)
 			}
 			t.Cleanup(cleanup.Cleanup)
+			if err := libovsdbOvnNBClient.Run(); err != nil {
+				t.Errorf("couldn't to start NB client: %v", err)
+			}
 
 			got, err := GetOvnGateways(libovsdbOvnNBClient)
 			if !sets.NewString(got...).HasAll(tt.want...) {
@@ -146,6 +149,9 @@ func TestGetGatewayPhysicalIPs(t *testing.T) {
 				t.Errorf("libovsdb client error: %v", err)
 			}
 			t.Cleanup(cleanup.Cleanup)
+			if err := libovsdbOvnNBClient.Run(); err != nil {
+				t.Errorf("couldn't to start NB client: %v", err)
+			}
 
 			got, err := GetGatewayPhysicalIPs(libovsdbOvnNBClient, "GR_ovn-control-plane")
 			if (err != nil) != tt.wantErr {

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -308,7 +308,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
 			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch, nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP)
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 
 		ginkgo.It("creates an IPv6 gateway in OVN", func() {
@@ -360,7 +360,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
 			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch, nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP)
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 
 		ginkgo.It("creates a dual-stack gateway in OVN", func() {
@@ -412,7 +412,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
 			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch, nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP)
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 
 		ginkgo.It("removes leftover SNAT entries during init", func() {
@@ -465,7 +465,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
 			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch, nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP)
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 	})
 
@@ -542,7 +542,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			// We don't set up the Allow from mgmt port ACL here
 			mgmtPortIP := ""
 			expectedDatabaseState := generateGatewayInitExpectedNB(testData, expectedOVNClusterRouter, expectedNodeSwitch, nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP)
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 
 	})
@@ -663,7 +663,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					Policies: []string{"match3-UUID", "match6-UUID"},
 				},
 			}
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 
 		ginkgo.It("cleans up a dual-stack gateway in OVN", func() {
@@ -783,7 +783,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					Policies: []string{"match3-UUID", "match6-UUID"},
 				},
 			}
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 		})
 	})
 })

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
@@ -68,7 +68,7 @@ func TestNewCache(t *testing.T) {
 		},
 	}
 
-	nbClient, cleanup, err := libovsdb.NewNBTestHarness(libovsdb.TestSetup{NBData: initialDb}, nil)
+	nbClient, cleanup, err := libovsdb.NewNBTestHarness(libovsdb.TestSetup{NBData: initialDb})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
@@ -73,6 +73,9 @@ func TestNewCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(cleanup.Cleanup)
+	if err := nbClient.Run(); err != nil {
+		t.Fatal(err)
+	}
 
 	c, err := newCache(nbClient)
 	if err != nil {

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
@@ -68,12 +68,12 @@ func TestNewCache(t *testing.T) {
 		},
 	}
 
-	testHarness, err := libovsdb.NewNBTestHarness(libovsdb.TestSetup{NBData: initialDb})
+	testHarness, err := libovsdb.NewNBTestHarness()
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(testHarness.Cleanup)
-	if err := testHarness.Run(); err != nil {
+	if err := testHarness.Run(libovsdb.TestSetup{NBData: initialDb}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
@@ -68,16 +68,16 @@ func TestNewCache(t *testing.T) {
 		},
 	}
 
-	nbClient, cleanup, err := libovsdb.NewNBTestHarness(libovsdb.TestSetup{NBData: initialDb})
+	testHarness, err := libovsdb.NewNBTestHarness(libovsdb.TestSetup{NBData: initialDb})
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(cleanup.Cleanup)
-	if err := nbClient.Run(); err != nil {
+	t.Cleanup(testHarness.Cleanup)
+	if err := testHarness.Run(); err != nil {
 		t.Fatal(err)
 	}
 
-	c, err := newCache(nbClient)
+	c, err := newCache(testHarness.NBClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -277,7 +277,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, clusterCIDR, config.IPv6Mode)
 
-			fakeOvn.controller.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(fakeOvn.nbClient, []string{node1.Name})
+			fakeOvn.controller.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(fakeOvn.testHarness.NBClient, []string{node1.Name})
 			_, err = fakeOvn.controller.joinSwIPManager.EnsureJoinLRPIPs(ovntypes.OVNClusterRouter)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gwLRPIPs, err := fakeOvn.controller.joinSwIPManager.EnsureJoinLRPIPs(node1.Name)
@@ -309,7 +309,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 			skipSnat := false
 			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{nodeSubnet}, l3Config, []*net.IPNet{joinLRPIPs}, []*net.IPNet{dLRPIPs}, skipSnat, node1.NodeMgmtPortIP)
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			// check the namespace again and ensure the address set
 			// being created with the right set of IPs in it.

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -74,7 +74,7 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 	}
 	o.init()
 
-	err = o.testHarness.Run()
+	err = o.testHarness.Run(o.dbSetup)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
@@ -95,7 +95,7 @@ func (o *FakeOVN) init() {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = o.watcher.Start()
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	o.testHarness, err = libovsdbtest.NewNBSBTestHarness(o.dbSetup)
+	o.testHarness, err = libovsdbtest.NewNBSBTestHarness()
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	o.stopChan = make(chan struct{})

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -2,8 +2,8 @@ package ovn
 
 import (
 	"github.com/onsi/gomega"
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -40,8 +40,8 @@ type FakeOVN struct {
 	stopChan     chan struct{}
 	asf          *addressset.FakeAddressSetFactory
 	fakeRecorder *record.FakeRecorder
-	nbClient     libovsdbclient.Client
-	sbClient     libovsdbclient.Client
+	nbClient     *libovsdb.Client
+	sbClient     *libovsdb.Client
 	dbSetup      libovsdbtest.TestSetup
 	nbsbCleanup  *libovsdbtest.Cleanup
 }
@@ -76,6 +76,11 @@ func (o *FakeOVN) start(objects ...runtime.Object) {
 		EgressFirewallClient: egressfirewallfake.NewSimpleClientset(egressFirewallObjects...),
 	}
 	o.init()
+
+	err = o.nbClient.Run()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = o.sbClient.Run()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
 func (o *FakeOVN) startWithDBSetup(dbSetup libovsdbtest.TestSetup, objects ...runtime.Object) {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -275,7 +275,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Eventually(func() string {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
 				}, 2).Should(gomega.MatchJSON(t.getAnnotationsJson()))
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
 
 				return nil
 			}
@@ -323,7 +323,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
 				}, 2).Should(gomega.MatchJSON(t.getAnnotationsJson()))
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
 				return nil
 			}
 
@@ -375,7 +375,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				gomega.Expect(pod).To(gomega.BeNil())
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
 				return nil
 			}
 
@@ -433,7 +433,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Eventually(func() string {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
 				}, 2).Should(gomega.MatchJSON(t.getAnnotationsJson()))
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
 				return nil
 			}
 
@@ -471,7 +471,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				// Add Pod logical port should succeed even without namespace
 				gomega.Expect(getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)).Should(gomega.MatchJSON(podJSON))
 
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
 
 				return nil
 			}
@@ -525,7 +525,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 					return getPodAnnotations(fakeOvn.fakeClient.KubeClient, t.namespace, t.podName)
 				}, 2).Should(gomega.MatchJSON(t.getAnnotationsJson()))
 
-				gomega.Eventually(fakeOvn.nbClient).Should(
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(
 					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
 				return nil
 			}
@@ -571,7 +571,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				fakeOvn.controller.WatchPods()
 
 				// check nbdb data is added
-				gomega.Eventually(fakeOvn.nbClient).Should(
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(
 					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t}, []string{"node1"})))
 				// check that the pod annotations are preserved
 				// makes sense only when handling is finished, therefore check after nbdb is updated
@@ -680,7 +680,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				fakeOvn.controller.WatchPods()
 
 				// check db values are updated to correlate with test pods settings
-				gomega.Eventually(fakeOvn.nbClient).Should(
+				gomega.Eventually(fakeOvn.testHarness.NBClient).Should(
 					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t1, t2}, []string{"node1", "node2"})))
 				// check annotations are preserved
 				// makes sense only when handling is finished, therefore check after nbdb is updated

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -2191,7 +2191,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 
 			var err error
 			var nbClient *libovsdb.Client
-			nbClient, nbCleanup, err = libovsdbtest.NewNBTestHarness(initialNbdb, nil)
+			nbClient, nbCleanup, err = libovsdbtest.NewNBTestHarness(initialNbdb)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = nbClient.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2218,7 +2218,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 
 			var err error
 			var nbClient *libovsdb.Client
-			nbClient, nbCleanup, err = libovsdbtest.NewNBTestHarness(initialNbdb, nil)
+			nbClient, nbCleanup, err = libovsdbtest.NewNBTestHarness(initialNbdb)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = nbClient.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -2244,7 +2244,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 
 			var err error
 			var nbClient *libovsdb.Client
-			nbClient, nbCleanup, err = libovsdbtest.NewNBTestHarness(initialNbdb, nil)
+			nbClient, nbCleanup, err = libovsdbtest.NewNBTestHarness(initialNbdb)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = nbClient.Run()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -2056,13 +2056,13 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 	)
 
 	ginkgo.BeforeEach(func() {
-		testHarness = nil
+		var err error
+		testHarness, err = libovsdbtest.NewNBTestHarness()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
 	ginkgo.AfterEach(func() {
-		if testHarness != nil {
-			testHarness.Cleanup()
-		}
+		testHarness.Cleanup()
 	})
 
 	ginkgo.It("computes match strings from address sets correctly", func() {
@@ -2172,8 +2172,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		gomega.Expect(gp.delNamespaceAddressSet(four)).To(gomega.BeFalse())
 	})
 
-	ginkgo.It("Tests AddAllowACLFromNode", func() {
-		ginkgo.By("adding an existing ACL to the node switch", func() {
+	ginkgo.Context("When calling AddAllowACLFromNode", func() {
+		ginkgo.It("adds an existing ACL to the node switch", func() {
 			initialNbdb := libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -2187,11 +2187,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 					},
 				},
 			}
-
-			var err error
-			testHarness, err = libovsdbtest.NewNBTestHarness(initialNbdb)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = testHarness.Run()
+			err := testHarness.Run(initialNbdb)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			err = addAllowACLFromNode(nodeName, ovntest.MustParseIP(ipv4MgmtIP), testHarness.NBClient)
@@ -2205,7 +2201,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 			gomega.Expect(testHarness.NBClient).Should(libovsdbtest.HaveData(expectedData...))
 		})
 
-		ginkgo.By("creating an ipv4 ACL and adding it to node switch", func() {
+		ginkgo.It("creates an ipv4 ACL and adding it to node switch", func() {
 			initialNbdb := libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -2213,11 +2209,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 					},
 				},
 			}
-
-			var err error
-			testHarness, err = libovsdbtest.NewNBTestHarness(initialNbdb)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = testHarness.Run()
+			err := testHarness.Run(initialNbdb)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			err = addAllowACLFromNode(nodeName, ovntest.MustParseIP(ipv4MgmtIP), testHarness.NBClient)
@@ -2230,7 +2222,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 			}
 			gomega.Expect(testHarness.NBClient).Should(libovsdbtest.HaveData(expectedData...))
 		})
-		ginkgo.By("creating an ipv6 ACL and adding it to node switch", func() {
+
+		ginkgo.It("creates an ipv6 ACL and adding it to node switch", func() {
 			initialNbdb := libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -2238,11 +2231,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 					},
 				},
 			}
-
-			var err error
-			testHarness, err = libovsdbtest.NewNBTestHarness(initialNbdb)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = testHarness.Run()
+			err := testHarness.Run(initialNbdb)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			err = addAllowACLFromNode(nodeName, ovntest.MustParseIP(ipv6MgmtIP), testHarness.NBClient)

--- a/go-controller/pkg/testing/libovsdb/libovsdb.go
+++ b/go-controller/pkg/testing/libovsdb/libovsdb.go
@@ -71,42 +71,55 @@ func (c *Cleanup) Cleanup() {
 func NewNBSBTestHarness(setup TestSetup) (*libovsdb.Client, *libovsdb.Client, *Cleanup, error) {
 	cleanup := newCleanup()
 
-	nbClient, _, err := NewNBTestHarness(setup, cleanup)
+	nbClient, err := newNBTestHarnessWithCleanup(setup, cleanup)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	sbClient, _, err := NewSBTestHarness(setup, cleanup)
+	sbClient, err := newSBTestHarnessWithCleanup(setup, cleanup)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	return nbClient, sbClient, cleanup, nil
 }
 
-// NewNBTestHarness runs NB server and returns corresponding client
-func NewNBTestHarness(setup TestSetup, cleanup *Cleanup) (*libovsdb.Client, *Cleanup, error) {
-	if cleanup == nil {
-		cleanup = newCleanup()
+// newNBTestHarnessWithCleanup runs NB server and returns corresponding client,
+// using the given cleanup to clean up the server and client
+func newNBTestHarnessWithCleanup(setup TestSetup, cleanup *Cleanup) (*libovsdb.Client, error) {
+	client, err := newOVSDBTestHarness(setup.NBData, newNBServer, newNBClient, cleanup)
+	if err != nil {
+		return nil, err
 	}
 
-	client, err := newOVSDBTestHarness(setup.NBData, newNBServer, newNBClient, cleanup)
+	return client, err
+}
+
+// NewNBTestHarness runs NB server and returns corresponding client
+func NewNBTestHarness(setup TestSetup) (*libovsdb.Client, *Cleanup, error) {
+	cleanup := newCleanup()
+	client, err := newNBTestHarnessWithCleanup(setup, cleanup)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return client, cleanup, err
 }
 
-// NewSBTestHarness runs SB server and returns corresponding client
-func NewSBTestHarness(setup TestSetup, cleanup *Cleanup) (*libovsdb.Client, *Cleanup, error) {
-	if cleanup == nil {
-		cleanup = newCleanup()
-	}
-
+// newSBTestHarnessWithCleanup runs SB server and returns corresponding client,
+// using the given cleanup to clean up the server and client
+func newSBTestHarnessWithCleanup(setup TestSetup, cleanup *Cleanup) (*libovsdb.Client, error) {
 	client, err := newOVSDBTestHarness(setup.SBData, newSBServer, newSBClient, cleanup)
+	if err != nil {
+		return nil, err
+	}
+	return client, err
+}
+
+// NewSBTestHarness runs SB server and returns corresponding client
+func NewSBTestHarness(setup TestSetup) (*libovsdb.Client, *Cleanup, error) {
+	cleanup := newCleanup()
+	client, err := newSBTestHarnessWithCleanup(setup, cleanup)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return client, cleanup, err
 }
 

--- a/go-controller/pkg/testing/libovsdb/libovsdb.go
+++ b/go-controller/pkg/testing/libovsdb/libovsdb.go
@@ -37,7 +37,7 @@ type TestSetup struct {
 
 type TestData interface{}
 
-type clientBuilderFn func(config.OvnAuthConfig, *Cleanup) (libovsdbclient.Client, error)
+type clientBuilderFn func(config.OvnAuthConfig, *Cleanup) (*libovsdb.Client, error)
 type serverBuilderFn func(config.OvnAuthConfig, []TestData) (*server.OvsdbServer, error)
 
 var validUUID = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
@@ -68,7 +68,7 @@ func (c *Cleanup) Cleanup() {
 }
 
 // NewNBSBTestHarness runs NB & SB OVSDB servers and returns corresponding clients
-func NewNBSBTestHarness(setup TestSetup) (libovsdbclient.Client, libovsdbclient.Client, *Cleanup, error) {
+func NewNBSBTestHarness(setup TestSetup) (*libovsdb.Client, *libovsdb.Client, *Cleanup, error) {
 	cleanup := newCleanup()
 
 	nbClient, _, err := NewNBTestHarness(setup, cleanup)
@@ -83,7 +83,7 @@ func NewNBSBTestHarness(setup TestSetup) (libovsdbclient.Client, libovsdbclient.
 }
 
 // NewNBTestHarness runs NB server and returns corresponding client
-func NewNBTestHarness(setup TestSetup, cleanup *Cleanup) (libovsdbclient.Client, *Cleanup, error) {
+func NewNBTestHarness(setup TestSetup, cleanup *Cleanup) (*libovsdb.Client, *Cleanup, error) {
 	if cleanup == nil {
 		cleanup = newCleanup()
 	}
@@ -97,7 +97,7 @@ func NewNBTestHarness(setup TestSetup, cleanup *Cleanup) (libovsdbclient.Client,
 }
 
 // NewSBTestHarness runs SB server and returns corresponding client
-func NewSBTestHarness(setup TestSetup, cleanup *Cleanup) (libovsdbclient.Client, *Cleanup, error) {
+func NewSBTestHarness(setup TestSetup, cleanup *Cleanup) (*libovsdb.Client, *Cleanup, error) {
 	if cleanup == nil {
 		cleanup = newCleanup()
 	}
@@ -110,7 +110,7 @@ func NewSBTestHarness(setup TestSetup, cleanup *Cleanup) (libovsdbclient.Client,
 	return client, cleanup, err
 }
 
-func newOVSDBTestHarness(serverData []TestData, newServer serverBuilderFn, newClient clientBuilderFn, cleanup *Cleanup) (libovsdbclient.Client, error) {
+func newOVSDBTestHarness(serverData []TestData, newServer serverBuilderFn, newClient clientBuilderFn, cleanup *Cleanup) (*libovsdb.Client, error) {
 	cfg := config.OvnAuthConfig{
 		Scheme:  config.OvnDBSchemeUnix,
 		Address: "unix:" + tempOVSDBSocketFileName(),
@@ -137,7 +137,7 @@ func newOVSDBTestHarness(serverData []TestData, newServer serverBuilderFn, newCl
 	return c, nil
 }
 
-func newNBClient(cfg config.OvnAuthConfig, cleanup *Cleanup) (libovsdbclient.Client, error) {
+func newNBClient(cfg config.OvnAuthConfig, cleanup *Cleanup) (*libovsdb.Client, error) {
 	stopChan := make(chan struct{})
 	libovsdbOvnNBClient, err := libovsdb.NewNBClientWithConfig(cfg, stopChan)
 	if err != nil {
@@ -153,7 +153,7 @@ func newNBClient(cfg config.OvnAuthConfig, cleanup *Cleanup) (libovsdbclient.Cli
 	return libovsdbOvnNBClient, err
 }
 
-func newSBClient(cfg config.OvnAuthConfig, cleanup *Cleanup) (libovsdbclient.Client, error) {
+func newSBClient(cfg config.OvnAuthConfig, cleanup *Cleanup) (*libovsdb.Client, error) {
 	stopChan := make(chan struct{})
 	libovsdbOvnSBClient, err := libovsdb.NewSBClientWithConfig(cfg, stopChan)
 	if err != nil {

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -165,6 +165,9 @@ func TestGetPortAddresses(t *testing.T) {
 				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
 			}
 			t.Cleanup(cleanup.Cleanup)
+			if err := nbClient.Run(); err != nil {
+				t.Fatal(err)
+			}
 
 			hardwareAddr, ips, err := GetPortAddresses(portName, nbClient)
 			if tc.isNotFound {

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -160,16 +160,16 @@ func TestGetPortAddresses(t *testing.T) {
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tc.dbSetup)
+			testHarness, err := libovsdbtest.NewNBTestHarness(tc.dbSetup)
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
 			}
-			t.Cleanup(cleanup.Cleanup)
-			if err := nbClient.Run(); err != nil {
+			t.Cleanup(testHarness.Cleanup)
+			if err := testHarness.Run(); err != nil {
 				t.Fatal(err)
 			}
 
-			hardwareAddr, ips, err := GetPortAddresses(portName, nbClient)
+			hardwareAddr, ips, err := GetPortAddresses(portName, testHarness.NBClient)
 			if tc.isNotFound {
 				assert.Nil(t, hardwareAddr)
 				assert.Nil(t, ips)

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -160,12 +160,12 @@ func TestGetPortAddresses(t *testing.T) {
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			testHarness, err := libovsdbtest.NewNBTestHarness(tc.dbSetup)
+			testHarness, err := libovsdbtest.NewNBTestHarness()
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
 			}
 			t.Cleanup(testHarness.Cleanup)
-			if err := testHarness.Run(); err != nil {
+			if err := testHarness.Run(tc.dbSetup); err != nil {
 				t.Fatal(err)
 			}
 

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -160,7 +160,7 @@ func TestGetPortAddresses(t *testing.T) {
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tc.dbSetup, nil)
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tc.dbSetup)
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
 			}

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -423,6 +423,9 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
 			}
 			t.Cleanup(cleanup.Cleanup)
+			if err := nbClient.Run(); err != nil {
+				t.Fatal(err)
+			}
 
 			_, ipnet, err := net.ParseCIDR(tc.inpSubnetStr)
 			if err != nil {

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -418,12 +418,12 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			testHarness, err := libovsdbtest.NewNBTestHarness(tc.initialNbdb)
+			testHarness, err := libovsdbtest.NewNBTestHarness()
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
 			}
 			t.Cleanup(testHarness.Cleanup)
-			if err := testHarness.Run(); err != nil {
+			if err := testHarness.Run(tc.initialNbdb); err != nil {
 				t.Fatal(err)
 			}
 

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -418,12 +418,12 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tc.initialNbdb)
+			testHarness, err := libovsdbtest.NewNBTestHarness(tc.initialNbdb)
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
 			}
-			t.Cleanup(cleanup.Cleanup)
-			if err := nbClient.Run(); err != nil {
+			t.Cleanup(testHarness.Cleanup)
+			if err := testHarness.Run(); err != nil {
 				t.Fatal(err)
 			}
 
@@ -434,21 +434,21 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 			var e error
 			if tc.setCfgHybridOvlyEnabled {
 				config.HybridOverlay.Enabled = true
-				if e = UpdateNodeSwitchExcludeIPs(nbClient, nodeName, ipnet); e != nil {
+				if e = UpdateNodeSwitchExcludeIPs(testHarness.NBClient, nodeName, ipnet); e != nil {
 					t.Fatal(fmt.Errorf("failed to update NodeSwitchExcludeIPs with Hybrid Overlay enabled err: %v", e))
 				}
 				config.HybridOverlay.Enabled = false
 			} else {
-				if e = UpdateNodeSwitchExcludeIPs(nbClient, nodeName, ipnet); e != nil {
+				if e = UpdateNodeSwitchExcludeIPs(testHarness.NBClient, nodeName, ipnet); e != nil {
 					t.Fatal(fmt.Errorf("failed to update NodeSwitchExcludeIPs with Hybrid Overlay disabled err: %v", e))
 				}
 
 			}
 
 			matcher := libovsdbtest.HaveDataIgnoringUUIDs(tc.expectedNbdb.NBData)
-			success, err := matcher.Match(nbClient)
+			success, err := matcher.Match(testHarness.NBClient)
 			if !success {
-				t.Fatal(fmt.Errorf("test: \"%s\" didn't match expected with actual, err: %v", tc.desc, matcher.FailureMessage(nbClient)))
+				t.Fatal(fmt.Errorf("test: \"%s\" didn't match expected with actual, err: %v", tc.desc, matcher.FailureMessage(testHarness.NBClient)))
 			}
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tc.desc, err))

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -418,7 +418,7 @@ func TestUpdateNodeSwitchExcludeIPs(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tc.initialNbdb, nil)
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tc.initialNbdb)
 			if err != nil {
 				t.Fatal(fmt.Errorf("test: \"%s\" failed to create test harness: %v", tc.desc, err))
 			}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/model/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/model/client.go
@@ -69,13 +69,14 @@ func NewClientDBModel(name string, models map[string]Model) (ClientDBModel, erro
 			if field := modelType.Elem().Field(i); field.Tag.Get("ovsdb") == "_uuid" &&
 				field.Type.Kind() == reflect.String {
 				hasUUID = true
+				break
 			}
 		}
 		if !hasUUID {
 			return ClientDBModel{}, fmt.Errorf("model is expected to have a string field called uuid")
 		}
 
-		types[table] = reflect.TypeOf(model)
+		types[table] = modelType
 	}
 	return ClientDBModel{
 		types: types,

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/model/database.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/model/database.go
@@ -94,12 +94,7 @@ func generateModelInfo(dbSchema ovsdb.DatabaseSchema, modelTypes map[string]refl
 			continue
 		}
 
-		mtype, ok := modelTypes[tableName]
-		if !ok {
-			errors = append(errors, fmt.Errorf("table %s not found in database model", tableName))
-			continue
-		}
-		obj := reflect.New(mtype.Elem()).Interface().(Model)
+		obj := reflect.New(tType.Elem()).Interface().(Model)
 		info, err := mapper.NewInfo(tableName, tableSchema, obj)
 		if err != nil {
 			errors = append(errors, err)

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/server/server.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/server/server.go
@@ -100,7 +100,10 @@ func (o *OvsdbServer) Close() {
 	o.readyMutex.Lock()
 	o.ready = false
 	o.readyMutex.Unlock()
-	o.listener.Close()
+	// Only close the listener if Serve() has been called
+	if o.listener != nil {
+		o.listener.Close()
+	}
 	close(o.done)
 }
 

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20211216134718-ab69150b65ee
+# github.com/ovn-org/libovsdb v0.6.1-0.20220105115935-66dba396bab5
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
 github.com/ovn-org/libovsdb/mapper


### PR DESCRIPTION
Instead of burning a ton of CPU on followers that aren't doing anything,
only start the ovsdb clients when leadership is acquired.