### PR TITLE
Add COPP to gateway routers for rate limiting pkts

### DIFF
--- a/go-controller/pkg/libovsdbops/copp.go
+++ b/go-controller/pkg/libovsdbops/copp.go
@@ -1,0 +1,116 @@
+package libovsdbops
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+)
+
+const (
+	// Default Meters created on GRs.
+	OVNARPRateLimiter              = "arp"
+	OVNARPResolveRateLimiter       = "arp-resolve"
+	OVNBFDRateLimiter              = "bfd"
+	OVNControllerEventsRateLimiter = "event-elb"
+	OVNICMPV4ErrorsRateLimiter     = "icmp4-error"
+	OVNICMPV6ErrorsRateLimiter     = "icmp6-error"
+	OVNRejectRateLimiter           = "reject"
+	OVNTCPRSTRateLimiter           = "tcp-reset"
+)
+
+func GetMeterNameForProtocol(protocol string) string {
+	return protocol + "-" + types.OvnRateLimitingMeter
+}
+
+// CreateDefaultCOPP creates the default COPP that needs to be added to each GR
+func CreateDefaultCOPP(nbClient libovsdbclient.Client) (string, error) {
+	coppUUIDResult := ""
+	defaultProtocolNames := []string{
+		OVNARPRateLimiter,
+		OVNARPResolveRateLimiter,
+		OVNBFDRateLimiter,
+		OVNControllerEventsRateLimiter,
+		OVNICMPV4ErrorsRateLimiter,
+		OVNICMPV6ErrorsRateLimiter,
+		OVNRejectRateLimiter,
+		OVNTCPRSTRateLimiter,
+	}
+	metersToAdd := make(map[string]string, len(defaultProtocolNames))
+	for _, protocol := range defaultProtocolNames {
+		// format: <OVNSupportedProtocolName>-rate-limiter
+		metersToAdd[protocol] = GetMeterNameForProtocol(protocol)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	controlPlaneProtection := []nbdb.Copp{}
+	// TODO(tssurya): querying based on maps is not efficient, fix this to use name field when
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2040852 is fixed
+	err := nbClient.WhereCache(func(copp *nbdb.Copp) bool { return reflect.DeepEqual(copp.Meters, metersToAdd) }).List(ctx, &controlPlaneProtection)
+	if err != nil && err != libovsdbclient.ErrNotFound {
+		return coppUUIDResult, fmt.Errorf("error while creating default COPP %+v:%v", controlPlaneProtection, err)
+	} else if len(controlPlaneProtection) == 0 {
+		// no copp found
+		// Create a meter band with 25 pktps rate.
+		meterBand := &nbdb.MeterBand{
+			Action: types.MeterAction,
+			Rate:   int(25), // hard-coding for now. TODO(tssurya): make this configurable if needed
+		}
+
+		// we cannot have a standalone meterBand, always needs to be created with a meter
+		// so the first meter is created with the band and rest of the meters then reference
+		// the same band.
+		meterFairness := true
+		meter := &nbdb.Meter{
+			Name: GetMeterNameForProtocol(defaultProtocolNames[0]),
+			Fair: &meterFairness,
+			Unit: types.PacketsPerSecond,
+		}
+		results, err := CreateMeterWithBand(nbClient, meter, meterBand)
+		if err != nil {
+			return coppUUIDResult, fmt.Errorf("error while creating default COPP %+v:%v", controlPlaneProtection, err)
+		}
+		meterBandUUID := results[0].UUID.GoUUID
+
+		// Create default meters for the various proto types with the above band
+		var opModels []OperationModel
+		for i := 1; i < len(defaultProtocolNames); i++ {
+			meter := &nbdb.Meter{
+				Name:  GetMeterNameForProtocol(defaultProtocolNames[i]),
+				Fair:  &meterFairness,
+				Unit:  types.PacketsPerSecond,
+				Bands: []string{meterBandUUID},
+			}
+			opModels = append(opModels, []OperationModel{
+				{
+					Model: meter,
+				},
+			}...)
+		}
+
+		// Create a COPP with the above meter and protocols
+		copp := &nbdb.Copp{Meters: metersToAdd}
+		opModels = append(opModels, []OperationModel{
+			{
+				Model: copp,
+			},
+		}...)
+		m := NewModelClient(nbClient)
+		results, err = m.CreateOrUpdate(opModels...)
+		if err != nil {
+			return coppUUIDResult, fmt.Errorf("error while creating default COPP %+v:%v", controlPlaneProtection, err)
+		}
+		// results will have default meters and copp at last index
+		coppUUIDResult = results[len(results)-1].UUID.GoUUID
+	} else {
+		// copp exists
+		coppUUIDResult = controlPlaneProtection[0].UUID
+	}
+
+	return coppUUIDResult, nil
+}

--- a/go-controller/pkg/libovsdbops/meter.go
+++ b/go-controller/pkg/libovsdbops/meter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/ovsdb"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -48,7 +49,7 @@ func UpdateMeterFairness(nbClient libovsdbclient.Client, meter *nbdb.Meter, fair
 
 // CreateMeterWithBand simulates the ovn-nbctl operation performed by the `meter-add` command. i.e create the Meter
 // and accompanying meter_band, and add the meterband to the meter only call this if the meter does not exist
-func CreateMeterWithBand(nbClient libovsdbclient.Client, meter *nbdb.Meter, meterBand *nbdb.MeterBand) error {
+func CreateMeterWithBand(nbClient libovsdbclient.Client, meter *nbdb.Meter, meterBand *nbdb.MeterBand) ([]ovsdb.OperationResult, error) {
 	opModels := []OperationModel{
 		{
 			Model: meterBand,
@@ -62,9 +63,11 @@ func CreateMeterWithBand(nbClient libovsdbclient.Client, meter *nbdb.Meter, mete
 	}
 
 	m := NewModelClient(nbClient)
-	if _, err := m.CreateOrUpdate(opModels...); err != nil {
-		return fmt.Errorf("error while creating Meter_Band %+v and Meter %+v error %v", meterBand, meter, err)
+	var results []ovsdb.OperationResult
+	var err error
+	if results, err = m.CreateOrUpdate(opModels...); err != nil {
+		return nil, fmt.Errorf("error while creating Meter_Band %+v and Meter %+v error %v", meterBand, meter, err)
 	}
 
-	return nil
+	return results, nil
 }

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -17,6 +17,8 @@ func getUUID(model model.Model) string {
 		return t.UUID
 	case *nbdb.BFD:
 		return t.UUID
+	case *nbdb.Copp:
+		return t.UUID
 	case *nbdb.GatewayChassis:
 		return t.UUID
 	case *nbdb.LoadBalancer:
@@ -61,6 +63,8 @@ func setUUID(model model.Model, uuid string) {
 	case *nbdb.AddressSet:
 		t.UUID = uuid
 	case *nbdb.BFD:
+		t.UUID = uuid
+	case *nbdb.Copp:
 		t.UUID = uuid
 	case *nbdb.GatewayChassis:
 		t.UUID = uuid
@@ -115,6 +119,10 @@ func copyIndexes(model model.Model) model.Model {
 			UUID:        t.UUID,
 			LogicalPort: t.LogicalPort,
 			DstIP:       t.DstIP,
+		}
+	case *nbdb.Copp:
+		return &nbdb.Copp{
+			UUID: t.UUID,
 		}
 	case *nbdb.GatewayChassis:
 		return &nbdb.GatewayChassis{
@@ -202,6 +210,8 @@ func getListFromModel(model model.Model) interface{} {
 		return &[]nbdb.AddressSet{}
 	case *nbdb.BFD:
 		return &[]nbdb.BFD{}
+	case *nbdb.Copp:
+		return &[]nbdb.Copp{}
 	case *nbdb.GatewayChassis:
 		return &[]nbdb.GatewayChassis{}
 	case *nbdb.LoadBalancer:

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -56,6 +57,13 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 		logicalRouter.LoadBalancerGroup = []string{oc.loadBalancerGroupUUID}
 	}
 
+	coppUUID, err := libovsdbops.CreateDefaultCOPP(oc.nbClient)
+	if err != nil || len(coppUUID) <= 0 {
+		klog.Warningf("Unable to create control plane protection on router %s:%v", gatewayRouter, err)
+	} else {
+		logicalRouter.Copp = &coppUUID
+	}
+
 	opModels := []libovsdbops.OperationModel{
 		{
 			Model:          &logicalRouter,
@@ -64,6 +72,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				&logicalRouter.Options,
 				&logicalRouter.ExternalIDs,
 				&logicalRouter.LoadBalancerGroup,
+				&logicalRouter.Copp,
 			},
 		},
 	}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -147,6 +147,38 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		}
 	}
 
+	testData = append(testData, &nbdb.MeterBand{
+		UUID:   "25-pktps-rate-limiter-UUID",
+		Action: types.MeterAction,
+		Rate:   int(25),
+	})
+	meters := map[string]string{
+		libovsdbops.OVNARPRateLimiter:              libovsdbops.GetMeterNameForProtocol(libovsdbops.OVNARPRateLimiter),
+		libovsdbops.OVNARPResolveRateLimiter:       libovsdbops.GetMeterNameForProtocol(libovsdbops.OVNARPResolveRateLimiter),
+		libovsdbops.OVNBFDRateLimiter:              libovsdbops.GetMeterNameForProtocol(libovsdbops.OVNBFDRateLimiter),
+		libovsdbops.OVNControllerEventsRateLimiter: libovsdbops.GetMeterNameForProtocol(libovsdbops.OVNControllerEventsRateLimiter),
+		libovsdbops.OVNICMPV4ErrorsRateLimiter:     libovsdbops.GetMeterNameForProtocol(libovsdbops.OVNICMPV4ErrorsRateLimiter),
+		libovsdbops.OVNICMPV6ErrorsRateLimiter:     libovsdbops.GetMeterNameForProtocol(libovsdbops.OVNICMPV6ErrorsRateLimiter),
+		libovsdbops.OVNRejectRateLimiter:           libovsdbops.GetMeterNameForProtocol(libovsdbops.OVNRejectRateLimiter),
+		libovsdbops.OVNTCPRSTRateLimiter:           libovsdbops.GetMeterNameForProtocol(libovsdbops.OVNTCPRSTRateLimiter),
+	}
+	fairness := true
+	for _, v := range meters {
+		testData = append(testData, &nbdb.Meter{
+			UUID:  v + "-UUID",
+			Bands: []string{"25-pktps-rate-limiter-UUID"},
+			Name:  v,
+			Unit:  types.PacketsPerSecond,
+			Fair:  &fairness,
+		})
+	}
+
+	copp := &nbdb.Copp{
+		UUID:   "copp-UUID",
+		Meters: meters,
+	}
+	testData = append(testData, copp)
+
 	testData = append(testData, &nbdb.LogicalRouter{
 		UUID: GRName + "-UUID",
 		Name: GRName,
@@ -165,6 +197,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		StaticRoutes:      grStaticRoutes,
 		Nat:               natUUIDs,
 		LoadBalancerGroup: []string{types.ClusterLBGroupName + "-UUID"},
+		Copp:              &copp.UUID,
 	})
 
 	testData = append(testData, expectedOVNClusterRouter)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -292,7 +292,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 			Unit: types.PacketsPerSecond,
 		}
 
-		if err := libovsdbops.CreateMeterWithBand(oc.nbClient, meter, meterBand); err != nil {
+		if _, err := libovsdbops.CreateMeterWithBand(oc.nbClient, meter, meterBand); err != nil {
 			klog.Warningf("ACL logging support enabled, however acl-logging meter could not be created: %v. "+
 				"Disabling ACL logging support", err)
 			oc.aclLoggingEnabled = false

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -93,10 +93,11 @@ const (
 	RouteAdvertisementICMPType    = 134
 	NeighborAdvertisementICMPType = 136
 
-	// ACL logging constants
-	OvnACLLoggingMeter = "acl-logging"
-	PacketsPerSecond   = "pktps"
-	MeterAction        = "drop"
+	// Meter constants
+	OvnACLLoggingMeter   = "acl-logging"
+	OvnRateLimitingMeter = "rate-limiter"
+	PacketsPerSecond     = "pktps"
+	MeterAction          = "drop"
 
 	// OVN-K8S Address Sets Names
 	HybridRoutePolicyPrefix = "hybrid-route-pods-"


### PR DESCRIPTION
**- What this PR does and why is it needed**

PR adds support for rate-limiting packets by availing the COPP feature provided by OVN. See https://bugzilla.redhat.com/show_bug.cgi?id=2011525 for details.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>


**- Special notes for reviewers**
We have set the rate to random value of 25 packets per second, can be made configurable in the future like we do for acl logging,


**- How to verify it**
Unit tests included. Verified on KIND:
```
sh-5.1# ovn-nbctl list copp
_uuid               : a1199870-9f5b-464b-b29c-52dc4f159244
meters              : {arp=arp-rate-limiter, arp-resolve=arp-resolve-rate-limiter, bfd=bfd-rate-limiter, event-elb=event-elb-rate-limiter, icmp4-error=icmp4-error-rate-limiter, icmp6-error=icmp6-error-rate-limiter, reject=reject-rate-limiter, tcp-reset=tcp-reset-rate-limiter}

sh-5.1# ovn-nbctl list meter     
_uuid               : c74b5459-0019-43a5-84e1-4b18e9b34b37
bands               : [bdefde19-abcb-4e32-b46b-da9c08a61d06]
external_ids        : {}
fair                : true
name                : event-elb-rate-limiter
unit                : pktps

_uuid               : fce0faf3-9325-4a4c-ad48-8d4b8ff221bc
bands               : [bdefde19-abcb-4e32-b46b-da9c08a61d06]
external_ids        : {}
fair                : true
name                : arp-resolve-rate-limiter
unit                : pktps

_uuid               : 71e7b4ab-01a5-45c1-88e9-c29e6cdede85
bands               : [bdefde19-abcb-4e32-b46b-da9c08a61d06]
external_ids        : {}
fair                : true
name                : arp-rate-limiter
unit                : pktps

_uuid               : 9db02f03-c3e3-4ca9-9c89-402c250ecdbb
bands               : [bdefde19-abcb-4e32-b46b-da9c08a61d06]
external_ids        : {}
fair                : true
name                : tcp-reset-rate-limiter
unit                : pktps

_uuid               : c9c5da14-0feb-442d-8f4a-b87ba19c04d0
bands               : [bdefde19-abcb-4e32-b46b-da9c08a61d06]
external_ids        : {}
fair                : true
name                : bfd-rate-limiter
unit                : pktps

_uuid               : c9e6b84c-0463-4b02-8874-83a92917d2f8
bands               : [bdefde19-abcb-4e32-b46b-da9c08a61d06]
external_ids        : {}
fair                : true
name                : icmp6-error-rate-limiter
unit                : pktps

_uuid               : 26461074-4738-4f84-9e6d-834f823a433b
bands               : [bdefde19-abcb-4e32-b46b-da9c08a61d06]
external_ids        : {}
fair                : true
name                : icmp4-error-rate-limiter
unit                : pktps

_uuid               : 1debd575-3e63-4684-b911-b6739241db04
bands               : [bdefde19-abcb-4e32-b46b-da9c08a61d06]
external_ids        : {}
fair                : true
name                : reject-rate-limiter
unit                : pktps

sh-5.1# ovn-nbctl list meter-band
_uuid               : bdefde19-abcb-4e32-b46b-da9c08a61d06
action              : drop
burst_size          : 0
external_ids        : {name=rate-limiter}
rate                : 25


```
```
ovn-nbctl list logical-router
_uuid               : 7c15cea8-52b6-4443-8a4e-b437a443529f
copp                : 11e52b42-e91a-4023-a394-9489eb690b5e
enabled             : []
external_ids        : {physical_ip="172.18.0.4", physical_ips="172.18.0.4"}
load_balancer       : [30804873-b8ff-4a42-9e5d-b3a200d23fc5]
load_balancer_group : [04c3d05b-204f-404f-a410-d61586bb5b47]
name                : GR_ovn-worker2
nat                 : [33dff7f2-4546-4e97-9244-99a6ef13339c]
options             : {always_learn_from_arp_request="false", chassis="83a675f6-ba7e-4e13-ad10-863905acae5a", dynamic_neigh_routers="true", lb_force_snat_ip=router_ip, snat-ct-zone="0"}
policies            : []
ports               : [217a3412-4365-4496-afb2-7562b17b33a3, aa720178-e905-4226-b077-c495143dc019]
static_routes       : [4b8668f6-cb27-4661-9b74-e746c80e9dc9, dc4f8ecc-8067-4ddc-a3c4-37c15167c339]

_uuid               : a044e1e0-aea1-4823-98fb-467b2d4672e8
copp                : 11e52b42-e91a-4023-a394-9489eb690b5e
enabled             : []
external_ids        : {physical_ip="172.18.0.2", physical_ips="172.18.0.2"}
load_balancer       : [30804873-b8ff-4a42-9e5d-b3a200d23fc5]
load_balancer_group : [04c3d05b-204f-404f-a410-d61586bb5b47]
name                : GR_ovn-worker
nat                 : [b1f2685b-4409-490c-a83a-e41ab2d6a7b9]
options             : {always_learn_from_arp_request="false", chassis="10580247-7be0-448d-9a21-8fd5a3d6c868", dynamic_neigh_routers="true", lb_force_snat_ip=router_ip, snat-ct-zone="0"}
policies            : []
ports               : [2ebdd035-5cdd-4b05-973d-a35d065f3e09, 64b155f6-3d1b-4680-92ec-90761b4de966]
static_routes       : [52bc6655-16fb-463f-8585-83e0a769f98d, bada6638-4322-4533-a7b3-902a3dc7e875]

_uuid               : 0ae155e9-27b1-4882-9662-ef4b38a85f77
copp                : 11e52b42-e91a-4023-a394-9489eb690b5e
enabled             : []
external_ids        : {physical_ip="172.18.0.3", physical_ips="172.18.0.3"}
load_balancer       : [90a8308d-3041-46fc-9736-f5f8fd4d42e2]
load_balancer_group : [04c3d05b-204f-404f-a410-d61586bb5b47]
name                : GR_ovn-control-plane
nat                 : [4a57c38b-fa7d-4fc7-a99c-f715ec688d60]
options             : {always_learn_from_arp_request="false", chassis="6bc90518-e6cb-45a3-aa8c-ac5e757bf26c", dynamic_neigh_routers="true", lb_force_snat_ip=router_ip, snat-ct-zone="0"}
policies            : []
ports               : [0c89bfad-8d5b-4bbe-9a40-e56da34c617e, 4f0492dd-7d16-4bae-b584-0a65661adf6d]
static_routes       : [90dcfeaa-dbbe-41cb-9676-e4c065429a21, f8da60d7-5bca-440a-9676-3d3ac1903bac]
```
