### PR TITLE
Multiple ExGW cache validation/improvements

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -197,7 +197,7 @@ func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.P
 			pod.Namespace, pod.Name, namespace, err)
 	}
 
-	nsInfo.routingExternalPodGWs[pod.Name] = egress
+	nsInfo.routingExternalPodGWs[makePodGWKey(pod)] = egress
 	nsUnlock()
 
 	klog.Infof("Adding routes for external gateway pod: %s, next hops: %q, namespace: %s, bfd-enabled: %t",
@@ -351,19 +351,20 @@ func (oc *Controller) deletePodExternalGW(pod *kapi.Pod) {
 	klog.Infof("Deleting routes for external gateway pod: %s, for namespace(s) %s", pod.Name,
 		podRoutingNamespaceAnno)
 	for _, namespace := range strings.Split(podRoutingNamespaceAnno, ",") {
-		oc.deletePodGWRoutesForNamespace(pod.Name, namespace)
+		oc.deletePodGWRoutesForNamespace(pod, namespace)
 	}
 }
 
 // deletePodGwRoutesForNamespace handles deleting all routes in a namespace for a specific pod GW
-func (oc *Controller) deletePodGWRoutesForNamespace(pod, namespace string) {
+func (oc *Controller) deletePodGWRoutesForNamespace(pod *kapi.Pod, namespace string) {
 	nsInfo, nsUnlock := oc.getNamespaceLocked(namespace, false)
 	if nsInfo == nil {
 		return
 	}
+	podGWKey := makePodGWKey(pod)
 	// check if any gateways were stored for this pod
-	foundGws, ok := nsInfo.routingExternalPodGWs[pod]
-	delete(nsInfo.routingExternalPodGWs, pod)
+	foundGws, ok := nsInfo.routingExternalPodGWs[podGWKey]
+	delete(nsInfo.routingExternalPodGWs, podGWKey)
 	nsUnlock()
 
 	if !ok || len(foundGws.gws) == 0 {
@@ -1249,4 +1250,8 @@ func (oc *Controller) buildOVNECMPCache() map[string][]*ovnRoute {
 		}
 	}
 	return ovnRouteCache
+}
+
+func makePodGWKey(pod *kapi.Pod) string {
+	return fmt.Sprintf("%s_%s", pod.Namespace, pod.Name)
 }

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -189,6 +189,14 @@ func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.P
 	if err != nil {
 		return fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
+	tmpPodGWs := oc.getRoutingPodGWs(nsInfo)
+	tmpPodGWs[pod.Name] = egress
+	if err = validateRoutingPodGWs(tmpPodGWs); err != nil {
+		nsUnlock()
+		return fmt.Errorf("unable to add pod: %s/%s as external gateway for namespace: %s, error: %v",
+			pod.Namespace, pod.Name, namespace, err)
+	}
+
 	nsInfo.routingExternalPodGWs[pod.Name] = egress
 	nsUnlock()
 

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -13,6 +13,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -60,12 +61,28 @@ func (oc *Controller) getRoutingExternalGWs(nsInfo *namespaceInfo) *gatewayInfo 
 	return &res
 }
 
-func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]*gatewayInfo {
+// wrapper function to log if there are duplicate gateway IPs present in the cache
+func validateRoutingPodGWs(podGWs map[string]gatewayInfo) error {
+	// map to hold IP/podName
+	ipTracker := make(map[string]string)
+	for podName, gwInfo := range podGWs {
+		for _, gwIP := range gwInfo.gws {
+			if foundPod, ok := ipTracker[gwIP.String()]; ok {
+				return fmt.Errorf("duplicate IP found in ECMP Pod route cache! IP: %q, first pod: %q, second "+
+					"pod: %q", gwIP, podName, foundPod)
+			}
+			ipTracker[gwIP.String()] = podName
+		}
+	}
+	return nil
+}
+
+func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]gatewayInfo {
 	// return a copy of the object so it can be handled without the
 	// namespace locked
-	res := make(map[string]*gatewayInfo)
+	res := make(map[string]gatewayInfo)
 	for k, v := range nsInfo.routingExternalPodGWs {
-		item := &gatewayInfo{
+		item := gatewayInfo{
 			bfdEnabled: v.bfdEnabled,
 			gws:        make([]net.IP, len(v.gws)),
 		}
@@ -77,7 +94,7 @@ func (oc *Controller) getRoutingPodGWs(nsInfo *namespaceInfo) map[string]*gatewa
 
 // addPodToNamespace adds the pod's IP to the namespace's address set and returns
 // pod's routing gateway info
-func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayInfo, map[string]*gatewayInfo, error) {
+func (oc *Controller) addPodToNamespace(ns string, ips []*net.IPNet) (*gatewayInfo, map[string]gatewayInfo, error) {
 	nsInfo, nsUnlock, err := oc.ensureNamespaceLocked(ns, true, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to ensure namespace locked: %v", err)
@@ -167,11 +184,17 @@ func (oc *Controller) multicastDeleteNamespace(ns *kapi.Namespace, nsInfo *names
 
 func parseRoutingExternalGWAnnotation(annotation string) ([]net.IP, error) {
 	var routingExternalGWs []net.IP
+	ipTracker := sets.NewString()
 	for _, v := range strings.Split(annotation, ",") {
 		parsedAnnotation := net.ParseIP(v)
 		if parsedAnnotation == nil {
 			return nil, fmt.Errorf("could not parse routing external gw annotation value %s", v)
 		}
+		if ipTracker.Has(parsedAnnotation.String()) {
+			klog.Warningf("Duplicate IP detected in routing external gw annotation: %s", annotation)
+			continue
+		}
+		ipTracker.Insert(parsedAnnotation.String())
 		routingExternalGWs = append(routingExternalGWs, parsedAnnotation)
 	}
 	return routingExternalGWs, nil

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -89,6 +89,7 @@ type namespaceInfo struct {
 
 	// routingExternalPodGWs contains a map of all pods serving as exgws as well as their
 	// exgw IPs
+	// key is <namespace>_<pod name>
 	routingExternalPodGWs map[string]gatewayInfo
 
 	multicastEnabled bool

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -465,7 +465,10 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 	for _, gw := range routingPodGWs {
 		if len(gw.gws) > 0 {
-			gateways = append(gateways, gw)
+			if err = validateRoutingPodGWs(routingPodGWs); err != nil {
+				klog.Error(err)
+			}
+			gateways = append(gateways, &gw)
 		} else {
 			klog.Warningf("Found routingPodGW with no gateways ip set for namespace %s", pod.Namespace)
 		}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -458,7 +458,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	// if we have any external or pod Gateways, add routes
-	gateways := make([]*gatewayInfo, 0)
+	gateways := make([]*gatewayInfo, 0, len(routingExternalGWs.gws)+len(routingPodGWs))
 
 	if len(routingExternalGWs.gws) > 0 {
 		gateways = append(gateways, routingExternalGWs)


### PR DESCRIPTION
Contains fixes which try to detect/validate unique IPs across pods serving as external gateways. Includes a fix where the pod exgw cache was being keyed only on pod name instead of namespaced name.