### PR TITLE
duplicated IPs can be assigned to multiple Pods

### DIFF
--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -1018,10 +1018,6 @@ func (oc *Controller) processObjectInTerminalState(objectsToRetry *retryObjs, ob
 // Note: when applying WatchResource to a new resource type, the appropriate resource-specific logic must be added to the
 // the different methods it calls.
 func (oc *Controller) WatchResource(objectsToRetry *retryObjs) *factory.Handler {
-	// track the retry entries and every 30 seconds (or upon explicit request) check if any objects
-	// need to be retried
-	go oc.periodicallyRetryResources(objectsToRetry)
-
 	addHandlerFunc, err := oc.watchFactory.GetResourceHandlerFunc(objectsToRetry.oType)
 	if err != nil {
 		klog.Errorf("No resource handler function found for resource %v. "+
@@ -1229,6 +1225,10 @@ func (oc *Controller) WatchResource(objectsToRetry *retryObjs) *factory.Handler 
 			},
 		},
 		syncFunc) // adds all existing objects at startup
+
+	// track the retry entries and every 30 seconds (or upon explicit request) check if any objects
+	// need to be retried
+	go oc.periodicallyRetryResources(objectsToRetry)
 
 	return handler
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -22,7 +22,10 @@ import (
 )
 
 func (oc *Controller) syncPodsRetriable(pods []interface{}) error {
-	// get the list of logical switch ports (equivalent to pods)
+	// get the list of logical switch ports (equivalent to pods). Reserve all existing Pod IPs to
+	// avoid subsequent new Pods getting the same duplicate Pod IP.
+	//
+	// TBD: Before this succeeds, add Pod handler should not continue to allocate IPs for the new Pods.
 	expectedLogicalPorts := make(map[string]bool)
 	for _, podInterface := range pods {
 		pod, ok := podInterface.(*kapi.Pod)


### PR DESCRIPTION
This commit addresses two issues:

When addNode() failed in addNodeAnnotations(), the node's IPAM can be
overwritten by subsequent addNode() retry attempts. As the result, the
same IP can be allocated to multiple pods.

retryPod worker is started too soon, which could start to handle add Pod
request and allocate duplicate Pod IPs before IPs of the existing Pods are
reserved in syncPods().

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->