### PR TITLE
daemonset.sh: Add missing install_j2_renderer function

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -4,6 +4,13 @@
 #Always exit on errors
 set -e
 
+install_j2_renderer() {
+  # ensure j2 renderer installed
+  pip install wheel --user
+  pip freeze | grep j2cli || pip install j2cli[yaml] --user
+  export PATH=~/.local/bin:$PATH
+}
+
 # The script renders j2 templates into yaml files in ../yaml/
 
 # ensure j2 renderer installed


### PR DESCRIPTION
`make fedora` complains:
```
# docker login -u ovnkube docker.io/ovnkube
# docker push docker.io/ovnkube/ovn-daemonset-f:latest
./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset-f:latest
'j2' not found, installing with 'pip'
./daemonset.sh: line 16: install_j2_renderer: command not found
make: *** [Makefile:40: fedora] Error 127
```
Reuse the `install_j2_renderer` function from `contrib/kind.sh`

Signed-off-by: Alin-Gabriel Serdean <aserdean@ovn.org>
