### PR TITLE
Delete stale conntrack entries for services

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -474,7 +474,7 @@ func (pr *PodRequest) deletePodConntrack() {
 				continue
 			}
 		}
-		err = util.DeleteConntrack(ip.Address.IP.String(), 0, "")
+		err = util.DeleteConntrack(ip.Address.IP.String(), 0, "", netlink.ConntrackReplyAnyIP)
 		if err != nil {
 			klog.Errorf("Failed to delete Conntrack Entry for %s: %v", ip.Address.IP.String(), err)
 			continue

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/vishvananda/netlink"
 
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -524,6 +525,48 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
 	}
 }
 
+// deleteConntrackForServiceVIP deletes the conntrack entries for the provided svcVIP:svcPort by comparing them to ConntrackOrigDstIP:ConntrackOrigDstPort
+func deleteConntrackForServiceVIP(svcVIPs []string, svcPorts []kapi.ServicePort, ns, name string) error {
+	for _, svcVIP := range svcVIPs {
+		for _, svcPort := range svcPorts {
+			err := util.DeleteConntrack(svcVIP, svcPort.Port, svcPort.Protocol, netlink.ConntrackOrigDstIP)
+			if err != nil {
+				return fmt.Errorf("failed to delete conntrack entry for service %s/%s with svcVIP %s, svcPort %d, protocol %s: %v",
+					ns, name, svcVIP, svcPort.Port, svcPort.Protocol, err)
+			}
+		}
+	}
+	return nil
+}
+
+// deleteConntrackForService deletes the conntrack entries corresponding to the service VIPs of the provided service
+func (npw *nodePortWatcher) deleteConntrackForService(service *kapi.Service) error {
+	// remove conntrack entries for LB VIPs and External IPs
+	externalIPs := util.GetExternalAndLBIPs(service)
+	if err := deleteConntrackForServiceVIP(externalIPs, service.Spec.Ports, service.Namespace, service.Name); err != nil {
+		return err
+	}
+	if util.ServiceTypeHasNodePort(service) {
+		// remove conntrack entries for NodePorts
+		nodeIPs := npw.nodeIPManager.ListAddresses()
+		for _, nodeIP := range nodeIPs {
+			for _, svcPort := range service.Spec.Ports {
+				err := util.DeleteConntrack(nodeIP.String(), svcPort.NodePort, svcPort.Protocol, netlink.ConntrackOrigDstIP)
+				if err != nil {
+					return fmt.Errorf("failed to delete conntrack entry for service %s/%s with nodeIP %s, nodePort %d, protocol %s: %v",
+						service.Namespace, service.Name, nodeIP, svcPort.Port, svcPort.Protocol, err)
+				}
+			}
+		}
+	}
+	// remove conntrack entries for ClusterIPs
+	clusterIPs := util.GetClusterIPs(service)
+	if err := deleteConntrackForServiceVIP(clusterIPs, service.Spec.Ports, service.Namespace, service.Name); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return
@@ -531,6 +574,13 @@ func (npw *nodePortWatcher) DeleteService(service *kapi.Service) {
 
 	klog.V(5).Infof("Deleting service %s in namespace %s", service.Name, service.Namespace)
 	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	// Remove all conntrack entries for the serviceVIPs of this service irrespective of protocol stack
+	// since service deletion is considered as unplugging the network cable and hence graceful termination
+	// is not guaranteed. See https://github.com/kubernetes/kubernetes/issues/108523#issuecomment-1074044415.
+	err := npw.deleteConntrackForService(service)
+	if err != nil {
+		klog.Errorf("Failed to delete conntrack entry for service %v: %v", name, err)
+	}
 	if svcConfig, exists := npw.getAndDeleteServiceInfo(name); exists {
 		delServiceRules(svcConfig.service, npw)
 	} else {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -482,7 +482,8 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) {
 		// No endpoint object exists yet so default to false
 		hasLocalHostNetworkEp = false
 	} else {
-		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+		nodeIPs := npw.nodeIPManager.ListAddresses()
+		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(ep, nodeIPs)
 	}
 
 	// If something didn't already do it add correct Service rules
@@ -555,7 +556,8 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 			klog.V(5).Infof("No endpoint found for service %s in namespace %s during sync", service.Name, service.Namespace)
 			continue
 		}
-		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+		nodeIPs := npw.nodeIPManager.ListAddresses()
+		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, nodeIPs)
 		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp)
 		// Delete OF rules for service if they exist
 		npw.updateServiceFlowCache(service, false, hasLocalHostNetworkEp)
@@ -591,7 +593,8 @@ func (npw *nodePortWatcher) AddEndpoints(ep *kapi.Endpoints) {
 	}
 
 	klog.V(5).Infof("Adding endpoints %s in namespace %s", ep.Name, ep.Namespace)
-	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, &npw.nodeIPManager.addresses)
+	nodeIPs := npw.nodeIPManager.ListAddresses()
+	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(ep, nodeIPs)
 
 	// Here we make sure the correct rules are programmed whenever an AddEndpoint
 	// event is received, only alter flows if we need to, i.e if cache wasn't
@@ -645,8 +648,9 @@ func (npw *nodePortWatcher) UpdateEndpoints(old *kapi.Endpoints, new *kapi.Endpo
 	}
 
 	// Update rules if hasLocalHostNetworkEpNew status changed.
-	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints(old, &npw.nodeIPManager.addresses)
-	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints(new, &npw.nodeIPManager.addresses)
+	nodeIPs := npw.nodeIPManager.ListAddresses()
+	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints(old, nodeIPs)
+	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints(new, nodeIPs)
 	if hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew {
 		npw.DeleteEndpoints(old)
 		npw.AddEndpoints(new)

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -13,7 +14,6 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -110,17 +110,18 @@ func countLocalEndpoints(ep *kapi.Endpoints, nodeName string) int {
 // hasLocalHostNetworkEndpoints returns true if there is at least one host-networked endpoint
 // in the provided list that is local to this node.
 // It returns false if none of the endpoints are local host-networked endpoints or if ep.Subsets is nil.
-func hasLocalHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses *sets.String) bool {
+func hasLocalHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses []net.IP) bool {
 	for i := range ep.Subsets {
 		ss := &ep.Subsets[i]
 		for i := range ss.Addresses {
 			addr := &ss.Addresses[i]
-			if nodeAddresses.Has(addr.IP) {
-				return true
+			for _, nodeIP := range nodeAddresses {
+				if nodeIP.String() == addr.IP {
+					return true
+				}
 			}
 		}
 	}
-
 	return false
 }
 

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
-	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -148,8 +147,4 @@ func getIntfName(gatewayIntf string) (string, error) {
 			intfName, stderr, err)
 	}
 	return intfName, nil
-}
-
-func deleteConntrack(ip string, port int32, protocol kapi.Protocol) error {
-	return util.DeleteConntrack(ip, port, protocol)
 }

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/upgrade"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/vishvananda/netlink"
 )
 
 // OvnNode is the object holder for utilities meant for node management
@@ -572,8 +573,8 @@ func (n *OvnNode) WatchEndpoints() {
 			epOld := old.(*kapi.Endpoints)
 			newEpAddressMap := buildEndpointAddressMap(epNew.Subsets)
 			for item := range buildEndpointAddressMap(epOld.Subsets) {
-				if _, ok := newEpAddressMap[item]; !ok {
-					err := deleteConntrack(item.ip, item.port, item.protocol)
+				if _, ok := newEpAddressMap[item]; !ok && item.protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
+					err := util.DeleteConntrack(item.ip, item.port, item.protocol, netlink.ConntrackReplyAnyIP)
 					if err != nil {
 						klog.Errorf("Failed to delete conntrack entry for %s: %v", item.ip, err)
 					}
@@ -583,11 +584,12 @@ func (n *OvnNode) WatchEndpoints() {
 		DeleteFunc: func(obj interface{}) {
 			ep := obj.(*kapi.Endpoints)
 			for item := range buildEndpointAddressMap(ep.Subsets) {
-				err := deleteConntrack(item.ip, item.port, item.protocol)
-				if err != nil {
-					klog.Errorf("Failed to delete conntrack entry for %s: %v", item.ip, err)
+				if item.protocol == kapi.ProtocolUDP { // flush conntrack only for UDP
+					err := util.DeleteConntrack(item.ip, item.port, item.protocol, netlink.ConntrackReplyAnyIP)
+					if err != nil {
+						klog.Errorf("Failed to delete conntrack entry for %s: %v", item.ip, err)
+					}
 				}
-
 			}
 		},
 	}, nil)

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -162,6 +162,20 @@ func GetClusterIPs(service *kapi.Service) []string {
 	return []string{}
 }
 
+// GetExternalAndLBIPs returns an array with the ExternalIPs and LoadBalancer IPs present in the service
+func GetExternalAndLBIPs(service *kapi.Service) []string {
+	svcVIPs := []string{}
+	svcVIPs = append(svcVIPs, service.Spec.ExternalIPs...)
+	if ServiceTypeHasLoadBalancer(service) {
+		for _, ingressVIP := range service.Status.LoadBalancer.Ingress {
+			if len(ingressVIP.IP) > 0 {
+				svcVIPs = append(svcVIPs, ingressVIP.IP)
+			}
+		}
+	}
+	return svcVIPs
+}
+
 // ValidatePort checks if the port is non-zero and port protocol is valid
 func ValidatePort(proto kapi.Protocol, port int32) error {
 	if port <= 0 || port > 65535 {
@@ -186,6 +200,11 @@ func ServiceTypeHasClusterIP(service *kapi.Service) bool {
 // ServiceTypeHasNodePort checks if the service has an associated NodePort or not
 func ServiceTypeHasNodePort(service *kapi.Service) bool {
 	return service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
+}
+
+// ServiceTypeHasLoadBalancer checks if the service has an associated LoadBalancer or not
+func ServiceTypeHasLoadBalancer(service *kapi.Service) bool {
+	return service.Spec.Type == kapi.ServiceTypeLoadBalancer
 }
 
 func ServiceExternalTrafficPolicyLocal(service *kapi.Service) bool {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

Currently when we delete a clusterIP service we don't cleanup the conntrack entries on the node. This PR adds the logic to do this + we add the tcp protocol to the conntrack filtering process (not sure if we had any reasons for not including TCP?)
    
This PR does two things:
1) cleanup conntrack entries irrespective of protocol stack for service deletion
2) cleanup conntrack entries only for UDP during endpoint deletion. See https://github.com/kubernetes/kubernetes/issues/108523#issuecomment-1074044415 for details.


**- Special notes for reviewers**
Debug logs capturing conntrack deletes (done for testing purposes):
```
I0223 20:48:13.136499  431210 gateway_shared_intf.go:575] SURYA 172.30.151.15, 30102, SCTP
I0223 20:48:13.136519  431210 helper_linux.go:154] SURYA 172.30.151.15, 30102, SCTP
I0223 20:48:13.136531  431210 net_linux.go:411] SURYA 172.30.151.15, 30102, SCTP, &{map[4:0xc000abca20] map[6:30102] 132}
I0223 20:48:13.136545  431210 conntrack_linux.go:93] SURYA &{map[4:0xc000abca20] map[6:30102] 132}
I0223 20:48:13.141386  431210 conntrack_linux.go:102] SURYA 	132 src=169.254.169.2 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.141397  431210 conntrack_linux.go:454] SURYA 	132 src=169.254.169.2 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.141405  431210 conntrack_linux.go:472] SURYA false


I0223 20:48:13.142452  431210 conntrack_linux.go:102] SURYA 	132 src=172.31.249.96 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=172.30.151.15 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.142465  431210 conntrack_linux.go:454] SURYA 	132 src=172.31.249.96 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=172.30.151.15 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.142473  431210 conntrack_linux.go:469] SURYA 	132 src=172.31.249.96 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=172.30.151.15 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.142482  431210 conntrack_linux.go:472] SURYA true
I0223 20:48:13.142487  431210 conntrack_linux.go:104] SURYA 	132 src=172.31.249.96 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=172.30.151.15 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0


I0223 20:48:13.146873  431210 conntrack_linux.go:102] SURYA 	132 src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 packets=0 bytes=0	src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.146880  431210 conntrack_linux.go:454] SURYA 	132 src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 packets=0 bytes=0	src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.146886  431210 conntrack_linux.go:469] SURYA 	132 src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 packets=0 bytes=0	src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.146891  431210 conntrack_linux.go:472] SURYA true
I0223 20:48:13.146894  431210 conntrack_linux.go:104] SURYA 	132 src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 packets=0 bytes=0	src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541 packets=0 bytes=0 mark=0

I0223 20:48:13.207980  431210 conntrack_linux.go:102] SURYA 	132 src=169.254.169.2 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.207986  431210 conntrack_linux.go:454] SURYA 	132 src=169.254.169.2 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.207991  431210 conntrack_linux.go:469] SURYA 	132 src=169.254.169.2 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0
I0223 20:48:13.207996  431210 conntrack_linux.go:472] SURYA true
I0223 20:48:13.207998  431210 conntrack_linux.go:104] SURYA 	132 src=169.254.169.2 dst=172.30.151.15 sport=47541 dport=30102 packets=0 bytes=0	src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 packets=0 bytes=0 mark=0

I0223 20:48:13.224066  431210 conntrack_linux.go:112] SURYA deleted 3 entries
```

**- How to verify it**
```
oc get svc
NAME          TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)            AGE
sctpservice   LoadBalancer   172.30.151.15   172.31.249.39   30102:31458/SCTP   4s
oc get pods -owide
NAME         READY   STATUS    RESTARTS   AGE     IP            NODE                            NOMINATED NODE   READINESS GATES
sctpclient   1/1     Running   0          4h17m   10.131.0.26   asood-2231-rxpwk-worker-qc5p5   <none>           <none>
sctpserver   1/1     Running   0          4h17m   10.131.0.27   asood-2231-rxpwk-worker-qc5p5   <none>           <none>
```
Once connection from client to server is established:
```
conntrack -E -p sctp
[NEW] sctp     132 3 src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 [UNREPLIED] src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541
    [NEW] sctp     132 3 src=172.31.249.96 dst=172.30.151.15 sport=47541 dport=30102 [UNREPLIED] src=172.30.151.15 dst=169.254.169.2 sport=30102 dport=47541 zone=64001
    [NEW] sctp     132 3 src=169.254.169.2 dst=172.30.151.15 sport=47541 dport=30102 [UNREPLIED] src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 zone=12
    [NEW] sctp     132 3 src=169.254.169.2 dst=10.131.0.27 sport=47541 dport=30102 [UNREPLIED] src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541
    [NEW] sctp     132 3 src=100.64.0.5 dst=10.131.0.27 sport=47541 dport=30102 [UNREPLIED] src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541 zone=27
 [UPDATE] sctp     132 3 src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541
 [UPDATE] sctp     132 3 COOKIE_ECHOED src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541
 [UPDATE] sctp     132 432000 ESTABLISHED src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541 [ASSURED]

```
During an active session:
```
conntrack -L -p sctp
sctp     132 431994 ESTABLISHED src=169.254.169.2 dst=172.30.151.15 sport=47541 dport=30102 src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 [ASSURED] mark=0 secctx=system_u:object_r:unlabeled_t:s0 zone=12 use=1
sctp     132 431994 ESTABLISHED src=172.31.249.96 dst=172.30.151.15 sport=47541 dport=30102 src=172.30.151.15 dst=169.254.169.2 sport=30102 dport=47541 [ASSURED] mark=0 secctx=system_u:object_r:unlabeled_t:s0 zone=64001 use=1
sctp     132 431994 ESTABLISHED src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541 [ASSURED] mark=0 secctx=system_u:object_r:unlabeled_t:s0 use=1
sctp     132 431994 ESTABLISHED src=169.254.169.2 dst=10.131.0.27 sport=47541 dport=30102 src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541 [ASSURED] mark=0 secctx=system_u:object_r:unlabeled_t:s0 use=1
sctp     132 431994 ESTABLISHED src=100.64.0.5 dst=10.131.0.27 sport=47541 dport=30102 src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541 [ASSURED] mark=0 secctx=system_u:object_r:unlabeled_t:s0 zone=27 use=1


```
When we delete the LB svc and recreate it with same VIP but now a new clusterIP:
```
oc get svc
NAME          TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)            AGE
sctpservice   LoadBalancer   172.30.206.3   172.31.249.39   30102:31692/SCTP   2m47s
```
```
[DESTROY] sctp     132 src=172.31.249.96 dst=172.30.151.15 sport=47541 dport=30102 src=172.30.151.15 dst=169.254.169.2 sport=30102 dport=47541 [ASSURED] zone=64001
[DESTROY] sctp     132 src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 src=172.30.151.15 dst=172.31.249.96 sport=30102 dport=47541 [ASSURED]
[DESTROY] sctp     132 src=169.254.169.2 dst=172.30.151.15 sport=47541 dport=30102 src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 [ASSURED] zone=12
[DESTROY] sctp     132 src=169.254.169.2 dst=10.131.0.27 sport=47541 dport=30102 src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541 [ASSURED]
[DESTROY] sctp     132 src=100.64.0.5 dst=10.131.0.27 sport=47541 dport=30102 src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541 [ASSURED] zone=27
    [NEW] sctp     132 30 src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 [UNREPLIED] src=172.30.206.3 dst=172.31.249.96 sport=30102 dport=47541
    [NEW] sctp     132 30 src=172.31.249.96 dst=172.30.206.3 sport=47541 dport=30102 [UNREPLIED] src=172.30.206.3 dst=169.254.169.2 sport=30102 dport=47541 zone=64001
    [NEW] sctp     132 30 src=169.254.169.2 dst=172.30.206.3 sport=47541 dport=30102 [UNREPLIED] src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 zone=12
    [NEW] sctp     132 30 src=169.254.169.2 dst=10.131.0.27 sport=47541 dport=30102 [UNREPLIED] src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541
    [NEW] sctp     132 30 src=100.64.0.5 dst=10.131.0.27 sport=47541 dport=30102 [UNREPLIED] src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541 zone=27
 [UPDATE] sctp     132 210 NONE src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 src=172.30.206.3 dst=172.31.249.96 sport=30102 dport=47541
```
As we can see ^ we clean up the entries properly and new ones are auto-populated.
```
sh-4.4# conntrack -L -p sctp
sctp     132 207 NONE src=169.254.169.2 dst=172.30.206.3 sport=47541 dport=30102 src=10.131.0.27 dst=169.254.169.2 sport=30102 dport=47541 mark=0 secctx=system_u:object_r:unlabeled_t:s0 zone=12 use=2
sctp     132 207 NONE src=172.31.249.96 dst=172.31.249.39 sport=47541 dport=30102 src=172.30.206.3 dst=172.31.249.96 sport=30102 dport=47541 mark=0 secctx=system_u:object_r:unlabeled_t:s0 use=1
sctp     132 207 NONE src=169.254.169.2 dst=10.131.0.27 sport=47541 dport=30102 src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541 mark=0 secctx=system_u:object_r:unlabeled_t:s0 use=2
sctp     132 207 NONE src=172.31.249.96 dst=172.30.206.3 sport=47541 dport=30102 src=172.30.206.3 dst=169.254.169.2 sport=30102 dport=47541 mark=0 secctx=system_u:object_r:unlabeled_t:s0 zone=64001 use=1
sctp     132 207 NONE src=100.64.0.5 dst=10.131.0.27 sport=47541 dport=30102 src=10.131.0.27 dst=100.64.0.5 sport=30102 dport=47541 mark=0 secctx=system_u:object_r:unlabeled_t:s0 zone=27 use=1

```

**- Description for the changelog**
`cleanup conntrack entries for clusterIP`