### PR TITLE
EgressIP: Fix update of CloudPrivateIPConfig

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -604,9 +604,9 @@ type cloudPrivateIPConfigOp struct {
 // IP, cloudPrivateIPConfigOp is a helper used to determine that sort of
 // operations from toAssign/toRemove
 func (oc *Controller) executeCloudPrivateIPConfigChange(egressIPName string, toAssign, toRemove []egressipv1.EgressIPStatusItem) error {
-	ops := make(map[string]cloudPrivateIPConfigOp, len(toAssign)+len(toRemove))
+	ops := make(map[string]*cloudPrivateIPConfigOp, len(toAssign)+len(toRemove))
 	for _, assignment := range toAssign {
-		ops[assignment.EgressIP] = cloudPrivateIPConfigOp{
+		ops[assignment.EgressIP] = &cloudPrivateIPConfigOp{
 			toAdd: assignment.Node,
 		}
 	}
@@ -614,7 +614,7 @@ func (oc *Controller) executeCloudPrivateIPConfigChange(egressIPName string, toA
 		if op, exists := ops[removal.EgressIP]; exists {
 			op.toDelete = removal.Node
 		} else {
-			ops[removal.EgressIP] = cloudPrivateIPConfigOp{
+			ops[removal.EgressIP] = &cloudPrivateIPConfigOp{
 				toDelete: removal.Node,
 			}
 		}
@@ -622,7 +622,7 @@ func (oc *Controller) executeCloudPrivateIPConfigChange(egressIPName string, toA
 	return oc.executeCloudPrivateIPConfigOps(egressIPName, ops)
 }
 
-func (oc *Controller) executeCloudPrivateIPConfigOps(egressIPName string, ops map[string]cloudPrivateIPConfigOp) error {
+func (oc *Controller) executeCloudPrivateIPConfigOps(egressIPName string, ops map[string]*cloudPrivateIPConfigOp) error {
 	for egressIP, op := range ops {
 		cloudPrivateIPConfigName := ipStringToCloudPrivateIPConfigName(egressIP)
 		cloudPrivateIPConfig, err := oc.watchFactory.GetCloudPrivateIPConfig(cloudPrivateIPConfigName)


### PR DESCRIPTION
`executeCloudPrivateIPConfigChange` computes the diff between what needs
to be assigned and removed, and passes the operations to `executeCloudPrivateIPConfigOps`.
However, the `ops` structure used isn't a pointer based structure,
meaning that for update operations: the modifications made for removals
didn't actually modify the same struct, leading to update operations
being treated as add operations and failing later on in `executeCloudPrivateIPConfigOps`.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->