### PR TITLE
Make sync failures fatal after retries

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -30,7 +31,7 @@ const (
 	ipv6AddressSetSuffix = "_v6"
 )
 
-type AddressSetIterFunc func(hashedName, namespace, suffix string)
+type AddressSetIterFunc func(hashedName, namespace, suffix string) error
 type AddressSetDoFunc func(as AddressSet) error
 
 // AddressSetFactory is an interface for managing address set objects
@@ -176,7 +177,7 @@ func (asf *ovnAddressSetFactory) EnsureAddressSet(name string) (AddressSet, erro
 	return &ovnAddressSets{nbClient: asf.nbClient, name: name, ipv4: v4set, ipv6: v6set}, nil
 }
 
-func forEachAddressSet(nbClient libovsdbclient.Client, do func(string)) error {
+func forEachAddressSet(nbClient libovsdbclient.Client, do func(string) error) error {
 	addrSetList := &[]nbdb.AddressSet{}
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
@@ -189,9 +190,17 @@ func forEachAddressSet(nbClient libovsdbclient.Client, do func(string)) error {
 		return fmt.Errorf("error reading address sets: %+v", err)
 	}
 
+	var errors []error
 	for _, addrSet := range *addrSetList {
-		do(addrSet.ExternalIDs["name"])
+		if err := do(addrSet.ExternalIDs["name"]); err != nil {
+			errors = append(errors, err)
+		}
 	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to iterate address sets: %v", utilerrors.NewAggregate(errors))
+	}
+
 	return nil
 }
 
@@ -200,14 +209,14 @@ func forEachAddressSet(nbClient libovsdbclient.Client, do func(string)) error {
 // OVN. (Unhashed address set names are of the form namespaceName[.suffix1.suffix2. .suffixN])
 func (asf *ovnAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIterFunc) error {
 	processedAddressSets := sets.String{}
-	err := forEachAddressSet(asf.nbClient, func(name string) {
+	return forEachAddressSet(asf.nbClient, func(name string) error {
 		// Remove the suffix from the address set name and normalize
 		addrSetName := truncateSuffixFromAddressSet(name)
 		if processedAddressSets.Has(addrSetName) {
 			// We have already processed the address set. In case of dual stack we will have _v4 and _v6
 			// suffixes for address sets. Since we are normalizing these two address sets through this API
 			// we will process only one normalized address set name.
-			return
+			return nil
 		}
 		processedAddressSets.Insert(addrSetName)
 		names := strings.Split(addrSetName, ".")
@@ -216,10 +225,8 @@ func (asf *ovnAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIter
 		if len(names) >= 2 {
 			nameSuffix = names[1]
 		}
-		iteratorFn(addrSetName, addrSetNamespace, nameSuffix)
+		return iteratorFn(addrSetName, addrSetNamespace, nameSuffix)
 	})
-
-	return err
 }
 
 func truncateSuffixFromAddressSet(asName string) string {

--- a/go-controller/pkg/ovn/address_set/address_set_cleanup.go
+++ b/go-controller/pkg/ovn/address_set/address_set_cleanup.go
@@ -16,7 +16,7 @@ func NonDualStackAddressSetCleanup(nbClient libovsdbclient.Client) error {
 	const old = 0
 	const new = 1
 	addressSets := map[string][2]bool{}
-	err := forEachAddressSet(nbClient, func(name string) {
+	err := forEachAddressSet(nbClient, func(name string) error {
 		shortName := truncateSuffixFromAddressSet(name)
 		spec, found := addressSets[shortName]
 		if !found {
@@ -30,6 +30,7 @@ func NonDualStackAddressSetCleanup(nbClient libovsdbclient.Client) error {
 			spec[new] = true
 		}
 		addressSets[shortName] = spec
+		return nil
 	})
 
 	if err != nil {

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 					},
 				}
 
-				err = asFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) {
+				err = asFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) error {
 					found := false
 					for _, n := range namespaces {
 						name := n.makeNames()
@@ -116,6 +116,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 						}
 					}
 					gomega.Expect(found).To(gomega.BeTrue())
+					return nil
 				})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				return nil

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -86,7 +86,9 @@ func (f *FakeAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIterF
 		if len(parts) >= 2 {
 			nameSuffix = parts[1]
 		}
-		iteratorFn(asName, addrSetNamespace, nameSuffix)
+		if err := iteratorFn(asName, addrSetNamespace, nameSuffix); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -2190,6 +2190,10 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 								Name: types.GWRouterPrefix + nodeName,
 								UUID: types.GWRouterPrefix + nodeName + "-UUID",
 							},
+							&nbdb.LogicalSwitch{
+								UUID: "node1",
+								Name: "node1",
+							},
 						},
 					},
 					&v1.NamespaceList{
@@ -2220,6 +2224,10 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName,
 						Networks: []string{"100.64.0.4/32"},
 					},
+					&nbdb.LogicalSwitch{
+						UUID: "node1",
+						Name: "node1",
+					},
 				}
 				injectNode(fakeOvn)
 				fakeOvn.controller.WatchNamespaces()
@@ -2240,6 +2248,10 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName + "-UUID",
 						Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + nodeName,
 						Networks: []string{"100.64.0.4/32"},
+					},
+					&nbdb.LogicalSwitch{
+						UUID: "node1",
+						Name: "node1",
 					},
 				}
 				err = deletePerPodGRSNAT(fakeOvn.controller.nbClient, nodeName, extIPs, []*net.IPNet{fullMaskPodNet})

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -40,12 +40,14 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 		expectedNs[ns.Name] = true
 	}
 
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) {
+	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) error {
 		if nameSuffix == "" && !expectedNs[namespaceName] {
 			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
 				klog.Errorf(err.Error())
+				return err
 			}
 		}
+		return nil
 	})
 	if err != nil {
 		klog.Errorf("Error in syncing namespaces: %v", err)

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -30,12 +30,17 @@ const (
 )
 
 func (oc *Controller) syncNamespaces(namespaces []interface{}) {
+	oc.syncWithRetry("syncNamespaces", func() error { return oc.syncNamespacesRetriable(namespaces) })
+}
+
+// This function implements the main body of work of syncNamespaces.
+// Upon failure, it may be invoked multiple times in order to avoid a pod restart.
+func (oc *Controller) syncNamespacesRetriable(namespaces []interface{}) error {
 	expectedNs := make(map[string]bool)
 	for _, nsInterface := range namespaces {
 		ns, ok := nsInterface.(*kapi.Namespace)
 		if !ok {
-			klog.Errorf("Spurious object in syncNamespaces: %v", nsInterface)
-			continue
+			return fmt.Errorf("spurious object in syncNamespaces: %v", nsInterface)
 		}
 		expectedNs[ns.Name] = true
 	}
@@ -50,8 +55,9 @@ func (oc *Controller) syncNamespaces(namespaces []interface{}) {
 		return nil
 	})
 	if err != nil {
-		klog.Errorf("Error in syncing namespaces: %v", err)
+		return fmt.Errorf("error in syncing namespaces: %v", err)
 	}
+	return nil
 }
 
 func (oc *Controller) getRoutingExternalGWs(nsInfo *namespaceInfo) *gatewayInfo {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -26,27 +26,39 @@ import (
 )
 
 func (oc *Controller) syncPods(pods []interface{}) {
+	oc.syncWithRetry("syncPods", func() error { return oc.syncPodsRetriable(pods) })
+}
+
+// This function implements the main body of work of syncPods.
+// Upon failure, it may be invoked multiple times in order to avoid a pod restart.
+func (oc *Controller) syncPodsRetriable(pods []interface{}) error {
 	var allOps []ovsdb.Operation
 	// get the list of logical switch ports (equivalent to pods)
 	expectedLogicalPorts := make(map[string]bool)
 	for _, podInterface := range pods {
 		pod, ok := podInterface.(*kapi.Pod)
 		if !ok {
-			klog.Errorf("Spurious object in syncPods: %v", podInterface)
-			continue
+			return fmt.Errorf("spurious object in syncPods: %v", podInterface)
 		}
 		annotations, err := util.UnmarshalPodAnnotation(pod.Annotations)
 		if util.PodScheduled(pod) && util.PodWantsNetwork(pod) && err == nil {
 			logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
 			expectedLogicalPorts[logicalPort] = true
 			if err = oc.waitForNodeLogicalSwitchInCache(pod.Spec.NodeName); err != nil {
-				klog.Errorf("Failed to wait for node %s to be added to cache. IP allocation may fail!",
+				return fmt.Errorf("failed to wait for node %s to be added to cache. IP allocation may fail!",
 					pod.Spec.NodeName)
 			}
 			if err = oc.lsManager.AllocateIPs(pod.Spec.NodeName, annotations.IPs); err != nil {
-				klog.Errorf("Couldn't allocate IPs: %s for pod: %s on node: %s"+
-					" error: %v", util.JoinIPNetIPs(annotations.IPs, " "), logicalPort,
-					pod.Spec.NodeName, err)
+				if err == ipallocator.ErrAllocated {
+					// already allocated: log an error but not stop syncPod from continuing
+					klog.Errorf("Already allocated IPs: %s for pod: %s on node: %s",
+						util.JoinIPNetIPs(annotations.IPs, " "), logicalPort,
+						pod.Spec.NodeName)
+				} else {
+					return fmt.Errorf("Couldn't allocate IPs: %s for pod: %s on node: %s"+
+						" error: %v", util.JoinIPNetIPs(annotations.IPs, " "), logicalPort,
+						pod.Spec.NodeName, err)
+				}
 			}
 		}
 	}
@@ -58,8 +70,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	defer cancel()
 	err := oc.nbClient.List(ctx, &lspList)
 	if err != nil {
-		klog.Errorf("Cannot sync pods, cannot retrieve list of logical switch ports (%+v)", err)
-		return
+		return fmt.Errorf("cannot sync pods, cannot retrieve list of logical switch ports (%+v)", err)
 	}
 	for _, lsp := range lspList {
 		portCache[lsp.UUID] = lsp
@@ -67,8 +78,7 @@ func (oc *Controller) syncPods(pods []interface{}) {
 	// get all the nodes from the watchFactory
 	nodes, err := oc.watchFactory.GetNodes()
 	if err != nil {
-		klog.Errorf("Failed to get nodes: %v", err)
-		return
+		return fmt.Errorf("failed to get nodes: %v", err)
 	}
 	for _, n := range nodes {
 		stalePorts := []string{}
@@ -76,17 +86,19 @@ func (oc *Controller) syncPods(pods []interface{}) {
 		ls := &nbdb.LogicalSwitch{}
 		if lsUUID, ok := oc.lsManager.GetUUID(n.Name); !ok {
 			klog.Errorf("Error getting logical switch for node %s: %s", n.Name, "Switch not in logical switch cache")
-			continue
+
+			// Not in cache: Try getting the logical switch from ovn database (slower method)
+			if ls, err = libovsdbops.FindSwitchByName(oc.nbClient, n.Name); err != nil {
+				return fmt.Errorf("can't find switch for node %s: %v", n.Name, err)
+			}
 		} else {
 			ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
 			defer cancel()
 
 			ls.UUID = lsUUID
 			if err := oc.nbClient.Get(ctx, ls); err != nil {
-				klog.Errorf("Error getting logical switch for node %d (UUID: %d) from ovn database (%v)", n.Name, ls.UUID, err)
-				continue
+				return fmt.Errorf("error getting logical switch for node %s (UUID: %s) from ovn database (%v)", n.Name, ls.UUID, err)
 			}
-
 		}
 		for _, port := range ls.Ports {
 			if portCache[port].ExternalIDs["pod"] == "true" {
@@ -102,16 +114,16 @@ func (oc *Controller) syncPods(pods []interface{}) {
 				Value:   stalePorts,
 			})
 			if err != nil {
-				klog.Errorf("Could not generate ops to delete stale ports from logical switch %s (%+v)", n.Name, err)
-				continue
+				return fmt.Errorf("could not generate ops to delete stale ports from logical switch %s (%+v)", n.Name, err)
 			}
 			allOps = append(allOps, ops...)
 		}
 	}
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, allOps)
 	if err != nil {
-		klog.Errorf("Could not remove stale logicalPorts from switches (%+v)", err)
+		return fmt.Errorf("could not remove stale logicalPorts from switches (%+v)", err)
 	}
+	return nil
 }
 
 func (oc *Controller) deleteLogicalPort(pod *kapi.Pod) {

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -127,7 +127,7 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 	}
 
 	stalePGs := []string{}
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, policyName string) {
+	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, policyName string) error {
 		if policyName != "" && !expectedPolicies[namespaceName][policyName] {
 			// policy doesn't exist on k8s. Delete the port group
 			portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
@@ -136,8 +136,10 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 			// delete the address sets for this old policy from OVN
 			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
 				klog.Errorf(err.Error())
+				return err
 			}
 		}
+		return nil
 	})
 	if err != nil {
 		klog.Errorf("Error in syncing network policies: %v", err)

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -108,13 +108,17 @@ func hashedPortGroup(s string) string {
 }
 
 func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
+	oc.syncWithRetry("syncNetworkPolicies", func() error { return oc.syncNetworkPoliciesRetriable(networkPolicies) })
+}
+
+// This function implements the main body of work of syncNetworkPolicies.
+// Upon failure, it may be invoked multiple times in order to avoid a pod restart.
+func (oc *Controller) syncNetworkPoliciesRetriable(networkPolicies []interface{}) error {
 	expectedPolicies := make(map[string]map[string]bool)
 	for _, npInterface := range networkPolicies {
 		policy, ok := npInterface.(*knet.NetworkPolicy)
 		if !ok {
-			klog.Errorf("Spurious object in syncNetworkPolicies: %v",
-				npInterface)
-			continue
+			return fmt.Errorf("spurious object in syncNetworkPolicies: %v", npInterface)
 		}
 
 		if nsMap, ok := expectedPolicies[policy.Namespace]; ok {
@@ -142,15 +146,16 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) {
 		return nil
 	})
 	if err != nil {
-		klog.Errorf("Error in syncing network policies: %v", err)
+		return fmt.Errorf("error in syncing network policies: %v", err)
 	}
 
 	if len(stalePGs) > 0 {
 		err = libovsdbops.DeletePortGroups(oc.nbClient, stalePGs...)
 		if err != nil {
-			klog.Errorf("Error removing stale port groups %v: %v", stalePGs, err)
+			return fmt.Errorf("error removing stale port groups %v: %v", stalePGs, err)
 		}
 	}
+	return nil
 }
 
 func addAllowACLFromNode(nodeName string, mgmtPortIP net.IP, nbClient libovsdbclient.Client) error {


### PR DESCRIPTION
Upon starting, failures when syncing OVN DB with K8 should
be considered fatal. Still, this change will introduce
retry logic to minimize pod restarts.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>