### PR TITLE
ovn_db_cluster metrics improvements

### DIFF
--- a/go-controller/pkg/metrics/ovn_db.go
+++ b/go-controller/pkg/metrics/ovn_db.go
@@ -520,6 +520,10 @@ func getOVNDBClusterStatusInfo(timeout int, direction, database string) (cluster
 				clusterStatus.logNotApplied = value
 			}
 		case "Connections":
+			// db cluster with 1 member has empty Connections list
+			if idx+2 >= len(line) {
+				continue
+			}
 			// the value is of the format `->0000 (->56d7) <-46ac <-56d7`
 			var connIn, connOut, connInErr, connOutErr float64
 			for _, conn := range strings.Fields(line[idx+2:]) {

--- a/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -98,8 +99,8 @@ func TestEnsureLocalRaftServerID(t *testing.T) {
 		return res.res, res.stderr, res.err
 	}
 
-	db := &dbProperties{
-		appCtl: mock,
+	db := &util.OvsDbProperties{
+		AppCtl: mock,
 	}
 
 	tests := []struct {
@@ -226,8 +227,8 @@ func TestEnsureLocalRaftServerID(t *testing.T) {
 				mockCalls[k] = v
 			}
 
-			db.dbName = tc.dbName
-			db.dbAlias = tc.dbAlias
+			db.DbName = tc.dbName
+			db.DbAlias = tc.dbAlias
 
 			err := ensureLocalRaftServerID(db)
 
@@ -270,8 +271,8 @@ func TestEnsureClusterRaftMembership(t *testing.T) {
 		KClient: fakeClient,
 	}
 
-	db := &dbProperties{
-		appCtl: mock,
+	db := &util.OvsDbProperties{
+		AppCtl: mock,
 	}
 	tests := []struct {
 		desc        string
@@ -359,8 +360,8 @@ func TestEnsureClusterRaftMembership(t *testing.T) {
 				mockCalls[k] = v
 			}
 
-			db.dbName = tc.dbName
-			db.dbAlias = tc.dbAlias
+			db.DbName = tc.dbName
+			db.DbAlias = tc.dbAlias
 			err := ensureClusterRaftMembership(db, kubeInterface)
 
 			// fail either if an error is seen but not expected
@@ -402,8 +403,8 @@ func TestEnsureClusterDNSRaftMembership(t *testing.T) {
 		KClient: fakeClient,
 	}
 
-	db := &dbProperties{
-		appCtl: mock,
+	db := &util.OvsDbProperties{
+		AppCtl: mock,
 	}
 	tests := []struct {
 		desc        string
@@ -491,8 +492,8 @@ func TestEnsureClusterDNSRaftMembership(t *testing.T) {
 				mockCalls[k] = v
 			}
 
-			db.dbName = tc.dbName
-			db.dbAlias = tc.dbAlias
+			db.DbName = tc.dbName
+			db.DbAlias = tc.dbAlias
 			err := ensureClusterRaftMembership(db, kubeInterface)
 
 			// fail either if an error is seen but not expected
@@ -525,9 +526,9 @@ func TestEnsureElectionTimeout(t *testing.T) {
 		return res.res, res.stderr, res.err
 	}
 
-	db := &dbProperties{
-		appCtl: mock,
-		dbName: "OVN_Northbound",
+	db := &util.OvsDbProperties{
+		AppCtl: mock,
+		DbName: "OVN_Northbound",
 	}
 	tests := []struct {
 		desc         string
@@ -645,7 +646,7 @@ func TestEnsureElectionTimeout(t *testing.T) {
 				mockCalls[k] = v
 			}
 
-			db.electionTimer = tc.timeout
+			db.ElectionTimer = tc.timeout
 			err := ensureElectionTimeout(db)
 
 			// fail either if an error is seen but not expected
@@ -682,8 +683,8 @@ func TestResetRaftDB(t *testing.T) {
 		return res.res, res.stderr, res.err
 	}
 
-	db := &dbProperties{
-		appCtl: mock,
+	db := &util.OvsDbProperties{
+		AppCtl: mock,
 	}
 	tests := []struct {
 		desc         string
@@ -738,13 +739,13 @@ func TestResetRaftDB(t *testing.T) {
 				mockCalls[k] = v
 			}
 
-			db.dbName = tc.dbName
-			db.dbAlias = filepath.Join(tmpDir, tc.dbAlias)
+			db.DbName = tc.dbName
+			db.DbAlias = filepath.Join(tmpDir, tc.dbAlias)
 
 			// resetRaftDb expects a file with the db alias' name. This can be an
 			// absolute path as well. Create it.
 			if tc.createDbFile {
-				createDbFile(t, db.dbAlias)
+				createDbFile(t, db.DbAlias)
 			}
 			// test resetRaftDb
 			err := resetRaftDB(db)

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -941,3 +941,32 @@ func DetectCheckPktLengthSupport(bridge string) (bool, error) {
 
 	return false, nil
 }
+
+type OvsDbProperties struct {
+	AppCtl        func(timeout int, args ...string) (string, string, error)
+	DbAlias       string
+	DbName        string
+	ElectionTimer int
+}
+
+// GetOvsDbProperties inits OvsDbProperties based on db file path given to it.
+// Now it only works with ovn dbs (nbdb and sbdb)
+func GetOvsDbProperties(db string) (*OvsDbProperties, error) {
+	if strings.Contains(db, "ovnnb") {
+		return &OvsDbProperties{
+			ElectionTimer: int(config.OvnNorth.ElectionTimer) * 1000,
+			AppCtl:        RunOVNNBAppCtlWithTimeout,
+			DbName:        "OVN_Northbound",
+			DbAlias:       db,
+		}, nil
+	} else if strings.Contains(db, "ovnsb") {
+		return &OvsDbProperties{
+			ElectionTimer: int(config.OvnSouth.ElectionTimer) * 1000,
+			AppCtl:        RunOVNSBAppCtlWithTimeout,
+			DbName:        "OVN_Southbound",
+			DbAlias:       db,
+		}, nil
+	} else {
+		return nil, fmt.Errorf("failed to parse ovn db type Northbound/Southbound from the path %s", db)
+	}
+}


### PR DESCRIPTION
1. Fix cluster/status parsing for single-member db cluster 
2. Use common DbProperties struct for dbmanager and ovn_db metrics.
3. Change command to check if db is clustered to the one that works
even if db file is not mounted.
4. Fix getting ovn{n/s}b_db schema-version for /var/run/ovn mount path

To see the changes, compare the following metrics
### SNO cluster
#### Before
ovn_db_cluster_ metrics are not exposed
```
oc -n openshift-ovn-kubernetes exec $POD -c ovnkube-node curl "127.0.0.1:29105/metrics" | grep "# HELP ovn_db_cluster" | wc -l
0
```  
#### After
All 15 metrics https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/metrics/ovn_db.go#L386-L400 are exposed 
```
oc -n openshift-ovn-kubernetes exec $POD -c ovnkube-node curl "127.0.0.1:29105/metrics" | grep "# HELP ovn_db_cluster" | wc -l
15
```  
### Regular cluster
#### Before
`nb_schema_version` and `sb_schema_version` are empty for `ovn_db_build_info` metric
```
oc -n openshift-ovn-kubernetes exec $POD -c ovnkube-node curl "127.0.0.1:29105/metrics" | grep ovn_db_build_info
ovn_db_build_info{nb_schema_version="",sb_schema_version="",version="2.16.3"} 1
```  
#### After
```
oc -n openshift-ovn-kubernetes exec $POD -c ovnkube-node curl "127.0.0.1:29105/metrics" | grep ovn_db_build_info
ovn_db_build_info{nb_schema_version="5.34.1",sb_schema_version="20.21.0",version="2.16.3"} 1
```  