### PR TITLE
configurable timeout for ovsdb connection

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -58,6 +58,7 @@ OVN_IPFIX_CACHE_ACTIVE_TIMEOUT=""
 OVN_HOST_NETWORK_NAMESPACE=""
 OVN_EX_GW_NETWORK_INTERFACE=""
 OVNKUBE_NODE_MGMT_PORT_NETDEV=""
+OVSDB_CONNECT_TIMEOUT=""
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -223,6 +224,9 @@ while [ "$1" != "" ]; do
   --ovnkube-node-mgmt-port-netdev)
     OVNKUBE_NODE_MGMT_PORT_NETDEV=$VALUE
     ;;
+  --ovsdb-connect-timeout)
+    OVSDB_CONNECT_TIMEOUT=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -340,6 +344,8 @@ ovn_ex_gw_networking_interface=${OVN_EX_GW_NETWORK_INTERFACE}
 echo "ovn_ex_gw_networking_interface: ${ovn_ex_gw_networking_interface}"
 ovnkube_node_mgmt_port_netdev=${OVNKUBE_NODE_MGMT_PORT_NETDEV}
 echo "ovnkube_node_mgmt_port_netdev: ${ovnkube_node_mgmt_port_netdev}"
+ovsdb_connect_timeout=${OVSDB_CONNECT_TIMEOUT}
+echo "ovsdb_connect_timeout: ${ovsdb_connect_timeout}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -431,6 +437,7 @@ ovn_image=${image} \
   ovn_master_count=${ovn_master_count} \
   ovn_gateway_mode=${ovn_gateway_mode} \
   ovn_ex_gw_networking_interface=${ovn_ex_gw_networking_interface} \
+  ovsdb_connect_timeout=${ovsdb_connect_timeout} \
   j2 ../templates/ovnkube-master.yaml.j2 -o ../yaml/ovnkube-master.yaml
 
 ovn_image=${image} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -79,6 +79,7 @@ fi
 # OVNKUBE_NODE_MGMT_PORT_NETDEV - ovnkube node management port netdev. valid when ovnkube node mode is: dpu, dpu-host
 # OVN_ENCAP_IP - encap IP to be used for OVN traffic on the node. mandatory in case ovnkube-node-mode=="dpu"
 # OVN_HOST_NETWORK_NAMESPACE - namespace to classify host network traffic for applying network policies
+# OVSDB_CONNECT_TIMEOUT - custom timeout value when connecting to nb/sb ovsdb (default 10 seconds)
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -247,6 +248,12 @@ fi
 
 OVS_RUNDIR=/var/run/openvswitch
 OVS_LOGDIR=/var/log/openvswitch
+
+# OVSDB_CONNECT_TIMEOUT
+ovsdb_connect_timeout_flag=
+if [ -n "${OVSDB_CONNECT_TIMEOUT}" ]; then
+  ovsdb_connect_timeout_flag="--ovsdb-connect-timeout ${OVSDB_CONNECT_TIMEOUT}"
+fi
 
 # =========================================
 
@@ -957,7 +964,8 @@ ovn-master() {
     ${egressip_enabled_flag} \
     ${egressfirewall_enabled_flag} \
     --metrics-bind-address ${ovnkube_master_metrics_bind_address} \
-    --host-network-namespace ${ovn_host_network_namespace} &
+    --host-network-namespace ${ovn_host_network_namespace} \
+    ${ovsdb_connect_timeout_flag} &
 
   echo "=============== ovn-master ========== running"
   wait_for_event attempts=3 process_ready ovnkube-master

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -265,6 +265,10 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: host_network_namespace
+        {% if ovsdb_connect_timeout!="" -%}
+        - name: OVSDB_CONNECT_TIMEOUT
+          value: "{{ovsdb_connect_timeout}}"
+        {% endif -%}
       # end of container
 
       volumes:

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -57,16 +58,17 @@ var (
 
 	// Default holds parsed config file parameters and command-line overrides
 	Default = DefaultConfig{
-		MTU:               1400,
-		ConntrackZone:     64000,
-		EncapType:         "geneve",
-		EncapIP:           "",
-		EncapPort:         DefaultEncapPort,
-		InactivityProbe:   100000, // in Milliseconds
-		OpenFlowProbe:     180,    // in Seconds
-		MonitorAll:        true,
-		LFlowCacheEnable:  true,
-		RawClusterSubnets: "10.128.0.0/14/23",
+		MTU:                 1400,
+		ConntrackZone:       64000,
+		EncapType:           "geneve",
+		EncapIP:             "",
+		EncapPort:           DefaultEncapPort,
+		InactivityProbe:     100000, // in Milliseconds
+		OpenFlowProbe:       180,    // in Seconds
+		MonitorAll:          true,
+		LFlowCacheEnable:    true,
+		RawClusterSubnets:   "10.128.0.0/14/23",
+		OVSDBConnectTimeout: types.OVSDBTimeout,
 	}
 
 	// Logging holds logging-related parsed config file parameters and command-line overrides
@@ -214,6 +216,8 @@ type DefaultConfig struct {
 	// ClusterSubnets holds parsed cluster subnet entries and may be used
 	// outside the config module.
 	ClusterSubnets []CIDRNetworkEntry
+	// OVSDBConnectTimeout indicates timeout when (re)connecting to ovsdb server
+	OVSDBConnectTimeout time.Duration `gcfg:"ovsdb-connect-timeout"`
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides
@@ -750,6 +754,13 @@ var CommonFlags = []cli.Flag{
 		Usage:       "The largest number of messages per second that gets logged before drop (default 20)",
 		Destination: &cliConfig.Logging.ACLLoggingRateLimit,
 		Value:       20,
+	},
+	&cli.DurationFlag{
+		Name:        "ovsdb-connect-timeout",
+		Usage:       "Specify timeout when (re)connecting to ovsdb",
+		Destination: &cliConfig.Default.OVSDBConnectTimeout,
+		Value:       types.OVSDBTimeout,
+		DefaultText: types.OVSDBTimeout.String(),
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/urfave/cli/v2"
 	kexec "k8s.io/utils/exec"
@@ -139,6 +140,7 @@ conntrack-zone=64321
 cluster-subnets=10.132.0.0/14/23
 lflow-cache-limit=1000
 lflow-cache-limit-kb=100000
+ovsdb-connect-timeout=19000000000
 
 [kubernetes]
 kubeconfig=/path/to/kubeconfig
@@ -288,6 +290,8 @@ var _ = Describe("Config Operations", func() {
 				gomega.Expect(a.Address).To(gomega.Equal(""))
 				gomega.Expect(a.CertCommonName).To(gomega.Equal(""))
 			}
+
+			gomega.Expect(Default.OVSDBConnectTimeout).To(gomega.Equal(10 * time.Second))
 			return nil
 		}
 		err := app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
@@ -559,6 +563,7 @@ var _ = Describe("Config Operations", func() {
 				{ovntest.MustParseIPNet("11.132.0.0/14"), 23},
 			}))
 
+			gomega.Expect(Default.OVSDBConnectTimeout).To(gomega.Equal(19 * time.Second))
 			return nil
 		}
 		err = app.Run([]string{app.Name, "-config-file=" + cfgFile.Name()})
@@ -629,7 +634,7 @@ var _ = Describe("Config Operations", func() {
 				{ovntest.MustParseIPNet("11.132.0.0/14"), 23},
 			}))
 			gomega.Expect(Default.MonitorAll).To(gomega.BeFalse())
-
+			gomega.Expect(Default.OVSDBConnectTimeout).To(gomega.Equal(25 * time.Second))
 			return nil
 		}
 		cliArgs := []string{
@@ -669,6 +674,7 @@ var _ = Describe("Config Operations", func() {
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=11.132.0.0/14/23",
 			"-monitor-all=false",
+			"-ovsdb-connect-timeout=25s",
 		}
 		err = app.Run(cliArgs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
currently ovsdb connection timeout is hardcoded to 20s, it might
not be sufficient when running large scale test.

this commit makes the timeout value configurable during startup
by specifying arg `--ovsdb-connect-timeout`, e.g.

`--ovsdb-connect-timeout 15s`

scripts and spec templates were also updated, so that the timeout
value can be set through `daemonset.sh`, e.g.

`./daemonset.sh --ovsdb-connect-timeout=25s`

Signed-off-by: xqu <xqu@nvidia.com>