### PR TITLE
External gateways E2E on host network

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -77,7 +77,6 @@ go test -timeout=0 -v . \
         -ginkgo.skip="${SKIPPED_TESTS}" \
         -provider skeleton \
         -kubeconfig ${KUBECONFIG} \
-        ${CONTAINER_RUNTIME:+"--container-runtime=${CONTAINER_RUNTIME}"} \
         ${NUM_NODES:+"--num-nodes=${NUM_NODES}"} \
         ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"} \
         ${E2E_REPORT_PREFIX:+"--report-prefix=${E2E_REPORT_PREFIX}"}


### PR DESCRIPTION
**- What this PR does and why is it needed**
Currently running the external gateways e2e tests is possible
only on kind deployments.

Adding support for using a host-networked container
instead of leveraging the kind network allows running
the tests from a host that can access the cluster.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
