### PR TITLE
Stop sending GARPs for LB VIPs on GR

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-21.12.0-3.fc35
+ARG ovnver=ovn-21.12.0-4.fc35
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1490,8 +1490,11 @@ func (oc *Controller) addEgressNode(egressNode *kapi.Node) error {
 	// continue to be routed to the old node which hosted the egress IP before
 	// it was moved, and the connections will fail.
 	lsp := nbdb.LogicalSwitchPort{
-		Name:    types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + egressNode.Name,
-		Options: map[string]string{"nat-addresses": "router"},
+		Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + egressNode.Name,
+		// Setting nat-addresses to router will send out GARPs for all externalIPs and LB VIPs
+		// hosted on the GR. Setting exclude-lb-vips-from-garp to true will make sure GARPs for
+		// LB VIPs are not sent, thereby preventing GARP overload.
+		Options: map[string]string{"nat-addresses": "router", "exclude-lb-vips-from-garp": "true"},
 	}
 	opModel := libovsdbops.OperationModel{
 		Model: &lsp,
@@ -1536,7 +1539,7 @@ func (oc *Controller) deleteEgressNode(egressNode *kapi.Node) error {
 	// from now on.
 	lsp := nbdb.LogicalSwitchPort{
 		Name:    types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + egressNode.Name,
-		Options: map[string]string{"nat-addresses": ""},
+		Options: map[string]string{"nat-addresses": "", "exclude-lb-vips-from-garp": ""},
 	}
 	opModel := libovsdbops.OperationModel{
 		Model: &lsp,

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -326,6 +326,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				lsp := &nbdb.LogicalSwitchPort{Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name}
 				fakeOvn.controller.nbClient.Get(context.Background(), lsp)
 				gomega.Eventually(lsp.Options["nat-addresses"]).Should(gomega.Equal("router"))
+				gomega.Eventually(lsp.Options["exclude-lb-vips-from-garp"]).Should(gomega.Equal("true"))
 
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				egressIPs, nodes := getEgressIPStatus(egressIPName)
@@ -426,8 +427,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -573,6 +575,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				lsp := &nbdb.LogicalSwitchPort{Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name}
 				fakeOvn.controller.nbClient.Get(context.Background(), lsp)
 				gomega.Eventually(lsp.Options["nat-addresses"]).Should(gomega.Equal("router"))
+				gomega.Eventually(lsp.Options["exclude-lb-vips-from-garp"]).Should(gomega.Equal("true"))
 
 				fakeOvn.controller.WatchEgressIP()
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
@@ -674,8 +677,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -1840,8 +1844,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -1849,8 +1854,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -1952,8 +1958,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -1961,8 +1968,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -2422,8 +2430,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -2431,8 +2440,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -2650,8 +2660,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node.Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node.Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -2798,8 +2809,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -2807,8 +2819,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -2959,8 +2972,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -3020,8 +3034,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -3029,8 +3044,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -3222,8 +3238,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -3407,8 +3424,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -3622,8 +3640,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -3685,8 +3704,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -3694,8 +3714,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -3893,8 +3914,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -3955,8 +3977,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -3964,8 +3987,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -4132,8 +4156,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -4197,8 +4222,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node1Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node1Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 					&nbdb.LogicalSwitchPort{
@@ -4206,8 +4232,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}
@@ -4289,8 +4316,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node2Name,
 						Type: "router",
 						Options: map[string]string{
-							"router-port":   types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
-							"nat-addresses": "router",
+							"router-port":               types.GWRouterToExtSwitchPrefix + "GR_" + node2Name,
+							"nat-addresses":             "router",
+							"exclude-lb-vips-from-garp": "true",
 						},
 					},
 				}


### PR DESCRIPTION
Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
When we set the nat-addresses=router option on the lsp of external switch;
```
sh-5.1# ovn-nbctl find logical-switch-port name=etor-GR_ovn-worker
_uuid               : 08101a36-07e3-4d69-a95e-2cb9f5ff1398
addresses           : ["02:42:ac:12:00:03"]
dhcpv4_options      : []
dhcpv6_options      : []
dynamic_addresses   : []
enabled             : []
external_ids        : {}
ha_chassis_group    : []
name                : etor-GR_ovn-worker
options             : {nat-addresses=router, router-port=rtoe-GR_ovn-worker}
parent_name         : []
port_security       : []
tag                 : []
tag_request         : []
type                : router
up                  : true
```
We end up sending GARPs for all LB IPs in addition to the externalIPs configured for SNAT/DNAT. This could mean lots of GARPs and each of the nodes in the cluster would reply to all these GARPs.

Even in a cluster with 50 nodes that have lots of clusterIPs this is unnecessary noise:
```
20:22:33.975158 Out 00:50:56:af:7f:8f ethertype ARP (0x0806), length 44: Request who-has 172.30.62.25 tell 172.30.62.25, length 28
20:22:33.975181   B 00:50:56:af:7f:8f ethertype ARP (0x0806), length 44: Request who-has 172.30.62.25 tell 172.30.62.25, length 28
20:22:33.975330 Out 00:50:56:af:7f:8f ethertype ARP (0x0806), length 44: Request who-has 172.30.245.223 tell 172.30.245.223, length 28
20:22:33.975336   B 00:50:56:af:7f:8f ethertype ARP (0x0806), length 44: Request who-has 172.30.245.223 tell 172.30.245.223, length 28
20:22:33.975407 Out 00:50:56:af:7f:8f ethertype ARP (0x0806), length 44: Request who-has 172.30.186.95 tell 172.30.186.95, length 28
20:22:33.975413   B 00:50:56:af:7f:8f ethertype ARP (0x0806), length 44: Request who-has 172.30.186.95 tell 172.30.186.95, length 28
20:22:33.975494 Out 00:50:56:af:7f:8f ethertype ARP (0x0806), length 44: Request who-has 172.30.162.199 tell 172.30.162.199, length 28
20:22:33.975502   B 00:50:56:af:7f:8f ethertype ARP (0x0806), length 44: Request who-has 172.30.162.199 tell 172.30.162.199, length 28
```

OVN added a new option in https://bugzilla.redhat.com/show_bug.cgi?id=2054394 called `exclude-lb-vips-from-garp="true"` which will stop garps for LB VIPs.
