### PR TITLE
add TLS support to metrics endpoint in ovnkube

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -948,6 +948,13 @@ ovn-master() {
   echo "egressfirewall_enabled_flag=${egressfirewall_enabled_flag}"
 
   ovnkube_master_metrics_bind_address="${metrics_endpoint_ip}:9409"
+  local ovnkube_metrics_tls_opts=""
+  if [[ ${OVNKUBE_METRICS_PK} != "" && ${OVNKUBE_METRICS_CERT} != "" ]]; then
+    ovnkube_metrics_tls_opts="
+        --node-server-privkey ${OVNKUBE_METRICS_PK}
+        --node-server-cert ${OVNKUBE_METRICS_CERT}
+      "
+  fi
 
   echo "=============== ovn-master ========== MASTER ONLY"
   /usr/bin/ovnkube \
@@ -967,6 +974,7 @@ ovn-master() {
     --pidfile ${OVN_RUNDIR}/ovnkube-master.pid \
     --logfile /var/log/ovn-kubernetes/ovnkube-master.log \
     ${ovn_master_ssl_opts} \
+    ${ovnkube_metrics_tls_opts} \
     ${multicast_enabled_flag} \
     ${ovn_acl_logging_rate_limit_flag} \
     ${egressip_enabled_flag} \
@@ -1187,6 +1195,14 @@ ovn-node() {
   ovn_metrics_bind_address="${metrics_endpoint_ip}:9476"
   ovnkube_node_metrics_bind_address="${metrics_endpoint_ip}:9410"
 
+  local ovnkube_metrics_tls_opts=""
+  if [[ ${OVNKUBE_METRICS_PK} != "" && ${OVNKUBE_METRICS_CERT} != "" ]]; then
+    ovnkube_metrics_tls_opts="
+        --node-server-privkey ${OVNKUBE_METRICS_PK}
+        --node-server-cert ${OVNKUBE_METRICS_CERT}
+      "
+  fi
+
   echo "=============== ovn-node   --init-node"
   /usr/bin/ovnkube --init-node ${K8S_NODE} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
@@ -1208,6 +1224,7 @@ ovn-node() {
     --pidfile ${OVN_RUNDIR}/ovnkube.pid \
     --logfile /var/log/ovn-kubernetes/ovnkube.log \
     ${ovn_node_ssl_opts} \
+    ${ovnkube_metrics_tls_opts} \
     --inactivity-probe=${ovn_remote_probe_interval} \
     ${monitor_all} \
     ${enable_lflow_cache} \

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -279,7 +279,8 @@ func runOvnKube(ctx *cli.Context) error {
 	// now that ovnkube master/node are running, lets expose the metrics HTTP endpoint if configured
 	// start the prometheus server to serve OVN K8s Metrics (default master port: 9409, node port: 9410)
 	if config.Metrics.BindAddress != "" {
-		metrics.StartMetricsServer(config.Metrics.BindAddress, config.Metrics.EnablePprof)
+		metrics.StartMetricsServer(config.Metrics.BindAddress, config.Metrics.EnablePprof,
+			config.Metrics.NodeServerCert, config.Metrics.NodeServerPrivKey)
 	}
 
 	// start the prometheus server to serve OVS and OVN Metrics (default port: 9476)
@@ -289,7 +290,8 @@ func runOvnKube(ctx *cli.Context) error {
 			metrics.RegisterOvsMetricsWithOvnMetrics()
 		}
 		metrics.RegisterOvnMetrics(ovnClientset.KubeClient, node)
-		metrics.StartOVNMetricsServer(config.Metrics.OVNMetricsBindAddress)
+		metrics.StartOVNMetricsServer(config.Metrics.OVNMetricsBindAddress,
+			config.Metrics.NodeServerCert, config.Metrics.NodeServerPrivKey)
 	}
 
 	// run until cancelled

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -309,6 +309,8 @@ type MetricsConfig struct {
 	OVNMetricsBindAddress string `gcfg:"ovn-metrics-bind-address"`
 	ExportOVSMetrics      bool   `gcfg:"export-ovs-metrics"`
 	EnablePprof           bool   `gcfg:"enable-pprof"`
+	NodeServerPrivKey     string `gcfg:"node-server-privkey"`
+	NodeServerCert        string `gcfg:"node-server-cert"`
 }
 
 // OVNKubernetesFeatureConfig holds OVN-Kubernetes feature enhancement config file parameters and command-line overrides
@@ -943,6 +945,16 @@ var MetricsFlags = []cli.Flag{
 		Usage:       "If true, then also accept pprof requests on the metrics port.",
 		Destination: &cliConfig.Metrics.EnablePprof,
 		Value:       Metrics.EnablePprof,
+	},
+	&cli.StringFlag{
+		Name:        "node-server-privkey",
+		Usage:       "Private key that the OVN node K8s metrics server uses to serve metrics over TLS.",
+		Destination: &cliConfig.Metrics.NodeServerPrivKey,
+	},
+	&cli.StringFlag{
+		Name:        "node-server-cert",
+		Usage:       "Certificate that the OVN node K8s metrics server uses to serve metrics over TLS.",
+		Destination: &cliConfig.Metrics.NodeServerCert,
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -154,6 +154,8 @@ bind-address=1.1.1.1:8080
 ovn-metrics-bind-address=1.1.1.2:8081
 export-ovs-metrics=true
 enable-pprof=true
+node-server-privkey=/path/to/node-metrics-private.key
+node-server-cert=/path/to/node-metrics.crt
 
 [logging]
 loglevel=5
@@ -278,6 +280,8 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal(DefaultAPIServer))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.16.1.0/24"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal(""))
+			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal(""))
+			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal(""))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.128.0.0/14"), 23},
 			}))
@@ -561,6 +565,8 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Metrics.OVNMetricsBindAddress).To(gomega.Equal("1.1.1.2:8081"))
 			gomega.Expect(Metrics.ExportOVSMetrics).To(gomega.Equal(true))
 			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
+			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal("/path/to/node-metrics-private.key"))
+			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal("/path/to/node-metrics.crt"))
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeSSL))
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal("/path/to/nb-client-private.key"))
@@ -640,6 +646,8 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Metrics.OVNMetricsBindAddress).To(gomega.Equal("2.2.2.3:8081"))
 			gomega.Expect(Metrics.ExportOVSMetrics).To(gomega.Equal(true))
 			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
+			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal("/tls/nodeprivkey"))
+			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal("/tls/nodecert"))
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeSSL))
 			gomega.Expect(OvnNorth.PrivKey).To(gomega.Equal("/client/privkey"))
@@ -699,6 +707,8 @@ var _ = Describe("Config Operations", func() {
 			"-sb-client-cert=/client/cert2",
 			"-sb-client-cacert=/client/cacert2",
 			"-sb-cert-common-name=testsbcommonname",
+			"-node-server-privkey=/tls/nodeprivkey",
+			"-node-server-cert=/tls/nodecert",
 			"-gateway-mode=shared",
 			"-nodeport",
 			"-gateway-v4-join-subnet=100.63.0.0/16",

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -368,8 +369,29 @@ func checkPodRunsOnGivenNode(clientset kubernetes.Interface, labels []string, k8
 		strings.Join(labels, ","), k8sNodeName)
 }
 
-// StartMetricsServer runs the prometheus listener so that OVN K8s metrics can be collected
-func StartMetricsServer(bindAddress string, enablePprof bool) {
+// using the cyrpto/tls module's GetCertificate() callback function helps in picking up
+// the latest certificate (due to cert rotation on cert expiry)
+func listenAndServeTLS(addr, certFile, privKeyFile string, handler http.Handler) error {
+	tlsConfig := &tls.Config{
+		GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(certFile, privKeyFile)
+			if err != nil {
+				return nil, fmt.Errorf("error generating x509 certs for metrics TLS endpoint: %v", err)
+			}
+			return &cert, nil
+		},
+	}
+	server := &http.Server{
+		Addr:      addr,
+		Handler:   handler,
+		TLSConfig: tlsConfig,
+	}
+	return server.ListenAndServeTLS("", "")
+}
+
+// StartMetricsServerTLS runs the prometheus listener so that OVN K8s metrics can be collected
+// It puts the endpoint behind TLS if certFile and keyFile are defined.
+func StartMetricsServer(bindAddress string, enablePprof bool, certFile string, keyFile string) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
@@ -382,7 +404,12 @@ func StartMetricsServer(bindAddress string, enablePprof bool) {
 	}
 
 	go utilwait.Until(func() {
-		err := http.ListenAndServe(bindAddress, mux)
+		var err error
+		if certFile != "" && keyFile != "" {
+			err = listenAndServeTLS(bindAddress, certFile, keyFile, mux)
+		} else {
+			err = http.ListenAndServe(bindAddress, mux)
+		}
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("starting metrics server failed: %v", err))
 		}
@@ -392,14 +419,19 @@ func StartMetricsServer(bindAddress string, enablePprof bool) {
 var ovnRegistry = prometheus.NewRegistry()
 
 // StartOVNMetricsServer runs the prometheus listener so that OVN metrics can be collected
-func StartOVNMetricsServer(bindAddress string) {
+func StartOVNMetricsServer(bindAddress, certFile, keyFile string) {
 	handler := promhttp.InstrumentMetricHandler(ovnRegistry,
 		promhttp.HandlerFor(ovnRegistry, promhttp.HandlerOpts{}))
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", handler)
 
 	go utilwait.Until(func() {
-		err := http.ListenAndServe(bindAddress, mux)
+		var err error
+		if certFile != "" && keyFile != "" {
+			err = listenAndServeTLS(bindAddress, certFile, keyFile, mux)
+		} else {
+			err = http.ListenAndServe(bindAddress, mux)
+		}
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("starting OVN metrics server failed: %v", err))
 		}


### PR DESCRIPTION
the assumption here is that the key/cert files are pre-generated and
mounted into the ovnkube container (running either as a master or node)
and paths for these files are exposed using OVNKUBE_METRICS_PK and
OVNKUBE_METRICS_CERT environment variables

@zshi-redhat @trozet @dcbw  PTAL