### PR TITLE
Remove nbctl daemon and fix upgrade tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,9 +277,12 @@ jobs:
     - name: Load docker image
       run: |
         docker load --input ${CI_IMAGE_MASTER_TAR}
-
-    - name: Check out code into the Go module directory - from PR branch
+        
+    - name: Check out code into the Go module directory - from Master branch
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       uses: actions/checkout@v2
+      with: 
+          ref: master
 
     - name: kind setup
       run: |
@@ -312,6 +315,9 @@ jobs:
     - name: Load docker image
       run: |
         docker load --input ${CI_IMAGE_PR_TAR}
+    
+    - name: Check out code into the Go module directory - from PR branch
+      uses: actions/checkout@v2
 
     - name: ovn upgrade
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ env:
   PARALLEL: true
 
   # This must be a directory
-  CI_IMAGE_CACHE: /tmp/image_cache/
+  CI_IMAGE_CACHE: tmp/image_cache/
   CI_IMAGE_MASTER_TAR: image-master.tar
   CI_IMAGE_PR_TAR: image-pr.tar
   CI_DIST_IMAGES_OUTPUT: dist/images/_output/
@@ -39,7 +39,6 @@ jobs:
         version: v1.45.2
         working-directory: go-controller
         args: --modules-download-mode=vendor --timeout=15m0s --verbose
-
   build-master:
     name: Build-master
     runs-on: ubuntu-latest
@@ -52,19 +51,27 @@ jobs:
         path: |
           ${{ env.CI_IMAGE_CACHE }}
         key: ${{ github.run_id }}-image-cache-master
-
+    # if CI_IMAGE_MASTER_TAR isn't in cache, try pulling it and saving to the cache rather 
+    # than building, resort back to building if the cache isn't populated and 
+    # pulling the image fails.
     - name: Check if master image build is needed
       id: is_master_image_build_needed
-      continue-on-error: true
+      continue-on-error: false
       run: |
         set -x
-        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ]; then
-            mkdir -p ${CI_DIST_IMAGES_OUTPUT}
-            cp ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_MASTER_TAR}.gz
-            gunzip ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_MASTER_TAR}.gz
-            echo "::set-output name=MASTER_IMAGE_RESTORED::true"
-        fi
+        if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}.gz ]; then
+            cp ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ${CI_IMAGE_MASTER_TAR}.gz
+            gunzip ${CI_IMAGE_MASTER_TAR}.gz
+            echo "::set-output name=MASTER_IMAGE_RESTORED_FROM_CACHE::true"
+            exit 0
+        fi 
+        
+        if docker pull ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master; then 
+            docker tag ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master ovn-daemonset-f:dev
 
+            echo "::set-output name=MASTER_IMAGE_RESTORED_FROM_GHCR::true"
+            exit 0
+        fi
     # only run the following steps if the master image was not found in the cache
     - name: Set up Go
       if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
@@ -74,13 +81,13 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory - from master branch
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_GHCR != 'true' && steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
       uses: actions/checkout@v2
       with:
         ref: master
 
     - name: Build - from master branch
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_GHCR != 'true' && steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
       run: |
         set -x
         pushd go-controller
@@ -89,36 +96,35 @@ jobs:
         popd
 
     - name: Build docker image - from master branch
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_GHCR != 'true' && steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
       run: |
         pushd dist/images
           sudo cp -f ../../go-controller/_output/go/bin/ovn* .
           echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
           docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
-          mkdir _output
-          docker save ovn-daemonset-f:dev > _output/${CI_IMAGE_MASTER_TAR}
-        popd
+        popd 
 
     - name: Cache master image
-      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
-      continue-on-error: true
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
+      continue-on-error: false
       run: |
         set -x
-        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR} ]; then
-            rm -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}
+        if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR} ]; then
+            rm -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}
         fi
-        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ]; then
-            rm -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz
+        if [ -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}.gz ]; then
+            rm -f ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}.gz
         fi
-        mkdir -p ${CI_IMAGE_CACHE}/
-        cp ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_MASTER_TAR} ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}
-        gzip ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}
+        docker save ovn-daemonset-f:dev -o ${CI_IMAGE_MASTER_TAR}
+        mkdir -p ${CI_IMAGE_CACHE}
+        cp ${CI_IMAGE_MASTER_TAR} ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}
+        gzip ${CI_IMAGE_CACHE}${CI_IMAGE_MASTER_TAR}
 
     # run the following always if none of the steps before failed
     - uses: actions/upload-artifact@v2
       with:
         name: test-image-master
-        path: ${{ env.CI_DIST_IMAGES_OUTPUT }}/${{ env.CI_IMAGE_MASTER_TAR }}
+        path: ${{ env.CI_IMAGE_MASTER_TAR }}
 
   build-pr:
     name: Build-PR
@@ -249,7 +255,7 @@ jobs:
       OVN_MULTICAST_ENABLE:  "false"
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ list to the above command. Set values are the default values.
     --ovn-loglevel-nb="-vconsole:info -vfile:info" \\ Log config for northbound db
     --ovn-loglevel-sb="-vconsole:info -vfile:info" \\ Log config for southboudn db
     --ovn-loglevel-controller="-vconsole:info" \\ Log config for ovn-controller
-    --ovn-loglevel-nbctld="-vconsole:info" \\ Log config for nbctl daemon
 ```
 
 If you are not running OVS directly in the nodes, you must apply the OVS Daemonset yaml.

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -43,7 +43,7 @@ usage() {
     echo "                 [-nl |--node-loglevel <num>] [-ml|--master-loglevel <num>]"
     echo "                 [-dbl|--dbchecker-loglevel <num>] [-ndl|--ovn-loglevel-northd <loglevel>]"
     echo "                 [-nbl|--ovn-loglevel-nb <loglevel>] [-sbl|--ovn-loglevel-sb <loglevel>]"
-    echo "                 [-cl |--ovn-loglevel-controller <loglevel>] [-dl|--ovn-loglevel-nbctld <loglevel>]"
+    echo "                 [-cl |--ovn-loglevel-controller <loglevel>]"
     echo "                 [-ep |--experimental-provider <name>] |"
     echo "                 [-eb |--egress-gw-separate-bridge] |"
     echo "                 [-lr |--local-kind-registry |"
@@ -86,7 +86,6 @@ usage() {
     echo "-nbl | --ovn-loglevel-nb            Log config for northbound DB DEFAULT: '-vconsole:info -vfile:info'."
     echo "-sbl | --ovn-loglevel-sb            Log config for southboudn DB DEFAULT: '-vconsole:info -vfile:info'."
     echo "-cl  | --ovn-loglevel-controller    Log config for ovn-controller DEFAULT: '-vconsole:info'."
-    echo "-dl  | --ovn-loglevel-nbctld        Log config for nbctl daemon DEFAULT: '-vconsole:info'."
     echo "-ep  | --experimental-provider      Use an experimental OCI provider such as podman, instead of docker. DEFAULT: Disabled."
     echo "-eb  | --egress-gw-separate-bridge  The external gateway traffic uses a separate bridge."
     echo "-lr  | --local-kind-registry        Configure kind to use a local docker registry rather than manually loading images"
@@ -207,9 +206,6 @@ parse_args() {
                                                 ;;
             -cl  | --ovn-loglevel-controller )  shift
                                                 OVN_LOG_LEVEL_CONTROLLER=$1
-                                                ;;
-            -dl  | --ovn-loglevel-nbctld )      shift
-                                                OVN_LOG_LEVEL_NBCTLD=$1
                                                 ;;
             -hns | --host-network-namespace )   OVN_HOST_NETWORK_NAMESPACE=$1
                                                 ;;
@@ -581,7 +577,6 @@ create_ovn_kube_manifests() {
     --ovn-loglevel-nb="${OVN_LOG_LEVEL_NB}" \
     --ovn-loglevel-sb="${OVN_LOG_LEVEL_SB}" \
     --ovn-loglevel-controller="${OVN_LOG_LEVEL_CONTROLLER}" \
-    --ovn-loglevel-nbctld="${OVN_LOG_LEVEL_NBCTLD}" \
     --egress-ip-enable=true \
     --egress-firewall-enable=true \
     --v4-join-subnet="${JOIN_SUBNET_IPV4}" \

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -56,7 +56,6 @@ fedora-dev: bld
                     --ovn-loglevel-nb="-vconsole:info -vfile:info" \
                     --ovn-loglevel-sb="-vconsole:info -vfile:info" \
                     --ovn-loglevel-controller="-vconsole:info" \
-                    --ovn-loglevel-nbctld="-vconsole:info" \
                     --ovn_nb_raft_election_timer="1000" \
                     --ovn_sb_raft_election_timer="1000"
 

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -144,9 +144,6 @@ while [ "$1" != "" ]; do
   --ovn-loglevel-controller)
     OVN_LOGLEVEL_CONTROLLER=$VALUE
     ;;
-  --ovn-loglevel-nbctld)
-    OVN_LOGLEVEL_NBCTLD=$VALUE
-    ;;
   --ovnkube-logfile-maxsize)
     OVNKUBE_LOGFILE_MAXSIZE=$VALUE
     ;;
@@ -291,8 +288,6 @@ ovn_loglevel_sb=${OVN_LOGLEVEL_SB:-"-vconsole:info -vfile:info"}
 echo "ovn_loglevel_sb: ${ovn_loglevel_sb}"
 ovn_loglevel_controller=${OVN_LOGLEVEL_CONTROLLER:-"-vconsole:info"}
 echo "ovn_loglevel_controller: ${ovn_loglevel_controller}"
-ovn_loglevel_nbctld=${OVN_LOGLEVEL_NBCTLD:-"-vconsole:info"}
-echo "ovn_loglevel_nbctld: ${ovn_loglevel_nbctld}"
 ovnkube_logfile_maxsize=${OVNKUBE_LOGFILE_MAXSIZE:-"100"}
 echo "ovnkube_logfile_maxsize: ${ovnkube_logfile_maxsize}"
 ovnkube_logfile_maxbackups=${OVNKUBE_LOGFILE_MAXBACKUPS:-"5"}
@@ -439,7 +434,6 @@ ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
   ovnkube_master_loglevel=${master_loglevel} \
   ovn_loglevel_northd=${ovn_loglevel_northd} \
-  ovn_loglevel_nbctld=${ovn_loglevel_nbctld} \
   ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
   ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
   ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -25,7 +25,6 @@ fi
 #    ovn-node       Runs ovnkube in node mode (v3)
 #    cleanup-ovn-node   Runs ovnkube to cleanup the node (v3)
 #    cleanup-ovs-server Cleanup ovs-server (v3)
-#    run-nbctld     Runs ovn-nbctl in the daemon mode (v3)
 #    display        Displays log files
 #    display_env    Displays environment variables
 #    ovn_debug      Displays ovn/ovs configuration and flows
@@ -90,7 +89,6 @@ ovn_loglevel_northd=${OVN_LOGLEVEL_NORTHD:-"-vconsole:info"}
 ovn_loglevel_nb=${OVN_LOGLEVEL_NB:-"-vconsole:info"}
 ovn_loglevel_sb=${OVN_LOGLEVEL_SB:-"-vconsole:info"}
 ovn_loglevel_controller=${OVN_LOGLEVEL_CONTROLLER:-"-vconsole:info"}
-ovn_loglevel_nbctld=${OVN_LOGLEVEL_NBCTLD:-"-vconsole:info"}
 
 ovnkubelogdir=/var/log/ovn-kubernetes
 
@@ -436,7 +434,7 @@ check_health() {
   "ovnnb_db" | "ovnsb_db")
     ctl_file=${OVN_RUNDIR}/${1}.ctl
     ;;
-  "ovn-northd" | "ovn-controller" | "ovn-nbctl")
+  "ovn-northd" | "ovn-controller")
     ctl_file=${OVN_RUNDIR}/${1}.${2}.ctl
     ;;
   "ovsdb-server" | "ovs-vswitchd")
@@ -488,7 +486,6 @@ display() {
   display_file "ovsdb-server" ${OVS_RUNDIR}/ovsdb-server.pid ${OVS_LOGDIR}/ovsdb-server.log
   display_file "ovn-controller" ${OVN_RUNDIR}/ovn-controller.pid ${OVN_LOGDIR}/ovn-controller.log
   display_file "ovnkube" ${OVN_RUNDIR}/ovnkube.pid ${ovnkubelogdir}/ovnkube.log
-  display_file "run-nbctld" ${OVN_RUNDIR}/ovn-nbctl.pid ${OVN_LOGDIR}/ovn-nbctl.log
   display_file "ovn-dbchecker" ${OVN_RUNDIR}/ovn-dbchecker.pid ${OVN_LOGDIR}/ovn-dbchecker.log
 }
 
@@ -880,9 +877,6 @@ ovn-master() {
   # wait for northd to start
   wait_for_event process_ready ovn-northd
 
-  echo "=============== ovn-master (wait for ovn-nbctl daemon) ========== MASTER ONLY"
-  wait_for_event process_ready ovn-nbctl
-
   # wait for ovs-servers to start since ovn-master sets some fields in OVS DB
   echo "=============== ovn-master - (wait for ovs)"
   wait_for_event ovs_ready
@@ -961,7 +955,6 @@ ovn-master() {
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
     --gateway-mode=${ovn_gateway_mode} \
-    --nbctl-daemon-mode \
     --loglevel=${ovnkube_loglevel} \
     --logfile-maxsize=${ovnkube_logfile_maxsize} \
     --logfile-maxbackups=${ovnkube_logfile_maxbackups} \
@@ -1270,32 +1263,6 @@ cleanup-ovn-node() {
 
 }
 
-# v3 - Runs ovn-nbctl in daemon mode
-run-nbctld() {
-  trap 'ovs-appctl -t ovn-nbctl exit >/dev/null 2>&1; exit 0' TERM
-  check_ovn_daemonset_version "3"
-  rm -f ${OVN_RUNDIR}/ovn-nbctl.pid
-  rm -f ${OVN_RUNDIR}/ovn-nbctl.*.ctl
-
-  echo "=============== run-nbctld - (wait for ready_to_start_node)"
-  wait_for_event ready_to_start_node
-
-  echo "ovn_nbdb ${ovn_nbdb}   ovn_sbdb ${ovn_sbdb}  ovn_nbdb_conn ${ovn_nbdb_conn}"
-  echo "ovn_loglevel_nbctld=${ovn_loglevel_nbctld}"
-
-  /usr/bin/ovn-nbctl ${ovn_loglevel_nbctld} --pidfile --db=${ovn_nbdb_conn} \
-    --log-file=${OVN_LOGDIR}/ovn-nbctl.log --detach ${ovndb_ctl_ssl_opts}
-
-  wait_for_event attempts=3 process_ready ovn-nbctl
-  echo "=============== run_ovn_nbctl ========== RUNNING"
-
-  tail --follow=name ${OVN_LOGDIR}/ovn-nbctl.log &
-  nbctl_tail_pid=$!
-
-  process_healthy ovn-nbctl ${nbctl_tail_pid}
-  echo "=============== run_ovn_nbctl ========== terminated"
-}
-
 # v3 - Runs ovn-kube-util in daemon mode to export prometheus metrics related to OVS.
 ovs-metrics() {
   check_ovn_daemonset_version "3"
@@ -1357,9 +1324,6 @@ case ${cmd} in
   ;;
 "ovn-node") # pod ovnkube-node container ovn-node
   ovn-node
-  ;;
-"run-nbctld") # pod ovnkube-master container run-nbctld
-  run-nbctld
   ;;
 "ovn-northd")
   ovn-northd

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -121,53 +121,6 @@ spec:
           periodSeconds: 60
       # end of container
 
-      - name: nbctl-daemon
-        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
-        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
-
-        command: ["/root/ovnkube.sh", "run-nbctld"]
-
-        securityContext:
-          runAsUser: 0
-
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /var/log/openvswitch/
-          name: host-var-log-ovs
-        - mountPath: /var/log/ovn/
-          name: host-var-log-ovs
-        - mountPath: /var/run/openvswitch/
-          name: host-var-run-ovs
-        - mountPath: /var/run/ovn/
-          name: host-var-run-ovs
-        - mountPath: /ovn-cert
-          name: host-ovn-cert
-          readOnly: true
-        resources:
-          requests:
-            cpu: 100m
-            memory: 300Mi
-        env:
-        - name: OVN_DAEMONSET_VERSION
-          value: "3"
-        - name: OVN_LOGLEVEL_NBCTLD
-          value: "{{ ovn_loglevel_nbctld }}"
-        - name: K8S_APISERVER
-          valueFrom:
-            configMapKeyRef:
-              name: ovn-config
-              key: k8s_apiserver
-        - name: OVN_SSL_ENABLE
-          value: "{{ ovn_ssl_en }}"
-
-        readinessProbe:
-          exec:
-            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-nbctl"]
-          initialDelaySeconds: 30
-          timeoutSeconds: 30
-          periodSeconds: 60
-        # end of container
-
       - name: ovnkube-master
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -92,7 +92,7 @@ usage: kind.sh [[[-cf |--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]
                  [-nl |--node-loglevel <num>] [-ml|--master-loglevel <num>]
                  [-dbl|--dbchecker-loglevel <num>] [-ndl|--ovn-loglevel-northd <loglevel>]
                  [-nbl|--ovn-loglevel-nb <loglevel>] [-sbl|--ovn-loglevel-sb <loglevel>]
-                 [-cl |--ovn-loglevel-controller <loglevel>] [-dl|--ovn-loglevel-nbctld <loglevel>]
+                 [-cl |--ovn-loglevel-controller <loglevel>]
                  [-ep |--experimental-provider <name>] |
                  [-eb |--egress-gw-separate-bridge]
                  [-h]]
@@ -131,7 +131,6 @@ usage: kind.sh [[[-cf |--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]
 -nbl | --ovn-loglevel-nb            Log config for northbound DB DEFAULT: '-vconsole:info -vfile:info'.
 -sbl | --ovn-loglevel-sb            Log config for southboudn DB DEFAULT: '-vconsole:info -vfile:info'.
 -cl  | --ovn-loglevel-controller    Log config for ovn-controller DEFAULT: '-vconsole:info'.
--dl  | --ovn-loglevel-nbctld        Log config for nbctl daemon DEFAULT: '-vconsole:info'.
 -ep  | --experimental-provider      Use an experimental OCI provider such as podman, instead of docker. DEFAULT: Disabled.
 -eb  | --egress-gw-separate-bridge  The external gateway traffic uses a separate bridge.
 --delete                      	    Delete current cluster

--- a/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
+++ b/go-controller/cmd/ovn-kube-util/app/readiness-probe.go
@@ -18,7 +18,6 @@ var callbacks = map[string]readinessFunc{
 	"ovnnb-db":       ovnNBDBReadiness,
 	"ovnsb-db":       ovnSBDBReadiness,
 	"ovn-northd":     ovnNorthdReadiness,
-	"ovn-nbctl":      ovnNbCtlReadiness,
 	"ovs-daemons":    ovsDaemonsReadiness,
 	"ovnkube-node":   ovnNodeReadiness,
 	"ovnnb-db-raft":  ovnNBDBRaftReadiness,
@@ -132,18 +131,6 @@ func ovnNorthdReadiness(target string) error {
 		return fmt.Errorf("failed to get sb-connection-status from %s: (%v)", target, err)
 	} else if sbConnectionStatus != "connected" {
 		return fmt.Errorf("%s sb-connection-status is %s", target, sbConnectionStatus)
-	}
-	return nil
-}
-
-func ovnNbCtlReadiness(target string) error {
-	// checking version works as it connects to the ovn-nbctl daemon and returns the version
-	// if nbctl isn't ready, version may fail to return
-	// NOTE: There is no nbctld process, but nbctl provides a daemon mode,
-	// which is invoked by using --detach option to start an ovn-nbctl in a daemon mode.
-	_, _, err := util.RunOVNAppctlWithTimeout(5, "-t", target, "version")
-	if err != nil {
-		return fmt.Errorf("failed to get version from %s: (%v)", target, err)
 	}
 	return nil
 }

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -137,9 +137,6 @@ var (
 		VXLANPort: DefaultVXLANPort,
 	}
 
-	// NbctlDaemon enables ovn-nbctl to run in daemon mode
-	NbctlDaemonMode bool
-
 	// UnprivilegedMode allows ovnkube-node to run without SYS_ADMIN capability, by performing interface setup in the CNI plugin
 	UnprivilegedMode bool
 
@@ -694,11 +691,6 @@ var CommonFlags = []cli.Flag{
 			"hostsubnet-prefix should be specified, but for backward compatibility " +
 			"it defaults to 24 if unspecified.",
 		Destination: &cliConfig.Default.RawClusterSubnets,
-	},
-	&cli.BoolFlag{
-		Name:        "nbctl-daemon-mode",
-		Usage:       "Run ovn-nbctl in daemon mode to improve performance in large clusters",
-		Destination: &NbctlDaemonMode,
 	},
 	&cli.BoolFlag{
 		Name:        "unprivileged-mode",

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -291,15 +291,6 @@ func RegisterMasterPerformance(nbClient libovsdbclient.Client) {
 	// This is set to not create circular import between metrics and util package
 	util.MetricOvnCliLatency = metricOvnCliLatency
 	registerWorkqueueMetrics(MetricOvnkubeNamespace, MetricOvnkubeSubsystemMaster)
-	prometheus.MustRegister(prometheus.NewCounterFunc(
-		prometheus.CounterOpts{
-			Namespace: MetricOvnkubeNamespace,
-			Subsystem: MetricOvnkubeSubsystemMaster,
-			Name:      "skipped_nbctl_daemon_total",
-			Help:      "The number of times we skipped using ovn-nbctl daemon and directly interacted with OVN NB DB",
-		}, func() float64 {
-			return float64(util.SkippedNbctlDaemonCounter)
-		}))
 	prometheus.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace: MetricOvnNamespace,


### PR DESCRIPTION
Remove the ability/config to run nbctl in daemon mode
in Ovn-Kubernetes.  This is due to the fact that 90%
of nbctl calls have been converted to using libovsdb clients
in the ovnkube-master process rendering the daemon obsolete.

Would like this to merge after https://github.com/ovn-org/ovn-kubernetes/pull/2697