### PR TITLE
gateway: fix test teardown order to really prevent nodeIP manager flake

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -168,8 +168,8 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		wg := &sync.WaitGroup{}
 		defer func() {
 			close(stop)
-			wf.Shutdown()
 			wg.Wait()
+			wf.Shutdown()
 		}()
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -438,8 +438,8 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		wg := &sync.WaitGroup{}
 		defer func() {
 			close(stop)
-			wf.Shutdown()
 			wg.Wait()
+			wf.Shutdown()
 		}()
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
@@ -748,8 +748,8 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 		wg := &sync.WaitGroup{}
 		defer func() {
 			close(stop)
-			wf.Shutdown()
 			wg.Wait()
+			wf.Shutdown()
 		}()
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
We need to stop the node IP manager before the factory, becuase the node IP
manager uses the factory.

Fixes: eb73081 node: wait for nodeIP and OpenFlow manager to stop before next test

@tssurya 