### PR TITLE
deletePerPodGRSNAT should match on externalIP

### DIFF
--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -227,7 +227,7 @@ func isEquivalentNAT(existing *nbdb.NAT, searched *nbdb.NAT) bool {
 	return true
 }
 
-func FindNatsUsingPredicate(nbClient libovsdbclient.Client, predicate func(item *nbdb.NAT) bool) ([]*nbdb.NAT, error) {
+func FindNATsUsingPredicate(nbClient libovsdbclient.Client, predicate func(item *nbdb.NAT) bool) ([]*nbdb.NAT, error) {
 	nats := []nbdb.NAT{}
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
@@ -243,8 +243,8 @@ func FindNatsUsingPredicate(nbClient libovsdbclient.Client, predicate func(item 
 	return natsPtrs, nil
 }
 
-// FindRoutersUsingNat looks up routers that have any of the provided nats in its column
-func FindRoutersUsingNat(nbClient libovsdbclient.Client, nats []*nbdb.NAT) ([]nbdb.LogicalRouter, error) {
+// FindRoutersUsingNAT looks up routers that have any of the provided nats in its column
+func FindRoutersUsingNAT(nbClient libovsdbclient.Client, nats []*nbdb.NAT) ([]nbdb.LogicalRouter, error) {
 	natUUIDs := sets.String{}
 	for _, nat := range nats {
 		if nat != nil {
@@ -272,7 +272,7 @@ func FindRoutersUsingNat(nbClient libovsdbclient.Client, nats []*nbdb.NAT) ([]nb
 	return routers, nil
 }
 
-func getRouterNats(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) ([]*nbdb.NAT, error) {
+func getRouterNATs(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) ([]*nbdb.NAT, error) {
 	nats := []*nbdb.NAT{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
@@ -292,7 +292,7 @@ func getRouterNats(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) (
 }
 
 // This non-public function can be leveraged by future cases when logical router is created with nats via libovsdb
-func addOrUpdateNatToRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, routerNats []*nbdb.NAT, nat *nbdb.NAT) ([]libovsdb.Operation, error) {
+func addOrUpdateNATToRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, routerNats []*nbdb.NAT, nat *nbdb.NAT) ([]libovsdb.Operation, error) {
 	if ops == nil {
 		ops = []libovsdb.Operation{}
 	}
@@ -346,20 +346,20 @@ func addOrUpdateNatToRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Op
 	return ops, nil
 }
 
-func AddOrUpdateNatsToRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, nats ...*nbdb.NAT) ([]libovsdb.Operation, error) {
+func AddOrUpdateNATsToRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, nats ...*nbdb.NAT) ([]libovsdb.Operation, error) {
 	router, err := findRouter(nbClient, router)
 	if err != nil {
 		return ops, err
 	}
 
-	routerNats, err := getRouterNats(nbClient, router)
+	routerNats, err := getRouterNATs(nbClient, router)
 	if err != nil {
 		return ops, err
 	}
 
 	for _, nat := range nats {
 		if nat != nil {
-			ops, err = addOrUpdateNatToRouterOps(nbClient, ops, router, routerNats, nat)
+			ops, err = addOrUpdateNATToRouterOps(nbClient, ops, router, routerNats, nat)
 			if err != nil {
 				return ops, err
 			}
@@ -369,7 +369,7 @@ func AddOrUpdateNatsToRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 	return ops, nil
 }
 
-func DeleteNatsFromRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, nats ...*nbdb.NAT) ([]libovsdb.Operation, error) {
+func DeleteNATsFromRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, router *nbdb.LogicalRouter, nats ...*nbdb.NAT) ([]libovsdb.Operation, error) {
 	if ops == nil {
 		ops = []libovsdb.Operation{}
 	}
@@ -379,7 +379,7 @@ func DeleteNatsFromRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Oper
 		return ops, err
 	}
 
-	routerNats, err := getRouterNats(nbClient, router)
+	routerNats, err := getRouterNATs(nbClient, router)
 	if err != nil {
 		return ops, err
 	}
@@ -427,9 +427,9 @@ func DeleteNatsFromRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Oper
 	return ops, nil
 }
 
-func AddOrUpdateNatsToRouter(nbClient libovsdbclient.Client, routerName string, nats ...*nbdb.NAT) error {
+func AddOrUpdateNATsToRouter(nbClient libovsdbclient.Client, routerName string, nats ...*nbdb.NAT) error {
 	router := &nbdb.LogicalRouter{Name: routerName}
-	ops, err := AddOrUpdateNatsToRouterOps(nbClient, nil, router, nats...)
+	ops, err := AddOrUpdateNATsToRouterOps(nbClient, nil, router, nats...)
 	if err != nil {
 		return err
 	}
@@ -438,9 +438,9 @@ func AddOrUpdateNatsToRouter(nbClient libovsdbclient.Client, routerName string, 
 	return err
 }
 
-func DeleteNatsFromRouter(nbClient libovsdbclient.Client, routerName string, nats ...*nbdb.NAT) error {
+func DeleteNATsFromRouter(nbClient libovsdbclient.Client, routerName string, nats ...*nbdb.NAT) error {
 	router := &nbdb.LogicalRouter{Name: routerName}
-	ops, err := DeleteNatsFromRouterOps(nbClient, nil, router, nats...)
+	ops, err := DeleteNATsFromRouterOps(nbClient, nil, router, nats...)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/libovsdbops/router_test.go
+++ b/go-controller/pkg/libovsdbops/router_test.go
@@ -8,7 +8,7 @@ import (
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 )
 
-func TestFindNatsUsingPredicate(t *testing.T) {
+func TestFindNATsUsingPredicate(t *testing.T) {
 	fakeNAT1 := &nbdb.NAT{
 		UUID: BuildNamedUUID(),
 		Type: nbdb.NATTypeSNAT,
@@ -62,9 +62,9 @@ func TestFindNatsUsingPredicate(t *testing.T) {
 			}
 			t.Cleanup(cleanup.Cleanup)
 
-			rc, err := FindNatsUsingPredicate(nbClient, tt.predFunc)
+			rc, err := FindNATsUsingPredicate(nbClient, tt.predFunc)
 			if err != nil {
-				t.Fatal(fmt.Errorf("FindNatsUsingPredicate() error = %v", err))
+				t.Fatal(fmt.Errorf("FindNATsUsingPredicate() error = %v", err))
 			}
 
 			if len(rc) != len(tt.expectedRc) {
@@ -89,7 +89,7 @@ func TestFindNatsUsingPredicate(t *testing.T) {
 	}
 }
 
-func TestFindRoutersUsingNat(t *testing.T) {
+func TestFindRoutersUsingNAT(t *testing.T) {
 	fakeNAT1 := &nbdb.NAT{
 		UUID: BuildNamedUUID(),
 		Type: nbdb.NATTypeSNAT,
@@ -167,9 +167,9 @@ func TestFindRoutersUsingNat(t *testing.T) {
 			}
 			t.Cleanup(cleanup.Cleanup)
 
-			rc, err := FindRoutersUsingNat(nbClient, tt.nats)
+			rc, err := FindRoutersUsingNAT(nbClient, tt.nats)
 			if err != nil {
-				t.Fatal(fmt.Errorf("FindRoutersUsingNat() error = %v", err))
+				t.Fatal(fmt.Errorf("FindRoutersUsingNAT() error = %v", err))
 			}
 
 			if len(rc) != len(tt.expectedRc) {
@@ -194,7 +194,7 @@ func TestFindRoutersUsingNat(t *testing.T) {
 	}
 }
 
-func TestDeleteNatsFromRouter(t *testing.T) {
+func TestDeleteNATsFromRouter(t *testing.T) {
 	fakeNAT1 := &nbdb.NAT{
 		UUID:       BuildNamedUUID(),
 		ExternalIP: "192.168.1.110",
@@ -305,9 +305,9 @@ func TestDeleteNatsFromRouter(t *testing.T) {
 			}
 			t.Cleanup(cleanup.Cleanup)
 
-			err = DeleteNatsFromRouter(nbClient, tt.routerName, tt.nats...)
+			err = DeleteNATsFromRouter(nbClient, tt.routerName, tt.nats...)
 			if err != nil && !tt.expectErr {
-				t.Fatal(fmt.Errorf("DeleteNatsFromRouter() error = %v", err))
+				t.Fatal(fmt.Errorf("DeleteNATsFromRouter() error = %v", err))
 			}
 
 			matcher := libovsdbtest.HaveData(tt.expectedNbdb.NBData)

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -582,7 +582,7 @@ func deletePerPodGRSNAT(nbClient libovsdbclient.Client, node string, podIPNets [
 		nat = libovsdbops.BuildRouterSNAT(nil, fullMaskPodNet, "", nil)
 		nats = append(nats, nat)
 	}
-	err = libovsdbops.DeleteNatsFromRouter(nbClient, gr, nats...)
+	err = libovsdbops.DeleteNATsFromRouter(nbClient, gr, nats...)
 	if err != nil {
 		return fmt.Errorf("failed to delete SNAT rule for pod on gateway router %s, "+
 			"error: %v", gr, err)
@@ -619,7 +619,7 @@ func addPerPodGRSNAT(nbClient libovsdbclient.Client, watchFactory *factory.Watch
 			nats = append(nats, nat)
 		}
 	}
-	if err := libovsdbops.AddOrUpdateNatsToRouter(nbClient, gr, nats...); err != nil {
+	if err := libovsdbops.AddOrUpdateNATsToRouter(nbClient, gr, nats...); err != nil {
 		return fmt.Errorf("failed to update SNAT for pods of router: %s, error: %v", gr, err)
 	}
 	return nil

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -2224,8 +2224,11 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
+				extIPs, err := getExternalIPsGRSNAT(fakeOvn.controller.watchFactory, pod[0].Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 				_, fullMaskPodNet, _ := net.ParseCIDR("10.128.1.3/32")
-				addPerPodGRSNAT(fakeOvn.controller.nbClient, fakeOvn.controller.watchFactory, &pod[0], []*net.IPNet{fullMaskPodNet})
+				addOrUpdatePerPodGRSNAT(fakeOvn.controller.nbClient, pod[0].Spec.NodeName, extIPs, []*net.IPNet{fullMaskPodNet})
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				finalNB = []libovsdbtest.TestData{
 					&nbdb.LogicalRouter{
@@ -2239,7 +2242,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Networks: []string{"100.64.0.4/32"},
 					},
 				}
-				err := deletePerPodGRSNAT(fakeOvn.controller.nbClient, nodeName, []*net.IPNet{fullMaskPodNet})
+				err = deletePerPodGRSNAT(fakeOvn.controller.nbClient, nodeName, extIPs, []*net.IPNet{fullMaskPodNet})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -908,7 +908,7 @@ func (oc *Controller) syncStaleSNATRules(egressIPToPodIPCache map[string]sets.St
 		return false
 	}
 
-	nats, err := libovsdbops.FindNatsUsingPredicate(oc.nbClient, predicate)
+	nats, err := libovsdbops.FindNATsUsingPredicate(oc.nbClient, predicate)
 	if err != nil {
 		klog.Errorf("Unable to sync egress IPs err: %v", err)
 		return
@@ -919,7 +919,7 @@ func (oc *Controller) syncStaleSNATRules(egressIPToPodIPCache map[string]sets.St
 		return
 	}
 
-	routers, err := libovsdbops.FindRoutersUsingNat(oc.nbClient, nats)
+	routers, err := libovsdbops.FindRoutersUsingNAT(oc.nbClient, nats)
 	if err != nil {
 		klog.Errorf("Unable to sync egress IPs, err: %v", err)
 		return
@@ -927,7 +927,7 @@ func (oc *Controller) syncStaleSNATRules(egressIPToPodIPCache map[string]sets.St
 
 	ops := []ovsdb.Operation{}
 	for _, router := range routers {
-		ops, err = libovsdbops.DeleteNatsFromRouterOps(oc.nbClient, ops, &router, nats...)
+		ops, err = libovsdbops.DeleteNATsFromRouterOps(oc.nbClient, ops, &router, nats...)
 		if err != nil {
 			klog.Errorf("Error deleting stale NAT from router %s: %v", router.Name, err)
 			continue
@@ -1923,7 +1923,7 @@ func createNATRuleOps(nbClient libovsdbclient.Client, podIPs []*net.IPNet, statu
 	router := &nbdb.LogicalRouter{
 		Name: util.GetGatewayRouterFromNode(status.Node),
 	}
-	ops, err := libovsdbops.AddOrUpdateNatsToRouterOps(nbClient, []ovsdb.Operation{}, router, nats...)
+	ops, err := libovsdbops.AddOrUpdateNATsToRouterOps(nbClient, []ovsdb.Operation{}, router, nats...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create snat rules, for router: %s, error: %v", router.Name, err)
 	}
@@ -1946,7 +1946,7 @@ func deleteNATRuleOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, pod
 	router := &nbdb.LogicalRouter{
 		Name: util.GetGatewayRouterFromNode(status.Node),
 	}
-	ops, err = libovsdbops.DeleteNatsFromRouterOps(nbClient, ops, router, nats...)
+	ops, err = libovsdbops.DeleteNATsFromRouterOps(nbClient, ops, router, nats...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to remove snat rules for router: %s, error: %v", router.Name, err)
 	}

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -106,7 +106,7 @@ func (oc *Controller) delPbrAndNatRules(nodeName string, lrpTypes []string) {
 	// because there will be none since this NAT is only for outbound traffic and not for inbound
 	mgmtPortName := types.K8sPrefix + nodeName
 	nat := libovsdbops.BuildRouterDNATAndSNAT(nil, nil, mgmtPortName, "", nil)
-	err := libovsdbops.DeleteNatsFromRouter(oc.nbClient, types.OVNClusterRouter, nat)
+	err := libovsdbops.DeleteNATsFromRouter(oc.nbClient, types.OVNClusterRouter, nat)
 	if err != nil {
 		klog.Errorf("Failed to delete the dnat_and_snat associated with the management "+
 			"port %s, error: %v", mgmtPortName, err)

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -68,10 +68,34 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 		},
 	}
 
+	var oldExtIPs []net.IP
+	// If l3gatewayAnnotation.IPAddresses changed, we need to update the perPodSNATs,
+	// so let's save the old value before we update the router for later use
+	oldlogicalGRRes := []nbdb.LogicalRouter{}
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	if err := oc.nbClient.WhereCache(func(lr *nbdb.LogicalRouter) bool {
+		return lr.Name == gatewayRouter
+	}).List(ctx, &oldlogicalGRRes); err != nil {
+		return fmt.Errorf("failed in retrieving %s, error: %v", gatewayRouter, err)
+	}
+	// no need to do anything if GR doesn't exist yet
+	if len(oldlogicalGRRes) > 0 {
+		oldExternalIPs := strings.Split(oldlogicalGRRes[0].ExternalIDs["physical_ips"], ",")
+		oldExtIPs = make([]net.IP, len(oldExternalIPs))
+		for i, oldExternalIP := range oldExternalIPs {
+			cidr := oldExternalIP + GetIPFullMask(oldExternalIP)
+			ip, _, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return fmt.Errorf("invalid cidr:%s error: %v", cidr, err)
+			}
+			oldExtIPs[i] = ip
+		}
+	}
+
 	if _, err := oc.modelClient.CreateOrUpdate(opModels...); err != nil {
 		return fmt.Errorf("failed to create logical router %v, err: %v", gatewayRouter, err)
 	}
-
 	gwSwitchPort := types.JoinSwitchToGWRouterPrefix + gatewayRouter
 	gwRouterPort := types.GWRouterToJoinSwitchPrefix + gatewayRouter
 
@@ -141,9 +165,6 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 	if _, err := oc.modelClient.CreateOrUpdate(opModels...); err != nil {
 		return fmt.Errorf("failed to add logical router port %q for gateway router %s, err: %v", gwRouterPort, gatewayRouter, err)
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
-	defer cancel()
 
 	for _, entry := range clusterIPSubnet {
 		drLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(entry), drLRPIfAddrs)
@@ -391,15 +412,41 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 	// if config.Gateway.DisabledSNATMultipleGWs is not set (by default it is not),
 	// the NAT rules for pods not having annotations to route through either external
 	// gws or pod CNFs will be added within pods.go addLogicalPort
+	externalIPs := make([]net.IP, len(l3GatewayConfig.IPAddresses))
+	for i, ip := range l3GatewayConfig.IPAddresses {
+		externalIPs[i] = ip.IP
+	}
+	var natsToUpdate []*nbdb.NAT
+	// If l3gatewayAnnotation.IPAddresses changed, we need to update the SNATs on the GR
+	if len(oldExtIPs) > 0 {
+		for _, externalIP := range externalIPs {
+			oldExternalIP, err := util.MatchIPFamily(utilnet.IsIPv6(externalIP), oldExtIPs)
+			if err != nil {
+				return fmt.Errorf("failed to update GW SNAT rule for pods on router %s error: %v", gatewayRouter, err)
+			}
+			if externalIP.String() != oldExternalIP[0].String() {
+				predicate := func(item *nbdb.NAT) bool {
+					return item.ExternalIP == oldExternalIP[0].String() && item.Type == nbdb.NATTypeSNAT
+				}
+				natsToUpdate, err = libovsdbops.FindNATsUsingPredicate(oc.nbClient, predicate)
+				if err != nil {
+					return fmt.Errorf("failed to update GW SNAT rule for pods on router %s error: %v", gatewayRouter, err)
+				}
+				for i := 0; i < len(natsToUpdate); i++ {
+					natsToUpdate[i].ExternalIP = externalIP.String()
+				}
+			}
+		}
+		err := libovsdbops.AddOrUpdateNATsToRouter(oc.nbClient, gatewayRouter, natsToUpdate...)
+		if err != nil {
+			return fmt.Errorf("failed to update GW SNAT rule for pod on router %s error: %v", gatewayRouter, err)
+		}
+	}
 	nats := make([]*nbdb.NAT, 0, len(clusterIPSubnet))
 	var nat *nbdb.NAT
 	if !config.Gateway.DisableSNATMultipleGWs {
 		// Default SNAT rules. DisableSNATMultipleGWs=false in LGW (traffic egresses via mp0) always.
 		// We are not checking for gateway mode to be shared explicitly to reduce topology differences.
-		externalIPs := make([]net.IP, len(l3GatewayConfig.IPAddresses))
-		for i, ip := range l3GatewayConfig.IPAddresses {
-			externalIPs[i] = ip.IP
-		}
 		for _, entry := range clusterIPSubnet {
 			externalIP, err := util.MatchIPFamily(utilnet.IsIPv6CIDR(entry), externalIPs)
 			if err != nil {

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -409,7 +409,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			nat = libovsdbops.BuildRouterSNAT(&externalIP[0], entry, "", nil)
 			nats = append(nats, nat)
 		}
-		err := libovsdbops.AddOrUpdateNatsToRouter(oc.nbClient, gatewayRouter, nats...)
+		err := libovsdbops.AddOrUpdateNATsToRouter(oc.nbClient, gatewayRouter, nats...)
 		if err != nil {
 			return fmt.Errorf("failed to update SNAT rule for pod on router %s error: %v", gatewayRouter, err)
 		}
@@ -419,7 +419,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			nat = libovsdbops.BuildRouterSNAT(nil, logicalSubnet, "", nil)
 			nats = append(nats, nat)
 		}
-		err := libovsdbops.DeleteNatsFromRouter(oc.nbClient, gatewayRouter, nats...)
+		err := libovsdbops.DeleteNATsFromRouter(oc.nbClient, gatewayRouter, nats...)
 		if err != nil {
 			return fmt.Errorf("failed to delete GW SNAT rule for pod on router %s error: %v", gatewayRouter, err)
 		}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -163,7 +163,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 	}
 
 	if config.Gateway.DisableSNATMultipleGWs {
-		if err := deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, portInfo.ips); err != nil {
+		if err := deletePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, []*net.IPNet{}, portInfo.ips); err != nil {
 			klog.Errorf(err.Error())
 		}
 	}
@@ -490,7 +490,9 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	} else if config.Gateway.DisableSNATMultipleGWs {
 		// Add NAT rules to pods if disable SNAT is set and does not have
 		// namespace annotations to go through external egress router
-		if err = addPerPodGRSNAT(oc.nbClient, oc.watchFactory, pod, podIfAddrs); err != nil {
+		if extIPs, err := getExternalIPsGRSNAT(oc.watchFactory, pod.Spec.NodeName); err != nil {
+			klog.Error(err.Error())
+		} else if err = addOrUpdatePerPodGRSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, podIfAddrs); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
`deletePerPodGRSNAT` until now used to delete all
the SNAT's matching on the podIP. However this
SNAT could either belong to nodeIP or egressIP.
We really shouldn't be deleting all the SNAT's
of a pod and instead let the corresponding
controllers decide when they want to delete the
specific SNAT.

However if we are doing this, then we need to be careful 
since we rely on the l3gateway annotation to figure
out which externalID is chosen for deletion of the SNAT.
In case the annotation gets updated between an add and
delete, we'd be left with an inconsistent state.

So we add support to update GR SNATs when
l3gateway.IPAddresses change. Currently we update the
GR object when l3gateway annotations change, but we
do not update the SNATs on the router. So we are left with
stale SNATs towards old IPs.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
