### PR TITLE
Fix Hybrid Overlay

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -25,11 +26,8 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 )
-
-const hoNodeCliArg string = "-no-hostsubnet-nodes=" + v1.LabelOSStable + "=windows"
 
 func newTestNode(name, os, ovnHostSubnet, hybridHostSubnet, drMAC string) v1.Node {
 	annotations := make(map[string]string)
@@ -109,8 +107,10 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			dbSetup := libovsdbtest.TestSetup{}
 			var libovsdbOvnNBClient libovsdbclient.Client
-			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			var libovsdbOvnSBClient libovsdbclient.Client
+
+			libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
 
 			m, err := NewMaster(
 				&kube.Kube{KClient: fakeClient},
@@ -118,6 +118,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
 				libovsdbOvnNBClient,
+				libovsdbOvnSBClient,
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -149,6 +150,11 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			}, 2).Should(MatchError(fmt.Sprintf("node %q has no \"k8s.ovn.org/node-subnets\" annotation", nodeName)))
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+
+			// nothing should be done in OVN dbs from HO running on windows node
+			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(dbSetup.NBData))
+			Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(dbSetup.SBData))
+
 			return nil
 		}
 
@@ -180,36 +186,42 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			expectedDatabaseState := []libovsdbtest.TestData{
-				&nbdb.LogicalRouterPolicy{
-					Priority: 1002,
-					ExternalIDs: map[string]string{
-						"name": "hybrid-subnet-node1",
-					},
-					Action:   nbdb.LogicalRouterPolicyActionReroute,
-					Nexthops: []string{nodeHOIP},
-					Match:    "inport == \"rtos-node1\" && ip4.dst == 11.1.0.0/16",
-					UUID:     "reroute-policy-UUID",
-				},
-				&nbdb.LogicalRouter{
-					Name:     types.OVNClusterRouter,
-					Policies: []string{"reroute-policy-UUID"},
-				},
-			}
-
+			// pre-existing nbdb objects
 			nodeSwitch := &nbdb.LogicalSwitch{
 				Name: nodeName,
-				UUID: nodeName + "-UUID",
+				UUID: libovsdbops.BuildNamedUUID(),
 			}
 
-			initialExpectedDB := append(expectedDatabaseState, nodeSwitch)
+			ovnClusterRouter := &nbdb.LogicalRouter{
+				Name: types.OVNClusterRouter,
+				UUID: libovsdbops.BuildNamedUUID(),
+			}
+
+			initialNBDB := []libovsdbtest.TestData{
+				nodeSwitch,
+				ovnClusterRouter,
+			}
+
+			// pre-existing sbdb objects
+			clusterRouterDatapath := &sbdb.DatapathBinding{
+				UUID:        libovsdbops.BuildNamedUUID(),
+				ExternalIDs: map[string]string{"logical-router": ovnClusterRouter.UUID, "name": types.OVNClusterRouter},
+			}
+
+			initialSBDB := []libovsdbtest.TestData{
+				clusterRouterDatapath,
+			}
 
 			dbSetup := libovsdbtest.TestSetup{
-				NBData: initialExpectedDB,
+				NBData: initialNBDB,
+				SBData: initialSBDB,
 			}
+
 			var libovsdbOvnNBClient libovsdbclient.Client
-			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			var libovsdbOvnSBClient libovsdbclient.Client
+
+			libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 			m, err := NewMaster(
@@ -218,18 +230,40 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
 				libovsdbOvnNBClient,
+				libovsdbOvnSBClient,
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Make the expected LSP is created and added to the node
+			// make sure the expected LSP is created and added to the node
 			expectedLSP := &nbdb.LogicalSwitchPort{
 				UUID:      libovsdbops.BuildNamedUUID(),
 				Name:      types.HybridOverlayPrefix + nodeName,
 				Addresses: []string{nodeHOMAC},
 			}
 
+			// make sure the expected LRP is created and added to cluster router
+			expectedLRP := &nbdb.LogicalRouterPolicy{
+				Priority: 1002,
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node1",
+				},
+				Action:   nbdb.LogicalRouterPolicyActionReroute,
+				Nexthops: []string{nodeHOIP},
+				Match:    "inport == \"rtos-node1\" && ip4.dst == 11.1.0.0/16",
+				UUID:     libovsdbops.BuildNamedUUID(),
+			}
+
 			nodeSwitch.Ports = []string{expectedLSP.UUID}
+			ovnClusterRouter.Policies = []string{expectedLRP.UUID}
+
+			expectedMACBinding := &sbdb.MACBinding{
+				UUID:        libovsdbops.BuildNamedUUID(),
+				Datapath:    clusterRouterDatapath.UUID,
+				IP:          nodeHOIP,
+				LogicalPort: types.RouterToSwitchPrefix + nodeName,
+				MAC:         nodeHOMAC,
+			}
 
 			f.Start(stopChan)
 			wg.Add(1)
@@ -249,25 +283,44 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			nodeSwitch.OtherConfig = map[string]string{"exclude_ips": "10.1.2.2"}
 
-			expectedDatabaseState = append(expectedDatabaseState, nodeSwitch, expectedLSP)
+			expectedNBDatabaseState := []libovsdbtest.TestData{
+				nodeSwitch,
+				ovnClusterRouter,
+				expectedLSP,
+				expectedLRP,
+			}
+
+			expectedSBDatabaseState := []libovsdbtest.TestData{
+				clusterRouterDatapath,
+				expectedMACBinding,
+			}
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
+			Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedSBDatabaseState))
 
 			err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), nodeName, *metav1.NewDeleteOptions(0))
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 
-			// In a real db, deleting the LSP would remove the reference here, but in our testing ovsdb server it does not
+			// LRP should have been deleted and removed
+			ovnClusterRouter.Policies = []string{}
+			// in a real db, deleting the LSP would remove the reference here, but in our testing ovsdb server it does not
 			// nodeSwitch.Ports = []string{}
-			expectedDatabaseState = []libovsdbtest.TestData{
-				&nbdb.LogicalRouter{
-					Name: types.OVNClusterRouter,
-				},
+			expectedNBDatabaseState = []libovsdbtest.TestData{
+				ovnClusterRouter,
 				nodeSwitch,
 			}
-			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+
+			// in a real db, deleting the HO LSP would result in the Mac Binding being removed as well
+			expectedSBDatabaseState = []libovsdbtest.TestData{
+				clusterRouterDatapath,
+				expectedMACBinding,
+			}
+
+			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedNBDatabaseState))
+			Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedSBDatabaseState))
 			return nil
 		}
 
@@ -280,7 +333,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("handles a Linux node with no annotation but an existing port", func() {
+	It("handles a Linux node with no annotation but an existing port and lrp", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				nodeName   string = "node1"
@@ -299,33 +352,79 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			dynAdd := nodeHOMAC + " " + nodeHOIP
-			expectedDatabaseState := []libovsdbtest.TestData{
-				&nbdb.LogicalRouterPolicy{
-					Priority: 1002,
-					ExternalIDs: map[string]string{
-						"name": "hybrid-subnet-node1",
-					},
-					Action:   nbdb.LogicalRouterPolicyActionReroute,
-					Nexthops: []string{nodeHOIP},
-					Match:    "inport == \"rtos-node1\" && ip4.dst == 11.1.0.0/16",
-					UUID:     "reroute-policy-UUID",
-				},
-				&nbdb.LogicalSwitchPort{
-					Name:             "int-" + nodeName,
-					Addresses:        []string{nodeHOMAC, nodeHOIP},
-					DynamicAddresses: &dynAdd,
-				},
-				&nbdb.LogicalRouter{
-					Name:     types.OVNClusterRouter,
-					Policies: []string{"reroute-policy-UUID"},
-				},
+
+			// pre-existing nbdb objects
+
+			existingLSP := &nbdb.LogicalSwitchPort{
+				UUID:             libovsdbops.BuildNamedUUID(),
+				Name:             types.HybridOverlayPrefix + nodeName,
+				Addresses:        []string{nodeHOMAC},
+				DynamicAddresses: &dynAdd,
 			}
+
+			existingLRP := &nbdb.LogicalRouterPolicy{
+				Priority: 1002,
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node1",
+				},
+				Action:   nbdb.LogicalRouterPolicyActionReroute,
+				Nexthops: []string{nodeHOIP},
+				Match:    "inport == \"rtos-node1\" && ip4.dst == 11.1.0.0/16",
+				UUID:     libovsdbops.BuildNamedUUID(),
+			}
+
+			nodeSwitch := &nbdb.LogicalSwitch{
+				Name:  nodeName,
+				UUID:  libovsdbops.BuildNamedUUID(),
+				Ports: []string{existingLSP.UUID},
+			}
+
+			ovnClusterRouter := &nbdb.LogicalRouter{
+				Name: types.OVNClusterRouter,
+				UUID: libovsdbops.BuildNamedUUID(),
+				// Something in the test harness causes this names uuid to be added again
+				// comment out for now
+				// Policies: []string{existingLRP.UUID},
+			}
+
+			initialNBDB := []libovsdbtest.TestData{
+				nodeSwitch,
+				ovnClusterRouter,
+				existingLRP,
+				existingLSP,
+			}
+
+			// pre-existing sbdb objects
+			clusterRouterDatapath := &sbdb.DatapathBinding{
+				UUID:        libovsdbops.BuildNamedUUID(),
+				ExternalIDs: map[string]string{"logical-router": ovnClusterRouter.UUID, "name": types.OVNClusterRouter},
+			}
+
+			// the mac binding should already exist
+			existingMACBinding := &sbdb.MACBinding{
+				UUID:        libovsdbops.BuildNamedUUID(),
+				Datapath:    clusterRouterDatapath.UUID,
+				IP:          nodeHOIP,
+				LogicalPort: types.RouterToSwitchPrefix + nodeName,
+				MAC:         nodeHOMAC,
+			}
+
+			initialSBDB := []libovsdbtest.TestData{
+				clusterRouterDatapath,
+				existingMACBinding,
+			}
+
 			dbSetup := libovsdbtest.TestSetup{
-				NBData: expectedDatabaseState,
+				NBData: initialNBDB,
+				SBData: initialSBDB,
 			}
+
 			var libovsdbOvnNBClient libovsdbclient.Client
-			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			var libovsdbOvnSBClient libovsdbclient.Client
+
+			// nothing will occur in the SBDB or NBDB in this instance because the HO lrp already exists
+			libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 			m, err := NewMaster(
@@ -334,6 +433,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
 				libovsdbOvnNBClient,
+				libovsdbOvnSBClient,
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -355,7 +455,11 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			}, 2).Should(HaveKeyWithValue(hotypes.HybridOverlayDRMAC, nodeHOMAC))
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+			// OVN DB state shouldn't change here
+			ovnClusterRouter.Policies = []string{existingLRP.UUID}
+			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(dbSetup.NBData))
+			Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveData(dbSetup.SBData))
+
 			return nil
 		}
 		err := app.Run([]string{
@@ -418,10 +522,15 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			}
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: initialDatabaseState,
+				SBData: nil,
 			}
 			var libovsdbOvnNBClient libovsdbclient.Client
-			libovsdbOvnNBClient, libovsdbCleanup, err = libovsdbtest.NewNBTestHarness(dbSetup, nil)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			var libovsdbOvnSBClient libovsdbclient.Client
+
+			// nothing will occur in the SBDB in this instance because we don't explicitly clean up any created
+			// mac bindings
+			libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
 
 			m, err := NewMaster(
 				&kube.Kube{KClient: fakeClient},
@@ -429,6 +538,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				f.Core().V1().Namespaces().Informer(),
 				f.Core().V1().Pods().Informer(),
 				libovsdbOvnNBClient,
+				libovsdbOvnSBClient,
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -487,6 +597,10 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedDatabaseState))
+
+			// nothing will written to sbdb here since the logical router policy already exists
+			Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(dbSetup.SBData))
+
 			return nil
 		}
 

--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -101,6 +101,8 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 			client.WithTable(&sbdb.SBGlobal{}),
 			// used for metrics
 			client.WithTable(&sbdb.PortBinding{}),
+			// used for hybrid-overlay
+			client.WithTable(&sbdb.DatapathBinding{}),
 		),
 	)
 	if err != nil {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -334,6 +334,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 			oc.watchFactory.NamespaceInformer(),
 			oc.watchFactory.PodInformer(),
 			oc.nbClient,
+			oc.sbClient,
 			informer.NewDefaultEventHandler,
 		)
 		if err != nil {

--- a/go-controller/pkg/util/ovn.go
+++ b/go-controller/pkg/util/ovn.go
@@ -18,23 +18,31 @@ import (
 
 // CreateMACBinding Creates MAC binding in OVN SBDB
 func CreateMACBinding(sbClient libovsdbclient.Client, logicalPort, datapathName string, portMAC net.HardwareAddr, nextHop net.IP) error {
-	datapath, err := libovsdbops.FindDatapathByExternalIDs(sbClient, map[string]string{"name": datapathName})
+	datapaths, err := libovsdbops.FindDatapathByExternalIDs(sbClient, map[string]string{"name": datapathName})
 	if err != nil {
 		return err
+	}
+
+	if len(datapaths) == 0 {
+		return fmt.Errorf("no datapath entries found for %s", datapathName)
+	}
+
+	if len(datapaths) > 1 {
+		return fmt.Errorf("multiple datapath entries found for %s", datapathName)
 	}
 
 	// find Create mac_binding if needed
 	mb := &sbdb.MACBinding{
 		LogicalPort: logicalPort,
-		MAC:         string(portMAC),
-		Datapath:    datapath.UUID,
-		IP:          string(nextHop),
+		MAC:         portMAC.String(),
+		Datapath:    datapaths[0].UUID,
+		IP:          nextHop.String(),
 	}
 
 	err = libovsdbops.CreateOrUpdateMacBinding(sbClient, mb)
 	if err != nil {
 		return fmt.Errorf("failed to create/update MAC_Binding entry of (%s, %s, %s, %s)"+
-			"error: %v", datapath.UUID, logicalPort, portMAC, nextHop, err)
+			"error: %v", datapaths[0].UUID, logicalPort, portMAC, nextHop, err)
 	}
 
 	return nil


### PR DESCRIPTION
https://github.com/ovn-org/ovn-kubernetes/commit/1b94cbb795af5817c7258109642d185bb3c3f07d

Managed to break Hybrid overlay specifically with the creation of the
MAC binding for the HO logical Port since we never actually passed
a valid sbClient to the ho Controller.

Also the unit tests were broken in the sense that we didn't have a test
that ensured we actually created all the needed OVN objects from
scratch, these objects are

The HO Logical Switch Port
The HO Logiacal Router Policy
The HO Mac binding

this commit fixes the above problems and more related to HO
found while fixing the tests

This bug was originally found in this downstream test run -> https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-network-operator/1250/pull-ci-openshift-cluster-network-operator-master-e2e-ovn-hybrid-step-registry/1471779495680675840