### PR TITLE
Metrics: Start OVN DB/Northd metrics only on OVNKube master

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -928,6 +928,7 @@ ovn-master() {
   fi
   echo "egressfirewall_enabled_flag=${egressfirewall_enabled_flag}"
 
+  ovn_metrics_bind_address="${metrics_endpoint_ip}:9477"
   ovnkube_master_metrics_bind_address="${metrics_endpoint_ip}:9409"
 
   echo "=============== ovn-master ========== MASTER ONLY"
@@ -954,6 +955,7 @@ ovn-master() {
     ${egressip_enabled_flag} \
     ${egressfirewall_enabled_flag} \
     --metrics-bind-address ${ovnkube_master_metrics_bind_address} \
+    --ovn-metrics-bind-address ${ovn_metrics_bind_address} \
     --host-network-namespace ${ovn_host_network_namespace} &
 
   echo "=============== ovn-master ========== running"

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -283,10 +283,15 @@ func runOvnKube(ctx *cli.Context) error {
 		metrics.StartMetricsServer(config.Kubernetes.MetricsBindAddress, config.Kubernetes.MetricsEnablePprof)
 	}
 
-	// start the prometheus server to serve OVN Metrics (default port: 9476)
+	// start the prometheus server to serve OVN Metrics
 	// Note: for ovnkube node mode dpu-host no ovn metrics is required as ovn is not running on the node.
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && config.Kubernetes.OVNMetricsBindAddress != "" {
-		metrics.RegisterOvnMetrics(ovnClientset.KubeClient, node)
+		if master != "" {
+			go metrics.RegisterOvnDBMetrics()
+			go metrics.RegisterOvnNorthdMetrics()
+		} else {
+			go metrics.RegisterOvnControllerMetrics()
+		}
 		metrics.StartOVNMetricsServer(config.Kubernetes.OVNMetricsBindAddress)
 	}
 

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -404,9 +404,3 @@ func StartOVNMetricsServer(bindAddress string) {
 		}
 	}, 5*time.Second, utilwait.NeverStop)
 }
-
-func RegisterOvnMetrics(clientset kubernetes.Interface, k8sNodeName string) {
-	go RegisterOvnDBMetrics(clientset, k8sNodeName)
-	go RegisterOvnControllerMetrics()
-	go RegisterOvnNorthdMetrics(clientset, k8sNodeName)
-}

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -2,12 +2,9 @@ package metrics
 
 import (
 	"strings"
-	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
 
@@ -89,21 +86,7 @@ var ovnNorthdStopwatchShowMetricsMap = map[string]*stopwatchMetricDetails{
 	"ovnsb_db_run":     {},
 }
 
-func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string) {
-	err := wait.PollImmediate(1*time.Second, 300*time.Second, func() (bool, error) {
-		return checkPodRunsOnGivenNode(clientset, []string{"app=ovnkube-master", "name=ovnkube-master"}, k8sNodeName, true)
-	})
-	if err != nil {
-		if err == wait.ErrWaitTimeout {
-			klog.Errorf("Timed out while checking if OVNKube Master Pod runs on this %q K8s Node: %v. "+
-				"Not registering OVN North Metrics on this Node", k8sNodeName, err)
-		} else {
-			klog.Infof("Not registering OVN North Metrics on this Node since ovn-northd is not running on this node.")
-		}
-		return
-	}
-	klog.Info("Found OVNKube Master Pod running on this node. Registering OVN North Metrics")
-
+func RegisterOvnNorthdMetrics() {
 	// ovn-northd metrics
 	getOvnNorthdVersionInfo()
 	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(


### PR DESCRIPTION
Previous to this change, if you enabled OVN metrics
endpoint on OVNKube master and OVNKube node you get
duplicate metrics for OVN DB/Northd.
If you enable just OVNKube node only, you must
have access to the OVN DB/Northd.

With this PR, a single OVNKube master leader will
export OVN DB/Northd metrics and OVNKube node can
solely focus on OVN controller metrics.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

@girishmg Can you take a look at this? I believe you were working on this originally.
