### PR TITLE
Set the OVS port as transient

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -281,17 +281,16 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 	for i, ip := range ifInfo.IPs {
 		ipStrs[i] = ip.String()
 	}
-	// Add the new sandbox's OVS port, tag the interface as transient so stale
-	// pod interfaces are scrubbed on hard reboot
+	// Add the new sandbox's OVS port, tag the port as transient so stale
+	// pod ports are scrubbed on hard reboot
 	ovsArgs := []string{
-		"add-port", "br-int", hostIfaceName, "--", "set",
+		"add-port", "br-int", hostIfaceName, "other_config:transient=true", "--", "set",
 		"interface", hostIfaceName,
 		fmt.Sprintf("external_ids:attached_mac=%s", ifInfo.MAC),
 		fmt.Sprintf("external_ids:iface-id=%s", ifaceID),
 		fmt.Sprintf("external_ids:iface-id-ver=%s", initialPodUID),
 		fmt.Sprintf("external_ids:ip_addresses=%s", strings.Join(ipStrs, ",")),
 		fmt.Sprintf("external_ids:sandbox=%s", sandboxID),
-		"other_config:transient=true",
 	}
 
 	if out, err := ovsExec(ovsArgs...); err != nil {

--- a/go-controller/pkg/node/node_dpu_test.go
+++ b/go-controller/pkg/node/node_dpu_test.go
@@ -26,8 +26,8 @@ func genOVSFindCmd(table, column, condition string) string {
 }
 
 func genOVSAddPortCmd(hostIfaceName, ifaceID, mac, ip, sandboxID, podUID string) string {
-	return fmt.Sprintf("ovs-vsctl --timeout=30 add-port br-int %s -- set interface %s external_ids:attached_mac=%s "+
-		"external_ids:iface-id=%s external_ids:iface-id-ver=%s external_ids:ip_addresses=%s external_ids:sandbox=%s other_config:transient=true",
+	return fmt.Sprintf("ovs-vsctl --timeout=30 add-port br-int %s other_config:transient=true -- set interface %s external_ids:attached_mac=%s "+
+		"external_ids:iface-id=%s external_ids:iface-id-ver=%s external_ids:ip_addresses=%s external_ids:sandbox=%s",
 		hostIfaceName, hostIfaceName, mac, ifaceID, podUID, ip, sandboxID)
 }
 


### PR DESCRIPTION
Set the ovs port as transient rather than the
interface. This along with configuring
systemd with `DELETE_TRANSIENT_PORTS = yes`
will result in the dedicated systemd service
`Delete Transient Ports` to remove stale
ovs ports and accompanying interfaces following
a hard reboot.

We found that this was done incorrectly in https://github.com/ovn-org/ovn-kubernetes/pull/2665/commits/e04c51346e574e229890071ffe60380e25ff9b59
 while debugging SNO + OVNK scale :( 
