### PR TITLE
Loadbalancer cache sync

### DIFF
--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -37,7 +37,7 @@ func findRouter(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) (*nb
 	}
 
 	if len(routers) == 0 {
-		return nil, libovsdbclient.ErrNotFound
+		return nil, fmt.Errorf("unable to find router %s: %w", router.Name, libovsdbclient.ErrNotFound)
 	}
 
 	router.UUID = routers[0].UUID

--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	ovnlb "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/loadbalancer"
@@ -135,6 +136,16 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 	}
 
 	return
+}
+
+// GetSvcName finds the service name (as a namespaced key) from a load balancer name
+func getSvcName(lbName string) string {
+	re := regexp.MustCompile(`^Service_([^ ]+)_(SCTP|UDP|TCP)`)
+	match := re.FindStringSubmatch("Service_default/my-service_TCP_node_router+switch_ovn-worker")
+	if len(match) > 1 {
+		return match[1]
+	}
+	return ""
 }
 
 // makeLBName creates the load balancer name - used to minimize churn

--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -96,13 +96,13 @@ func (r *repair) runBeforeSync() {
 		namespace, name, err := cache.SplitMetaNamespaceKey(owner)
 		if err != nil || namespace == "" {
 			klog.Warningf("Service LB %#v has unreadable owner, deleting", lb)
-			staleLBs = append(staleLBs, lb.UUID)
+			staleLBs = append(staleLBs, lb.UUIDs.UnsortedList()...)
 		}
 
 		_, err = r.serviceLister.Services(namespace).Get(name)
 		if apierrors.IsNotFound(err) {
 			klog.V(5).Infof("Found stale service LB %#v", lb)
-			staleLBs = append(staleLBs, lb.UUID)
+			staleLBs = append(staleLBs, lb.UUIDs.UnsortedList()...)
 		}
 	}
 
@@ -168,7 +168,7 @@ func (r *repair) deleteLegacyLBs() error {
 	klog.V(2).Infof("Deleting %d legacy LBs", len(legacyLBs))
 	toDelete := make([]string, 0, len(legacyLBs))
 	for _, lb := range legacyLBs {
-		toDelete = append(toDelete, lb.UUID)
+		toDelete = append(toDelete, lb.UUIDs.UnsortedList()...)
 	}
 	if err := ovnlb.DeleteLBs(r.nbClient, toDelete); err != nil {
 		return fmt.Errorf("failed to delete LBs: %w", err)

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -359,7 +359,7 @@ func (c *Controller) syncService(key string) error {
 	if ok && ovnlb.LoadBalancersEqualNoUUID(existingLBs, lbs) && !hasDupes {
 		klog.V(3).Infof("Skipping no-op change for service %s", key)
 	} else {
-		klog.V(5).Infof("Services do not match, existing lbs: %#v, built lbs: %#v", existingLBs, lbs)
+		klog.V(5).Infof("Services do not match, *EXISTING LBs: %#v, *BUILT LBs: %#v", existingLBs, lbs)
 		// Actually apply load-balancers to OVN.
 		//
 		// Note: this may fail if a node was deleted between listing nodes and applying.

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 )
 
 var globalCache *LBCache
@@ -37,14 +38,17 @@ func GetLBCache(nbClient libovsdbclient.Client) (*LBCache, error) {
 type LBCache struct {
 	sync.Mutex
 
+	// cache keys on lb name
 	existing map[string]*CachedLB
 }
 
 // we don't need to store / populate all information, just a subset
 type CachedLB struct {
-	Name        string
-	Protocol    string
-	UUID        string
+	Name     string
+	Protocol string
+	// UUIDs are plural because there may be more than one LB in OVN with the same name
+	// The Name on a load_balancer is not unique in OVN, but it is in OVNK
+	UUIDs       sets.String
 	ExternalIDs map[string]string
 	VIPs        sets.String // don't care about backend IPs, just the vips
 
@@ -53,30 +57,50 @@ type CachedLB struct {
 	Groups   sets.String
 }
 
+// AddOrUpdateEntry adds an entry to the cache or updates it with a UUID
+// returns a list of UUIDs associated with this entry
+func (c *LBCache) AddOrUpdateEntry(name, uuid string) []string {
+	c.Lock()
+	defer c.Unlock()
+	if _, ok := c.existing[name]; ok {
+		c.existing[name].UUIDs.Insert(uuid)
+	} else {
+		c.existing[name] = &CachedLB{
+			Name:  name,
+			UUIDs: sets.NewString(uuid),
+		}
+	}
+
+	return c.existing[name].UUIDs.UnsortedList()
+}
+
 // update the database with any existing LBs, along with any
 // that were deleted.
 func (c *LBCache) update(existing []LB, toDelete []string) {
 	c.Lock()
 	defer c.Unlock()
-	for _, uuid := range toDelete {
-		delete(c.existing, uuid)
+	for _, name := range toDelete {
+		delete(c.existing, name)
 	}
 
 	for _, lb := range existing {
 		if lb.UUID == "" {
 			panic(fmt.Sprintf("coding error: cache add LB %s with no UUID", lb.Name))
 		}
-		c.existing[lb.UUID] = &CachedLB{
-			Name:        lb.Name,
-			UUID:        lb.UUID,
-			Protocol:    strings.ToLower(lb.Protocol),
-			ExternalIDs: lb.ExternalIDs,
-			VIPs:        getVips(&lb),
 
-			Switches: sets.NewString(lb.Switches...),
-			Routers:  sets.NewString(lb.Routers...),
-			Groups:   sets.NewString(lb.Groups...),
+		if _, ok := c.existing[lb.Name]; !ok {
+			existingLB := &CachedLB{Name: lb.Name, UUIDs: sets.NewString()}
+			c.existing[lb.Name] = existingLB
 		}
+
+		c.existing[lb.Name].UUIDs.Insert(lb.UUID)
+		c.existing[lb.Name].Protocol = strings.ToLower(lb.Protocol)
+		c.existing[lb.Name].ExternalIDs = lb.ExternalIDs
+		c.existing[lb.Name].VIPs = getVips(&lb)
+		c.existing[lb.Name].Switches = sets.NewString(lb.Switches...)
+		c.existing[lb.Name].Routers = sets.NewString(lb.Routers...)
+		c.existing[lb.Name].Groups = sets.NewString(lb.Groups...)
+
 	}
 }
 
@@ -86,7 +110,7 @@ func (c *LBCache) removeVips(toRemove []DeleteVIPEntry) {
 	defer c.Unlock()
 
 	for _, entry := range toRemove {
-		lb := c.existing[entry.LBUUID]
+		lb := c.existing[entry.LBName]
 		if lb == nil {
 			continue
 		}
@@ -123,20 +147,38 @@ func getVips(lb *LB) sets.String {
 }
 
 // Find searches through the cache for load balancers that match the list of external IDs.
-// It returns all found load balancers, indexed by uuid.
-func (c *LBCache) Find(externalIDs map[string]string) map[string]*CachedLB {
+// It returns all found load balancers, indexed by name.
+func (c *LBCache) Find(externalIDs map[string]string) map[string]CachedLB {
 	c.Lock()
 	defer c.Unlock()
 
-	out := map[string]*CachedLB{}
+	out := map[string]CachedLB{}
 
-	for uuid, lb := range c.existing {
+	for name, lb := range c.existing {
 		if extIDsMatch(externalIDs, lb.ExternalIDs) {
-			out[uuid] = lb
+			out[name] = *lb
 		}
 	}
 
 	return out
+}
+
+// Get fetches UUIDs for LB name
+func (c *LBCache) Get(name string) []string {
+	c.Lock()
+	defer c.Unlock()
+
+	return c.existing[name].UUIDs.UnsortedList()
+}
+
+// fetches LB name by UUID
+func (c *LBCache) getByUUID(uuid string) string {
+	for name, lb := range c.existing {
+		if lb.UUIDs.Has(uuid) {
+			return name
+		}
+	}
+	return ""
 }
 
 // extIDsMatch returns true if have is a superset of want.
@@ -154,6 +196,17 @@ func extIDsMatch(want, have map[string]string) bool {
 	return true
 }
 
+// FindLegacyLBExtIDKey takes into account legacy lbs use a format of <name> = "yes"
+// find the corresponding ID and return it
+func FindLegacyLBExtIDKey(extIDs map[string]string) string {
+	for k, v := range extIDs {
+		if v == "yes" {
+			return k
+		}
+	}
+	return ""
+}
+
 // newCache creates a lbCache, populated with all existing load balancers
 func newCache(nbClient libovsdbclient.Client) (*LBCache, error) {
 	// first, list all load balancers
@@ -166,7 +219,26 @@ func newCache(nbClient libovsdbclient.Client) (*LBCache, error) {
 	c.existing = make(map[string]*CachedLB, len(lbs))
 
 	for i := range lbs {
-		c.existing[lbs[i].UUID] = &lbs[i]
+		key := lbs[i].Name
+		// legacy LBs do not use a name and instead use external ids
+		// copy those to name for the cache
+		if len(key) == 0 {
+			key = FindLegacyLBExtIDKey(lbs[i].ExternalIDs)
+		}
+		if len(key) > 0 {
+			// check if this LB is already in cache
+			if _, ok := c.existing[lbs[i].Name]; ok {
+				c.existing[lbs[i].Name].UUIDs.Insert(lbs[i].UUIDs.UnsortedList()...)
+				klog.Warningf("Duplicate Load Balancers found in OVN for name %q, UUIDs: %+v",
+					lbs[i].Name, lbs[i].UUIDs.UnsortedList())
+			} else {
+				c.existing[lbs[i].Name] = &lbs[i]
+			}
+		} else {
+			klog.Warningf("Load balancer has no name and no legacy UUID, will ignore from LB Cache! LB: %#v",
+				lbs[i])
+		}
+
 	}
 
 	switches, err := libovsdbops.ListSwitchesWithLoadBalancers(nbClient)
@@ -176,8 +248,9 @@ func newCache(nbClient libovsdbclient.Client) (*LBCache, error) {
 
 	for _, ls := range switches {
 		for _, lbuuid := range ls.LoadBalancer {
-			if lb, ok := c.existing[lbuuid]; ok {
-				lb.Switches.Insert(ls.Name)
+			cacheLBName := c.getByUUID(lbuuid)
+			if cacheLBName != "" {
+				c.existing[cacheLBName].Switches.Insert(ls.Name)
 			}
 		}
 	}
@@ -189,8 +262,9 @@ func newCache(nbClient libovsdbclient.Client) (*LBCache, error) {
 
 	for _, router := range routers {
 		for _, lbuuid := range router.LoadBalancer {
-			if lb, ok := c.existing[lbuuid]; ok {
-				lb.Routers.Insert(router.Name)
+			cacheLBName := c.getByUUID(lbuuid)
+			if cacheLBName != "" {
+				c.existing[cacheLBName].Routers.Insert(router.Name)
 			}
 		}
 	}
@@ -202,8 +276,9 @@ func newCache(nbClient libovsdbclient.Client) (*LBCache, error) {
 
 	for _, group := range groups {
 		for _, lbuuid := range group.LoadBalancer {
-			if lb, ok := c.existing[lbuuid]; ok {
-				lb.Groups.Insert(group.Name)
+			cacheLBName := c.getByUUID(lbuuid)
+			if cacheLBName != "" {
+				c.existing[cacheLBName].Groups.Insert(group.Name)
 			}
 		}
 	}
@@ -221,7 +296,7 @@ func listLBs(nbClient libovsdbclient.Client) ([]CachedLB, error) {
 	out := make([]CachedLB, 0, len(lbs))
 	for _, lb := range lbs {
 		res := CachedLB{
-			UUID:        lb.UUID,
+			UUIDs:       sets.NewString(lb.UUID),
 			Name:        lb.Name,
 			ExternalIDs: lb.ExternalIDs,
 			VIPs:        sets.String{},

--- a/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/lb_cache_test.go
@@ -80,8 +80,8 @@ func TestNewCache(t *testing.T) {
 	}
 
 	assert.Equal(t, map[string]*CachedLB{
-		"cb6ebcb0-c12d-4404-ada7-5aa2b898f06b": {
-			UUID:     "cb6ebcb0-c12d-4404-ada7-5aa2b898f06b",
+		"Service_default/kubernetes_TCP_node_router_ovn-control-plane": {
+			UUIDs:    sets.NewString("cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"),
 			Name:     "Service_default/kubernetes_TCP_node_router_ovn-control-plane",
 			Protocol: "tcp",
 			ExternalIDs: map[string]string{
@@ -97,8 +97,8 @@ func TestNewCache(t *testing.T) {
 			},
 			Groups: sets.String{},
 		},
-		"7dc190c4-c615-467f-af83-9856d832c9a0": {
-			UUID:     "7dc190c4-c615-467f-af83-9856d832c9a0",
+		"Service_default/kubernetes_TCP_node_switch_ovn-control-plane_merged": {
+			UUIDs:    sets.NewString("7dc190c4-c615-467f-af83-9856d832c9a0"),
 			Name:     "Service_default/kubernetes_TCP_node_switch_ovn-control-plane_merged",
 			Protocol: "tcp",
 			ExternalIDs: map[string]string{
@@ -119,16 +119,16 @@ func TestNewCache(t *testing.T) {
 	}, c.existing)
 
 	c.RemoveRouter("GR_ovn-worker")
-	assert.Equal(t, c.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Routers, sets.String{
+	assert.Equal(t, c.existing["Service_default/kubernetes_TCP_node_switch_ovn-control-plane_merged"].Routers, sets.String{
 		"GR_ovn-worker2": {},
 	})
 
 	c.RemoveSwitch("ovn-worker")
-	assert.Equal(t, c.existing["7dc190c4-c615-467f-af83-9856d832c9a0"].Switches, sets.String{
+	assert.Equal(t, c.existing["Service_default/kubernetes_TCP_node_switch_ovn-control-plane_merged"].Switches, sets.String{
 		"ovn-control-plane": {},
 	})
 	// nothing changed
-	assert.Equal(t, c.existing["cb6ebcb0-c12d-4404-ada7-5aa2b898f06b"].Switches, sets.String{
+	assert.Equal(t, c.existing["Service_default/kubernetes_TCP_node_router_ovn-control-plane"].Switches, sets.String{
 		"ovn-worker2": {},
 	})
 }

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -98,12 +98,12 @@ func EnsureLBs(nbClient libovsdbclient.Client, externalIDs map[string]string, LB
 
 	ops, err := libovsdbops.CreateOrUpdateLoadBalancersOps(nbClient, nil, existinglbs...)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create or update load balancer ops: %v", err)
 	}
 
 	ops, err = libovsdbops.CreateLoadBalancersOps(nbClient, ops, newlbs...)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create or load balancer ops: %v", err)
 	}
 
 	// cache switches for this round of ops
@@ -120,13 +120,13 @@ func EnsureLBs(nbClient libovsdbclient.Client, externalIDs map[string]string, LB
 	for k, v := range addLBsToSwitch {
 		ops, err = libovsdbops.AddLoadBalancersToSwitchOps(nbClient, ops, getSwitch(k), v...)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to make load balancer to switch ops: %v", err)
 		}
 	}
 	for k, v := range removeLBsFromSwitch {
 		ops, err = libovsdbops.RemoveLoadBalancersFromSwitchOps(nbClient, ops, getSwitch(k), v...)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to make remove load balancer to switch ops: %v", err)
 		}
 	}
 
@@ -144,13 +144,13 @@ func EnsureLBs(nbClient libovsdbclient.Client, externalIDs map[string]string, LB
 	for k, v := range addLBsToRouter {
 		ops, err = libovsdbops.AddLoadBalancersToRouterOps(nbClient, ops, getRouter(k), v...)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to make load balancer to router ops: %v", err)
 		}
 	}
 	for k, v := range removesLBsFromRouter {
 		ops, err = libovsdbops.RemoveLoadBalancersFromRouterOps(nbClient, ops, getRouter(k), v...)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to make remove load balancer to router ops: %v", err)
 		}
 	}
 
@@ -168,13 +168,13 @@ func EnsureLBs(nbClient libovsdbclient.Client, externalIDs map[string]string, LB
 	for k, v := range addLBsToGroups {
 		ops, err = libovsdbops.AddLoadBalancersToGroupOps(nbClient, ops, getGroup(k), v...)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to make load balancer to group ops: %v", err)
 		}
 	}
 	for k, v := range removeLBsFromGroups {
 		ops, err = libovsdbops.RemoveLoadBalancersFromGroupOps(nbClient, ops, getGroup(k), v...)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to make remove load balancer to group ops: %v", err)
 		}
 	}
 
@@ -187,12 +187,12 @@ func EnsureLBs(nbClient libovsdbclient.Client, externalIDs map[string]string, LB
 	}
 	ops, err = libovsdbops.DeleteLoadBalancersOps(nbClient, ops, deleteLBs...)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to make delete load balancer to ops: %v", err)
 	}
 
 	_, err = libovsdbops.TransactAndCheckAndSetUUIDs(nbClient, lbs, ops)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to execute load balancer ovn txn: %v", err)
 	}
 
 	for _, lb := range lbs {


### PR DESCRIPTION
Preserves the OVNK LB cache in order to make look ups more efficient. Migrates the OVNK LB cache to be indexed by service name, since that is our unique property. Adds a hook in libovsdb to update the OVNK cache with all newly add load balancers in OVN. OVNK now on ensureLB detects if there are duplicate UUIDs for a desired LB name, and then removes them if so. Also, pulls in @jcaamano patch which avoids unnecessary LB finds for existing LBs that are in the OVNK cache, which increases performance.

**- How to verify it**
1. Launch a KIND cluster
2. Create a service called "my-service"
3. Go into ovn-nbctl, create a new LB with the same name:
[root@ovn-control-plane ~]# ovn-nbctl create load_balancer name=Service_default/my-service_TCP_cluster
839d6d36-3bdd-446b-b6b6-3c8c3d46692c
4. Verify there are 2 LBs with the same name in OVN now:
[root@ovn-control-plane ~]# ovn-nbctl list load_balancer | grep my-service | grep Service_default/my-service_TCP_cluster
name                : "Service_default/my-service_TCP_cluster"
name                : "Service_default/my-service_TCP_cluster"
5. Modify a property of the service, triggering a service update.
6. OVNK will print out the line:
E0120 23:56:59.699201      63 loadbalancer.go:52] Multiple OVN load balancer UUIDs detected for load balancer name: Service_default/my-service_TCP_cluster. UUIDs: map[839d6d36-3bdd-446b-b6b6-3c8c3d46692c:{} 9dc53cd3-abc1-4e8c-8362-f250190d5251:{}]
7. The above LBs will be removed in OVN and a new one will be created:
[root@ovn-control-plane ~]# ovn-nbctl list load_balancer | grep my-service | grep Service_default/my-service_TCP_cluster
name                : "Service_default/my-service_TCP_cluster"

_uuid               : c2d38078-598b-4345-ac60-6017e21343d4
external_ids        : {"k8s.ovn.org/kind"=Service, "k8s.ovn.org/owner"="default/my-service"}
health_check        : []
ip_port_mappings    : {}
name                : "Service_default/my-service_TCP_cluster"
options             : {event="false", reject="true", skip_snat="false"}
protocol            : tcp
selection_fields    : []
vips                : {"1.1.1.1:81"="", "10.96.71.227:81"=""}

