### PR TITLE
Fix the node deletion cleanup.

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1190,14 +1190,29 @@ func (oc *Controller) deleteNodeLogicalNetwork(nodeName string) error {
 	lbCache.RemoveSwitch(nodeName)
 	// Remove the logical switch associated with the node
 	logicalRouterPortName := types.RouterToSwitchPrefix + nodeName
+	clusterRouterModel := nbdb.LogicalRouter{}
+	nodeLogicalRouterPort := nbdb.LogicalRouterPort{
+		Name: logicalRouterPortName,
+	}
 	opModels := []libovsdbops.OperationModel{
 		{
 			Model:          &nbdb.LogicalSwitch{},
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 		},
 		{
-			Model:          &nbdb.LogicalRouterPort{},
-			ModelPredicate: func(lrp *nbdb.LogicalRouterPort) bool { return lrp.Name == logicalRouterPortName },
+			Model: &nodeLogicalRouterPort,
+			DoAfter: func() {
+				if nodeLogicalRouterPort.UUID != "" {
+					clusterRouterModel.Ports = []string{nodeLogicalRouterPort.UUID}
+				}
+			},
+		},
+		{
+			Model:          &clusterRouterModel,
+			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
+			OnModelMutations: []interface{}{
+				&clusterRouterModel.Ports,
+			},
 		},
 	}
 	if err := oc.modelClient.Delete(opModels...); err != nil {


### PR DESCRIPTION
When a node is deleted, the node logical switch and logical router
port connecting to the cluster router were not cleaned up in Northbound
db.  Fix this issue.

Issue 2711
https://github.com/ovn-org/ovn-kubernetes/issues/2711

Fixes: 79652ddc21c("delete port connecting the distributed router to node's logical switch")
Signed-off-by: Numan Siddique <numans@ovn.org>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->