### PR TITLE
CI: Fix log message for failed commands in pokeEndpointHostname

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -255,8 +255,8 @@ func pokeEndpointHostname(clientContainer, protocol, targetHost string, targetPo
 	framework.ExpectNoError(err, "failed to run command on external container")
 	hostName, err := parseNetexecResponse(res)
 	if err != nil {
-		fmt.Printf("FAILED Command was %s", curlCommand)
-		fmt.Printf("FAILED Response was %v", res)
+		framework.Logf("FAILED Command was %s", curlCommand)
+		framework.Logf("FAILED Response was %v", res)
 	}
 	framework.ExpectNoError(err)
 
@@ -390,8 +390,8 @@ func pokeEndpointClientIP(clientContainer, protocol, targetHost string, targetPo
 	framework.ExpectNoError(err)
 	ip, _, err := net.SplitHostPort(clientIP)
 	if err != nil {
-		fmt.Printf("FAILED Command was %s", curlCommand)
-		fmt.Printf("FAILED Response was %v", res)
+		framework.Logf("FAILED Command was %s", curlCommand)
+		framework.Logf("FAILED Response was %v", res)
 	}
 	framework.ExpectNoError(err, "failed to parse client ip:port")
 


### PR DESCRIPTION
Fix log message for failed commands in pokeEndpointHostname.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->