### PR TITLE
Use libovsdb API for Wait operation

### DIFF
--- a/go-controller/pkg/libovsdbops/model_client.go
+++ b/go-controller/pkg/libovsdbops/model_client.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"reflect"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
@@ -118,7 +119,7 @@ type OperationModel struct {
 	// Name indicates that during a Create the model will have a predicate
 	// operation to ensure a duplicate txn will not occur. See:
 	// https://bugzilla.redhat.com/show_bug.cgi?id=2042001
-	Name string
+	Name interface{}
 }
 
 // WithClient is useful for ad-hoc override of the targetted OVS DB. Can be used,
@@ -295,31 +296,24 @@ func (m *ModelClient) create(opModel *OperationModel) ([]ovsdb.Operation, error)
 	// ACL we would have to use external_ids + name for unique match
 	// However external_ids would be a performance hit, and in one case we use
 	// an empty name and external_ids for addAllowACLFromNode
-	if len(opModel.Name) > 0 && o[0].Table != "ACL" {
+	if opModel.Name != nil && o[0].Table != "ACL" {
 		timeout := types.OVSDBWaitTimeout
-		ops = append(ops, ovsdb.Operation{
-			Op:      ovsdb.OperationWait,
-			Timeout: &timeout,
-			Table:   o[0].Table,
-			Where:   []ovsdb.Condition{{Column: "name", Function: ovsdb.ConditionEqual, Value: opModel.Name}},
-			Columns: []string{"name"},
-			Until:   "!=",
-			Rows:    []ovsdb.Row{{"name": opModel.Name}},
-		})
+		condition := model.Condition{
+			Field:    opModel.Name,
+			Function: ovsdb.ConditionEqual,
+			Value:    getString(opModel.Name),
+		}
+		waitOps, err := m.client.Where(opModel.Model, condition).Wait(ovsdb.WaitConditionNotEqual, &timeout, opModel.Model, opModel.Name)
+		if err != nil {
+			return nil, err
+		}
+		ops = append(ops, waitOps...)
 	} else if info, err := m.client.Cache().DatabaseModel().NewModelInfo(opModel.Model); err == nil {
 		if name, err := info.FieldByColumn("name"); err == nil {
-			objName, ok := name.(string)
-			if !ok {
-				if strPtr, ok := name.(*string); ok {
-					if strPtr != nil {
-						objName = *strPtr
-					}
-				}
-			}
+			objName := getString(name)
 			if len(objName) > 0 {
 				klog.Warningf("OVSDB Create operation detected without setting opModel Name. Name: %s, %#v",
 					objName, info)
-
 			}
 		}
 	}
@@ -410,4 +404,16 @@ func addToExistingResult(model interface{}, existingResult interface{}) {
 	resultPtr := reflect.ValueOf(existingResult)
 	resultVal := reflect.Indirect(resultPtr)
 	resultVal.Set(reflect.Append(resultVal, reflect.Indirect(reflect.ValueOf(model))))
+}
+
+func getString(field interface{}) string {
+	objName, ok := field.(string)
+	if !ok {
+		if strPtr, ok := field.(*string); ok {
+			if strPtr != nil {
+				objName = *strPtr
+			}
+		}
+	}
+	return objName
 }

--- a/go-controller/pkg/libovsdbops/portgroup.go
+++ b/go-controller/pkg/libovsdbops/portgroup.go
@@ -2,6 +2,7 @@ package libovsdbops
 
 import (
 	"context"
+
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
@@ -66,15 +67,16 @@ func createOrUpdatePortGroupOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 
 	if err == libovsdbclient.ErrNotFound {
 		timeout := types.OVSDBWaitTimeout
-		ops = append(ops, libovsdb.Operation{
-			Op:      libovsdb.OperationWait,
-			Timeout: &timeout,
-			Table:   "Port_Group",
-			Where:   []libovsdb.Condition{{Column: "name", Function: libovsdb.ConditionEqual, Value: pg.Name}},
-			Columns: []string{"name"},
-			Until:   "!=",
-			Rows:    []libovsdb.Row{{"name": pg.Name}},
-		})
+		condition := model.Condition{
+			Field:    &pg.Name,
+			Function: libovsdb.ConditionEqual,
+			Value:    pg.Name,
+		}
+		waitOps, err := nbClient.Where(pg, condition).Wait(libovsdb.WaitConditionNotEqual, &timeout, pg, &pg.Name)
+		if err != nil {
+			return nil, err
+		}
+		ops = append(ops, waitOps...)
 		op, err := nbClient.Create(pg)
 		if err != nil {
 			return nil, err

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -320,7 +320,7 @@ func AddACLToNodeSwitch(nbClient libovsdbclient.Client, nodeName string, nodeACL
 			},
 		},
 		{
-			Name:           nodeSwitch.Name,
+			Name:           &nodeSwitch.Name,
 			Model:          &nodeSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 			OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -379,7 +379,7 @@ func (oc *Controller) createEgressFirewallRules(priority int, match, action, ext
 		switches = append(switches, &lsw)
 		opModels = append(opModels, []libovsdbops.OperationModel{
 			{
-				Name:           lsw.Name,
+				Name:           &lsw.Name,
 				Model:          &lsw,
 				ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == lsn },
 				OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -295,7 +295,7 @@ func (oc *Controller) createBFDStaticRoute(bfdEnabled bool, gw net.IP, podIP, gr
 				}
 			},
 		}, {
-			Name:  logicalRouter.Name,
+			Name:  &logicalRouter.Name,
 			Model: &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool {
 				return lr.Name == gr
@@ -697,7 +697,7 @@ func (oc *Controller) addHybridRoutePolicyForPod(podIP net.IP, node string) erro
 				},
 			},
 			{
-				Name:           logicalRouter.Name,
+				Name:           &logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 				OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1951,7 +1951,7 @@ func (e *egressIPController) createEgressReroutePolicy(filterOption, egressIPNam
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -2286,7 +2286,7 @@ func (oc *Controller) createLogicalRouterPolicy(match string, priority int) erro
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -67,7 +67,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 
 	opModels := []libovsdbops.OperationModel{
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 			OnModelUpdates: []interface{}{
@@ -128,7 +128,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			},
 		},
 		{
-			Name:           logicalSwitch.Name,
+			Name:           &logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.OVNJoinSwitch },
 			OnModelMutations: []interface{}{
@@ -165,7 +165,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 			OnModelMutations: []interface{}{
@@ -217,7 +217,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				},
 			},
 			{
-				Name:           logicalRouter.Name,
+				Name:           &logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 				OnModelMutations: []interface{}{
@@ -287,7 +287,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				},
 			},
 			{
-				Name:           logicalRouter.Name,
+				Name:           &logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 				OnModelMutations: []interface{}{
@@ -329,7 +329,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 				},
 			},
 			{
-				Name:           logicalRouter.Name,
+				Name:           &logicalRouter.Name,
 				Model:          &logicalRouter,
 				ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 				OnModelMutations: []interface{}{
@@ -382,7 +382,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 					},
 				},
 				{
-					Name:           logicalRouter.Name,
+					Name:           &logicalRouter.Name,
 					Model:          &logicalRouter,
 					ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 					OnModelMutations: []interface{}{
@@ -506,7 +506,7 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 	}
 	opModels := []libovsdbops.OperationModel{
 		{
-			Name:           externalLogicalSwitch.Name,
+			Name:           &externalLogicalSwitch.Name,
 			Model:          &externalLogicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == externalSwitch },
 		},
@@ -545,7 +545,7 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 			},
 		},
 		{
-			Name:           externalLogicalSwitch.Name,
+			Name:           &externalLogicalSwitch.Name,
 			Model:          &externalLogicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == externalSwitch },
 			OnModelMutations: []interface{}{
@@ -589,7 +589,7 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == gatewayRouter },
 			OnModelMutations: []interface{}{
@@ -626,7 +626,7 @@ func (oc *Controller) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRo
 			},
 		},
 		{
-			Name:           externalLogicalSwitch.Name,
+			Name:           &externalLogicalSwitch.Name,
 			Model:          &externalLogicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == externalSwitch },
 			OnModelMutations: []interface{}{
@@ -795,7 +795,7 @@ func (oc *Controller) createPolicyBasedRoutes(match, priority, nexthops string) 
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -328,7 +328,7 @@ func (oc *Controller) StartClusterMaster() error {
 		// mention that field in OnModelUpdates or ModelPredicate.
 		opModels := []libovsdbops.OperationModel{
 			{
-				Name:  loadBalancerGroup.Name,
+				Name:  &loadBalancerGroup.Name,
 				Model: &loadBalancerGroup,
 			},
 		}
@@ -381,7 +381,7 @@ func (oc *Controller) SetupMaster(existingNodeNames []string) error {
 	}
 	opModels := []libovsdbops.OperationModel{
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 		},
@@ -444,7 +444,7 @@ func (oc *Controller) SetupMaster(existingNodeNames []string) error {
 	}
 	opModels = []libovsdbops.OperationModel{
 		{
-			Name:           logicalSwitch.Name,
+			Name:           &logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.OVNJoinSwitch },
 		},
@@ -494,7 +494,7 @@ func (oc *Controller) SetupMaster(existingNodeNames []string) error {
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -524,7 +524,7 @@ func (oc *Controller) SetupMaster(existingNodeNames []string) error {
 			},
 		},
 		{
-			Name:           logicalSwitch.Name,
+			Name:           &logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == types.OVNJoinSwitch },
 			OnModelMutations: []interface{}{
@@ -559,7 +559,7 @@ func (oc *Controller) addNodeLogicalSwitchPort(logicalSwitchName, portName, port
 			},
 		},
 		{
-			Name:           logicalSwitch.Name,
+			Name:           &logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchName },
 			OnModelMutations: []interface{}{
@@ -627,7 +627,7 @@ func (oc *Controller) syncNodeManagementPort(node *kapi.Node, hostSubnets []*net
 					},
 				},
 				{
-					Name:           logicalRouter.Name,
+					Name:           &logicalRouter.Name,
 					Model:          &logicalRouter,
 					ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 					OnModelMutations: []interface{}{
@@ -757,7 +757,7 @@ func (oc *Controller) syncNodeClusterRouterPort(node *kapi.Node, hostSubnets []*
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -782,7 +782,7 @@ func (oc *Controller) syncNodeClusterRouterPort(node *kapi.Node, hostSubnets []*
 	// Set the gateway chassis of the LRP. (Use "Update" so that the old value, if any, would be replaced)
 	opModels = []libovsdbops.OperationModel{
 		{
-			Name:  gatewayChassis.Name,
+			Name:  &gatewayChassis.Name,
 			Model: &gatewayChassis,
 			OnModelUpdates: []interface{}{
 				&gatewayChassis.ChassisName,
@@ -879,7 +879,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 			},
 		},
 		{
-			Name:           logicalRouter.Name,
+			Name:           &logicalRouter.Name,
 			Model:          &logicalRouter,
 			ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == types.OVNClusterRouter },
 			OnModelMutations: []interface{}{
@@ -888,7 +888,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 			ErrNotFound: true,
 		},
 		{
-			Name:           logicalSwitch.Name,
+			Name:           &logicalSwitch.Name,
 			Model:          &logicalSwitch,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 			OnModelUpdates: []interface{}{
@@ -951,7 +951,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 		// Create the Node's Logical Switch and set it's subnet
 		opModels = []libovsdbops.OperationModel{
 			{
-				Name:  logicalSwitch.Name,
+				Name:  &logicalSwitch.Name,
 				Model: &logicalSwitch,
 				OnModelMutations: []interface{}{
 					&logicalSwitch.OtherConfig,

--- a/go-controller/pkg/ovn/topology_version.go
+++ b/go-controller/pkg/ovn/topology_version.go
@@ -52,7 +52,7 @@ func (oc *Controller) reportTopologyVersion(ctx context.Context) error {
 		ExternalIDs: logicalRouterRes[0].ExternalIDs,
 	}
 	opModel := libovsdbops.OperationModel{
-		Name:           logicalRouter.Name,
+		Name:           &logicalRouter.Name,
 		Model:          &logicalRouter,
 		ModelPredicate: func(lr *nbdb.LogicalRouter) bool { return lr.Name == ovntypes.OVNClusterRouter },
 		OnModelUpdates: []interface{}{

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -297,7 +297,7 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 
 	opModels := []libovsdbops.OperationModel{
 		{
-			Name:           logicalSwitchDes.Name,
+			Name:           &logicalSwitchDes.Name,
 			Model:          &logicalSwitchDes,
 			ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == nodeName },
 			OnModelMutations: []interface{}{


### PR DESCRIPTION
The ovn kubernetes directly uses libovsdb.OperationWait operation
to check for a object existence before creating any entity into
nbdb. This commit changes it to use new Wait API which is more
user friendly.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>