### PR TITLE
Fixes handling errors for getting IPs for pods

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -573,7 +573,7 @@ func (oc *Controller) createNamespaceAddrSetAllPods(ns string) (addressset.Addre
 	} else {
 		ips = make([]net.IP, 0, len(existingPods))
 		for _, pod := range existingPods {
-			if pod.Status.PodIP != "" && !pod.Spec.HostNetwork {
+			if !pod.Spec.HostNetwork {
 				podIPs, err := util.GetAllPodIPs(pod)
 				if err != nil {
 					klog.Warningf(err.Error())

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1194,7 +1194,10 @@ func (oc *Controller) handlePeerPodSelectorAddUpdate(gp *gressPolicy, objs ...in
 		}
 		pods = append(pods, pod)
 	}
-	if err := gp.addPeerPods(pods...); err != nil {
+	// If no IP is found, the pod handler may not have added it by the time the network policy handler
+	// processed this pod event. It will grab it during the pod update event to add the annotation,
+	// so don't log an error here.
+	if err := gp.addPeerPods(pods...); err != nil && !errors.Is(err, util.ErrNoPodIPFound) {
 		klog.Errorf(err.Error())
 	}
 }

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -238,7 +239,7 @@ func TestGetAllPodIPs(t *testing.T) {
 		{
 			desc:     "test when pod.status.PodIP is empty",
 			inpPod:   &v1.Pod{},
-			errMatch: fmt.Errorf("no pod IPs found on pod"),
+			errMatch: ErrNoPodIPFound,
 		},
 		{
 			desc: "test when pod.status.PodIP is non-empty",
@@ -269,7 +270,7 @@ func TestGetAllPodIPs(t *testing.T) {
 					},
 				},
 			},
-			outExp: []net.IP{},
+			errMatch: ErrNoPodIPFound,
 		},
 	}
 	for i, tc := range tests {
@@ -279,7 +280,11 @@ func TestGetAllPodIPs(t *testing.T) {
 			if tc.errAssert {
 				assert.Error(t, e)
 			} else if tc.errMatch != nil {
-				assert.Contains(t, e.Error(), tc.errMatch.Error())
+				if errors.Is(tc.errMatch, ErrNoPodIPFound) {
+					assert.ErrorIs(t, e, ErrNoPodIPFound)
+				} else {
+					assert.Contains(t, e.Error(), tc.errMatch.Error())
+				}
 			} else {
 				assert.Equal(t, tc.outExp, res)
 			}


### PR DESCRIPTION
When network policy would go to add peer pods via the handler, it would
commonly fail on initial add because it would fail to get pod IPs, due
to racing with the pod handler for the pod add event. This is OK,
because eventually the pod will get an update event once the ovn
annotation is added and the network policy handler will add it. However,
this would cause an error log to be spammed, especially with a lot of
pods and network policies in place.

This commit ignores logging errors on policy add/update events where the
pod has no IP either in the OVN annotation or in the KAPI pod IP fields.

Additionally, changes GetAllPodIPs function to be more readable and
eliminates a check in namespace.go for legacy PodIP field.

Signed-off-by: Tim Rozet <trozet@redhat.com>

