### PR TITLE
node: wait for nodeIP and OpenFlow manager to stop before next test

### DIFF
--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -24,7 +24,7 @@ import (
 type Gateway interface {
 	informer.ServiceAndEndpointsEventHandler
 	Init(factory.NodeWatchFactory) error
-	Run(<-chan struct{}, *sync.WaitGroup)
+	Start(<-chan struct{}, *sync.WaitGroup)
 	GetGatewayBridgeIface() string
 }
 
@@ -169,16 +169,14 @@ func (g *gateway) Init(wf factory.NodeWatchFactory) error {
 	return nil
 }
 
-func (g *gateway) Run(stopChan <-chan struct{}, wg *sync.WaitGroup) {
+func (g *gateway) Start(stopChan <-chan struct{}, wg *sync.WaitGroup) {
 	if g.nodeIPManager != nil {
-		g.nodeIPManager.Run(stopChan)
+		g.nodeIPManager.Run(stopChan, wg)
 	}
 
 	if g.openflowManager != nil {
 		klog.Info("Spawning Conntrack Rule Check Thread")
-		wg.Add(1)
-		defer wg.Done()
-		g.openflowManager.Run(stopChan)
+		g.openflowManager.Run(stopChan, wg)
 	}
 }
 

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -165,9 +165,11 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		stop := make(chan struct{})
 		wf, err := factory.NewNodeWatchFactory(fakeClient, nodeName)
 		Expect(err).NotTo(HaveOccurred())
+		wg := &sync.WaitGroup{}
 		defer func() {
 			close(stop)
 			wf.Shutdown()
+			wg.Wait()
 		}()
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -196,7 +198,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			go sharedGw.Run(stop, &sync.WaitGroup{})
+			sharedGw.Start(stop, wg)
 
 			// Verify the code moved eth0's IP address, MAC, and routes
 			// over to breth0
@@ -433,9 +435,11 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		stop := make(chan struct{})
 		wf, err := factory.NewNodeWatchFactory(fakeClient, nodeName)
 		Expect(err).NotTo(HaveOccurred())
+		wg := &sync.WaitGroup{}
 		defer func() {
 			close(stop)
 			wf.Shutdown()
+			wg.Wait()
 		}()
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -465,7 +469,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			go sharedGw.Run(stop, &sync.WaitGroup{})
+			sharedGw.Start(stop, wg)
 			return nil
 		})
 
@@ -741,9 +745,11 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 		stop := make(chan struct{})
 		wf, err := factory.NewNodeWatchFactory(fakeClient, nodeName)
 		Expect(err).NotTo(HaveOccurred())
+		wg := &sync.WaitGroup{}
 		defer func() {
 			close(stop)
 			wf.Shutdown()
+			wg.Wait()
 		}()
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -772,7 +778,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			go localGw.Run(stop, &sync.WaitGroup{})
+			localGw.Start(stop, wg)
 
 			// Verify the code moved eth0's IP address, MAC, and routes
 			// over to breth0

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -431,7 +431,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 	if err := waiter.Wait(); err != nil {
 		return err
 	}
-	go n.gateway.Run(n.stopChan, wg)
+	n.gateway.Start(n.stopChan, wg)
 	klog.Infof("Gateway and management port readiness took %v", time.Since(start))
 
 	// Note(adrianc): DPU deployments are expected to support the new shared gateway changes, upgrade flow

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -68,7 +68,7 @@ func (c *addressManager) delAddr(ip net.IP) bool {
 	return false
 }
 
-func (c *addressManager) Run(stopChan <-chan struct{}) {
+func (c *addressManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) {
 	var addrChan chan netlink.AddrUpdate
 	addrSubscribeOptions := netlink.AddrSubscribeOptions{
 		ErrorCallback: func(err error) {
@@ -87,7 +87,10 @@ func (c *addressManager) Run(stopChan <-chan struct{}) {
 		return true, nil
 	}
 
+	doneWg.Add(1)
 	go func() {
+		defer doneWg.Done()
+
 		addressSyncTimer := time.NewTicker(30 * time.Second)
 
 		subscribed, err := subScribeFcn()


### PR DESCRIPTION
While the code would close the stopChan when each test was complete,
nothing waited for the nodeIPManager and OpenFlow managers to
actually break out of their loops and return. This could lead to
spillover into the next test and cause flakes like:

```
I0217 21:55:45.508740   18937 reflector.go:225] Stopping reflector *v1.Service (0s) from k8s.io/client-go/informers/factory.go:134
Gateway Operations DPU DPU Host Operations
  sets up a shared interface gateway DPU host
  /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/gateway_init_linux_test.go:1097
I0217 21:55:45.508328   18937 node_ip_handler_linux.go:221] Node address annotation being set to: map[10.1.1.37:{} 172.17.0.1:{}] addrChanged: true
I0217 21:55:45.509576   18937 kube.go:99] Setting annotations map[k8s.ovn.org/host-addresses:["10.1.1.37","172.17.0.1"]] on node node1
I0217 21:55:45.511568   18937 handler.go:151] Removed *v1.Endpoints event handler 2
I0217 21:55:45.515597   18937 node_ip_handler_linux.go:213] Skipping non-useable IP address for host: 127.0.0.1
I0217 21:55:45.516074   18937 node_ip_handler_linux.go:213] Skipping non-useable IP address for host: ::1
I0217 21:55:45.516532   18937 node_ip_handler_linux.go:213] Skipping non-useable IP address for host: fe80::20d:3aff:fe4f:eba4
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x2215afd]

goroutine 1323 [running]:
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.(*addressManager).doesNodeHostAddressesMatch(0xc0006415e0)
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/node_ip_handler_linux.go:157 +0xfd
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.(*addressManager).sync(0xc0006415e0)
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/node_ip_handler_linux.go:220 +0x22f
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.(*addressManager).Run.func2()
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/node_ip_handler_linux.go:86 +0x156
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.(*addressManager).Run.func3()
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/node_ip_handler_linux.go:103 +0x792
created by github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.(*addressManager).Run
	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/node/node_ip_handler_linux.go:90 +0x356
make: *** [Makefile:46: check] Error 2
```