### PR TITLE
Add logical switch UUID to the logical switch manager struct

### DIFF
--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					},
 				)
 
-				t.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
@@ -230,7 +230,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						},
 					},
 				)
-				t.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
@@ -369,7 +369,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						},
 					},
 				)
-				t.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
@@ -527,7 +527,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					)
-					t.populateLogicalSwitchCache(fakeOvn)
+					t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 
 					injectNode(fakeOvn)
 					fakeOvn.controller.WatchNamespaces()
@@ -682,7 +682,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						},
 					)
 					config.IPv6Mode = true
-					t.populateLogicalSwitchCache(fakeOvn)
+					t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 					injectNode(fakeOvn)
 					fakeOvn.controller.WatchNamespaces()
 					fakeOvn.controller.WatchPods()
@@ -791,7 +791,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					)
-					t.populateLogicalSwitchCache(fakeOvn)
+					t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 
 					injectNode(fakeOvn)
 					fakeOvn.controller.WatchNamespaces()
@@ -986,7 +986,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						},
 					},
 				)
-				t.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
@@ -1124,7 +1124,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						},
 					},
 				)
-				t.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
@@ -1269,7 +1269,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						},
 					},
 				)
-				t.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
@@ -1410,7 +1410,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 							},
 						},
 					)
-					t.populateLogicalSwitchCache(fakeOvn)
+					t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 					injectNode(fakeOvn)
 					fakeOvn.controller.WatchNamespaces()
 					fakeOvn.controller.WatchPods()
@@ -1609,7 +1609,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						},
 					},
 				)
-				t.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
@@ -1722,7 +1722,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						},
 					},
 				)
-				t.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
@@ -1809,6 +1809,10 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				fakeOvn.startWithDBSetup(
 					libovsdbtest.TestSetup{
 						NBData: []libovsdbtest.TestData{
+							&nbdb.LogicalSwitch{
+								UUID: "node1",
+								Name: "node1",
+							},
 							&nbdb.BFD{
 								UUID:        bfd1NamedUUID,
 								DstIP:       "9.0.0.1",
@@ -1843,7 +1847,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						},
 					},
 				)
-				t.populateLogicalSwitchCache(fakeOvn)
+				t.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
@@ -1853,6 +1857,25 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				finalNB := []libovsdbtest.TestData{
+					&nbdb.LogicalSwitchPort{
+						UUID:      "lsp1",
+						Addresses: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+						ExternalIDs: map[string]string{
+							"pod":       "true",
+							"namespace": "namespace1",
+						},
+						Name: "namespace1_myPod",
+						Options: map[string]string{
+							"iface-id-ver":      "myPod",
+							"requested-chassis": "node1",
+						},
+						PortSecurity: []string{"0a:58:0a:80:01:03 10.128.1.3"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID:  "node1",
+						Name:  "node1",
+						Ports: []string{"lsp1"},
+					},
 					&nbdb.LogicalRouterStaticRoute{
 						UUID:       "static-route-1-UUID",
 						IPPrefix:   "10.128.1.3/32",

--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager_test.go
@@ -49,7 +49,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 
 				expectedIPs := []string{"10.1.1.3", "2000::3"}
 
-				err = lsManager.AddNode(testNode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
+				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ips, err := lsManager.AllocateNextIPs(testNode.nodeName)
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 				}
 				config.HybridOverlay.Enabled = true
 				expectedIPs = []string{"10.1.1.4", "2000::4"}
-				err = lsManager.AddNode(testHONode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
+				err = lsManager.AddNode(testHONode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ips, err = lsManager.AllocateNextIPs(testHONode.nodeName)
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 					subnets:  []string{},
 				}
 
-				err = lsManager.AddNode(testNode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
+				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				noHostSubnet := lsManager.IsNonHostSubnetSwitch(testNode.nodeName)
 				gomega.Expect(noHostSubnet).To(gomega.BeTrue())
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 
 				expectedIPs := []string{"10.1.1.3", "2000::3"}
 
-				err = lsManager.AddNode(testNode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
+				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ips, err := lsManager.AllocateNextIPs(testNode.nodeName)
@@ -125,7 +125,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 				}
 				testNode.subnets = []string{"10.1.2.0/24"}
 				expectedIPs = []string{"10.1.2.3"}
-				err = lsManager.AddNode(testNode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
+				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ips, err = lsManager.AllocateNextIPs(testNode.nodeName)
@@ -159,7 +159,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 					{"10.1.1.4", "2000::4"},
 				}
 
-				err = lsManager.AddNode(testNode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
+				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				for _, expectedIPs := range expectedIPAllocations {
 					ips, err := lsManager.AllocateNextIPs(testNode.nodeName)
@@ -190,7 +190,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 					{"10.1.1.4"},
 				}
 
-				err = lsManager.AddNode(testNode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
+				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				for _, expectedIPs := range expectedIPAllocations {
 					ips, err := lsManager.AllocateNextIPs(testNode.nodeName)
@@ -227,7 +227,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 					{"10.1.1.6", "10.1.2.6"},
 				}
 
-				err = lsManager.AddNode(testNode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
+				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// exhaust valid ips in second subnet
 				for _, expectedIPs := range expectedIPAllocations {
@@ -264,7 +264,7 @@ var _ = ginkgo.Describe("OVN Logical Switch Manager operations", func() {
 					"2000::2/64",
 				}
 				allocatedIPNets := ovntest.MustParseIPNets(allocatedIPs...)
-				err = lsManager.AddNode(testNode.nodeName, ovntest.MustParseIPNets(testNode.subnets...))
+				err = lsManager.AddNode(testNode.nodeName, "", ovntest.MustParseIPNets(testNode.subnets...))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = lsManager.AllocateIPs(testNode.nodeName, allocatedIPNets)
 				klog.Errorf("Error: %v", err)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -983,7 +983,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 
 			clusterController.SCTPSupport = true
-			clusterController.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(clusterController.nbClient, []string{node1.Name})
+			clusterController.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(clusterController.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})
 			_, _ = clusterController.joinSwIPManager.EnsureJoinLRPIPs(types.OVNClusterRouter)
 
 			// Let the real code run and ensure OVN database sync
@@ -1171,7 +1171,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 
 			clusterController.SCTPSupport = true
-			clusterController.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(clusterController.nbClient, []string{node1.Name})
+			clusterController.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(clusterController.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})
 			_, _ = clusterController.joinSwIPManager.EnsureJoinLRPIPs(types.OVNClusterRouter)
 
 			// Let the real code run and ensure OVN database sync

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -277,7 +277,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, clusterCIDR, config.IPv6Mode)
 
-			fakeOvn.controller.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(fakeOvn.nbClient, []string{node1.Name})
+			fakeOvn.controller.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(fakeOvn.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})
 			_, err = fakeOvn.controller.joinSwIPManager.EnsureJoinLRPIPs(ovntypes.OVNClusterRouter)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gwLRPIPs, err := fakeOvn.controller.joinSwIPManager.EnsureJoinLRPIPs(node1.Name)

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -73,10 +73,20 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	for _, n := range nodes {
 		stalePorts := []string{}
 		// find the logical switch for the node
-		ls, err := findLogicalSwitch(oc.nbClient, n.Name)
-		if err != nil {
-			klog.Errorf("Error getting logical switch for node %s: %v", n.Name, err)
+		ls := &nbdb.LogicalSwitch{}
+		if lsUUID, ok := oc.lsManager.GetUUID(n.Name); !ok {
+			klog.Errorf("Error getting logical switch for node %s: %s", n.Name, "Switch not in logical switch cache")
 			continue
+		} else {
+			ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+			defer cancel()
+
+			ls.UUID = lsUUID
+			if err := oc.nbClient.Get(ctx, ls); err != nil {
+				klog.Errorf("Error getting logical switch for node %d (UUID: %d) from ovn database (%v)", n.Name, ls.UUID, err)
+				continue
+			}
+
 		}
 		for _, port := range ls.Ports {
 			if portCache[port].ExternalIDs["pod"] == "true" {
@@ -122,7 +132,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		klog.Errorf(err.Error())
 		// If ovnkube-master restarts, it is also possible the Pod's logical switch port
 		// is not re-added into the cache. Delete logical switch port anyway.
-		err = ovnNBLSPDel(oc.nbClient, logicalPort, pod.Spec.NodeName)
+		err = oc.ovnNBLSPDel(logicalPort, pod.Spec.NodeName)
 		if err != nil {
 			klog.Errorf(err.Error())
 		}
@@ -143,7 +153,7 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {
 		klog.Errorf(err.Error())
 	}
 
-	err = ovnNBLSPDel(oc.nbClient, logicalPort, pod.Spec.NodeName)
+	err = oc.ovnNBLSPDel(logicalPort, pod.Spec.NodeName)
 	if err != nil {
 		klog.Errorf(err.Error())
 	}
@@ -169,17 +179,14 @@ func (oc *Controller) waitForNodeLogicalSwitch(nodeName string) (*nbdb.LogicalSw
 	// is created by the node watch
 	ls := &nbdb.LogicalSwitch{Name: nodeName}
 	if err := wait.PollImmediate(30*time.Millisecond, 30*time.Second, func() (bool, error) {
-		logicalSwitch, err := findLogicalSwitch(oc.nbClient, nodeName)
-		if err != nil && err != libovsdbclient.ErrNotFound {
-			return false, err
-		}
-		if err == nil {
-			ls = logicalSwitch
+		if lsUUID, ok := oc.lsManager.GetUUID(nodeName); !ok {
+			return false, fmt.Errorf("error getting logical switch for node %s: %s", nodeName, "switch not in logical switch cache")
+		} else {
+			ls.UUID = lsUUID
 			return true, nil
 		}
-		return false, nil
 	}); err != nil {
-		return nil, fmt.Errorf("timed out waiting for logical switch in libovsdb cache %q subnet: %v", nodeName, err)
+		return nil, fmt.Errorf("timed out waiting for logical switch in logical switch cache %q subnet: %v", nodeName, err)
 	}
 	return ls, nil
 }
@@ -618,21 +625,23 @@ func (oc *Controller) getPortAddresses(nodeName, portName string) (net.HardwareA
 }
 
 // ovnNBLSPDel deletes the given logical switch using the libovsdb library
-func ovnNBLSPDel(client libovsdbclient.Client, logicalPort, logicalSwitch string) error {
+func (oc *Controller) ovnNBLSPDel(logicalPort, logicalSwitch string) error {
 	var allOps []ovsdb.Operation
-	ls, err := findLogicalSwitch(client, logicalSwitch)
-	if err != nil {
-		return fmt.Errorf("could not find logicalSwitch %s - %v", logicalSwitch, err)
+	ls := &nbdb.LogicalSwitch{}
+	if lsUUID, ok := oc.lsManager.GetUUID(logicalSwitch); !ok {
+		return fmt.Errorf("error getting logical switch for node %s: %s", logicalSwitch, "switch not in logical switch cache")
+	} else {
+		ls.UUID = lsUUID
 	}
 
 	lsp := &nbdb.LogicalSwitchPort{Name: logicalPort}
 	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
 	defer cancel()
-	err = client.Get(ctx, lsp)
+	err := oc.nbClient.Get(ctx, lsp)
 	if err != nil {
 		return fmt.Errorf("cannot delete logical switch port %s failed retrieving the object %v", logicalPort, err)
 	}
-	ops, err := client.Where(ls).Mutate(ls, model.Mutation{
+	ops, err := oc.nbClient.Where(ls).Mutate(ls, model.Mutation{
 		Field:   &ls.Ports,
 		Mutator: ovsdb.MutateOperationDelete,
 		Value:   []string{lsp.UUID},
@@ -642,39 +651,15 @@ func ovnNBLSPDel(client libovsdbclient.Client, logicalPort, logicalSwitch string
 	}
 	allOps = append(allOps, ops...)
 	//for testing purposes the explicit delete of the logical switch port is required
-	ops, err = client.Where(lsp).Delete()
+	ops, err = oc.nbClient.Where(lsp).Delete()
 	if err != nil {
 		return fmt.Errorf("cannot generate ops delete logical switch port %s: %v", logicalPort, err)
 	}
 	allOps = append(allOps, ops...)
 
-	_, err = libovsdbops.TransactAndCheck(client, allOps)
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, allOps)
 	if err != nil {
 		return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
 	}
 	return nil
-}
-
-func findLogicalSwitch(nbClient libovsdbclient.Client, logicalSwitchName string) (*nbdb.LogicalSwitch, error) {
-	logicalSwitches := []nbdb.LogicalSwitch{}
-	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
-	defer cancel()
-	err := nbClient.WhereCache(
-		func(ls *nbdb.LogicalSwitch) bool {
-			return ls.Name == logicalSwitchName
-		}).List(ctx, &logicalSwitches)
-
-	if err != nil {
-		return nil, fmt.Errorf("error finding logical switch %s: %v", logicalSwitchName, err)
-	}
-
-	if len(logicalSwitches) == 0 {
-		return nil, libovsdbclient.ErrNotFound
-	}
-
-	if len(logicalSwitches) > 1 {
-		return nil, fmt.Errorf("unexpectedly found multiple logical switches: %v", logicalSwitches)
-	}
-
-	return &logicalSwitches[0], nil
 }

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -553,7 +553,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations with IP Address Family", f
 					setIpMode(m)
 
 					for _, tPod := range tPods {
-						tPod.populateLogicalSwitchCache(fakeOvn)
+						tPod.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 					}
 
 					fakeOvn.controller.WatchNamespaces()
@@ -648,7 +648,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations with IP Address Family", f
 					})...))
 
 					for _, tPod := range tPods {
-						tPod.populateLogicalSwitchCache(fakeOvn)
+						tPod.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 						_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(tPod.namespace).Create(context.TODO(), newPod(
 							tPod.namespace, tPod.podName, tPod.nodeName, tPod.podIP), metav1.CreateOptions{})
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -948,7 +948,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -1047,7 +1047,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, "")
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -1156,7 +1156,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						Items: []knet.NetworkPolicy{*networkPolicy},
 					},
 				)
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -1275,7 +1275,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -1456,7 +1456,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -1572,7 +1572,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -1679,7 +1679,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNetworkPolicy()
@@ -1777,7 +1777,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				nPodTest.populateLogicalSwitchCache(fakeOvn)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				fakeOvn.controller.WatchNamespaces()
 				fakeOvn.controller.WatchPods()
 				fakeOvn.controller.WatchNetworkPolicy()


### PR DESCRIPTION
using the logical switch manager to keep a cache of logical switch
UUIDs. Use the cache for adding and removing pods, this should increase
the performance since we don't have to figure out the UUID of the
applicable logical switches for every operation

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->