### PR TITLE
kube: bump kube API QPS to 50

### DIFF
--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -88,8 +88,8 @@ func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error
 	if err != nil {
 		return nil, err
 	}
-	kconfig.QPS = 25
-	kconfig.Burst = 25
+	kconfig.QPS = 50
+	kconfig.Burst = 50
 	// if all the clients are behind HA-Proxy, then on the K8s API server side we only
 	// see the HAProxy's IP and we can't tell the actual client making the request.
 	kconfig.UserAgent = fmt.Sprintf("%s/%s@%s (%s/%s) kubernetes/%s",


### PR DESCRIPTION
In some scale tests we get client-side throttling.

Though perhaps we should get @squeed to do another audit of our direct API usage.

@trozet @jcaamano @tssurya 