### PR TITLE
Metrics: add config duration recorder

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -577,6 +577,7 @@ create_ovn_kube_manifests() {
     --ovn-loglevel-nb="${OVN_LOG_LEVEL_NB}" \
     --ovn-loglevel-sb="${OVN_LOG_LEVEL_SB}" \
     --ovn-loglevel-controller="${OVN_LOG_LEVEL_CONTROLLER}" \
+    --ovnkube-config-duration-enable=true \
     --egress-ip-enable=true \
     --egress-firewall-enable=true \
     --egress-qos-enable=true \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -74,6 +74,7 @@ OVN_IPFIX_CACHE_ACTIVE_TIMEOUT=""
 OVN_HOST_NETWORK_NAMESPACE=""
 OVN_EX_GW_NETWORK_INTERFACE=""
 OVNKUBE_NODE_MGMT_PORT_NETDEV=""
+OVNKUBE_CONFIG_DURATION_ENABLE=
 
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
@@ -245,6 +246,9 @@ while [ "$1" != "" ]; do
   --ovnkube-node-mgmt-port-netdev)
     OVNKUBE_NODE_MGMT_PORT_NETDEV=$VALUE
     ;;
+  --ovnkube-config-duration-enable)
+    OVNKUBE_CONFIG_DURATION_ENABLE=$VALUE
+    ;;
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
     exit 1
@@ -374,6 +378,8 @@ ovn_ex_gw_networking_interface=${OVN_EX_GW_NETWORK_INTERFACE}
 echo "ovn_ex_gw_networking_interface: ${ovn_ex_gw_networking_interface}"
 ovnkube_node_mgmt_port_netdev=${OVNKUBE_NODE_MGMT_PORT_NETDEV}
 echo "ovnkube_node_mgmt_port_netdev: ${ovnkube_node_mgmt_port_netdev}"
+ovnkube_config_duration_enable=${OVNKUBE_CONFIG_DURATION_ENABLE}
+echo "ovnkube_config_duration_enable: ${ovnkube_config_duration_enable}"
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -450,6 +456,7 @@ ovn_image=${image} \
   ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
   ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
   ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
+  ovnkube_config_duration_enable=${ovnkube_config_duration_enable} \
   ovn_acl_logging_rate_limit=${ovn_acl_logging_rate_limit} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -229,6 +229,7 @@ ovn_ipfix_cache_active_timeout=${OVN_IPFIX_CACHE_ACTIVE_TIMEOUT:-} \
 ovnkube_node_mode=${OVNKUBE_NODE_MODE:-"full"}
 # OVNKUBE_NODE_mgmt_PORT_NETDEV - is the net device to be used for management port
 ovnkube_node_mgmt_port_netdev=${OVNKUBE_NODE_MGMT_PORT_NETDEV:-}
+ovnkube_config_duration_enable=${OVNKUBE_CONFIG_DURATION_ENABLE:-false}
 # OVN_ENCAP_IP - encap IP to be used for OVN traffic on the node
 ovn_encap_ip=${OVN_ENCAP_IP:-}
 
@@ -966,6 +967,12 @@ ovn-master() {
       "
   fi
 
+  ovnkube_config_duration_enable_flag=
+  if [[ ${ovnkube_config_duration_enable} == "true" ]]; then
+    ovnkube_config_duration_enable_flag="--metrics-enable-config-duration"
+  fi
+  echo "ovnkube_config_duration_enable_flag: ${ovnkube_config_duration_enable_flag}"
+
   echo "=============== ovn-master ========== MASTER ONLY"
   /usr/bin/ovnkube \
     --init-master ${K8S_NODE} \
@@ -990,6 +997,7 @@ ovn-master() {
     ${egressip_enabled_flag} \
     ${egressfirewall_enabled_flag} \
     ${egressqos_enabled_flag} \
+    ${ovnkube_config_duration_enable_flag} \
     --metrics-bind-address ${ovnkube_master_metrics_bind_address} \
     --host-network-namespace ${ovn_host_network_namespace} &
 

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -162,6 +162,8 @@ spec:
           value: "{{ ovnkube_logfile_maxbackups }}"
         - name: OVNKUBE_LOGFILE_MAXAGE
           value: "{{ ovnkube_logfile_maxage }}"
+        - name: OVNKUBE_CONFIG_DURATION_ENABLE
+          value: "{{ ovnkube_config_duration_enable }}"
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,15 @@
+# Metrics
+## OVN-Kubernetes master
+This includes a description of a selective set of metrics and to explore the exhausted set, see `go-controller/pkg/metrics/master.go`
+### Configuration duration recorder
+#### Setup
+Enabled by default with the `kind.sh` (in directory `$ROOT/contrib`) [Kind](https://kind.sigs.k8s.io/) setup script.
+Disabled by default for binary ovnkube-master and enabled with flag `--metrics-enable-config-duration`.
+#### High-level description
+This set of metrics gives a result for the upper bound duration which means, it has taken at most this amount of seconds to apply the configuration to all nodes. It does not represent the exact accurate time to apply only this configuration.
+Measurement accuracy can be impacted by other parallel processing that might be occurring while the measurement is in progress therefore, the accuracy of the measurements should only indicate upper bound duration to roll out configuration changes.
+#### Metrics
+| Name | Prometheus type | Description  |
+|--|--|--|
+|ovnkube_master_network_programming_duration_seconds | Histogram | The duration to apply network configuration for a kind (e.g. pod, service, networkpolicy). Configuration includes add, update and delete events for kinds. This includes OVN-Kubernetes master and OVN duration.
+|ovnkube_master_network_programming_ovn_duration_seconds| Histogram  | The duration for OVN to apply network configuration for a kind (e.g. pod, service, networkpolicy).

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -316,6 +316,9 @@ type MetricsConfig struct {
 	EnablePprof           bool   `gcfg:"enable-pprof"`
 	NodeServerPrivKey     string `gcfg:"node-server-privkey"`
 	NodeServerCert        string `gcfg:"node-server-cert"`
+	// EnableConfigDuration holds the boolean flag to enable OVN-Kubernetes master to monitor OVN-Kubernetes master
+	// configuration duration and optionally, its application to all nodes
+	EnableConfigDuration bool `gcfg:"enable-config-duration"`
 }
 
 // OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
@@ -975,6 +978,11 @@ var MetricsFlags = []cli.Flag{
 		Name:        "node-server-cert",
 		Usage:       "Certificate that the OVN node K8s metrics server uses to serve metrics over TLS.",
 		Destination: &cliConfig.Metrics.NodeServerCert,
+	},
+	&cli.BoolFlag{
+		Name:        "metrics-enable-config-duration",
+		Usage:       "Enables monitoring OVN-Kubernetes master and OVN configuration duration",
+		Destination: &cliConfig.Metrics.EnableConfigDuration,
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -156,6 +156,7 @@ export-ovs-metrics=true
 enable-pprof=true
 node-server-privkey=/path/to/node-metrics-private.key
 node-server-cert=/path/to/node-metrics.crt
+enable-config-duration=true
 
 [logging]
 loglevel=5
@@ -567,6 +568,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
 			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal("/path/to/node-metrics-private.key"))
 			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal("/path/to/node-metrics.crt"))
+			gomega.Expect(Metrics.EnableConfigDuration).To(gomega.Equal(true))
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeSSL))
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal("/path/to/nb-client-private.key"))
@@ -648,6 +650,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
 			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal("/tls/nodeprivkey"))
 			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal("/tls/nodecert"))
+			gomega.Expect(Metrics.EnableConfigDuration).To(gomega.Equal(true))
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeSSL))
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal("/client/privkey"))
@@ -723,6 +726,7 @@ var _ = Describe("Config Operations", func() {
 			"-export-ovs-metrics=false",
 			"-metrics-enable-pprof=false",
 			"-ofctrl-wait-before-clear=5000",
+			"-metrics-enable-config-duration=true",
 		}
 		err = app.Run(cliArgs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -2,6 +2,8 @@ package metrics
 
 import (
 	"fmt"
+	"hash/fnv"
+	"math"
 	"runtime"
 	"strconv"
 	"sync"
@@ -10,7 +12,9 @@ import (
 	"github.com/ovn-org/libovsdb/cache"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
@@ -245,6 +249,33 @@ var metricPortBindingUpLatency = prometheus.NewHistogram(prometheus.HistogramOpt
 	Help:      "The duration between a pods port binding chassis update and port binding up observed in cache",
 	Buckets:   prometheus.ExponentialBuckets(.01, 2, 15),
 })
+
+var metricNetworkProgramming prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "network_programming_duration_seconds",
+	Help: "The duration to apply network configuration for a kind (e.g. pod, service, networkpolicy). " +
+		"Configuration includes add, update and delete events for each kind.",
+	Buckets: merge(
+		prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
+		prometheus.LinearBuckets(1, 1, 59),      // 1s, 2s, 3s, ... 59s
+		prometheus.LinearBuckets(60, 5, 12),     // 60s, 65s, 70s, ... 115s
+		prometheus.LinearBuckets(120, 30, 11))}, // 2min, 2.5min, 3min, ..., 7min
+	[]string{
+		"kind",
+	})
+
+var metricNetworkProgrammingOVN = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "network_programming_ovn_duration_seconds",
+	Help:      "The duration for OVN to apply network configuration",
+	Buckets: merge(
+		prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
+		prometheus.LinearBuckets(1, 1, 59),      // 1s, 2s, 3s, ... 59s
+		prometheus.LinearBuckets(60, 5, 12),     // 60s, 65s, 70s, ... 115s
+		prometheus.LinearBuckets(120, 30, 11))}, // 2min, 2.5min, 3min, ..., 7min
+)
 
 const (
 	globalOptionsTimestampField     = "e2e_timestamp"
@@ -696,6 +727,516 @@ func getPodUIDFromPortBinding(row *sbdb.PortBinding) kapimtypes.UID {
 		return ""
 	}
 	return kapimtypes.UID(podUID)
+}
+
+const (
+	updateOVNMeasurementChSize = 500
+	deleteOVNMeasurementChSize = 50
+	processChSize              = 1000
+	nbGlobalTable              = "NB_Global"
+	//fixme: remove when bug is fixed in OVN (Red Hat bugzilla bug number 2074019). Also, handle overflow event.
+	maxNbCfg               = math.MaxUint32 - 1000
+	maxMeasurementLifetime = 20 * time.Minute
+)
+
+type ovnMeasurement struct {
+	// time just before ovsdb tx is called
+	startTimestamp time.Time
+	// time when the nbCfg value and its associated configuration is applied to all nodes
+	endTimestamp time.Time
+	// OVN measurement complete - start and end timestamps are valid
+	complete bool
+	// nb_cfg value that started the measurement
+	nbCfg int
+}
+
+// measurement stores a measurement attempt through OVN-Kubernetes master and optionally OVN
+type measurement struct {
+	// kubernetes kind e.g. pod or service
+	kind string
+	// time when Add is executed
+	startTimestamp time.Time
+	// time when End is executed
+	endTimestamp time.Time
+	// if true endTimestamp is valid
+	end bool
+	// time when this measurement expires. Set during Add
+	expiresAt time.Time
+	// OVN measurement(s) via AddOVN
+	ovnMeasurements []ovnMeasurement
+}
+
+// hvCfgUpdate holds the information received from OVN Northbound event handler
+type hvCfgUpdate struct {
+	// timestamp is in milliseconds
+	timestamp int
+	hvCfg     int
+}
+
+type ConfigDurationRecorder struct {
+	// rate at which measurements are allowed. Probabilistically, 1 in every measurementRate
+	measurementRate uint64
+	measurements    map[string]measurement
+	// controls RW access to measurements map
+	measurementsMu sync.RWMutex
+	// channel to trigger processing a measurement following call to End func. Channel string is kind/namespace/name
+	triggerProcessCh chan string
+	enabled          bool
+}
+
+// global variable is needed because this functionality is accessed in many functions
+var cdr *ConfigDurationRecorder
+
+func GetConfigDurationRecorder() *ConfigDurationRecorder {
+	if cdr == nil {
+		cdr = &ConfigDurationRecorder{}
+	}
+	return cdr
+}
+
+var configDurationRegOnce sync.Once
+
+//Run monitors the config duration for OVN-Kube master to configure k8 kinds. A measurement maybe allowed and this is
+// related to the number of k8 nodes, N [1] and by argument k [2] where there is a probability that 1 out of N*k
+// measurement attempts are allowed. If k=0, all measurements are allowed. mUpdatePeriod determines the period to
+// process and publish metrics
+// [1] 1<N<inf, [2] 0<=k<inf
+func (cr *ConfigDurationRecorder) Run(nbClient libovsdbclient.Client, kube kube.Interface, k float64,
+	workerLoopPeriod time.Duration, stop <-chan struct{}) {
+	// ** configuration duration recorder - intro **
+	// We measure the duration to configure whatever k8 kind (pod, services, etc.) object and optionally its application
+	// to all nodes. Metrics record this duration. This will give a rough upper bound of how long it takes OVN-Kubernetes
+	// master container (CMS) and optionally (if AddOVN is called), OVN to configure all nodes under its control.
+	// Not every attempt to record will result in a measurement if argument k > 0. The measurement rate is proportional to
+	// the number of nodes, N and argument k. 1 out of every N*k attempted measurements will succeed.
+
+	// For the optional OVN measurement by calling AddOVN, when the CMS is about to make a transaction to configure
+	// whatever kind, a call to AddOVN function allows the caller to measure OVN duration.
+	// An ovsdb operation is returned to the caller of AddOVN, which they can bundle with their existing transactions
+	// sent to OVN which will tell OVN to measure how long it takes to configure all nodes with the config in the transaction.
+	// Config duration then waits for OVN to configure all nodes and calculates the time delta.
+
+	// ** configuration duration recorder - caveats **
+	// For the optional OVN recording, it does not give you an exact time duration for how long it takes to configure your
+	// k8 kind. When you are recording how long it takes OVN to complete your configuration to all nodes, other
+	// transactions may have occurred which may increases the overall time. You may also get longer processing times if one
+	// or more nodes are unavailable because we are measuring how long the functionality takes to apply to ALL nodes.
+
+	// ** configuration duration recorder - How the duration of the config is measured within OVN **
+	// We increment the nb_cfg integer value in the NB_Global table.
+	// ovn-northd notices the nb_cfg change and copies the nb_cfg value to SB_Global table field nb_cfg along with any
+	// other configuration that is changed in OVN Northbound database.
+	// All ovn-controllers detect nb_cfg value change and generate a 'barrier' on the openflow connection to the
+	// nodes ovs-vswitchd. Once ovn-controllers receive the 'barrier processed' reply from ovs-vswitchd which
+	// indicates that all relevant openflow operations associated with NB_Globals nb_cfg value have been
+	// propagated to the nodes OVS, it copies the SB_Global nb_cfg value to its Chassis_Private table nb_cfg record.
+	// ovn-northd detects changes to the Chassis_Private startRecords and computes the minimum nb_cfg for all Chassis_Private
+	// nb_cfg and stores this in NB_Global hv_cfg field along with a timestamp to field hv_cfg_timestamp which
+	// reflects the time when the slowest chassis catches up with the northbound configuration.
+	configDurationRegOnce.Do(func() {
+		prometheus.MustRegister(metricNetworkProgramming)
+		prometheus.MustRegister(metricNetworkProgrammingOVN)
+	})
+
+	cr.measurements = make(map[string]measurement)
+	// watch node count and adjust measurement rate if node count changes
+	cr.runMeasurementRateAdjuster(kube, k, time.Hour, stop)
+	// we currently do not clean the following channels up upon exit
+	cr.triggerProcessCh = make(chan string, processChSize)
+	updateOVNMeasurementCh := make(chan hvCfgUpdate, updateOVNMeasurementChSize)
+	deleteOVNMeasurementCh := make(chan int, deleteOVNMeasurementChSize)
+	go cr.processMeasurements(workerLoopPeriod, updateOVNMeasurementCh, deleteOVNMeasurementCh, stop)
+
+	nbClient.Cache().AddEventHandler(&cache.EventHandlerFuncs{
+		UpdateFunc: func(table string, old model.Model, new model.Model) {
+			if table != nbGlobalTable {
+				return
+			}
+			oldRow := old.(*nbdb.NBGlobal)
+			newRow := new.(*nbdb.NBGlobal)
+
+			if oldRow.HvCfg != newRow.HvCfg && oldRow.HvCfgTimestamp != newRow.HvCfgTimestamp && newRow.HvCfgTimestamp > 0 {
+				select {
+				case updateOVNMeasurementCh <- hvCfgUpdate{hvCfg: newRow.HvCfg, timestamp: newRow.HvCfgTimestamp}:
+				default:
+					klog.Warning("Config duration recorder: unable to update OVN measurement")
+					select {
+					case deleteOVNMeasurementCh <- newRow.HvCfg:
+					default:
+					}
+				}
+			}
+		},
+	})
+	cr.enabled = true
+}
+
+// Start allows the caller to attempt measurement of a control plane configuration duration, as a metric,
+// the duration between functions Start and End. Optionally, if you wish to record OVN config duration,
+// call AddOVN which will add the duration for OVN to apply the configuration to all nodes.
+// The caller must pass kind,namespace,name which will be used to determine if the object
+// is allowed to record. To allow no locking, each go routine that calls this function, can determine itself
+// if it is allowed to measure.
+// There is a mandatory two-step process to complete a measurement.
+// Step 1) Call Start when you wish to begin a measurement - ideally when processing for the object starts
+// Step 2) Call End which will complete a measurement
+// Optionally, call AddOVN when you are making a transaction to OVN in order to add on the OVN duration to an existing
+// measurement. This must be called between Start and End. Not every call to Start will result in a measurement
+// and the rate of measurements depends on the number of nodes and function Run arg k.
+// Only one measurement for a kind/namespace/name is allowed until the current measurement is Ended (via End) and
+// processed. This is guaranteed by workqueues (even with multiple workers) and informer event handlers.
+func (cr *ConfigDurationRecorder) Start(kind, namespace, name string) (time.Time, bool) {
+	if !cr.enabled {
+		return time.Time{}, false
+	}
+	kindNamespaceName := fmt.Sprintf("%s/%s/%s", kind, namespace, name)
+	if !cr.allowedToMeasure(kindNamespaceName) {
+		return time.Time{}, false
+	}
+	measurementTimestamp := time.Now()
+	cr.measurementsMu.Lock()
+	_, found := cr.measurements[kindNamespaceName]
+	// we only record for measurements that aren't in-progress
+	if !found {
+		cr.measurements[kindNamespaceName] = measurement{kind: kind, startTimestamp: measurementTimestamp,
+			expiresAt: measurementTimestamp.Add(maxMeasurementLifetime)}
+	}
+	cr.measurementsMu.Unlock()
+	return measurementTimestamp, !found
+}
+
+// allowedToMeasure determines if we are allowed to measure or not. To avoid the cost of synchronisation by using locks,
+// we use probability. For a value of kindNamespaceName that returns true, it will always return true.
+func (cr *ConfigDurationRecorder) allowedToMeasure(kindNamespaceName string) bool {
+	if cr.measurementRate == 0 {
+		return true
+	}
+	// 1 in measurementRate chance of true
+	if hashToNumber(kindNamespaceName)%cr.measurementRate == 0 {
+		return true
+	}
+	return false
+}
+
+func (cr *ConfigDurationRecorder) End(kind, namespace, name string) time.Time {
+	if !cr.enabled {
+		return time.Time{}
+	}
+	kindNamespaceName := fmt.Sprintf("%s/%s/%s", kind, namespace, name)
+	if !cr.allowedToMeasure(kindNamespaceName) {
+		return time.Time{}
+	}
+	measurementTimestamp := time.Now()
+	cr.measurementsMu.Lock()
+	if m, ok := cr.measurements[kindNamespaceName]; ok {
+		if !m.end {
+			m.end = true
+			m.endTimestamp = measurementTimestamp
+			cr.measurements[kindNamespaceName] = m
+			// if there are no OVN measurements, trigger immediate processing
+			if len(m.ovnMeasurements) == 0 {
+				select {
+				case cr.triggerProcessCh <- kindNamespaceName:
+				default:
+					// doesn't matter if channel is full because the measurement will be processed later anyway
+				}
+			}
+		}
+	} else {
+		// This can happen if Start was rejected for a resource because a measurement was in-progress for this
+		// kind/namespace/name, but during execution of this resource, the measurement was completed and now no record
+		// is found.
+		measurementTimestamp = time.Time{}
+	}
+	cr.measurementsMu.Unlock()
+	return measurementTimestamp
+}
+
+// AddOVN adds OVN config duration to an existing recording - previously started by calling function Start
+// It will return ovsdb operations which a user can add to existing operations they wish to track.
+// Upon successful transaction of the operations to the ovsdb server, the user of this function must call a call-back
+// function to lock-in the request to measure and report. Failure to call the call-back function, will result in no OVN
+// measurement and no metrics are reported. AddOVN will result in a no-op if Start isn't called previously for the same
+// kind/namespace/name.
+// If multiple AddOVN is called between Start and End for the same kind/namespace/name, then the
+// OVN durations will be summed and added to the total. There is an assumption that processing of kind/namespace/name is
+// sequential
+func (cr *ConfigDurationRecorder) AddOVN(nbClient libovsdbclient.Client, kind, namespace, name string) (
+	[]ovsdb.Operation, func(), time.Time, error) {
+	if !cr.enabled {
+		return []ovsdb.Operation{}, func() {}, time.Time{}, nil
+	}
+	kindNamespaceName := fmt.Sprintf("%s/%s/%s", kind, namespace, name)
+	if !cr.allowedToMeasure(kindNamespaceName) {
+		return []ovsdb.Operation{}, func() {}, time.Time{}, nil
+	}
+	cr.measurementsMu.RLock()
+	m, ok := cr.measurements[kindNamespaceName]
+	cr.measurementsMu.RUnlock()
+	if !ok {
+		// no measurement found, therefore no-op
+		return []ovsdb.Operation{}, func() {}, time.Time{}, nil
+	}
+	if m.end {
+		// existing measurement in-progress and not processed yet, therefore no-op
+		return []ovsdb.Operation{}, func() {}, time.Time{}, nil
+	}
+	nbGlobal := &nbdb.NBGlobal{}
+	nbGlobal, err := libovsdbops.GetNBGlobal(nbClient, nbGlobal)
+	if err != nil {
+		return []ovsdb.Operation{}, func() {}, time.Time{}, fmt.Errorf("failed to find OVN Northbound NB_Global table"+
+			" entry: %v", err)
+	}
+	if nbGlobal.NbCfg < 0 {
+		return []ovsdb.Operation{}, func() {}, time.Time{}, fmt.Errorf("nb_cfg is negative, failed to add OVN measurement")
+	}
+	//stop recording if we are close to overflow
+	if nbGlobal.NbCfg > maxNbCfg {
+		return []ovsdb.Operation{}, func() {}, time.Time{}, fmt.Errorf("unable to measure OVN due to nb_cfg being close to overflow")
+	}
+	ops, err := nbClient.Where(nbGlobal).Mutate(nbGlobal, model.Mutation{
+		Field:   &nbGlobal.NbCfg,
+		Mutator: ovsdb.MutateOperationAdd,
+		Value:   1,
+	})
+	if err != nil {
+		return []ovsdb.Operation{}, func() {}, time.Time{}, fmt.Errorf("failed to create update operation: %v", err)
+	}
+	ovnStartTimestamp := time.Now()
+
+	return ops, func() {
+		// there can be a race condition here where we queue the wrong nbCfg value, but it is ok as long as it is
+		// less than or equal the hv_cfg value we see and this is the case because of atomic increments for nb_cfg
+		cr.measurementsMu.Lock()
+		m, ok = cr.measurements[kindNamespaceName]
+		if !ok {
+			klog.Errorf("Config duration recorder: expected a measurement entry. Call Start before AddOVN"+
+				" for %s", kindNamespaceName)
+			cr.measurementsMu.Unlock()
+			return
+		}
+		m.ovnMeasurements = append(m.ovnMeasurements, ovnMeasurement{startTimestamp: ovnStartTimestamp,
+			nbCfg: nbGlobal.NbCfg + 1})
+		cr.measurements[kindNamespaceName] = m
+		cr.measurementsMu.Unlock()
+	}, ovnStartTimestamp, nil
+}
+
+// runMeasurementRateAdjuster will adjust the rate of measurements based on the number of nodes in the cluster and arg k
+func (cr *ConfigDurationRecorder) runMeasurementRateAdjuster(kube kube.Interface, k float64, nodeCheckPeriod time.Duration,
+	stop <-chan struct{}) {
+	var currentMeasurementRate, newMeasurementRate uint64
+
+	updateMeasurementRate := func() {
+		if nodeCount, err := getNodeCount(kube); err != nil {
+			klog.Errorf("Config duration recorder: failed to update ticker duration considering node count: %v", err)
+		} else {
+			newMeasurementRate = uint64(math.Round(k * float64(nodeCount)))
+			if newMeasurementRate != currentMeasurementRate {
+				if newMeasurementRate > 0 {
+					currentMeasurementRate = newMeasurementRate
+					cr.measurementRate = newMeasurementRate
+				}
+				klog.V(5).Infof("Config duration recorder: updated measurement rate to approx 1 in"+
+					" every %d requests", newMeasurementRate)
+			}
+		}
+	}
+
+	// initial measurement rate adjustment
+	updateMeasurementRate()
+
+	go func() {
+		nodeCheckTicker := time.NewTicker(nodeCheckPeriod)
+		for {
+			select {
+			case <-nodeCheckTicker.C:
+				updateMeasurementRate()
+			case <-stop:
+				nodeCheckTicker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+// processMeasurements manages the measurements map. It calculates metrics and cleans up finished or stale measurements
+func (cr *ConfigDurationRecorder) processMeasurements(period time.Duration, updateOVNMeasurementCh chan hvCfgUpdate,
+	deleteOVNMeasurementCh chan int, stop <-chan struct{}) {
+	ticker := time.NewTicker(period)
+	var ovnKDelta, ovnDelta float64
+
+	for {
+		select {
+		case <-stop:
+			ticker.Stop()
+			return
+		// remove measurements if channel updateOVNMeasurementCh overflows, therefore we cannot trust existing measurements
+		case hvCfg := <-deleteOVNMeasurementCh:
+			cr.measurementsMu.Lock()
+			removeOVNMeasurements(cr.measurements, hvCfg)
+			cr.measurementsMu.Unlock()
+		case h := <-updateOVNMeasurementCh:
+			cr.measurementsMu.Lock()
+			cr.addHvCfg(h.hvCfg, h.timestamp)
+			cr.measurementsMu.Unlock()
+		// used for processing measurements that didn't require OVN measurement. Helps to keep measurement map small
+		case kindNamespaceName := <-cr.triggerProcessCh:
+			cr.measurementsMu.Lock()
+			m, ok := cr.measurements[kindNamespaceName]
+			if !ok {
+				klog.Errorf("Config duration recorder: expected measurement, but not found")
+				cr.measurementsMu.Unlock()
+				continue
+			}
+			if !m.end {
+				cr.measurementsMu.Unlock()
+				continue
+			}
+			if len(m.ovnMeasurements) != 0 {
+				cr.measurementsMu.Unlock()
+				continue
+			}
+			ovnKDelta = m.endTimestamp.Sub(m.startTimestamp).Seconds()
+			metricNetworkProgramming.With(prometheus.Labels{"kind": m.kind}).Observe(ovnKDelta)
+			klog.V(5).Infof("Config duration recorder: kind/namespace/name %s. OVN-Kubernetes master took %v"+
+				" seconds. No OVN measurement.", kindNamespaceName, ovnKDelta)
+			delete(cr.measurements, kindNamespaceName)
+			cr.measurementsMu.Unlock()
+		// used for processing measurements that require OVN measurement or do not or are expired.
+		case <-ticker.C:
+			start := time.Now()
+			cr.measurementsMu.Lock()
+			// process and clean up measurements
+			for kindNamespaceName, m := range cr.measurements {
+				if start.After(m.expiresAt) {
+					// measurement may expire if OVN is degraded or End wasn't called
+					klog.Warningf("Config duration recorder: measurement expired for %s", kindNamespaceName)
+					delete(cr.measurements, kindNamespaceName)
+					continue
+				}
+				if !m.end {
+					// measurement didn't end yet, process later
+					continue
+				}
+				// for when no ovn measurements requested
+				if len(m.ovnMeasurements) == 0 {
+					ovnKDelta = m.endTimestamp.Sub(m.startTimestamp).Seconds()
+					metricNetworkProgramming.With(prometheus.Labels{"kind": m.kind}).Observe(ovnKDelta)
+					klog.V(5).Infof("Config duration recorder: kind/namespace/name %s. OVN-Kubernetes master"+
+						" took %v seconds. No OVN measurement.", kindNamespaceName, ovnKDelta)
+					delete(cr.measurements, kindNamespaceName)
+					continue
+				}
+				// for each kind/namespace/name, there can be multiple calls to AddOVN between start and end
+				// we sum all the OVN durations and add it to the start and end duration
+				// first lets make sure all OVN measurements are finished
+				if complete := allOVNMeasurementsComplete(m.ovnMeasurements); !complete {
+					continue
+				}
+
+				ovnKDelta = m.endTimestamp.Sub(m.startTimestamp).Seconds()
+				ovnDelta = calculateOVNDuration(m.ovnMeasurements)
+				metricNetworkProgramming.With(prometheus.Labels{"kind": m.kind}).Observe(ovnKDelta + ovnDelta)
+				metricNetworkProgrammingOVN.Observe(ovnDelta)
+				klog.V(5).Infof("Config duration recorder: kind/namespace/name %s. OVN-Kubernetes master took"+
+					" %v seconds. OVN took %v seconds. Total took %v seconds", kindNamespaceName, ovnKDelta,
+					ovnDelta, ovnDelta+ovnKDelta)
+				delete(cr.measurements, kindNamespaceName)
+			}
+			cr.measurementsMu.Unlock()
+		}
+	}
+}
+
+func (cr *ConfigDurationRecorder) addHvCfg(hvCfg, hvCfgTimestamp int) {
+	var altered bool
+	for i, m := range cr.measurements {
+		altered = false
+		for iOvnM, ovnM := range m.ovnMeasurements {
+			if ovnM.complete {
+				continue
+			}
+			if ovnM.nbCfg <= hvCfg {
+				ovnM.endTimestamp = time.UnixMilli(int64(hvCfgTimestamp))
+				ovnM.complete = true
+				m.ovnMeasurements[iOvnM] = ovnM
+				altered = true
+			}
+		}
+		if altered {
+			cr.measurements[i] = m
+		}
+	}
+}
+
+// removeOVNMeasurements remove any OVN measurements less than or equal argument hvCfg
+func removeOVNMeasurements(measurements map[string]measurement, hvCfg int) {
+	for kindNamespaceName, m := range measurements {
+		var indexToDelete []int
+		for i, ovnM := range m.ovnMeasurements {
+			if ovnM.nbCfg <= hvCfg {
+				indexToDelete = append(indexToDelete, i)
+			}
+		}
+		if len(indexToDelete) == 0 {
+			continue
+		}
+		if len(indexToDelete) == len(m.ovnMeasurements) {
+			delete(measurements, kindNamespaceName)
+		}
+		for _, iDel := range indexToDelete {
+			m.ovnMeasurements = removeOVNMeasurement(m.ovnMeasurements, iDel)
+		}
+		measurements[kindNamespaceName] = m
+	}
+}
+
+func removeOVNMeasurement(oM []ovnMeasurement, i int) []ovnMeasurement {
+	oM[i] = oM[len(oM)-1]
+	return oM[:len(oM)-1]
+}
+func hashToNumber(s string) uint64 {
+	h := fnv.New64()
+	h.Write([]byte(s))
+	return h.Sum64()
+}
+
+func calculateOVNDuration(ovnMeasurements []ovnMeasurement) float64 {
+	var totalDuration float64
+	for _, oM := range ovnMeasurements {
+		if !oM.complete {
+			continue
+		}
+		totalDuration += oM.endTimestamp.Sub(oM.startTimestamp).Seconds()
+	}
+	return totalDuration
+}
+
+func allOVNMeasurementsComplete(ovnMeasurements []ovnMeasurement) bool {
+	for _, oM := range ovnMeasurements {
+		if !oM.complete {
+			return false
+		}
+	}
+	return true
+}
+
+// merge direct copy from k8 pkg/proxy/metrics/metrics.go
+func merge(slices ...[]float64) []float64 {
+	result := make([]float64, 1)
+	for _, s := range slices {
+		result = append(result, s...)
+	}
+	return result
+}
+
+func getNodeCount(kube kube.Interface) (int, error) {
+	nodes, err := kube.GetNodes()
+	if err != nil {
+		return 0, fmt.Errorf("unable to retrieve node list: %v", err)
+	}
+	return len(nodes.Items), nil
 }
 
 // setNbE2eTimestamp return true if setting timestamp to NB global options is successful

--- a/go-controller/pkg/metrics/master_test.go
+++ b/go-controller/pkg/metrics/master_test.go
@@ -1,0 +1,241 @@
+package metrics
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics/mocks"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientgo "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func setupOvn(nbData libovsdbtest.TestSetup) (client.Client, client.Client, *libovsdbtest.Cleanup) {
+	nbClient, sbClient, cleanup, err := libovsdbtest.NewNBSBTestHarness(nbData)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	return sbClient, nbClient, cleanup
+}
+
+func getKubeClient(nodeCount int) *kube.Kube {
+	var nodes []corev1.Node
+	for i := 0; i < nodeCount; i++ {
+		nodes = append(nodes, corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("nodeName-%d", i),
+			},
+		})
+	}
+	kubeFakeClient := fakeclientgo.NewSimpleClientset(&corev1.NodeList{Items: nodes})
+	fakeClient := &util.OVNClientset{
+		KubeClient: kubeFakeClient,
+	}
+	return &kube.Kube{fakeClient.KubeClient, nil, nil, nil}
+}
+
+func setHvCfg(nbClient client.Client, hvCfg int, hvCfgTimestamp time.Time) {
+	nbGlobal := nbdb.NBGlobal{}
+	nbGlobalResp, err := libovsdbops.GetNBGlobal(nbClient, &nbGlobal)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	nbGlobalResp.HvCfg = hvCfg
+	nbGlobalResp.HvCfgTimestamp = int(hvCfgTimestamp.UnixMilli())
+	ops, err := nbClient.Where(nbGlobalResp).Update(nbGlobalResp, &nbGlobalResp.HvCfg, &nbGlobalResp.HvCfgTimestamp)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(ops).To(gomega.HaveLen(1))
+	_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+var _ = ginkgo.Describe("Config Duration Operations", func() {
+	var (
+		instance       *ConfigDurationRecorder
+		k              *kube.Kube
+		nbClient       client.Client
+		cleanup        *libovsdbtest.Cleanup
+		stop           chan struct{}
+		testNamespaceA = "testnamespacea"
+		testPodNameA   = "testpoda"
+		testNamespaceB = "testnamespaceb"
+		testPodNameB   = "testpodb"
+	)
+
+	ginkgo.BeforeEach(func() {
+		cdr = nil
+		instance = GetConfigDurationRecorder()
+		k = getKubeClient(1)
+		stop = make(chan struct{})
+		_, nbClient, cleanup = setupOvn(libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{&nbdb.NBGlobal{UUID: "cd-op-uuid"}}})
+	})
+
+	ginkgo.AfterEach(func() {
+		cleanup.Cleanup()
+		close(stop)
+	})
+
+	ginkgo.Context("Runtime", func() {
+		ginkgo.It("records correctly", func() {
+			instance.Run(nbClient, k, 0, time.Millisecond, stop)
+			histoMock := mocks.NewHistogramVecMock()
+			metricNetworkProgramming = histoMock
+			startTimestamp, ok := instance.Start("pod", testNamespaceA, testPodNameA)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(startTimestamp.IsZero()).Should(gomega.BeFalse())
+			endTimestamp := instance.End("pod", testNamespaceA, testPodNameA)
+			var histoValue float64
+			gomega.Eventually(func() bool {
+				select {
+				case histoValue = <-histoMock.GetCh():
+					return true
+				default:
+					return false
+				}
+			}).Should(gomega.BeTrue())
+			delta := endTimestamp.Sub(startTimestamp).Seconds()
+			gomega.Expect(math.Round(histoValue)).Should(gomega.BeNumerically("==", math.Round(delta)))
+			histoMock.Cleanup()
+		})
+
+		ginkgo.It("records correctly with OVN latency", func() {
+			instance.Run(nbClient, k, 0, time.Millisecond, stop)
+			histoMock := mocks.NewHistogramVecMock()
+			metricNetworkProgramming = histoMock
+			startTimestamp, ok := instance.Start("pod", testNamespaceA, testPodNameA)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(startTimestamp.IsZero()).Should(gomega.BeFalse())
+			ops, txOkCallback, startOVNTimestamp, err := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
+			gomega.Expect(ops).Should(gomega.HaveLen(1))
+			gomega.Expect(err).Should(gomega.BeNil())
+			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			txOkCallback()
+			endTimestamp := instance.End("pod", testNamespaceA, testPodNameA)
+			endOVNTimestamp := startOVNTimestamp.Add(10 * time.Second)
+			setHvCfg(nbClient, 1, endOVNTimestamp)
+			delta := endOVNTimestamp.Sub(startOVNTimestamp).Seconds() + startTimestamp.Sub(endTimestamp).Seconds()
+			var histoValue float64
+			gomega.Eventually(func() bool {
+				select {
+				case histoValue = <-histoMock.GetCh():
+					return true
+				default:
+					return false
+				}
+			}).Should(gomega.BeTrue())
+			gomega.Expect(math.Round(histoValue)).Should(gomega.BeNumerically("==", math.Round(delta)))
+			histoMock.Cleanup()
+		})
+
+		ginkgo.It("records multiple different objs including adding OVN latency", func() {
+			instance.Run(nbClient, k, 0, time.Millisecond, stop)
+			histoMock := mocks.NewHistogramVecMock()
+			metricNetworkProgramming = histoMock
+			// recording 1
+			startTimestamp, ok := instance.Start("pod", testNamespaceA, testPodNameA)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(startTimestamp.IsZero()).Should(gomega.BeFalse())
+			ops, txOkCallback, startOVNTimestamp, err := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
+			gomega.Expect(ops).Should(gomega.HaveLen(1))
+			gomega.Expect(err).Should(gomega.BeNil())
+			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			txOkCallback()
+			endTimestamp := instance.End("pod", testNamespaceA, testPodNameA)
+			endOVNTimestamp := startOVNTimestamp.Add(10 * time.Second)
+			setHvCfg(nbClient, 1, endOVNTimestamp)
+			deltaFirstObj := endOVNTimestamp.Sub(startOVNTimestamp).Seconds() + startTimestamp.Sub(endTimestamp).Seconds()
+			// recording 2 with different obj
+			startTimestamp, ok = instance.Start("networkpolicy", testNamespaceB, testPodNameB)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(startTimestamp.IsZero()).Should(gomega.BeFalse())
+			ops, txOkCallback, startOVNTimestamp, err = instance.AddOVN(nbClient, "networkpolicy", testNamespaceB, testPodNameB)
+			gomega.Expect(ops).Should(gomega.HaveLen(1))
+			gomega.Expect(err).Should(gomega.BeNil())
+			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			txOkCallback()
+			endTimestamp = instance.End("networkpolicy", testNamespaceB, testPodNameB)
+			endOVNTimestamp = startOVNTimestamp.Add(10 * time.Second)
+			setHvCfg(nbClient, 2, endOVNTimestamp)
+			deltaSecondObj := endOVNTimestamp.Sub(startOVNTimestamp).Seconds() + startTimestamp.Sub(endTimestamp).Seconds()
+			var histoValue float64
+			gomega.Eventually(func() bool {
+				if len(histoMock.GetCh()) != 2 {
+					return false
+				}
+				var tmp float64
+				for i := 0; i < 2; i++ {
+					select {
+					case tmp = <-histoMock.GetCh():
+						histoValue += tmp
+					default:
+						return false
+					}
+				}
+				return true
+			}).Should(gomega.BeTrue())
+			gomega.Expect(math.Round(histoValue)).Should(gomega.BeNumerically("==", math.Round(deltaFirstObj+deltaSecondObj)))
+			histoMock.Cleanup()
+		})
+
+		ginkgo.It("denies recording when no start called", func() {
+			instance.Run(nbClient, k, 0, time.Millisecond, stop)
+			ops, _, _, _ := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
+			gomega.Expect(ops).Should(gomega.HaveLen(0))
+		})
+
+		ginkgo.It("allows multiple addOVN records for the same obj", func() {
+			instance.Run(nbClient, k, 0, time.Millisecond, stop)
+			histoMock := mocks.NewHistogramVecMock()
+			metricNetworkProgramming = histoMock
+			// recording 1
+			startTimestamp, ok := instance.Start("pod", testNamespaceA, testPodNameA)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(startTimestamp.IsZero()).Should(gomega.BeFalse())
+			// first addOVN
+			ops, txOkCallback, firstStartOVNTimestamp, err := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
+			gomega.Expect(ops).Should(gomega.HaveLen(1))
+			gomega.Expect(err).Should(gomega.BeNil())
+			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			txOkCallback()
+			// second addOVN
+			ops, txOkCallback, secondStartOVNTimestamp, err := instance.AddOVN(nbClient, "pod", testNamespaceA, testPodNameA)
+			gomega.Expect(ops).Should(gomega.HaveLen(1))
+			gomega.Expect(err).Should(gomega.BeNil())
+			_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			txOkCallback()
+			endTimestamp := instance.End("pod", testNamespaceA, testPodNameA)
+			endOVNTimestamp := secondStartOVNTimestamp.Add(10 * time.Second)
+			setHvCfg(nbClient, 2, endOVNTimestamp)
+			firstOVNDelta := endOVNTimestamp.Sub(firstStartOVNTimestamp).Seconds()
+			secondOVNDelta := endOVNTimestamp.Sub(secondStartOVNTimestamp).Seconds()
+			delta := endTimestamp.Sub(startTimestamp).Seconds() + firstOVNDelta + secondOVNDelta
+			var histoValue float64
+			gomega.Eventually(func() bool {
+				if len(histoMock.GetCh()) != 1 {
+					return false
+				}
+				select {
+				case histoValue = <-histoMock.GetCh():
+					return true
+				default:
+					return false
+				}
+			}).Should(gomega.BeTrue())
+			gomega.Expect(math.Round(histoValue)).Should(gomega.BeNumerically("==", math.Round(delta)))
+			histoMock.Cleanup()
+		})
+	})
+})

--- a/go-controller/pkg/metrics/metrics_suite_test.go
+++ b/go-controller/pkg/metrics/metrics_suite_test.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestClusterNode(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Metrics Operations Suite")
+}

--- a/go-controller/pkg/metrics/mocks/histogram.go
+++ b/go-controller/pkg/metrics/mocks/histogram.go
@@ -1,0 +1,82 @@
+package mocks
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+)
+
+type HistogramMock struct {
+	ch chan float64
+}
+
+func NewHistogramMock() *HistogramMock {
+	return &HistogramMock{ch: make(chan float64, 10)}
+}
+
+func (HistogramMock) Desc() *prometheus.Desc {
+	panic("unimplemented")
+}
+
+func (HistogramMock) Write(*io_prometheus_client.Metric) error {
+	panic("unimplemented")
+}
+
+func (HistogramMock) Describe(chan<- *prometheus.Desc) {
+	panic("unimplemented")
+}
+
+func (HistogramMock) Collect(chan<- prometheus.Metric) {
+	panic("implement me")
+}
+
+func (h HistogramMock) Observe(value float64) {
+	h.ch <- value
+}
+
+type HistorgramVecMock struct {
+	mock HistogramMock
+}
+
+func (m *HistorgramVecMock) Describe(chan<- *prometheus.Desc) {
+	panic("unimplemented")
+}
+
+func (m *HistorgramVecMock) With(prometheus.Labels) prometheus.Observer {
+	return m.mock
+}
+
+func (m *HistorgramVecMock) GetMetricWith(prometheus.Labels) (prometheus.Observer, error) {
+	panic("unimplemented")
+}
+
+func (m *HistorgramVecMock) GetMetricWithLabelValues(_ ...string) (prometheus.Observer, error) {
+	panic("unimplemented")
+}
+
+func (m *HistorgramVecMock) WithLabelValues(...string) prometheus.Observer {
+	return m.mock
+}
+
+func (m *HistorgramVecMock) MustCurryWith(prometheus.Labels) prometheus.ObserverVec {
+	panic("unimplemented")
+}
+
+func (m *HistorgramVecMock) CurryWith(prometheus.Labels) (prometheus.ObserverVec, error) {
+	panic("unimplemented")
+}
+
+func (m *HistorgramVecMock) Collect(chan<- prometheus.Metric) {
+	panic("unimplemented")
+}
+
+func (m *HistorgramVecMock) GetCh() chan float64 {
+	return m.mock.ch
+}
+
+func (m *HistorgramVecMock) Cleanup() {
+	close(m.mock.ch)
+}
+
+func NewHistogramVecMock() *HistorgramVecMock {
+	return &HistorgramVecMock{mock: *NewHistogramMock()}
+}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -223,10 +223,10 @@ func (oc *Controller) StartClusterMaster() error {
 	metrics.RunTimestamp(oc.stopChan, oc.sbClient, oc.nbClient)
 	metrics.MonitorIPSec(oc.nbClient)
 	if config.Metrics.EnableConfigDuration {
-		// with k=20,
-		//  for a cluster with 10 nodes, measurement of 1 in every 200 requests
-		//  for a cluster with 100 nodes, measurement of 1 in every 2000 requests
-		metrics.GetConfigDurationRecorder().Run(oc.nbClient, oc.kube, 20, time.Second*5, oc.stopChan)
+		// with k=10,
+		//  for a cluster with 10 nodes, measurement of 1 in every 100 requests
+		//  for a cluster with 100 nodes, measurement of 1 in every 1000 requests
+		metrics.GetConfigDurationRecorder().Run(oc.nbClient, oc.kube, 10, time.Second*5, oc.stopChan)
 	}
 	oc.podRecorder.Run(oc.sbClient, oc.stopChan)
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -222,6 +222,12 @@ func (oc *Controller) StartClusterMaster() error {
 	metrics.RegisterMasterFunctional()
 	metrics.RunTimestamp(oc.stopChan, oc.sbClient, oc.nbClient)
 	metrics.MonitorIPSec(oc.nbClient)
+	if config.Metrics.EnableConfigDuration {
+		// with k=20,
+		//  for a cluster with 10 nodes, measurement of 1 in every 200 requests
+		//  for a cluster with 100 nodes, measurement of 1 in every 2000 requests
+		metrics.GetConfigDurationRecorder().Run(oc.nbClient, oc.kube, 20, time.Second*5, oc.stopChan)
+	}
 	oc.podRecorder.Run(oc.sbClient, oc.stopChan)
 
 	// enableOVNLogicalDataPathGroups sets an OVN flag to enable logical datapath

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -222,7 +222,7 @@ func (oc *Controller) StartClusterMaster() error {
 	metrics.RegisterMasterFunctional()
 	metrics.RunTimestamp(oc.stopChan, oc.sbClient, oc.nbClient)
 	metrics.MonitorIPSec(oc.nbClient)
-	oc.metricsRecorder.Run(oc.sbClient, oc.stopChan)
+	oc.podRecorder.Run(oc.sbClient, oc.stopChan)
 
 	// enableOVNLogicalDataPathGroups sets an OVN flag to enable logical datapath
 	// groups on OVN 20.12 and later. The option is ignored if OVN doesn't

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -446,7 +446,7 @@ func (oc *Controller) recordAddEvent(objType reflect.Type, obj interface{}) {
 	case factory.PodType:
 		klog.V(5).Infof("Recording add event on pod")
 		pod := obj.(*kapi.Pod)
-		oc.metricsRecorder.AddPod(pod.UID)
+		oc.podRecorder.AddPod(pod.UID)
 	}
 }
 
@@ -456,7 +456,7 @@ func (oc *Controller) recordDeleteEvent(objType reflect.Type, obj interface{}) {
 	case factory.PodType:
 		klog.V(5).Infof("Recording add event on pod")
 		pod := obj.(*kapi.Pod)
-		oc.metricsRecorder.CleanPod(pod.UID)
+		oc.podRecorder.CleanPod(pod.UID)
 	}
 }
 

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -217,7 +217,7 @@ type Controller struct {
 	addNodeFailed               sync.Map
 	nodeClusterRouterPortFailed sync.Map
 
-	metricsRecorder *metrics.ControlPlaneRecorder
+	podRecorder metrics.PodRecorder
 }
 
 const (
@@ -304,7 +304,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		sbClient:                 libovsdbOvnSBClient,
 		svcController:            svcController,
 		svcFactory:               svcFactory,
-		metricsRecorder:          metrics.NewControlPlaneRecorder(),
+		podRecorder:              metrics.NewPodRecorder(),
 	}
 }
 

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -562,7 +562,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	if err != nil {
 		return fmt.Errorf("error transacting operations %+v: %v", ops, err)
 	}
-	oc.metricsRecorder.AddLSP(pod.UID)
+	oc.podRecorder.AddLSP(pod.UID)
 
 	// if somehow lspUUID is empty, there is a bug here with interpreting OVSDB results
 	if len(lsp.UUID) == 0 {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -176,10 +176,17 @@ func (oc *Controller) deleteLogicalPort(pod *kapi.Pod, portInfo *lpInfo) (err er
 	}
 	allOps = append(allOps, ops...)
 
+	recordOps, txOkCallBack, _, err := metrics.GetConfigDurationRecorder().AddOVN(oc.nbClient, "pod", pod.Namespace,
+		pod.Name)
+	if err != nil {
+		klog.Errorf("Failed to record config duration: %v", err)
+	}
+	allOps = append(allOps, recordOps...)
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, allOps)
 	if err != nil {
 		return fmt.Errorf("cannot delete logical switch port %s, %v", logicalPort, err)
 	}
+	txOkCallBack()
 
 	// do not remove SNATs/GW routes/IPAM for an IP address unless we have validated no other pod is using it
 	if !shouldRelease {
@@ -556,12 +563,20 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 		return fmt.Errorf("error creating logical switch port %+v on switch %+v: %+v", *lsp, *ls, err)
 	}
 
+	recordOps, txOkCallBack, _, err := metrics.GetConfigDurationRecorder().AddOVN(oc.nbClient, "pod", pod.Namespace,
+		pod.Name)
+	if err != nil {
+		klog.Errorf("Config duration recorder: %v", err)
+	}
+	ops = append(ops, recordOps...)
+
 	transactStart := time.Now()
 	_, err = libovsdbops.TransactAndCheckAndSetUUIDs(oc.nbClient, lsp, ops)
 	libovsdbExecuteTime = time.Since(transactStart)
 	if err != nil {
 		return fmt.Errorf("error transacting operations %+v: %v", ops, err)
 	}
+	txOkCallBack()
 	oc.podRecorder.AddLSP(pod.UID)
 
 	// if somehow lspUUID is empty, there is a bug here with interpreting OVSDB results


### PR DESCRIPTION
Provides a mechanism to record config duration within OVN-K
for kubernete kinds from when event handler fires for a given
resource until processing is complete.
Exposes the duration as a histogram.

Optionally, provides a way to record OVN duration.

Currently added for the following k8 kinds:
* pod
* networkpolicy
* service


Signed-off-by: Martin Kennelly <mkennell@redhat.com>
