### PR TITLE
sbdb model: Re-run libovsdb modelgen on SB OVN schema

### DIFF
--- a/go-controller/pkg/sbdb/bfd.go
+++ b/go-controller/pkg/sbdb/bfd.go
@@ -10,10 +10,10 @@ type (
 )
 
 var (
+	BFDStatusAdminDown BFDStatus = "admin_down"
 	BFDStatusDown      BFDStatus = "down"
 	BFDStatusInit      BFDStatus = "init"
 	BFDStatusUp        BFDStatus = "up"
-	BFDStatusAdminDown BFDStatus = "admin_down"
 )
 
 // BFD defines an object in BFD table

--- a/go-controller/pkg/sbdb/dhcp_options.go
+++ b/go-controller/pkg/sbdb/dhcp_options.go
@@ -11,14 +11,14 @@ type (
 
 var (
 	DHCPOptionsTypeBool         DHCPOptionsType = "bool"
-	DHCPOptionsTypeUint8        DHCPOptionsType = "uint8"
-	DHCPOptionsTypeUint16       DHCPOptionsType = "uint16"
-	DHCPOptionsTypeUint32       DHCPOptionsType = "uint32"
+	DHCPOptionsTypeDomains      DHCPOptionsType = "domains"
+	DHCPOptionsTypeHostID       DHCPOptionsType = "host_id"
 	DHCPOptionsTypeIpv4         DHCPOptionsType = "ipv4"
 	DHCPOptionsTypeStaticRoutes DHCPOptionsType = "static_routes"
 	DHCPOptionsTypeStr          DHCPOptionsType = "str"
-	DHCPOptionsTypeHostID       DHCPOptionsType = "host_id"
-	DHCPOptionsTypeDomains      DHCPOptionsType = "domains"
+	DHCPOptionsTypeUint16       DHCPOptionsType = "uint16"
+	DHCPOptionsTypeUint32       DHCPOptionsType = "uint32"
+	DHCPOptionsTypeUint8        DHCPOptionsType = "uint8"
 )
 
 // DHCPOptions defines an object in DHCP_Options table

--- a/go-controller/pkg/sbdb/dhcpv6_options.go
+++ b/go-controller/pkg/sbdb/dhcpv6_options.go
@@ -11,8 +11,8 @@ type (
 
 var (
 	DHCPv6OptionsTypeIpv6 DHCPv6OptionsType = "ipv6"
-	DHCPv6OptionsTypeStr  DHCPv6OptionsType = "str"
 	DHCPv6OptionsTypeMAC  DHCPv6OptionsType = "mac"
+	DHCPv6OptionsTypeStr  DHCPv6OptionsType = "str"
 )
 
 // DHCPv6Options defines an object in DHCPv6_Options table

--- a/go-controller/pkg/sbdb/load_balancer.go
+++ b/go-controller/pkg/sbdb/load_balancer.go
@@ -10,9 +10,9 @@ type (
 )
 
 var (
+	LoadBalancerProtocolSCTP LoadBalancerProtocol = "sctp"
 	LoadBalancerProtocolTCP  LoadBalancerProtocol = "tcp"
 	LoadBalancerProtocolUDP  LoadBalancerProtocol = "udp"
-	LoadBalancerProtocolSCTP LoadBalancerProtocol = "sctp"
 )
 
 // LoadBalancer defines an object in Load_Balancer table

--- a/go-controller/pkg/sbdb/logical_flow.go
+++ b/go-controller/pkg/sbdb/logical_flow.go
@@ -10,8 +10,8 @@ type (
 )
 
 var (
-	LogicalFlowPipelineIngress LogicalFlowPipeline = "ingress"
 	LogicalFlowPipelineEgress  LogicalFlowPipeline = "egress"
+	LogicalFlowPipelineIngress LogicalFlowPipeline = "ingress"
 )
 
 // LogicalFlow defines an object in Logical_Flow table

--- a/go-controller/pkg/sbdb/model.go
+++ b/go-controller/pkg/sbdb/model.go
@@ -49,7 +49,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_Southbound",
-  "version": "20.20.0",
+  "version": "20.21.0",
   "tables": {
     "Address_Set": {
       "columns": {
@@ -132,10 +132,10 @@ var schema = `{
               "enum": [
                 "set",
                 [
+                  "admin_down",
                   "down",
                   "init",
-                  "up",
-                  "admin_down"
+                  "up"
                 ]
               ]
             }
@@ -159,7 +159,6 @@ var schema = `{
               "type": "uuid",
               "refTable": "Encap"
             },
-            "min": 1,
             "max": "unlimited"
           }
         },
@@ -230,8 +229,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -281,8 +279,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "is_connected": {
@@ -295,8 +292,7 @@ var schema = `{
               "type": "integer",
               "minInteger": 1000
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "other_config": {
@@ -349,8 +345,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "event_info": {
@@ -400,14 +395,14 @@ var schema = `{
                 "set",
                 [
                   "bool",
-                  "uint8",
-                  "uint16",
-                  "uint32",
+                  "domains",
+                  "host_id",
                   "ipv4",
                   "static_routes",
                   "str",
-                  "host_id",
-                  "domains"
+                  "uint16",
+                  "uint32",
+                  "uint8"
                 ]
               ]
             }
@@ -437,8 +432,8 @@ var schema = `{
                 "set",
                 [
                   "ipv6",
-                  "str",
-                  "mac"
+                  "mac",
+                  "str"
                 ]
               ]
             }
@@ -454,7 +449,6 @@ var schema = `{
               "type": "uuid",
               "refTable": "Datapath_Binding"
             },
-            "min": 1,
             "max": "unlimited"
           }
         },
@@ -606,8 +600,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -662,8 +655,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -707,8 +699,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "HA_Chassis",
-              "refType": "strong"
+              "refTable": "HA_Chassis"
             },
             "min": 0,
             "max": "unlimited"
@@ -747,8 +738,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "datapath": {
@@ -758,8 +748,7 @@ var schema = `{
               "refTable": "Datapath_Binding",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "ports": {
@@ -798,8 +787,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "eth_src": {
@@ -810,8 +798,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "ip4_src": {
@@ -825,8 +812,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "query_interval": {
@@ -834,8 +820,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "query_max_resp": {
@@ -843,8 +828,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "seq_no": {
@@ -855,8 +839,7 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       },
@@ -912,14 +895,13 @@ var schema = `{
               "enum": [
                 "set",
                 [
+                  "sctp",
                   "tcp",
-                  "udp",
-                  "sctp"
+                  "udp"
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "vips": {
@@ -961,8 +943,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -983,8 +964,7 @@ var schema = `{
               "type": "uuid",
               "refTable": "Datapath_Binding"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "logical_dp_group": {
@@ -993,8 +973,7 @@ var schema = `{
               "type": "uuid",
               "refTable": "Logical_DP_Group"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "match": {
@@ -1007,8 +986,8 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "ingress",
-                  "egress"
+                  "egress",
+                  "ingress"
                 ]
               ]
             }
@@ -1079,10 +1058,8 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Meter_Band",
-              "refType": "strong"
+              "refTable": "Meter_Band"
             },
-            "min": 1,
             "max": "unlimited"
           }
         },
@@ -1194,8 +1171,7 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "datapath": {
@@ -1213,8 +1189,7 @@ var schema = `{
               "refTable": "Encap",
               "refType": "weak"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "external_ids": {
@@ -1233,8 +1208,7 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Gateway_Chassis",
-              "refType": "strong"
+              "refTable": "Gateway_Chassis"
             },
             "min": 0,
             "max": "unlimited"
@@ -1244,11 +1218,9 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "HA_Chassis_Group",
-              "refType": "strong"
+              "refTable": "HA_Chassis_Group"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "logical_port": {
@@ -1289,8 +1261,17 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
+          }
+        },
+        "requested_chassis": {
+          "type": {
+            "key": {
+              "type": "uuid",
+              "refTable": "Chassis",
+              "refType": "weak"
+            },
+            "min": 0
           }
         },
         "tag": {
@@ -1300,8 +1281,7 @@ var schema = `{
               "minInteger": 1,
               "maxInteger": 4095
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "tunnel_key": {
@@ -1321,8 +1301,7 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "virtual_parent": {
@@ -1330,8 +1309,7 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       },
@@ -1463,8 +1441,7 @@ var schema = `{
               "type": "uuid",
               "refTable": "SSL"
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       }
@@ -1556,8 +1533,7 @@ var schema = `{
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         },
         "src_ip": {
@@ -1573,14 +1549,13 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "online",
+                  "error",
                   "offline",
-                  "error"
+                  "online"
                 ]
               ]
             },
-            "min": 0,
-            "max": 1
+            "min": 0
           }
         }
       },

--- a/go-controller/pkg/sbdb/port_binding.go
+++ b/go-controller/pkg/sbdb/port_binding.go
@@ -7,23 +7,24 @@ import "github.com/ovn-org/libovsdb/model"
 
 // PortBinding defines an object in Port_Binding table
 type PortBinding struct {
-	UUID           string            `ovsdb:"_uuid"`
-	Chassis        *string           `ovsdb:"chassis"`
-	Datapath       string            `ovsdb:"datapath"`
-	Encap          *string           `ovsdb:"encap"`
-	ExternalIDs    map[string]string `ovsdb:"external_ids"`
-	GatewayChassis []string          `ovsdb:"gateway_chassis"`
-	HaChassisGroup *string           `ovsdb:"ha_chassis_group"`
-	LogicalPort    string            `ovsdb:"logical_port"`
-	MAC            []string          `ovsdb:"mac"`
-	NatAddresses   []string          `ovsdb:"nat_addresses"`
-	Options        map[string]string `ovsdb:"options"`
-	ParentPort     *string           `ovsdb:"parent_port"`
-	Tag            *int              `ovsdb:"tag"`
-	TunnelKey      int               `ovsdb:"tunnel_key"`
-	Type           string            `ovsdb:"type"`
-	Up             *bool             `ovsdb:"up"`
-	VirtualParent  *string           `ovsdb:"virtual_parent"`
+	UUID             string            `ovsdb:"_uuid"`
+	Chassis          *string           `ovsdb:"chassis"`
+	Datapath         string            `ovsdb:"datapath"`
+	Encap            *string           `ovsdb:"encap"`
+	ExternalIDs      map[string]string `ovsdb:"external_ids"`
+	GatewayChassis   []string          `ovsdb:"gateway_chassis"`
+	HaChassisGroup   *string           `ovsdb:"ha_chassis_group"`
+	LogicalPort      string            `ovsdb:"logical_port"`
+	MAC              []string          `ovsdb:"mac"`
+	NatAddresses     []string          `ovsdb:"nat_addresses"`
+	Options          map[string]string `ovsdb:"options"`
+	ParentPort       *string           `ovsdb:"parent_port"`
+	RequestedChassis *string           `ovsdb:"requested_chassis"`
+	Tag              *int              `ovsdb:"tag"`
+	TunnelKey        int               `ovsdb:"tunnel_key"`
+	Type             string            `ovsdb:"type"`
+	Up               *bool             `ovsdb:"up"`
+	VirtualParent    *string           `ovsdb:"virtual_parent"`
 }
 
 func copyPortBindingChassis(a *string) *string {
@@ -222,6 +223,24 @@ func equalPortBindingParentPort(a, b *string) bool {
 	return *a == *b
 }
 
+func copyPortBindingRequestedChassis(a *string) *string {
+	if a == nil {
+		return nil
+	}
+	b := *a
+	return &b
+}
+
+func equalPortBindingRequestedChassis(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return *a == *b
+}
+
 func copyPortBindingTag(a *int) *int {
 	if a == nil {
 		return nil
@@ -287,6 +306,7 @@ func (a *PortBinding) DeepCopyInto(b *PortBinding) {
 	b.NatAddresses = copyPortBindingNatAddresses(a.NatAddresses)
 	b.Options = copyPortBindingOptions(a.Options)
 	b.ParentPort = copyPortBindingParentPort(a.ParentPort)
+	b.RequestedChassis = copyPortBindingRequestedChassis(a.RequestedChassis)
 	b.Tag = copyPortBindingTag(a.Tag)
 	b.Up = copyPortBindingUp(a.Up)
 	b.VirtualParent = copyPortBindingVirtualParent(a.VirtualParent)
@@ -320,6 +340,7 @@ func (a *PortBinding) Equals(b *PortBinding) bool {
 		equalPortBindingNatAddresses(a.NatAddresses, b.NatAddresses) &&
 		equalPortBindingOptions(a.Options, b.Options) &&
 		equalPortBindingParentPort(a.ParentPort, b.ParentPort) &&
+		equalPortBindingRequestedChassis(a.RequestedChassis, b.RequestedChassis) &&
 		equalPortBindingTag(a.Tag, b.Tag) &&
 		a.TunnelKey == b.TunnelKey &&
 		a.Type == b.Type &&

--- a/go-controller/pkg/sbdb/service_monitor.go
+++ b/go-controller/pkg/sbdb/service_monitor.go
@@ -13,9 +13,9 @@ type (
 var (
 	ServiceMonitorProtocolTCP   ServiceMonitorProtocol = "tcp"
 	ServiceMonitorProtocolUDP   ServiceMonitorProtocol = "udp"
-	ServiceMonitorStatusOnline  ServiceMonitorStatus   = "online"
-	ServiceMonitorStatusOffline ServiceMonitorStatus   = "offline"
 	ServiceMonitorStatusError   ServiceMonitorStatus   = "error"
+	ServiceMonitorStatusOffline ServiceMonitorStatus   = "offline"
+	ServiceMonitorStatusOnline  ServiceMonitorStatus   = "online"
 )
 
 // ServiceMonitor defines an object in Service_Monitor table


### PR DESCRIPTION
Bring sbdb model and ovn version in sync.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Possible solution for https://bugzilla.redhat.com/show_bug.cgi?id=2052398. 

Downstream, I saw errors like:
~~~
cache "msg"="during libovsdb cache populate2" "error"="unable to apply row modifications: FieldByColumn: column requested_chassis not found in orm info" "database"="OVN_Southbound"
~~~
That column is new in OVN 20.21.0. I looked at upstream latest and downstream 4.10 and our SB schema is still 20.20.0 everywhere  https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/sbdb/model.go#L52 and precisely that column is missing from our schema. I also generated a new model with modelgen and that column sure is now added:
~~~
[root@ovnkubernetes model]# pwd
/root/model
[root@ovnkubernetes model]# modelgen ovs-sb.ovsschema
[root@ovnkubernetes model]# 
~~~

~~~
[root@ovnkubernetes model]# diff -u /root/development/ovn-kubernetes/go-controller/pkg/sbdb/model.go model.go | egrep "version|requested_chassis"
-  "version": "20.20.0",
+  "version": "20.21.0",
+        "requested_chassis": {
~~~

To add to this, when I actually spawn a 4.10 version of the NB DB, and a 4.9 version of the SB DB with ovnkube-master for 4.10 *without* an updated schema file, I get:
~~~
[root@ovnkubernetes contrib]# oc logs -n ovn-kubernetes ovnkube-master-f4c69764c-9w6qr -c ovnkube-master | tail -n 5
I0224 13:00:55.690608      35 cache.go:650] cache "msg"="processing update" "database"="OVN_Northbound" "table"="NB_Global" "uuid"="944fc621-f421-4999-b171-aa6473326b0c" 
I0224 13:00:55.690662      35 cache.go:657] cache "msg"="creating row" "database"="OVN_Northbound" "table"="NB_Global" "uuid"="944fc621-f421-4999-b171-aa6473326b0c" "model"="&{UUID:944fc621-f421-4999-b171-aa6473326b0c Connections:[0f855cfd-5ad1-431b-aed3-107612d36118] ExternalIDs:map[] HvCfg:0 HvCfgTimestamp:0 Ipsec:false Name: NbCfg:0 NbCfgTimestamp:0 Options:map[mac_prefix:4e:17:05 max_tunid:16711680 northd_internal_version:21.03.1-20.16.1-56.0 northd_probe_interval:5000 svc_monitor_mac:8a:44:59:92:6c:24] SbCfg:0 SbCfgTimestamp:0 SSL:<nil>}"
I0224 13:00:55.690784      35 client.go:303]  "msg"="trying to connect" "database"="OVN_Southbound" "endpoint"="tcp:172.18.0.2:6642"
F0224 13:00:55.695731      35 ovnkube.go:133] error when trying to initialize libovsdb SB client: failed to connect to tcp:172.18.0.2:6642: database OVN_Southbound validation error (1): Mapper Error. Object type sbdb.LogicalFlow contains field ControllerMeter (*string) ovs tag controller_meter: Column does not exist in schema
info: Waiting for process_ready ovnkube-master to come up, waiting 5s ...
~~~

When I do the same with ovnkube-master *with* an updated schema file, I get:
~~~
F0224 12:54:10.722794      34 ovnkube.go:133] error when trying to initialize libovsdb SB client: failed to connect to tcp:172.18.0.2:6642: database OVN_Southbound validation error (2): Mapper Error. Object type sbdb.PortBinding contains field RequestedChassis (*string) ovs tag requested_chassis: Column does not exist in schema. Mapper Error. Object type sbdb.LogicalFlow contains field ControllerMeter (*string) ovs tag controller_meter: Column does not exist in schema
~~~

We catch at least the discrepancy for logical flow due to:
~~~
[akaris@linux sbdb (release-4.10)]$ git show f895b42c88 | head -n 20
commit f895b42c880105d1a7ed9eef85126579721fb8e1
Author: Dumitru Ceara <dceara@redhat.com>
Date:   Tue Nov 9 15:50:03 2021 +0100

    Re-run libovsdb modelgen on LB Groups enabled OVN schema.
    
    Signed-off-by: Dumitru Ceara <dceara@redhat.com>

diff --git a/go-controller/pkg/nbdb/acl.go b/go-controller/pkg/nbdb/acl.go
index a01dff7a6..5f40e459c 100644
--- a/go-controller/pkg/nbdb/acl.go
+++ b/go-controller/pkg/nbdb/acl.go
@@ -30,6 +30,7 @@ type ACL struct {
 	Action      ACLAction         `ovsdb:"action"`
 	Direction   ACLDirection      `ovsdb:"direction"`
 	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	Label       int               `ovsdb:"label"`
 	Log         bool              `ovsdb:"log"`
 	Match       string            `ovsdb:"match"`
 	Meter       *string           `ovsdb:"meter"`
~~~

With this PR, bring the schema and the SBDB in line.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->