### PR TITLE
CI: Retest only failed E2E jobs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
     paths: [ "dist/images/Dockerfile*"]
 
 env:
-  GO_VERSION: 1.16.3
+  GO_VERSION: 1.17.6
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,18 +37,43 @@ jobs:
     name: Build-master
     runs-on: ubuntu-latest
     steps:
+    # Create a cache for the built master image
+    - name: Restore master image cache
+      id: image_cache_master
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/image_cache/
+        key: ${{ github.run_id }}-image-cache-master
+
+    - name: Check if master image build is needed
+      id: is_master_image_build_needed
+      continue-on-error: true
+      run: |
+        set -x
+        if [ -f /tmp/image_cache/image-master.tar.gz ]; then
+            mkdir -p dist/images/_output
+            cp /tmp/image_cache/image-master.tar.gz dist/images/_output/image-master.tar.gz
+            gunzip dist/images/_output/image-master.tar.gz
+            echo "::set-output name=MASTER_IMAGE_RESTORED::true"
+        fi
+
+    # only run the following steps if the master image was not found in the cache
     - name: Set up Go
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
       uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory - from master branch
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
       uses: actions/checkout@v2
       with:
         ref: master
 
     - name: Build - from master branch
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
       run: |
         set -x
         pushd go-controller
@@ -57,6 +82,7 @@ jobs:
         popd
 
     - name: Build docker image - from master branch
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
       run: |
         pushd dist/images
           sudo cp -f ../../go-controller/_output/go/bin/ovn* .
@@ -66,6 +92,21 @@ jobs:
           docker save ovn-daemonset-f:dev > _output/image-master.tar
         popd
 
+    - name: Cache master image
+      if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
+      continue-on-error: true
+      run: |
+        if [ -f /tmp/image_cache/image-master.tar ]; then
+            rm -f /tmp/image_cache/image-master.tar
+        fi
+        if [ -f /tmp/image_cache/image-master.tar.gz ]; then
+            rm -f /tmp/image_cache/image-master.tar.gz
+        fi
+        mkdir -p /tmp/image_cache/
+        cp dist/images/_output/image-master.tar /tmp/image_cache/image-master.tar
+        gzip /tmp/image_cache/image-master.tar
+
+    # run the following always if none of the steps before failed
     - uses: actions/upload-artifact@v2
       with:
         name: test-image-master
@@ -75,16 +116,41 @@ jobs:
     name: Build-PR
     runs-on: ubuntu-latest
     steps:
+    # Create a cache for the build PR image
+    - name: Restore PR image cache
+      id: image_cache_pr
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/image_cache/
+        key: ${{ github.run_id }}-image-cache-pr
+
+    - name: Check if PR image build is needed
+      id: is_pr_image_build_needed
+      continue-on-error: true
+      run: |
+        set -x
+        if [ -f /tmp/image_cache/image-pr.tar.gz ]; then
+            mkdir -p dist/images/_output
+            cp /tmp/image_cache/image-pr.tar.gz dist/images/_output/image-pr.tar.gz
+            gunzip dist/images/_output/image-pr.tar.gz
+            echo "::set-output name=PR_IMAGE_RESTORED::true"
+        fi
+
+    # only run the following steps if the PR image was not found in the cache
     - name: Set up Go
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory - from current pr branch
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       uses: actions/checkout@v2
 
     - name: Build and Test - from current pr branch
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       run: |
         set -x
         pushd go-controller
@@ -96,6 +162,7 @@ jobs:
         popd
 
     - name: Build docker image - from current pr branch
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       run: |
         pushd dist/images
           sudo cp -f ../../go-controller/_output/go/bin/ovn* .
@@ -105,19 +172,17 @@ jobs:
           docker save ovn-daemonset-f:pr > _output/image-pr.tar
         popd
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: test-image-pr
-        path: dist/images/_output/image-pr.tar
-
     - name: Upload Junit Reports
-      if: always()
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && always()
+      continue-on-error: true
       uses: actions/upload-artifact@v2
       with:
         name: junit-unit
         path: '**/_artifacts/**.xml'
 
     - name: Submit code coverage to Coveralls
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
+      continue-on-error: true
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GO111MODULE: off
@@ -132,6 +197,26 @@ jobs:
 
         gover
         goveralls -coverprofile=gover.coverprofile -service=github
+
+    - name: Cache PR image
+      if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
+      continue-on-error: true
+      run: |
+        if [ -f /tmp/image_cache/image-pr.tar ]; then
+            rm -f /tmp/image_cache/image-pr.tar
+        fi
+        if [ -f /tmp/image_cache/image-pr.tar.gz ]; then
+           rm -f /tmp/image_cache/image-pr.tar.gz
+        fi
+        mkdir -p /tmp/image_cache/
+        cp dist/images/_output/image-pr.tar /tmp/image_cache/image-pr.tar
+        gzip /tmp/image_cache/image-pr.tar
+
+    # run the following if none of the previous steps failed
+    - uses: actions/upload-artifact@v2
+      with:
+        name: test-image-pr
+        path: dist/images/_output/image-pr.tar
 
   ovn-upgrade-e2e:
     name: Upgrade OVN from Master to PR branch based image
@@ -154,45 +239,83 @@ jobs:
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_MULTICAST_ENABLE:  "false"
     steps:
+    # This will write to key ${{ env.JOB_NAME }}-${{ github.run_id }}
+    - name: Initialize last run status cache
+      id: last_run_status_cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/last_run_status
+        key: ${{ env.JOB_NAME }}-${{ github.run_id }}-last-run-status
+
+    # The last run status comes from the run_cache file in the cache
+    # Verify all of the following steps. Only execute them if the cache does not
+    # contain: steps.last_run_status.outputs.STATUS != 'completed' and if none
+    # of the previous steps have failed
+    - name: Fetch last run status from file in cache
+      id: last_run_status
+      run: |
+        if  [ -f /tmp/last_run_status ]; then
+            cat /tmp/last_run_status
+        fi
+
+    # Create a cache for test results
+    - name: Create cache for run logs
+      id: run_log_cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/run_logs/
+        key: ${{ env.JOB_NAME }}-${{ github.run_id }}-run-logs
+
     - name: Set up Go
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       uses: actions/setup-go@v1
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Set up environment
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         export GOPATH=$(go env GOPATH)
         echo "GOPATH=$GOPATH" >> $GITHUB_ENV
         echo "$GOPATH/bin" >> $GITHUB_PATH
 
     - name: Free up disk space
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
 
-    - uses: actions/download-artifact@v2
+    - name: Download test-image-master
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
+      uses: actions/download-artifact@v2
       with:
         name: test-image-master
 
     - name: Disable ufw
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
       # Not needed for KIND deployments, so just disable all the time.
       run: |
         sudo ufw disable
 
     - name: Load docker image
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         docker load --input image-master.tar
 
     - name: Check out code into the Go module directory - from PR branch
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       uses: actions/checkout@v2
 
     - name: kind setup
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         export OVN_IMAGE="ovn-daemonset-f:dev"
         make -C test install-kind
 
-    - name: Export logs
-      if: always()
+    - name: Export kind logs
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       run: |
         mkdir -p /tmp/kind/logs
         kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
@@ -202,42 +325,69 @@ jobs:
         docker exec ovn-worker crictl images
         docker exec ovn-worker2 crictl images 
 
-    - name: Upload logs
-      if: always()
+    - name: Upload kind logs
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       uses: actions/upload-artifact@v2
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
 
-    - uses: actions/download-artifact@v2
+    - name: Download test-image-pr
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
+      uses: actions/download-artifact@v2
       with:
         name: test-image-pr
 
     - name: Load docker image
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         docker load --input image-pr.tar
 
     - name: ovn upgrade
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
+        mkdir -p /tmp/run_logs
+        exec > >(tee -a /tmp/run_logs/logs_ovn_upgrade.txt) 2>&1
         export OVN_IMAGE="ovn-daemonset-f:pr"
         make -C test upgrade-ovn
 
     - name: Run E2E shard-conformance
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
+        mkdir -p /tmp/run_logs
+        exec > >(tee -a /tmp/run_logs/logs_shard_conformance.txt) 2>&1
         make -C test shard-conformance
 
-    - name: Export logs
-      if: always()
+    - name: Export kind logs
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       run: |
         mkdir -p /tmp/kind/logs-kind-pr-branch
         kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs-kind-pr-branch
 
-    - name: Upload logs
-      if: always()
+    - name: Upload kind logs
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       uses: actions/upload-artifact@v2
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}-after-upgrade
         path: /tmp/kind/logs-kind-pr-branch
+
+    # The following steps will run if the job is marked completed and no step failed
+    - name: Display run logs from successful tests
+      if: steps.last_run_status.outputs.STATUS == 'completed' && success()
+      continue-on-error: true
+      run: |
+        if  [ -f /tmp/run_logs/logs_ovn_upgrade.txt ]; then
+            cat /tmp/run_logs/logs_ovn_upgrade.txt
+        fi
+        if  [ -f /tmp/run_logs/logs_shard_conformance.txt ]; then
+            cat /tmp/run_logs/logs_shard_conformance.txt
+        fi
+
+    # This will set the name=STATUS to 'completed' if none of the above steps
+    # failed
+    - name: Set last run status to completed
+      run: |
+        echo '::set-output name=STATUS::completed' > /tmp/last_run_status
 
   e2e:
     name: e2e
@@ -294,20 +444,52 @@ jobs:
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"
       KIND_IPV6_SUPPORT: "${{ matrix.ipfamily == 'IPv6' || matrix.ipfamily == 'dualstack' }}"
     steps:
+    # This will write to key ${{ env.JOB_NAME }}-${{ github.run_id }}
+    - name: Initialize last run status cache
+      id: last_run_status_cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/last_run_status
+        key: ${{ env.JOB_NAME }}-${{ github.run_id }}-last-run-status
+
+    # The last run status comes from the run_cache file in the cache
+    # Verify all of the following steps. Only execute them if the cache does not
+    # contain: steps.last_run_status.outputs.STATUS != 'completed' and if none
+    # of the previous steps have failed
+    - name: Fetch last run status from file in cache
+      id: last_run_status
+      run: |
+        if  [ -f /tmp/last_run_status ]; then
+            cat /tmp/last_run_status
+        fi
+
+    # Create a cache for test results
+    - name: Create cache for run logs
+      id: run_log_cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/run_logs/
+        key: ${{ env.JOB_NAME }}-${{ github.run_id }}-run-logs
 
     - name: Free up disk space
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
 
     - name: Set up Go
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       uses: actions/checkout@v2
 
     - name: Set up environment
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         export GOPATH=$(go env GOPATH)
         echo "GOPATH=$GOPATH" >> $GITHUB_ENV
@@ -316,47 +498,77 @@ jobs:
           echo OVN_TEST_EX_GW_NETWORK=kindexgw >> $GITHUB_ENV
           echo OVN_ENABLE_EX_GW_NETWORK_BRIDGE=true >> $GITHUB_ENV
         fi
+
     - name: Disable ufw
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
       # Not needed for KIND deployments, so just disable all the time.
       run: |
         sudo ufw disable
-    - uses: actions/download-artifact@v2
+
+    - name: Download test-image-pr
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
+      uses: actions/download-artifact@v2
       with:
         name: test-image-pr
 
     - name: Load docker image
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         docker load --input image-pr.tar
+
     - name: kind setup
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       timeout-minutes: 30
       run: |
         export OVN_IMAGE="ovn-daemonset-f:pr"
         make -C test install-kind
+
     - name: Run Tests
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       # e2e tests take ~60 minutes normally, 90 should be more than enough
       # set 2 1/2 hours for control-plane tests as these might take a while
       timeout-minutes: ${{ matrix.target == 'control-plane' && 150 || 90 }}
       run: |
+        mkdir -p /tmp/run_logs
+        exec > >(tee -a /tmp/run_logs/logs.txt) 2>&1
         make -C test ${{ matrix.target }}
+
+    # The following steps will always run unless the job is marked as completed
     - name: Upload Junit Reports
-      if: always()
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       uses: actions/upload-artifact@v2
       with:
         name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: './test/_artifacts/*.xml'
 
-    - name: Export logs
-      if: always()
+    - name: Export kind logs
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       run: |
         mkdir -p /tmp/kind/logs
         kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
-    - name: Upload logs
-      if: always()
+
+    - name: Upload kind logs
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       uses: actions/upload-artifact@v2
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
+
+    # The following steps will run if the job is marked completed and no step failed
+    - name: Display run logs from successful tests
+      if: steps.last_run_status.outputs.STATUS == 'completed' && success()
+      continue-on-error: true
+      run: |
+        if  [ -f /tmp/run_logs/logs.txt ]; then
+            cat /tmp/run_logs/logs.txt
+        fi
+
+    # This will set the name=STATUS to 'completed' if none of the above steps
+    # failed
+    - name: Set last run status to completed
+      run: |
+        echo '::set-output name=STATUS::completed' > /tmp/last_run_status
 
   e2e-dual-conversion:
     name: e2e-dual-conversion
@@ -377,66 +589,135 @@ jobs:
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_MULTICAST_ENABLE:  "false"
     steps:
+    # This will write to key ${{ env.JOB_NAME }}-${{ github.run_id }}
+    - name: Initialize last run status cache
+      id: last_run_status_cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/last_run_status
+        key: ${{ env.JOB_NAME }}-${{ github.run_id }}-last-run-status
+
+    # The last run status comes from the run_cache file in the cache
+    # Verify all of the following steps. Only execute them if the cache does not
+    # contain: steps.last_run_status.outputs.STATUS != 'completed' and if none
+    # of the previous steps have failed
+    - name: Fetch last run status from file in cache
+      id: last_run_status
+      run: |
+        if  [ -f /tmp/last_run_status ]; then
+            cat /tmp/last_run_status
+        fi
+
+    # Create a cache for test results
+    - name: Create cache for run logs
+      id: run_log_cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/run_logs/
+        key: ${{ env.JOB_NAME }}-${{ github.run_id }}-run-logs
 
     - name: Set up Go
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
 
     - name: Check out code into the Go module directory
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       uses: actions/checkout@v2
 
     - name: Set up environment
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         export GOPATH=$(go env GOPATH)
         echo "GOPATH=$GOPATH" >> $GITHUB_ENV
         echo "$GOPATH/bin" >> $GITHUB_PATH
+
     - name: Disable ufw
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
       # Not needed for KIND deployments, so just disable all the time.
       run: |
         sudo ufw disable
-    - uses: actions/download-artifact@v2
+
+    - name: Download test-image-pr
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
+      uses: actions/download-artifact@v2
       with:
         name: test-image-pr
 
     - name: Load docker image
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         docker load --input image-pr.tar
+
     - name: kind IPv4 setup
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         export OVN_IMAGE="ovn-daemonset-f:pr"
         make -C test install-kind
+
     - name: Run Single-Stack Tests
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
+        mkdir -p /tmp/run_logs
+        exec > >(tee -a /tmp/run_logs/single_stack_logs.txt) 2>&1
         make -C test shard-test WHAT="Networking Granular Checks"
+
     - name: Convert IPv4 cluster to Dual Stack
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
         ./contrib/kind-dual-stack-conversion.sh
+
     - name: Run Dual-Stack Tests
+      if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
+        mkdir -p /tmp/run_logs
+        exec > >(tee -a /tmp/run_logs/dual_stack_logs.txt) 2>&1
         KIND_IPV4_SUPPORT="true"
         KIND_IPV6_SUPPORT="true"
         make -C test shard-test WHAT="Networking Granular Checks\|DualStack"
+
     - name: Upload Junit Reports
-      if: always()
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       uses: actions/upload-artifact@v2
       with:
         name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: './test/_artifacts/*.xml'
 
-    - name: Export logs
-      if: always()
+    - name: Export kind logs
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       run: |
         mkdir -p /tmp/kind/logs
         kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
-    - name: Upload logs
-      if: always()
+
+    - name: Upload kind logs
+      if: steps.last_run_status.outputs.STATUS != 'completed' && always()
       uses: actions/upload-artifact@v2
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
+
+    # The following steps will run if the job is marked completed and no step failed
+    - name: Display run logs from successful tests
+      if: steps.last_run_status.outputs.STATUS == 'completed' && success()
+      continue-on-error: true
+      run: |
+        if  [ -f /tmp/run_logs/single_stack_logs.txt ]; then
+            cat /tmp/run_logs/single_stack_logs.txt
+        fi
+        if  [ -f /tmp/run_logs/dual_stack_logs.txt ]; then
+            cat /tmp/run_logs/dual_stack_logs.txt
+        fi
+
+    # This will set the name=STATUS to 'completed' if none of the above steps
+    # failed
+    - name: Set last run status to completed
+      run: |
+        echo '::set-output name=STATUS::completed' > /tmp/last_run_status
 
   e2e-periodic:
     name: e2e-periodic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,23 @@ env:
   # Current Serial tests are not relevant for OVN
   PARALLEL: true
 
+  # This must be a directory
+  CI_IMAGE_CACHE: /tmp/image_cache/
+  # This must be a directory
+  CI_RUN_LOG_CACHE: /tmp/run_logs/
+  # This must be a file
+  CI_LAST_RUN_STATUS_CACHE: /tmp/last_run_status
+
+  CI_IMAGE_MASTER_TAR: image-master.tar
+  CI_IMAGE_PR_TAR: image-pr.tar
+  CI_DIST_IMAGES_OUTPUT: dist/images/_output/
+
+  CI_LOGS_OVN_UPGRADE: logs_ovn_upgrade.txt
+  CI_LOGS_SHARD_CONFORMANCE: logs_shard_conformance.txt
+  CI_LOGS_GENERIC: logs.txt
+  CI_LOGS_DUAL_STACK: dual_stack_logs.txt
+  CI_LOGS_SINGLE_STACK: single_stack_logs.txt
+
 jobs:
   # separate job for parallelism
   lint:
@@ -43,7 +60,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          /tmp/image_cache/
+          ${{ env.CI_IMAGE_CACHE }}
         key: ${{ github.run_id }}-image-cache-master
 
     - name: Check if master image build is needed
@@ -51,10 +68,10 @@ jobs:
       continue-on-error: true
       run: |
         set -x
-        if [ -f /tmp/image_cache/image-master.tar.gz ]; then
-            mkdir -p dist/images/_output
-            cp /tmp/image_cache/image-master.tar.gz dist/images/_output/image-master.tar.gz
-            gunzip dist/images/_output/image-master.tar.gz
+        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ]; then
+            mkdir -p ${CI_DIST_IMAGES_OUTPUT}
+            cp ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_MASTER_TAR}.gz
+            gunzip ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_MASTER_TAR}.gz
             echo "::set-output name=MASTER_IMAGE_RESTORED::true"
         fi
 
@@ -89,28 +106,29 @@ jobs:
           echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
           docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
           mkdir _output
-          docker save ovn-daemonset-f:dev > _output/image-master.tar
+          docker save ovn-daemonset-f:dev > _output/${CI_IMAGE_MASTER_TAR}
         popd
 
     - name: Cache master image
       if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED != 'true' && success()
       continue-on-error: true
       run: |
-        if [ -f /tmp/image_cache/image-master.tar ]; then
-            rm -f /tmp/image_cache/image-master.tar
+        set -x
+        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR} ]; then
+            rm -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}
         fi
-        if [ -f /tmp/image_cache/image-master.tar.gz ]; then
-            rm -f /tmp/image_cache/image-master.tar.gz
+        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz ]; then
+            rm -f ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}.gz
         fi
-        mkdir -p /tmp/image_cache/
-        cp dist/images/_output/image-master.tar /tmp/image_cache/image-master.tar
-        gzip /tmp/image_cache/image-master.tar
+        mkdir -p ${CI_IMAGE_CACHE}/
+        cp ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_MASTER_TAR} ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}
+        gzip ${CI_IMAGE_CACHE}/${CI_IMAGE_MASTER_TAR}
 
     # run the following always if none of the steps before failed
     - uses: actions/upload-artifact@v2
       with:
         name: test-image-master
-        path: dist/images/_output/image-master.tar
+        path: ${{ env.CI_DIST_IMAGES_OUTPUT }}/${{ env.CI_IMAGE_MASTER_TAR }}
 
   build-pr:
     name: Build-PR
@@ -122,7 +140,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          /tmp/image_cache/
+          ${{ env.CI_IMAGE_CACHE }}
         key: ${{ github.run_id }}-image-cache-pr
 
     - name: Check if PR image build is needed
@@ -130,10 +148,10 @@ jobs:
       continue-on-error: true
       run: |
         set -x
-        if [ -f /tmp/image_cache/image-pr.tar.gz ]; then
-            mkdir -p dist/images/_output
-            cp /tmp/image_cache/image-pr.tar.gz dist/images/_output/image-pr.tar.gz
-            gunzip dist/images/_output/image-pr.tar.gz
+        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz ]; then
+            mkdir -p ${CI_DIST_IMAGES_OUTPUT}
+            cp ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR}.gz
+            gunzip ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR}.gz
             echo "::set-output name=PR_IMAGE_RESTORED::true"
         fi
 
@@ -169,7 +187,7 @@ jobs:
           echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
           docker build -t ovn-daemonset-f:pr -f Dockerfile.fedora .
           mkdir _output
-          docker save ovn-daemonset-f:pr > _output/image-pr.tar
+          docker save ovn-daemonset-f:pr > _output/${CI_IMAGE_PR_TAR}
         popd
 
     - name: Upload Junit Reports
@@ -202,21 +220,22 @@ jobs:
       if: steps.is_pr_image_build_needed.outputs.PR_IMAGE_RESTORED != 'true' && success()
       continue-on-error: true
       run: |
-        if [ -f /tmp/image_cache/image-pr.tar ]; then
-            rm -f /tmp/image_cache/image-pr.tar
+        set -x
+        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR} ]; then
+            rm -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
         fi
-        if [ -f /tmp/image_cache/image-pr.tar.gz ]; then
-           rm -f /tmp/image_cache/image-pr.tar.gz
+        if [ -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz ]; then
+           rm -f ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}.gz
         fi
-        mkdir -p /tmp/image_cache/
-        cp dist/images/_output/image-pr.tar /tmp/image_cache/image-pr.tar
-        gzip /tmp/image_cache/image-pr.tar
+        mkdir -p ${CI_IMAGE_CACHE}/
+        cp ${CI_DIST_IMAGES_OUTPUT}/${CI_IMAGE_PR_TAR} ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
+        gzip ${CI_IMAGE_CACHE}/${CI_IMAGE_PR_TAR}
 
     # run the following if none of the previous steps failed
     - uses: actions/upload-artifact@v2
       with:
         name: test-image-pr
-        path: dist/images/_output/image-pr.tar
+        path: ${{ env.CI_DIST_IMAGES_OUTPUT }}/${{ env.CI_IMAGE_PR_TAR }}
 
   ovn-upgrade-e2e:
     name: Upgrade OVN from Master to PR branch based image
@@ -245,7 +264,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          /tmp/last_run_status
+          ${{ env.CI_LAST_RUN_STATUS_CACHE }}
         key: ${{ env.JOB_NAME }}-${{ github.run_id }}-last-run-status
 
     # The last run status comes from the run_cache file in the cache
@@ -255,8 +274,8 @@ jobs:
     - name: Fetch last run status from file in cache
       id: last_run_status
       run: |
-        if  [ -f /tmp/last_run_status ]; then
-            cat /tmp/last_run_status
+        if  [ -f ${CI_LAST_RUN_STATUS_CACHE} ]; then
+            cat ${CI_LAST_RUN_STATUS_CACHE}
         fi
 
     # Create a cache for test results
@@ -265,7 +284,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          /tmp/run_logs/
+          ${{ env.CI_RUN_LOG_CACHE }}
         key: ${{ env.JOB_NAME }}-${{ github.run_id }}-run-logs
 
     - name: Set up Go
@@ -302,7 +321,7 @@ jobs:
     - name: Load docker image
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
-        docker load --input image-master.tar
+        docker load --input ${CI_IMAGE_MASTER_TAR}
 
     - name: Check out code into the Go module directory - from PR branch
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
@@ -341,21 +360,21 @@ jobs:
     - name: Load docker image
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
-        docker load --input image-pr.tar
+        docker load --input ${CI_IMAGE_PR_TAR}
 
     - name: ovn upgrade
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
-        mkdir -p /tmp/run_logs
-        exec > >(tee -a /tmp/run_logs/logs_ovn_upgrade.txt) 2>&1
+        mkdir -p ${CI_RUN_LOG_CACHE}
+        exec > >(tee -a ${CI_RUN_LOG_CACHE}/${CI_LOGS_OVN_UPGRADE}) 2>&1
         export OVN_IMAGE="ovn-daemonset-f:pr"
         make -C test upgrade-ovn
 
     - name: Run E2E shard-conformance
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
-        mkdir -p /tmp/run_logs
-        exec > >(tee -a /tmp/run_logs/logs_shard_conformance.txt) 2>&1
+        mkdir -p ${CI_RUN_LOG_CACHE}
+        exec > >(tee -a ${CI_RUN_LOG_CACHE}/${CI_LOGS_SHARD_CONFORMANCE}) 2>&1
         make -C test shard-conformance
 
     - name: Export kind logs
@@ -376,18 +395,18 @@ jobs:
       if: steps.last_run_status.outputs.STATUS == 'completed' && success()
       continue-on-error: true
       run: |
-        if  [ -f /tmp/run_logs/logs_ovn_upgrade.txt ]; then
-            cat /tmp/run_logs/logs_ovn_upgrade.txt
+        if  [ -f ${CI_RUN_LOG_CACHE}/${CI_LOGS_OVN_UPGRADE} ]; then
+            cat ${CI_RUN_LOG_CACHE}/${CI_LOGS_OVN_UPGRADE}
         fi
-        if  [ -f /tmp/run_logs/logs_shard_conformance.txt ]; then
-            cat /tmp/run_logs/logs_shard_conformance.txt
+        if  [ -f ${CI_RUN_LOG_CACHE}/${CI_LOGS_SHARD_CONFORMANCE} ]; then
+            cat ${CI_RUN_LOG_CACHE}/${CI_LOGS_SHARD_CONFORMANCE}
         fi
 
     # This will set the name=STATUS to 'completed' if none of the above steps
     # failed
     - name: Set last run status to completed
       run: |
-        echo '::set-output name=STATUS::completed' > /tmp/last_run_status
+        echo '::set-output name=STATUS::completed' > ${CI_LAST_RUN_STATUS_CACHE}
 
   e2e:
     name: e2e
@@ -450,7 +469,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          /tmp/last_run_status
+          ${{ env.CI_LAST_RUN_STATUS_CACHE }}
         key: ${{ env.JOB_NAME }}-${{ github.run_id }}-last-run-status
 
     # The last run status comes from the run_cache file in the cache
@@ -460,8 +479,8 @@ jobs:
     - name: Fetch last run status from file in cache
       id: last_run_status
       run: |
-        if  [ -f /tmp/last_run_status ]; then
-            cat /tmp/last_run_status
+        if  [ -f ${CI_LAST_RUN_STATUS_CACHE} ]; then
+            cat ${CI_LAST_RUN_STATUS_CACHE}
         fi
 
     # Create a cache for test results
@@ -470,7 +489,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          /tmp/run_logs/
+          ${{ env.CI_RUN_LOG_CACHE }}
         key: ${{ env.JOB_NAME }}-${{ github.run_id }}-run-logs
 
     - name: Free up disk space
@@ -515,7 +534,7 @@ jobs:
     - name: Load docker image
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
-        docker load --input image-pr.tar
+        docker load --input ${CI_IMAGE_PR_TAR}
 
     - name: kind setup
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
@@ -530,8 +549,8 @@ jobs:
       # set 2 1/2 hours for control-plane tests as these might take a while
       timeout-minutes: ${{ matrix.target == 'control-plane' && 150 || 90 }}
       run: |
-        mkdir -p /tmp/run_logs
-        exec > >(tee -a /tmp/run_logs/logs.txt) 2>&1
+        mkdir -p ${CI_RUN_LOG_CACHE}
+        exec > >(tee -a ${CI_RUN_LOG_CACHE}/${CI_LOGS_GENERIC}) 2>&1
         make -C test ${{ matrix.target }}
 
     # The following steps will always run unless the job is marked as completed
@@ -560,15 +579,15 @@ jobs:
       if: steps.last_run_status.outputs.STATUS == 'completed' && success()
       continue-on-error: true
       run: |
-        if  [ -f /tmp/run_logs/logs.txt ]; then
-            cat /tmp/run_logs/logs.txt
+        if  [ -f ${CI_RUN_LOG_CACHE}/${CI_LOGS_GENERIC} ]; then
+            cat ${CI_RUN_LOG_CACHE}/${CI_LOGS_GENERIC}
         fi
 
     # This will set the name=STATUS to 'completed' if none of the above steps
     # failed
     - name: Set last run status to completed
       run: |
-        echo '::set-output name=STATUS::completed' > /tmp/last_run_status
+        echo '::set-output name=STATUS::completed' > ${CI_LAST_RUN_STATUS_CACHE}
 
   e2e-dual-conversion:
     name: e2e-dual-conversion
@@ -595,7 +614,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          /tmp/last_run_status
+          ${{ env.CI_LAST_RUN_STATUS_CACHE }}
         key: ${{ env.JOB_NAME }}-${{ github.run_id }}-last-run-status
 
     # The last run status comes from the run_cache file in the cache
@@ -605,8 +624,8 @@ jobs:
     - name: Fetch last run status from file in cache
       id: last_run_status
       run: |
-        if  [ -f /tmp/last_run_status ]; then
-            cat /tmp/last_run_status
+        if  [ -f ${CI_LAST_RUN_STATUS_CACHE} ]; then
+            cat ${CI_LAST_RUN_STATUS_CACHE}
         fi
 
     # Create a cache for test results
@@ -615,7 +634,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          /tmp/run_logs/
+          ${{ env.CI_RUN_LOG_CACHE }}
         key: ${{ env.JOB_NAME }}-${{ github.run_id }}-run-logs
 
     - name: Set up Go
@@ -652,7 +671,7 @@ jobs:
     - name: Load docker image
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
-        docker load --input image-pr.tar
+        docker load --input ${CI_IMAGE_PR_TAR}
 
     - name: kind IPv4 setup
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
@@ -663,8 +682,8 @@ jobs:
     - name: Run Single-Stack Tests
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
-        mkdir -p /tmp/run_logs
-        exec > >(tee -a /tmp/run_logs/single_stack_logs.txt) 2>&1
+        mkdir -p ${CI_RUN_LOG_CACHE}
+        exec > >(tee -a ${CI_RUN_LOG_CACHE}/${CI_LOGS_SINGLE_STACK}) 2>&1
         make -C test shard-test WHAT="Networking Granular Checks"
 
     - name: Convert IPv4 cluster to Dual Stack
@@ -675,8 +694,8 @@ jobs:
     - name: Run Dual-Stack Tests
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       run: |
-        mkdir -p /tmp/run_logs
-        exec > >(tee -a /tmp/run_logs/dual_stack_logs.txt) 2>&1
+        mkdir -p ${CI_RUN_LOG_CACHE}
+        exec > >(tee -a ${CI_RUN_LOG_CACHE}/${CI_LOGS_DUAL_STACK}) 2>&1
         KIND_IPV4_SUPPORT="true"
         KIND_IPV6_SUPPORT="true"
         make -C test shard-test WHAT="Networking Granular Checks\|DualStack"
@@ -706,18 +725,18 @@ jobs:
       if: steps.last_run_status.outputs.STATUS == 'completed' && success()
       continue-on-error: true
       run: |
-        if  [ -f /tmp/run_logs/single_stack_logs.txt ]; then
-            cat /tmp/run_logs/single_stack_logs.txt
+        if  [ -f ${CI_RUN_LOG_CACHE}/${CI_LOGS_SINGLE_STACK} ]; then
+            cat ${CI_RUN_LOG_CACHE}/${CI_LOGS_SINGLE_STACK}
         fi
-        if  [ -f /tmp/run_logs/dual_stack_logs.txt ]; then
-            cat /tmp/run_logs/dual_stack_logs.txt
+        if  [ -f ${CI_RUN_LOG_CACHE}/${CI_LOGS_DUAL_STACK} ]; then
+            cat ${CI_RUN_LOG_CACHE}/${CI_LOGS_DUAL_STACK}
         fi
 
     # This will set the name=STATUS to 'completed' if none of the above steps
     # failed
     - name: Set last run status to completed
       run: |
-        echo '::set-output name=STATUS::completed' > /tmp/last_run_status
+        echo '::set-output name=STATUS::completed' > ${CI_LAST_RUN_STATUS_CACHE}
 
   e2e-periodic:
     name: e2e-periodic
@@ -768,7 +787,7 @@ jobs:
           name: test-image-pr
       - name: Load docker image
         run: |
-          docker load --input image-pr.tar
+          docker load --input ${CI_IMAGE_PR_TAR}
       - name: kind setup
         run: |
           export OVN_IMAGE="ovn-daemonset-f:pr"


### PR DESCRIPTION
Only retest failed E2E jobs out of the matrix. Do the same for DualStack
and Upgrade tests. Test results will be stored inside github's cache and
if a sub-job was marked as completed, it is skipped and its results from
the run before are going to be displayed instead.
Also cache master and PR builds.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->