### PR TITLE
Add a way to provide API token file

### DIFF
--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -73,9 +73,10 @@ func NewCNIServer(rundir string, useOVSExternalIDs bool, factory factory.NodeWat
 		podLister:         corev1listers.NewPodLister(factory.LocalPodInformer().GetIndexer()),
 		kclient:           kclient,
 		kubeAuth: &KubeAPIAuth{
-			Kubeconfig:    config.Kubernetes.Kubeconfig,
-			KubeAPIServer: config.Kubernetes.APIServer,
-			KubeAPIToken:  config.Kubernetes.Token,
+			Kubeconfig:       config.Kubernetes.Kubeconfig,
+			KubeAPIServer:    config.Kubernetes.APIServer,
+			KubeAPIToken:     config.Kubernetes.Token,
+			KubeAPITokenFile: config.Kubernetes.TokenFile,
 		},
 	}
 

--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -150,6 +150,7 @@ func kubeClientsetFromConfig(auth *KubeAPIAuth) (*kubernetes.Clientset, error) {
 		Kubeconfig: auth.Kubeconfig,
 		APIServer:  auth.KubeAPIServer,
 		Token:      auth.KubeAPIToken,
+		TokenFile:  auth.KubeAPITokenFile,
 		CAData:     caData,
 	})
 }

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -29,6 +29,9 @@ type KubeAPIAuth struct {
 	KubeAPIServer string `json:"kube-api-server,omitempty"`
 	// KubeAPIToken is a Kubernetes API token (not required if kubeconfig is given)
 	KubeAPIToken string `json:"kube-api-token,omitempty"`
+	// KubeAPITokenFile is the path to Kubernetes API token
+	// If set, it is periodically read and takes precedence over KubeAPIToken
+	KubeAPITokenFile string `json:"kube-api-token-file,omitempty"`
 	// KubeCAData is the Base64-ed Kubernetes API CA certificate data (not required if kubeconfig is given)
 	KubeCAData string `json:"kube-ca-data,omitempty"`
 }

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -144,6 +144,7 @@ lflow-cache-limit-kb=100000
 kubeconfig=/path/to/kubeconfig
 apiserver=https://1.2.3.4:6443
 token=TG9yZW0gaXBzdW0gZ
+tokenFile=/path/to/token
 cacert=/path/to/kubeca.crt
 service-cidrs=172.18.0.0/24
 no-hostsubnet-nodes=label=another-test-label
@@ -267,6 +268,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(""))
 			gomega.Expect(Kubernetes.CAData).To(gomega.Equal([]byte{}))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal(""))
+			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal(""))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal(DefaultAPIServer))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.16.1.0/24"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal(""))
@@ -309,6 +311,11 @@ var _ = Describe("Config Operations", func() {
 				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-api-token",
 				Output: "asadfasdfasrw3atr3r3rf33fasdaa3233",
 			})
+			// k8s-api-token-file
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-api-token-file",
+				Output: "/new/path/to/token",
+			})
 			// k8s-ca-certificate
 			fname, fdata, err := createTempFile("ca.crt")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -326,6 +333,7 @@ var _ = Describe("Config Operations", func() {
 				OvnNorthAddress: true,
 				K8sAPIServer:    true,
 				K8sToken:        true,
+				K8sTokenFile:    true,
 				K8sCert:         true,
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -336,7 +344,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(fname))
 			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(fdata))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("asadfasdfasrw3atr3r3rf33fasdaa3233"))
-
+			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/new/path/to/token"))
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeTCP))
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal(""))
 			gomega.Expect(OvnNorth.Cert).To(gomega.Equal(""))
@@ -372,6 +380,11 @@ var _ = Describe("Config Operations", func() {
 				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-api-token",
 				Output: "asadfasdfasrw3atr3r3rf33fasdaa3233",
 			})
+			// k8s-api-token-file
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:k8s-api-token-file",
+				Output: "/new/path/to/token",
+			})
 			// k8s-ca-certificate
 			fname, fdata, err := createTempFile("kube-cacert.pem")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -393,6 +406,7 @@ var _ = Describe("Config Operations", func() {
 				OvnNorthAddress: true,
 				K8sAPIServer:    true,
 				K8sToken:        true,
+				K8sTokenFile:    true,
 				K8sCert:         true,
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -403,6 +417,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(fname))
 			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(fdata))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("asadfasdfasrw3atr3r3rf33fasdaa3233"))
+			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/new/path/to/token"))
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeTCP))
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal(""))
@@ -441,7 +456,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(caFile))
 			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(caData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("TG9yZW0gaXBzdW0gZ"))
-
+			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal(tokenFile))
 			return nil
 		}
 		err2 := app.Run([]string{app.Name})
@@ -458,6 +473,9 @@ var _ = Describe("Config Operations", func() {
 
 		os.Setenv("K8S_TOKEN", "this is the  token test")
 		defer os.Setenv("K8S_TOKEN", "")
+
+		os.Setenv("K8S_TOKEN_FILE", "/new/path/to/token")
+		defer os.Setenv("K8S_TOKEN_FILE", "")
 
 		os.Setenv("K8S_APISERVER", "https://9.2.3.4:6443")
 		defer os.Setenv("K8S_APISERVER", "")
@@ -478,6 +496,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
 			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("this is the  token test"))
+			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/new/path/to/token"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://9.2.3.4:6443"))
 
 			return nil
@@ -525,6 +544,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
 			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("TG9yZW0gaXBzdW0gZ"))
+			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/path/to/token"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://1.2.3.4:6443"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.18.0.0/24"))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
@@ -597,6 +617,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
 			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("asdfasdfasdfasfd"))
+			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/new/path/to/token"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://4.4.3.2:8080"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.15.0.0/24"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal("test=pass"))
@@ -649,6 +670,7 @@ var _ = Describe("Config Operations", func() {
 			"-k8s-apiserver=https://4.4.3.2:8080",
 			"-k8s-cacert=" + kubeCAFile,
 			"-k8s-token=asdfasdfasdfasfd",
+			"-k8s-token-file=/new/path/to/token",
 			"-k8s-service-cidrs=172.15.0.0/24",
 			"-nb-address=ssl:6.5.4.3:6651",
 			"-no-hostsubnet-nodes=test=pass",
@@ -927,6 +949,7 @@ mode=shared
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
 			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("asdfasdfasdfasfd"))
+			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/new/path/to/token"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://4.4.3.2:8080"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal("label=another-test-label"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.15.0.0/24"))
@@ -970,6 +993,7 @@ mode=shared
 			"-k8s-apiserver=https://4.4.3.2:8080",
 			"-k8s-cacert=" + kubeCAFile,
 			"-k8s-token=asdfasdfasdfasfd",
+			"-k8s-token-file=/new/path/to/token",
 			"-k8s-service-cidr=172.15.0.0/24",
 			"-nb-address=ssl:6.5.4.3:6651,ssl:6.5.4.4:6651,ssl:6.5.4.5:6651",
 			"-nb-client-privkey=/client/privkey",
@@ -1021,6 +1045,7 @@ mode=shared
 			gomega.Expect(Kubernetes.CACert).To(gomega.Equal(kubeCAFile))
 			gomega.Expect(Kubernetes.CAData).To(gomega.Equal(kubeCAData))
 			gomega.Expect(Kubernetes.Token).To(gomega.Equal("TG9yZW0gaXBzdW0gZ"))
+			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/path/to/token"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.18.0.0/24"))
 
 			return nil

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -75,6 +75,7 @@ func newKubernetesRestConfig(conf *config.KubernetesConfig) (*rest.Config, error
 		kconfig = &rest.Config{
 			Host:            conf.APIServer,
 			BearerToken:     conf.Token,
+			BearerTokenFile: conf.TokenFile,
 			TLSClientConfig: rest.TLSClientConfig{CAData: conf.CAData},
 		}
 	} else if strings.HasPrefix(conf.APIServer, "http") {


### PR DESCRIPTION
API token can expire and we should not rely only on the token itself.
If BearerTokenFile is provided it is periodically read and takes precedence over BearerToken.

More info on SA token expiration: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md#safe-rollout-of-time-bound-token

Signed-off-by: Patryk Diak <pdiak@redhat.com>