### PR TITLE
Fix router err msgs + linter update

### DIFF
--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# pin golangci-lint version to 1.42.0
-VERSION=v1.42.0
+# pin golangci-lint version to 1.44.0
+VERSION=v1.44.0
 if [ "$#" -ne 1 ]; then
     echo "Expected command line argument - container runtime (docker/podman) got $# arguments: $@"
     exit 1


### PR DESCRIPTION
Just adds some more explicit error messages about updating/deleting SNATs, and bumps golang linter version.