### PR TITLE
ETP=local, SGW: Add DNAT rule towards masquerade

### DIFF
--- a/docs/design/external_traffic_policy.md
+++ b/docs/design/external_traffic_policy.md
@@ -208,13 +208,7 @@ networked pods or cluster networked pods
 
 ### Host -> Service -> OVN Pod
 
-#### **Shared Gateway Mode**
-
-Documentation will be updated after https://bugzilla.redhat.com/show_bug.cgi?id=2025467 is fixed.
-
-#### **Local Gateway Mode**
-
-This case is similar to steps 3-6 on `External -> Service -> OVN Pod` traffic senario we saw above for local gateway.
+This case is similar to steps 3-6 on `External -> Service -> OVN Pod` traffic senario we saw above for local gateway. The traffic will flow from host->PRE-ROUTING iptable rule DNAT towards `169.254.169.3`, which gets routed into `ovn-k8s-mp0` and hits the load balancer on the node-local-switch preserving sourceIP.
 
 ### Host -> Service -> Host
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -474,25 +474,22 @@ func delServiceRules(service *kapi.Service, npw *nodePortWatcher) {
 			// | svcHasLocalHostNetEndPnt | ExternalTrafficPolicy | GatewayMode  |     Scenario for deletion      |
 			// |--------------------------|-----------------------|--------------|--------------------------------|
 			// |                          |                       |              |      deletes the REDIRECT      |
-			// |         true             |          local        | shared/local |      rules for etp=local +     |
+			// |         true             |          local        | shared+local |      rules for etp=local +     |
 			// |                          |                       |              |      host-networked eps        |
 			// |--------------------------|-----------------------|--------------|--------------------------------|
 			// |                          |                       |              | deletes the DNAT rules for     |
-			// |         false            |          local        |   local      | etp=local + non-local-host-net |
+			// |         false            |          local        | shared+local | etp=local + non-local-host-net |
 			// |                          |                       |              | eps towards masqueradeIP       |
 			// |--------------------------|-----------------------|--------------|--------------------------------|
-			// |                          |                       |              |                                |
-			// |         false            |          cluster      | shared/local |   	deletes the DNAT rules    |
-			// |         false            |           local       |   shared     |         towards clusterIP      |
+			// |                          |                       |              |    deletes the DNAT rules      |
+			// |         false            |          cluster      | shared+local |   	towards clusterIP         |
 			// |                          |                       |              |       for the default case     |
 			// +--------------------------+-----------------------+--------------+--------------------------------+
 
 			// case1: deletes the REDIRECT rules for etp=local + host-networked pods in both gw modes
 			delGatewayIptRules(service, true)
-			// case2 Or case3a/3b:
-			// deletes the DNAT rules towards masqueradeIP for etp=local + ovn-k pods in LGW mode OR
-			// deletes the DNAT rules towards clusterIP for etp=local + ovn-k pods in SGW mode OR
-			// deletes the DNAT rules towards clusterIP for etp=cluster in both gw modes
+			// case2: deletes the DNAT rules towards masqueradeIP for etp=local + ovn-k pods in both gw modes OR
+			// case3: deletes the DNAT rules towards clusterIP for etp=cluster in both gw modes
 			delGatewayIptRules(service, false)
 		}
 		return
@@ -501,10 +498,8 @@ func delServiceRules(service *kapi.Service, npw *nodePortWatcher) {
 	// For host only mode always try and delete all rules here
 	// case1: deletes the REDIRECT rules for etp=local + host-networked pods in both gw modes
 	delGatewayIptRules(service, true)
-	// case2 Or case3a/3b:
-	// deletes the DNAT rules towards masqueradeIP for etp=local + ovn-k pods in LGW mode OR
-	// deletes the DNAT rules towards clusterIP for etp=local + ovn-k pods in SGW mode OR
-	// deletes the DNAT rules towards clusterIP for etp=cluster in both gw modes
+	// case2: deletes the DNAT rules towards masqueradeIP for etp=local + ovn-k pods in both gw modes OR
+	// case3: deletes the DNAT rules towards clusterIP for etp=cluster in both gw modes
 	delGatewayIptRules(service, false)
 }
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Host -> svc (ETP=local) backed by ovn pods
does not work in SGW because we add the DNAT
rule that converts the NP to CIP before it
hits the LB on the GR.

Current flow which is wrong:

1) traffic from host gets DNAT-ed to clusterIP svc using iptables
2) traffic sent to br-ex
3) hits the GR load balancer
4) gets DNAT-ed to the backend pods,
5) depending on if this is on the same node or a different one,
we'll have packet delivered to the pod if its on the same node,
or it passes via geneve tunnel to the destination node where the pod lives.

Technically if the backends are not local to the node, the
request should get rejected. This PR removes the iptable DNAT rule
if the traffic is of ETP=local type.

New flow:

1) NP traffic from host is sent to br-ex
3) hits the GR load balancer with skip_snat=true - special to etp
4) gets DNAT-ed to the backend pods if they exist locally on the
node else get rejected,

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->



**- Description for the changelog**
`Fixes traffic flow: Host-> svc(ETP=local) backed by ovn pods`