### PR TITLE
WIP Bug 2074009: libovsdbops: remove chassis should also delete chassis_private

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -102,6 +102,8 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 			client.WithTable(&sbdb.MACBinding{}),
 			// used by libovsdbops
 			client.WithTable(&sbdb.Chassis{}),
+			// used by libovsdbops
+			client.WithTable(&sbdb.ChassisPrivate{}),
 			// used for metrics
 			client.WithTable(&sbdb.SBGlobal{}),
 			// used for metrics

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -49,6 +49,8 @@ func getUUID(model model.Model) string {
 		return t.UUID
 	case *sbdb.Chassis:
 		return t.UUID
+	case *sbdb.ChassisPrivate:
+		return t.UUID
 	case *sbdb.MACBinding:
 		return t.UUID
 	default:
@@ -95,6 +97,8 @@ func setUUID(model model.Model, uuid string) {
 	case *nbdb.Meter:
 		t.UUID = uuid
 	case *sbdb.Chassis:
+		t.UUID = uuid
+	case *sbdb.ChassisPrivate:
 		t.UUID = uuid
 	case *sbdb.MACBinding:
 		t.UUID = uuid
@@ -191,6 +195,11 @@ func copyIndexes(model model.Model) model.Model {
 			UUID: t.UUID,
 			Name: t.Name,
 		}
+	case *sbdb.ChassisPrivate:
+		return &sbdb.ChassisPrivate{
+			UUID: t.UUID,
+			Name: t.Name,
+		}
 	case *sbdb.MACBinding:
 		return &sbdb.MACBinding{
 			UUID:        t.UUID,
@@ -242,6 +251,8 @@ func getListFromModel(model model.Model) interface{} {
 		return &[]nbdb.Meter{}
 	case *sbdb.Chassis:
 		return &[]sbdb.Chassis{}
+	case *sbdb.ChassisPrivate:
+		return &[]sbdb.ChassisPrivate{}
 	case *sbdb.MACBinding:
 		return &[]sbdb.MACBinding{}
 	default:


### PR DESCRIPTION
Removing rows from ovn chassis table should also remove the corresponding
row in the chassis private table. That is needed to avoid warning errors
in northd that look like:

    ovn_northd|WARN|Chassis does not exist for Chassis_Private record

Ref code: https://github.com/ovn-org/ovn/blob/b22684d4e37c3dd205a959925b6e3f1827bbe045/northd/ovn-northd.c#L483-L496

Reported-at: https://bugzilla.redhat.com/show_bug.cgi?id=2074009
Signed-off-by: Flavio Fernandes <flaviof@redhat.com>

