### PR TITLE
Fixes improper validation of gw cache on pod add

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -191,7 +191,7 @@ func (oc *Controller) addPodExternalGWForNamespace(namespace string, pod *kapi.P
 		return fmt.Errorf("failed to ensure namespace locked: %v", err)
 	}
 	tmpPodGWs := oc.getRoutingPodGWs(nsInfo)
-	tmpPodGWs[pod.Name] = egress
+	tmpPodGWs[makePodGWKey(pod)] = egress
 	if err = validateRoutingPodGWs(tmpPodGWs); err != nil {
 		nsUnlock()
 		return fmt.Errorf("unable to add pod: %s/%s as external gateway for namespace: %s, error: %v",


### PR DESCRIPTION
The map is keyed by namespace_pod, but was accidentally adding the new
pod by pod name only. If this was a retry pod add it could result in the
an error like:

duplicate IP found in ECMP Pod route cache! IP: "192.168.222.33",
first pod: "dep-serving-33-4-serving-job-66f7948f5d-dzx52", second pod:
"serving-ns-33_dep-serving-33-4-serving-job-66f7948f5d-dzx52"

Signed-off-by: Tim Rozet <trozet@redhat.com>

