### PR TITLE
metrics: add option to expose OVS metrics on the node

### DIFF
--- a/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
+++ b/go-controller/cmd/ovn-kube-util/app/ovs-exporter.go
@@ -34,7 +34,7 @@ var OvsExporterCommand = cli.Command{
 		mux.Handle("/metrics", promhttp.Handler())
 
 		// register ovs metrics that will be served off of /metrics path
-		metrics.RegisterOvsMetrics()
+		metrics.RegisterStandaloneOvsMetrics()
 
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -282,9 +282,12 @@ func runOvnKube(ctx *cli.Context) error {
 		metrics.StartMetricsServer(config.Metrics.BindAddress, config.Metrics.EnablePprof)
 	}
 
-	// start the prometheus server to serve OVN Metrics (default port: 9476)
-	// Note: for ovnkube node mode dpu-host no ovn metrics is required as ovn is not running on the node.
+	// start the prometheus server to serve OVS and OVN Metrics (default port: 9476)
+	// Note: for ovnkube node mode dpu-host no metrics is required as ovs/ovn is not running on the node.
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost && config.Metrics.OVNMetricsBindAddress != "" {
+		if config.Metrics.ExportOVSMetrics {
+			metrics.RegisterOvsMetricsWithOvnMetrics()
+		}
 		metrics.RegisterOvnMetrics(ovnClientset.KubeClient, node)
 		metrics.StartOVNMetricsServer(config.Metrics.OVNMetricsBindAddress)
 	}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -307,6 +307,7 @@ type KubernetesConfig struct {
 type MetricsConfig struct {
 	BindAddress           string `gcfg:"bind-address"`
 	OVNMetricsBindAddress string `gcfg:"ovn-metrics-bind-address"`
+	ExportOVSMetrics      bool   `gcfg:"export-ovs-metrics"`
 	EnablePprof           bool   `gcfg:"enable-pprof"`
 }
 
@@ -931,6 +932,11 @@ var MetricsFlags = []cli.Flag{
 		Name:        "ovn-metrics-bind-address",
 		Usage:       "The IP address and port for the OVN metrics server to serve on (set to 0.0.0.0 for all IPv4 interfaces)",
 		Destination: &cliConfig.Metrics.OVNMetricsBindAddress,
+	},
+	&cli.BoolFlag{
+		Name:        "export-ovs-metrics",
+		Usage:       "When true exports OVS metrics from the OVN metrics server",
+		Destination: &cliConfig.Metrics.ExportOVSMetrics,
 	},
 	&cli.BoolFlag{
 		Name:        "metrics-enable-pprof",

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -152,6 +152,7 @@ no-hostsubnet-nodes=label=another-test-label
 [metrics]
 bind-address=1.1.1.1:8080
 ovn-metrics-bind-address=1.1.1.2:8081
+export-ovs-metrics=true
 enable-pprof=true
 
 [logging]
@@ -558,6 +559,7 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Metrics.BindAddress).To(gomega.Equal("1.1.1.1:8080"))
 			gomega.Expect(Metrics.OVNMetricsBindAddress).To(gomega.Equal("1.1.1.2:8081"))
+			gomega.Expect(Metrics.ExportOVSMetrics).To(gomega.Equal(true))
 			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeSSL))
@@ -636,6 +638,7 @@ var _ = Describe("Config Operations", func() {
 
 			gomega.Expect(Metrics.BindAddress).To(gomega.Equal("2.2.2.2:8080"))
 			gomega.Expect(Metrics.OVNMetricsBindAddress).To(gomega.Equal("2.2.2.3:8081"))
+			gomega.Expect(Metrics.ExportOVSMetrics).To(gomega.Equal(true))
 			gomega.Expect(Metrics.EnablePprof).To(gomega.Equal(true))
 
 			gomega.Expect(OvnNorth.Scheme).To(gomega.Equal(OvnDBSchemeSSL))
@@ -706,6 +709,7 @@ var _ = Describe("Config Operations", func() {
 			"-monitor-all=false",
 			"-metrics-bind-address=2.2.2.2:8080",
 			"-ovn-metrics-bind-address=2.2.2.3:8081",
+			"-export-ovs-metrics=false",
 			"-metrics-enable-pprof=false",
 		}
 		err = app.Run(cliArgs)

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -401,7 +401,7 @@ func StartOVNMetricsServer(bindAddress string) {
 	go utilwait.Until(func() {
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("starting metrics server failed: %v", err))
+			utilruntime.HandleError(fmt.Errorf("starting OVN metrics server failed: %v", err))
 		}
 	}, 5*time.Second, utilwait.NeverStop)
 }


### PR DESCRIPTION
Instead of through the extra OVS metrics exporter utility. We're already doing node and OVN metrics in ovnkube, might as well do OVS there too.
    
NOTE: this is based on https://github.com/ovn-org/ovn-kubernetes/pull/2923