### PR TITLE
[Egress IP]: Fix spurious error logs

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -326,20 +326,26 @@ func (oc *Controller) reconcileEgressIPNamespace(old, new *v1.Namespace) error {
 	return nil
 }
 
-func (oc *Controller) reconcileEgressIPPod(old, new *v1.Pod) error {
+func (oc *Controller) reconcileEgressIPPod(old, new *v1.Pod) (err error) {
 	oldPod, newPod := &v1.Pod{}, &v1.Pod{}
+	namespace := &v1.Namespace{}
 	if old != nil {
 		oldPod = old
+		namespace, err = oc.watchFactory.GetNamespace(oldPod.Namespace)
+		if err != nil {
+			return err
+		}
 	}
 	if new != nil {
 		newPod = new
+		namespace, err = oc.watchFactory.GetNamespace(newPod.Namespace)
+		if err != nil {
+			return err
+		}
 	}
+
 	newPodLabels := labels.Set(newPod.Labels)
 	oldPodLabels := labels.Set(oldPod.Labels)
-	namespace, err := oc.watchFactory.GetNamespace(newPod.Namespace)
-	if err != nil {
-		return err
-	}
 
 	// If the namespace the pod belongs to does not have any labels, just return
 	// it can't match any EgressIP object
@@ -1322,7 +1328,7 @@ func (oc *Controller) addNodeForEgress(node *v1.Node) error {
 		return err
 	}
 	if err := oc.initEgressIPAllocator(node); err != nil {
-		return fmt.Errorf("egress node initialization error: %v", err)
+		klog.V(5).Infof("Egress node initialization error: %v", err)
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -851,7 +851,7 @@ func (oc *Controller) WatchEgressNodes() {
 			// happened after we processed the ADD for that object, hence keep
 			// retrying for all UPDATEs.
 			if err := oc.initEgressIPAllocator(newNode); err != nil {
-				klog.Error(err)
+				klog.V(5).Infof("Egress node initialization error: %v", err)
 			}
 			oldLabels := oldNode.GetLabels()
 			newLabels := newNode.GetLabels()


### PR DESCRIPTION
When a pod currently gets deleted we continuously log:

```
E1216 04:58:39.376563       1 ovn.go:1018] Unable to delete egress IP matching pod: win-webserver-ec2amaz-9f873gh-deployment-kgqn7-78cffcfbf9-cn8n9/wmco-test, err: namespace "" not found
```

because the `new` argument passed to `reconcileEgressIPPod` is nil and hence we utilize an empty `newPod` when trying to get the namespace. This leads to spurious error logs. 

Also, most errors returned from `initEgressIPAllocator` are transient and just caused by some other controller not having annotated the node object at that point. Hence don't log it as an error. 

/assign @trozet 
 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->