### PR TITLE
Don't nuke conntrack entries for SCTP

### DIFF
--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -387,11 +387,6 @@ func DeleteConntrack(ip string, port int32, protocol kapi.Protocol) error {
 		if err := filter.AddProtocol(17); err != nil {
 			return fmt.Errorf("could not add Protocol UDP to conntrack filter %v", err)
 		}
-	} else if protocol == kapi.ProtocolSCTP {
-		// 132 = SCTP protocol
-		if err := filter.AddProtocol(132); err != nil {
-			return fmt.Errorf("could not add Protocol SCTP to conntrack filter %v", err)
-		}
 	}
 	if port > 0 {
 		if err := filter.AddPort(netlink.ConntrackOrigDstPort, uint16(port)); err != nil {


### PR DESCRIPTION
Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

Until now we were following what kube-proxy does and nuking entries for SCTP when endpoints go away (the fix was added to handle the case when pods get deleted without terminating their connections properly); but this causes issues where we disrupt graceful termination of pod traffic and or service traffic (if these pods are backends and we delete services that also cause endpoints to be deleted). Let's remove SCTP from this list since its connection oriented and its expected that ESTABLISHED connections continue to work (after we fix https://bugzilla.redhat.com/show_bug.cgi?id=2060021) even after services or endpoints are deleted and close with proper protocol aborts (like CLOSE/SHUTDOWN) that will cause conntrack to remove these entries automatically.


**- Special notes for reviewers**
A similar PR to remove the SCTP protocol from the deleteConntrack function will be submitted to upstream kube-proxy which will then be consumed by sdn.

**- How to verify it**
Once the OVN PR merges, we'll want to make sure we are indeed allowing the close of ESTABLISHED connections.

**- Description for the changelog**
`Stop removing SCTP conntrack entries on endpoints delete`