### PR TITLE
cleanup: read from informers where possible

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -83,7 +83,7 @@ func NewMaster(kube kube.Interface,
 	}
 
 	// Mark existing hostsubnets as already allocated
-	existingNodes, err := m.kube.GetNodes()
+	existingNodes, err := m.kube.GetNodes() //nolint:staticcheck // We need to list nodes before the informer starts
 	if err != nil {
 		return nil, fmt.Errorf("error in initializing/fetching subnets: %v", err)
 	}

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -555,7 +555,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(initialDatabaseState))
 
 			k := &kube.Kube{KClient: fakeClient}
-			updatedNode, err := k.GetNode(nodeName)
+			updatedNode, err := k.GetNode(nodeName) //nolint:staticcheck
 			Expect(err).NotTo(HaveOccurred())
 
 			nodeAnnotator := kube.NewNodeAnnotator(k, updatedNode.Name)
@@ -564,7 +564,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() (map[string]string, error) {
-				updatedNode, err = k.GetNode(nodeName)
+				updatedNode, err = k.GetNode(nodeName) //nolint:staticcheck
 				if err != nil {
 					return nil, err
 				}

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -12,6 +12,7 @@ import (
 	egressfirewallapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	egressfirewallscheme "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/scheme"
 	egressfirewallinformerfactory "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/informers/externalversions"
+	egressfirewalllisters "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/listers/egressfirewall/v1"
 
 	egressipapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	egressipscheme "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/scheme"
@@ -587,6 +588,11 @@ func (wf *WatchFactory) GetNamespacesBySelector(labelSelector metav1.LabelSelect
 	return namespaceLister.List(selector)
 }
 
+func (wf *WatchFactory) GetEgressFirewalls() ([]*egressfirewallapi.EgressFirewall, error) {
+	l := wf.informers[egressFirewallType].lister.(egressfirewalllisters.EgressFirewallLister)
+	return l.List(nil)
+}
+
 // GetNetworkPolicy gets a specific network policy by the namespace/name
 func (wf *WatchFactory) GetNetworkPolicy(namespace, name string) (*knet.NetworkPolicy, error) {
 	networkPolicyLister := wf.informers[policyType].lister.(netlisters.NetworkPolicyLister)
@@ -595,6 +601,10 @@ func (wf *WatchFactory) GetNetworkPolicy(namespace, name string) (*knet.NetworkP
 
 func (wf *WatchFactory) NodeInformer() cache.SharedIndexInformer {
 	return wf.informers[nodeType].inf
+}
+
+func (wf *WatchFactory) NodeLister() listers.NodeLister {
+	return wf.informers[nodeType].lister.(listers.NodeLister)
 }
 
 // LocalPodInformer returns a shared Informer that may or may not only

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -336,7 +336,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 		return err
 	}
 
-	if node, err = n.Kube.GetNode(n.name); err != nil {
+	if node, err = n.Kube.GetNode(n.name); err != nil { //nolint:staticcheck
 		return fmt.Errorf("error retrieving node %s: %v", n.name, err)
 	}
 
@@ -364,7 +364,7 @@ func (n *OvnNode) Start(wg *sync.WaitGroup) error {
 
 	// First wait for the node logical switch to be created by the Master, timeout is 300s.
 	err = wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
-		if node, err = n.Kube.GetNode(n.name); err != nil {
+		if node, err = n.watchFactory.GetNode(n.name); err != nil {
 			klog.Infof("Waiting to retrieve node %s: %v", n.name, err)
 			return false, nil
 		}

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -190,12 +190,12 @@ func (oc *Controller) syncEgressFirewallRetriable(egressFirewalls []interface{})
 	}
 
 	// get all the k8s EgressFirewall Objects
-	egressFirewallList, err := oc.kube.GetEgressFirewalls()
+	egressFirewallList, err := oc.watchFactory.GetEgressFirewalls()
 	if err != nil {
 		return fmt.Errorf("cannot reconcile the state of egressfirewalls in ovn database and k8s. err: %v", err)
 	}
 	// delete entries from the map that exist in k8s and ovn
-	for _, egressFirewall := range egressFirewallList.Items {
+	for _, egressFirewall := range egressFirewallList {
 		delete(ovnEgressFirewalls, egressFirewall.Namespace)
 	}
 	// any that are left are spurious and should be cleaned up

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -231,7 +231,7 @@ func (oc *Controller) StartClusterMaster(masterNodeName string) error {
 		return err
 	}
 
-	existingNodes, err := oc.kube.GetNodes()
+	existingNodes, err := oc.kube.GetNodes() //nolint:staticcheck // We need to list nodes before the informer starts
 	if err != nil {
 		klog.Errorf("Error in fetching nodes: %v", err)
 		return err
@@ -1302,7 +1302,7 @@ func (oc *Controller) clearInitialNodeNetworkUnavailableCondition(origNode, newN
 	resultErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var err error
 
-		oldNode, err := oc.kube.GetNode(origNode.Name)
+		oldNode, err := oc.kube.GetNode(origNode.Name) //nolint:staticcheck
 		if err != nil {
 			return err
 		}
@@ -1336,8 +1336,8 @@ func (oc *Controller) clearInitialNodeNetworkUnavailableCondition(origNode, newN
 // this is the worker function that does the periodic sync of nodes from kube API
 // and sbdb and deletes chassis that are stale
 func (oc *Controller) syncNodesPeriodic() {
-	//node names is a slice of all node names
-	nodes, err := oc.kube.GetNodes()
+	// node names is a slice of all node names
+	nodes, err := oc.kube.GetNodes() //nolint:staticcheck // We need to list nodes before the informer starts
 	if err != nil {
 		klog.Errorf("Error getting existing nodes from kube API: %v", err)
 		return

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -447,7 +447,7 @@ func (oc *Controller) Run(wg *sync.WaitGroup, nodeName string) error {
 	}
 
 	// Update topology version on node
-	node, err := oc.kube.GetNode(nodeName)
+	node, err := oc.kube.GetNode(nodeName) //nolint:staticcheck
 	if err != nil {
 		return fmt.Errorf("unable to get node: %s", nodeName)
 	}

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -226,7 +226,7 @@ func ensureClusterRaftMembership(db *dbProperties, kclient kube.Interface) error
 	members := r.FindAllStringSubmatch(out, -1)
 	kickedMembersCount := 0
 	dbAppLabel := map[string]string{"ovn-db-pod": "true"}
-	dbPods, err := kclient.GetPods(config.Kubernetes.OVNConfigNamespace,
+	dbPods, err := kclient.GetPods(config.Kubernetes.OVNConfigNamespace, //nolint:staticcheck // We don't have a running informer
 		metav1.LabelSelector{
 			MatchLabels: dbAppLabel,
 		})


### PR DESCRIPTION
This changes some code to read from the existing informer store wherever possible. It was noticed in #2844 that we were hitting 50 qps, which is a lot. This doesn't directly attempt to fix that, but patches up some obvious places where we can do better.

Signed-off-by: Casey Callendrello <cdc@redhat.com>