### PR TITLE
Check if pod exists before re-adding SNAT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,13 +274,13 @@ jobs:
          # in agnhost images. Disable them for now.
          - {"ipfamily": "dualstack", "target": "control-plane"}
          - {"ipfamily": "ipv6", "target": "control-plane"}
-         # No need to run disable-snat-multiple-gws with local GW mode
+         # No need to run disable-snat-multiple-gws with local GW mode || shard conformance
          - {"disable-snat-multiple-gws": "noSnatGW", "gateway-mode": "local"}
+         - {"disable-snat-multiple-gws": "noSnatGW", "target": "shard-conformance"}
          - {"second-bridge": "2br", "gateway-mode": "local"}
          - {"second-bridge": "2br", "disable-snat-multiple-gws": "snatGW"}
          - {"second-bridge": "2br", "ha": "HA"}
          - {"second-bridge": "2br", "target": "control-plane"}
-         - {"second-bridge": "1br", "disable-snat-multiple-gws": "noSnatGW"}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}"

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1481,10 +1481,15 @@ func (e *egressIPController) deletePodEgressIPAssignment(egressIPName string, st
 	}
 
 	if config.Gateway.DisableSNATMultipleGWs {
-		// add snats to->nodeIP (on the node where the pod exists) for these podIPs after deleting the snat to->egressIP
-		err = addPerPodGRSNAT(e.nbClient, e.watchFactory, pod, podIPs)
+		fetchPod, err := e.watchFactory.GetPod(pod.Namespace, pod.Name)
 		if err != nil {
-			return err
+			klog.Warningf("Failed to get pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		} else {
+			// if the pod still exists, add snats to->nodeIP (on the node where the pod exists) for these podIPs after deleting the snat to->egressIP
+			err = addPerPodGRSNAT(e.nbClient, e.watchFactory, fetchPod, podIPs)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
In order to make egressIPs and externalgws compatible, we re-add the SNAT to nodeIP during pod deletion 
when disableSNATMultipleGWs is true. While doing this, we need to check if the pod exists or not, because
`delLogicalPort` is called first before `deletePodEgressIPAssignment`. This will leave stale SNATs behind.
This bug was introduced in https://github.com/ovn-org/ovn-kubernetes/pull/2686
Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
