### PR TITLE
Log message fixes, possible nil dereference, and duplicate import

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_windows.go
@@ -222,7 +222,7 @@ func (n *NodeController) DeleteNode(node *kapi.Node) error {
 	network, err := hcn.GetNetworkByID(n.networkID)
 	if err != nil {
 		if _, isNotExist := err.(hcn.NetworkNotFoundError); !isNotExist {
-			return fmt.Errorf("Couldn't retrieve network with ID '%s' on node '%s'", n.networkID, node.Name)
+			return fmt.Errorf("couldn't retrieve network with ID '%s' on node '%s'", n.networkID, node.Name)
 		}
 		return nil
 	}

--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -114,16 +114,16 @@ func ofctlExec(args ...string) (string, error) {
 	cmd.SetStderr(&stderr)
 
 	cmdStr := strings.Join(args, " ")
-	klog.V(5).Infof("exec: %s %s", ofctlPath, cmdStr)
+	klog.V(5).Infof("Exec: %s %s", ofctlPath, cmdStr)
 
 	err := cmd.Run()
 	if err != nil {
 		stderrStr := stderr.String()
-		klog.Errorf("exec: %s %s : stderr: %q", ofctlPath, cmdStr, stderrStr)
+		klog.Errorf("Exec: %s %s : stderr: %q", ofctlPath, cmdStr, stderrStr)
 		return "", fmt.Errorf("failed to run '%s %s': %v\n  %q", ofctlPath, cmdStr, err, stderrStr)
 	}
 	stdoutStr := stdout.String()
-	klog.V(5).Infof("exec: %s %s: stdout: %q", ofctlPath, cmdStr, stdoutStr)
+	klog.V(5).Infof("Exec: %s %s: stdout: %q", ofctlPath, cmdStr, stdoutStr)
 
 	trimmed := strings.TrimSpace(stdoutStr)
 	// If output is a single line, strip the trailing newline

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1213,10 +1213,10 @@ func rawExec(exec kexec.Interface, cmd string, args ...string) (string, error) {
 		return "", err
 	}
 
-	klog.V(5).Infof("exec: %s %s", cmdPath, strings.Join(args, " "))
+	klog.V(5).Infof("Exec: %s %s", cmdPath, strings.Join(args, " "))
 	out, err := exec.Command(cmdPath, args...).CombinedOutput()
 	if err != nil {
-		klog.V(5).Infof("exec: %s %s => %v", cmdPath, strings.Join(args, " "), err)
+		klog.V(5).Infof("Exec: %s %s => %v", cmdPath, strings.Join(args, " "), err)
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -49,7 +48,7 @@ type OvnNode struct {
 }
 
 // NewNode creates a new controller for node management
-func NewNode(kubeClient kubernetes.Interface, wf factory.NodeWatchFactory, name string, stopChan chan struct{}, eventRecorder record.EventRecorder) *OvnNode {
+func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name string, stopChan chan struct{}, eventRecorder record.EventRecorder) *OvnNode {
 	return &OvnNode{
 		name:         name,
 		client:       kubeClient,

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -574,7 +574,7 @@ func (as *ovnAddressSet) deleteIPs(ips []net.IP) error {
 }
 
 func (as *ovnAddressSet) destroy() error {
-	klog.V(5).Infof("destroy(%s)", asDetail(as))
+	klog.V(5).Infof("Destroy(%s)", asDetail(as))
 	addrset := &nbdb.AddressSet{UUID: as.uuid}
 	ops, err := as.nbClient.Where(addrset).Delete()
 	if err != nil {

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -103,12 +103,12 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) *nodeTracker {
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					klog.Errorf("couldn't understand non-tombstone object")
+					klog.Errorf("Couldn't understand non-tombstone object")
 					return
 				}
 				node, ok = tombstone.Obj.(*v1.Node)
 				if !ok {
-					klog.Errorf("couldn't understand tombstone object")
+					klog.Errorf("Couldn't understand tombstone object")
 					return
 				}
 			}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1669,7 +1669,7 @@ func (oc *Controller) checkEgressNodesReachability() {
 		for nodeName, shouldDelete := range reAddOrDelete {
 			node, err := oc.watchFactory.GetNode(nodeName)
 			if err != nil {
-				klog.Errorf("Node: %s reachability changed, but could not retrieve node from cache, err: %v", node.Name, err)
+				klog.Errorf("Node: %s reachability changed, but could not retrieve node from cache, err: %v", nodeName, err)
 			}
 			if shouldDelete {
 				klog.Warningf("Node: %s is detected as unreachable, deleting it from egress assignment", node.Name)

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
@@ -267,7 +267,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 				err = lsManager.AddNode(testNode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = lsManager.AllocateIPs(testNode.nodeName, allocatedIPNets)
-				klog.Errorf("error: %v", err)
+				klog.Errorf("Error: %v", err)
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				return nil
 			}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -518,7 +518,7 @@ func (oc *Controller) iterateRetryPods(updateAll bool) {
 		}
 
 		if !util.PodScheduled(kPod) {
-			klog.V(5).Infof("retry: %s not scheduled", podDesc)
+			klog.V(5).Infof("Retry: %s not scheduled", podDesc)
 			continue
 		}
 		podEntry.backoffSec = (podEntry.backoffSec * 2)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -44,7 +44,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 					pod.Spec.NodeName)
 			}
 			if err = oc.lsManager.AllocateIPs(pod.Spec.NodeName, annotations.IPs); err != nil {
-				klog.Errorf("couldn't allocate IPs: %s for pod: %s on node: %s"+
+				klog.Errorf("Couldn't allocate IPs: %s for pod: %s on node: %s"+
 					" error: %v", util.JoinIPNetIPs(annotations.IPs, " "), logicalPort,
 					pod.Spec.NodeName, err)
 			}

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -201,13 +201,13 @@ func (runsvc *defaultExecRunner) RunCmd(cmd kexec.Cmd, cmdPath string, envVars [
 
 	counter := atomic.AddUint64(&runCounter, 1)
 	logCmd := fmt.Sprintf("%s %s", cmdPath, strings.Join(args, " "))
-	klog.V(5).Infof("exec(%d): %s", counter, logCmd)
+	klog.V(5).Infof("Exec(%d): %s", counter, logCmd)
 
 	err := cmd.Run()
-	klog.V(5).Infof("exec(%d): stdout: %q", counter, stdout)
-	klog.V(5).Infof("exec(%d): stderr: %q", counter, stderr)
+	klog.V(5).Infof("Exec(%d): stdout: %q", counter, stdout)
+	klog.V(5).Infof("Exec(%d): stderr: %q", counter, stderr)
 	if err != nil {
-		klog.V(5).Infof("exec(%d): err: %v", counter, err)
+		klog.V(5).Infof("Exec(%d): err: %v", counter, err)
 	}
 	return stdout, stderr, err
 }


### PR DESCRIPTION
This PR fixes the following issues:

* fix regex that was matching malformatted logs and errors
  
  the current regex wasn't matching `single quote` in the first word. for
example -- can't, couldn't and so on . furthermore, it had issues with Klog.*S() invocations as well. fixed them.

*  avoid duplicate imports of packages
*  avoid possible nil pointer dereference


