### PR TITLE
Implement InternalTrafficPolicy=Local

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -312,7 +312,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 			managementPortConfig, n.Kube, n.watchFactory)
 	case config.GatewayModeShared:
 		klog.Info("Preparing Shared Gateway")
-		gw, err = newSharedGateway(n.name, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator, n.Kube,
+		gw, err = newSharedGateway(n.name, subnets, gatewayNextHops, gatewayIntf, egressGWInterface, ifAddrs, nodeAnnotator, n.Kube,
 			managementPortConfig, n.watchFactory)
 	case config.GatewayModeDisabled:
 		var chassisID string

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -109,6 +109,18 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface eth0 ofport",
 			Output: "7",
 		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",
+			Output: "0",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ip -4 rule",
+			Output: "0",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ip -4 rule add fwmark 0x1745ec lookup 7 prio 30",
+			Output: "0",
+		})
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovs-ofctl -O OpenFlow13 --bundle replace-flows breth0 -",
 		})
@@ -189,7 +201,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			defer GinkgoRecover()
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
-			sharedGw, err := newSharedGateway(nodeName, gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator, k,
+			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator, k,
 				&fakeMgmtPortConfig, wf)
 			Expect(err).NotTo(HaveOccurred())
 			err = sharedGw.Init(wf)
@@ -233,13 +245,21 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				"OUTPUT": []string{
 					"-j OVN-KUBE-EXTERNALIP",
 					"-j OVN-KUBE-NODEPORT",
+					"-j OVN-KUBE-ITP",
 				},
 				"OVN-KUBE-NODEPORT":      []string{},
 				"OVN-KUBE-EXTERNALIP":    []string{},
 				"OVN-KUBE-SNAT-MGMTPORT": []string{},
 				"OVN-KUBE-ETP":           []string{},
+				"OVN-KUBE-ITP":           []string{},
 			},
 			"filter": {},
+			"mangle": {
+				"OUTPUT": []string{
+					"-j OVN-KUBE-ITP",
+				},
+				"OVN-KUBE-ITP": []string{},
+			},
 		}
 		f4 := iptV4.(*util.FakeIPTables)
 		err = f4.MatchState(expectedTables)
@@ -248,6 +268,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		expectedTables = map[string]util.FakeTable{
 			"nat":    {},
 			"filter": {},
+			"mangle": {},
 		}
 		f6 := iptV6.(*util.FakeIPTables)
 		err = f6.MatchState(expectedTables)
@@ -380,6 +401,18 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface " + hostRep + " ofport",
 			Output: "9",
 		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",
+			Output: "0",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ip -4 rule",
+			Output: "0",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ip -4 rule add fwmark 0x1745ec lookup 7 prio 30",
+			Output: "0",
+		})
 		// cleanup flows
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovs-ofctl -O OpenFlow13 --bundle replace-flows " + brphys + " -",
@@ -461,7 +494,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
 			// provide host IP as GR IP
 			gwIPs := []*net.IPNet{ovntest.MustParseIPNet(hostCIDR)}
-			sharedGw, err := newSharedGateway(nodeName, gatewayNextHops,
+			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops,
 				gatewayIntf, "", gwIPs, nodeAnnotator, k, &fakeMgmtPortConfig, wf)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -651,6 +684,18 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Output: "7",
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",
+			Output: "0",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ip -4 rule",
+			Output: "0",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+			Cmd:    "ip -4 rule add fwmark 0x1745ec lookup 7 prio 30",
+			Output: "0",
+		})
+		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd: "ovs-ofctl show breth0",
 			Output: `
 OFPT_FEATURES_REPLY (xid=0x2): dpid:00000242ac120002
@@ -707,7 +752,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 			v1.ServiceTypeClusterIP,
 			[]string{externalIP},
 			v1.ServiceStatus{},
-			false,
+			false, false,
 		)
 		endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{})
 
@@ -815,6 +860,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 				"OUTPUT": []string{
 					"-j OVN-KUBE-EXTERNALIP",
 					"-j OVN-KUBE-NODEPORT",
+					"-j OVN-KUBE-ITP",
 				},
 				"OVN-KUBE-NODEPORT": []string{},
 				"OVN-KUBE-EXTERNALIP": []string{
@@ -825,6 +871,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 				},
 				"OVN-KUBE-SNAT-MGMTPORT": []string{},
 				"OVN-KUBE-ETP":           []string{},
+				"OVN-KUBE-ITP":           []string{},
 			},
 			"filter": {
 				"FORWARD": []string{
@@ -835,6 +882,12 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 					"-i ovn-k8s-mp0 -m comment --comment from OVN to localhost -j ACCEPT",
 				},
 			},
+			"mangle": {
+				"OUTPUT": []string{
+					"-j OVN-KUBE-ITP",
+				},
+				"OVN-KUBE-ITP": []string{},
+			},
 		}
 		f4 := iptV4.(*util.FakeIPTables)
 		err = f4.MatchState(expectedTables)
@@ -843,6 +896,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 		expectedTables = map[string]util.FakeTable{
 			"nat":    {},
 			"filter": {},
+			"mangle": {},
 		}
 		f6 := iptV6.(*util.FakeIPTables)
 		err = f6.MatchState(expectedTables)

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -103,6 +103,9 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 		}
 
 		if config.Gateway.NodeportEnable {
+			if err := initSvcViaMgmPortRoutingRules(hostSubnets); err != nil {
+				return err
+			}
 			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge.patchPort, gwBridge.bridgeName, gwBridge.uplinkName, gwBridge.ips, gw.openflowManager, gw.nodeIPManager, watchFactory)
 			if err != nil {
 				return err

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -29,6 +29,7 @@ func initFakeNodePortWatcher(iptV4, iptV6 util.IPTablesHelper) *nodePortWatcher 
 	initIPTable := map[string]util.FakeTable{
 		"nat":    {},
 		"filter": {},
+		"mangle": {},
 	}
 
 	f4 := iptV4.(*util.FakeIPTables)
@@ -92,10 +93,15 @@ func newObjectMeta(name, namespace string) metav1.ObjectMeta {
 	}
 }
 
-func newService(name, namespace, ip string, ports []v1.ServicePort, serviceType v1.ServiceType, externalIPs []string, serviceStatus v1.ServiceStatus, isETPLocal bool) *v1.Service {
+func newService(name, namespace, ip string, ports []v1.ServicePort, serviceType v1.ServiceType,
+	externalIPs []string, serviceStatus v1.ServiceStatus, isETPLocal, isITPLocal bool) *v1.Service {
 	externalTrafficPolicy := v1.ServiceExternalTrafficPolicyTypeCluster
+	internalTrafficPolicy := v1.ServiceInternalTrafficPolicyCluster
 	if isETPLocal {
 		externalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+	}
+	if isITPLocal {
+		internalTrafficPolicy = v1.ServiceInternalTrafficPolicyLocal
 	}
 	return &v1.Service{
 		ObjectMeta: newObjectMeta(name, namespace),
@@ -105,6 +111,7 @@ func newService(name, namespace, ip string, ports []v1.ServicePort, serviceType 
 			Type:                  serviceType,
 			ExternalIPs:           externalIPs,
 			ExternalTrafficPolicy: externalTrafficPolicy,
+			InternalTrafficPolicy: &internalTrafficPolicy,
 		},
 		Status: serviceStatus,
 	}
@@ -176,7 +183,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeClusterIP,
 					[]string{externalIP},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				fakeRules := getExternalIPTRules(service.Spec.Ports[0], externalIP, service.Spec.ClusterIP, false, false)
@@ -202,6 +209,7 @@ var _ = Describe("Node Operations", func() {
 						},
 					},
 					"filter": {},
+					"mangle": {},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -230,6 +238,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
@@ -237,8 +246,15 @@ var _ = Describe("Node Operations", func() {
 						},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
@@ -271,7 +287,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeClusterIP,
 					[]string{externalIP},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 				fakeOvnNode.start(ctx,
 					&v1.ServiceList{
@@ -295,6 +311,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{},
 						"OVN-KUBE-EXTERNALIP": []string{
@@ -302,8 +319,15 @@ var _ = Describe("Node Operations", func() {
 						},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -330,7 +354,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeNodePort,
 					nil,
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 				endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{})
 
@@ -358,6 +382,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -365,8 +390,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-EXTERNALIP":    []string{},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -393,7 +425,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeNodePort,
 					nil,
 					v1.ServiceStatus{},
-					true,
+					true, false,
 				)
 				addr := v1.EndpointAddress{
 					IP: "10.244.0.3",
@@ -436,6 +468,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -447,8 +480,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 						},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -489,7 +529,7 @@ var _ = Describe("Node Operations", func() {
 							}},
 						},
 					},
-					false,
+					false, false,
 				)
 				endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{})
 
@@ -517,6 +557,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -527,8 +568,15 @@ var _ = Describe("Node Operations", func() {
 						},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -562,7 +610,7 @@ var _ = Describe("Node Operations", func() {
 							}},
 						},
 					},
-					true,
+					true, false,
 				)
 				// endpoints.Subset is empty and yet this will come under !hasLocalHostNetEp case
 				endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{})
@@ -590,6 +638,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -606,8 +655,15 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 						},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 				expectedLBIngressFlows := []string{
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
@@ -654,7 +710,7 @@ var _ = Describe("Node Operations", func() {
 							}},
 						},
 					},
-					false, // ETP=cluster
+					false, false, // ETP=cluster
 				)
 				// endpoints.Subset is empty and yet this will come under !hasLocalHostNetEp case
 				endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{})
@@ -682,6 +738,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -692,8 +749,15 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
 						},
 						"OVN-KUBE-ETP": []string{},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				expectedLBIngressFlows := []string{
@@ -749,7 +813,7 @@ var _ = Describe("Node Operations", func() {
 							}},
 						},
 					},
-					true,
+					true, false,
 				)
 				// endpoints.Subset is empty and yet this will come under !hasLocalHostNetEp case
 				endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{})
@@ -777,6 +841,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -793,8 +858,15 @@ var _ = Describe("Node Operations", func() {
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 						},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 				expectedNodePortFlows := []string{
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=check_pkt_larger(1414)->reg0[0],resubmit(,11)",
@@ -845,7 +917,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeNodePort,
 					nil,
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 				service.Spec.ClusterIPs = []string{"10.129.0.2", "fd00:10:96::10"}
 				endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{})
@@ -874,6 +946,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIPs[0], service.Spec.Ports[0].Port),
@@ -881,8 +954,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-EXTERNALIP":    []string{},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -896,6 +976,7 @@ var _ = Describe("Node Operations", func() {
 						},
 					},
 					"filter": {},
+					"mangle": {},
 				}
 				f6 := iptV6.(*util.FakeIPTables)
 				err = f6.MatchState(expectedTables6)
@@ -932,7 +1013,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeClusterIP,
 					[]string{externalIPv4, externalIPv6},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 				service.Spec.ClusterIPs = []string{clusterIPv4, clusterIPv6}
 				fakeOvnNode.start(ctx,
@@ -958,6 +1039,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIPv4, service.Spec.Ports[0].Port, clusterIPv4, service.Spec.Ports[0].Port),
@@ -965,8 +1047,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-NODEPORT":      []string{},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -980,6 +1069,7 @@ var _ = Describe("Node Operations", func() {
 						},
 					},
 					"filter": {},
+					"mangle": {},
 				}
 
 				f6 := iptV6.(*util.FakeIPTables)
@@ -1011,7 +1101,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeClusterIP,
 					[]string{externalIP},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				fakeOvnNode.start(ctx,
@@ -1037,13 +1127,21 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT":      []string{},
 						"OVN-KUBE-EXTERNALIP":    []string{},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -1052,6 +1150,7 @@ var _ = Describe("Node Operations", func() {
 				expectedTables = map[string]util.FakeTable{
 					"nat":    {},
 					"filter": {},
+					"mangle": {},
 				}
 				f6 := iptV6.(*util.FakeIPTables)
 				err = f6.MatchState(expectedTables)
@@ -1077,7 +1176,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeNodePort,
 					nil,
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				fakeOvnNode.start(ctx,
@@ -1103,13 +1202,21 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT":      []string{},
 						"OVN-KUBE-EXTERNALIP":    []string{},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -1119,6 +1226,7 @@ var _ = Describe("Node Operations", func() {
 				expectedTables = map[string]util.FakeTable{
 					"nat":    {},
 					"filter": {},
+					"mangle": {},
 				}
 
 				f6 := iptV6.(*util.FakeIPTables)
@@ -1150,7 +1258,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeClusterIP,
 					[]string{externalIP},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				fakeOvnNode.start(ctx,
@@ -1175,6 +1283,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-EXTERNALIP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -1182,8 +1291,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-NODEPORT":      []string{},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -1204,11 +1320,19 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
@@ -1236,7 +1360,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeNodePort,
 					nil,
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				fakeOvnNode.start(ctx,
@@ -1261,6 +1385,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, nodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -1268,8 +1393,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-EXTERNALIP":    []string{},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -1290,11 +1422,19 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
@@ -1321,7 +1461,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeNodePort,
 					nil,
 					v1.ServiceStatus{},
-					true,
+					true, false,
 				)
 				addr := v1.EndpointAddress{
 					IP: "10.244.0.3",
@@ -1364,6 +1504,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -1375,8 +1516,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 						},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 := iptV4.(*util.FakeIPTables)
@@ -1399,11 +1547,19 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
@@ -1434,7 +1590,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeNodePort,
 					nil,
 					v1.ServiceStatus{},
-					true,
+					true, false,
 				)
 				addr := v1.EndpointAddress{
 					IP: "10.244.0.3",
@@ -1477,6 +1633,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -1488,8 +1645,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 						},
+						"OVN-KUBE-ITP": []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 				expectedFlows := []string{
 					// default
@@ -1517,11 +1681,19 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)
@@ -1554,7 +1726,7 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceTypeNodePort,
 					nil,
 					v1.ServiceStatus{},
-					true,
+					true, false,
 				)
 				addr := v1.EndpointAddress{
 					IP: "192.168.18.15", // host-networked endpoint local to this node
@@ -1600,6 +1772,7 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-NODEPORT": []string{
 							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
@@ -1607,8 +1780,15 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-EXTERNALIP":    []string{},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
+						"OVN-KUBE-ITP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 				expectedFlows := []string{
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,nat(dst=10.244.0.1:443),table=6)",
@@ -1637,11 +1817,292 @@ var _ = Describe("Node Operations", func() {
 						"OUTPUT": []string{
 							"-j OVN-KUBE-EXTERNALIP",
 							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-SNAT-MGMTPORT": []string{},
+						"OVN-KUBE-ITP":           []string{},
+						"OVN-KUBE-ETP":           []string{},
+					},
+					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
+				}
+
+				f4 = iptV4.(*util.FakeIPTables)
+				err = f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				Expect(flows).To(BeNil())
+
+				fakeOvnNode.shutdown()
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("manages iptables rules and openflows for NodePort backed by ovn-k pods where ITP=local and ETP=local", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.Gateway.Mode = config.GatewayModeShared
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							NodePort: int32(31111),
+							Protocol: v1.ProtocolTCP,
+							Port:     int32(8080),
+						},
+					},
+					v1.ServiceTypeNodePort,
+					nil,
+					v1.ServiceStatus{},
+					true, true,
+				)
+				addr := v1.EndpointAddress{
+					IP: "10.244.0.3",
+				}
+				port := v1.EndpointPort{
+					Name: "https",
+					Port: int32(443),
+				}
+				ep := v1.EndpointSubset{
+					Addresses: []v1.EndpointAddress{
+						addr,
+					},
+					Ports: []v1.EndpointPort{
+						port,
+					},
+				}
+				// endpoints.Subset is ovn-networked so this will come under !hasLocalHostNetEp case
+				endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{ep})
+
+				fakeOvnNode.start(ctx,
+					&v1.ServiceList{
+						Items: []v1.Service{
+							service,
+						},
+					},
+					&endpoints,
+				)
+
+				fNPW.watchFactory = fakeOvnNode.watcher
+				startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)
+				fNPW.AddService(&service)
+
+				expectedTables := map[string]util.FakeTable{
+					"nat": {
+						"PREROUTING": []string{
+							"-j OVN-KUBE-ETP",
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OUTPUT": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-NODEPORT": []string{
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-SNAT-MGMTPORT": []string{
+							fmt.Sprintf("-p TCP --dport %v -j RETURN", service.Spec.Ports[0].NodePort),
+						},
+						"OVN-KUBE-ITP": []string{},
+						"OVN-KUBE-ETP": []string{
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
+						},
+					},
+					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %d -j MARK --set-xmark %s", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, ovnkubeITPMark),
+						},
+					},
+				}
+				expectedFlows := []string{
+					// default
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=check_pkt_larger(1414)->reg0[0],resubmit(,11)",
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, tcp, tp_src=31111, actions=output:eth0",
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				Expect(flows).To(Equal(expectedFlows))
+
+				fNPW.DeleteService(&service)
+
+				expectedTables = map[string]util.FakeTable{
+					"nat": {
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"OVN-KUBE-ITP":        []string{},
+						"PREROUTING": []string{
+							"-j OVN-KUBE-ETP",
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OUTPUT": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
 						},
 						"OVN-KUBE-SNAT-MGMTPORT": []string{},
 						"OVN-KUBE-ETP":           []string{},
 					},
 					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
+				}
+
+				f4 = iptV4.(*util.FakeIPTables)
+				err = f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+
+				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				Expect(flows).To(BeNil())
+
+				fakeOvnNode.shutdown()
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("manages iptables rules and openflows for NodePort backed by local-host-networked pods where ETP=local and ITP=local", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.Gateway.Mode = config.GatewayModeLocal
+				outport := int32(443)
+				service := *newService("service1", "namespace1", "10.129.0.2",
+					[]v1.ServicePort{
+						{
+							NodePort:   int32(31111),
+							Protocol:   v1.ProtocolTCP,
+							Port:       int32(8080),
+							TargetPort: intstr.FromInt(int(outport)),
+						},
+					},
+					v1.ServiceTypeNodePort,
+					nil,
+					v1.ServiceStatus{},
+					true, true,
+				)
+				addr := v1.EndpointAddress{
+					IP: "192.168.18.15", // host-networked endpoint local to this node
+				}
+				port := v1.EndpointPort{
+					Name: "https",
+					Port: int32(443),
+				}
+				ep := v1.EndpointSubset{
+					Addresses: []v1.EndpointAddress{
+						addr,
+					},
+					Ports: []v1.EndpointPort{
+						port,
+					},
+				}
+				// endpoints.Subset is ovn-networked so this will come under !hasLocalHostNetEp case
+				endpoints := *newEndpoints("service1", "namespace1", []v1.EndpointSubset{ep})
+
+				fakeOvnNode.start(ctx,
+					&v1.ServiceList{
+						Items: []v1.Service{
+							service,
+						},
+					},
+					&endpoints,
+				)
+
+				fNPW.watchFactory = fakeOvnNode.watcher
+				startNodePortWatcher(fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig)
+				// to ensure the endpoint is local-host-networked
+				res := fNPW.nodeIPManager.addresses.Has(ep.Addresses[0].IP)
+				Expect(res).To(BeTrue())
+				fNPW.AddService(&service)
+				expectedTables := map[string]util.FakeTable{
+					"nat": {
+						"PREROUTING": []string{
+							"-j OVN-KUBE-ETP",
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OUTPUT": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-NODEPORT": []string{
+							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, service.Spec.ClusterIP, service.Spec.Ports[0].Port),
+						},
+						"OVN-KUBE-EXTERNALIP":    []string{},
+						"OVN-KUBE-SNAT-MGMTPORT": []string{},
+						"OVN-KUBE-ITP": []string{
+							fmt.Sprintf("-p %s -d %s --dport %d -j REDIRECT --to-port %d", service.Spec.Ports[0].Protocol, service.Spec.ClusterIP, service.Spec.Ports[0].Port, int32(service.Spec.Ports[0].TargetPort.IntValue())),
+						},
+						"OVN-KUBE-ETP": []string{},
+					},
+					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
+				}
+				expectedFlows := []string{
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=ct(commit,zone=64003,nat(dst=10.244.0.1:443),table=6)",
+					"cookie=0xe745ecf105, priority=110, table=6, actions=output:LOCAL",
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=LOCAL, tcp, tp_src=443, actions=ct(zone=64003 nat,table=7)",
+					"cookie=0xe745ecf105, priority=110, table=7, actions=output:eth0",
+				}
+
+				f4 := iptV4.(*util.FakeIPTables)
+				err := f4.MatchState(expectedTables)
+				Expect(err).NotTo(HaveOccurred())
+				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
+				Expect(flows).To(Equal(expectedFlows))
+
+				fNPW.DeleteService(&service)
+
+				expectedTables = map[string]util.FakeTable{
+					"nat": {
+						"OVN-KUBE-EXTERNALIP": []string{},
+						"OVN-KUBE-NODEPORT":   []string{},
+						"PREROUTING": []string{
+							"-j OVN-KUBE-ETP",
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+						},
+						"OUTPUT": []string{
+							"-j OVN-KUBE-EXTERNALIP",
+							"-j OVN-KUBE-NODEPORT",
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-SNAT-MGMTPORT": []string{},
+						"OVN-KUBE-ITP":           []string{},
+						"OVN-KUBE-ETP":           []string{},
+					},
+					"filter": {},
+					"mangle": {
+						"OUTPUT": []string{
+							"-j OVN-KUBE-ITP",
+						},
+						"OVN-KUBE-ITP": []string{},
+					},
 				}
 
 				f4 = iptV4.(*util.FakeIPTables)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -35,6 +35,13 @@ const (
 	ctMarkOVN = "0x1"
 	// ctMarkHost is the conntrack mark value for host traffic
 	ctMarkHost = "0x2"
+	// ovnkubeITPMark is the fwmark used for host->ITP=local svc traffic. Note that the fwmark is not a part
+	// of the packet, but just stored by kernel in its memory to track/filter packet. Hence fwmark is lost as
+	// soon as packet exits the host.
+	ovnkubeITPMark = "0x1745ec" // constant itp(174)-service(5ec)
+	// ovnkubeSvcViaMgmPortRT is the number of the custom routing table used to steer host->service
+	// traffic packets into OVN via ovn-k8s-mp0. Currently only used for ITP=local traffic.
+	ovnkubeSvcViaMgmPortRT = "7"
 )
 
 var (
@@ -425,27 +432,38 @@ func delServiceRules(service *kapi.Service, npw *nodePortWatcher) {
 		npw.ofm.requestFlowSync()
 		if !npw.dpuMode {
 			// Always try and delete all rules here in full mode & in host only mode. We don't touch iptables in dpu mode.
-			// +--------------------------+-----------------------+--------------+--------------------------------+
-			// | svcHasLocalHostNetEndPnt | ExternalTrafficPolicy | GatewayMode  |     Scenario for deletion      |
-			// |--------------------------|-----------------------|--------------|--------------------------------|
-			// |                          |                       |              | deletes the DNAT rules for     |
-			// |         false            |          local        | shared+local | etp=local + non-local-host-net |
-			// |                          |                       |              | eps towards masqueradeIP       |
-			// |--------------------------|-----------------------|--------------|--------------------------------|
-			// |                          |                       |              |    deletes the DNAT rules      |
-			// |         false            |          cluster      | shared+local |   	towards clusterIP         |
-			// |                          |                       |              |       for the default case     |
-			// +--------------------------+-----------------------+--------------+--------------------------------+
+			// +--------------------------+-----------------------+-----------------------+--------------------------------+
+			// | svcHasLocalHostNetEndPnt | ExternalTrafficPolicy | InternalTrafficPolicy |     Scenario for deletion      |
+			// |--------------------------|-----------------------|-----------------------|--------------------------------|
+			// |                          |                       |                       |      deletes the MARK          |
+			// |         false            |         cluster       |          local        |      rules for itp=local       |
+			// |                          |                       |                       |       called from mangle       |
+			// |--------------------------|-----------------------|-----------------------|--------------------------------|
+			// |                          |                       |                       |      deletes the REDIRECT      |
+			// |         true             |         cluster       |          local        |      rules towards target      |
+			// |                          |                       |                       |       port for itp=local       |
+			// |--------------------------|-----------------------|-----------------------|--------------------------------|
+			// |                          |                       |                       | deletes the DNAT rules for     |
+			// |         false            |          local        |          cluster      |    non-local-host-net          |
+			// |                          |                       |                       | eps towards masqueradeIP +     |
+			// |                          |                       |                       | DNAT rules towards clusterIP   |
+			// |--------------------------|-----------------------|-----------------------|--------------------------------|
+			// |                          |                       |                       |    deletes the DNAT rules      |
+			// |       false||true        |          cluster      |          cluster      |   	towards clusterIP          |
+			// |                          |                       |                       |       for the default case     |
+			// |--------------------------|-----------------------|-----------------------|--------------------------------|
+			// |                          |                       |                       |      deletes all the rules     |
+			// |       false||true        |          local        |          local        |   for etp=local + itp=local    |
+			// |                          |                       |                       |   + default dnat towards CIP   |
+			// +--------------------------+-----------------------+-----------------------+--------------------------------+
 
-			// case1: deletes the DNAT rules towards masqueradeIP for etp=local + ovn-k pods in both gw modes OR
-			// case2: deletes the DNAT rules towards clusterIP for etp=cluster in both gw modes
+			delGatewayIptRules(service, true)
 			delGatewayIptRules(service, false)
 		}
 		return
 	}
 
-	// case1: deletes the DNAT rules towards masqueradeIP for etp=local + ovn-k pods in both gw modes OR
-	// case2: deletes the DNAT rules towards clusterIP for etp=cluster in both gw modes
+	delGatewayIptRules(service, true)
 	delGatewayIptRules(service, false)
 }
 
@@ -456,7 +474,8 @@ func serviceUpdateNotNeeded(old, new *kapi.Service) bool {
 		reflect.DeepEqual(new.Spec.ClusterIPs, old.Spec.ClusterIPs) &&
 		reflect.DeepEqual(new.Spec.Type, old.Spec.Type) &&
 		reflect.DeepEqual(new.Status.LoadBalancer.Ingress, old.Status.LoadBalancer.Ingress) &&
-		reflect.DeepEqual(new.Spec.ExternalTrafficPolicy, old.Spec.ExternalTrafficPolicy)
+		reflect.DeepEqual(new.Spec.ExternalTrafficPolicy, old.Spec.ExternalTrafficPolicy) &&
+		reflect.DeepEqual(*new.Spec.InternalTrafficPolicy, *old.Spec.InternalTrafficPolicy)
 }
 
 // AddService handles configuring shared gateway bridge flows to steer External IP, Node Port, Ingress LB traffic into OVN
@@ -492,7 +511,8 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) {
 
 	if serviceUpdateNotNeeded(old, new) {
 		klog.V(5).Infof("Skipping service update for: %s as change does not apply to any of .Spec.Ports, "+
-			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.ClusterIPs, .Spec.Type, .Status.LoadBalancer.Ingress, .Spec.ExternalTrafficPolicy", new.Name)
+			".Spec.ExternalIP, .Spec.ClusterIP, .Spec.ClusterIPs, .Spec.Type, .Status.LoadBalancer.Ingress, "+
+			".Spec.ExternalTrafficPolicy, .Spec.InternalTrafficPolicy", new.Name)
 		return
 	}
 	// Update the service in svcConfig if we need to so that other handler
@@ -612,10 +632,11 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) {
 	npw.ofm.requestFlowSync()
 	// sync IPtables rules once only for Full mode
 	if !npw.dpuMode {
-		for _, chain := range []string{iptableNodePortChain, iptableExternalIPChain, iptableETPChain, iptableMgmPortChain} {
-			// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
+		// (NOTE: Order is important, add jump to iptableETPChain before jump to NP/EIP chains)
+		for _, chain := range []string{iptableITPChain, iptableNodePortChain, iptableExternalIPChain, iptableETPChain, iptableMgmPortChain} {
 			recreateIPTRules("nat", chain, keepIPTRules)
 		}
+		recreateIPTRules("mangle", iptableITPChain, keepIPTRules)
 	}
 }
 
@@ -741,7 +762,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) {
 			continue
 		}
 		// Add correct iptables rules.
-		// TODO: ETP is not implemented for smart NIC mode.
+		// TODO: ETP and ITP is not implemented for smart NIC mode.
 		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, false)...)
 	}
 
@@ -1210,7 +1231,52 @@ func setBridgeOfPorts(bridge *bridgeConfiguration) error {
 	return nil
 }
 
-func newSharedGateway(nodeName string, gwNextHops []net.IP, gwIntf, egressGWIntf string,
+// initSvcViaMgmPortRoutingRules creates the svc2managementport routing table, routes and rules
+// that let's us forward service traffic to ovn-k8s-mp0 as opposed to the default route towards breth0
+func initSvcViaMgmPortRoutingRules(hostSubnets []*net.IPNet) error {
+	// create ovnkubeSvcViaMgmPortRT and service route towards ovn-k8s-mp0
+	for _, hostSubnet := range hostSubnets {
+		isIPv6 := utilnet.IsIPv6CIDR(hostSubnet)
+		gatewayIP := util.GetNodeGatewayIfAddr(hostSubnet).IP.String()
+		for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+			if isIPv6 == utilnet.IsIPv6CIDR(svcCIDR) {
+				if stdout, stderr, err := util.RunIP("route", "replace", "table", ovnkubeSvcViaMgmPortRT, svcCIDR.String(), "via", gatewayIP, "dev", types.K8sMgmtIntfName); err != nil {
+					return fmt.Errorf("error adding routing table entry into custom routing table: %s: stdout: %s, stderr: %s, err: %v", ovnkubeSvcViaMgmPortRT, stdout, stderr, err)
+				}
+				klog.V(5).Infof("Successfully added route into custom routing table: %s", ovnkubeSvcViaMgmPortRT)
+			}
+		}
+	}
+
+	createRule := func(family string) error {
+		stdout, stderr, err := util.RunIP(family, "rule")
+		if err != nil {
+			return fmt.Errorf("error listing routing rules, stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+		}
+		if !strings.Contains(stdout, fmt.Sprintf("from all fwmark %s lookup %s", ovnkubeITPMark, ovnkubeSvcViaMgmPortRT)) {
+			if stdout, stderr, err := util.RunIP(family, "rule", "add", "fwmark", ovnkubeITPMark, "lookup", ovnkubeSvcViaMgmPortRT, "prio", "30"); err != nil {
+				return fmt.Errorf("error adding routing rule for service via management table (%s): stdout: %s, stderr: %s, err: %v", ovnkubeSvcViaMgmPortRT, stdout, stderr, err)
+			}
+		}
+		return nil
+	}
+
+	// create ip rule that will forward ovnkubeITPMark marked packets to ovnkubeITPRoutingTable
+	if config.IPv4Mode {
+		if err := createRule("-4"); err != nil {
+			return fmt.Errorf("could not add IPv4 rule: %v", err)
+		}
+	}
+	if config.IPv6Mode {
+		if err := createRule("-6"); err != nil {
+			return fmt.Errorf("could not add IPv6 rule: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP, gwIntf, egressGWIntf string,
 	gwIPs []*net.IPNet, nodeAnnotator kube.Annotator, kube kube.Interface, cfg *managementPortConfig, watchFactory factory.NodeWatchFactory) (*gateway, error) {
 	klog.Info("Creating new shared gateway")
 	gw := &gateway{}
@@ -1280,6 +1346,9 @@ func newSharedGateway(nodeName string, gwNextHops []net.IP, gwIntf, egressGWIntf
 		}
 
 		if config.Gateway.NodeportEnable {
+			if err := initSvcViaMgmPortRoutingRules(subnets); err != nil {
+				return err
+			}
 			klog.Info("Creating Shared Gateway Node Port Watcher")
 			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge.patchPort, gwBridge.bridgeName, gwBridge.uplinkName, gwBridge.ips, gw.openflowManager, gw.nodeIPManager, watchFactory)
 			if err != nil {

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -111,6 +111,7 @@ func checkMgmtPortTestIptables(configs []managementPortTestConfig, mgmtPortName 
 				},
 			},
 			"filter": {},
+			"mangle": {},
 		}
 		if cfg.protocol == iptables.ProtocolIPv4 {
 			err = fakeIpv4.MatchState(expectedTables)

--- a/go-controller/pkg/node/port_claim_test.go
+++ b/go-controller/pkg/node/port_claim_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				pcw.AddService(service)
@@ -172,7 +172,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				pcw.AddService(service)
@@ -211,7 +211,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				pcw.AddService(service)
@@ -250,7 +250,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				pcw.AddService(service)
@@ -282,7 +282,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				pcw.AddService(service)
@@ -319,7 +319,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 				newService := newService("service7", "namespace1", "10.129.0.2",
 					[]kapi.ServicePort{
@@ -335,7 +335,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				pcw.UpdateService(oldService, newService)
@@ -365,7 +365,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 				newService := newService("service9", "namespace1", "10.129.0.2",
 					[]kapi.ServicePort{
@@ -381,7 +381,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				portMap := make(map[utilnet.LocalPort]bool)
@@ -427,7 +427,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeClusterIP,
 					[]string{"8.8.8.8", "10.10.10.10"},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 				portMap := make(map[utilnet.LocalPort]bool)
 				lp, _ := utilnet.NewLocalPort(getDescription("", service, false), "8.8.8.8", "", 8088, utilnet.TCP)
@@ -472,7 +472,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				portMap := make(map[utilnet.LocalPort]bool)
@@ -519,7 +519,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"8.8.8.8"},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				portMap := make(map[utilnet.LocalPort]bool)
@@ -564,7 +564,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				portMap := make(map[utilnet.LocalPort]bool)
@@ -617,7 +617,7 @@ var _ = Describe("Node Operations", func() {
 					kapi.ServiceTypeNodePort,
 					[]string{"127.0.0.1", "8.8.8.8"},
 					v1.ServiceStatus{},
-					false,
+					false, false,
 				)
 
 				errors := handleService(service, lpm.open)

--- a/go-controller/pkg/ovn/controller/services/load_balancer.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer.go
@@ -31,6 +31,9 @@ type lbConfig struct {
 	// that means, skipSNAT, and remove any non-local endpoints.
 	// (see below)
 	externalTrafficLocal bool
+	// if true, then vips added on the switch are in "local" mode
+	// that means, remove any non-local endpoints.
+	internalTrafficLocal bool
 	// indicates if this LB is configuring service of type NodePort.
 	hasNodePort bool
 }
@@ -56,16 +59,19 @@ var protos = []v1.Protocol{
 // - services with NodePort set
 // - services with host-network endpoints
 // - services with ExternalTrafficPolicy=Local
+// - services with InternalTrafficPolicy=Local
 func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice) (perNodeConfigs []lbConfig, clusterConfigs []lbConfig) {
 	// For each svcPort, determine if it will be applied per-node or cluster-wide
 	for _, svcPort := range service.Spec.Ports {
 		eps := util.GetLbEndpoints(endpointSlices, svcPort)
 
-		// if ExternalTrafficPolicy is local, then we need to do things a bit differently
+		// if ExternalTrafficPolicy or InternalTrafficPolicy is local, then we need to do things a bit differently
 		externalTrafficLocal := (service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal)
+		internalTrafficLocal := (service.Spec.InternalTrafficPolicy != nil) && (*service.Spec.InternalTrafficPolicy == v1.ServiceInternalTrafficPolicyLocal)
 
 		// NodePort services get a per-node load balancer, but with the node's physical IP as the vip
 		// Thus, the vip "node" will be expanded later.
+		// This is NEVER influenced by InternalTrafficPolicy
 		if svcPort.NodePort != 0 {
 			nodePortLBConfig := lbConfig{
 				protocol:             svcPort.Protocol,
@@ -73,6 +79,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 				vips:                 []string{placeholderNodeIPs}, // shortcut for all-physical-ips
 				eps:                  eps,
 				externalTrafficLocal: externalTrafficLocal,
+				internalTrafficLocal: false, // always false for non-ClusterIPs
 				hasNodePort:          true,
 			}
 			perNodeConfigs = append(perNodeConfigs, nodePortLBConfig)
@@ -96,6 +103,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 
 		// if ETP=Local, then treat ExternalIPs and LoadBalancer IPs specially
 		// otherwise, they're just cluster IPs
+		// This is NEVER influenced by InternalTrafficPolicy
 		if externalTrafficLocal && len(externalVips) > 0 {
 			externalIPConfig := lbConfig{
 				protocol:             svcPort.Protocol,
@@ -103,6 +111,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 				vips:                 externalVips,
 				eps:                  eps,
 				externalTrafficLocal: true,
+				internalTrafficLocal: false, // always false for non-ClusterIPs
 				hasNodePort:          false,
 			}
 			perNodeConfigs = append(perNodeConfigs, externalIPConfig)
@@ -118,6 +127,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 			vips:                 vips,
 			eps:                  eps,
 			externalTrafficLocal: false, // always false for ClusterIPs
+			internalTrafficLocal: internalTrafficLocal,
 			hasNodePort:          false,
 		}
 
@@ -127,7 +137,7 @@ func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.Endp
 		// - ETP=local service backed by non-local-host-networked endpoints
 		//
 		// In that case, we need to create per-node LBs.
-		if hasHostEndpoints(eps.V4IPs) || hasHostEndpoints(eps.V6IPs) {
+		if hasHostEndpoints(eps.V4IPs) || hasHostEndpoints(eps.V6IPs) || internalTrafficLocal {
 			perNodeConfigs = append(perNodeConfigs, clusterIPConfig)
 		} else {
 			clusterConfigs = append(clusterConfigs, clusterIPConfig)
@@ -293,8 +303,14 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 
 				if config.externalTrafficLocal {
 					// for ExternalTrafficPolicy=Local, remove non-local endpoints from the router/switch targets
+					// NOTE: on the switches, filtered eps are used only by masqueradeVIP
 					routerV4targetips = util.FilterIPsSlice(routerV4targetips, node.nodeSubnets(), true)
 					routerV6targetips = util.FilterIPsSlice(routerV6targetips, node.nodeSubnets(), true)
+					switchV4targetips = util.FilterIPsSlice(switchV4targetips, node.nodeSubnets(), true)
+					switchV6targetips = util.FilterIPsSlice(switchV6targetips, node.nodeSubnets(), true)
+				}
+				if config.internalTrafficLocal {
+					// for InternalTrafficPolicy=Local, remove non-local endpoints from the switch targets only
 					switchV4targetips = util.FilterIPsSlice(switchV4targetips, node.nodeSubnets(), true)
 					switchV6targetips = util.FilterIPsSlice(switchV6targetips, node.nodeSubnets(), true)
 				}
@@ -343,10 +359,21 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 							Targets: targetsETP,
 						})
 					}
-					switchRules = append(switchRules, ovnlb.LBRule{
-						Source:  ovnlb.Addr{IP: vip, Port: config.inport},
-						Targets: targets,
-					})
+					if config.internalTrafficLocal && util.IsClusterIP(vip) { // ITP only applicable to CIP
+						targetsITP := ovnlb.JoinHostsPort(switchV4targetips, config.eps.Port)
+						if isv6 {
+							targetsITP = ovnlb.JoinHostsPort(switchV6targetips, config.eps.Port)
+						}
+						switchRules = append(switchRules, ovnlb.LBRule{
+							Source:  ovnlb.Addr{IP: vip, Port: config.inport},
+							Targets: targetsITP,
+						})
+					} else {
+						switchRules = append(switchRules, ovnlb.LBRule{
+							Source:  ovnlb.Addr{IP: vip, Port: config.inport},
+							Targets: targets,
+						})
+					}
 
 					// There is also a per-router rule
 					// with targets that *may* be different

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -96,6 +96,7 @@ func newFakeWithProtocol(protocol iptables.Protocol) *FakeIPTables {
 	// Prepopulate some common tables
 	ipt.tables["nat"] = newFakeTable()
 	ipt.tables["filter"] = newFakeTable()
+	ipt.tables["mangle"] = newFakeTable()
 	return ipt
 }
 

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -211,6 +211,10 @@ func ServiceExternalTrafficPolicyLocal(service *kapi.Service) bool {
 	return service.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeLocal
 }
 
+func ServiceInternalTrafficPolicyLocal(service *kapi.Service) bool {
+	return service.Spec.InternalTrafficPolicy != nil && *service.Spec.InternalTrafficPolicy == kapi.ServiceInternalTrafficPolicyLocal
+}
+
 // GetNodePrimaryIP extracts the primary IP address from the node status in the  API
 func GetNodePrimaryIP(node *kapi.Node) (string, error) {
 	if node == nil {

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -201,6 +201,21 @@ ipLoop:
 	return out
 }
 
+// IsClusterIP checks if the provided IP is a clusterIP
+func IsClusterIP(svcVIP string) bool {
+	ip := net.ParseIP(svcVIP)
+	is4 := ip.To4() != nil
+	for _, svcCIDR := range config.Kubernetes.ServiceCIDRs {
+		if is4 && svcCIDR.IP.To4() != nil && svcCIDR.Contains(ip) {
+			return true
+		}
+		if !is4 && svcCIDR.IP.To4() == nil && svcCIDR.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 func GetLogicalPortName(podNamespace, podName string) string {
 	return composePortName(podNamespace, podName)
 }

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -59,9 +59,6 @@ should set default value on new IngressClass
 # RACE CONDITION IN TEST, SEE https://github.com/kubernetes/kubernetes/pull/90254
 should prevent Ingress creation if more than 1 IngressClass marked as default
 
-# Skip ITP=local till we support it
-\[Feature:ServiceInternalTrafficPolicy\]
-
 # TODO: Figure out why the below test is failing and if we need to add support in OVN-K for them
 validates that there is no conflict between pods with same hostPort but different hostIP and protocol
 "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Implements InternalTrafficPolicy=Local

**- Special notes for reviewers**
Documentation has been added, please check it out for design details.
Tests: Upstream k8s e2e's are pretty good and testing this feature well. Added unit tests to capture our LB filter logic on the switches and iptable rules on the nodes.

**- How to verify it**
```
[surya@hidden-temple yaml_debugging]$ oc get pods -owide
NAME                             READY   STATUS    RESTARTS   AGE     IP           NODE          NOMINATED NODE   READINESS GATES
hello-world-1-7fd8cdc9df-57p8n   1/1     Running   0          3m52s   10.244.0.4   ovn-worker2   <none>           <none>
hello-world-1-7fd8cdc9df-brg68   1/1     Running   0          3m52s   10.244.1.4   ovn-worker    <none>           <none>
```
```
[surya@hidden-temple yaml_debugging]$ oc get svc
NAME            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
hello-world-1   NodePort    10.96.121.181   <none>        8080:31741/TCP   3m35s
```
```
sh-5.1# ovn-nbctl lb-list
UUID                                    LB                  PROTO      VIP                   IPs
c729fe65-3a52-4213-9727-f34e57b94527    Service_default/    tcp        10.96.121.181:8080    
                                                            tcp        172.18.0.4:31741      10.244.0.4:8080,10.244.1.4:8080
9976bdb4-30c0-412b-95a7-cab44ad16ff9    Service_default/    tcp        10.96.121.181:8080    10.244.1.4:8080
                                                            tcp        172.18.0.2:31741      10.244.0.4:8080,10.244.1.4:8080
fc695058-5559-41c9-8d5c-3cc00ce44c82    Service_default/    tcp        10.96.121.181:8080    10.244.0.4:8080
                                                            tcp        172.18.0.3:31741      10.244.0.4:8080,10.244.1.4:8080
```

**- Description for the changelog**
`Implements ITP=local`