### PR TITLE
Edited README_MANUAL.md to Fix this issue: flag provided but not defi…

### DIFF
--- a/README_MANUAL.md
+++ b/README_MANUAL.md
@@ -26,8 +26,9 @@ this repository. To compile it, you will need golang installed.  You can
 install golang with:
 
 ```
-wget -nv https://dl.google.com/go/go1.9.2.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz
+wget -nv https://go.dev/dl/go1.17.6.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz
+export PATH=$PATH:/usr/local/go/bin
 ```
 
 You need to set your GOPATH, clone the ovn-kubernetes repo, compile and


### PR DESCRIPTION
Edited README_MANUAL.md to Fix this issue: flag provided but not defined: -mod

Testing: Build go-controller after the fix.
Signed-off-by: Ali Hassan Ahmed Khan alihasanahmedkhan@gmail.com

- What this PR does and why is it needed

While using the go1.9.2.linux-amd64.tar.gz this error occurs when trying to make the go-controller ###flag provided but not defined: -mod. Updating the go version to the latest version resolve this problem. And I have tested the go-controller build on the latest go version.

- Special notes for reviewers
Edited README_MANUAL.md and update the go version download link and add command to export PATH.

- How to verify it
You can verify it by installing the latest go version and then make a go-controller.

- Description for the changelog
While using the go1.9.2.linux-amd64.tar.gz this error occurs when trying to make the go-controller ###flag provided but not defined: -mod. Updating the go version to the latest version resolve this problem