### PR TITLE
Move nb/sbctl metrics to master

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -242,7 +242,7 @@ func runOvnKube(ctx *cli.Context) error {
 		// register prometheus metrics exported by the master
 		// this must be done prior to calling controller start
 		// since we capture some metrics in Start()
-		metrics.RegisterMasterMetrics(libovsdbOvnSBClient)
+		metrics.RegisterMasterMetrics(libovsdbOvnNBClient, libovsdbOvnSBClient)
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil,
 			libovsdbOvnNBClient, libovsdbOvnSBClient, util.EventRecorder(ovnClientset.KubeClient))

--- a/go-controller/pkg/metrics/ovn_northd.go
+++ b/go-controller/pkg/metrics/ovn_northd.go
@@ -124,24 +124,6 @@ func RegisterOvnNorthdMetrics(clientset kubernetes.Interface, k8sNodeName string
 		prometheus.GaugeOpts{
 			Namespace: MetricOvnNamespace,
 			Subsystem: MetricOvnSubsystemNorthd,
-			Name:      "probe_interval",
-			Help: "The maximum number of milliseconds of idle time on connection to the OVN SB " +
-				"and NB DB before sending an inactivity probe message",
-		}, func() float64 {
-			stdout, stderr, err := util.RunOVNNbctlWithTimeout(5, "get", "NB_Global", ".",
-				"options:northd_probe_interval")
-			if err != nil {
-				klog.Errorf("Failed to get northd_probe_interval value "+
-					"stderr(%s) :(%v)", stderr, err)
-				return 0
-			}
-			return parseMetricToFloat(MetricOvnSubsystemNorthd, "probe_interval", stdout)
-		},
-	))
-	ovnRegistry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Namespace: MetricOvnNamespace,
-			Subsystem: MetricOvnSubsystemNorthd,
 			Name:      "status",
 			Help:      "Specifies whether this instance of ovn-northd is standby(0) or active(1) or paused(2).",
 		}, func() float64 {


### PR DESCRIPTION
The two metrics:
- metricDBE2eTimestamp
- probe_interval

both make nb/sbctl calls to the OVN dbs, and
to ensure we only make ovsdb client connections
in the master process it makes sense to move these
to the master's set of metrics

It also renames the `probe_interval` metric to
`northd_probe_interval` to make things a bit easier
to parse

Follow up from the upstream meeting and the following slack thread 
https://ovn-org.slack.com/archives/C010SQ5FSNL/p1639585451036600
