### PR TITLE
[DNM][WIP] Set flows with in_port=LOCAL to output: NORMAL in commonFlows

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1016,10 +1016,11 @@ func commonFlows(ofPortPhys, bridgeMacAddress, ofPortPatch, ofPortHost string) [
 
 		// table 0, packets coming from host Commit connections with ct_mark ctMarkHost
 		// so that reverse direction goes back to the host.
+		// output:NORMAL to avoid problems with invalid port number when NetworkManager is restarted.
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ip, "+
-				"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
-				defaultOpenFlowCookie, ofPortHost, config.Default.ConntrackZone, ctMarkHost, ofPortPhys))
+				"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:NORMAL",
+				defaultOpenFlowCookie, ofPortHost, config.Default.ConntrackZone, ctMarkHost))
 
 		// table 0, packets coming from external. Send it through conntrack and
 		// resubmit to table 1 to know the state and mark of the connection.
@@ -1037,10 +1038,11 @@ func commonFlows(ofPortPhys, bridgeMacAddress, ofPortPatch, ofPortHost string) [
 
 		// table 0, packets coming from host. Commit connections with ct_mark ctMarkHost
 		// so that reverse direction goes back to the host.
+		// output:NORMAL to avoid problems with invalid port number when NetworkManager is restarted.
 		dftFlows = append(dftFlows,
 			fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ipv6, "+
-				"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
-				defaultOpenFlowCookie, ofPortHost, config.Default.ConntrackZone, ctMarkHost, ofPortPhys))
+				"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:NORMAL",
+				defaultOpenFlowCookie, ofPortHost, config.Default.ConntrackZone, ctMarkHost))
 
 		// table 0, packets coming from external. Send it through conntrack and
 		// resubmit to table 1 to know the state and mark of the connection.


### PR DESCRIPTION
When NetworkManager is restarted, all interfaces are removed from the
external bridge (br-ex / beth0). In such scenarios, ports' OVS IDs
change and the existing flows point to wrong output: port numbers. This
effectively leads to packet drops of all traffic that originates at
LOCAL and the node will not be able to request an IP address via DHCP.
Send traffic that originates from the LOCAL interface to output: NORMAL
to have it use normal switch action instead of using hardcoded OVS port
IDs.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
See https://bugzilla.redhat.com/show_bug.cgi?id=2048352

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->