### PR TITLE
Fix nodePort service backed by pods on hybrid overlay nodes

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -333,6 +333,7 @@ func (m *MasterController) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet,
 		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.dst == %s`,
 			ovntypes.RouterToSwitchPrefix, nodeName, L3Prefix, hybridCIDR)
 
+		// Logic route policy to steer packet from pod to hybrid overlay nodes
 		logicalRouterPolicy := nbdb.LogicalRouterPolicy{
 			Priority: ovntypes.HybridOverlaySubnetPriority,
 			ExternalIDs: map[string]string{
@@ -342,31 +343,110 @@ func (m *MasterController) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet,
 			Nexthops: []string{drIP.String()},
 			Match:    matchStr,
 		}
-		p := func(item *nbdb.LogicalRouterPolicy) bool {
+
+		if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &logicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
 			return item.Priority == logicalRouterPolicy.Priority &&
 				item.ExternalIDs["name"] == logicalRouterPolicy.ExternalIDs["name"]
-		}
-
-		if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &logicalRouterPolicy, p); err != nil {
+		}); err != nil {
 			return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
 		}
-		klog.Infof("Created hybrid overlay logical route policy for node %s", nodeName)
 
 		logicalPort := ovntypes.RouterToSwitchPrefix + nodeName
 		if err := util.CreateMACBinding(m.sbClient, logicalPort, ovntypes.OVNClusterRouter, portMac, drIP); err != nil {
 			return fmt.Errorf("failed to create MAC Binding for hybrid overlay: %v", err)
 		}
+
+		// Logic route policy to steer packet from external to nodePort service backed by non-ovnkube pods to hybrid overlay nodes
+		gwLRPIfAddrs, err := util.GetLRPAddrs(m.nbClient, ovntypes.GWRouterToJoinSwitchPrefix+ovntypes.GWRouterPrefix+nodeName)
+		if err != nil {
+			return err
+		}
+		gwLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), gwLRPIfAddrs)
+		if err != nil {
+			return err
+		}
+		grMatchStr := fmt.Sprintf(`%s.src == %s && %s.dst == %s`,
+			L3Prefix, gwLRPIfAddr.IP.String(), L3Prefix, hybridCIDR)
+		grLogicalRouterPolicy := nbdb.LogicalRouterPolicy{
+			Priority: ovntypes.HybridOverlaySubnetPriority,
+			ExternalIDs: map[string]string{
+				"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
+			},
+			Action:   nbdb.LogicalRouterPolicyActionReroute,
+			Nexthops: []string{drIP.String()},
+			Match:    grMatchStr,
+		}
+
+		if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &grLogicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
+			return item.Priority == grLogicalRouterPolicy.Priority &&
+				item.ExternalIDs["name"] == grLogicalRouterPolicy.ExternalIDs["name"]
+		}); err != nil {
+			return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
+		}
+		klog.Infof("Created hybrid overlay logical route policies for node %s", nodeName)
+
+		// Static route to steer packets from external to nodePort service backed by pods on hybrid overlay node.
+		// This route is to used for triggering above route policy
+		clutsterRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
+			IPPrefix: hybridCIDR.String(),
+			Nexthop:  drIP.String(),
+			ExternalIDs: map[string]string{
+				"name": ovntypes.HybridSubnetPrefix + nodeName,
+			},
+		}
+		if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &clutsterRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
+			return item.IPPrefix == clutsterRouterStaticRoutes.IPPrefix && item.Nexthop == clutsterRouterStaticRoutes.Nexthop &&
+				item.ExternalIDs["name"] == clutsterRouterStaticRoutes.ExternalIDs["name"]
+		}); err != nil {
+			return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", clutsterRouterStaticRoutes.IPPrefix, clutsterRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
+		}
+		klog.Infof("Created hybrid overlay logical route static route at cluster router for node %s", nodeName)
+
+		// Static route to steer packets from external to nodePort service backed by pods on hybrid overlay node to cluster router.
+		drLRPIfAddrs, err := util.GetLRPAddrs(m.nbClient, ovntypes.GWRouterToJoinSwitchPrefix+ovntypes.OVNClusterRouter)
+		if err != nil {
+			return err
+		}
+		drLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), drLRPIfAddrs)
+		if err != nil {
+			return fmt.Errorf("failed to match cluster router join interface IPs: %v, err: %v", drLRPIfAddr, err)
+		}
+		nodeGWRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
+			IPPrefix: hybridCIDR.String(),
+			Nexthop:  drLRPIfAddr.IP.String(),
+			ExternalIDs: map[string]string{
+				"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
+			},
+		}
+		if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(m.nbClient, ovntypes.GWRouterPrefix+nodeName, &nodeGWRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
+			return item.IPPrefix == nodeGWRouterStaticRoutes.IPPrefix && item.Nexthop == nodeGWRouterStaticRoutes.Nexthop &&
+				item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"]
+		}); err != nil {
+			return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
+		}
+		klog.Infof("Created hybrid overlay logical route static route at gateway router for node %s", nodeName)
 	}
 	return nil
 }
 
 func (m *MasterController) removeHybridLRPolicySharedGW(nodeName string) error {
-	policyName := ovntypes.HybridSubnetPrefix + nodeName
-	p := func(item *nbdb.LogicalRouterPolicy) bool {
-		return item.ExternalIDs["name"] == policyName
+	name := ovntypes.HybridSubnetPrefix + nodeName
+
+	if err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterPolicy) bool {
+		return item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName || item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName+"-gr"
+	}); err != nil {
+		return fmt.Errorf("failed to delete policy %s from %s, error: %v", name, ovntypes.OVNClusterRouter, err)
 	}
-	if err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, p); err != nil {
-		return fmt.Errorf("failed to delete policy %s from %s, error: %v", policyName, ovntypes.OVNClusterRouter, err)
+
+	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterStaticRoute) bool {
+		return item.ExternalIDs["name"] == name
+	}); err != nil {
+		return fmt.Errorf("failed to delete static route %s from %s, error: %v", name, ovntypes.OVNClusterRouter, err)
+	}
+	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(m.nbClient, ovntypes.GWRouterPrefix+nodeName, func(item *nbdb.LogicalRouterStaticRoute) bool {
+		return item.ExternalIDs["name"] == name+"-gr"
+	}); err != nil {
+		return fmt.Errorf("failed to delete static route %s from %s, error: %v", name+"gr", ovntypes.GWRouterPrefix+nodeName, err)
 	}
 	return nil
 }

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -174,6 +174,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				nodeSubnet string = "10.1.2.0/24"
 				nodeHOIP   string = "10.1.2.3"
 				nodeHOMAC  string = "0a:58:0a:01:02:03"
+				hoSubnet   string = "11.1.0.0/16"
 			)
 
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
@@ -196,9 +197,32 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				UUID: types.OVNClusterRouter + "-UUID",
 			}
 
+			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
+				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
+				Networks: []string{"100.64.0.1/16"},
+				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
+			}
+			ovnClusterRouter.Ports = []string{ovnClusterRouterLRP.UUID}
+
+			nodeGWRouter := &nbdb.LogicalRouter{
+				Name: types.GWRouterPrefix + nodeName,
+				UUID: types.GWRouterPrefix + nodeName + "-UUID",
+			}
+
+			nodeGWLRP := &nbdb.LogicalRouterPort{
+				Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName,
+				Networks: []string{"100.64.0.2/16"},
+				UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName + "-UUID",
+			}
+
+			nodeGWRouter.Ports = []string{nodeGWLRP.UUID}
+
 			initialNBDB := []libovsdbtest.TestData{
 				nodeSwitch,
 				ovnClusterRouter,
+				ovnClusterRouterLRP,
+				nodeGWRouter,
+				nodeGWLRP,
 			}
 
 			// pre-existing sbdb objects
@@ -242,7 +266,18 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			// make sure the expected LRP is created and added to cluster router
-			expectedLRP := &nbdb.LogicalRouterPolicy{
+			expectedLRP1 := &nbdb.LogicalRouterPolicy{
+				Priority: 1002,
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node1-gr",
+				},
+				Action:   nbdb.LogicalRouterPolicyActionReroute,
+				Nexthops: []string{nodeHOIP},
+				Match:    "ip4.src == 100.64.0.2 && ip4.dst == 11.1.0.0/16",
+				UUID:     "expectedLRP-1-UUID",
+			}
+
+			expectedLRP2 := &nbdb.LogicalRouterPolicy{
 				Priority: 1002,
 				ExternalIDs: map[string]string{
 					"name": "hybrid-subnet-node1",
@@ -250,11 +285,31 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				Action:   nbdb.LogicalRouterPolicyActionReroute,
 				Nexthops: []string{nodeHOIP},
 				Match:    "inport == \"rtos-node1\" && ip4.dst == 11.1.0.0/16",
-				UUID:     "expectedLRP-UUID",
+				UUID:     "expectedLRP-2-UUID",
+			}
+
+			expectedLRSR := &nbdb.LogicalRouterStaticRoute{
+				IPPrefix: hoSubnet,
+				Nexthop:  nodeHOIP,
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node1",
+				},
+				UUID: "expectedLRSR-UUID",
 			}
 
 			nodeSwitch.Ports = []string{expectedLSP.UUID}
-			ovnClusterRouter.Policies = []string{expectedLRP.UUID}
+			ovnClusterRouter.Policies = []string{expectedLRP1.UUID, expectedLRP2.UUID}
+			ovnClusterRouter.StaticRoutes = []string{expectedLRSR.UUID}
+
+			expectedGRLRSR := &nbdb.LogicalRouterStaticRoute{
+				IPPrefix: hoSubnet,
+				Nexthop:  "100.64.0.1",
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node1-gr",
+				},
+				UUID: "expectedGRLRSR-UUID",
+			}
+			nodeGWRouter.StaticRoutes = []string{expectedGRLRSR.UUID}
 
 			expectedMACBinding := &sbdb.MACBinding{
 				Datapath:    clusterRouterDatapath.UUID,
@@ -284,8 +339,14 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			expectedNBDatabaseState := []libovsdbtest.TestData{
 				nodeSwitch,
 				ovnClusterRouter,
+				ovnClusterRouterLRP,
+				nodeGWRouter,
+				nodeGWLRP,
 				expectedLSP,
-				expectedLRP,
+				expectedLRP1,
+				expectedLRP2,
+				expectedLRSR,
+				expectedGRLRSR,
 			}
 
 			expectedSBDatabaseState := []libovsdbtest.TestData{
@@ -308,9 +369,16 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			// LSP should have been deleted and removed
 			nodeSwitch.Ports = []string{}
 
+			// Static Route should have been deleted and removed
+			ovnClusterRouter.StaticRoutes = []string{}
+			nodeGWRouter.StaticRoutes = []string{}
+
 			expectedNBDatabaseState = []libovsdbtest.TestData{
 				ovnClusterRouter,
 				nodeSwitch,
+				nodeGWRouter,
+				nodeGWLRP,
+				ovnClusterRouterLRP,
 			}
 
 			// in a real db, deleting the HO LSP would result in the Mac Binding being removed as well
@@ -340,6 +408,7 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				nodeSubnet string = "10.1.2.0/24"
 				nodeHOIP   string = "10.1.2.3"
 				nodeHOMAC  string = "00:00:00:52:19:d2"
+				hoSubnet   string = "11.1.0.0/16"
 			)
 
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
@@ -362,7 +431,18 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				DynamicAddresses: &dynAdd,
 			}
 
-			existingLRP := &nbdb.LogicalRouterPolicy{
+			existingLRP1 := &nbdb.LogicalRouterPolicy{
+				UUID:     "hybrid-subnet-node1-1-UUID",
+				Priority: 1002,
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node1-gr",
+				},
+				Action:   nbdb.LogicalRouterPolicyActionReroute,
+				Nexthops: []string{nodeHOIP},
+				Match:    "ip4.src == 100.64.0.2 && ip4.dst == 11.1.0.0/16",
+			}
+
+			existingLRP2 := &nbdb.LogicalRouterPolicy{
 				Priority: 1002,
 				ExternalIDs: map[string]string{
 					"name": "hybrid-subnet-node1",
@@ -370,13 +450,37 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				Action:   nbdb.LogicalRouterPolicyActionReroute,
 				Nexthops: []string{nodeHOIP},
 				Match:    "inport == \"rtos-node1\" && ip4.dst == 11.1.0.0/16",
-				UUID:     "hybrid-subnet-node1-UUID",
+				UUID:     "hybrid-subnet-node1-2-UUID",
+			}
+
+			existingLRSR := &nbdb.LogicalRouterStaticRoute{
+				UUID:     "hybrid-subnet-node1-LRSR-UUID",
+				IPPrefix: hoSubnet,
+				Nexthop:  nodeHOIP,
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node1",
+				},
+			}
+
+			existingGRLRSR := &nbdb.LogicalRouterStaticRoute{
+				UUID:     "hybrid-subnet-node1-GRLRSR-UUID",
+				IPPrefix: hoSubnet,
+				Nexthop:  "100.64.0.1",
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node1-gr",
+				},
 			}
 
 			nodeSwitch := &nbdb.LogicalSwitch{
 				Name:  nodeName,
-				UUID:  nodeName + "-UUID",
+				UUID:  nodeName + "-LS-UUID",
 				Ports: []string{existingLSP.UUID},
+			}
+
+			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
+				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
+				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
+				Networks: []string{"100.64.0.1/16"},
 			}
 
 			ovnClusterRouter := &nbdb.LogicalRouter{
@@ -384,14 +488,33 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 				UUID: types.OVNClusterRouter + "-UUID",
 				// Something in the test harness causes this names uuid to be added again
 				// comment out for now
-				// Policies: []string{existingLRP.UUID},
+
+				Ports: []string{ovnClusterRouterLRP.UUID},
+			}
+			nodeGWLRP := &nbdb.LogicalRouterPort{
+				UUID:     nodeName + "-LRP-UUID",
+				Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + nodeName,
+				Networks: []string{"100.64.0.2/16"},
+			}
+
+			nodeGWRouter := &nbdb.LogicalRouter{
+				UUID:         nodeName + "-LR-UUID",
+				Name:         types.GWRouterPrefix + nodeName,
+				Ports:        []string{nodeGWLRP.UUID},
+				StaticRoutes: []string{existingGRLRSR.UUID},
 			}
 
 			initialNBDB := []libovsdbtest.TestData{
 				nodeSwitch,
 				ovnClusterRouter,
-				existingLRP,
+				existingLRP1,
+				existingLRP2,
+				existingLRSR,
+				existingGRLRSR,
 				existingLSP,
+				ovnClusterRouterLRP,
+				nodeGWRouter,
+				nodeGWLRP,
 			}
 
 			// pre-existing sbdb objects
@@ -456,7 +579,8 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 
 			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			// OVN DB state shouldn't change here
-			ovnClusterRouter.Policies = []string{existingLRP.UUID}
+			ovnClusterRouter.Policies = []string{existingLRP1.UUID, existingLRP2.UUID}
+			ovnClusterRouter.StaticRoutes = []string{existingLRSR.UUID}
 			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(dbSetup.NBData))
 			Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveData(dbSetup.SBData))
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -776,10 +776,32 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 }
 
 func (oc *Controller) addNodeAnnotations(node *kapi.Node, hostSubnets []*net.IPNet) error {
+	gwLRPIPs, err := oc.joinSwIPManager.EnsureJoinLRPIPs(node.Name)
+	if err != nil {
+		return fmt.Errorf("failed to allocate join switch port IP address for node %s: %v", node.Name, err)
+	}
+	var v4Addr, v6Addr *net.IPNet
+	for _, ip := range gwLRPIPs {
+		if ip.IP.To4() != nil {
+			v4Addr = ip
+		} else if ip.IP.To16() != nil {
+			v6Addr = ip
+		}
+	}
+	gwLPRAnnotations, err := util.CreateNodeGateRouterLRPAddrAnnotation(v4Addr, v6Addr)
+	if err != nil {
+		return fmt.Errorf("failed to marshal node %q annotation for Gateway LRP IP %v",
+			node.Name, gwLRPIPs)
+	}
+
 	nodeAnnotations, err := util.CreateNodeHostSubnetAnnotation(hostSubnets)
 	if err != nil {
 		return fmt.Errorf("failed to marshal node %q annotation for subnet %s",
 			node.Name, util.JoinIPNets(hostSubnets, ","))
+	}
+
+	for k, v := range gwLPRAnnotations {
+		nodeAnnotations[k] = v
 	}
 	// FIXME: the real solution is to reconcile the node object. Once we have a work-queue based
 	// implementation where we can add the item back to the work queue when it fails to


### PR DESCRIPTION
In a cluster with hybrid overlay, after the ingress traffic is DNATed
by the ovnkube node's gateway router LB rule, the dst ip of some packets
will be changed to the ip of non-onvkube managed pods. We need to
steer this traffic to the hybrid overlay vxlan tunnel through the
node switch.

With this patch, the packects will be first forwarded from the GR to
cluster router. Then based on the routing policy, the packets will be
forwarded to the hybrid overlay bridge. At the hybrid overlay bridge
stateless SNAT rules will change the src ip to the node's Distributed
Router's.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->