### PR TITLE
Set l3GWConfig.mode correctly

### DIFF
--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -216,7 +216,7 @@ func gatewayInitInternal(nodeName, gwIntf, egressGatewayIntf string, subnets []*
 	}
 
 	l3GwConfig := util.L3GatewayConfig{
-		Mode:           config.GatewayModeShared,
+		Mode:           config.Gateway.Mode,
 		ChassisID:      chassisID,
 		InterfaceID:    gatewayBridge.interfaceID,
 		MACAddress:     gatewayBridge.macAddress,

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -897,7 +897,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			ifaceID := node1.PhysicalBridgeName + "_" + node1.Name
 			vlanID := uint(1024)
 			l3Config := &util.L3GatewayConfig{
-				Mode:           config.GatewayModeShared,
+				Mode:           config.GatewayModeLocal,
 				ChassisID:      node1.SystemID,
 				InterfaceID:    ifaceID,
 				MACAddress:     ovntest.MustParseMAC(node1.PhysicalBridgeMAC),

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -163,9 +163,6 @@ func (cfg *L3GatewayConfig) UnmarshalJSON(bytes []byte) error {
 		if err != nil {
 			return fmt.Errorf("bad 'vlan-id' value %q: %v", cfgjson.VLANID, err)
 		}
-		if cfg.Mode != config.GatewayModeShared && uint(vlanID64) != 0 {
-			return fmt.Errorf("vlan-id is supported only in shared gateway mode")
-		}
 		// VLANID is used for specifying TagRequest on the logical switch port
 		// connected to the external logical switch, NB DB specifies a maximum
 		// value on the TagRequest to 4095, hence validate this:

--- a/go-controller/pkg/util/node_annotations_unit_test.go
+++ b/go-controller/pkg/util/node_annotations_unit_test.go
@@ -113,10 +113,6 @@ func TestL3GatewayConfig_UnmarshalJSON(t *testing.T) {
 			inputParam: []byte(`{"mode":"shared","vlan-id":"A"}`),
 			errMatch:   fmt.Errorf("bad 'vlan-id' value"),
 		},
-		{desc: "error: test VLANID is supported only in shared gateway mode",
-			inputParam: []byte(`{"mode":"local","vlan-id":"223"}`),
-			errMatch:   fmt.Errorf("vlan-id is supported only in shared gateway mode"),
-		},
 		{
 			desc:       "success: test valid VLANID input",
 			inputParam: []byte(`{"mode":"shared","vlan-id":"223"}`),


### PR DESCRIPTION
**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
The "mode" field in the l3gw annotation
actually denotes if there is a gateway
or not, and it means "have we created
an interface that we share with the node".
The value for this is always "shared" for
both local and shared modes and this is
confusing. Let's just update this with
the right mode.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>


**- Special notes for reviewers**
We are unfortunately stuck with the names "local" and "shared" for historical reasons. Note that LGW no longer contains a "br-local" and "breth0" exists on both LGW & SGW, so LGW also contains the "shared interface with the node". Wish we could expose "egressRoutingViaHost" versus "egressRoutingViaOVN" instead.


**- How to verify it**
Spin up a KIND cluster, depending on the gateway-mode if you do a oc describe on the node, you can see:
```
k8s.ovn.org/l3-gateway-config:
                      {"default":{"mode":"local","interface-id":"breth0_ovn-worker","mac-address":"02:42:ac:12:00:03","ip-addresses":["172.18.0.3/16"],"ip-addre...
```
versus
```
k8s.ovn.org/l3-gateway-config:
                      {"default":{"mode":"shared","interface-id":"breth0_ovn-worker","mac-address":"02:42:ac:12:00:03","ip-addresses":["172.18.0.3/16"],"ip-addre...

```