### PR TITLE
change networkpolicy ACLs to use "apply-after-lb" for egress network policy 

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-21.12.0-4.fc35
+ARG ovnver=ovn-21.12.0-5.fc35
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/go-controller/pkg/libovsdbops/acl.go
+++ b/go-controller/pkg/libovsdbops/acl.go
@@ -124,7 +124,7 @@ func ensureACLUUID(acl *nbdb.ACL) {
 	}
 }
 
-func BuildACL(name string, direction nbdb.ACLDirection, priority int, match string, action nbdb.ACLAction, meter string, severity nbdb.ACLSeverity, log bool, externalIds map[string]string) *nbdb.ACL {
+func BuildACL(name string, direction nbdb.ACLDirection, priority int, match string, action nbdb.ACLAction, meter string, severity nbdb.ACLSeverity, log bool, externalIds map[string]string, options map[string]string) *nbdb.ACL {
 	name = fmt.Sprintf("%.63s", name)
 
 	var realName *string
@@ -139,8 +139,7 @@ func BuildACL(name string, direction nbdb.ACLDirection, priority int, match stri
 	if len(severity) != 0 {
 		realSeverity = &severity
 	}
-
-	return &nbdb.ACL{
+	acl := &nbdb.ACL{
 		Name:        realName,
 		Direction:   direction,
 		Match:       match,
@@ -150,7 +149,10 @@ func BuildACL(name string, direction nbdb.ACLDirection, priority int, match stri
 		Log:         log,
 		Meter:       realMeter,
 		ExternalIDs: externalIds,
+		Options:     options,
 	}
+
+	return acl
 }
 
 func createOrUpdateACLOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, acl *nbdb.ACL) ([]libovsdb.Operation, error) {

--- a/go-controller/pkg/nbdb/acl.go
+++ b/go-controller/pkg/nbdb/acl.go
@@ -37,6 +37,7 @@ type ACL struct {
 	Match       string            `ovsdb:"match"`
 	Meter       *string           `ovsdb:"meter"`
 	Name        *string           `ovsdb:"name"`
+	Options     map[string]string `ovsdb:"options"`
 	Priority    int               `ovsdb:"priority"`
 	Severity    *ACLSeverity      `ovsdb:"severity"`
 }
@@ -103,6 +104,32 @@ func equalACLName(a, b *string) bool {
 	return *a == *b
 }
 
+func copyACLOptions(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalACLOptions(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
 func copyACLSeverity(a *ACLSeverity) *ACLSeverity {
 	if a == nil {
 		return nil
@@ -126,6 +153,7 @@ func (a *ACL) DeepCopyInto(b *ACL) {
 	b.ExternalIDs = copyACLExternalIDs(a.ExternalIDs)
 	b.Meter = copyACLMeter(a.Meter)
 	b.Name = copyACLName(a.Name)
+	b.Options = copyACLOptions(a.Options)
 	b.Severity = copyACLSeverity(a.Severity)
 }
 
@@ -154,6 +182,7 @@ func (a *ACL) Equals(b *ACL) bool {
 		a.Match == b.Match &&
 		equalACLMeter(a.Meter, b.Meter) &&
 		equalACLName(a.Name, b.Name) &&
+		equalACLOptions(a.Options, b.Options) &&
 		a.Priority == b.Priority &&
 		equalACLSeverity(a.Severity, b.Severity)
 }

--- a/go-controller/pkg/nbdb/logical_router_static_route.go
+++ b/go-controller/pkg/nbdb/logical_router_static_route.go
@@ -24,6 +24,7 @@ type LogicalRouterStaticRoute struct {
 	Options     map[string]string               `ovsdb:"options"`
 	OutputPort  *string                         `ovsdb:"output_port"`
 	Policy      *LogicalRouterStaticRoutePolicy `ovsdb:"policy"`
+	RouteTable  string                          `ovsdb:"route_table"`
 }
 
 func copyLogicalRouterStaticRouteBFD(a *string) *string {
@@ -164,7 +165,8 @@ func (a *LogicalRouterStaticRoute) Equals(b *LogicalRouterStaticRoute) bool {
 		a.Nexthop == b.Nexthop &&
 		equalLogicalRouterStaticRouteOptions(a.Options, b.Options) &&
 		equalLogicalRouterStaticRouteOutputPort(a.OutputPort, b.OutputPort) &&
-		equalLogicalRouterStaticRoutePolicy(a.Policy, b.Policy)
+		equalLogicalRouterStaticRoutePolicy(a.Policy, b.Policy) &&
+		a.RouteTable == b.RouteTable
 }
 
 func (a *LogicalRouterStaticRoute) EqualsModel(b model.Model) bool {

--- a/go-controller/pkg/nbdb/model.go
+++ b/go-controller/pkg/nbdb/model.go
@@ -45,7 +45,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_Northbound",
-  "version": "5.33.1",
+  "version": "5.35.1",
   "tables": {
     "ACL": {
       "columns": {
@@ -125,6 +125,18 @@ var schema = `{
             },
             "min": 0,
             "max": 1
+          }
+        },
+        "options": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": "unlimited"
           }
         },
         "priority": {
@@ -1094,6 +1106,9 @@ var schema = `{
             "min": 0,
             "max": 1
           }
+        },
+        "route_table": {
+          "type": "string"
         }
       }
     },

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -88,6 +88,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					false,
 					map[string]string{"egressFirewall": "none"},
+					nil,
 				)
 				purgeACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -101,6 +102,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					false,
 					map[string]string{"egressFirewall": "default"},
+					nil,
 				)
 				keepACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -115,6 +117,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					false,
 					map[string]string{"egressFirewall": "default"},
+					nil,
 				)
 				otherACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -248,6 +251,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -336,6 +340,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 				ipv6ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -432,6 +437,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 
 				udpACL.UUID = libovsdbops.BuildNamedUUID()
@@ -529,6 +535,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -633,6 +640,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -712,6 +720,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					false,
 					map[string]string{"egressFirewall": "none"},
+					nil,
 				)
 				purgeACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -725,6 +734,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					false,
 					map[string]string{"egressFirewall": "default"},
+					nil,
 				)
 				keepACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -739,6 +749,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					false,
 					map[string]string{"egressFirewall": "default"},
+					nil,
 				)
 				otherACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -867,6 +878,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -950,6 +962,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 				ipv6ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -1043,6 +1056,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 
 				udpACL.UUID = libovsdbops.BuildNamedUUID()
@@ -1124,6 +1138,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 
@@ -1212,6 +1227,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 					"",
 					false,
 					map[string]string{"egressFirewall": "namespace1"},
+					nil,
 				)
 				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
 

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -359,8 +359,15 @@ func (gp *gressPolicy) buildLocalPodACLs(portGroupName, aclLogging string) []*nb
 
 // buildACLAllow builds an allow-related ACL for a given given match
 func (gp *gressPolicy) buildACLAllow(match, l4Match string, ipBlockCIDR int, aclLogging string) *nbdb.ACL {
+	var direction string
+	var options map[string]string
+	if gp.policyType == knet.PolicyTypeIngress {
+		direction = nbdb.ACLDirectionToLport
+	} else {
+		direction = nbdb.ACLDirectionFromLport
+		options = map[string]string{"apply-after-lb": "true"}
+	}
 	priority := types.DefaultAllowPriority
-	direction := nbdb.ACLDirectionToLport
 	action := nbdb.ACLActionAllowRelated
 	aclName := fmt.Sprintf("%s_%s_%v", gp.policyNamespace, gp.policyName, gp.idx)
 
@@ -389,7 +396,7 @@ func (gp *gressPolicy) buildACLAllow(match, l4Match string, ipBlockCIDR int, acl
 		policyTypeNum:          policyTypeIndex,
 	}
 
-	acl := libovsdbops.BuildACL(aclName, direction, priority, match, action, types.OvnACLLoggingMeter, getACLLoggingSeverity(aclLogging), aclLogging != "", externalIds)
+	acl := libovsdbops.BuildACL(aclName, direction, priority, match, action, types.OvnACLLoggingMeter, getACLLoggingSeverity(aclLogging), aclLogging != "", externalIds, options)
 	return acl
 }
 


### PR DESCRIPTION
Currently all network policy ACLs are placed on the OVN ingress pipeline. Since the first ACL of the highest priority is action is followed there is no way to ensure the correct operation of network policies when multiple apply to the same pod.
    
Splitting the ACLs onto both the ingress and egress pipelines allows all the egress network policies to be evaluated followed by the ingress so correct action is always assured


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->