### PR TITLE
Using "update" instead of "mutate" when updating GatewayChassis of LRP.

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -779,6 +779,7 @@ func (oc *Controller) syncNodeClusterRouterPort(node *kapi.Node, hostSubnets []*
 		Priority:    1,
 	}
 
+	// Set the gateway chassis of the LRP. (Use "Update" so that the old value, if any, would be replaced)
 	opModels = []libovsdbops.OperationModel{
 		{
 			Name:  gatewayChassis.Name,
@@ -795,7 +796,7 @@ func (oc *Controller) syncNodeClusterRouterPort(node *kapi.Node, hostSubnets []*
 		},
 		{
 			Model: &logicalRouterPort,
-			OnModelMutations: []interface{}{
+			OnModelUpdates: []interface{}{
 				&logicalRouterPort.GatewayChassis,
 			},
 			ErrNotFound: true,
@@ -803,7 +804,7 @@ func (oc *Controller) syncNodeClusterRouterPort(node *kapi.Node, hostSubnets []*
 	}
 
 	if _, err := oc.modelClient.CreateOrUpdate(opModels...); err != nil {
-		klog.Errorf("Failed to add gateway chassis %s to logical router port %s, error: %v", chassisID, lrpName, err)
+		klog.Errorf("Failed to set gateway chassis %s to logical router port %s, error: %v", chassisID, lrpName, err)
 		return err
 	}
 


### PR DESCRIPTION
To sync the logical router port, we used to delete and add it back in
the same trasanction with ovn-nbctl, making sure no existing dirty data
are left. However, now using libovsdb, we are using mutate to set the
gateway_chassis, and if the LRP has an old gateway chassis set already,
this mutation would add an extra gateway chassis instead of replacing
the old one. This can happen when the chassisID annotation changes,
resulting multiple gateway chassis set for the LRP, leading to
unexpected behavior, such as BFD being enabled.

Signed-off-by: Han Zhou <hzhou@ovn.org>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->