### PR TITLE
Fixes finding default gateway for configured GW interface

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -138,7 +138,7 @@ func getGatewayNextHops() ([]net.IP, string, error) {
 	}
 	gatewayIntf := config.Gateway.Interface
 	if needIPv4NextHop || needIPv6NextHop || gatewayIntf == "" {
-		defaultGatewayIntf, defaultGatewayNextHops, err := getDefaultGatewayInterfaceDetails()
+		defaultGatewayIntf, defaultGatewayNextHops, err := getDefaultGatewayInterfaceDetails(gatewayIntf)
 		if err != nil {
 			return nil, "", err
 		}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -974,6 +974,15 @@ var _ = Describe("Gateway Init Operations", func() {
 		It("sets up a shared interface gateway with tagged VLAN", func() {
 			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0IP, eth0GWIP, eth0CIDR, 3000)
 		})
+
+		config.Gateway.Interface = eth0Name
+		It("sets up a shared interface gateway with predetermined gateway interface", func() {
+			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0IP, eth0GWIP, eth0CIDR, 0)
+		})
+
+		It("sets up a shared interface gateway with tagged VLAN + predetermined gateway interface", func() {
+			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0IP, eth0GWIP, eth0CIDR, 3000)
+		})
 	})
 })
 


### PR DESCRIPTION
The code for determining the default gateway was not taking into
consideration if the gateway interfaces was provided via config and
would return any default gateway found on the host. This is an issue
when a system has more than 1 default gateway, as well as if a user
provided an interface other than the real default gateway interface.

If the gateway interface is provided via config, the code now scopes
default routes found to only that interface.

Signed-off-by: Tim Rozet <trozet@redhat.com>

