### PR TITLE
templates: switch dnsPolicy to Default for hostNetwork pods

### DIFF
--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -70,6 +70,7 @@ spec:
         - name: registry-credentials
       serviceAccountName: ovn
       hostNetwork: true
+      dnsPolicy: Default
 
       # required to be scheduled on node with k8s.ovn.org/ovnkube-db=true label but can
       # only have one instance per node

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -59,6 +59,7 @@ spec:
       # as all pods.
       serviceAccountName: ovn
       hostNetwork: true
+      dnsPolicy: Default
       containers:
       # firewall rules for ovn - assumed to be setup
       # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -36,6 +36,7 @@ spec:
       # as all pods.
       serviceAccountName: ovn
       hostNetwork: true
+      dnsPolicy: Default
 
       # required to be scheduled on a linux node with node-role.kubernetes.io/master label and
       # only one instance of ovnkube-master pod per node

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -32,6 +32,7 @@ spec:
       # as all pods.
       serviceAccountName: ovn
       hostNetwork: true
+      dnsPolicy: Default
       {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}
       containers:
 

--- a/dist/templates/ovs-node.yaml.j2
+++ b/dist/templates/ovs-node.yaml.j2
@@ -30,6 +30,7 @@ spec:
     spec:
       priorityClassName: "system-cluster-critical"
       hostNetwork: true
+      dnsPolicy: Default
       {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}
       containers:
 


### PR DESCRIPTION
**- What this PR does and why is it needed**

This commit changes the spec.dnsPolicy to Default for hostNetwork pods
so they use the hosts DNS. Even this is currently already the case for
pods having hostNetwork:true and spec.dnsPolicy DNSClusterFirst (which
is the default) this makes it more clear (https://github.com/kubernetes/kubernetes/blob/0424c7c74d926b4fe3193059e003e9056b429d28/pkg/kubelet/network/dns/dns.go#L303-L322)

**- How to verify it**
Check that all of the ovn pods which use host network have the dnsPolicy `Default`:
`$ kubectl -n ovn-kubernetes get po -ojsonpath='{.items[?(@.spec.hostNetwork)].spec.dnsPolicy}'`

**- Description for the changelog**
none