### PR TITLE
Add metric to record gateway modes

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -487,6 +488,9 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			return fmt.Errorf("failed to delete GW SNAT rule for pod on router %s error: %v", gatewayRouter, err)
 		}
 	}
+
+	// recording gateway mode metrics here after gateway setup is done
+	metrics.RecordEgressRoutingViaHost()
 
 	return nil
 }


### PR DESCRIPTION
A metric is the first step towards telemetry and we need
to know the count of lgw users. This will be a first step
towards that.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
