### PR TITLE
Add retry logic to egress firewall

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-
 	egressfirewallapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	egressfirewallscheme "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/clientset/versioned/scheme"
 	egressfirewallinformerfactory "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/informers/externalversions"
+	egressfirewalllister "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/listers/egressfirewall/v1"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	egressipapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	egressipscheme "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/scheme"
@@ -596,6 +596,11 @@ func (wf *WatchFactory) GetNamespacesBySelector(labelSelector metav1.LabelSelect
 func (wf *WatchFactory) GetNetworkPolicy(namespace, name string) (*knet.NetworkPolicy, error) {
 	networkPolicyLister := wf.informers[policyType].lister.(netlisters.NetworkPolicyLister)
 	return networkPolicyLister.NetworkPolicies(namespace).Get(name)
+}
+
+func (wf *WatchFactory) GetEgressFirewall(namespace, name string) (*egressfirewallapi.EgressFirewall, error) {
+	egressFirewallLister := wf.informers[egressFirewallType].lister.(egressfirewalllister.EgressFirewallLister)
+	return egressFirewallLister.EgressFirewalls(namespace).Get(name)
 }
 
 func (wf *WatchFactory) NodeInformer() cache.SharedIndexInformer {

--- a/go-controller/pkg/ovn/egressfirewall_dns.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns.go
@@ -84,7 +84,7 @@ func (e *EgressDNS) Add(namespace, dnsName string) (addressset.AddressSet, error
 
 }
 
-func (e *EgressDNS) Delete(namespace string) bool {
+func (e *EgressDNS) Delete(namespace string) (bool, error) {
 	e.lock.Lock()
 	var dnsNamesToDelete []string
 
@@ -96,7 +96,7 @@ func (e *EgressDNS) Delete(namespace string) bool {
 			// the dnsEntry appears in no other namespace, so delete the address_set
 			err := dnsEntry.dnsAddressSet.Destroy()
 			if err != nil {
-				klog.Errorf("Error deleting EgressFirewall AddressSet for dnsName: %s %v", dnsName, err)
+				return false, fmt.Errorf("error deleting EgressFirewall AddressSet for dnsName: %s %v", dnsName, err)
 			}
 			// the dnsEntry is no longer needed because nothing references it, so delete it
 			delete(e.dnsEntries, dnsName)
@@ -111,7 +111,7 @@ func (e *EgressDNS) Delete(namespace string) bool {
 		// blocks only if Run() is busy updating its internal values)
 		e.deleted <- name
 	}
-	return len(e.dnsEntries) == 0
+	return len(e.dnsEntries) == 0, nil
 }
 
 func (e *EgressDNS) Update(dns string) (bool, error) {

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"net"
 
@@ -17,6 +18,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	t "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/urfave/cli/v2"
 
@@ -675,9 +677,266 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		})
+		ginkgo.It("correctly retries adding and updating an egressfirewall", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					node1Name string = "node1"
+				)
 
+				InitialNodeSwitch := &nbdb.LogicalSwitch{
+					UUID: libovsdbops.BuildNamedUUID(),
+					Name: node1Name,
+				}
+
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						InitialNodeSwitch,
+					},
+				}
+
+				namespace1 := *newNamespace("namespace1")
+				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+					{
+						Type: "Allow",
+						To: egressfirewallapi.EgressFirewallDestination{
+							CIDRSelector: "1.2.3.4/23",
+						},
+					},
+				})
+				egressFirewall1 := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+					{
+						Type: "Deny",
+						To: egressfirewallapi.EgressFirewallDestination{
+							CIDRSelector: "1.2.3.4/23",
+						},
+					},
+				})
+
+				fakeOVN.startWithDBSetup(dbSetup,
+					&egressfirewallapi.EgressFirewallList{
+						Items: []egressfirewallapi.EgressFirewall{
+							*egressFirewall,
+						},
+					},
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespace1,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							{
+								Status: v1.NodeStatus{
+									Phase: v1.NodeRunning,
+								},
+								ObjectMeta: newObjectMeta(node1Name, ""),
+							},
+						},
+					})
+
+				fakeOVN.controller.WatchNamespaces()
+				fakeOVN.controller.WatchEgressFirewall()
+
+				ipv4ACL := libovsdbops.BuildACL(
+					"",
+					t.DirectionToLPort,
+					t.EgressFirewallStartPriority,
+					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && ip4.dst != 10.128.0.0/14",
+					nbdb.ACLActionAllow,
+					"",
+					"",
+					false,
+					map[string]string{"egressFirewall": "namespace1"},
+					nil,
+				)
+				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
+
+				// new ACL will be added to the switch
+				finalNodeSwitch := &nbdb.LogicalSwitch{
+					UUID: InitialNodeSwitch.UUID,
+					Name: node1Name,
+					ACLs: []string{ipv4ACL.UUID},
+				}
+
+				// new ACL will be added to the switch
+				expectedDatabaseState := []libovsdb.TestData{
+					ipv4ACL,
+					finalNodeSwitch,
+				}
+
+				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+
+				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				ginkgo.By("Bringing down NBDB")
+				// inject transient problem, nbdb is down
+				fakeOVN.controller.nbClient.Close()
+				gomega.Eventually(func() bool {
+					return fakeOVN.controller.nbClient.Connected()
+				}).Should(gomega.BeFalse())
+
+				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall1.Namespace).Update(context.TODO(), egressFirewall1, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
+				time.Sleep(ovntypes.OVSDBTimeout + time.Second)
+				// check to see if the retry cache has an entry for this policy
+				key := getEgressFirewallNamespacedName(egressFirewall)
+				gomega.Eventually(func() *retryObjEntry {
+					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+				}).ShouldNot(gomega.BeNil())
+				connCtx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+				defer cancel()
+				resetNBClient(connCtx, fakeOVN.controller.nbClient)
+				fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
+				ipv4ACL.Action = nbdb.ACLActionDrop
+
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				// check the cache no longer has the entry
+				gomega.Eventually(func() *retryObjEntry {
+					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+				}).Should(gomega.BeNil())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		})
+		ginkgo.It("correctly retries deleting an egressfirewall", func() {
+			app.Action = func(ctx *cli.Context) error {
+				const (
+					node1Name string = "node1"
+					node2Name string = "node2"
+				)
+
+				nodeSwitch1 := &nbdb.LogicalSwitch{
+					UUID: libovsdbops.BuildNamedUUID(),
+					Name: node1Name,
+				}
+				nodeSwitch2 := &nbdb.LogicalSwitch{
+					UUID: libovsdbops.BuildNamedUUID(),
+					Name: node2Name,
+				}
+
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						nodeSwitch1,
+						nodeSwitch2,
+					},
+				}
+
+				namespace1 := *newNamespace("namespace1")
+				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+					{
+						Type: "Allow",
+						Ports: []egressfirewallapi.EgressFirewallPort{
+							{
+								Protocol: "TCP",
+								Port:     100,
+							},
+						},
+						To: egressfirewallapi.EgressFirewallDestination{
+							CIDRSelector: "1.2.3.5/23",
+						},
+					},
+				})
+
+				fakeOVN.startWithDBSetup(dbSetup,
+					&egressfirewallapi.EgressFirewallList{
+						Items: []egressfirewallapi.EgressFirewall{
+							*egressFirewall,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							{
+								Status: v1.NodeStatus{
+									Phase: v1.NodeRunning,
+								},
+								ObjectMeta: newObjectMeta(node1Name, ""),
+							},
+							{
+								Status: v1.NodeStatus{
+									Phase: v1.NodeRunning,
+								},
+								ObjectMeta: newObjectMeta(node2Name, ""),
+							},
+						},
+					})
+
+				fakeOVN.controller.WatchEgressFirewall()
+
+				ipv4ACL := libovsdbops.BuildACL(
+					"",
+					t.DirectionToLPort,
+					t.EgressFirewallStartPriority,
+					"(ip4.dst == 1.2.3.5/23) && ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 ))) && ip4.dst != 10.128.0.0/14",
+					nbdb.ACLActionAllow,
+					"",
+					"",
+					false,
+					map[string]string{"egressFirewall": "namespace1"},
+					nil,
+				)
+				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
+
+				// new ACL will be added to the switches
+				nodeSwitch1.ACLs = []string{ipv4ACL.UUID}
+				nodeSwitch2.ACLs = []string{ipv4ACL.UUID}
+
+				expectedDatabaseState := []libovsdb.TestData{
+					ipv4ACL,
+					nodeSwitch1,
+					nodeSwitch2,
+				}
+
+				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("Bringing down NBDB")
+				// inject transient problem, nbdb is down
+				fakeOVN.controller.nbClient.Close()
+				gomega.Eventually(func() bool {
+					return fakeOVN.controller.nbClient.Connected()
+				}).Should(gomega.BeFalse())
+
+				err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
+				time.Sleep(ovntypes.OVSDBTimeout + time.Second)
+				// check to see if the retry cache has an entry for this policy
+				key := getEgressFirewallNamespacedName(egressFirewall)
+				gomega.Eventually(func() *retryObjEntry {
+					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+				}).ShouldNot(gomega.BeNil())
+				connCtx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+				defer cancel()
+				resetNBClient(connCtx, fakeOVN.controller.nbClient)
+				fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
+
+				// ACL should be removed from switches after egfw is deleted
+				nodeSwitch1.ACLs = []string{}
+				nodeSwitch2.ACLs = []string{}
+				expectedDatabaseState = []libovsdb.TestData{
+					nodeSwitch1,
+					nodeSwitch2,
+				}
+
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				// check the cache no longer has the entry
+				gomega.Eventually(func() *retryObjEntry {
+					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+				}).Should(gomega.BeNil())
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
-
 })
 
 var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode", func() {
@@ -1261,7 +1520,232 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		})
+		ginkgo.It("correctly retries adding and updating an egressfirewall", func() {
+			app.Action = func(ctx *cli.Context) error {
+				initialJoinSwitch := &nbdb.LogicalSwitch{
+					UUID: libovsdbops.BuildNamedUUID(),
+					Name: "join",
+				}
 
+				namespace1 := *newNamespace("namespace1")
+				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+					{
+						Type: "Allow",
+						To: egressfirewallapi.EgressFirewallDestination{
+							CIDRSelector: "1.2.3.4/23",
+						},
+					},
+				})
+				egressFirewall1 := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+					{
+						Type: "Deny",
+						To: egressfirewallapi.EgressFirewallDestination{
+							CIDRSelector: "1.2.3.4/23",
+						},
+					},
+				})
+
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						initialJoinSwitch,
+					},
+				}
+				fakeOVN.startWithDBSetup(dbSetup,
+					&egressfirewallapi.EgressFirewallList{
+						Items: []egressfirewallapi.EgressFirewall{
+							*egressFirewall,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							{
+								Status: v1.NodeStatus{
+									Phase: v1.NodeRunning,
+								},
+								ObjectMeta: newObjectMeta(node1Name, ""),
+							},
+						},
+					})
+
+				fakeOVN.controller.WatchEgressFirewall()
+
+				ipv4ACL := libovsdbops.BuildACL(
+					"",
+					t.DirectionToLPort,
+					t.EgressFirewallStartPriority,
+					"(ip4.dst == 1.2.3.4/23) && ip4.src == $a10481622940199974102 && inport == \""+t.JoinSwitchToGWRouterPrefix+t.OVNClusterRouter+"\"",
+					nbdb.ACLActionAllow,
+					"",
+					"",
+					false,
+					map[string]string{"egressFirewall": "namespace1"},
+					nil,
+				)
+				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
+
+				// new ACL will be added to the switch
+				finalJoinSwitch := &nbdb.LogicalSwitch{
+					UUID: initialJoinSwitch.UUID,
+					Name: "join",
+					ACLs: []string{ipv4ACL.UUID},
+				}
+
+				expectedDatabaseState := []libovsdb.TestData{
+					ipv4ACL,
+					finalJoinSwitch,
+				}
+
+				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+
+				_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Get(context.TODO(), egressFirewall.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				ginkgo.By("Bringing down NBDB")
+				// inject transient problem, nbdb is down
+				fakeOVN.controller.nbClient.Close()
+				gomega.Eventually(func() bool {
+					return fakeOVN.controller.nbClient.Connected()
+				}).Should(gomega.BeFalse())
+
+				_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall1.Namespace).Update(context.TODO(), egressFirewall1, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
+				time.Sleep(ovntypes.OVSDBTimeout + time.Second)
+				// check to see if the retry cache has an entry for this policy
+				key := getEgressFirewallNamespacedName(egressFirewall)
+				gomega.Eventually(func() *retryObjEntry {
+					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+				}).ShouldNot(gomega.BeNil())
+				connCtx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+				defer cancel()
+				resetNBClient(connCtx, fakeOVN.controller.nbClient)
+				fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
+				ipv4ACL.Action = nbdb.ACLActionDrop
+
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				// check the cache no longer has the entry
+				gomega.Eventually(func() *retryObjEntry {
+					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+				}).Should(gomega.BeNil())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		})
+		ginkgo.It("correctly retries deleting an egressfirewall", func() {
+			app.Action = func(ctx *cli.Context) error {
+				initialJoinSwitch := &nbdb.LogicalSwitch{
+					UUID: libovsdbops.BuildNamedUUID(),
+					Name: "join",
+				}
+
+				namespace1 := *newNamespace("namespace1")
+				egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
+					{
+						Type: "Allow",
+						Ports: []egressfirewallapi.EgressFirewallPort{
+							{
+								Protocol: "TCP",
+								Port:     100,
+							},
+						},
+						To: egressfirewallapi.EgressFirewallDestination{
+							CIDRSelector: "1.2.3.5/23",
+						},
+					},
+				})
+
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						initialJoinSwitch,
+					},
+				}
+				fakeOVN.startWithDBSetup(dbSetup,
+					&egressfirewallapi.EgressFirewallList{
+						Items: []egressfirewallapi.EgressFirewall{
+							*egressFirewall,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							{
+								Status: v1.NodeStatus{
+									Phase: v1.NodeRunning,
+								},
+								ObjectMeta: newObjectMeta(node1Name, ""),
+							},
+						},
+					})
+
+				fakeOVN.controller.WatchEgressFirewall()
+
+				ipv4ACL := libovsdbops.BuildACL(
+					"",
+					t.DirectionToLPort,
+					t.EgressFirewallStartPriority,
+					"(ip4.dst == 1.2.3.5/23) && "+
+						"ip4.src == $a10481622940199974102 && ((tcp && ( tcp.dst == 100 ))) && inport == \""+t.JoinSwitchToGWRouterPrefix+t.OVNClusterRouter+"\"",
+					nbdb.ACLActionAllow,
+					"",
+					"",
+					false,
+					map[string]string{"egressFirewall": "namespace1"},
+					nil,
+				)
+				ipv4ACL.UUID = libovsdbops.BuildNamedUUID()
+
+				// new ACL will be added to the switch
+				finalJoinSwitch := &nbdb.LogicalSwitch{
+					UUID: initialJoinSwitch.UUID,
+					Name: "join",
+					ACLs: []string{ipv4ACL.UUID},
+				}
+
+				expectedDatabaseState := []libovsdb.TestData{
+					ipv4ACL,
+					finalJoinSwitch,
+				}
+
+				gomega.Expect(fakeOVN.nbClient).To(libovsdbtest.HaveData(expectedDatabaseState))
+				ginkgo.By("Bringing down NBDB")
+				// inject transient problem, nbdb is down
+				fakeOVN.controller.nbClient.Close()
+				gomega.Eventually(func() bool {
+					return fakeOVN.controller.nbClient.Connected()
+				}).Should(gomega.BeFalse())
+
+				err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// sleep long enough for TransactWithRetry to fail, causing NP Add to fail
+				time.Sleep(ovntypes.OVSDBTimeout + time.Second)
+				// check to see if the retry cache has an entry for this policy
+				key := getEgressFirewallNamespacedName(egressFirewall)
+				gomega.Eventually(func() *retryObjEntry {
+					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+				}).ShouldNot(gomega.BeNil())
+				connCtx, cancel := context.WithTimeout(context.Background(), ovntypes.OVSDBTimeout)
+				defer cancel()
+				resetNBClient(connCtx, fakeOVN.controller.nbClient)
+				fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
+
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				// check the cache no longer has the entry
+				gomega.Eventually(func() *retryObjEntry {
+					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
+				}).Should(gomega.BeNil())
+
+				// join switch should return to orignal state, egfw was deleted
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(fakeOVN.dbSetup.NBData))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 })


### PR DESCRIPTION
use the object retry infra with egress firewall feature and add additional unit-test,
remove egress-firewall update and update retry since retry infra will handle it.
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>