### PR TITLE
some OVN NB Table's Name field is a pointer type since its optional

### DIFF
--- a/go-controller/pkg/libovsdbops/model_client.go
+++ b/go-controller/pkg/libovsdbops/model_client.go
@@ -302,9 +302,18 @@ func (m *ModelClient) create(opModel *OperationModel) ([]ovsdb.Operation, error)
 		})
 	} else if info, err := m.client.Cache().DatabaseModel().NewModelInfo(opModel.Model); err == nil {
 		if name, err := info.FieldByColumn("name"); err == nil {
-			if len(fmt.Sprint(name)) > 0 {
+			objName, ok := name.(string)
+			if !ok {
+				if strPtr, ok := name.(*string); ok {
+					if strPtr != nil {
+						objName = *strPtr
+					}
+				}
+			}
+			if len(objName) > 0 {
 				klog.Warningf("OVSDB Create operation detected without setting opModel Name. Name: %s, %#v",
-					name, info)
+					objName, info)
+
 			}
 		}
 	}


### PR DESCRIPTION
nil string pointer wasn't properly checked while determining whether
it had empty value

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@dcbw @trozet PTAL