### PR TITLE
Move memory-trimming-on-compaction out of dbchecker to nbdb/sbdb init

### DIFF
--- a/go-controller/cmd/ovndbchecker/ovndbchecker.go
+++ b/go-controller/cmd/ovndbchecker/ovndbchecker.go
@@ -182,10 +182,6 @@ func runOvnKubeDBChecker(ctx *cli.Context) error {
 		return err
 	}
 
-	if err = ovndbmanager.EnableDBMemTrimming(); err != nil {
-		return err
-	}
-
 	stopChan := make(chan struct{})
 	go ovndbmanager.RunDBChecker(
 		&kube.Kube{

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -340,29 +340,6 @@ func resetRaftDB(db *dbProperties) error {
 	return nil
 }
 
-// EnableDBMemTrimming enables memory trimming on DB compaction for NBDB and SBDB. Every 10 minutes the DBs are compacted
-// and excess memory on the heap is freed. By enabling memory trimming, the freed memory will be returned back to the OS
-func EnableDBMemTrimming() error {
-	out, stderr, err := util.RunOVNNBAppCtlWithTimeout(5, "list-commands")
-	if err != nil {
-		return fmt.Errorf("unable to list supported commands for ovn-appctl, stderr: %s, error: %v", stderr, err)
-	}
-	if !strings.Contains(out, "memory-trim-on-compaction") {
-		klog.Warning("memory-trim-on-compaction unsupported in this version of OVN. OVN DBs may experience high " +
-			"memory growth")
-		return nil
-	}
-	_, stderr, err = util.RunOVNNBAppCtlWithTimeout(5, "ovsdb-server/memory-trim-on-compaction", "on")
-	if err != nil {
-		return fmt.Errorf("unable to turn on memory trimming for NB DB, stderr: %s, error: %v", stderr, err)
-	}
-	_, stderr, err = util.RunOVNSBAppCtlWithTimeout(5, "ovsdb-server/memory-trim-on-compaction", "on")
-	if err != nil {
-		return fmt.Errorf("unable to turn on memory trimming for SB DB, stderr: %s, error: %v", stderr, err)
-	}
-	return nil
-}
-
 func propertiesForDB(db string) *dbProperties {
 	if strings.Contains(db, "ovnnb") {
 		return &dbProperties{


### PR DESCRIPTION
In order to avoid any potential bringup race conditions between dbchecker container
and sbdb/nbdb we move the memory trimming check and enable to start of each db.
Note: memory trim config is not persistent and need to be applied everytime sbdb/nbdb restarts.

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
