### PR TITLE
Fixes handler locking

### DIFF
--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -89,13 +89,8 @@ type informer struct {
 
 func (i *informer) forEachQueuedHandler(f func(h *Handler)) {
 	i.RLock()
-	curHandlers := make([]*Handler, 0, len(i.handlers))
+	defer i.RUnlock()
 	for _, handler := range i.handlers {
-		curHandlers = append(curHandlers, handler)
-	}
-	i.RUnlock()
-
-	for _, handler := range curHandlers {
 		f(handler)
 	}
 }


### PR DESCRIPTION
The informer lock is held to add and remove handlers, as well as execute
handlers in the non-federated queue case. However, in federated queue
the handlers were being copied while locked, and then executed. This
allows handlers to execute even after the handler has been removed from
the informer.

Signed-off-by: Tim Rozet <trozet@redhat.com>

