### PR TITLE
Fixes delete retry on network policy recreation

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -780,12 +780,29 @@ func (oc *Controller) WatchNetworkPolicy() {
 		AddFunc: func(obj interface{}) {
 			policy := obj.(*kapisnetworking.NetworkPolicy)
 			oc.initRetryPolicy(policy)
+			oc.checkAndSkipRetryPolicy(policy)
+			// If there is a delete entry this is a network policy being added
+			// with the same name as a previous network policy that failed deletion.
+			// Destroy it first before we add the new policy.
+			if retryEntry := oc.getPolicyRetryEntry(policy); retryEntry != nil && retryEntry.oldPolicy != nil {
+				klog.Infof("Detected stale policy during new policy add with the same name: %s/%s",
+					policy.Namespace, policy.Name)
+				if err := oc.deleteNetworkPolicy(retryEntry.oldPolicy, nil); err != nil {
+					oc.unSkipRetryPolicy(policy)
+					klog.Errorf("Failed to delete stale network policy %s, during add: %v",
+						getPolicyNamespacedName(policy), err)
+					return
+				}
+				oc.removeDeleteFromRetryPolicy(policy)
+			}
+			start := time.Now()
 			if err := oc.addNetworkPolicy(policy); err != nil {
 				klog.Errorf("Failed to create network policy %s, error: %v",
 					getPolicyNamespacedName(policy), err)
 				oc.unSkipRetryPolicy(policy)
 				return
 			}
+			klog.Infof("Created Network Policy: %s took: %v", getPolicyNamespacedName(policy), time.Since(start))
 			oc.checkAndDeleteRetryPolicy(policy)
 		},
 		UpdateFunc: func(old, newer interface{}) {
@@ -793,7 +810,17 @@ func (oc *Controller) WatchNetworkPolicy() {
 			newPolicy := newer.(*kapisnetworking.NetworkPolicy)
 			if !reflect.DeepEqual(oldPolicy, newPolicy) {
 				oc.checkAndSkipRetryPolicy(oldPolicy)
-				if err := oc.deleteNetworkPolicy(oldPolicy, nil); err != nil {
+				// check if there was already a retry entry with an old policy
+				// else just look to delete the old policy in the update
+				if retryEntry := oc.getPolicyRetryEntry(oldPolicy); retryEntry != nil && retryEntry.oldPolicy != nil {
+					if err := oc.deleteNetworkPolicy(retryEntry.oldPolicy, nil); err != nil {
+						oc.initRetryPolicy(newPolicy)
+						oc.unSkipRetryPolicy(oldPolicy)
+						klog.Errorf("Failed to delete stale network policy %s, during update: %v",
+							getPolicyNamespacedName(oldPolicy), err)
+						return
+					}
+				} else if err := oc.deleteNetworkPolicy(oldPolicy, nil); err != nil {
 					oc.initRetryPolicyWithDelete(oldPolicy, nil)
 					oc.initRetryPolicy(newPolicy)
 					oc.unSkipRetryPolicy(oldPolicy)

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"github.com/onsi/gomega"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	egressfirewall "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
+	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
+	egressip "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -13,11 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
-
-	egressfirewall "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
-	egressfirewallfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/fake"
-	egressip "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
-	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
 )
 
 const (
@@ -111,10 +110,14 @@ func (o *FakeOVN) resetNBClient(ctx context.Context) {
 	if o.controller.nbClient.Connected() {
 		o.controller.nbClient.Close()
 	}
-	gomega.Eventually(o.controller.nbClient.Connected()).Should(gomega.BeFalse())
+	gomega.Eventually(func() bool {
+		return o.controller.nbClient.Connected()
+	}).Should(gomega.BeFalse())
 	err := o.controller.nbClient.Connect(ctx)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Eventually(o.controller.nbClient.Connected()).Should(gomega.BeTrue())
+	gomega.Eventually(func() bool {
+		return o.controller.nbClient.Connected()
+	}).Should(gomega.BeTrue())
 	_, err = o.controller.nbClient.MonitorAll(ctx)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }

--- a/go-controller/pkg/ovn/policy_retry.go
+++ b/go-controller/pkg/ovn/policy_retry.go
@@ -182,8 +182,8 @@ func (oc *Controller) RequestRetryPolicy() {
 	}
 }
 
-// Used for Unit Tests only
-func (oc *Controller) getRetryEntry(policy *knet.NetworkPolicy) *retryNetPolEntry {
+// getPolicyRetryEntry returns a copy of a policy retry entry from the cache
+func (oc *Controller) getPolicyRetryEntry(policy *knet.NetworkPolicy) *retryNetPolEntry {
 	oc.retryNetPolLock.Lock()
 	defer oc.retryNetPolLock.Unlock()
 	key := getPolicyNamespacedName(policy)

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1205,7 +1205,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
-		ginkgo.It("correctly retries creating a networkpolicy allowing a port to a local pod", func() {
+		ginkgo.It("correctly retries creating a network policy allowing a port to a local pod", func() {
 			app.Action = func(ctx *cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 				nPodTest := newTPod(
@@ -1303,7 +1303,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				ginkgo.By("Bringing down NBDB")
 				// inject transient problem, nbdb is down
 				fakeOvn.controller.nbClient.Close()
-				gomega.Eventually(fakeOvn.controller.nbClient.Connected()).Should(gomega.BeFalse())
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.nbClient.Connected()
+				}).Should(gomega.BeFalse())
 
 				// Create a second NP
 				ginkgo.By("Creating and deleting another policy that references that pod")
@@ -1314,8 +1316,10 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
 				time.Sleep(types.OVSDBTimeout + time.Second)
 				// check to see if the retry cache has an entry for this policy
-				fakeOvn.controller.getRetryEntry(networkPolicy2)
-				gomega.Eventually(fakeOvn.controller.getRetryEntry(networkPolicy2)).ShouldNot(gomega.BeNil())
+				fakeOvn.controller.getPolicyRetryEntry(networkPolicy2)
+				gomega.Eventually(func() *retryNetPolEntry {
+					return fakeOvn.controller.getPolicyRetryEntry(networkPolicy2)
+				}).ShouldNot(gomega.BeNil())
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				fakeOvn.resetNBClient(connCtx)
@@ -1325,7 +1329,159 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedDataWithPolicy2 := append(expectedData, gressPolicy2ExpectedData...)
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedDataWithPolicy2...))
 				// check the cache no longer has the entry
-				gomega.Eventually(fakeOvn.controller.getRetryEntry(networkPolicy)).Should(gomega.BeNil())
+				gomega.Eventually(func() *retryNetPolEntry {
+					return fakeOvn.controller.getPolicyRetryEntry(networkPolicy2)
+				}).Should(gomega.BeNil())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("correctly retries recreating a network policy with the same name", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespace1 := *newNamespace(namespaceName1)
+				nPodTest := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespace1.Name,
+				)
+				nPod := newPod(nPodTest.namespace, nPodTest.podName, nPodTest.nodeName, nPodTest.podIP)
+
+				const (
+					labelName string = "pod-name"
+					labelVal  string = "server"
+					portNum   int32  = 81
+				)
+				nPod.Labels[labelName] = labelVal
+
+				tcpProtocol := v1.Protocol(v1.ProtocolTCP)
+				networkPolicy := newNetworkPolicy("networkpolicy1", namespace1.Name,
+					metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							labelName: labelVal,
+						},
+					},
+					[]knet.NetworkPolicyIngressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+					[]knet.NetworkPolicyEgressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+				)
+
+				// This is not yet going to be created
+				networkPolicy2 := newNetworkPolicy("networkpolicy1", namespace1.Name,
+					metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							labelName: labelVal,
+						},
+					},
+					[]knet.NetworkPolicyIngressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum + 1},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+					[]knet.NetworkPolicyEgressRule{{
+						Ports: []knet.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: portNum + 1},
+							Protocol: &tcpProtocol,
+						}},
+					}},
+				)
+
+				npTest := kNetworkPolicy{}
+				gressPolicy1ExpectedData := npTest.getPolicyData(networkPolicy, []string{nPodTest.portUUID}, nil, []int32{portNum}, nbdb.ACLSeverityInfo)
+				defaultDenyExpectedData := npTest.getDefaultDenyData(networkPolicy, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo)
+				expectedData := []libovsdb.TestData{}
+				expectedData = append(expectedData, gressPolicy1ExpectedData...)
+				expectedData = append(expectedData, defaultDenyExpectedData...)
+				expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{namespace1},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{*nPod},
+					},
+					&knet.NetworkPolicyList{
+						Items: []knet.NetworkPolicy{*networkPolicy},
+					},
+				)
+				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				fakeOvn.controller.WatchNamespaces()
+				fakeOvn.controller.WatchPods()
+				fakeOvn.controller.WatchNetworkPolicy()
+
+				ginkgo.By("Creating a network policy that applies to a pod")
+
+				_, err := fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName1, []string{nPodTest.podIP})
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+
+				ginkgo.By("Bringing down NBDB")
+				// inject transient problem, nbdb is down
+				fakeOvn.controller.nbClient.Close()
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.nbClient.Connected()
+				}).Should(gomega.BeFalse())
+
+				ginkgo.By("Delete the first network policy")
+				err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Delete(context.TODO(), networkPolicy.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
+				time.Sleep(types.OVSDBTimeout + time.Second)
+				// check to see if the retry cache has an entry for this policy
+				gomega.Eventually(func() *retryNetPolEntry {
+					return fakeOvn.controller.getPolicyRetryEntry(networkPolicy2)
+				}).ShouldNot(gomega.BeNil())
+				retryEntry := fakeOvn.controller.getPolicyRetryEntry(networkPolicy2)
+				ginkgo.By("retry entry new policy should be nil")
+				gomega.Expect(retryEntry.newPolicy).To(gomega.BeNil())
+				ginkgo.By("retry entry old policy should not be nil")
+				gomega.Expect(retryEntry.oldPolicy).NotTo(gomega.BeNil())
+				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+				defer cancel()
+				fakeOvn.resetNBClient(connCtx)
+
+				ginkgo.By("Create a new network policy with same name")
+
+				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Create(context.TODO(), networkPolicy2, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gressPolicy2ExpectedData := npTest.getPolicyData(networkPolicy2, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo)
+				defaultDenyExpectedData2 := npTest.getDefaultDenyData(networkPolicy2, []string{nPodTest.portUUID}, nbdb.ACLSeverityInfo)
+
+				expectedData = []libovsdb.TestData{}
+				// FIXME(trozet): libovsdb server doesn't remove referenced ACLs to PG when deleting the PG
+				// https://github.com/ovn-org/libovsdb/issues/219
+				expectedPolicy1ACLs := gressPolicy1ExpectedData[:len(gressPolicy1ExpectedData)-1]
+				expectedData = append(expectedData, expectedPolicy1ACLs...)
+				expectedData = append(expectedData, gressPolicy2ExpectedData...)
+				expectedData = append(expectedData, defaultDenyExpectedData2...)
+				expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+				// check the cache no longer has the entry
+				gomega.Eventually(func() *retryNetPolEntry {
+					return fakeOvn.controller.getPolicyRetryEntry(networkPolicy)
+				}).Should(gomega.BeNil())
 
 				return nil
 			}
@@ -1933,7 +2089,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
-		ginkgo.It("retries a deleted networkpolicy", func() {
+		ginkgo.It("retries a deleted network policy", func() {
 			app.Action = func(ctx *cli.Context) error {
 				namespace1 := *newNamespace(namespaceName1)
 
@@ -2001,7 +2157,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 						},
 					},
 				)
-				gomega.Eventually(fakeOvn.controller.nbClient.Connected()).Should(gomega.BeTrue())
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.nbClient.Connected()
+				}).Should(gomega.BeTrue())
 
 				nPodTest.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
 				fakeOvn.controller.WatchNamespaces()
@@ -2015,14 +2173,18 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				// inject transient problem, nbdb is down
 				fakeOvn.controller.nbClient.Close()
-				gomega.Eventually(fakeOvn.controller.nbClient.Connected()).Should(gomega.BeFalse())
+				gomega.Eventually(func() bool {
+					return fakeOvn.controller.nbClient.Connected()
+				}).Should(gomega.BeFalse())
 				err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Delete(context.TODO(), networkPolicy.Name, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
 				time.Sleep(types.OVSDBTimeout + time.Second)
 				// check to see if the retry cache has an entry for this policy
-				gomega.Eventually(fakeOvn.controller.getRetryEntry(networkPolicy)).ShouldNot(gomega.BeNil())
+				gomega.Eventually(func() *retryNetPolEntry {
+					return fakeOvn.controller.getPolicyRetryEntry(networkPolicy)
+				}).ShouldNot(gomega.BeNil())
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				fakeOvn.resetNBClient(connCtx)
@@ -2036,7 +2198,9 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				gomega.Eventually(fakeOvn.controller.nbClient).Should(libovsdb.HaveData(append(acls, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)))
 
 				// check the cache no longer has the entry
-				gomega.Eventually(fakeOvn.controller.getRetryEntry(networkPolicy)).Should(gomega.BeNil())
+				gomega.Eventually(func() *retryNetPolEntry {
+					return fakeOvn.controller.getPolicyRetryEntry(networkPolicy)
+				}).Should(gomega.BeNil())
 				return nil
 			}
 


### PR DESCRIPTION
This fixes a case where:
  1. A network policy foo/bar is deleted, but fails
  2. foo/bar with delete is added to retry cache
  3. foo/bar is recreated in kapi
  4. foo/bar gets added in network policy handler

In the above scenario we would not clean up the old network policy, and
just add the new one. If that was successful we would miss cleaning up
the old policy.

Signed-off-by: Tim Rozet <trozet@redhat.com>

