### PR TITLE
Fix GetPodsBySelector/GetNamespacesBySelector

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -509,10 +509,14 @@ func (wf *WatchFactory) GetPods(namespace string) ([]*kapi.Pod, error) {
 	return podLister.Pods(namespace).List(labels.Everything())
 }
 
-// GetPods returns all the pods in a given namespace by the label selector
-func (wf *WatchFactory) GetPodsBySelector(namespace string, selector metav1.LabelSelector) ([]*kapi.Pod, error) {
+// GetPodsBySelector returns all the pods in a given namespace by the label selector
+func (wf *WatchFactory) GetPodsBySelector(namespace string, labelSelector metav1.LabelSelector) ([]*kapi.Pod, error) {
 	podLister := wf.informers[podType].lister.(listers.PodLister)
-	return podLister.Pods(namespace).List(labels.Set(selector.MatchLabels).AsSelector())
+	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		return nil, err
+	}
+	return podLister.Pods(namespace).List(selector)
 }
 
 // GetNodes returns the node specs of all the nodes
@@ -572,10 +576,14 @@ func (wf *WatchFactory) GetNamespaces() ([]*kapi.Namespace, error) {
 	return namespaceLister.List(labels.Everything())
 }
 
-// GetNamespaces returns a list of namespaces in the cluster by the label selector
-func (wf *WatchFactory) GetNamespacesBySelector(selector metav1.LabelSelector) ([]*kapi.Namespace, error) {
+// GetNamespacesBySelector returns a list of namespaces in the cluster by the label selector
+func (wf *WatchFactory) GetNamespacesBySelector(labelSelector metav1.LabelSelector) ([]*kapi.Namespace, error) {
 	namespaceLister := wf.informers[namespaceType].lister.(listers.NamespaceLister)
-	return namespaceLister.List(labels.Set(selector.MatchLabels).AsSelector())
+	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		return nil, err
+	}
+	return namespaceLister.List(selector)
 }
 
 func (wf *WatchFactory) NodeInformer() cache.SharedIndexInformer {


### PR DESCRIPTION
Previously only MatchLabels was used to create a label selector and MatchExpressions was ignored.

It causes a bug when if there is an egressip create that uses `matchExpressions` it picks all namespaces:
```
apiVersion: k8s.ovn.org/v1
kind: EgressIP
metadata:
  name: test
spec:
  egressIPs:
  - 10.0.128.101
  namespaceSelector:
    matchExpressions:
      - key: e2e-run
        operator: Exists
  podSelector: {}
```

Signed-off-by: Patryk Diak <pdiak@redhat.com>