### PR TITLE
Fixes race for namespace logging level update

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1102,6 +1102,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 			policy.Name, policy.Namespace, err)
 	}
 	defer nsUnlock()
+	nsInfo.networkPolicies[policy.Name] = np
 	// there may have been a namespace update for ACL logging while we were creating the NP
 	// update it
 	if err := oc.setACLLoggingForNamespace(policy.Namespace, nsInfo); err != nil {
@@ -1110,7 +1111,6 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 		klog.Infof("Namespace %s: ACL logging setting updated to deny=%s allow=%s",
 			policy.Namespace, nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
 	}
-	nsInfo.networkPolicies[policy.Name] = np
 	return nil
 }
 


### PR DESCRIPTION
Updating the ACL logging by checking the namespace was added to the
network policy handler as part of:
https://github.com/ovn-org/ovn-kubernetes/pull/2809

However, the policy was not added to the namespace before updating the
logging levels. Therefore the current policy would not be processed
during logging level updates in this path.

Reported-by: Andrew Stoycos <astoycos@redhat.com>

Signed-off-by: Tim Rozet <trozet@redhat.com>

