### PR TITLE
node, services: detect when node IPs change

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -538,6 +538,12 @@ func (wf *WatchFactory) GetService(namespace, name string) (*kapi.Service, error
 	return serviceLister.Services(namespace).Get(name)
 }
 
+// GetServices returns all services
+func (wf *WatchFactory) GetServices() ([]*kapi.Service, error) {
+	serviceLister := wf.informers[serviceType].lister.(listers.ServiceLister)
+	return serviceLister.List(labels.Everything())
+}
+
 // GetEndpoints returns the endpoints list in a given namespace
 func (wf *WatchFactory) GetEndpoints(namespace string) ([]*kapi.Endpoints, error) {
 	endpointsLister := wf.informers[endpointsType].lister.(listers.EndpointsLister)

--- a/go-controller/pkg/factory/types.go
+++ b/go-controller/pkg/factory/types.go
@@ -48,6 +48,7 @@ type NodeWatchFactory interface {
 	GetNode(name string) (*kapi.Node, error)
 
 	GetService(namespace, name string) (*kapi.Service, error)
+	GetServices() ([]*kapi.Service, error)
 	GetEndpoint(namespace, name string) (*kapi.Endpoints, error)
 }
 

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -41,6 +41,7 @@ type gateway struct {
 	nodeIPManager   *addressManager
 	initFunc        func() error
 	readyFunc       func() (bool, error)
+	initDone        bool
 }
 
 func (g *gateway) AddService(svc *kapi.Service) {
@@ -166,6 +167,7 @@ func (g *gateway) Init(wf factory.NodeWatchFactory) error {
 			g.DeleteEndpoints(ep)
 		},
 	}, nil)
+	g.initDone = true
 	return nil
 }
 

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -71,7 +71,7 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 			return err
 		}
 
-		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory)
+		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory, nil)
 
 		if config.Gateway.NodeportEnable {
 			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge.patchPort, gwBridge.bridgeName, gwBridge.uplinkName, gwBridge.ips, gw.openflowManager, gw.nodeIPManager, watchFactory)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -58,7 +58,7 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNClientset, fak
 	}
 
 	k := &kube.Kube{fakeClient.KubeClient, nil, nil, nil}
-	n.nodeIPManager = newAddressManager(fakeNodeName, k, fakeMgmtPortConfig, n.watchFactory)
+	n.nodeIPManager = newAddressManager(fakeNodeName, k, fakeMgmtPortConfig, n.watchFactory, nil)
 	localHostNetEp := "192.168.18.15/32"
 	ip, _, _ := net.ParseCIDR(localHostNetEp)
 	n.nodeIPManager.addAddr(ip)

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -116,11 +116,13 @@ func hasLocalHostNetworkEndpoints(ep *kapi.Endpoints, nodeAddresses *sets.String
 		for i := range ss.Addresses {
 			addr := &ss.Addresses[i]
 			if nodeAddresses.Has(addr.IP) {
+				klog.V(5).Infof("Endpoints %s/%s has host-local endpoints", ep.Namespace, ep.Name)
 				return true
 			}
 		}
 	}
 
+	klog.V(5).Infof("Endpoints %s/%s does NOT have host-local endpoints", ep.Namespace, ep.Name)
 	return false
 }
 

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -493,3 +493,7 @@ func ParseNodeHostAddresses(node *kapi.Node) (sets.String, error) {
 
 	return sets.NewString(cfg...), nil
 }
+
+func NodeHostAddressesChanged(oldNode, newNode *kapi.Node) bool {
+	return oldNode.Annotations[ovnNodeHostAddresses] != newNode.Annotations[ovnNodeHostAddresses]
+}


### PR DESCRIPTION
It was discovered that, on the node, we don't actually react to ip address set changes correctly. We set annotations, but don't recreate any necessary flows.

This is problematic for cases where "secondary" node IPs are added after initialization.

This change has two parts:
- Re-sync services on the node (for shared-gw mode) if ip set changes
- Use the host-addresses annotation when computing "local" endpoints in
  the service controller