### PR TITLE
node, master: don't use Node objects for coordinating topology version

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -269,7 +269,7 @@ func runOvnKube(ctx *cli.Context) error {
 		metrics.RegisterNodeMetrics()
 		start := time.Now()
 		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, stopChan, util.EventRecorder(ovnClientset.KubeClient))
-		if err := n.Start(wg); err != nil {
+		if err := n.Start(ctx.Context, wg); err != nil {
 			return err
 		}
 		end := time.Since(start)

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -522,8 +522,13 @@ func (wf *WatchFactory) GetPodsBySelector(namespace string, labelSelector metav1
 
 // GetNodes returns the node specs of all the nodes
 func (wf *WatchFactory) GetNodes() ([]*kapi.Node, error) {
+	return wf.ListNodes(labels.Everything())
+}
+
+// ListNodes returns nodes that match a selector
+func (wf *WatchFactory) ListNodes(selector labels.Selector) ([]*kapi.Node, error) {
 	nodeLister := wf.informers[nodeType].lister.(listers.NodeLister)
-	return nodeLister.List(labels.Everything())
+	return nodeLister.List(selector)
 }
 
 // GetNode returns the node spec of a given node by name

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -46,6 +46,8 @@ type NodeWatchFactory interface {
 	LocalPodInformer() cache.SharedIndexInformer
 
 	GetNode(name string) (*kapi.Node, error)
+	GetNodes() ([]*kapi.Node, error)
+	ListNodes(selector labels.Selector) ([]*kapi.Node, error)
 
 	GetService(namespace, name string) (*kapi.Service, error)
 	GetEndpoint(namespace, name string) (*kapi.Endpoints, error)

--- a/go-controller/pkg/node/controllers/upgrade/node_upgrade.go
+++ b/go-controller/pkg/node/controllers/upgrade/node_upgrade.go
@@ -6,231 +6,118 @@ import (
 	"strconv"
 	"time"
 
+	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/informers"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	corelisters "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 )
 
-const (
-	controllerName = "node-upgrade-controller"
-)
-
-// upgradeController checks the OVN master nodes periodically
-// for upgrade annotation
+// upgradeController detects TopologyVersion edges as broadcast from the ovn-kube master.
+// Previously, ovn-kube used an annotation on the Node object. We now use a ConfigMap as the
+// coordination point, but will read from Nodes to handle upgrading an existing cluster.
 type upgradeController struct {
-	client          kubernetes.Interface
-	informerFactory informers.SharedInformerFactory
-	// nodeLister is able to list/get nodes and is populated
-	// by the shared informer passed to upgradeController
-	nodeLister corelisters.NodeLister
-	// nodeSynced returns true if the node shared informer
-	// has been synced at least once. Added as a member to the struct to allow
-	// injection for testing.
-	nodesSynced cache.InformerSynced
-
-	queue workqueue.RateLimitingInterface
-
-	// Holds the initially found version
-	initialTopoVersion int
+	client kubernetes.Interface
+	wf     factory.NodeWatchFactory
 }
 
 // NewController creates a new upgrade controller
-func NewController(client kubernetes.Interface) *upgradeController {
+func NewController(client kubernetes.Interface, wf factory.NodeWatchFactory) *upgradeController {
 	uc := &upgradeController{
 		client: client,
-		queue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
-	}
-
-	// note this will change in the future to control-plane:
-	// https://github.com/kubernetes/kubernetes/pull/95382
-	masterNode, err := labels.NewRequirement("node-role.kubernetes.io/master", selection.Exists, nil)
-	if err != nil {
-		klog.Fatalf("Unable to create labels.NewRequirement: %v", err)
-	}
-
-	labelSelector := labels.NewSelector()
-	labelSelector = labelSelector.Add(*masterNode)
-
-	uc.informerFactory = informers.NewSharedInformerFactoryWithOptions(client, 0,
-		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.LabelSelector = labelSelector.String()
-		}))
-	nodeInformer := uc.informerFactory.Core().V1().Nodes()
-	klog.Info("Setting up event handlers for node upgrade")
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    uc.onNodeAdd,
-		UpdateFunc: uc.onNodeUpdate,
-	})
-	uc.nodeLister = nodeInformer.Lister()
-	uc.nodesSynced = nodeInformer.Informer().HasSynced
-	uc.initialTopoVersion, err = uc.detectInitialVersion(labelSelector)
-	if err != nil {
-		klog.Fatalf("Unable to run initial version detection: %v", err)
+		wf:     wf,
 	}
 	return uc
 }
 
-// onNodeAdd queues the Node for processing.
-func (uc *upgradeController) onNodeAdd(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
-		return
-	}
-	klog.V(4).Infof("Adding node %s", key)
-	uc.queue.Add(key)
-}
-
-// onNodeUpdate updates the Node Selector in the cache and queues the Node for processing.
-func (uc *upgradeController) onNodeUpdate(oldObj, newObj interface{}) {
-	oldNode := oldObj.(*v1.Node)
-	newNode := newObj.(*v1.Node)
-
-	// don't process resync or objects that are marked for deletion
-	if oldNode.ResourceVersion == newNode.ResourceVersion ||
-		!newNode.GetDeletionTimestamp().IsZero() {
-		return
-	}
-
-	key, err := cache.MetaNamespaceKeyFunc(newObj)
-	if err == nil {
-		uc.queue.Add(key)
-	}
-}
-
-func (uc *upgradeController) Run(stopCh <-chan struct{}) error {
-	defer utilruntime.HandleCrash()
-	defer uc.queue.ShutDown()
-
-	klog.Infof("Starting controller %s", controllerName)
-	defer klog.Infof("Shutting down controller %s", controllerName)
-
-	informerStop := make(chan struct{})
-	uc.informerFactory.Start(informerStop)
-	// Wait for the caches to be synced
-	klog.Info("Waiting for informer caches to sync")
-	if !cache.WaitForNamedCacheSync(controllerName, stopCh, uc.nodesSynced) {
-		return fmt.Errorf("error syncing cache")
-	}
-
-	ticker := time.NewTicker(1 * time.Second)
-	deadline := time.After(30 * time.Minute)
-	klog.Info("Waiting for OVN Masters to upgrade to switchover K8S Service route")
-	for {
-		select {
-		case <-ticker.C:
-			if uc.processNextWorkItem() {
-				klog.Infof("Masters have completed upgrade from topology version %d to %d",
-					uc.initialTopoVersion, ovntypes.OvnCurrentTopologyVersion)
-				ticker.Stop()
-				close(informerStop)
-				return nil
+// WaitForTopologyVerions polls continuously until the running master has reported a topology of
+// at least the minimum requested.
+func (uc *upgradeController) WaitForTopologyVersion(ctx context.Context, minVersion int, timeout time.Duration) error {
+	return wait.PollWithContext(ctx, 10*time.Second, timeout, func(ctx context.Context) (bool, error) {
+		ver, err := uc.GetTopologyVersion(ctx)
+		if err == nil {
+			if ver >= minVersion {
+				klog.Infof("Cluster topology version is now %d", ver)
+				return true, nil
 			}
-		case <-deadline:
-			ticker.Stop()
-			close(informerStop)
-			klog.Fatal("Failed to detect completion of master upgrade after 30 minutes. Check if " +
-				"ovnkube-masters have upgraded correctly!")
-		case <-stopCh:
-			ticker.Stop()
-			close(informerStop)
-			return nil
+
+			klog.Infof("Cluster topology version %d < %d", ver, minVersion)
+			return false, nil
 		}
-	}
-}
-
-// if work is complete returns true
-func (uc *upgradeController) processNextWorkItem() bool {
-	eKey, quit := uc.queue.Get()
-	if quit {
-		return false
-	}
-	defer uc.queue.Done(eKey)
-
-	done, err := uc.detectUpgradeDone(eKey.(string))
-	if err != nil {
-		utilruntime.HandleError(err)
-	}
-	uc.queue.Forget(eKey)
-	return done
-}
-
-// returns true if upgrade is detected as complete
-func (uc *upgradeController) detectUpgradeDone(nodeName string) (bool, error) {
-	klog.Infof("Processing node update for %s", nodeName)
-	// Get current Node from the cache
-	node, err := uc.nodeLister.Get(nodeName)
-	// It´s unlikely that we have an error different that "Not Found Object"
-	// because we are getting the object from the informer´s cache
-	if err != nil && !apierrors.IsNotFound(err) {
-		return false, err
-	}
-	topoVer, ok := node.Annotations[ovntypes.OvnK8sTopoAnno]
-	if ok && len(topoVer) > 0 {
-		ver, err := strconv.Atoi(topoVer)
-		if err != nil {
-			klog.Warningf("Illegal value detected for %s, on node: %s, value: %s, error: %v",
-				ovntypes.OvnK8sTopoAnno, node.Name, topoVer, err)
-			return false, err
-		}
-		if ver == ovntypes.OvnCurrentTopologyVersion {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// DetermineOVNTopoVersionOnNode determines what OVN Topology version is being used
-func (uc *upgradeController) detectInitialVersion(selector labels.Selector) (int, error) {
-	// Find out the current OVN topology version by checking "k8s.ovn.org/topo-version" annotation on Master nodes
-	nodeList, err := uc.client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: selector.String(),
+		klog.Errorf("Failed to retrieve topology version: %v", err)
+		return false, nil // swallow error so we retry
 	})
+}
+
+// GetTopologyVersion polls the coordination points (Nodes and ConfigMaps) until
+// the master has reported a version
+func (uc *upgradeController) GetTopologyVersion(ctx context.Context) (int, error) {
+	// First, check the config map
+	ns := globalconfig.Kubernetes.OVNConfigNamespace
+	name := ovntypes.OvnK8sStatusCMName
+	cm, err := uc.client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		klog.Warningf("Error retrieving ConfigMap %s/%s: %v", ns, name, err)
+		return -1, err
+	}
+	if err == nil {
+		tv, ok := cm.Data[ovntypes.OvnK8sStatusKeyTopoVersion]
+		if ok {
+			out, err := strconv.Atoi(tv)
+			if err == nil {
+				klog.Infof("Detected cluster topology version %d from ConfigMap %s/%s", out, ns, name)
+				return out, nil
+			} else {
+				klog.Infof("ConfigMap %s/%s had invalid value in %s: %s %v", ns, name, ovntypes.OvnK8sStatusKeyTopoVersion, tv, err)
+			}
+		}
+	}
+
+	// Masters not yet upgraded, check Node objects
+	klog.Infof("Could not determine TopologyVersion via configmap, falling back to Nodes")
+
+	masterNode, err := labels.NewRequirement("node-role.kubernetes.io/master", selection.Exists, nil)
+	if err != nil {
+		klog.Fatalf("Unable to create labels.NewRequirement: %v", err)
+	}
+	nodes, err := uc.wf.ListNodes(labels.NewSelector().Add(*masterNode))
 	if err != nil {
 		return -1, fmt.Errorf("unable to get nodes for checking topo version: %v", err)
 	}
 
-	verFound := false
-	ver := 0
-	maxVers := ver
+	ver := -1
+	nodeName := ""
 	// say, we have three ovnkube-master Pods. on rolling update, one of the Pods will
 	// perform the topology/master upgrade and set the topology-version annotation for
 	// that node. other ovnkube-master Pods will be in standby mode and wouldn't have
 	// updated the annotation. so, we need to get the topology-version from all the
 	// nodes and pick the maximum value.
-	for _, node := range nodeList.Items {
-		topoVer, ok := node.Annotations[ovntypes.OvnK8sTopoAnno]
+	for _, node := range nodes {
+		topoVer, ok := node.Annotations[ovntypes.OvnK8sTopoAnno] //nolint:staticcheck
 		if ok && len(topoVer) > 0 {
-			ver, err = strconv.Atoi(topoVer)
+			v, err := strconv.Atoi(topoVer)
 			if err != nil {
 				klog.Warningf("Illegal value detected for %s, on node: %s, value: %s, error: %v",
-					ovntypes.OvnK8sTopoAnno, node.Name, topoVer, err)
+					ovntypes.OvnK8sTopoAnno, node.Name, topoVer, err) //nolint:staticcheck
 			} else {
-				verFound = true
-				if ver > maxVers {
-					maxVers = ver
+				if v > ver {
+					nodeName = node.Name
+					ver = v
 				}
 			}
 		}
 	}
 
-	if !verFound {
-		klog.Warningf("Unable to detect topology version on nodes")
+	if ver == -1 {
+		return -1, fmt.Errorf("could not find the topology annotation on Nodes")
 	}
-	return maxVers, nil
-}
 
-func (uc *upgradeController) GetInitialTopoVersion() int {
-	return uc.initialTopoVersion
+	klog.Infof("Detected cluster topology version %d from Node %s", ver, nodeName)
+	return ver, nil
 }

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"sync"
 
 	. "github.com/onsi/gomega"
@@ -70,5 +71,5 @@ func (o *FakeOVNNode) init() {
 	Expect(err).NotTo(HaveOccurred())
 
 	o.node = NewNode(o.fakeClient.KubeClient, o.watcher, fakeNodeName, o.stopChan, o.recorder)
-	o.node.Start(o.wg)
+	o.node.Start(context.TODO(), o.wg)
 }

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -5,11 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"math/rand"
 	"net"
 	"reflect"
-	"strconv"
 	"sync"
 	"time"
 
@@ -23,7 +21,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	svccontroller "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/unidling"
@@ -316,7 +313,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 }
 
 // Run starts the actual watching.
-func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
+func (oc *Controller) Run(ctx context.Context, wg *sync.WaitGroup) error {
 	// Start and sync the watch factory to begin listening for events
 	if err := oc.watchFactory.Start(); err != nil {
 		return err
@@ -411,95 +408,19 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 	}
 
 	// Final step to cleanup after resource handlers have synced
-	err := oc.ovnTopologyCleanup()
+	err := oc.ovnTopologyCleanup(ctx)
 	if err != nil {
 		klog.Errorf("Failed to cleanup OVN topology to version %d: %v", ovntypes.OvnCurrentTopologyVersion, err)
 		return err
 	}
 
-	// Master is fully running and resource handlers have synced, update Topology version in OVN
-	currentTopologyVersion := strconv.Itoa(ovntypes.OvnCurrentTopologyVersion)
-	logicalRouterRes := []nbdb.LogicalRouter{}
-	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
-	defer cancel()
-	if err := oc.nbClient.WhereCache(func(lr *nbdb.LogicalRouter) bool {
-		return lr.Name == ovntypes.OVNClusterRouter
-	}).List(ctx, &logicalRouterRes); err != nil {
-		return fmt.Errorf("failed in retrieving %s, error: %v", ovntypes.OVNClusterRouter, err)
-	}
-	// Update topology version on distributed cluster router
-	logicalRouterRes[0].ExternalIDs["k8s-ovn-topo-version"] = currentTopologyVersion
-	logicalRouter := nbdb.LogicalRouter{
-		Name:        ovntypes.OVNClusterRouter,
-		ExternalIDs: logicalRouterRes[0].ExternalIDs,
-	}
-	opModel := libovsdbops.OperationModel{
-		Name:           logicalRouter.Name,
-		Model:          &logicalRouter,
-		ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == ovntypes.OVNClusterRouter },
-		OnModelUpdates: []interface{}{
-			&logicalRouter.ExternalIDs,
-		},
-		ErrNotFound: true,
-	}
-	if _, err := oc.modelClient.CreateOrUpdate(opModel); err != nil {
-		return fmt.Errorf("failed to generate set topology version in OVN, err: %v", err)
-	}
-
-	// Update topology version on node
-	node, err := oc.kube.GetNode(nodeName)
-	if err != nil {
-		return fmt.Errorf("unable to get node: %s", nodeName)
-	}
-	err = oc.kube.SetAnnotationsOnNode(node.Name, map[string]interface{}{ovntypes.OvnK8sTopoAnno: strconv.Itoa(ovntypes.OvnCurrentTopologyVersion)})
-	if err != nil {
-		return fmt.Errorf("failed to set topology annotation for node %s", node.Name)
-	}
-
-	return nil
-}
-
-func (oc *Controller) ovnTopologyCleanup() error {
-	ver, err := oc.determineOVNTopoVersionFromOVN()
-	if err != nil {
+	// Master is fully running and resource handlers have synced, update Topology version in OVN and the ConfigMap
+	if err := oc.reportTopologyVersion(ctx); err != nil {
+		klog.Errorf("Failed to report topology version: %v", err)
 		return err
 	}
 
-	// Cleanup address sets in non dual stack formats in all versions known to possibly exist.
-	if ver <= ovntypes.OvnPortBindingTopoVersion {
-		err = addressset.NonDualStackAddressSetCleanup(oc.nbClient)
-	}
-	return err
-}
-
-// determineOVNTopoVersionFromOVN determines what OVN Topology version is being used
-// If "k8s-ovn-topo-version" key in external_ids column does not exist, it is prior to OVN topology versioning
-// and therefore set version number to OvnCurrentTopologyVersion
-func (oc *Controller) determineOVNTopoVersionFromOVN() (int, error) {
-	ver := 0
-	logicalRouterRes := []nbdb.LogicalRouter{}
-	ctx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
-	defer cancel()
-	if err := oc.nbClient.WhereCache(func(lr *nbdb.LogicalRouter) bool {
-		return lr.Name == ovntypes.OVNClusterRouter
-	}).List(ctx, &logicalRouterRes); err != nil {
-		return ver, fmt.Errorf("failed in retrieving %s to determine the current version of OVN logical topology: "+
-			"error: %v", ovntypes.OVNClusterRouter, err)
-	}
-	if len(logicalRouterRes) == 0 {
-		// no OVNClusterRouter exists, DB is empty, nothing to upgrade
-		return math.MaxInt32, nil
-	}
-	v, exists := logicalRouterRes[0].ExternalIDs["k8s-ovn-topo-version"]
-	if !exists {
-		klog.Infof("No version string found. The OVN topology is before versioning is introduced. Upgrade needed")
-		return ver, nil
-	}
-	ver, err := strconv.Atoi(v)
-	if err != nil {
-		return 0, fmt.Errorf("invalid OVN topology version string for the cluster, err: %v", err)
-	}
-	return ver, nil
+	return nil
 }
 
 // syncPeriodic adds a goroutine that periodically does some work

--- a/go-controller/pkg/ovn/topology_version.go
+++ b/go-controller/pkg/ovn/topology_version.go
@@ -1,0 +1,148 @@
+package ovn
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+
+	globalconfig "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+func (oc *Controller) ovnTopologyCleanup(ctx context.Context) error {
+	ver, err := oc.determineOVNTopoVersionFromOVN(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Cleanup address sets in non dual stack formats in all versions known to possibly exist.
+	if ver <= ovntypes.OvnPortBindingTopoVersion {
+		err = addressset.NonDualStackAddressSetCleanup(oc.nbClient)
+	}
+	return err
+}
+
+// reportTopologyVersion saves the topology version to two places:
+// - an ExternalID on the ovn_cluster_router LogicalRouter in nbdb
+// - a ConfigMap. This is used by nodes to determine the cluster's topology
+func (oc *Controller) reportTopologyVersion(ctx context.Context) error {
+	currentTopologyVersion := strconv.Itoa(ovntypes.OvnCurrentTopologyVersion)
+	logicalRouterRes := []nbdb.LogicalRouter{}
+	ctx, cancel := context.WithTimeout(ctx, ovntypes.OVSDBTimeout)
+	defer cancel()
+	if err := oc.nbClient.WhereCache(func(lr *nbdb.LogicalRouter) bool {
+		return lr.Name == ovntypes.OVNClusterRouter
+	}).List(ctx, &logicalRouterRes); err != nil {
+		return fmt.Errorf("failed in retrieving %s, error: %v", ovntypes.OVNClusterRouter, err)
+	}
+	// Update topology version on distributed cluster router
+	logicalRouterRes[0].ExternalIDs["k8s-ovn-topo-version"] = currentTopologyVersion
+	logicalRouter := nbdb.LogicalRouter{
+		Name:        ovntypes.OVNClusterRouter,
+		ExternalIDs: logicalRouterRes[0].ExternalIDs,
+	}
+	opModel := libovsdbops.OperationModel{
+		Name:           logicalRouter.Name,
+		Model:          &logicalRouter,
+		ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == ovntypes.OVNClusterRouter },
+		OnModelUpdates: []interface{}{
+			&logicalRouter.ExternalIDs,
+		},
+		ErrNotFound: true,
+	}
+	if _, err := oc.modelClient.CreateOrUpdate(opModel); err != nil {
+		return fmt.Errorf("failed to generate set topology version in OVN, err: %v", err)
+	}
+	klog.Infof("Updated Logical_Router %s topology version to %s", ovntypes.OVNClusterRouter, currentTopologyVersion)
+
+	// Report topology version in a ConfigMap
+	// (we used to report this via annotations on our Node)
+	cm := corev1apply.ConfigMap(ovntypes.OvnK8sStatusCMName, globalconfig.Kubernetes.OVNConfigNamespace)
+	cm.Data = map[string]string{ovntypes.OvnK8sStatusKeyTopoVersion: currentTopologyVersion}
+	if _, err := oc.client.CoreV1().ConfigMaps(globalconfig.Kubernetes.OVNConfigNamespace).Apply(ctx, cm, metav1.ApplyOptions{
+		Force:        true,
+		FieldManager: "ovn-kubernetes",
+	}); err != nil {
+		return err
+	}
+
+	klog.Infof("Updated ConfigMap %s/%s topology version to %s", *cm.Namespace, *cm.Name, currentTopologyVersion)
+
+	return oc.cleanTopologyAnnotation()
+}
+
+// Remove the old topology annotation from nodes, if it exists.
+func (oc *Controller) cleanTopologyAnnotation() error {
+	// Unset the old topology annotation on all Node objects
+	nodes, err := oc.watchFactory.GetNodes()
+	if err != nil {
+		return err
+	}
+	anno := ovntypes.OvnK8sTopoAnno //nolint // otherwise we get deprecation warnings (this variable is deprecated)
+	for _, node := range nodes {
+		if _, ok := node.Annotations[anno]; !ok {
+			continue
+		}
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			node, err := oc.kube.GetNode(node.Name)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+			if _, ok := node.Annotations[anno]; ok {
+				newNode := node.DeepCopy()
+				delete(newNode.Annotations, anno)
+				klog.Infof("Deleting topology annotation from node %s", node.Name)
+				return oc.kube.PatchNode(node, newNode)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// determineOVNTopoVersionFromOVN determines what OVN Topology version is being used
+// If "k8s-ovn-topo-version" key in external_ids column does not exist, it is prior to OVN topology versioning
+// and therefore set version number to OvnCurrentTopologyVersion
+func (oc *Controller) determineOVNTopoVersionFromOVN(ctx context.Context) (int, error) {
+	ver := 0
+	logicalRouterRes := []nbdb.LogicalRouter{}
+	ctx, cancel := context.WithTimeout(ctx, ovntypes.OVSDBTimeout)
+	defer cancel()
+	if err := oc.nbClient.WhereCache(func(lr *nbdb.LogicalRouter) bool {
+		return lr.Name == ovntypes.OVNClusterRouter
+	}).List(ctx, &logicalRouterRes); err != nil {
+		return ver, fmt.Errorf("failed in retrieving %s to determine the current version of OVN logical topology: "+
+			"error: %v", ovntypes.OVNClusterRouter, err)
+	}
+	if len(logicalRouterRes) == 0 {
+		// no OVNClusterRouter exists, DB is empty, nothing to upgrade
+		return math.MaxInt32, nil
+	}
+	v, exists := logicalRouterRes[0].ExternalIDs["k8s-ovn-topo-version"]
+	if !exists {
+		klog.Infof("No version string found. The OVN topology is before versioning is introduced. Upgrade needed")
+		return ver, nil
+	}
+	ver, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid OVN topology version string for the cluster, err: %v", err)
+	}
+	return ver, nil
+}

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -111,9 +111,14 @@ const (
 	OvnCurrentTopologyVersion      = OvnRoutingViaHostTopoVersion
 
 	// OVN-K8S annotation & taint constants
-	OvnK8sPrefix           = "k8s.ovn.org"
+	OvnK8sPrefix = "k8s.ovn.org"
+	// Deprecated: we used to set topology version as an annotation on the node. We don't do this anymore.
 	OvnK8sTopoAnno         = OvnK8sPrefix + "/" + "topology-version"
 	OvnK8sSmallMTUTaintKey = OvnK8sPrefix + "/" + "mtu-too-small"
+
+	// name of the configmap used to synchronize status (e.g. watch for topology changes)
+	OvnK8sStatusCMName         = "control-plane-status"
+	OvnK8sStatusKeyTopoVersion = "topology-version"
 
 	// Monitoring constants
 	SFlowAgent = "ovn-k8s-mp0"


### PR DESCRIPTION
We would like to run the OVN-Kubernetes control-plane off-cluster. This means we can no longer use the Node object for coordinating topology version. This change:
- Moves topology-version to a ConfigMap
- Deletes the topology-version annotation from Nodes.
- Other random cleanups.