### PR TITLE
Docs/go-controller: update minimum go version to v1.16

### DIFF
--- a/go-controller/README.md
+++ b/go-controller/README.md
@@ -4,7 +4,7 @@ The golang based ovn controller is a reliable way to deploy the OVN SDN using ku
 
 ### Build
 
-Ensure go version >= 1.8
+Ensure go version >= 1.16
 
 ```
 cd go-controller


### PR DESCRIPTION
Some go-controlle submodules make use of the go fs
package that were added to go version 1.16.

Trying to compile go-controlle module using go versions
older than v1.16 will cause some compilation issues.

Signed-off-by: Mohammad Heib <mheib@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->