### PR TITLE
Fix cache building used for removing stale egress IPs

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1117,9 +1117,13 @@ func (oc *Controller) generatePodIPCacheForEgressIP(eIPs []interface{}) (map[str
 				continue
 			}
 			for _, pod := range pods {
-				for _, podIP := range pod.Status.PodIPs {
-					ip := net.ParseIP(podIP.IP)
-					egressIPToPodIPCache[egressIP.Name].Insert(ip.String())
+				logicalPort, err := oc.logicalPortCache.get(util.GetLogicalPortName(pod.Namespace, pod.Name))
+				if err != nil {
+					klog.Errorf("Error getting logical port %s, err: %v", util.GetLogicalPortName(pod.Namespace, pod.Name), err)
+					continue
+				}
+				for _, ipNet := range logicalPort.ips {
+					egressIPToPodIPCache[egressIP.Name].Insert(ipNet.IP.String())
 				}
 			}
 		}


### PR DESCRIPTION
When a pod matching an egress ip is scheduled and `ovnkube-master` is not running the following happens once `ovnkube-master` starts again:
1. The new POD gets an IP address assigned
2. Egress IP is configured using the following logic to get the pod IP: https://github.com/ovn-org/ovn-kubernetes/blob/7ba85e84aa489761d4958d953e0a1daeb0c10e8c/go-controller/pkg/ovn/egressip.go#L852-L869
3. Egress IP ovn config is removed  [here](https://github.com/ovn-org/ovn-kubernetes/blob/7ba85e84aa489761d4958d953e0a1daeb0c10e8c/go-controller/pkg/ovn/egressip.go#L1023) because `pod.Status.PodIPs`  is still empty when [generatePodIPCacheForEgressIP](https://github.com/ovn-org/ovn-kubernetes/blob/7ba85e84aa489761d4958d953e0a1daeb0c10e8c/go-controller/pkg/ovn/egressip.go#L1100) is called.

It is a timing issue that is resolved by following the same approach during configuring and cleaning up the stale egress IPs.

https://bugzilla.redhat.com/show_bug.cgi?id=2048841