### PR TITLE
Use 0o prefixes for octal constants

### DIFF
--- a/go-controller/cmd/ovndbchecker/ovndbchecker.go
+++ b/go-controller/cmd/ovndbchecker/ovndbchecker.go
@@ -135,7 +135,7 @@ func setupPIDFile(pidfile string) error {
 
 	// Create if it doesn't exist, else exit with error
 	if os.IsNotExist(err) {
-		if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+		if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
 			klog.Errorf("Failed to write pidfile %s (%v). Ignoring..", pidfile, err)
 		}
 	} else {
@@ -147,7 +147,7 @@ func setupPIDFile(pidfile string) error {
 		_, err1 := os.Stat("/proc/" + string(pid[:]) + "/cmdline")
 		if os.IsNotExist(err1) {
 			// Left over pid from dead process
-			if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+			if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
 				klog.Errorf("Failed to write pidfile %s (%v). Ignoring..", pidfile, err)
 			}
 		} else {

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -150,7 +150,7 @@ func setupPIDFile(pidfile string) error {
 
 	// Create if it doesn't exist, else exit with error
 	if os.IsNotExist(err) {
-		if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+		if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
 			klog.Errorf("Failed to write pidfile %s (%v). Ignoring..", pidfile, err)
 		}
 	} else {
@@ -162,7 +162,7 @@ func setupPIDFile(pidfile string) error {
 		_, err1 := os.Stat("/proc/" + string(pid[:]) + "/cmdline")
 		if os.IsNotExist(err1) {
 			// Left over pid from dead process
-			if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+			if err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
 				klog.Errorf("Failed to write pidfile %s (%v). Ignoring..", pidfile, err)
 			}
 		} else {

--- a/go-controller/pkg/cni/cniserver_linux.go
+++ b/go-controller/pkg/cni/cniserver_linux.go
@@ -53,7 +53,7 @@ func (s *Server) Start(requestFunc cniRequestFunc) error {
 		}
 
 		// Check permissions
-		if info.Mode()&0777 != 0700 {
+		if info.Mode()&0o777 != 0o700 {
 			return fmt.Errorf("insecure permissions on pod info socket directory %s: %v", s.rundir, info.Mode())
 		}
 
@@ -62,7 +62,7 @@ func (s *Server) Start(requestFunc cniRequestFunc) error {
 			return fmt.Errorf("failed to remove old pod info socket %s: %v", socketPath, err)
 		}
 	}
-	if err := os.MkdirAll(s.rundir, 0700); err != nil {
+	if err := os.MkdirAll(s.rundir, 0o700); err != nil {
 		return fmt.Errorf("failed to create pod info socket directory %s: %v", s.rundir, err)
 	}
 
@@ -73,7 +73,7 @@ func (s *Server) Start(requestFunc cniRequestFunc) error {
 	if err != nil {
 		return fmt.Errorf("failed to listen on pod info socket: %v", err)
 	}
-	if err := os.Chmod(socketPath, 0600); err != nil {
+	if err := os.Chmod(socketPath, 0o600); err != nil {
 		l.Close()
 		return fmt.Errorf("failed to set pod info socket mode: %v", err)
 	}

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -69,7 +69,7 @@ func renameLink(curName, newName string) error {
 }
 
 func setSysctl(sysctl string, newVal int) error {
-	return ioutil.WriteFile(sysctl, []byte(strconv.Itoa(newVal)), 0640)
+	return ioutil.WriteFile(sysctl, []byte(strconv.Itoa(newVal)), 0o640)
 }
 
 func moveIfToNetns(ifname string, netns ns.NetNS) error {

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -116,7 +116,7 @@ var _ = AfterSuite(func() {
 func createTempFile(name string) (string, []byte, error) {
 	fileData := []byte{0x20}
 	fname := filepath.Join(tmpDir, name)
-	if err := ioutil.WriteFile(fname, fileData, 0644); err != nil {
+	if err := ioutil.WriteFile(fname, fileData, 0o644); err != nil {
 		return "", nil, err
 	}
 	return fname, fileData, nil
@@ -124,7 +124,7 @@ func createTempFile(name string) (string, []byte, error) {
 
 func createTempFileContent(name, value string) (string, error) {
 	fname := filepath.Join(tmpDir, name)
-	if err := ioutil.WriteFile(fname, []byte(value), 0644); err != nil {
+	if err := ioutil.WriteFile(fname, []byte(value), 0o644); err != nil {
 		return "", err
 	}
 	return fname, nil
@@ -211,7 +211,7 @@ mode=full
 		}
 		newData += line + "\n"
 	}
-	return ioutil.WriteFile(path, []byte(newData), 0644)
+	return ioutil.WriteFile(path, []byte(newData), 0o644)
 }
 
 var _ = Describe("Config Operations", func() {
@@ -677,7 +677,7 @@ var _ = Describe("Config Operations", func() {
 	It("overrides config file and defaults with CLI legacy service-cluster-ip-range option", func() {
 		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
 service-cidrs=172.18.0.0/24
-`), 0644)
+`), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		app.Action = func(ctx *cli.Context) error {
@@ -700,7 +700,7 @@ service-cidrs=172.18.0.0/24
 	It("accepts legacy service-cidr config file option", func() {
 		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[kubernetes]
 service-cidr=172.18.0.0/24
-`), 0644)
+`), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		app.Action = func(ctx *cli.Context) error {
@@ -736,7 +736,7 @@ service-cidr=172.18.0.0/24
 	It("overrides config file and defaults with CLI legacy cluster-subnet option", func() {
 		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[default]
 cluster-subnets=172.18.0.0/23
-`), 0644)
+`), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		app.Action = func(ctx *cli.Context) error {
@@ -792,7 +792,7 @@ cluster-subnets=172.18.0.0/23
 	It("overrides config file and defaults with CLI legacy --init-gateways option", func() {
 		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[gateway]
 mode=local
-`), 0644)
+`), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		app.Action = func(ctx *cli.Context) error {
@@ -815,7 +815,7 @@ mode=local
 	It("overrides config file and defaults with CLI legacy --gateway-local option", func() {
 		err := ioutil.WriteFile(cfgFile.Name(), []byte(`[gateway]
 mode=shared
-`), 0644)
+`), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		app.Action = func(ctx *cli.Context) error {
@@ -1186,7 +1186,7 @@ mtu=1234
 
 [foobar]
 foo=bar
-`), 0644)
+`), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		app.Action = func(ctx *cli.Context) error {
@@ -1215,7 +1215,7 @@ mtu=1234
 
 [foobar
 foo=bar
-`), 0644)
+`), 0o644)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		app.Action = func(ctx *cli.Context) error {

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -44,7 +44,7 @@ var _ = AfterSuite(func() {
 
 func createTempFile(name string) (string, error) {
 	fname := filepath.Join(tmpDir, name)
-	if err := ioutil.WriteFile(fname, []byte{0x20}, 0644); err != nil {
+	if err := ioutil.WriteFile(fname, []byte{0x20}, 0o644); err != nil {
 		return "", err
 	}
 	return fname, nil

--- a/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
@@ -625,7 +625,7 @@ func keyForArgs(args ...string) string {
 func createDbFile(t *testing.T, name string) {
 	_, err := os.Stat(name)
 	if os.IsNotExist(err) {
-		f, err := os.OpenFile(name, os.O_RDONLY|os.O_CREATE, 0644)
+		f, err := os.OpenFile(name, os.O_RDONLY|os.O_CREATE, 0o644)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}

--- a/go-controller/pkg/util/nicstobridge.go
+++ b/go-controller/pkg/util/nicstobridge.go
@@ -206,7 +206,7 @@ func setupDefaultFile() {
 
 	// The defaultFile does not contain '--delete-transient-ports' set.
 	// We should set it.
-	f, err := os.OpenFile(defaultFile, os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(defaultFile, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		klog.Errorf("Failed to open %s to write (%v)", defaultFile, err)
 		return

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -19,7 +19,7 @@ import (
 func TestRunningPlatform(t *testing.T) {
 	// Below is defined in ovs.go file
 	AppFs = afero.NewMemMapFs()
-	AppFs.MkdirAll("/etc", 0755)
+	AppFs.MkdirAll("/etc", 0o755)
 	tests := []struct {
 		desc            string
 		fileContent     []byte
@@ -35,31 +35,31 @@ func TestRunningPlatform(t *testing.T) {
 			desc:            "failed to find platform name",
 			expErr:          fmt.Errorf("failed to find the platform name"),
 			fileContent:     []byte("NAME="),
-			filePermissions: 0755,
+			filePermissions: 0o755,
 		},
 		{
 			desc:            "platform name returned is RHEL",
 			expOut:          "RHEL",
 			fileContent:     []byte("NAME=\"CentOS Linux\""),
-			filePermissions: 0755,
+			filePermissions: 0o755,
 		},
 		{
 			desc:            "platform name returned is Ubuntu",
 			expOut:          "Ubuntu",
 			fileContent:     []byte("NAME=\"Debian\""),
-			filePermissions: 0755,
+			filePermissions: 0o755,
 		},
 		{
 			desc:            "platform name returned is Photon",
 			expOut:          "Photon",
 			fileContent:     []byte("NAME=\"VMware\""),
-			filePermissions: 0755,
+			filePermissions: 0o755,
 		},
 		{
 			desc:            "unknown platform",
 			expErr:          fmt.Errorf("unknown platform"),
 			fileContent:     []byte("NAME=\"blah\""),
-			filePermissions: 0755,
+			filePermissions: 0o755,
 		},
 	}
 	for i, tc := range tests {
@@ -166,9 +166,9 @@ func TestGetNbctlSocketPath(t *testing.T) {
 			dirFileMocks: []ovntest.AferoDirMockHelper{
 				{
 					DirName:     "/some/blah/",
-					Permissions: 0755,
+					Permissions: 0o755,
 					Files: []ovntest.AferoFileMockHelper{
-						{"/some/blah/path", 0755, []byte("blah")},
+						{"/some/blah/path", 0o755, []byte("blah")},
 					},
 				},
 			},
@@ -179,9 +179,9 @@ func TestGetNbctlSocketPath(t *testing.T) {
 			dirFileMocks: []ovntest.AferoDirMockHelper{
 				{
 					DirName:     "/some/blah/",
-					Permissions: 0755,
+					Permissions: 0o755,
 					Files: []ovntest.AferoFileMockHelper{
-						{"/some/blah/path", 0755, []byte("blah")},
+						{"/some/blah/path", 0o755, []byte("blah")},
 					},
 				},
 			},
@@ -192,10 +192,10 @@ func TestGetNbctlSocketPath(t *testing.T) {
 			dirFileMocks: []ovntest.AferoDirMockHelper{
 				{
 					DirName:     "/var/run/ovn/",
-					Permissions: 0755,
+					Permissions: 0o755,
 					Files: []ovntest.AferoFileMockHelper{
-						{"/var/run/ovn/ovn-nbctl.pid", 0755, []byte("pid")},
-						{"/var/run/ovn/ovn-nbctl.pid.ctl", 0755, []byte("blah")},
+						{"/var/run/ovn/ovn-nbctl.pid", 0o755, []byte("pid")},
+						{"/var/run/ovn/ovn-nbctl.pid.ctl", 0o755, []byte("blah")},
 					},
 				},
 			},
@@ -256,9 +256,9 @@ func TestGetNbctlArgsAndEnv(t *testing.T) {
 			dirFileMocks: []ovntest.AferoDirMockHelper{
 				{
 					DirName:     "/some/blah/",
-					Permissions: 0755,
+					Permissions: 0o755,
 					Files: []ovntest.AferoFileMockHelper{
-						{"/some/blah/path", 0755, []byte("blah")},
+						{"/some/blah/path", 0o755, []byte("blah")},
 					},
 				},
 			},
@@ -412,9 +412,9 @@ func TestRunOVNNorthAppCtl(t *testing.T) {
 			dirFileMocks: []ovntest.AferoDirMockHelper{
 				{
 					DirName:     "/var/run/ovn/",
-					Permissions: 0755,
+					Permissions: 0o755,
 					Files: []ovntest.AferoFileMockHelper{
-						{"/var/run/ovn/ovn-northd.pid", 0755, []byte("pid")},
+						{"/var/run/ovn/ovn-northd.pid", 0o755, []byte("pid")},
 					},
 				},
 			},
@@ -485,9 +485,9 @@ func TestRunOVNControllerAppCtl(t *testing.T) {
 			dirFileMocks: []ovntest.AferoDirMockHelper{
 				{
 					DirName:     "/var/run/ovn/",
-					Permissions: 0755,
+					Permissions: 0o755,
 					Files: []ovntest.AferoFileMockHelper{
-						{"/var/run/ovn/ovn-controller.pid", 0755, []byte("pid")},
+						{"/var/run/ovn/ovn-controller.pid", 0o755, []byte("pid")},
 					},
 				},
 			},
@@ -556,9 +556,9 @@ func TestRunOvsVswitchdAppCtl(t *testing.T) {
 			dirFileMocks: []ovntest.AferoDirMockHelper{
 				{
 					DirName:     "/var/run/openvswitch/",
-					Permissions: 0755,
+					Permissions: 0o755,
 					Files: []ovntest.AferoFileMockHelper{
-						{"/var/run/openvswitch/ovs-vswitchd.pid", 0755, []byte("pid")},
+						{"/var/run/openvswitch/ovs-vswitchd.pid", 0o755, []byte("pid")},
 					},
 				},
 			},


### PR DESCRIPTION
Go 1.13 introduced 0o prefixes for octal constants, for consistency
with 0b and 0x prefixes and to improve readability. See
https://go.dev/doc/go1.13#language for details.

This changes all octal constants to use 0o prefixes.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->