### PR TITLE
cni: fix logspam suppression for non-existing OVS port

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -355,7 +355,7 @@ func (pr *PodRequest) ConfigureInterface(podLister corev1listers.PodLister, kcli
 		err = ConfigureOVS(pr.ctx, pr.PodNamespace, pr.PodName, hostIface.Name, ifInfo, pr.SandboxID,
 			podLister, kclient)
 		if err != nil {
-			pr.deletePorts(hostIface.Name)
+			pr.deletePorts(hostIface.Name, pr.PodNamespace, pr.PodName)
 			return nil, err
 		}
 	}
@@ -444,22 +444,12 @@ func (pr *PodRequest) UnconfigureInterface(ifInfo *PodInterfaceInfo) error {
 		return nil
 	}
 
-	// host side interface deletion
+	// host side deletion of OVS port and kernel interface
 	ifName := pr.SandboxID[:15]
-	out, err := ovsExec("del-port", "br-int", ifName)
-	if err != nil && !strings.Contains(out, "no port named") {
-		// DEL should be idempotent; don't return an error just log it
-		klog.Warningf("Failed to delete OVS port %s %s from br-int: %v\n %q", ifName, podDesc, err, string(out))
-	}
-	err = clearPodBandwidth(pr.SandboxID)
-	if err != nil {
+	pr.deletePorts(ifName, pr.PodNamespace, pr.PodName)
+
+	if err := clearPodBandwidth(pr.SandboxID); err != nil {
 		klog.Warningf("Failed to clearPodBandwidth sandbox %v %s: %v", pr.SandboxID, podDesc, err)
-	}
-	// In SmartNic (CX5) case, there is no point in deleting the representor port
-	if pr.CNIConf.DeviceID == "" {
-		if err = util.LinkDelete(ifName); err != nil {
-			klog.Warningf("Failed to delete interface %s %s: %v", ifName, podDesc, err)
-		}
 	}
 	pr.deletePodConntrack()
 	return nil
@@ -492,14 +482,18 @@ func (pr *PodRequest) deletePodConntrack() {
 	}
 }
 
-func (pr *PodRequest) deletePorts(ifaceName string) {
+func (pr *PodRequest) deletePorts(ifaceName, podNamespace, podName string) {
+	podDesc := fmt.Sprintf("%s/%s", podNamespace, podName)
+
 	out, err := ovsExec("del-port", "br-int", ifaceName)
-	if err != nil && !strings.Contains(out, "no port named") {
+	if err != nil && !strings.Contains(err.Error(), "no port named") {
 		// DEL should be idempotent; don't return an error just log it
-		klog.Warningf("Failed to delete OVS port %s: %v\n  %q", ifaceName, err, string(out))
+		klog.Warningf("Failed to delete pod %q OVS port %s: %v\n  %q", podDesc, ifaceName, err, string(out))
 	}
 	// skip deleting representor ports
 	if pr.CNIConf.DeviceID == "" {
-		_ = util.LinkDelete(ifaceName)
+		if err = util.LinkDelete(ifaceName); err != nil {
+			klog.Warningf("Failed to delete pod %q interface %s: %v", podDesc, ifaceName, err)
+		}
 	}
 }


### PR DESCRIPTION
ovsExec() doesn't return stderr in 'output', as it instead
returns a custom error with the stderr included in the error
message.

Fixes suppression of messages like:

```
W0205 18:14:55.491330    2131 helper_linux.go:452] Failed to delete OVS port 288c3f1cf2fdea0 for pod kubectl-608/agnhost-primary-kfhfv from br-int: failed to run 'ovs-vsctl --timeout=30 del-port br-int 288c3f1cf2fdea0': exit status 1
  "ovs-vsctl: no port named 288c3f1cf2fdea0\n"
 ""
```
