### PR TITLE
change the direction of the network policy acls to be consistant

### DIFF
--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -359,8 +359,14 @@ func (gp *gressPolicy) buildLocalPodACLs(portGroupName, aclLogging string) []*nb
 
 // buildACLAllow builds an allow-related ACL for a given given match
 func (gp *gressPolicy) buildACLAllow(match, l4Match string, ipBlockCIDR int, aclLogging string) *nbdb.ACL {
+	var direction string
+	if gp.policyType == knet.PolicyTypeIngress {
+		direction = nbdb.ACLDirectionToLport
+	} else {
+		direction = nbdb.ACLDirectionFromLport
+
+	}
 	priority := types.DefaultAllowPriority
-	direction := nbdb.ACLDirectionToLport
 	action := nbdb.ACLActionAllowRelated
 	aclName := fmt.Sprintf("%s_%s_%v", gp.policyNamespace, gp.policyName, gp.idx)
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -215,9 +215,14 @@ func defaultDenyPortGroup(namespace, gressSuffix string) string {
 
 func buildDenyACLs(namespace, policy, pg, aclLogging string, policyType knet.PolicyType) (denyACL, allowACL *nbdb.ACL) {
 	denyMatch := getACLMatch(pg, "", policyType)
-	denyACL = buildACL(namespace, pg, policy, nbdb.ACLDirectionToLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
 	allowMatch := getACLMatch(pg, "arp", policyType)
-	allowACL = buildACL(namespace, pg, "ARPallowPolicy", nbdb.ACLDirectionToLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
+	if policyType == knet.PolicyTypeIngress {
+		denyACL = buildACL(namespace, pg, policy, nbdb.ACLDirectionToLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
+		allowACL = buildACL(namespace, pg, "ARPallowPolicy", nbdb.ACLDirectionToLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
+	} else {
+		denyACL = buildACL(namespace, pg, policy, nbdb.ACLDirectionFromLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
+		allowACL = buildACL(namespace, pg, "ARPallowPolicy", nbdb.ACLDirectionFromLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
+	}
 	return
 }
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -92,7 +92,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 	shouldBeLogged := logSeverity != nbdb.ACLSeverityInfo
 	egressDenyACL := libovsdbops.BuildACL(
 		networkPolicy.Namespace+"_"+networkPolicy.Name,
-		nbdb.ACLDirectionToLport,
+		nbdb.ACLDirectionFromLport,
 		types.DefaultDenyPriority,
 		"inport == @"+pgHash+"_"+egressDenyPG,
 		nbdb.ACLActionDrop,
@@ -107,7 +107,7 @@ func (n kNetworkPolicy) getDefaultDenyData(networkPolicy *knet.NetworkPolicy, po
 
 	egressAllowACL := libovsdbops.BuildACL(
 		networkPolicy.Namespace+"_ARPallowPolicy",
-		nbdb.ACLDirectionToLport,
+		nbdb.ACLDirectionFromLport,
 		types.DefaultAllowPriority,
 		"inport == @"+pgHash+"_"+egressDenyPG+" && arp",
 		nbdb.ACLActionAllow,
@@ -244,7 +244,7 @@ func (n kNetworkPolicy) getPolicyData(networkPolicy *knet.NetworkPolicy, policyP
 			egressAsMatch := asMatch(append(peerNamespaces, getAddressSetName(networkPolicy.Namespace, networkPolicy.Name, knet.PolicyTypeEgress, i)))
 			acl := libovsdbops.BuildACL(
 				aclName,
-				nbdb.ACLDirectionToLport,
+				nbdb.ACLDirectionFromLport,
 				types.DefaultAllowPriority,
 				fmt.Sprintf("ip4.dst == {%s} && inport == @%s", egressAsMatch, pgHash),
 				nbdb.ACLActionAllowRelated,
@@ -266,7 +266,7 @@ func (n kNetworkPolicy) getPolicyData(networkPolicy *knet.NetworkPolicy, policyP
 		for _, v := range tcpPeerPorts {
 			acl := libovsdbops.BuildACL(
 				aclName,
-				nbdb.ACLDirectionToLport,
+				nbdb.ACLDirectionFromLport,
 				types.DefaultAllowPriority,
 				fmt.Sprintf("ip4 && tcp && tcp.dst==%d && inport == @%s", v, pgHash),
 				nbdb.ACLActionAllowRelated,


### PR DESCRIPTION
before this patch all the network policy ACLs where in direction
ToLport which will work correctly if pods effected by the policies are
on seporate nodes. If the two pods exist on the same node the and have
the same direction the first ACL that matches will dictate the
interaction causing egress network policies to override ingress network
policies for pods in the same node

By splitting the policies directions the both ACLs will be evaluated
because one ACL exists on the ingress pipeline and the other will exist
on the egress pipeline

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>


fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2037647
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->