### PR TITLE
Update nbdb and sbdb with modelgen supporting copy/equal

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20211201215911-5a82bae32e46
 	github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366
-	github.com/ovn-org/libovsdb v0.6.1-0.20211216134718-ab69150b65ee
+	github.com/ovn-org/libovsdb v0.6.1-0.20220114142803-22bd5be40a40
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/afero v1.4.1

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -352,8 +352,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mo
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366 h1:/llKlbXC7F6rqTkAl2GE//9GDR0iDsqJEFvvJ1kLJXg=
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366/go.mod h1:HJeHsH6mPyrrOVS/2j1zcztGAJG9ETKbqtlyohs84yY=
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
-github.com/ovn-org/libovsdb v0.6.1-0.20211216134718-ab69150b65ee h1:QccSNi42WX6zICnX1R5s/5Zv1M8nZz8AsAA+ZlP/TyQ=
-github.com/ovn-org/libovsdb v0.6.1-0.20211216134718-ab69150b65ee/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
+github.com/ovn-org/libovsdb v0.6.1-0.20220114142803-22bd5be40a40 h1:zXMyrYVkUNX1tZwrv1BeikXPSwSD/VlwCwdwggmD17g=
+github.com/ovn-org/libovsdb v0.6.1-0.20220114142803-22bd5be40a40/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/pkg/nbdb/acl.go
+++ b/go-controller/pkg/nbdb/acl.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	ACLAction    = string
 	ACLDirection = string
@@ -38,3 +40,128 @@ type ACL struct {
 	Priority    int               `ovsdb:"priority"`
 	Severity    *ACLSeverity      `ovsdb:"severity"`
 }
+
+func copyACLExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalACLExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyACLMeter(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalACLMeter(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyACLName(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalACLName(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyACLSeverity(a *ACLSeverity) *ACLSeverity {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalACLSeverity(a, b *ACLSeverity) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *ACL) DeepCopyInto(b *ACL) {
+	*b = *a
+	b.ExternalIDs = copyACLExternalIDs(a.ExternalIDs)
+	b.Meter = copyACLMeter(a.Meter)
+	b.Name = copyACLName(a.Name)
+	b.Severity = copyACLSeverity(a.Severity)
+}
+
+func (a *ACL) DeepCopy() *ACL {
+	b := new(ACL)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *ACL) CloneModelInto(b model.Model) {
+	c := b.(*ACL)
+	a.DeepCopyInto(c)
+}
+
+func (a *ACL) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *ACL) Equals(b *ACL) bool {
+	return a.UUID == b.UUID &&
+		a.Action == b.Action &&
+		a.Direction == b.Direction &&
+		equalACLExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Label == b.Label &&
+		a.Log == b.Log &&
+		a.Match == b.Match &&
+		equalACLMeter(a.Meter, b.Meter) &&
+		equalACLName(a.Name, b.Name) &&
+		a.Priority == b.Priority &&
+		equalACLSeverity(a.Severity, b.Severity)
+}
+
+func (a *ACL) EqualsModel(b model.Model) bool {
+	c := b.(*ACL)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &ACL{}
+var _ model.ComparableModel = &ACL{}

--- a/go-controller/pkg/nbdb/address_set.go
+++ b/go-controller/pkg/nbdb/address_set.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // AddressSet defines an object in Address_Set table
 type AddressSet struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -10,3 +12,89 @@ type AddressSet struct {
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Name        string            `ovsdb:"name"`
 }
+
+func copyAddressSetAddresses(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalAddressSetAddresses(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyAddressSetExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalAddressSetExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *AddressSet) DeepCopyInto(b *AddressSet) {
+	*b = *a
+	b.Addresses = copyAddressSetAddresses(a.Addresses)
+	b.ExternalIDs = copyAddressSetExternalIDs(a.ExternalIDs)
+}
+
+func (a *AddressSet) DeepCopy() *AddressSet {
+	b := new(AddressSet)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *AddressSet) CloneModelInto(b model.Model) {
+	c := b.(*AddressSet)
+	a.DeepCopyInto(c)
+}
+
+func (a *AddressSet) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *AddressSet) Equals(b *AddressSet) bool {
+	return a.UUID == b.UUID &&
+		equalAddressSetAddresses(a.Addresses, b.Addresses) &&
+		equalAddressSetExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Name == b.Name
+}
+
+func (a *AddressSet) EqualsModel(b model.Model) bool {
+	c := b.(*AddressSet)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &AddressSet{}
+var _ model.ComparableModel = &AddressSet{}

--- a/go-controller/pkg/nbdb/bfd.go
+++ b/go-controller/pkg/nbdb/bfd.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	BFDStatus = string
 )
@@ -26,3 +28,172 @@ type BFD struct {
 	Options     map[string]string `ovsdb:"options"`
 	Status      *BFDStatus        `ovsdb:"status"`
 }
+
+func copyBFDDetectMult(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalBFDDetectMult(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyBFDExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalBFDExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyBFDMinRx(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalBFDMinRx(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyBFDMinTx(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalBFDMinTx(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyBFDOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalBFDOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyBFDStatus(a *BFDStatus) *BFDStatus {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalBFDStatus(a, b *BFDStatus) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *BFD) DeepCopyInto(b *BFD) {
+	*b = *a
+	b.DetectMult = copyBFDDetectMult(a.DetectMult)
+	b.ExternalIDs = copyBFDExternalIDs(a.ExternalIDs)
+	b.MinRx = copyBFDMinRx(a.MinRx)
+	b.MinTx = copyBFDMinTx(a.MinTx)
+	b.Options = copyBFDOptions(a.Options)
+	b.Status = copyBFDStatus(a.Status)
+}
+
+func (a *BFD) DeepCopy() *BFD {
+	b := new(BFD)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *BFD) CloneModelInto(b model.Model) {
+	c := b.(*BFD)
+	a.DeepCopyInto(c)
+}
+
+func (a *BFD) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *BFD) Equals(b *BFD) bool {
+	return a.UUID == b.UUID &&
+		equalBFDDetectMult(a.DetectMult, b.DetectMult) &&
+		a.DstIP == b.DstIP &&
+		equalBFDExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.LogicalPort == b.LogicalPort &&
+		equalBFDMinRx(a.MinRx, b.MinRx) &&
+		equalBFDMinTx(a.MinTx, b.MinTx) &&
+		equalBFDOptions(a.Options, b.Options) &&
+		equalBFDStatus(a.Status, b.Status)
+}
+
+func (a *BFD) EqualsModel(b model.Model) bool {
+	c := b.(*BFD)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &BFD{}
+var _ model.ComparableModel = &BFD{}

--- a/go-controller/pkg/nbdb/connection.go
+++ b/go-controller/pkg/nbdb/connection.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // Connection defines an object in Connection table
 type Connection struct {
 	UUID            string            `ovsdb:"_uuid"`
@@ -14,3 +16,160 @@ type Connection struct {
 	Status          map[string]string `ovsdb:"status"`
 	Target          string            `ovsdb:"target"`
 }
+
+func copyConnectionExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalConnectionExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyConnectionInactivityProbe(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalConnectionInactivityProbe(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyConnectionMaxBackoff(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalConnectionMaxBackoff(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyConnectionOtherConfig(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalConnectionOtherConfig(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyConnectionStatus(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalConnectionStatus(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *Connection) DeepCopyInto(b *Connection) {
+	*b = *a
+	b.ExternalIDs = copyConnectionExternalIDs(a.ExternalIDs)
+	b.InactivityProbe = copyConnectionInactivityProbe(a.InactivityProbe)
+	b.MaxBackoff = copyConnectionMaxBackoff(a.MaxBackoff)
+	b.OtherConfig = copyConnectionOtherConfig(a.OtherConfig)
+	b.Status = copyConnectionStatus(a.Status)
+}
+
+func (a *Connection) DeepCopy() *Connection {
+	b := new(Connection)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *Connection) CloneModelInto(b model.Model) {
+	c := b.(*Connection)
+	a.DeepCopyInto(c)
+}
+
+func (a *Connection) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *Connection) Equals(b *Connection) bool {
+	return a.UUID == b.UUID &&
+		equalConnectionExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalConnectionInactivityProbe(a.InactivityProbe, b.InactivityProbe) &&
+		a.IsConnected == b.IsConnected &&
+		equalConnectionMaxBackoff(a.MaxBackoff, b.MaxBackoff) &&
+		equalConnectionOtherConfig(a.OtherConfig, b.OtherConfig) &&
+		equalConnectionStatus(a.Status, b.Status) &&
+		a.Target == b.Target
+}
+
+func (a *Connection) EqualsModel(b model.Model) bool {
+	c := b.(*Connection)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &Connection{}
+var _ model.ComparableModel = &Connection{}

--- a/go-controller/pkg/nbdb/copp.go
+++ b/go-controller/pkg/nbdb/copp.go
@@ -3,8 +3,69 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // Copp defines an object in Copp table
 type Copp struct {
 	UUID   string            `ovsdb:"_uuid"`
 	Meters map[string]string `ovsdb:"meters"`
 }
+
+func copyCoppMeters(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalCoppMeters(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *Copp) DeepCopyInto(b *Copp) {
+	*b = *a
+	b.Meters = copyCoppMeters(a.Meters)
+}
+
+func (a *Copp) DeepCopy() *Copp {
+	b := new(Copp)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *Copp) CloneModelInto(b model.Model) {
+	c := b.(*Copp)
+	a.DeepCopyInto(c)
+}
+
+func (a *Copp) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *Copp) Equals(b *Copp) bool {
+	return a.UUID == b.UUID &&
+		equalCoppMeters(a.Meters, b.Meters)
+}
+
+func (a *Copp) EqualsModel(b model.Model) bool {
+	c := b.(*Copp)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &Copp{}
+var _ model.ComparableModel = &Copp{}

--- a/go-controller/pkg/nbdb/dhcp_options.go
+++ b/go-controller/pkg/nbdb/dhcp_options.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // DHCPOptions defines an object in DHCP_Options table
 type DHCPOptions struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -10,3 +12,91 @@ type DHCPOptions struct {
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Options     map[string]string `ovsdb:"options"`
 }
+
+func copyDHCPOptionsExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalDHCPOptionsExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyDHCPOptionsOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalDHCPOptionsOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *DHCPOptions) DeepCopyInto(b *DHCPOptions) {
+	*b = *a
+	b.ExternalIDs = copyDHCPOptionsExternalIDs(a.ExternalIDs)
+	b.Options = copyDHCPOptionsOptions(a.Options)
+}
+
+func (a *DHCPOptions) DeepCopy() *DHCPOptions {
+	b := new(DHCPOptions)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *DHCPOptions) CloneModelInto(b model.Model) {
+	c := b.(*DHCPOptions)
+	a.DeepCopyInto(c)
+}
+
+func (a *DHCPOptions) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *DHCPOptions) Equals(b *DHCPOptions) bool {
+	return a.UUID == b.UUID &&
+		a.Cidr == b.Cidr &&
+		equalDHCPOptionsExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalDHCPOptionsOptions(a.Options, b.Options)
+}
+
+func (a *DHCPOptions) EqualsModel(b model.Model) bool {
+	c := b.(*DHCPOptions)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &DHCPOptions{}
+var _ model.ComparableModel = &DHCPOptions{}

--- a/go-controller/pkg/nbdb/dns.go
+++ b/go-controller/pkg/nbdb/dns.go
@@ -3,9 +3,98 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // DNS defines an object in DNS table
 type DNS struct {
 	UUID        string            `ovsdb:"_uuid"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Records     map[string]string `ovsdb:"records"`
 }
+
+func copyDNSExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalDNSExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyDNSRecords(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalDNSRecords(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *DNS) DeepCopyInto(b *DNS) {
+	*b = *a
+	b.ExternalIDs = copyDNSExternalIDs(a.ExternalIDs)
+	b.Records = copyDNSRecords(a.Records)
+}
+
+func (a *DNS) DeepCopy() *DNS {
+	b := new(DNS)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *DNS) CloneModelInto(b model.Model) {
+	c := b.(*DNS)
+	a.DeepCopyInto(c)
+}
+
+func (a *DNS) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *DNS) Equals(b *DNS) bool {
+	return a.UUID == b.UUID &&
+		equalDNSExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalDNSRecords(a.Records, b.Records)
+}
+
+func (a *DNS) EqualsModel(b model.Model) bool {
+	c := b.(*DNS)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &DNS{}
+var _ model.ComparableModel = &DNS{}

--- a/go-controller/pkg/nbdb/forwarding_group.go
+++ b/go-controller/pkg/nbdb/forwarding_group.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // ForwardingGroup defines an object in Forwarding_Group table
 type ForwardingGroup struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -13,3 +15,92 @@ type ForwardingGroup struct {
 	Vip         string            `ovsdb:"vip"`
 	Vmac        string            `ovsdb:"vmac"`
 }
+
+func copyForwardingGroupChildPort(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalForwardingGroupChildPort(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyForwardingGroupExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalForwardingGroupExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *ForwardingGroup) DeepCopyInto(b *ForwardingGroup) {
+	*b = *a
+	b.ChildPort = copyForwardingGroupChildPort(a.ChildPort)
+	b.ExternalIDs = copyForwardingGroupExternalIDs(a.ExternalIDs)
+}
+
+func (a *ForwardingGroup) DeepCopy() *ForwardingGroup {
+	b := new(ForwardingGroup)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *ForwardingGroup) CloneModelInto(b model.Model) {
+	c := b.(*ForwardingGroup)
+	a.DeepCopyInto(c)
+}
+
+func (a *ForwardingGroup) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *ForwardingGroup) Equals(b *ForwardingGroup) bool {
+	return a.UUID == b.UUID &&
+		equalForwardingGroupChildPort(a.ChildPort, b.ChildPort) &&
+		equalForwardingGroupExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Liveness == b.Liveness &&
+		a.Name == b.Name &&
+		a.Vip == b.Vip &&
+		a.Vmac == b.Vmac
+}
+
+func (a *ForwardingGroup) EqualsModel(b model.Model) bool {
+	c := b.(*ForwardingGroup)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &ForwardingGroup{}
+var _ model.ComparableModel = &ForwardingGroup{}

--- a/go-controller/pkg/nbdb/gateway_chassis.go
+++ b/go-controller/pkg/nbdb/gateway_chassis.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // GatewayChassis defines an object in Gateway_Chassis table
 type GatewayChassis struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -12,3 +14,93 @@ type GatewayChassis struct {
 	Options     map[string]string `ovsdb:"options"`
 	Priority    int               `ovsdb:"priority"`
 }
+
+func copyGatewayChassisExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalGatewayChassisExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyGatewayChassisOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalGatewayChassisOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *GatewayChassis) DeepCopyInto(b *GatewayChassis) {
+	*b = *a
+	b.ExternalIDs = copyGatewayChassisExternalIDs(a.ExternalIDs)
+	b.Options = copyGatewayChassisOptions(a.Options)
+}
+
+func (a *GatewayChassis) DeepCopy() *GatewayChassis {
+	b := new(GatewayChassis)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *GatewayChassis) CloneModelInto(b model.Model) {
+	c := b.(*GatewayChassis)
+	a.DeepCopyInto(c)
+}
+
+func (a *GatewayChassis) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *GatewayChassis) Equals(b *GatewayChassis) bool {
+	return a.UUID == b.UUID &&
+		a.ChassisName == b.ChassisName &&
+		equalGatewayChassisExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Name == b.Name &&
+		equalGatewayChassisOptions(a.Options, b.Options) &&
+		a.Priority == b.Priority
+}
+
+func (a *GatewayChassis) EqualsModel(b model.Model) bool {
+	c := b.(*GatewayChassis)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &GatewayChassis{}
+var _ model.ComparableModel = &GatewayChassis{}

--- a/go-controller/pkg/nbdb/gen.go
+++ b/go-controller/pkg/nbdb/gen.go
@@ -1,3 +1,3 @@
 package nbdb
 
-//go:generate modelgen -p nbdb -o . ovn-nb.ovsschema
+//go:generate modelgen --extended -p nbdb -o . ovn-nb.ovsschema

--- a/go-controller/pkg/nbdb/ha_chassis.go
+++ b/go-controller/pkg/nbdb/ha_chassis.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // HAChassis defines an object in HA_Chassis table
 type HAChassis struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -10,3 +12,64 @@ type HAChassis struct {
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Priority    int               `ovsdb:"priority"`
 }
+
+func copyHAChassisExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalHAChassisExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *HAChassis) DeepCopyInto(b *HAChassis) {
+	*b = *a
+	b.ExternalIDs = copyHAChassisExternalIDs(a.ExternalIDs)
+}
+
+func (a *HAChassis) DeepCopy() *HAChassis {
+	b := new(HAChassis)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *HAChassis) CloneModelInto(b model.Model) {
+	c := b.(*HAChassis)
+	a.DeepCopyInto(c)
+}
+
+func (a *HAChassis) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *HAChassis) Equals(b *HAChassis) bool {
+	return a.UUID == b.UUID &&
+		a.ChassisName == b.ChassisName &&
+		equalHAChassisExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Priority == b.Priority
+}
+
+func (a *HAChassis) EqualsModel(b model.Model) bool {
+	c := b.(*HAChassis)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &HAChassis{}
+var _ model.ComparableModel = &HAChassis{}

--- a/go-controller/pkg/nbdb/ha_chassis_group.go
+++ b/go-controller/pkg/nbdb/ha_chassis_group.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // HAChassisGroup defines an object in HA_Chassis_Group table
 type HAChassisGroup struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -10,3 +12,89 @@ type HAChassisGroup struct {
 	HaChassis   []string          `ovsdb:"ha_chassis"`
 	Name        string            `ovsdb:"name"`
 }
+
+func copyHAChassisGroupExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalHAChassisGroupExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyHAChassisGroupHaChassis(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalHAChassisGroupHaChassis(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *HAChassisGroup) DeepCopyInto(b *HAChassisGroup) {
+	*b = *a
+	b.ExternalIDs = copyHAChassisGroupExternalIDs(a.ExternalIDs)
+	b.HaChassis = copyHAChassisGroupHaChassis(a.HaChassis)
+}
+
+func (a *HAChassisGroup) DeepCopy() *HAChassisGroup {
+	b := new(HAChassisGroup)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *HAChassisGroup) CloneModelInto(b model.Model) {
+	c := b.(*HAChassisGroup)
+	a.DeepCopyInto(c)
+}
+
+func (a *HAChassisGroup) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *HAChassisGroup) Equals(b *HAChassisGroup) bool {
+	return a.UUID == b.UUID &&
+		equalHAChassisGroupExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalHAChassisGroupHaChassis(a.HaChassis, b.HaChassis) &&
+		a.Name == b.Name
+}
+
+func (a *HAChassisGroup) EqualsModel(b model.Model) bool {
+	c := b.(*HAChassisGroup)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &HAChassisGroup{}
+var _ model.ComparableModel = &HAChassisGroup{}

--- a/go-controller/pkg/nbdb/load_balancer.go
+++ b/go-controller/pkg/nbdb/load_balancer.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	LoadBalancerProtocol        = string
 	LoadBalancerSelectionFields = string
@@ -32,3 +34,219 @@ type LoadBalancer struct {
 	SelectionFields []LoadBalancerSelectionFields `ovsdb:"selection_fields"`
 	Vips            map[string]string             `ovsdb:"vips"`
 }
+
+func copyLoadBalancerExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLoadBalancerExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLoadBalancerHealthCheck(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLoadBalancerHealthCheck(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLoadBalancerIPPortMappings(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLoadBalancerIPPortMappings(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLoadBalancerOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLoadBalancerOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLoadBalancerProtocol(a *LoadBalancerProtocol) *LoadBalancerProtocol {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLoadBalancerProtocol(a, b *LoadBalancerProtocol) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLoadBalancerSelectionFields(a []LoadBalancerSelectionFields) []LoadBalancerSelectionFields {
+	if a == nil {
+		return nil
+	}
+	b := make([]LoadBalancerSelectionFields, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLoadBalancerSelectionFields(a, b []LoadBalancerSelectionFields) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLoadBalancerVips(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLoadBalancerVips(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *LoadBalancer) DeepCopyInto(b *LoadBalancer) {
+	*b = *a
+	b.ExternalIDs = copyLoadBalancerExternalIDs(a.ExternalIDs)
+	b.HealthCheck = copyLoadBalancerHealthCheck(a.HealthCheck)
+	b.IPPortMappings = copyLoadBalancerIPPortMappings(a.IPPortMappings)
+	b.Options = copyLoadBalancerOptions(a.Options)
+	b.Protocol = copyLoadBalancerProtocol(a.Protocol)
+	b.SelectionFields = copyLoadBalancerSelectionFields(a.SelectionFields)
+	b.Vips = copyLoadBalancerVips(a.Vips)
+}
+
+func (a *LoadBalancer) DeepCopy() *LoadBalancer {
+	b := new(LoadBalancer)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LoadBalancer) CloneModelInto(b model.Model) {
+	c := b.(*LoadBalancer)
+	a.DeepCopyInto(c)
+}
+
+func (a *LoadBalancer) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LoadBalancer) Equals(b *LoadBalancer) bool {
+	return a.UUID == b.UUID &&
+		equalLoadBalancerExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalLoadBalancerHealthCheck(a.HealthCheck, b.HealthCheck) &&
+		equalLoadBalancerIPPortMappings(a.IPPortMappings, b.IPPortMappings) &&
+		a.Name == b.Name &&
+		equalLoadBalancerOptions(a.Options, b.Options) &&
+		equalLoadBalancerProtocol(a.Protocol, b.Protocol) &&
+		equalLoadBalancerSelectionFields(a.SelectionFields, b.SelectionFields) &&
+		equalLoadBalancerVips(a.Vips, b.Vips)
+}
+
+func (a *LoadBalancer) EqualsModel(b model.Model) bool {
+	c := b.(*LoadBalancer)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LoadBalancer{}
+var _ model.ComparableModel = &LoadBalancer{}

--- a/go-controller/pkg/nbdb/load_balancer_group.go
+++ b/go-controller/pkg/nbdb/load_balancer_group.go
@@ -3,9 +3,69 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // LoadBalancerGroup defines an object in Load_Balancer_Group table
 type LoadBalancerGroup struct {
 	UUID         string   `ovsdb:"_uuid"`
 	LoadBalancer []string `ovsdb:"load_balancer"`
 	Name         string   `ovsdb:"name"`
 }
+
+func copyLoadBalancerGroupLoadBalancer(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLoadBalancerGroupLoadBalancer(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *LoadBalancerGroup) DeepCopyInto(b *LoadBalancerGroup) {
+	*b = *a
+	b.LoadBalancer = copyLoadBalancerGroupLoadBalancer(a.LoadBalancer)
+}
+
+func (a *LoadBalancerGroup) DeepCopy() *LoadBalancerGroup {
+	b := new(LoadBalancerGroup)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LoadBalancerGroup) CloneModelInto(b model.Model) {
+	c := b.(*LoadBalancerGroup)
+	a.DeepCopyInto(c)
+}
+
+func (a *LoadBalancerGroup) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LoadBalancerGroup) Equals(b *LoadBalancerGroup) bool {
+	return a.UUID == b.UUID &&
+		equalLoadBalancerGroupLoadBalancer(a.LoadBalancer, b.LoadBalancer) &&
+		a.Name == b.Name
+}
+
+func (a *LoadBalancerGroup) EqualsModel(b model.Model) bool {
+	c := b.(*LoadBalancerGroup)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LoadBalancerGroup{}
+var _ model.ComparableModel = &LoadBalancerGroup{}

--- a/go-controller/pkg/nbdb/load_balancer_health_check.go
+++ b/go-controller/pkg/nbdb/load_balancer_health_check.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // LoadBalancerHealthCheck defines an object in Load_Balancer_Health_Check table
 type LoadBalancerHealthCheck struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -10,3 +12,91 @@ type LoadBalancerHealthCheck struct {
 	Options     map[string]string `ovsdb:"options"`
 	Vip         string            `ovsdb:"vip"`
 }
+
+func copyLoadBalancerHealthCheckExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLoadBalancerHealthCheckExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLoadBalancerHealthCheckOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLoadBalancerHealthCheckOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *LoadBalancerHealthCheck) DeepCopyInto(b *LoadBalancerHealthCheck) {
+	*b = *a
+	b.ExternalIDs = copyLoadBalancerHealthCheckExternalIDs(a.ExternalIDs)
+	b.Options = copyLoadBalancerHealthCheckOptions(a.Options)
+}
+
+func (a *LoadBalancerHealthCheck) DeepCopy() *LoadBalancerHealthCheck {
+	b := new(LoadBalancerHealthCheck)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LoadBalancerHealthCheck) CloneModelInto(b model.Model) {
+	c := b.(*LoadBalancerHealthCheck)
+	a.DeepCopyInto(c)
+}
+
+func (a *LoadBalancerHealthCheck) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LoadBalancerHealthCheck) Equals(b *LoadBalancerHealthCheck) bool {
+	return a.UUID == b.UUID &&
+		equalLoadBalancerHealthCheckExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalLoadBalancerHealthCheckOptions(a.Options, b.Options) &&
+		a.Vip == b.Vip
+}
+
+func (a *LoadBalancerHealthCheck) EqualsModel(b model.Model) bool {
+	c := b.(*LoadBalancerHealthCheck)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LoadBalancerHealthCheck{}
+var _ model.ComparableModel = &LoadBalancerHealthCheck{}

--- a/go-controller/pkg/nbdb/logical_router.go
+++ b/go-controller/pkg/nbdb/logical_router.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // LogicalRouter defines an object in Logical_Router table
 type LogicalRouter struct {
 	UUID              string            `ovsdb:"_uuid"`
@@ -18,3 +20,287 @@ type LogicalRouter struct {
 	Ports             []string          `ovsdb:"ports"`
 	StaticRoutes      []string          `ovsdb:"static_routes"`
 }
+
+func copyLogicalRouterCopp(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalRouterCopp(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalRouterEnabled(a *bool) *bool {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalRouterEnabled(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalRouterExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterLoadBalancer(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterLoadBalancer(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterLoadBalancerGroup(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterLoadBalancerGroup(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterNat(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterNat(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPolicies(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterPolicies(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPorts(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterPorts(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterStaticRoutes(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterStaticRoutes(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *LogicalRouter) DeepCopyInto(b *LogicalRouter) {
+	*b = *a
+	b.Copp = copyLogicalRouterCopp(a.Copp)
+	b.Enabled = copyLogicalRouterEnabled(a.Enabled)
+	b.ExternalIDs = copyLogicalRouterExternalIDs(a.ExternalIDs)
+	b.LoadBalancer = copyLogicalRouterLoadBalancer(a.LoadBalancer)
+	b.LoadBalancerGroup = copyLogicalRouterLoadBalancerGroup(a.LoadBalancerGroup)
+	b.Nat = copyLogicalRouterNat(a.Nat)
+	b.Options = copyLogicalRouterOptions(a.Options)
+	b.Policies = copyLogicalRouterPolicies(a.Policies)
+	b.Ports = copyLogicalRouterPorts(a.Ports)
+	b.StaticRoutes = copyLogicalRouterStaticRoutes(a.StaticRoutes)
+}
+
+func (a *LogicalRouter) DeepCopy() *LogicalRouter {
+	b := new(LogicalRouter)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LogicalRouter) CloneModelInto(b model.Model) {
+	c := b.(*LogicalRouter)
+	a.DeepCopyInto(c)
+}
+
+func (a *LogicalRouter) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LogicalRouter) Equals(b *LogicalRouter) bool {
+	return a.UUID == b.UUID &&
+		equalLogicalRouterCopp(a.Copp, b.Copp) &&
+		equalLogicalRouterEnabled(a.Enabled, b.Enabled) &&
+		equalLogicalRouterExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalLogicalRouterLoadBalancer(a.LoadBalancer, b.LoadBalancer) &&
+		equalLogicalRouterLoadBalancerGroup(a.LoadBalancerGroup, b.LoadBalancerGroup) &&
+		a.Name == b.Name &&
+		equalLogicalRouterNat(a.Nat, b.Nat) &&
+		equalLogicalRouterOptions(a.Options, b.Options) &&
+		equalLogicalRouterPolicies(a.Policies, b.Policies) &&
+		equalLogicalRouterPorts(a.Ports, b.Ports) &&
+		equalLogicalRouterStaticRoutes(a.StaticRoutes, b.StaticRoutes)
+}
+
+func (a *LogicalRouter) EqualsModel(b model.Model) bool {
+	c := b.(*LogicalRouter)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LogicalRouter{}
+var _ model.ComparableModel = &LogicalRouter{}

--- a/go-controller/pkg/nbdb/logical_router_policy.go
+++ b/go-controller/pkg/nbdb/logical_router_policy.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	LogicalRouterPolicyAction = string
 )
@@ -24,3 +26,139 @@ type LogicalRouterPolicy struct {
 	Options     map[string]string         `ovsdb:"options"`
 	Priority    int                       `ovsdb:"priority"`
 }
+
+func copyLogicalRouterPolicyExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterPolicyExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPolicyNexthop(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalRouterPolicyNexthop(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalRouterPolicyNexthops(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterPolicyNexthops(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPolicyOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterPolicyOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *LogicalRouterPolicy) DeepCopyInto(b *LogicalRouterPolicy) {
+	*b = *a
+	b.ExternalIDs = copyLogicalRouterPolicyExternalIDs(a.ExternalIDs)
+	b.Nexthop = copyLogicalRouterPolicyNexthop(a.Nexthop)
+	b.Nexthops = copyLogicalRouterPolicyNexthops(a.Nexthops)
+	b.Options = copyLogicalRouterPolicyOptions(a.Options)
+}
+
+func (a *LogicalRouterPolicy) DeepCopy() *LogicalRouterPolicy {
+	b := new(LogicalRouterPolicy)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LogicalRouterPolicy) CloneModelInto(b model.Model) {
+	c := b.(*LogicalRouterPolicy)
+	a.DeepCopyInto(c)
+}
+
+func (a *LogicalRouterPolicy) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LogicalRouterPolicy) Equals(b *LogicalRouterPolicy) bool {
+	return a.UUID == b.UUID &&
+		a.Action == b.Action &&
+		equalLogicalRouterPolicyExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Match == b.Match &&
+		equalLogicalRouterPolicyNexthop(a.Nexthop, b.Nexthop) &&
+		equalLogicalRouterPolicyNexthops(a.Nexthops, b.Nexthops) &&
+		equalLogicalRouterPolicyOptions(a.Options, b.Options) &&
+		a.Priority == b.Priority
+}
+
+func (a *LogicalRouterPolicy) EqualsModel(b model.Model) bool {
+	c := b.(*LogicalRouterPolicy)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LogicalRouterPolicy{}
+var _ model.ComparableModel = &LogicalRouterPolicy{}

--- a/go-controller/pkg/nbdb/logical_router_port.go
+++ b/go-controller/pkg/nbdb/logical_router_port.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // LogicalRouterPort defines an object in Logical_Router_Port table
 type LogicalRouterPort struct {
 	UUID           string            `ovsdb:"_uuid"`
@@ -18,3 +20,258 @@ type LogicalRouterPort struct {
 	Options        map[string]string `ovsdb:"options"`
 	Peer           *string           `ovsdb:"peer"`
 }
+
+func copyLogicalRouterPortEnabled(a *bool) *bool {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalRouterPortEnabled(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalRouterPortExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterPortExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPortGatewayChassis(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterPortGatewayChassis(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPortHaChassisGroup(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalRouterPortHaChassisGroup(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalRouterPortIpv6Prefix(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterPortIpv6Prefix(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPortIpv6RaConfigs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterPortIpv6RaConfigs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPortNetworks(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalRouterPortNetworks(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPortOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterPortOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterPortPeer(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalRouterPortPeer(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *LogicalRouterPort) DeepCopyInto(b *LogicalRouterPort) {
+	*b = *a
+	b.Enabled = copyLogicalRouterPortEnabled(a.Enabled)
+	b.ExternalIDs = copyLogicalRouterPortExternalIDs(a.ExternalIDs)
+	b.GatewayChassis = copyLogicalRouterPortGatewayChassis(a.GatewayChassis)
+	b.HaChassisGroup = copyLogicalRouterPortHaChassisGroup(a.HaChassisGroup)
+	b.Ipv6Prefix = copyLogicalRouterPortIpv6Prefix(a.Ipv6Prefix)
+	b.Ipv6RaConfigs = copyLogicalRouterPortIpv6RaConfigs(a.Ipv6RaConfigs)
+	b.Networks = copyLogicalRouterPortNetworks(a.Networks)
+	b.Options = copyLogicalRouterPortOptions(a.Options)
+	b.Peer = copyLogicalRouterPortPeer(a.Peer)
+}
+
+func (a *LogicalRouterPort) DeepCopy() *LogicalRouterPort {
+	b := new(LogicalRouterPort)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LogicalRouterPort) CloneModelInto(b model.Model) {
+	c := b.(*LogicalRouterPort)
+	a.DeepCopyInto(c)
+}
+
+func (a *LogicalRouterPort) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LogicalRouterPort) Equals(b *LogicalRouterPort) bool {
+	return a.UUID == b.UUID &&
+		equalLogicalRouterPortEnabled(a.Enabled, b.Enabled) &&
+		equalLogicalRouterPortExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalLogicalRouterPortGatewayChassis(a.GatewayChassis, b.GatewayChassis) &&
+		equalLogicalRouterPortHaChassisGroup(a.HaChassisGroup, b.HaChassisGroup) &&
+		equalLogicalRouterPortIpv6Prefix(a.Ipv6Prefix, b.Ipv6Prefix) &&
+		equalLogicalRouterPortIpv6RaConfigs(a.Ipv6RaConfigs, b.Ipv6RaConfigs) &&
+		a.MAC == b.MAC &&
+		a.Name == b.Name &&
+		equalLogicalRouterPortNetworks(a.Networks, b.Networks) &&
+		equalLogicalRouterPortOptions(a.Options, b.Options) &&
+		equalLogicalRouterPortPeer(a.Peer, b.Peer)
+}
+
+func (a *LogicalRouterPort) EqualsModel(b model.Model) bool {
+	c := b.(*LogicalRouterPort)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LogicalRouterPort{}
+var _ model.ComparableModel = &LogicalRouterPort{}

--- a/go-controller/pkg/nbdb/logical_router_static_route.go
+++ b/go-controller/pkg/nbdb/logical_router_static_route.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	LogicalRouterStaticRoutePolicy = string
 )
@@ -23,3 +25,152 @@ type LogicalRouterStaticRoute struct {
 	OutputPort  *string                         `ovsdb:"output_port"`
 	Policy      *LogicalRouterStaticRoutePolicy `ovsdb:"policy"`
 }
+
+func copyLogicalRouterStaticRouteBFD(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalRouterStaticRouteBFD(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalRouterStaticRouteExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterStaticRouteExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterStaticRouteOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalRouterStaticRouteOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalRouterStaticRouteOutputPort(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalRouterStaticRouteOutputPort(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalRouterStaticRoutePolicy(a *LogicalRouterStaticRoutePolicy) *LogicalRouterStaticRoutePolicy {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalRouterStaticRoutePolicy(a, b *LogicalRouterStaticRoutePolicy) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *LogicalRouterStaticRoute) DeepCopyInto(b *LogicalRouterStaticRoute) {
+	*b = *a
+	b.BFD = copyLogicalRouterStaticRouteBFD(a.BFD)
+	b.ExternalIDs = copyLogicalRouterStaticRouteExternalIDs(a.ExternalIDs)
+	b.Options = copyLogicalRouterStaticRouteOptions(a.Options)
+	b.OutputPort = copyLogicalRouterStaticRouteOutputPort(a.OutputPort)
+	b.Policy = copyLogicalRouterStaticRoutePolicy(a.Policy)
+}
+
+func (a *LogicalRouterStaticRoute) DeepCopy() *LogicalRouterStaticRoute {
+	b := new(LogicalRouterStaticRoute)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LogicalRouterStaticRoute) CloneModelInto(b model.Model) {
+	c := b.(*LogicalRouterStaticRoute)
+	a.DeepCopyInto(c)
+}
+
+func (a *LogicalRouterStaticRoute) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LogicalRouterStaticRoute) Equals(b *LogicalRouterStaticRoute) bool {
+	return a.UUID == b.UUID &&
+		equalLogicalRouterStaticRouteBFD(a.BFD, b.BFD) &&
+		equalLogicalRouterStaticRouteExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.IPPrefix == b.IPPrefix &&
+		a.Nexthop == b.Nexthop &&
+		equalLogicalRouterStaticRouteOptions(a.Options, b.Options) &&
+		equalLogicalRouterStaticRouteOutputPort(a.OutputPort, b.OutputPort) &&
+		equalLogicalRouterStaticRoutePolicy(a.Policy, b.Policy)
+}
+
+func (a *LogicalRouterStaticRoute) EqualsModel(b model.Model) bool {
+	c := b.(*LogicalRouterStaticRoute)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LogicalRouterStaticRoute{}
+var _ model.ComparableModel = &LogicalRouterStaticRoute{}

--- a/go-controller/pkg/nbdb/logical_switch.go
+++ b/go-controller/pkg/nbdb/logical_switch.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // LogicalSwitch defines an object in Logical_Switch table
 type LogicalSwitch struct {
 	UUID              string            `ovsdb:"_uuid"`
@@ -18,3 +20,293 @@ type LogicalSwitch struct {
 	Ports             []string          `ovsdb:"ports"`
 	QOSRules          []string          `ovsdb:"qos_rules"`
 }
+
+func copyLogicalSwitchACLs(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalSwitchACLs(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchCopp(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchCopp(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalSwitchDNSRecords(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalSwitchDNSRecords(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalSwitchExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchForwardingGroups(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalSwitchForwardingGroups(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchLoadBalancer(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalSwitchLoadBalancer(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchLoadBalancerGroup(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalSwitchLoadBalancerGroup(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchOtherConfig(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalSwitchOtherConfig(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchPorts(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalSwitchPorts(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchQOSRules(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalSwitchQOSRules(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *LogicalSwitch) DeepCopyInto(b *LogicalSwitch) {
+	*b = *a
+	b.ACLs = copyLogicalSwitchACLs(a.ACLs)
+	b.Copp = copyLogicalSwitchCopp(a.Copp)
+	b.DNSRecords = copyLogicalSwitchDNSRecords(a.DNSRecords)
+	b.ExternalIDs = copyLogicalSwitchExternalIDs(a.ExternalIDs)
+	b.ForwardingGroups = copyLogicalSwitchForwardingGroups(a.ForwardingGroups)
+	b.LoadBalancer = copyLogicalSwitchLoadBalancer(a.LoadBalancer)
+	b.LoadBalancerGroup = copyLogicalSwitchLoadBalancerGroup(a.LoadBalancerGroup)
+	b.OtherConfig = copyLogicalSwitchOtherConfig(a.OtherConfig)
+	b.Ports = copyLogicalSwitchPorts(a.Ports)
+	b.QOSRules = copyLogicalSwitchQOSRules(a.QOSRules)
+}
+
+func (a *LogicalSwitch) DeepCopy() *LogicalSwitch {
+	b := new(LogicalSwitch)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LogicalSwitch) CloneModelInto(b model.Model) {
+	c := b.(*LogicalSwitch)
+	a.DeepCopyInto(c)
+}
+
+func (a *LogicalSwitch) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LogicalSwitch) Equals(b *LogicalSwitch) bool {
+	return a.UUID == b.UUID &&
+		equalLogicalSwitchACLs(a.ACLs, b.ACLs) &&
+		equalLogicalSwitchCopp(a.Copp, b.Copp) &&
+		equalLogicalSwitchDNSRecords(a.DNSRecords, b.DNSRecords) &&
+		equalLogicalSwitchExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalLogicalSwitchForwardingGroups(a.ForwardingGroups, b.ForwardingGroups) &&
+		equalLogicalSwitchLoadBalancer(a.LoadBalancer, b.LoadBalancer) &&
+		equalLogicalSwitchLoadBalancerGroup(a.LoadBalancerGroup, b.LoadBalancerGroup) &&
+		a.Name == b.Name &&
+		equalLogicalSwitchOtherConfig(a.OtherConfig, b.OtherConfig) &&
+		equalLogicalSwitchPorts(a.Ports, b.Ports) &&
+		equalLogicalSwitchQOSRules(a.QOSRules, b.QOSRules)
+}
+
+func (a *LogicalSwitch) EqualsModel(b model.Model) bool {
+	c := b.(*LogicalSwitch)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LogicalSwitch{}
+var _ model.ComparableModel = &LogicalSwitch{}

--- a/go-controller/pkg/nbdb/logical_switch_port.go
+++ b/go-controller/pkg/nbdb/logical_switch_port.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // LogicalSwitchPort defines an object in Logical_Switch_Port table
 type LogicalSwitchPort struct {
 	UUID             string            `ovsdb:"_uuid"`
@@ -22,3 +24,324 @@ type LogicalSwitchPort struct {
 	Type             string            `ovsdb:"type"`
 	Up               *bool             `ovsdb:"up"`
 }
+
+func copyLogicalSwitchPortAddresses(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalSwitchPortAddresses(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchPortDhcpv4Options(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchPortDhcpv4Options(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalSwitchPortDhcpv6Options(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchPortDhcpv6Options(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalSwitchPortDynamicAddresses(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchPortDynamicAddresses(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalSwitchPortEnabled(a *bool) *bool {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchPortEnabled(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalSwitchPortExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalSwitchPortExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchPortHaChassisGroup(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchPortHaChassisGroup(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalSwitchPortOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalSwitchPortOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchPortParentName(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchPortParentName(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalSwitchPortPortSecurity(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalSwitchPortPortSecurity(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalSwitchPortTag(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchPortTag(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalSwitchPortTagRequest(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchPortTagRequest(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalSwitchPortUp(a *bool) *bool {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalSwitchPortUp(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *LogicalSwitchPort) DeepCopyInto(b *LogicalSwitchPort) {
+	*b = *a
+	b.Addresses = copyLogicalSwitchPortAddresses(a.Addresses)
+	b.Dhcpv4Options = copyLogicalSwitchPortDhcpv4Options(a.Dhcpv4Options)
+	b.Dhcpv6Options = copyLogicalSwitchPortDhcpv6Options(a.Dhcpv6Options)
+	b.DynamicAddresses = copyLogicalSwitchPortDynamicAddresses(a.DynamicAddresses)
+	b.Enabled = copyLogicalSwitchPortEnabled(a.Enabled)
+	b.ExternalIDs = copyLogicalSwitchPortExternalIDs(a.ExternalIDs)
+	b.HaChassisGroup = copyLogicalSwitchPortHaChassisGroup(a.HaChassisGroup)
+	b.Options = copyLogicalSwitchPortOptions(a.Options)
+	b.ParentName = copyLogicalSwitchPortParentName(a.ParentName)
+	b.PortSecurity = copyLogicalSwitchPortPortSecurity(a.PortSecurity)
+	b.Tag = copyLogicalSwitchPortTag(a.Tag)
+	b.TagRequest = copyLogicalSwitchPortTagRequest(a.TagRequest)
+	b.Up = copyLogicalSwitchPortUp(a.Up)
+}
+
+func (a *LogicalSwitchPort) DeepCopy() *LogicalSwitchPort {
+	b := new(LogicalSwitchPort)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LogicalSwitchPort) CloneModelInto(b model.Model) {
+	c := b.(*LogicalSwitchPort)
+	a.DeepCopyInto(c)
+}
+
+func (a *LogicalSwitchPort) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LogicalSwitchPort) Equals(b *LogicalSwitchPort) bool {
+	return a.UUID == b.UUID &&
+		equalLogicalSwitchPortAddresses(a.Addresses, b.Addresses) &&
+		equalLogicalSwitchPortDhcpv4Options(a.Dhcpv4Options, b.Dhcpv4Options) &&
+		equalLogicalSwitchPortDhcpv6Options(a.Dhcpv6Options, b.Dhcpv6Options) &&
+		equalLogicalSwitchPortDynamicAddresses(a.DynamicAddresses, b.DynamicAddresses) &&
+		equalLogicalSwitchPortEnabled(a.Enabled, b.Enabled) &&
+		equalLogicalSwitchPortExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalLogicalSwitchPortHaChassisGroup(a.HaChassisGroup, b.HaChassisGroup) &&
+		a.Name == b.Name &&
+		equalLogicalSwitchPortOptions(a.Options, b.Options) &&
+		equalLogicalSwitchPortParentName(a.ParentName, b.ParentName) &&
+		equalLogicalSwitchPortPortSecurity(a.PortSecurity, b.PortSecurity) &&
+		equalLogicalSwitchPortTag(a.Tag, b.Tag) &&
+		equalLogicalSwitchPortTagRequest(a.TagRequest, b.TagRequest) &&
+		a.Type == b.Type &&
+		equalLogicalSwitchPortUp(a.Up, b.Up)
+}
+
+func (a *LogicalSwitchPort) EqualsModel(b model.Model) bool {
+	c := b.(*LogicalSwitchPort)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LogicalSwitchPort{}
+var _ model.ComparableModel = &LogicalSwitchPort{}

--- a/go-controller/pkg/nbdb/meter.go
+++ b/go-controller/pkg/nbdb/meter.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	MeterUnit = string
 )
@@ -21,3 +23,110 @@ type Meter struct {
 	Name        string            `ovsdb:"name"`
 	Unit        MeterUnit         `ovsdb:"unit"`
 }
+
+func copyMeterBands(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalMeterBands(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyMeterExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalMeterExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyMeterFair(a *bool) *bool {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalMeterFair(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *Meter) DeepCopyInto(b *Meter) {
+	*b = *a
+	b.Bands = copyMeterBands(a.Bands)
+	b.ExternalIDs = copyMeterExternalIDs(a.ExternalIDs)
+	b.Fair = copyMeterFair(a.Fair)
+}
+
+func (a *Meter) DeepCopy() *Meter {
+	b := new(Meter)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *Meter) CloneModelInto(b model.Model) {
+	c := b.(*Meter)
+	a.DeepCopyInto(c)
+}
+
+func (a *Meter) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *Meter) Equals(b *Meter) bool {
+	return a.UUID == b.UUID &&
+		equalMeterBands(a.Bands, b.Bands) &&
+		equalMeterExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalMeterFair(a.Fair, b.Fair) &&
+		a.Name == b.Name &&
+		a.Unit == b.Unit
+}
+
+func (a *Meter) EqualsModel(b model.Model) bool {
+	c := b.(*Meter)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &Meter{}
+var _ model.ComparableModel = &Meter{}

--- a/go-controller/pkg/nbdb/meter_band.go
+++ b/go-controller/pkg/nbdb/meter_band.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	MeterBandAction = string
 )
@@ -19,3 +21,65 @@ type MeterBand struct {
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Rate        int               `ovsdb:"rate"`
 }
+
+func copyMeterBandExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalMeterBandExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *MeterBand) DeepCopyInto(b *MeterBand) {
+	*b = *a
+	b.ExternalIDs = copyMeterBandExternalIDs(a.ExternalIDs)
+}
+
+func (a *MeterBand) DeepCopy() *MeterBand {
+	b := new(MeterBand)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *MeterBand) CloneModelInto(b model.Model) {
+	c := b.(*MeterBand)
+	a.DeepCopyInto(c)
+}
+
+func (a *MeterBand) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *MeterBand) Equals(b *MeterBand) bool {
+	return a.UUID == b.UUID &&
+		a.Action == b.Action &&
+		a.BurstSize == b.BurstSize &&
+		equalMeterBandExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Rate == b.Rate
+}
+
+func (a *MeterBand) EqualsModel(b model.Model) bool {
+	c := b.(*MeterBand)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &MeterBand{}
+var _ model.ComparableModel = &MeterBand{}

--- a/go-controller/pkg/nbdb/nat.go
+++ b/go-controller/pkg/nbdb/nat.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	NATType = string
 )
@@ -27,3 +29,174 @@ type NAT struct {
 	Options           map[string]string `ovsdb:"options"`
 	Type              NATType           `ovsdb:"type"`
 }
+
+func copyNATAllowedExtIPs(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalNATAllowedExtIPs(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyNATExemptedExtIPs(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalNATExemptedExtIPs(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyNATExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalNATExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyNATExternalMAC(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalNATExternalMAC(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyNATLogicalPort(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalNATLogicalPort(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyNATOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalNATOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *NAT) DeepCopyInto(b *NAT) {
+	*b = *a
+	b.AllowedExtIPs = copyNATAllowedExtIPs(a.AllowedExtIPs)
+	b.ExemptedExtIPs = copyNATExemptedExtIPs(a.ExemptedExtIPs)
+	b.ExternalIDs = copyNATExternalIDs(a.ExternalIDs)
+	b.ExternalMAC = copyNATExternalMAC(a.ExternalMAC)
+	b.LogicalPort = copyNATLogicalPort(a.LogicalPort)
+	b.Options = copyNATOptions(a.Options)
+}
+
+func (a *NAT) DeepCopy() *NAT {
+	b := new(NAT)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *NAT) CloneModelInto(b model.Model) {
+	c := b.(*NAT)
+	a.DeepCopyInto(c)
+}
+
+func (a *NAT) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *NAT) Equals(b *NAT) bool {
+	return a.UUID == b.UUID &&
+		equalNATAllowedExtIPs(a.AllowedExtIPs, b.AllowedExtIPs) &&
+		equalNATExemptedExtIPs(a.ExemptedExtIPs, b.ExemptedExtIPs) &&
+		equalNATExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.ExternalIP == b.ExternalIP &&
+		equalNATExternalMAC(a.ExternalMAC, b.ExternalMAC) &&
+		a.ExternalPortRange == b.ExternalPortRange &&
+		a.LogicalIP == b.LogicalIP &&
+		equalNATLogicalPort(a.LogicalPort, b.LogicalPort) &&
+		equalNATOptions(a.Options, b.Options) &&
+		a.Type == b.Type
+}
+
+func (a *NAT) EqualsModel(b model.Model) bool {
+	c := b.(*NAT)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &NAT{}
+var _ model.ComparableModel = &NAT{}

--- a/go-controller/pkg/nbdb/nb_global.go
+++ b/go-controller/pkg/nbdb/nb_global.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // NBGlobal defines an object in NB_Global table
 type NBGlobal struct {
 	UUID           string            `ovsdb:"_uuid"`
@@ -19,3 +21,144 @@ type NBGlobal struct {
 	SbCfgTimestamp int               `ovsdb:"sb_cfg_timestamp"`
 	SSL            *string           `ovsdb:"ssl"`
 }
+
+func copyNBGlobalConnections(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalNBGlobalConnections(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyNBGlobalExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalNBGlobalExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyNBGlobalOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalNBGlobalOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyNBGlobalSSL(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalNBGlobalSSL(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *NBGlobal) DeepCopyInto(b *NBGlobal) {
+	*b = *a
+	b.Connections = copyNBGlobalConnections(a.Connections)
+	b.ExternalIDs = copyNBGlobalExternalIDs(a.ExternalIDs)
+	b.Options = copyNBGlobalOptions(a.Options)
+	b.SSL = copyNBGlobalSSL(a.SSL)
+}
+
+func (a *NBGlobal) DeepCopy() *NBGlobal {
+	b := new(NBGlobal)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *NBGlobal) CloneModelInto(b model.Model) {
+	c := b.(*NBGlobal)
+	a.DeepCopyInto(c)
+}
+
+func (a *NBGlobal) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *NBGlobal) Equals(b *NBGlobal) bool {
+	return a.UUID == b.UUID &&
+		equalNBGlobalConnections(a.Connections, b.Connections) &&
+		equalNBGlobalExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.HvCfg == b.HvCfg &&
+		a.HvCfgTimestamp == b.HvCfgTimestamp &&
+		a.Ipsec == b.Ipsec &&
+		a.Name == b.Name &&
+		a.NbCfg == b.NbCfg &&
+		a.NbCfgTimestamp == b.NbCfgTimestamp &&
+		equalNBGlobalOptions(a.Options, b.Options) &&
+		a.SbCfg == b.SbCfg &&
+		a.SbCfgTimestamp == b.SbCfgTimestamp &&
+		equalNBGlobalSSL(a.SSL, b.SSL)
+}
+
+func (a *NBGlobal) EqualsModel(b model.Model) bool {
+	c := b.(*NBGlobal)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &NBGlobal{}
+var _ model.ComparableModel = &NBGlobal{}

--- a/go-controller/pkg/nbdb/port_group.go
+++ b/go-controller/pkg/nbdb/port_group.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // PortGroup defines an object in Port_Group table
 type PortGroup struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -11,3 +13,115 @@ type PortGroup struct {
 	Name        string            `ovsdb:"name"`
 	Ports       []string          `ovsdb:"ports"`
 }
+
+func copyPortGroupACLs(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalPortGroupACLs(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyPortGroupExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalPortGroupExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyPortGroupPorts(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalPortGroupPorts(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *PortGroup) DeepCopyInto(b *PortGroup) {
+	*b = *a
+	b.ACLs = copyPortGroupACLs(a.ACLs)
+	b.ExternalIDs = copyPortGroupExternalIDs(a.ExternalIDs)
+	b.Ports = copyPortGroupPorts(a.Ports)
+}
+
+func (a *PortGroup) DeepCopy() *PortGroup {
+	b := new(PortGroup)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *PortGroup) CloneModelInto(b model.Model) {
+	c := b.(*PortGroup)
+	a.DeepCopyInto(c)
+}
+
+func (a *PortGroup) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *PortGroup) Equals(b *PortGroup) bool {
+	return a.UUID == b.UUID &&
+		equalPortGroupACLs(a.ACLs, b.ACLs) &&
+		equalPortGroupExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Name == b.Name &&
+		equalPortGroupPorts(a.Ports, b.Ports)
+}
+
+func (a *PortGroup) EqualsModel(b model.Model) bool {
+	c := b.(*PortGroup)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &PortGroup{}
+var _ model.ComparableModel = &PortGroup{}

--- a/go-controller/pkg/nbdb/qos.go
+++ b/go-controller/pkg/nbdb/qos.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	QoSAction    = string
 	QoSBandwidth = string
@@ -27,3 +29,121 @@ type QoS struct {
 	Match       string            `ovsdb:"match"`
 	Priority    int               `ovsdb:"priority"`
 }
+
+func copyQoSAction(a map[string]int) map[string]int {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]int, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalQoSAction(a, b map[string]int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyQoSBandwidth(a map[string]int) map[string]int {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]int, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalQoSBandwidth(a, b map[string]int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyQoSExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalQoSExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *QoS) DeepCopyInto(b *QoS) {
+	*b = *a
+	b.Action = copyQoSAction(a.Action)
+	b.Bandwidth = copyQoSBandwidth(a.Bandwidth)
+	b.ExternalIDs = copyQoSExternalIDs(a.ExternalIDs)
+}
+
+func (a *QoS) DeepCopy() *QoS {
+	b := new(QoS)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *QoS) CloneModelInto(b model.Model) {
+	c := b.(*QoS)
+	a.DeepCopyInto(c)
+}
+
+func (a *QoS) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *QoS) Equals(b *QoS) bool {
+	return a.UUID == b.UUID &&
+		equalQoSAction(a.Action, b.Action) &&
+		equalQoSBandwidth(a.Bandwidth, b.Bandwidth) &&
+		a.Direction == b.Direction &&
+		equalQoSExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Match == b.Match &&
+		a.Priority == b.Priority
+}
+
+func (a *QoS) EqualsModel(b model.Model) bool {
+	c := b.(*QoS)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &QoS{}
+var _ model.ComparableModel = &QoS{}

--- a/go-controller/pkg/nbdb/ssl.go
+++ b/go-controller/pkg/nbdb/ssl.go
@@ -3,6 +3,8 @@
 
 package nbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // SSL defines an object in SSL table
 type SSL struct {
 	UUID            string            `ovsdb:"_uuid"`
@@ -14,3 +16,68 @@ type SSL struct {
 	SSLCiphers      string            `ovsdb:"ssl_ciphers"`
 	SSLProtocols    string            `ovsdb:"ssl_protocols"`
 }
+
+func copySSLExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalSSLExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *SSL) DeepCopyInto(b *SSL) {
+	*b = *a
+	b.ExternalIDs = copySSLExternalIDs(a.ExternalIDs)
+}
+
+func (a *SSL) DeepCopy() *SSL {
+	b := new(SSL)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *SSL) CloneModelInto(b model.Model) {
+	c := b.(*SSL)
+	a.DeepCopyInto(c)
+}
+
+func (a *SSL) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *SSL) Equals(b *SSL) bool {
+	return a.UUID == b.UUID &&
+		a.BootstrapCaCert == b.BootstrapCaCert &&
+		a.CaCert == b.CaCert &&
+		a.Certificate == b.Certificate &&
+		equalSSLExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.PrivateKey == b.PrivateKey &&
+		a.SSLCiphers == b.SSLCiphers &&
+		a.SSLProtocols == b.SSLProtocols
+}
+
+func (a *SSL) EqualsModel(b model.Model) bool {
+	c := b.(*SSL)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &SSL{}
+var _ model.ComparableModel = &SSL{}

--- a/go-controller/pkg/sbdb/address_set.go
+++ b/go-controller/pkg/sbdb/address_set.go
@@ -3,9 +3,69 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // AddressSet defines an object in Address_Set table
 type AddressSet struct {
 	UUID      string   `ovsdb:"_uuid"`
 	Addresses []string `ovsdb:"addresses"`
 	Name      string   `ovsdb:"name"`
 }
+
+func copyAddressSetAddresses(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalAddressSetAddresses(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *AddressSet) DeepCopyInto(b *AddressSet) {
+	*b = *a
+	b.Addresses = copyAddressSetAddresses(a.Addresses)
+}
+
+func (a *AddressSet) DeepCopy() *AddressSet {
+	b := new(AddressSet)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *AddressSet) CloneModelInto(b model.Model) {
+	c := b.(*AddressSet)
+	a.DeepCopyInto(c)
+}
+
+func (a *AddressSet) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *AddressSet) Equals(b *AddressSet) bool {
+	return a.UUID == b.UUID &&
+		equalAddressSetAddresses(a.Addresses, b.Addresses) &&
+		a.Name == b.Name
+}
+
+func (a *AddressSet) EqualsModel(b model.Model) bool {
+	c := b.(*AddressSet)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &AddressSet{}
+var _ model.ComparableModel = &AddressSet{}

--- a/go-controller/pkg/sbdb/bfd.go
+++ b/go-controller/pkg/sbdb/bfd.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	BFDStatus = string
 )
@@ -28,3 +30,98 @@ type BFD struct {
 	SrcPort     int               `ovsdb:"src_port"`
 	Status      BFDStatus         `ovsdb:"status"`
 }
+
+func copyBFDExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalBFDExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyBFDOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalBFDOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *BFD) DeepCopyInto(b *BFD) {
+	*b = *a
+	b.ExternalIDs = copyBFDExternalIDs(a.ExternalIDs)
+	b.Options = copyBFDOptions(a.Options)
+}
+
+func (a *BFD) DeepCopy() *BFD {
+	b := new(BFD)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *BFD) CloneModelInto(b model.Model) {
+	c := b.(*BFD)
+	a.DeepCopyInto(c)
+}
+
+func (a *BFD) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *BFD) Equals(b *BFD) bool {
+	return a.UUID == b.UUID &&
+		a.DetectMult == b.DetectMult &&
+		a.Disc == b.Disc &&
+		a.DstIP == b.DstIP &&
+		equalBFDExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.LogicalPort == b.LogicalPort &&
+		a.MinRx == b.MinRx &&
+		a.MinTx == b.MinTx &&
+		equalBFDOptions(a.Options, b.Options) &&
+		a.SrcPort == b.SrcPort &&
+		a.Status == b.Status
+}
+
+func (a *BFD) EqualsModel(b model.Model) bool {
+	c := b.(*BFD)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &BFD{}
+var _ model.ComparableModel = &BFD{}

--- a/go-controller/pkg/sbdb/chassis.go
+++ b/go-controller/pkg/sbdb/chassis.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // Chassis defines an object in Chassis table
 type Chassis struct {
 	UUID                string            `ovsdb:"_uuid"`
@@ -15,3 +17,171 @@ type Chassis struct {
 	TransportZones      []string          `ovsdb:"transport_zones"`
 	VtepLogicalSwitches []string          `ovsdb:"vtep_logical_switches"`
 }
+
+func copyChassisEncaps(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalChassisEncaps(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyChassisExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalChassisExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyChassisOtherConfig(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalChassisOtherConfig(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyChassisTransportZones(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalChassisTransportZones(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyChassisVtepLogicalSwitches(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalChassisVtepLogicalSwitches(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *Chassis) DeepCopyInto(b *Chassis) {
+	*b = *a
+	b.Encaps = copyChassisEncaps(a.Encaps)
+	b.ExternalIDs = copyChassisExternalIDs(a.ExternalIDs)
+	b.OtherConfig = copyChassisOtherConfig(a.OtherConfig)
+	b.TransportZones = copyChassisTransportZones(a.TransportZones)
+	b.VtepLogicalSwitches = copyChassisVtepLogicalSwitches(a.VtepLogicalSwitches)
+}
+
+func (a *Chassis) DeepCopy() *Chassis {
+	b := new(Chassis)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *Chassis) CloneModelInto(b model.Model) {
+	c := b.(*Chassis)
+	a.DeepCopyInto(c)
+}
+
+func (a *Chassis) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *Chassis) Equals(b *Chassis) bool {
+	return a.UUID == b.UUID &&
+		equalChassisEncaps(a.Encaps, b.Encaps) &&
+		equalChassisExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Hostname == b.Hostname &&
+		a.Name == b.Name &&
+		a.NbCfg == b.NbCfg &&
+		equalChassisOtherConfig(a.OtherConfig, b.OtherConfig) &&
+		equalChassisTransportZones(a.TransportZones, b.TransportZones) &&
+		equalChassisVtepLogicalSwitches(a.VtepLogicalSwitches, b.VtepLogicalSwitches)
+}
+
+func (a *Chassis) EqualsModel(b model.Model) bool {
+	c := b.(*Chassis)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &Chassis{}
+var _ model.ComparableModel = &Chassis{}

--- a/go-controller/pkg/sbdb/chassis_private.go
+++ b/go-controller/pkg/sbdb/chassis_private.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // ChassisPrivate defines an object in Chassis_Private table
 type ChassisPrivate struct {
 	UUID           string            `ovsdb:"_uuid"`
@@ -12,3 +14,85 @@ type ChassisPrivate struct {
 	NbCfg          int               `ovsdb:"nb_cfg"`
 	NbCfgTimestamp int               `ovsdb:"nb_cfg_timestamp"`
 }
+
+func copyChassisPrivateChassis(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalChassisPrivateChassis(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyChassisPrivateExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalChassisPrivateExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *ChassisPrivate) DeepCopyInto(b *ChassisPrivate) {
+	*b = *a
+	b.Chassis = copyChassisPrivateChassis(a.Chassis)
+	b.ExternalIDs = copyChassisPrivateExternalIDs(a.ExternalIDs)
+}
+
+func (a *ChassisPrivate) DeepCopy() *ChassisPrivate {
+	b := new(ChassisPrivate)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *ChassisPrivate) CloneModelInto(b model.Model) {
+	c := b.(*ChassisPrivate)
+	a.DeepCopyInto(c)
+}
+
+func (a *ChassisPrivate) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *ChassisPrivate) Equals(b *ChassisPrivate) bool {
+	return a.UUID == b.UUID &&
+		equalChassisPrivateChassis(a.Chassis, b.Chassis) &&
+		equalChassisPrivateExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Name == b.Name &&
+		a.NbCfg == b.NbCfg &&
+		a.NbCfgTimestamp == b.NbCfgTimestamp
+}
+
+func (a *ChassisPrivate) EqualsModel(b model.Model) bool {
+	c := b.(*ChassisPrivate)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &ChassisPrivate{}
+var _ model.ComparableModel = &ChassisPrivate{}

--- a/go-controller/pkg/sbdb/connection.go
+++ b/go-controller/pkg/sbdb/connection.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // Connection defines an object in Connection table
 type Connection struct {
 	UUID            string            `ovsdb:"_uuid"`
@@ -16,3 +18,162 @@ type Connection struct {
 	Status          map[string]string `ovsdb:"status"`
 	Target          string            `ovsdb:"target"`
 }
+
+func copyConnectionExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalConnectionExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyConnectionInactivityProbe(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalConnectionInactivityProbe(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyConnectionMaxBackoff(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalConnectionMaxBackoff(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyConnectionOtherConfig(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalConnectionOtherConfig(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyConnectionStatus(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalConnectionStatus(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *Connection) DeepCopyInto(b *Connection) {
+	*b = *a
+	b.ExternalIDs = copyConnectionExternalIDs(a.ExternalIDs)
+	b.InactivityProbe = copyConnectionInactivityProbe(a.InactivityProbe)
+	b.MaxBackoff = copyConnectionMaxBackoff(a.MaxBackoff)
+	b.OtherConfig = copyConnectionOtherConfig(a.OtherConfig)
+	b.Status = copyConnectionStatus(a.Status)
+}
+
+func (a *Connection) DeepCopy() *Connection {
+	b := new(Connection)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *Connection) CloneModelInto(b model.Model) {
+	c := b.(*Connection)
+	a.DeepCopyInto(c)
+}
+
+func (a *Connection) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *Connection) Equals(b *Connection) bool {
+	return a.UUID == b.UUID &&
+		equalConnectionExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalConnectionInactivityProbe(a.InactivityProbe, b.InactivityProbe) &&
+		a.IsConnected == b.IsConnected &&
+		equalConnectionMaxBackoff(a.MaxBackoff, b.MaxBackoff) &&
+		equalConnectionOtherConfig(a.OtherConfig, b.OtherConfig) &&
+		a.ReadOnly == b.ReadOnly &&
+		a.Role == b.Role &&
+		equalConnectionStatus(a.Status, b.Status) &&
+		a.Target == b.Target
+}
+
+func (a *Connection) EqualsModel(b model.Model) bool {
+	c := b.(*Connection)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &Connection{}
+var _ model.ComparableModel = &Connection{}

--- a/go-controller/pkg/sbdb/controller_event.go
+++ b/go-controller/pkg/sbdb/controller_event.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	ControllerEventEventType = string
 )
@@ -19,3 +21,84 @@ type ControllerEvent struct {
 	EventType ControllerEventEventType `ovsdb:"event_type"`
 	SeqNum    int                      `ovsdb:"seq_num"`
 }
+
+func copyControllerEventChassis(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalControllerEventChassis(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyControllerEventEventInfo(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalControllerEventEventInfo(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *ControllerEvent) DeepCopyInto(b *ControllerEvent) {
+	*b = *a
+	b.Chassis = copyControllerEventChassis(a.Chassis)
+	b.EventInfo = copyControllerEventEventInfo(a.EventInfo)
+}
+
+func (a *ControllerEvent) DeepCopy() *ControllerEvent {
+	b := new(ControllerEvent)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *ControllerEvent) CloneModelInto(b model.Model) {
+	c := b.(*ControllerEvent)
+	a.DeepCopyInto(c)
+}
+
+func (a *ControllerEvent) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *ControllerEvent) Equals(b *ControllerEvent) bool {
+	return a.UUID == b.UUID &&
+		equalControllerEventChassis(a.Chassis, b.Chassis) &&
+		equalControllerEventEventInfo(a.EventInfo, b.EventInfo) &&
+		a.EventType == b.EventType &&
+		a.SeqNum == b.SeqNum
+}
+
+func (a *ControllerEvent) EqualsModel(b model.Model) bool {
+	c := b.(*ControllerEvent)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &ControllerEvent{}
+var _ model.ComparableModel = &ControllerEvent{}

--- a/go-controller/pkg/sbdb/datapath_binding.go
+++ b/go-controller/pkg/sbdb/datapath_binding.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // DatapathBinding defines an object in Datapath_Binding table
 type DatapathBinding struct {
 	UUID          string            `ovsdb:"_uuid"`
@@ -10,3 +12,89 @@ type DatapathBinding struct {
 	LoadBalancers []string          `ovsdb:"load_balancers"`
 	TunnelKey     int               `ovsdb:"tunnel_key"`
 }
+
+func copyDatapathBindingExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalDatapathBindingExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyDatapathBindingLoadBalancers(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalDatapathBindingLoadBalancers(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *DatapathBinding) DeepCopyInto(b *DatapathBinding) {
+	*b = *a
+	b.ExternalIDs = copyDatapathBindingExternalIDs(a.ExternalIDs)
+	b.LoadBalancers = copyDatapathBindingLoadBalancers(a.LoadBalancers)
+}
+
+func (a *DatapathBinding) DeepCopy() *DatapathBinding {
+	b := new(DatapathBinding)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *DatapathBinding) CloneModelInto(b model.Model) {
+	c := b.(*DatapathBinding)
+	a.DeepCopyInto(c)
+}
+
+func (a *DatapathBinding) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *DatapathBinding) Equals(b *DatapathBinding) bool {
+	return a.UUID == b.UUID &&
+		equalDatapathBindingExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalDatapathBindingLoadBalancers(a.LoadBalancers, b.LoadBalancers) &&
+		a.TunnelKey == b.TunnelKey
+}
+
+func (a *DatapathBinding) EqualsModel(b model.Model) bool {
+	c := b.(*DatapathBinding)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &DatapathBinding{}
+var _ model.ComparableModel = &DatapathBinding{}

--- a/go-controller/pkg/sbdb/dhcp_options.go
+++ b/go-controller/pkg/sbdb/dhcp_options.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	DHCPOptionsType = string
 )
@@ -26,3 +28,37 @@ type DHCPOptions struct {
 	Name string          `ovsdb:"name"`
 	Type DHCPOptionsType `ovsdb:"type"`
 }
+
+func (a *DHCPOptions) DeepCopyInto(b *DHCPOptions) {
+	*b = *a
+}
+
+func (a *DHCPOptions) DeepCopy() *DHCPOptions {
+	b := new(DHCPOptions)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *DHCPOptions) CloneModelInto(b model.Model) {
+	c := b.(*DHCPOptions)
+	a.DeepCopyInto(c)
+}
+
+func (a *DHCPOptions) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *DHCPOptions) Equals(b *DHCPOptions) bool {
+	return a.UUID == b.UUID &&
+		a.Code == b.Code &&
+		a.Name == b.Name &&
+		a.Type == b.Type
+}
+
+func (a *DHCPOptions) EqualsModel(b model.Model) bool {
+	c := b.(*DHCPOptions)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &DHCPOptions{}
+var _ model.ComparableModel = &DHCPOptions{}

--- a/go-controller/pkg/sbdb/dhcpv6_options.go
+++ b/go-controller/pkg/sbdb/dhcpv6_options.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	DHCPv6OptionsType = string
 )
@@ -20,3 +22,37 @@ type DHCPv6Options struct {
 	Name string            `ovsdb:"name"`
 	Type DHCPv6OptionsType `ovsdb:"type"`
 }
+
+func (a *DHCPv6Options) DeepCopyInto(b *DHCPv6Options) {
+	*b = *a
+}
+
+func (a *DHCPv6Options) DeepCopy() *DHCPv6Options {
+	b := new(DHCPv6Options)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *DHCPv6Options) CloneModelInto(b model.Model) {
+	c := b.(*DHCPv6Options)
+	a.DeepCopyInto(c)
+}
+
+func (a *DHCPv6Options) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *DHCPv6Options) Equals(b *DHCPv6Options) bool {
+	return a.UUID == b.UUID &&
+		a.Code == b.Code &&
+		a.Name == b.Name &&
+		a.Type == b.Type
+}
+
+func (a *DHCPv6Options) EqualsModel(b model.Model) bool {
+	c := b.(*DHCPv6Options)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &DHCPv6Options{}
+var _ model.ComparableModel = &DHCPv6Options{}

--- a/go-controller/pkg/sbdb/dns.go
+++ b/go-controller/pkg/sbdb/dns.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // DNS defines an object in DNS table
 type DNS struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -10,3 +12,116 @@ type DNS struct {
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Records     map[string]string `ovsdb:"records"`
 }
+
+func copyDNSDatapaths(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalDNSDatapaths(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyDNSExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalDNSExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyDNSRecords(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalDNSRecords(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *DNS) DeepCopyInto(b *DNS) {
+	*b = *a
+	b.Datapaths = copyDNSDatapaths(a.Datapaths)
+	b.ExternalIDs = copyDNSExternalIDs(a.ExternalIDs)
+	b.Records = copyDNSRecords(a.Records)
+}
+
+func (a *DNS) DeepCopy() *DNS {
+	b := new(DNS)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *DNS) CloneModelInto(b model.Model) {
+	c := b.(*DNS)
+	a.DeepCopyInto(c)
+}
+
+func (a *DNS) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *DNS) Equals(b *DNS) bool {
+	return a.UUID == b.UUID &&
+		equalDNSDatapaths(a.Datapaths, b.Datapaths) &&
+		equalDNSExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalDNSRecords(a.Records, b.Records)
+}
+
+func (a *DNS) EqualsModel(b model.Model) bool {
+	c := b.(*DNS)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &DNS{}
+var _ model.ComparableModel = &DNS{}

--- a/go-controller/pkg/sbdb/encap.go
+++ b/go-controller/pkg/sbdb/encap.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	EncapType = string
 )
@@ -21,3 +23,65 @@ type Encap struct {
 	Options     map[string]string `ovsdb:"options"`
 	Type        EncapType         `ovsdb:"type"`
 }
+
+func copyEncapOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalEncapOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *Encap) DeepCopyInto(b *Encap) {
+	*b = *a
+	b.Options = copyEncapOptions(a.Options)
+}
+
+func (a *Encap) DeepCopy() *Encap {
+	b := new(Encap)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *Encap) CloneModelInto(b model.Model) {
+	c := b.(*Encap)
+	a.DeepCopyInto(c)
+}
+
+func (a *Encap) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *Encap) Equals(b *Encap) bool {
+	return a.UUID == b.UUID &&
+		a.ChassisName == b.ChassisName &&
+		a.IP == b.IP &&
+		equalEncapOptions(a.Options, b.Options) &&
+		a.Type == b.Type
+}
+
+func (a *Encap) EqualsModel(b model.Model) bool {
+	c := b.(*Encap)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &Encap{}
+var _ model.ComparableModel = &Encap{}

--- a/go-controller/pkg/sbdb/fdb.go
+++ b/go-controller/pkg/sbdb/fdb.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // FDB defines an object in FDB table
 type FDB struct {
 	UUID    string `ovsdb:"_uuid"`
@@ -10,3 +12,37 @@ type FDB struct {
 	MAC     string `ovsdb:"mac"`
 	PortKey int    `ovsdb:"port_key"`
 }
+
+func (a *FDB) DeepCopyInto(b *FDB) {
+	*b = *a
+}
+
+func (a *FDB) DeepCopy() *FDB {
+	b := new(FDB)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *FDB) CloneModelInto(b model.Model) {
+	c := b.(*FDB)
+	a.DeepCopyInto(c)
+}
+
+func (a *FDB) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *FDB) Equals(b *FDB) bool {
+	return a.UUID == b.UUID &&
+		a.DpKey == b.DpKey &&
+		a.MAC == b.MAC &&
+		a.PortKey == b.PortKey
+}
+
+func (a *FDB) EqualsModel(b model.Model) bool {
+	c := b.(*FDB)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &FDB{}
+var _ model.ComparableModel = &FDB{}

--- a/go-controller/pkg/sbdb/gateway_chassis.go
+++ b/go-controller/pkg/sbdb/gateway_chassis.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // GatewayChassis defines an object in Gateway_Chassis table
 type GatewayChassis struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -12,3 +14,112 @@ type GatewayChassis struct {
 	Options     map[string]string `ovsdb:"options"`
 	Priority    int               `ovsdb:"priority"`
 }
+
+func copyGatewayChassisChassis(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalGatewayChassisChassis(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyGatewayChassisExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalGatewayChassisExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyGatewayChassisOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalGatewayChassisOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *GatewayChassis) DeepCopyInto(b *GatewayChassis) {
+	*b = *a
+	b.Chassis = copyGatewayChassisChassis(a.Chassis)
+	b.ExternalIDs = copyGatewayChassisExternalIDs(a.ExternalIDs)
+	b.Options = copyGatewayChassisOptions(a.Options)
+}
+
+func (a *GatewayChassis) DeepCopy() *GatewayChassis {
+	b := new(GatewayChassis)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *GatewayChassis) CloneModelInto(b model.Model) {
+	c := b.(*GatewayChassis)
+	a.DeepCopyInto(c)
+}
+
+func (a *GatewayChassis) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *GatewayChassis) Equals(b *GatewayChassis) bool {
+	return a.UUID == b.UUID &&
+		equalGatewayChassisChassis(a.Chassis, b.Chassis) &&
+		equalGatewayChassisExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Name == b.Name &&
+		equalGatewayChassisOptions(a.Options, b.Options) &&
+		a.Priority == b.Priority
+}
+
+func (a *GatewayChassis) EqualsModel(b model.Model) bool {
+	c := b.(*GatewayChassis)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &GatewayChassis{}
+var _ model.ComparableModel = &GatewayChassis{}

--- a/go-controller/pkg/sbdb/gen.go
+++ b/go-controller/pkg/sbdb/gen.go
@@ -1,3 +1,3 @@
 package sbdb
 
-//go:generate modelgen -p sbdb -o . ovn-sb.ovsschema
+//go:generate modelgen --extended -p sbdb -o . ovn-sb.ovsschema

--- a/go-controller/pkg/sbdb/ha_chassis.go
+++ b/go-controller/pkg/sbdb/ha_chassis.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // HAChassis defines an object in HA_Chassis table
 type HAChassis struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -10,3 +12,83 @@ type HAChassis struct {
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
 	Priority    int               `ovsdb:"priority"`
 }
+
+func copyHAChassisChassis(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalHAChassisChassis(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyHAChassisExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalHAChassisExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *HAChassis) DeepCopyInto(b *HAChassis) {
+	*b = *a
+	b.Chassis = copyHAChassisChassis(a.Chassis)
+	b.ExternalIDs = copyHAChassisExternalIDs(a.ExternalIDs)
+}
+
+func (a *HAChassis) DeepCopy() *HAChassis {
+	b := new(HAChassis)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *HAChassis) CloneModelInto(b model.Model) {
+	c := b.(*HAChassis)
+	a.DeepCopyInto(c)
+}
+
+func (a *HAChassis) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *HAChassis) Equals(b *HAChassis) bool {
+	return a.UUID == b.UUID &&
+		equalHAChassisChassis(a.Chassis, b.Chassis) &&
+		equalHAChassisExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Priority == b.Priority
+}
+
+func (a *HAChassis) EqualsModel(b model.Model) bool {
+	c := b.(*HAChassis)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &HAChassis{}
+var _ model.ComparableModel = &HAChassis{}

--- a/go-controller/pkg/sbdb/ha_chassis_group.go
+++ b/go-controller/pkg/sbdb/ha_chassis_group.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // HAChassisGroup defines an object in HA_Chassis_Group table
 type HAChassisGroup struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -11,3 +13,115 @@ type HAChassisGroup struct {
 	Name        string            `ovsdb:"name"`
 	RefChassis  []string          `ovsdb:"ref_chassis"`
 }
+
+func copyHAChassisGroupExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalHAChassisGroupExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyHAChassisGroupHaChassis(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalHAChassisGroupHaChassis(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyHAChassisGroupRefChassis(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalHAChassisGroupRefChassis(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *HAChassisGroup) DeepCopyInto(b *HAChassisGroup) {
+	*b = *a
+	b.ExternalIDs = copyHAChassisGroupExternalIDs(a.ExternalIDs)
+	b.HaChassis = copyHAChassisGroupHaChassis(a.HaChassis)
+	b.RefChassis = copyHAChassisGroupRefChassis(a.RefChassis)
+}
+
+func (a *HAChassisGroup) DeepCopy() *HAChassisGroup {
+	b := new(HAChassisGroup)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *HAChassisGroup) CloneModelInto(b model.Model) {
+	c := b.(*HAChassisGroup)
+	a.DeepCopyInto(c)
+}
+
+func (a *HAChassisGroup) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *HAChassisGroup) Equals(b *HAChassisGroup) bool {
+	return a.UUID == b.UUID &&
+		equalHAChassisGroupExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalHAChassisGroupHaChassis(a.HaChassis, b.HaChassis) &&
+		a.Name == b.Name &&
+		equalHAChassisGroupRefChassis(a.RefChassis, b.RefChassis)
+}
+
+func (a *HAChassisGroup) EqualsModel(b model.Model) bool {
+	c := b.(*HAChassisGroup)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &HAChassisGroup{}
+var _ model.ComparableModel = &HAChassisGroup{}

--- a/go-controller/pkg/sbdb/igmp_group.go
+++ b/go-controller/pkg/sbdb/igmp_group.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // IGMPGroup defines an object in IGMP_Group table
 type IGMPGroup struct {
 	UUID     string   `ovsdb:"_uuid"`
@@ -11,3 +13,101 @@ type IGMPGroup struct {
 	Datapath *string  `ovsdb:"datapath"`
 	Ports    []string `ovsdb:"ports"`
 }
+
+func copyIGMPGroupChassis(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalIGMPGroupChassis(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyIGMPGroupDatapath(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalIGMPGroupDatapath(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyIGMPGroupPorts(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalIGMPGroupPorts(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *IGMPGroup) DeepCopyInto(b *IGMPGroup) {
+	*b = *a
+	b.Chassis = copyIGMPGroupChassis(a.Chassis)
+	b.Datapath = copyIGMPGroupDatapath(a.Datapath)
+	b.Ports = copyIGMPGroupPorts(a.Ports)
+}
+
+func (a *IGMPGroup) DeepCopy() *IGMPGroup {
+	b := new(IGMPGroup)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *IGMPGroup) CloneModelInto(b model.Model) {
+	c := b.(*IGMPGroup)
+	a.DeepCopyInto(c)
+}
+
+func (a *IGMPGroup) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *IGMPGroup) Equals(b *IGMPGroup) bool {
+	return a.UUID == b.UUID &&
+		a.Address == b.Address &&
+		equalIGMPGroupChassis(a.Chassis, b.Chassis) &&
+		equalIGMPGroupDatapath(a.Datapath, b.Datapath) &&
+		equalIGMPGroupPorts(a.Ports, b.Ports)
+}
+
+func (a *IGMPGroup) EqualsModel(b model.Model) bool {
+	c := b.(*IGMPGroup)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &IGMPGroup{}
+var _ model.ComparableModel = &IGMPGroup{}

--- a/go-controller/pkg/sbdb/ip_multicast.go
+++ b/go-controller/pkg/sbdb/ip_multicast.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // IPMulticast defines an object in IP_Multicast table
 type IPMulticast struct {
 	UUID          string `ovsdb:"_uuid"`
@@ -18,3 +20,159 @@ type IPMulticast struct {
 	SeqNo         int    `ovsdb:"seq_no"`
 	TableSize     *int   `ovsdb:"table_size"`
 }
+
+func copyIPMulticastEnabled(a *bool) *bool {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalIPMulticastEnabled(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyIPMulticastIdleTimeout(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalIPMulticastIdleTimeout(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyIPMulticastQuerier(a *bool) *bool {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalIPMulticastQuerier(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyIPMulticastQueryInterval(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalIPMulticastQueryInterval(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyIPMulticastQueryMaxResp(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalIPMulticastQueryMaxResp(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyIPMulticastTableSize(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalIPMulticastTableSize(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *IPMulticast) DeepCopyInto(b *IPMulticast) {
+	*b = *a
+	b.Enabled = copyIPMulticastEnabled(a.Enabled)
+	b.IdleTimeout = copyIPMulticastIdleTimeout(a.IdleTimeout)
+	b.Querier = copyIPMulticastQuerier(a.Querier)
+	b.QueryInterval = copyIPMulticastQueryInterval(a.QueryInterval)
+	b.QueryMaxResp = copyIPMulticastQueryMaxResp(a.QueryMaxResp)
+	b.TableSize = copyIPMulticastTableSize(a.TableSize)
+}
+
+func (a *IPMulticast) DeepCopy() *IPMulticast {
+	b := new(IPMulticast)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *IPMulticast) CloneModelInto(b model.Model) {
+	c := b.(*IPMulticast)
+	a.DeepCopyInto(c)
+}
+
+func (a *IPMulticast) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *IPMulticast) Equals(b *IPMulticast) bool {
+	return a.UUID == b.UUID &&
+		a.Datapath == b.Datapath &&
+		equalIPMulticastEnabled(a.Enabled, b.Enabled) &&
+		a.EthSrc == b.EthSrc &&
+		equalIPMulticastIdleTimeout(a.IdleTimeout, b.IdleTimeout) &&
+		a.Ip4Src == b.Ip4Src &&
+		a.Ip6Src == b.Ip6Src &&
+		equalIPMulticastQuerier(a.Querier, b.Querier) &&
+		equalIPMulticastQueryInterval(a.QueryInterval, b.QueryInterval) &&
+		equalIPMulticastQueryMaxResp(a.QueryMaxResp, b.QueryMaxResp) &&
+		a.SeqNo == b.SeqNo &&
+		equalIPMulticastTableSize(a.TableSize, b.TableSize)
+}
+
+func (a *IPMulticast) EqualsModel(b model.Model) bool {
+	c := b.(*IPMulticast)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &IPMulticast{}
+var _ model.ComparableModel = &IPMulticast{}

--- a/go-controller/pkg/sbdb/load_balancer.go
+++ b/go-controller/pkg/sbdb/load_balancer.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	LoadBalancerProtocol = string
 )
@@ -23,3 +25,165 @@ type LoadBalancer struct {
 	Protocol    *LoadBalancerProtocol `ovsdb:"protocol"`
 	Vips        map[string]string     `ovsdb:"vips"`
 }
+
+func copyLoadBalancerDatapaths(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLoadBalancerDatapaths(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLoadBalancerExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLoadBalancerExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLoadBalancerOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLoadBalancerOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLoadBalancerProtocol(a *LoadBalancerProtocol) *LoadBalancerProtocol {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLoadBalancerProtocol(a, b *LoadBalancerProtocol) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLoadBalancerVips(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLoadBalancerVips(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *LoadBalancer) DeepCopyInto(b *LoadBalancer) {
+	*b = *a
+	b.Datapaths = copyLoadBalancerDatapaths(a.Datapaths)
+	b.ExternalIDs = copyLoadBalancerExternalIDs(a.ExternalIDs)
+	b.Options = copyLoadBalancerOptions(a.Options)
+	b.Protocol = copyLoadBalancerProtocol(a.Protocol)
+	b.Vips = copyLoadBalancerVips(a.Vips)
+}
+
+func (a *LoadBalancer) DeepCopy() *LoadBalancer {
+	b := new(LoadBalancer)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LoadBalancer) CloneModelInto(b model.Model) {
+	c := b.(*LoadBalancer)
+	a.DeepCopyInto(c)
+}
+
+func (a *LoadBalancer) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LoadBalancer) Equals(b *LoadBalancer) bool {
+	return a.UUID == b.UUID &&
+		equalLoadBalancerDatapaths(a.Datapaths, b.Datapaths) &&
+		equalLoadBalancerExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Name == b.Name &&
+		equalLoadBalancerOptions(a.Options, b.Options) &&
+		equalLoadBalancerProtocol(a.Protocol, b.Protocol) &&
+		equalLoadBalancerVips(a.Vips, b.Vips)
+}
+
+func (a *LoadBalancer) EqualsModel(b model.Model) bool {
+	c := b.(*LoadBalancer)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LoadBalancer{}
+var _ model.ComparableModel = &LoadBalancer{}

--- a/go-controller/pkg/sbdb/logical_dp_group.go
+++ b/go-controller/pkg/sbdb/logical_dp_group.go
@@ -3,8 +3,67 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // LogicalDPGroup defines an object in Logical_DP_Group table
 type LogicalDPGroup struct {
 	UUID      string   `ovsdb:"_uuid"`
 	Datapaths []string `ovsdb:"datapaths"`
 }
+
+func copyLogicalDPGroupDatapaths(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalLogicalDPGroupDatapaths(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *LogicalDPGroup) DeepCopyInto(b *LogicalDPGroup) {
+	*b = *a
+	b.Datapaths = copyLogicalDPGroupDatapaths(a.Datapaths)
+}
+
+func (a *LogicalDPGroup) DeepCopy() *LogicalDPGroup {
+	b := new(LogicalDPGroup)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LogicalDPGroup) CloneModelInto(b model.Model) {
+	c := b.(*LogicalDPGroup)
+	a.DeepCopyInto(c)
+}
+
+func (a *LogicalDPGroup) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LogicalDPGroup) Equals(b *LogicalDPGroup) bool {
+	return a.UUID == b.UUID &&
+		equalLogicalDPGroupDatapaths(a.Datapaths, b.Datapaths)
+}
+
+func (a *LogicalDPGroup) EqualsModel(b model.Model) bool {
+	c := b.(*LogicalDPGroup)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LogicalDPGroup{}
+var _ model.ComparableModel = &LogicalDPGroup{}

--- a/go-controller/pkg/sbdb/logical_flow.go
+++ b/go-controller/pkg/sbdb/logical_flow.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	LogicalFlowPipeline = string
 )
@@ -26,3 +28,155 @@ type LogicalFlow struct {
 	TableID         int                 `ovsdb:"table_id"`
 	Tags            map[string]string   `ovsdb:"tags"`
 }
+
+func copyLogicalFlowControllerMeter(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalFlowControllerMeter(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalFlowExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalFlowExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyLogicalFlowLogicalDatapath(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalFlowLogicalDatapath(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalFlowLogicalDpGroup(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalLogicalFlowLogicalDpGroup(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyLogicalFlowTags(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalLogicalFlowTags(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *LogicalFlow) DeepCopyInto(b *LogicalFlow) {
+	*b = *a
+	b.ControllerMeter = copyLogicalFlowControllerMeter(a.ControllerMeter)
+	b.ExternalIDs = copyLogicalFlowExternalIDs(a.ExternalIDs)
+	b.LogicalDatapath = copyLogicalFlowLogicalDatapath(a.LogicalDatapath)
+	b.LogicalDpGroup = copyLogicalFlowLogicalDpGroup(a.LogicalDpGroup)
+	b.Tags = copyLogicalFlowTags(a.Tags)
+}
+
+func (a *LogicalFlow) DeepCopy() *LogicalFlow {
+	b := new(LogicalFlow)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *LogicalFlow) CloneModelInto(b model.Model) {
+	c := b.(*LogicalFlow)
+	a.DeepCopyInto(c)
+}
+
+func (a *LogicalFlow) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *LogicalFlow) Equals(b *LogicalFlow) bool {
+	return a.UUID == b.UUID &&
+		a.Actions == b.Actions &&
+		equalLogicalFlowControllerMeter(a.ControllerMeter, b.ControllerMeter) &&
+		equalLogicalFlowExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalLogicalFlowLogicalDatapath(a.LogicalDatapath, b.LogicalDatapath) &&
+		equalLogicalFlowLogicalDpGroup(a.LogicalDpGroup, b.LogicalDpGroup) &&
+		a.Match == b.Match &&
+		a.Pipeline == b.Pipeline &&
+		a.Priority == b.Priority &&
+		a.TableID == b.TableID &&
+		equalLogicalFlowTags(a.Tags, b.Tags)
+}
+
+func (a *LogicalFlow) EqualsModel(b model.Model) bool {
+	c := b.(*LogicalFlow)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &LogicalFlow{}
+var _ model.ComparableModel = &LogicalFlow{}

--- a/go-controller/pkg/sbdb/mac_binding.go
+++ b/go-controller/pkg/sbdb/mac_binding.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // MACBinding defines an object in MAC_Binding table
 type MACBinding struct {
 	UUID        string `ovsdb:"_uuid"`
@@ -11,3 +13,38 @@ type MACBinding struct {
 	LogicalPort string `ovsdb:"logical_port"`
 	MAC         string `ovsdb:"mac"`
 }
+
+func (a *MACBinding) DeepCopyInto(b *MACBinding) {
+	*b = *a
+}
+
+func (a *MACBinding) DeepCopy() *MACBinding {
+	b := new(MACBinding)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *MACBinding) CloneModelInto(b model.Model) {
+	c := b.(*MACBinding)
+	a.DeepCopyInto(c)
+}
+
+func (a *MACBinding) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *MACBinding) Equals(b *MACBinding) bool {
+	return a.UUID == b.UUID &&
+		a.Datapath == b.Datapath &&
+		a.IP == b.IP &&
+		a.LogicalPort == b.LogicalPort &&
+		a.MAC == b.MAC
+}
+
+func (a *MACBinding) EqualsModel(b model.Model) bool {
+	c := b.(*MACBinding)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &MACBinding{}
+var _ model.ComparableModel = &MACBinding{}

--- a/go-controller/pkg/sbdb/meter.go
+++ b/go-controller/pkg/sbdb/meter.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	MeterUnit = string
 )
@@ -19,3 +21,62 @@ type Meter struct {
 	Name  string    `ovsdb:"name"`
 	Unit  MeterUnit `ovsdb:"unit"`
 }
+
+func copyMeterBands(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalMeterBands(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *Meter) DeepCopyInto(b *Meter) {
+	*b = *a
+	b.Bands = copyMeterBands(a.Bands)
+}
+
+func (a *Meter) DeepCopy() *Meter {
+	b := new(Meter)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *Meter) CloneModelInto(b model.Model) {
+	c := b.(*Meter)
+	a.DeepCopyInto(c)
+}
+
+func (a *Meter) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *Meter) Equals(b *Meter) bool {
+	return a.UUID == b.UUID &&
+		equalMeterBands(a.Bands, b.Bands) &&
+		a.Name == b.Name &&
+		a.Unit == b.Unit
+}
+
+func (a *Meter) EqualsModel(b model.Model) bool {
+	c := b.(*Meter)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &Meter{}
+var _ model.ComparableModel = &Meter{}

--- a/go-controller/pkg/sbdb/meter_band.go
+++ b/go-controller/pkg/sbdb/meter_band.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	MeterBandAction = string
 )
@@ -18,3 +20,37 @@ type MeterBand struct {
 	BurstSize int             `ovsdb:"burst_size"`
 	Rate      int             `ovsdb:"rate"`
 }
+
+func (a *MeterBand) DeepCopyInto(b *MeterBand) {
+	*b = *a
+}
+
+func (a *MeterBand) DeepCopy() *MeterBand {
+	b := new(MeterBand)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *MeterBand) CloneModelInto(b model.Model) {
+	c := b.(*MeterBand)
+	a.DeepCopyInto(c)
+}
+
+func (a *MeterBand) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *MeterBand) Equals(b *MeterBand) bool {
+	return a.UUID == b.UUID &&
+		a.Action == b.Action &&
+		a.BurstSize == b.BurstSize &&
+		a.Rate == b.Rate
+}
+
+func (a *MeterBand) EqualsModel(b model.Model) bool {
+	c := b.(*MeterBand)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &MeterBand{}
+var _ model.ComparableModel = &MeterBand{}

--- a/go-controller/pkg/sbdb/multicast_group.go
+++ b/go-controller/pkg/sbdb/multicast_group.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // MulticastGroup defines an object in Multicast_Group table
 type MulticastGroup struct {
 	UUID      string   `ovsdb:"_uuid"`
@@ -11,3 +13,63 @@ type MulticastGroup struct {
 	Ports     []string `ovsdb:"ports"`
 	TunnelKey int      `ovsdb:"tunnel_key"`
 }
+
+func copyMulticastGroupPorts(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalMulticastGroupPorts(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *MulticastGroup) DeepCopyInto(b *MulticastGroup) {
+	*b = *a
+	b.Ports = copyMulticastGroupPorts(a.Ports)
+}
+
+func (a *MulticastGroup) DeepCopy() *MulticastGroup {
+	b := new(MulticastGroup)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *MulticastGroup) CloneModelInto(b model.Model) {
+	c := b.(*MulticastGroup)
+	a.DeepCopyInto(c)
+}
+
+func (a *MulticastGroup) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *MulticastGroup) Equals(b *MulticastGroup) bool {
+	return a.UUID == b.UUID &&
+		a.Datapath == b.Datapath &&
+		a.Name == b.Name &&
+		equalMulticastGroupPorts(a.Ports, b.Ports) &&
+		a.TunnelKey == b.TunnelKey
+}
+
+func (a *MulticastGroup) EqualsModel(b model.Model) bool {
+	c := b.(*MulticastGroup)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &MulticastGroup{}
+var _ model.ComparableModel = &MulticastGroup{}

--- a/go-controller/pkg/sbdb/port_binding.go
+++ b/go-controller/pkg/sbdb/port_binding.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // PortBinding defines an object in Port_Binding table
 type PortBinding struct {
 	UUID           string            `ovsdb:"_uuid"`
@@ -23,3 +25,312 @@ type PortBinding struct {
 	Up             *bool             `ovsdb:"up"`
 	VirtualParent  *string           `ovsdb:"virtual_parent"`
 }
+
+func copyPortBindingChassis(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalPortBindingChassis(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyPortBindingEncap(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalPortBindingEncap(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyPortBindingExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalPortBindingExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyPortBindingGatewayChassis(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalPortBindingGatewayChassis(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyPortBindingHaChassisGroup(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalPortBindingHaChassisGroup(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyPortBindingMAC(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalPortBindingMAC(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyPortBindingNatAddresses(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalPortBindingNatAddresses(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyPortBindingOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalPortBindingOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyPortBindingParentPort(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalPortBindingParentPort(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyPortBindingTag(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalPortBindingTag(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyPortBindingUp(a *bool) *bool {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalPortBindingUp(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyPortBindingVirtualParent(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalPortBindingVirtualParent(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *PortBinding) DeepCopyInto(b *PortBinding) {
+	*b = *a
+	b.Chassis = copyPortBindingChassis(a.Chassis)
+	b.Encap = copyPortBindingEncap(a.Encap)
+	b.ExternalIDs = copyPortBindingExternalIDs(a.ExternalIDs)
+	b.GatewayChassis = copyPortBindingGatewayChassis(a.GatewayChassis)
+	b.HaChassisGroup = copyPortBindingHaChassisGroup(a.HaChassisGroup)
+	b.MAC = copyPortBindingMAC(a.MAC)
+	b.NatAddresses = copyPortBindingNatAddresses(a.NatAddresses)
+	b.Options = copyPortBindingOptions(a.Options)
+	b.ParentPort = copyPortBindingParentPort(a.ParentPort)
+	b.Tag = copyPortBindingTag(a.Tag)
+	b.Up = copyPortBindingUp(a.Up)
+	b.VirtualParent = copyPortBindingVirtualParent(a.VirtualParent)
+}
+
+func (a *PortBinding) DeepCopy() *PortBinding {
+	b := new(PortBinding)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *PortBinding) CloneModelInto(b model.Model) {
+	c := b.(*PortBinding)
+	a.DeepCopyInto(c)
+}
+
+func (a *PortBinding) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *PortBinding) Equals(b *PortBinding) bool {
+	return a.UUID == b.UUID &&
+		equalPortBindingChassis(a.Chassis, b.Chassis) &&
+		a.Datapath == b.Datapath &&
+		equalPortBindingEncap(a.Encap, b.Encap) &&
+		equalPortBindingExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalPortBindingGatewayChassis(a.GatewayChassis, b.GatewayChassis) &&
+		equalPortBindingHaChassisGroup(a.HaChassisGroup, b.HaChassisGroup) &&
+		a.LogicalPort == b.LogicalPort &&
+		equalPortBindingMAC(a.MAC, b.MAC) &&
+		equalPortBindingNatAddresses(a.NatAddresses, b.NatAddresses) &&
+		equalPortBindingOptions(a.Options, b.Options) &&
+		equalPortBindingParentPort(a.ParentPort, b.ParentPort) &&
+		equalPortBindingTag(a.Tag, b.Tag) &&
+		a.TunnelKey == b.TunnelKey &&
+		a.Type == b.Type &&
+		equalPortBindingUp(a.Up, b.Up) &&
+		equalPortBindingVirtualParent(a.VirtualParent, b.VirtualParent)
+}
+
+func (a *PortBinding) EqualsModel(b model.Model) bool {
+	c := b.(*PortBinding)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &PortBinding{}
+var _ model.ComparableModel = &PortBinding{}

--- a/go-controller/pkg/sbdb/port_group.go
+++ b/go-controller/pkg/sbdb/port_group.go
@@ -3,9 +3,69 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // PortGroup defines an object in Port_Group table
 type PortGroup struct {
 	UUID  string   `ovsdb:"_uuid"`
 	Name  string   `ovsdb:"name"`
 	Ports []string `ovsdb:"ports"`
 }
+
+func copyPortGroupPorts(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalPortGroupPorts(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *PortGroup) DeepCopyInto(b *PortGroup) {
+	*b = *a
+	b.Ports = copyPortGroupPorts(a.Ports)
+}
+
+func (a *PortGroup) DeepCopy() *PortGroup {
+	b := new(PortGroup)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *PortGroup) CloneModelInto(b model.Model) {
+	c := b.(*PortGroup)
+	a.DeepCopyInto(c)
+}
+
+func (a *PortGroup) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *PortGroup) Equals(b *PortGroup) bool {
+	return a.UUID == b.UUID &&
+		a.Name == b.Name &&
+		equalPortGroupPorts(a.Ports, b.Ports)
+}
+
+func (a *PortGroup) EqualsModel(b model.Model) bool {
+	c := b.(*PortGroup)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &PortGroup{}
+var _ model.ComparableModel = &PortGroup{}

--- a/go-controller/pkg/sbdb/rbac_permission.go
+++ b/go-controller/pkg/sbdb/rbac_permission.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // RBACPermission defines an object in RBAC_Permission table
 type RBACPermission struct {
 	UUID          string   `ovsdb:"_uuid"`
@@ -11,3 +13,88 @@ type RBACPermission struct {
 	Table         string   `ovsdb:"table"`
 	Update        []string `ovsdb:"update"`
 }
+
+func copyRBACPermissionAuthorization(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalRBACPermissionAuthorization(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copyRBACPermissionUpdate(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalRBACPermissionUpdate(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *RBACPermission) DeepCopyInto(b *RBACPermission) {
+	*b = *a
+	b.Authorization = copyRBACPermissionAuthorization(a.Authorization)
+	b.Update = copyRBACPermissionUpdate(a.Update)
+}
+
+func (a *RBACPermission) DeepCopy() *RBACPermission {
+	b := new(RBACPermission)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *RBACPermission) CloneModelInto(b model.Model) {
+	c := b.(*RBACPermission)
+	a.DeepCopyInto(c)
+}
+
+func (a *RBACPermission) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *RBACPermission) Equals(b *RBACPermission) bool {
+	return a.UUID == b.UUID &&
+		equalRBACPermissionAuthorization(a.Authorization, b.Authorization) &&
+		a.InsertDelete == b.InsertDelete &&
+		a.Table == b.Table &&
+		equalRBACPermissionUpdate(a.Update, b.Update)
+}
+
+func (a *RBACPermission) EqualsModel(b model.Model) bool {
+	c := b.(*RBACPermission)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &RBACPermission{}
+var _ model.ComparableModel = &RBACPermission{}

--- a/go-controller/pkg/sbdb/rbac_role.go
+++ b/go-controller/pkg/sbdb/rbac_role.go
@@ -3,9 +3,71 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // RBACRole defines an object in RBAC_Role table
 type RBACRole struct {
 	UUID        string            `ovsdb:"_uuid"`
 	Name        string            `ovsdb:"name"`
 	Permissions map[string]string `ovsdb:"permissions"`
 }
+
+func copyRBACRolePermissions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalRBACRolePermissions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *RBACRole) DeepCopyInto(b *RBACRole) {
+	*b = *a
+	b.Permissions = copyRBACRolePermissions(a.Permissions)
+}
+
+func (a *RBACRole) DeepCopy() *RBACRole {
+	b := new(RBACRole)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *RBACRole) CloneModelInto(b model.Model) {
+	c := b.(*RBACRole)
+	a.DeepCopyInto(c)
+}
+
+func (a *RBACRole) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *RBACRole) Equals(b *RBACRole) bool {
+	return a.UUID == b.UUID &&
+		a.Name == b.Name &&
+		equalRBACRolePermissions(a.Permissions, b.Permissions)
+}
+
+func (a *RBACRole) EqualsModel(b model.Model) bool {
+	c := b.(*RBACRole)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &RBACRole{}
+var _ model.ComparableModel = &RBACRole{}

--- a/go-controller/pkg/sbdb/sb_global.go
+++ b/go-controller/pkg/sbdb/sb_global.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // SBGlobal defines an object in SB_Global table
 type SBGlobal struct {
 	UUID        string            `ovsdb:"_uuid"`
@@ -13,3 +15,138 @@ type SBGlobal struct {
 	Options     map[string]string `ovsdb:"options"`
 	SSL         *string           `ovsdb:"ssl"`
 }
+
+func copySBGlobalConnections(a []string) []string {
+	if a == nil {
+		return nil
+	}
+	b := make([]string, len(a))
+	copy(b, a)
+	return b
+}
+
+func equalSBGlobalConnections(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func copySBGlobalExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalSBGlobalExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copySBGlobalOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalSBGlobalOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copySBGlobalSSL(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalSBGlobalSSL(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *SBGlobal) DeepCopyInto(b *SBGlobal) {
+	*b = *a
+	b.Connections = copySBGlobalConnections(a.Connections)
+	b.ExternalIDs = copySBGlobalExternalIDs(a.ExternalIDs)
+	b.Options = copySBGlobalOptions(a.Options)
+	b.SSL = copySBGlobalSSL(a.SSL)
+}
+
+func (a *SBGlobal) DeepCopy() *SBGlobal {
+	b := new(SBGlobal)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *SBGlobal) CloneModelInto(b model.Model) {
+	c := b.(*SBGlobal)
+	a.DeepCopyInto(c)
+}
+
+func (a *SBGlobal) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *SBGlobal) Equals(b *SBGlobal) bool {
+	return a.UUID == b.UUID &&
+		equalSBGlobalConnections(a.Connections, b.Connections) &&
+		equalSBGlobalExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.Ipsec == b.Ipsec &&
+		a.NbCfg == b.NbCfg &&
+		equalSBGlobalOptions(a.Options, b.Options) &&
+		equalSBGlobalSSL(a.SSL, b.SSL)
+}
+
+func (a *SBGlobal) EqualsModel(b model.Model) bool {
+	c := b.(*SBGlobal)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &SBGlobal{}
+var _ model.ComparableModel = &SBGlobal{}

--- a/go-controller/pkg/sbdb/service_monitor.go
+++ b/go-controller/pkg/sbdb/service_monitor.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	ServiceMonitorProtocol = string
 	ServiceMonitorStatus   = string
@@ -29,3 +31,135 @@ type ServiceMonitor struct {
 	SrcMAC      string                  `ovsdb:"src_mac"`
 	Status      *ServiceMonitorStatus   `ovsdb:"status"`
 }
+
+func copyServiceMonitorExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalServiceMonitorExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyServiceMonitorOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalServiceMonitorOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func copyServiceMonitorProtocol(a *ServiceMonitorProtocol) *ServiceMonitorProtocol {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalServiceMonitorProtocol(a, b *ServiceMonitorProtocol) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyServiceMonitorStatus(a *ServiceMonitorStatus) *ServiceMonitorStatus {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalServiceMonitorStatus(a, b *ServiceMonitorStatus) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *ServiceMonitor) DeepCopyInto(b *ServiceMonitor) {
+	*b = *a
+	b.ExternalIDs = copyServiceMonitorExternalIDs(a.ExternalIDs)
+	b.Options = copyServiceMonitorOptions(a.Options)
+	b.Protocol = copyServiceMonitorProtocol(a.Protocol)
+	b.Status = copyServiceMonitorStatus(a.Status)
+}
+
+func (a *ServiceMonitor) DeepCopy() *ServiceMonitor {
+	b := new(ServiceMonitor)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *ServiceMonitor) CloneModelInto(b model.Model) {
+	c := b.(*ServiceMonitor)
+	a.DeepCopyInto(c)
+}
+
+func (a *ServiceMonitor) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *ServiceMonitor) Equals(b *ServiceMonitor) bool {
+	return a.UUID == b.UUID &&
+		equalServiceMonitorExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.IP == b.IP &&
+		a.LogicalPort == b.LogicalPort &&
+		equalServiceMonitorOptions(a.Options, b.Options) &&
+		a.Port == b.Port &&
+		equalServiceMonitorProtocol(a.Protocol, b.Protocol) &&
+		a.SrcIP == b.SrcIP &&
+		a.SrcMAC == b.SrcMAC &&
+		equalServiceMonitorStatus(a.Status, b.Status)
+}
+
+func (a *ServiceMonitor) EqualsModel(b model.Model) bool {
+	c := b.(*ServiceMonitor)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &ServiceMonitor{}
+var _ model.ComparableModel = &ServiceMonitor{}

--- a/go-controller/pkg/sbdb/ssl.go
+++ b/go-controller/pkg/sbdb/ssl.go
@@ -3,6 +3,8 @@
 
 package sbdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 // SSL defines an object in SSL table
 type SSL struct {
 	UUID            string            `ovsdb:"_uuid"`
@@ -14,3 +16,68 @@ type SSL struct {
 	SSLCiphers      string            `ovsdb:"ssl_ciphers"`
 	SSLProtocols    string            `ovsdb:"ssl_protocols"`
 }
+
+func copySSLExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalSSLExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *SSL) DeepCopyInto(b *SSL) {
+	*b = *a
+	b.ExternalIDs = copySSLExternalIDs(a.ExternalIDs)
+}
+
+func (a *SSL) DeepCopy() *SSL {
+	b := new(SSL)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *SSL) CloneModelInto(b model.Model) {
+	c := b.(*SSL)
+	a.DeepCopyInto(c)
+}
+
+func (a *SSL) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *SSL) Equals(b *SSL) bool {
+	return a.UUID == b.UUID &&
+		a.BootstrapCaCert == b.BootstrapCaCert &&
+		a.CaCert == b.CaCert &&
+		a.Certificate == b.Certificate &&
+		equalSSLExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		a.PrivateKey == b.PrivateKey &&
+		a.SSLCiphers == b.SSLCiphers &&
+		a.SSLProtocols == b.SSLProtocols
+}
+
+func (a *SSL) EqualsModel(b model.Model) bool {
+	c := b.(*SSL)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &SSL{}
+var _ model.ComparableModel = &SSL{}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
@@ -127,12 +127,12 @@ func (r *RowCache) RowByModel(m model.Model) model.Model {
 	if uuid.(string) != "" {
 		return r.rowByUUID(uuid.(string))
 	}
-	for index := range r.indexes {
+	for index, vals := range r.indexes {
 		val, err := valueFromIndex(info, index)
 		if err != nil {
 			continue
 		}
-		if uuid, ok := r.indexes[index][val]; ok {
+		if uuid, ok := vals[val]; ok {
 			return r.rowByUUID(uuid)
 		}
 	}
@@ -154,13 +154,13 @@ func (r *RowCache) Create(uuid string, m model.Model, checkIndexes bool) error {
 		return err
 	}
 	newIndexes := newColumnToValue(r.dbModel.Schema.Table(r.name).Indexes)
-	for index := range r.indexes {
+	for index, vals := range r.indexes {
 		val, err := valueFromIndex(info, index)
 		if err != nil {
 			return err
 		}
 
-		if existing, ok := r.indexes[index][val]; ok && checkIndexes {
+		if existing, ok := vals[val]; ok && checkIndexes {
 			return NewIndexExistsError(r.name, val, string(index), uuid, existing)
 		}
 
@@ -169,8 +169,9 @@ func (r *RowCache) Create(uuid string, m model.Model, checkIndexes bool) error {
 
 	// write indexes
 	for k1, v1 := range newIndexes {
+		vals := r.indexes[k1]
 		for k2, v2 := range v1 {
-			r.indexes[k1][k2] = v2
+			vals[k2] = v2
 		}
 	}
 	r.cache[uuid] = model.Clone(m)
@@ -197,7 +198,7 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 	newIndexes := newColumnToValue(indexes)
 	oldIndexes := newColumnToValue(indexes)
 	var errs []error
-	for index := range r.indexes {
+	for index, vals := range r.indexes {
 		var err error
 		oldVal, err := valueFromIndex(oldInfo, index)
 		if err != nil {
@@ -215,7 +216,7 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 		// old and new values are NOT the same
 
 		// check that there are no conflicts
-		if conflict, ok := r.indexes[index][newVal]; ok && checkIndexes && conflict != uuid {
+		if conflict, ok := vals[newVal]; ok && checkIndexes && conflict != uuid {
 			errs = append(errs, NewIndexExistsError(
 				r.name,
 				newVal,
@@ -233,14 +234,16 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 	}
 	// write indexes
 	for k1, v1 := range newIndexes {
+		vals := r.indexes[k1]
 		for k2, v2 := range v1 {
-			r.indexes[k1][k2] = v2
+			vals[k2] = v2
 		}
 	}
 	// delete old indexes
 	for k1, v1 := range oldIndexes {
+		vals := r.indexes[k1]
 		for k2 := range v1 {
-			delete(r.indexes[k1], k2)
+			delete(vals, k2)
 		}
 	}
 	r.cache[uuid] = model.Clone(m)
@@ -256,12 +259,12 @@ func (r *RowCache) IndexExists(row model.Model) error {
 	if err != nil {
 		return nil
 	}
-	for index := range r.indexes {
+	for index, vals := range r.indexes {
 		val, err := valueFromIndex(info, index)
 		if err != nil {
 			continue
 		}
-		if existing, ok := r.indexes[index][val]; ok && existing != uuid.(string) {
+		if existing, ok := vals[val]; ok && existing != uuid.(string) {
 			return NewIndexExistsError(
 				r.name,
 				val,
@@ -286,7 +289,7 @@ func (r *RowCache) Delete(uuid string) error {
 	if err != nil {
 		return err
 	}
-	for index := range r.indexes {
+	for index, vals := range r.indexes {
 		oldVal, err := valueFromIndex(oldInfo, index)
 		if err != nil {
 			return err
@@ -294,8 +297,8 @@ func (r *RowCache) Delete(uuid string) error {
 		// only remove the index if it is pointing to this uuid
 		// otherwise we can cause a consistency issue if we've processed
 		// updates out of order
-		if r.indexes[index][oldVal] == uuid {
-			delete(r.indexes[index], oldVal)
+		if vals[oldVal] == uuid {
+			delete(vals, oldVal)
 		}
 	}
 	delete(r.cache, uuid)
@@ -470,8 +473,9 @@ func NewTableCache(dbModel model.DatabaseModel, data Data, logger *logr.Logger) 
 		if _, ok := dbModel.Schema.Tables[table]; !ok {
 			return nil, fmt.Errorf("table %s is not in schema", table)
 		}
+		rowCache := cache[table]
 		for uuid, row := range rowData {
-			if err := cache[table].Create(uuid, row, true); err != nil {
+			if err := rowCache.Create(uuid, row, true); err != nil {
 				return nil, err
 			}
 		}
@@ -583,7 +587,7 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 					return err
 				}
 				if existing := tCache.Row(uuid); existing != nil {
-					if !reflect.DeepEqual(newModel, existing) {
+					if !model.Equal(newModel, existing) {
 						logger.V(5).Info("updating row", "old:", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", newModel))
 						if err := tCache.Update(uuid, newModel, false); err != nil {
 							return err
@@ -655,12 +659,12 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				if existing == nil {
 					return NewErrCacheInconsistent(fmt.Sprintf("row with uuid %s does not exist", uuid))
 				}
-				modified := tCache.Row(uuid)
+				modified := model.Clone(existing)
 				err := t.ApplyModifications(table, modified, *row.Modify)
 				if err != nil {
 					return fmt.Errorf("unable to apply row modifications: %v", err)
 				}
-				if !reflect.DeepEqual(modified, existing) {
+				if !model.Equal(modified, existing) {
 					logger.V(5).Info("updating row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))
 					if err := tCache.Update(uuid, modified, false); err != nil {
 						return err
@@ -710,7 +714,10 @@ func (t *TableCache) AddEventHandler(handler EventHandler) {
 func (t *TableCache) Run(stopCh <-chan struct{}) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	go t.eventProcessor.Run(stopCh)
+	go func() {
+		defer wg.Done()
+		t.eventProcessor.Run(stopCh)
+	}()
 	wg.Wait()
 }
 

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/api.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/api.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -223,8 +222,7 @@ func (a api) Get(ctx context.Context, m model.Model) error {
 		return ErrNotFound
 	}
 
-	foundBytes, _ := json.Marshal(found)
-	_ = json.Unmarshal(foundBytes, m)
+	model.CloneInto(found, m)
 
 	return nil
 }

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/model/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/model/client.go
@@ -69,13 +69,14 @@ func NewClientDBModel(name string, models map[string]Model) (ClientDBModel, erro
 			if field := modelType.Elem().Field(i); field.Tag.Get("ovsdb") == "_uuid" &&
 				field.Type.Kind() == reflect.String {
 				hasUUID = true
+				break
 			}
 		}
 		if !hasUUID {
 			return ClientDBModel{}, fmt.Errorf("model is expected to have a string field called uuid")
 		}
 
-		types[table] = reflect.TypeOf(model)
+		types[table] = modelType
 	}
 	return ClientDBModel{
 		types: types,

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/model/database.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/model/database.go
@@ -94,12 +94,7 @@ func generateModelInfo(dbSchema ovsdb.DatabaseSchema, modelTypes map[string]refl
 			continue
 		}
 
-		mtype, ok := modelTypes[tableName]
-		if !ok {
-			errors = append(errors, fmt.Errorf("table %s not found in database model", tableName))
-			continue
-		}
-		obj := reflect.New(mtype.Elem()).Interface().(Model)
+		obj := reflect.New(tType.Elem()).Interface().(Model)
 		info, err := mapper.NewInfo(tableName, tableSchema, obj)
 		if err != nil {
 			errors = append(errors, err)

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
@@ -3,6 +3,8 @@
 
 package serverdb
 
+import "github.com/ovn-org/libovsdb/model"
+
 type (
 	DatabaseModel = string
 )
@@ -25,3 +27,118 @@ type Database struct {
 	Schema    *string       `ovsdb:"schema"`
 	Sid       *string       `ovsdb:"sid"`
 }
+
+func copyDatabaseCid(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalDatabaseCid(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyDatabaseIndex(a *int) *int {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalDatabaseIndex(a, b *int) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyDatabaseSchema(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalDatabaseSchema(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func copyDatabaseSid(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalDatabaseSid(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
+func (a *Database) DeepCopyInto(b *Database) {
+	*b = *a
+	b.Cid = copyDatabaseCid(a.Cid)
+	b.Index = copyDatabaseIndex(a.Index)
+	b.Schema = copyDatabaseSchema(a.Schema)
+	b.Sid = copyDatabaseSid(a.Sid)
+}
+
+func (a *Database) DeepCopy() *Database {
+	b := new(Database)
+	a.DeepCopyInto(b)
+	return b
+}
+
+func (a *Database) CloneModelInto(b model.Model) {
+	c := b.(*Database)
+	a.DeepCopyInto(c)
+}
+
+func (a *Database) CloneModel() model.Model {
+	return a.DeepCopy()
+}
+
+func (a *Database) Equals(b *Database) bool {
+	return a.UUID == b.UUID &&
+		equalDatabaseCid(a.Cid, b.Cid) &&
+		a.Connected == b.Connected &&
+		equalDatabaseIndex(a.Index, b.Index) &&
+		a.Leader == b.Leader &&
+		a.Model == b.Model &&
+		a.Name == b.Name &&
+		equalDatabaseSchema(a.Schema, b.Schema) &&
+		equalDatabaseSid(a.Sid, b.Sid)
+}
+
+func (a *Database) EqualsModel(b model.Model) bool {
+	c := b.(*Database)
+	return a.Equals(c)
+}
+
+var _ model.CloneableModel = &Database{}
+var _ model.ComparableModel = &Database{}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/gen.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/gen.go
@@ -3,4 +3,4 @@ package serverdb
 // server_model is a database model for the special _Server database that all
 // ovsdb instances export. It reports back status of the server process itself.
 
-//go:generate ../../bin/modelgen  -p serverdb -o . _server.ovsschema
+//go:generate ../../bin/modelgen --extended -p serverdb -o . _server.ovsschema

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/server/server.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/server/server.go
@@ -100,7 +100,10 @@ func (o *OvsdbServer) Close() {
 	o.readyMutex.Lock()
 	o.ready = false
 	o.readyMutex.Unlock()
-	o.listener.Close()
+	// Only close the listener if Serve() has been called
+	if o.listener != nil {
+		o.listener.Close()
+	}
 	close(o.done)
 }
 

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20211216134718-ab69150b65ee
+# github.com/ovn-org/libovsdb v0.6.1-0.20220114142803-22bd5be40a40
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
 github.com/ovn-org/libovsdb/mapper


### PR DESCRIPTION
Bump libovsdb with performance enhancements:
* cache: clone model for modification rather than do another lookup
* cache: avoid repeated map lookups
* modelgen: add copy and equal methods for models

Update nbdb and sbdb with latest modelgen which generates copy/equal methods for the models