### PR TITLE
Fixes node retry test and updating nodes next hop

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -204,7 +204,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			{
 				Model: &logicalRouterStaticRoute,
 				ModelPredicate: func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
-					return lrsr.IPPrefix == entry.String() && lrsr.Nexthop == drLRPIfAddr.IP.String() && util.SliceHasStringItem(tmpRouters[0].StaticRoutes, lrsr.UUID)
+					return lrsr.IPPrefix == entry.String() && util.SliceHasStringItem(tmpRouters[0].StaticRoutes, lrsr.UUID)
 				},
 				OnModelUpdates: []interface{}{
 					&logicalRouterStaticRoute.IPPrefix,
@@ -275,7 +275,7 @@ func (oc *Controller) gatewayInit(nodeName string, clusterIPSubnet []*net.IPNet,
 			{
 				Model: &logicalRouterStaticRoute,
 				ModelPredicate: func(lrsr *nbdb.LogicalRouterStaticRoute) bool {
-					return lrsr.OutputPort != nil && *lrsr.OutputPort == externalRouterPort && lrsr.Nexthop == nextHop.String()
+					return lrsr.OutputPort != nil && *lrsr.OutputPort == externalRouterPort && lrsr.IPPrefix == allIPs
 				},
 				OnModelUpdates: []interface{}{
 					&logicalRouterStaticRoute.Nexthop,

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -275,7 +275,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			// Add cluster LB Group to node switch.
 			expectedNodeSwitch.LoadBalancerGroup = []string{expectedClusterLBGroup.UUID}
 
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, clusterCIDR, config.IPv6Mode)
+			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
 			fakeOvn.controller.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(fakeOvn.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})
 			_, err = fakeOvn.controller.joinSwIPManager.EnsureJoinLRPIPs(ovntypes.OVNClusterRouter)


### PR DESCRIPTION
Changes the test to actually trigger an update event by updating the
node annotation with a new nexthop for the node. This revealed a bug in
the gateway update logic where we were using the nexthop as a predicate
for deciding on updating or adding a new route. Really route updates
should be based on IP prefix and not on destination.

Signed-off-by: Tim Rozet <trozet@redhat.com>

