### PR TITLE
fix node retry unit-test to make sure node creating happen while NBDB is down

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1382,7 +1382,8 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Eventually(func() bool {
 				return clusterController.nbClient.Connected()
 			}).Should(gomega.BeFalse())
-
+			_, err = fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), testNode.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// sleep long enough for TransactWithRetry to fail, causing node Add to fail
 			time.Sleep(types.OVSDBTimeout + time.Second)
 			// syncGateway should fail because we brought NBDB down


### PR DESCRIPTION
It was noticed node retry occasionally failing unit-test
In the failing runs NBDB was shut down after node was fully added hence we couldn't inject error and trigger retry logic i.e retry cache was empty.
logs from failing run
```
2022-04-12T16:26:06.1837312Z I0412 16:26:06.183634   19320 master.go:1200] Node node1 now has a new chassis ID, delete its stale chassis in SBDB
2022-04-12T16:26:06.1840493Z I0412 16:26:06.183956   19320 pods_retry.go:212] Iterate retry pods already requested
2022-04-12T16:26:06.1843855Z I0412 16:26:06.184166   19320 ovn.go:1178] Bootstrapping existing nodes and cleaning stale nodes took 386.617431ms
2022-04-12T16:26:06.1845888Z [1mSTEP[0m: injecting node add errors
2022-04-12T16:26:06.1850890Z [1mSTEP[0m: Bringing down NBDB
```
delayed access k8s node resource till NBDB shutdown is completed to ensure node Add/Update happening while NBDB is down so we can get errors.