### PR TITLE
CI: Wait on namespace deletion for host networked test pods

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -2225,10 +2225,9 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 
 		ginkgo.AfterEach(func() {
 			deleteClusterExternalContainer(clientContainerName)
-		})
-		ginkgo.JustAfterEach(func() {
-			// Since we're using host neworked pods in the test wait until namespaces delete after each test
-			framework.WaitForNamespacesDeleted(f.ClientSet, []string{f.Namespace.Name}, wait.ForeverTestTimeout)
+			// f.Delete will delete the namespace and run WaitForNamespacesDeleted
+			// This is inside the Context and will happen before the framework's teardown inside the Describe
+			f.DeleteNamespace(f.Namespace.Name)
 		})
 
 		// Make sure ingress traffic can reach host pod backends for a service without SNAT when externalTrafficPolicy is set to local
@@ -2350,9 +2349,10 @@ var _ = ginkgo.Describe("host to host-networked pods traffic validation", func()
 				maxTries = len(endPoints)*len(endPoints) + 30
 			}
 		})
-		ginkgo.JustAfterEach(func() {
-			// Since we're using host neworked pods in the test wait until namespaces delete after each test
-			framework.WaitForNamespacesDeleted(f.ClientSet, []string{f.Namespace.Name}, wait.ForeverTestTimeout)
+		ginkgo.AfterEach(func() {
+			// f.Delete will delete the namespace and run WaitForNamespacesDeleted
+			// This is inside the Context and will happen before the framework's teardown inside the Describe
+			f.DeleteNamespace(f.Namespace.Name)
 		})
 		// Make sure host sourced traffic can reach host pod backends for a service without SNAT when externalTrafficPolicy is set to local
 		// Only verify with http


### PR DESCRIPTION
Delete and wait for namespaces inside Context.AfterEach with
f.DeleteNamespace(f.Namespace.Name). This makes sure that we actually
wait for the Namespaces to be deleted and avoids that host network pods
hog ports for too long.

Close #2728

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->