### PR TITLE
Network Policy: Ensures handler serialized shutdown

### DIFF
--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -331,7 +331,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = wf.Start()
 			Expect(err).NotTo(HaveOccurred())
-			h := wf.addHandler(objType, namespace, sel,
+			h := wf.addHandler(objType, namespace, defaultHandlerTag, sel,
 				cache.ResourceEventHandlerFuncs{},
 				func(objs []interface{}) {
 					defer GinkgoRecover()
@@ -407,7 +407,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			err = wf.Start()
 			Expect(err).NotTo(HaveOccurred())
 			var addCalls int32
-			h := wf.addHandler(objType, "", nil,
+			h := wf.addHandler(objType, "", defaultHandlerTag, nil,
 				cache.ResourceEventHandlerFuncs{
 					AddFunc: func(obj interface{}) {
 						atomic.AddInt32(&addCalls, 1)
@@ -500,7 +500,7 @@ var _ = Describe("Watch Factory Operations", func() {
 
 	addFilteredHandler := func(wf *WatchFactory, objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandlerFuncs) (*Handler, *handlerCalls) {
 		calls := handlerCalls{}
-		h := wf.addHandler(objType, namespace, sel, cache.ResourceEventHandlerFuncs{
+		h := wf.addHandler(objType, namespace, defaultHandlerTag, sel, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				defer GinkgoRecover()
 				atomic.AddInt32(&calls.added, 1)

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -32,7 +32,7 @@ type NodeWatchFactory interface {
 	Start() error
 
 	AddServiceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
-	AddFilteredServiceHandler(namespace string, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
+	AddFilteredServiceHandler(namespace string, tag uint64, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler
 	RemoveServiceHandler(handler *Handler)
 
 	AddEndpointsHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{})) *Handler


### PR DESCRIPTION
In the code we add several handlers to pod, namespace, service
informers depending on the definition of the network policy. We track
these via the network policy entry in the namespace cache, adding each
handler to a slice. During network policy deletion, we shutdown all the
handlers by requesting them to be detached by the watch factory. This
operation was non-blocking for 2 reasons:
  1. Although all handlers required informer lock to be removed,
     federated handlers did not need informer read lock to execute.
  2. Handlers were being removed inside of a goroutine.

Due to this behavior, when a policy was being deleted and handlers were
"shutdown" there was no guarantee that an in-process handler on a
federated queue, would not finish adding/updating a new object, after
the handlers were supposed to be shutdown.

To solve this problem, we used np.deleted, a field that the handlers
could reference to know if they should ignore adding an object in the
case where things are shutting down. However, this mechanism requires
access to the np object itself and needs a lock on the np. This is the
root cause of why we cannot hold the np lock while we are adding
handlers during network policy creation time. This causes a bunch of
headaches with complicated locking scenarios.

This commit removes this complex locking, and ensures network policy
creation can hold the np lock the entire time, while also reducing
access required to np fields in the handlers. It does the following:
  1. Make federated queue event processing have a read lock on the
     informer.
  2. When adding handlers, introduce a new "tag" which can be used to
     group operations on a bunch of handlers.
  3. Network policy no longer holds handlers in fields of the np object.
     Instead it creates handlers with a unique tag corresponding to that
     policy.
  4. Handlers are no longer removed in a goroutine and is a blocking
     function.
  5. When a Network policy is deleted, it calls to watch factory to
     destroy all handlers by it's tag (policyHandlerID).
  6. Remove the need for np.delete and np.created. Remove access
     as much as possible to the np object inside of the handlers.
  7. For handlers that still need to access the np, they use a new
     subLock which is used to guard against access to np between
     handlers.

Signed-off-by: Tim Rozet <trozet@redhat.com>

