### PR TITLE
vendor: bump libovsdb to c8b4494412b1a0ba1396dd162a9a2d497c80f2b0

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20211201215911-5a82bae32e46
 	github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366
-	github.com/ovn-org/libovsdb v0.6.1-0.20220127023511-a619f0fd93be
+	github.com/ovn-org/libovsdb v0.6.1-0.20220225160119-c8b4494412b1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/afero v1.4.1

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -401,6 +401,8 @@ github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366/go.mod h1:HJeH
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
 github.com/ovn-org/libovsdb v0.6.1-0.20220127023511-a619f0fd93be h1:U8WVtNNTfBKj/5OE3uBe57oNJ+x5KSMl+3hM7iLSbdk=
 github.com/ovn-org/libovsdb v0.6.1-0.20220127023511-a619f0fd93be/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
+github.com/ovn-org/libovsdb v0.6.1-0.20220225160119-c8b4494412b1 h1:nz+mlIM2KFAJGhrKb68KBl36rFn2mLAp+kfskm2nfl0=
+github.com/ovn-org/libovsdb v0.6.1-0.20220225160119-c8b4494412b1/go.mod h1:aLvY7gPs/vLyJXF+PpZzvWlR5LB4QNJvBYIQMskJLZk=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/pkg/libovsdbops/meter_test.go
+++ b/go-controller/pkg/libovsdbops/meter_test.go
@@ -57,6 +57,11 @@ func (c *MockConditionalAPI) Delete() ([]ovsdb.Operation, error) {
 	return nil, nil
 }
 
+// Wait is an empty mock method.
+func (c *MockConditionalAPI) Wait(ovsdb.WaitCondition, *int, model.Model, ...interface{}) ([]ovsdb.Operation, error) {
+	return nil, nil
+}
+
 // MockLibOvsDbClient is a mock implementation of libovsdbclient.ConditionalAPI.
 type MockLibOvsDbClient struct {
 	libovsdbclient.ConditionalAPI

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
@@ -457,7 +457,6 @@ type TableCache struct {
 	cache          map[string]*RowCache
 	eventProcessor *eventProcessor
 	dbModel        model.DatabaseModel
-	errorChan      chan error
 	ovsdb.NotificationHandler
 	mutex  sync.RWMutex
 	logger *logr.Logger
@@ -500,7 +499,6 @@ func NewTableCache(dbModel model.DatabaseModel, data Data, logger *logr.Logger) 
 		eventProcessor: eventProcessor,
 		dbModel:        dbModel,
 		mutex:          sync.RWMutex{},
-		errorChan:      make(chan error),
 		logger:         logger,
 	}, nil
 }
@@ -545,7 +543,6 @@ func (t *TableCache) Update(context interface{}, tableUpdates ovsdb.TableUpdates
 	}
 	if err := t.Populate(tableUpdates); err != nil {
 		t.logger.Error(err, "during libovsdb cache populate")
-		t.errorChan <- NewErrCacheInconsistent(err.Error())
 		return err
 	}
 	return nil
@@ -560,7 +557,6 @@ func (t *TableCache) Update2(context interface{}, tableUpdates ovsdb.TableUpdate
 	}
 	if err := t.Populate2(tableUpdates); err != nil {
 		t.logger.Error(err, "during libovsdb cache populate2")
-		t.errorChan <- NewErrCacheInconsistent(err.Error())
 		return err
 	}
 	return nil
@@ -677,7 +673,7 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				modified := model.Clone(existing)
 				err := t.ApplyModifications(table, modified, *row.Modify)
 				if err != nil {
-					return fmt.Errorf("unable to apply row modifications: %v", err)
+					return fmt.Errorf("unable to apply row modifications: %w", err)
 				}
 				if !model.Equal(modified, existing) {
 					logger.V(5).Info("updating row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))
@@ -734,11 +730,6 @@ func (t *TableCache) Run(stopCh <-chan struct{}) {
 		t.eventProcessor.Run(stopCh)
 	}()
 	wg.Wait()
-}
-
-// Errors returns a channel where errors that occur during cache propagation can be received
-func (t *TableCache) Errors() <-chan error {
-	return t.errorChan
 }
 
 // newRowCache creates a new row cache with the provided data

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/api.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/api.go
@@ -16,6 +16,7 @@ import (
 type API interface {
 	// List populates a slice of Models objects based on their type
 	// The function parameter must be a pointer to a slice of Models
+	// Models can be structs or pointers to structs
 	// If the slice is null, the entire cache will be copied into the slice
 	// If it has a capacity != 0, only 'capacity' elements will be filled in
 	List(ctx context.Context, result interface{}) error
@@ -69,6 +70,10 @@ type ConditionalAPI interface {
 
 	// Delete returns the Operations needed to delete the models selected via the condition
 	Delete() ([]ovsdb.Operation, error)
+
+	// Wait returns the operations needed to perform the wait specified
+	// by the until condition, timeout, row and columns based on provided parameters.
+	Wait(ovsdb.WaitCondition, *int, model.Model, ...interface{}) ([]ovsdb.Operation, error)
 }
 
 // ErrWrongType is used to report the user provided parameter has the wrong type
@@ -104,7 +109,23 @@ func (a api) List(ctx context.Context, result interface{}) error {
 		return &ErrWrongType{resultPtr.Type(), "Expected pointer to slice of valid Models"}
 	}
 
-	table, err := a.getTableFromModel(reflect.New(resultVal.Type().Elem()).Interface())
+	// List accepts a slice of Models that can be either structs or pointer to
+	// structs
+	var appendValue func(reflect.Value)
+	var m model.Model
+	if resultVal.Type().Elem().Kind() == reflect.Ptr {
+		m = reflect.New(resultVal.Type().Elem().Elem()).Interface()
+		appendValue = func(v reflect.Value) {
+			resultVal.Set(reflect.Append(resultVal, v))
+		}
+	} else {
+		m = reflect.New(resultVal.Type().Elem()).Interface()
+		appendValue = func(v reflect.Value) {
+			resultVal.Set(reflect.Append(resultVal, reflect.Indirect(v)))
+		}
+	}
+
+	table, err := a.getTableFromModel(m)
 	if err != nil {
 		return err
 	}
@@ -141,7 +162,7 @@ func (a api) List(ctx context.Context, result interface{}) error {
 		// clone only the models that match the predicate
 		m := model.Clone(row)
 
-		resultVal.Set(reflect.Append(resultVal, reflect.Indirect(reflect.ValueOf(m))))
+		appendValue(reflect.ValueOf(m))
 		i++
 	}
 	return nil
@@ -401,6 +422,80 @@ func (a api) Delete() ([]ovsdb.Operation, error) {
 				Where: condition,
 			},
 		)
+	}
+
+	return operations, nil
+}
+
+func (a api) Wait(untilConFun ovsdb.WaitCondition, timeout *int, model model.Model, fields ...interface{}) ([]ovsdb.Operation, error) {
+	var operations []ovsdb.Operation
+
+	/*
+		    Ref: https://datatracker.ietf.org/doc/html/rfc7047.txt#section-5.2.6
+
+			lb := &nbdb.LoadBalancer{}
+			condition := model.Condition{
+				Field:    &lb.Name,
+				Function: ovsdb.ConditionEqual,
+				Value:    "lbName",
+			}
+			timeout0 := 0
+			client.Where(lb, condition).Wait(
+				ovsdb.WaitConditionNotEqual, // Until
+				&timeout0, // Timeout
+				&lb, // Row (and Table)
+				&lb.Name, // Cols (aka fields)
+			)
+	*/
+
+	conditions, err := a.cond.Generate()
+	if err != nil {
+		return nil, err
+	}
+
+	table, err := a.getTableFromModel(model)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := a.cache.DatabaseModel().NewModelInfo(model)
+	if err != nil {
+		return nil, err
+	}
+
+	var columnNames []string
+	if len(fields) > 0 {
+		columnNames = make([]string, 0, len(fields))
+		for _, f := range fields {
+			colName, err := info.ColumnByPtr(f)
+			if err != nil {
+				return nil, err
+			}
+			columnNames = append(columnNames, colName)
+		}
+	}
+
+	row, err := a.cache.Mapper().NewRow(info, fields...)
+	if err != nil {
+		return nil, err
+	}
+	rows := []ovsdb.Row{row}
+
+	for _, condition := range conditions {
+		operation := ovsdb.Operation{
+			Op:      ovsdb.OperationWait,
+			Table:   table,
+			Where:   condition,
+			Until:   string(untilConFun),
+			Columns: columnNames,
+			Rows:    rows,
+		}
+
+		if timeout != nil {
+			operation.Timeout = timeout
+		}
+
+		operations = append(operations, operation)
 	}
 
 	return operations, nil

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/mapper/info.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/mapper/info.go
@@ -7,6 +7,24 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
+// ErrColumnNotFound is an error that can occur when the column does not exist for a table
+type ErrColumnNotFound struct {
+	column string
+	table  string
+}
+
+// Error implements the error interface
+func (e *ErrColumnNotFound) Error() string {
+	return fmt.Sprintf("column: %s not found in table: %s", e.column, e.table)
+}
+
+func NewErrColumnNotFound(column, table string) *ErrColumnNotFound {
+	return &ErrColumnNotFound{
+		column: column,
+		table:  table,
+	}
+}
+
 // Info is a struct that wraps an object with its metadata
 type Info struct {
 	// FieldName indexed by column
@@ -25,7 +43,7 @@ type Metadata struct {
 func (i *Info) FieldByColumn(column string) (interface{}, error) {
 	fieldName, ok := i.Metadata.Fields[column]
 	if !ok {
-		return nil, fmt.Errorf("FieldByColumn: column %s not found in orm info", column)
+		return nil, NewErrColumnNotFound(column, i.Metadata.TableName)
 	}
 	return reflect.ValueOf(i.Obj).Elem().FieldByName(fieldName).Interface(), nil
 }

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/condition.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/condition.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ConditionFunction string
+type WaitCondition string
 
 const (
 	// ConditionLessThan is the less than condition
@@ -25,6 +26,11 @@ const (
 	ConditionIncludes ConditionFunction = "includes"
 	// ConditionExcludes is the excludes condition
 	ConditionExcludes ConditionFunction = "excludes"
+
+	// WaitConditionEqual is the equal condition
+	WaitConditionEqual WaitCondition = "=="
+	// WaitConditionNotEqual is the not equal condition
+	WaitConditionNotEqual WaitCondition = "!="
 )
 
 // Condition is described in RFC 7047: 5.1

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -232,7 +232,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220127023511-a619f0fd93be
+# github.com/ovn-org/libovsdb v0.6.1-0.20220225160119-c8b4494412b1
 ## explicit; go 1.16
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client


### PR DESCRIPTION
```
9598c132c2616 Fixes client error handling
fc5e884e9f41a Moves client error handling from the cache to client
87acccaf29896 client: use LastTransactionID when the only monitor is a CondSince one
5b14611220b61 test: Using wait api with integration
bb1929ac6d2ec Mapper: FieldByColumn error message shall contain table name
ebe15cf84d8c4 Fix libovsdb server close
976fa4167e523 adding Wait to client api
6791b3ba1f1ce api: support pointer to slice of Models for List
```