### PR TITLE
Refactor OVN-Kube master metrics

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -239,10 +239,8 @@ func runOvnKube(ctx *cli.Context) error {
 			return fmt.Errorf("error when trying to initialize libovsdb SB client: %v", err)
 		}
 
-		// register prometheus metrics exported by the master
-		// this must be done prior to calling controller start
-		// since we capture some metrics in Start()
-		metrics.RegisterMasterMetrics(libovsdbOvnNBClient, libovsdbOvnSBClient)
+		// register prometheus metrics that do not depend on becoming ovnkube-master leader
+		metrics.RegisterMasterBase()
 
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil,
 			libovsdbOvnNBClient, libovsdbOvnSBClient, util.EventRecorder(ovnClientset.KubeClient))

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -23,10 +23,10 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-// metricNbE2eTimestamp is the UNIX timestamp value set to NB DB. A corresponding metric
-// 'sb_e2e_timestamp' for SB DB will contain the timestamp that was written to NB DB.
-// This is registered within func RunTimestamp in order to allow gathering this metric on
-// the fly when metrics are scraped.
+// metricNbE2eTimestamp is the UNIX timestamp value set to NB DB. Northd will eventually copy this
+// timestamp from NB DB to SB DB. The metric 'sb_e2e_timestamp' stores the timestamp that is
+// read from SB DB. This is registered within func RunTimestamp in order to allow gathering this
+// metric on the fly when metrics are scraped.
 var metricNbE2eTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -531,10 +531,16 @@ func (ps *ControlPlaneRecorder) Run(sbClient libovsdbclient.Client) {
 
 	sbClient.Cache().AddEventHandler(&cache.EventHandlerFuncs{
 		AddFunc: func(table string, model model.Model) {
-			go ps.AddPortBindingEvent(table, model)
+			if table != portBindingTable {
+				return
+			}
+			go ps.AddPortBindingEvent(model)
 		},
 		UpdateFunc: func(table string, old model.Model, new model.Model) {
-			go ps.UpdatePortBindingEvent(table, old, new)
+			if table != portBindingTable {
+				return
+			}
+			go ps.UpdatePortBindingEvent(old, new)
 		},
 		DeleteFunc: func(table string, model model.Model) {
 		},
@@ -571,10 +577,7 @@ func (ps *ControlPlaneRecorder) AddLSPEvent(podUID kapimtypes.UID) {
 	r.timestampType = logicalSwitchPort
 }
 
-func (ps *ControlPlaneRecorder) AddPortBindingEvent(table string, m model.Model) {
-	if table != portBindingTable {
-		return
-	}
+func (ps *ControlPlaneRecorder) AddPortBindingEvent(m model.Model) {
 	var r *record
 	now := time.Now()
 	row := m.(*sbdb.PortBinding)
@@ -597,10 +600,7 @@ func (ps *ControlPlaneRecorder) AddPortBindingEvent(table string, m model.Model)
 	r.timestampType = portBinding
 }
 
-func (ps *ControlPlaneRecorder) UpdatePortBindingEvent(table string, old, new model.Model) {
-	if table != portBindingTable {
-		return
-	}
+func (ps *ControlPlaneRecorder) UpdatePortBindingEvent(old, new model.Model) {
 	var r *record
 	oldRow := old.(*sbdb.PortBinding)
 	newRow := new.(*sbdb.PortBinding)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -214,6 +214,8 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	klog.Infof("Starting cluster master")
 
+	metrics.RegisterMasterPerformance(oc.nbClient)
+	metrics.RegisterMasterFunctional()
 	metrics.RunTimestamp(oc.stopChan, oc.sbClient, oc.nbClient)
 	metrics.MonitorIPSec(oc.nbClient)
 	oc.metricsRecorder.Run(oc.sbClient)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -92,8 +92,7 @@ func (oc *Controller) Start(nodeName string, wg *sync.WaitGroup, ctx context.Con
 					end := time.Since(start)
 					metrics.MetricMasterReadyDuration.Set(end.Seconds())
 				}()
-				// run only on the active master node.
-				metrics.StartMasterMetricUpdater(oc.stopChan, oc.nbClient)
+
 				if err := oc.StartClusterMaster(nodeName); err != nil {
 					panic(err.Error())
 				}
@@ -215,6 +214,8 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	klog.Infof("Starting cluster master")
 
+	metrics.RunTimestamp(oc.stopChan, oc.sbClient, oc.nbClient)
+	metrics.MonitorIPSec(oc.nbClient)
 	oc.metricsRecorder.Run(oc.sbClient)
 
 	// enableOVNLogicalDataPathGroups sets an OVN flag to enable logical datapath

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -215,6 +215,8 @@ func (oc *Controller) upgradeOVNTopology(existingNodes *kapi.NodeList) error {
 func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 	klog.Infof("Starting cluster master")
 
+	oc.metricsRecorder.Run(oc.sbClient)
+
 	// enableOVNLogicalDataPathGroups sets an OVN flag to enable logical datapath
 	// groups on OVN 20.12 and later. The option is ignored if OVN doesn't
 	// understand it. Logical datapath groups reduce the size of the southbound

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -311,7 +311,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		svcController:            svcController,
 		svcFactory:               svcFactory,
 		modelClient:              modelClient,
-		metricsRecorder:          metrics.NewControlPlaneRecorder(libovsdbOvnSBClient),
+		metricsRecorder:          metrics.NewControlPlaneRecorder(),
 	}
 }
 


### PR DESCRIPTION
See commits.
Summary:
* Register and run control plane pod watcher metrics when ovnkube-master is leader
* Register and run IPSec / timestamp metrics when ovnkube-master is leader
* Register metrics after becoming leader so there isn't lots of followers posting blank metrics.

This should save us some CPU and help confuse the user a little less.