### PR TITLE
Egress firewall don't block host network

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -82,6 +82,10 @@ func newEgressFirewallRule(rawEgressFirewallRule egressfirewallapi.EgressFirewal
 	return efr, nil
 }
 
+func (oc *Controller) createNodeAllowACLs(match string) error {
+
+}
+
 func (oc *Controller) addNodeForEgressFirewall(node *v1.Node) error {
 	v4Addr, v6Addr := getNodeInternalAddrs(node)
 	if v4Addr != nil {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -138,6 +138,10 @@ type Controller struct {
 	externalGWCache map[ktypes.NamespacedName]*externalRouteInfo
 	exGWCacheMutex  sync.RWMutex
 
+	// An addressSet of all the node host Addresses
+	nodeAddressSet      addressset.AddressSet
+	nodeAddressSetMutex sync.RWMutex
+
 	// egressFirewalls is a map of namespaces and the egressFirewall attached to it
 	egressFirewalls sync.Map
 
@@ -359,23 +363,7 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 		oc.egressFirewallDNS.Run(egressFirewallDNSDefaultDuration)
 		oc.egressFirewallHandler = oc.WatchEgressFirewall()
 
-		// For shared gateway mode we need to initialize a watcher on nodes
-		// which setup allow ACLs for egress firewall matching pods to the host
-		// network. This can only be done in shared gateway mode because we
-		// program the ACLs on the join switch, as supposed to local gateway
-		// mode which does so on the node's switch. For local gateway mode there
-		// is no way to fix this issue. Given that this "allow ACL" needs to
-		// take precedence over all egress firewall rules (and needs to have a
-		// priority of 10001) for connectivity to work to the host network: it
-		// would also take precedence over all network policy ACLs (which are
-		// also programmed on the node's switch). Hence if a user would create a
-		// network policy denying access to the Kubernetes service API, this
-		// default allow ACL would overwrite it and grant access (since the
-		// egress firewall priority supersede the network policy ones), hence
-		// why this cannot be done in local gateway mode.
-		if config.Gateway.Mode == config.GatewayModeShared {
-			oc.WatchEgressFirewallNodes()
-		}
+		oc.WatchEgressFirewallNodes()
 	}
 
 	klog.Infof("Completing all the Watchers took %v", time.Since(start))

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -67,7 +67,7 @@ const (
 	// firewall matching pods. This is done as to make sure egress firewall
 	// matching pods can still connect to the host network on all cluster nodes,
 	// even though a "deny 0.0.0.0/0" rule is specified.
-	DefaultEgressFirewallAllowPriority = "10001"
+	DefaultEgressFirewallAllowPriority = 10001
 	// EgressFirewallStartPriority is the priority from which the ACL priority
 	// will be decremented on a per rule basis. This means that the first rule
 	// defined for a namespace will have this priority, and the second one will

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -61,7 +61,22 @@ const (
 	DefaultDenyPriority = 1000
 
 	// priority of logical router policies on the OVNClusterRouter
-	EgressFirewallStartPriority           = 10000
+
+	// DefaultEgressFirewallAllowPriority is the ACL priority for the default
+	// allow ACL rules, enabling access to all cluster nodes from egress
+	// firewall matching pods. This is done as to make sure egress firewall
+	// matching pods can still connect to the host network on all cluster nodes,
+	// even though a "deny 0.0.0.0/0" rule is specified.
+	DefaultEgressFirewallAllowPriority = "10001"
+	// EgressFirewallStartPriority is the priority from which the ACL priority
+	// will be decremented on a per rule basis. This means that the first rule
+	// defined for a namespace will have this priority, and the second one will
+	// have this priority minus one, etc.
+	EgressFirewallStartPriority = 10000
+	// MinimumReservedEgressFirewallPriority is the minimum priority for which
+	// the ACL priority for egress firewall rules can be decremented to. This
+	// means that an EgressFirewall object can have 8000 rules defined and no
+	// rule will have a priority lower than this.
 	MinimumReservedEgressFirewallPriority = 2000
 	MGMTPortPolicyPriority                = "1005"
 	NodeSubnetPolicyPriority              = "1004"

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1303,7 +1303,7 @@ spec:
 		// and re-enable this check
 
 		// ginkgo.By("6. Check connectivity to the kubernetes API IP and verify that it works")
-		// err = wait.PollImmediate(retryInterval, retryTimeout, targetAPIServiceAndTest(podNamespace.Name, []string{pod1Name, pod2Name}))
+		// err = wait.PollImmediate(retryInterval, retryTimeout, targetDestinationAndTest(podNamespace.Name, fmt.Sprintf("https://%s/version", net.JoinHostPort(getApiAddress(), "443")), []string{pod1Name, pod2Name}))
 		// framework.ExpectNoError(err, "Step 6. Check connectivity to the kubernetes API IP and verify that it works, failed, err %v", err)
 
 		ginkgo.By("7. Check connectivity to the other pod IP and verify that it works")


### PR DESCRIPTION
this commit allows host networked pods to not be blocked by egressFirewalls in both shared and local gateway modes. An address set is created with all the node IPs in it and in shared gateway mode an additional ACL is created to allow traffic to the nodes. Local gateway mode is more problematic, since the acls are on the nodes switch we need to use negation to allow the traffic to host network pods similar to how clusterCIDR traffic is ignored.



<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->