### PR TITLE
Bug 1996128: Remove test "should have ipv4 and ipv6 node podCIDRs" from disabled tests

### DIFF
--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -20,7 +20,6 @@ DisruptionController
 # FEATURES NOT AVAILABLE IN OUR CI ENVIRONMENT
 \[Feature:Federation\]
 should have ipv4 and ipv6 internal node ip
-should have ipv4 and ipv6 node podCIDRs
 
 # TESTS THAT ASSUME KUBE-PROXY
 kube-proxy


### PR DESCRIPTION
Test "should have ipv4 and ipv6 node podCIDRs" was removed from e2e tests in kubernetes 1.23 (https://github.com/kubernetes/kubernetes/pull/105079), so no need to skip it.

closes #1996128
