### PR TITLE
NodePort services shall preserve flows and IPT during IP AF migration

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -56,7 +56,7 @@ func deleteLocalNodeAccessBridge() error {
 
 // addGatewayIptRules adds the necessary iptable rules for a service on the node
 func addGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) {
-	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt)
+	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt, 0)
 
 	if err := addIptRules(rules); err != nil {
 		klog.Errorf("Failed to add iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)
@@ -64,8 +64,9 @@ func addGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) {
 }
 
 // delGatewayIptRules removes the iptable rules for a service from the node
-func delGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) {
-	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt)
+// addressFamily can be either "0" for both addressFamilies, or "4" or "6" to delete only a single AF.
+func delGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, addressFamily int) {
+	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt, addressFamily)
 
 	if err := delIptRules(rules); err != nil {
 		klog.Errorf("Failed to delete iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)

--- a/go-controller/pkg/util/iptables.go
+++ b/go-controller/pkg/util/iptables.go
@@ -258,7 +258,7 @@ func (f *FakeIPTables) MatchState(tables map[string]FakeTable) error {
 			for k := range *foundTable {
 				foundKeys = append(foundKeys, k)
 			}
-			return fmt.Errorf("expected %v chains from table %s, got %v", keys, tableName, foundKeys)
+			return fmt.Errorf("expected the following chains from table %s: %v; but got the following chains: %v", tableName, keys, foundKeys)
 		}
 		for chainName, chain := range table {
 			foundChain, err := foundTable.getChain(chainName)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -462,6 +462,26 @@ func addressIsIP(address v1.NodeAddress) bool {
 	return true
 }
 
+// addressIsIPv4 tells whether the given address is an
+// IPv4 address.
+func addressIsIPv4(address v1.NodeAddress) bool {
+	addr := net.ParseIP(address.Address)
+	if addr == nil {
+		return false
+	}
+	return utilnet.IsIPv4String(addr.String())
+}
+
+// addressIsIPv6 tells whether the given address is an
+// IPv6 address.
+func addressIsIPv6(address v1.NodeAddress) bool {
+	addr := net.ParseIP(address.Address)
+	if addr == nil {
+		return false
+	}
+	return utilnet.IsIPv6String(addr.String())
+}
+
 // Returns pod's ipv4 and ipv6 addresses IN ORDER
 func getPodAddresses(pod *v1.Pod) (string, string) {
 	var ipv4Res, ipv6Res string


### PR DESCRIPTION
When updating a NodePort service's IP ipFamilyPolicy (and nothing
else), do not delete rules and flows for the base IP Address Family.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->