### PR TITLE
Pull up switch names from cache while creating ACLs

### DIFF
--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -105,6 +105,20 @@ func FindPerNodeJoinSwitches(nbClient libovsdbclient.Client) ([]nbdb.LogicalSwit
 	return switches, nil
 }
 
+func FindAllNodeLocalSwitches(nbClient libovsdbclient.Client) ([]nbdb.LogicalSwitch, error) {
+	// Find all node switches
+	nodeSwichLookupFcn := func(item *nbdb.LogicalSwitch) bool {
+		// Ignore external and Join switches(both legacy and current)
+		return !(strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == "join" || strings.HasPrefix(item.Name, types.ExternalSwitchPrefix))
+	}
+
+	switches, err := findSwitchesByPredicate(nbClient, nodeSwichLookupFcn)
+	if err != nil {
+		return nil, err
+	}
+	return switches, nil
+}
+
 func AddLoadBalancersToSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lswitch *nbdb.LogicalSwitch, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
 	if ops == nil {
 		ops = []libovsdb.Operation{}

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -343,12 +343,12 @@ func (oc *Controller) addEgressFirewallRules(ef *egressFirewall, hashedAddressSe
 func (oc *Controller) createEgressFirewallRules(priority int, match, action, externalID string) error {
 	logicalSwitches := []string{}
 	if config.Gateway.Mode == config.GatewayModeLocal {
-		nodes, err := oc.watchFactory.GetNodes()
+		nodeLocalSwitches, err := libovsdbops.FindAllNodeLocalSwitches(oc.nbClient)
 		if err != nil {
 			return fmt.Errorf("unable to setup egress firewall ACLs on cluster nodes, err: %v", err)
 		}
-		for _, node := range nodes {
-			logicalSwitches = append(logicalSwitches, node.Name)
+		for _, nodeLocalSwitch := range nodeLocalSwitches {
+			logicalSwitches = append(logicalSwitches, nodeLocalSwitch.Name)
 		}
 	} else {
 		logicalSwitches = append(logicalSwitches, types.OVNJoinSwitch)


### PR DESCRIPTION
While creating ACLs, we are using the
nodeNames as the switch names on which
the ACLs need to be created on. This
will break on hybrid-overlay mode
since not all nodes have the OVN
switches. Let's use the libovsdb cache.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
It is happening on pre-libovsdb times as well:

```
2021-10-26T10:38:38.106Z|02433|nbctl|INFO|Running command run
--id=@acl -- create acl priority=9999 direction=to-lport "match=\"(ip4.dst == $a5773229689678011375)
&& ip4.src == $a5811396932658691220 && ip4.dst != 10.128.0.0/14\"" action=allow external-ids:egressFirewall=test
-- add logical_switch winworker-mff7b acls @acl

E1026 10:38:38.106660       1 ovn.go:893] error executing create ACL command,
stderr: "ovn-nbctl: no row \"winworker-mff7b\" in table Logical_Switch\n",
OVN command '/usr/bin/ovn-nbctl --timeout=15 --id=@acl create acl priority=9999
direction=to-lport match="(ip4.dst == $a5773229689678011375) && ip4.src == $a5811396932658691220
&& ip4.dst != 10.128.0.0/14" action=allow external-ids:egressFirewall=test -- add logical_switch
winworker-mff7b acls @acl' failed: exit status 1
```

Need to fix this on master and then fix the nbctl version.