### PR TITLE
Bump OVN version to 22.03 in schema and CI

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-21.12.0-5.fc35
+ARG ovnver=ovn-22.03.0-1.fc35
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -20,7 +20,7 @@ else
 CONTAINER_RUNTIME=docker
 endif
 CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1; echo $$?)
-OVN_VERSION ?= v21.09.1
+OVN_VERSION ?= v22.03.0
 
 .PHONY: all build check test
 

--- a/go-controller/hack/update-codegen.sh
+++ b/go-controller/hack/update-codegen.sh
@@ -10,7 +10,7 @@ if  ! ( command -v modelgen > /dev/null ); then
   olddir="${PWD}"
   builddir="$(mktemp -d)"
   cd "${builddir}"
-  GO111MODULE=on go install github.com/ovn-org/libovsdb/cmd/modelgen@8b93f8d269af
+  GO111MODULE=on go install github.com/ovn-org/libovsdb/cmd/modelgen@2cbe2d093e1247d42050306dd5c9a2d6c11f2460
   cd "${olddir}"
   if [[ "${builddir}" == /tmp/* ]]; then #paranoia
       rm -rf "${builddir}"

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -130,6 +130,7 @@ func copyIndexes(model model.Model) model.Model {
 	case *nbdb.Copp:
 		return &nbdb.Copp{
 			UUID: t.UUID,
+			Name: t.Name,
 		}
 	case *nbdb.GatewayChassis:
 		return &nbdb.GatewayChassis{

--- a/go-controller/pkg/nbdb/copp.go
+++ b/go-controller/pkg/nbdb/copp.go
@@ -7,8 +7,36 @@ import "github.com/ovn-org/libovsdb/model"
 
 // Copp defines an object in Copp table
 type Copp struct {
-	UUID   string            `ovsdb:"_uuid"`
-	Meters map[string]string `ovsdb:"meters"`
+	UUID        string            `ovsdb:"_uuid"`
+	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	Meters      map[string]string `ovsdb:"meters"`
+	Name        string            `ovsdb:"name"`
+}
+
+func copyCoppExternalIDs(a map[string]string) map[string]string {
+	if a == nil {
+		return nil
+	}
+	b := make(map[string]string, len(a))
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func equalCoppExternalIDs(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
 }
 
 func copyCoppMeters(a map[string]string) map[string]string {
@@ -39,6 +67,7 @@ func equalCoppMeters(a, b map[string]string) bool {
 
 func (a *Copp) DeepCopyInto(b *Copp) {
 	*b = *a
+	b.ExternalIDs = copyCoppExternalIDs(a.ExternalIDs)
 	b.Meters = copyCoppMeters(a.Meters)
 }
 
@@ -59,7 +88,9 @@ func (a *Copp) CloneModel() model.Model {
 
 func (a *Copp) Equals(b *Copp) bool {
 	return a.UUID == b.UUID &&
-		equalCoppMeters(a.Meters, b.Meters)
+		equalCoppExternalIDs(a.ExternalIDs, b.ExternalIDs) &&
+		equalCoppMeters(a.Meters, b.Meters) &&
+		a.Name == b.Name
 }
 
 func (a *Copp) EqualsModel(b model.Model) bool {

--- a/go-controller/pkg/nbdb/model.go
+++ b/go-controller/pkg/nbdb/model.go
@@ -45,7 +45,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_Northbound",
-  "version": "5.35.1",
+  "version": "6.1.0",
   "tables": {
     "ACL": {
       "columns": {
@@ -363,6 +363,18 @@ var schema = `{
     },
     "Copp": {
       "columns": {
+        "external_ids": {
+          "type": {
+            "key": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "min": 0,
+            "max": "unlimited"
+          }
+        },
         "meters": {
           "type": {
             "key": {
@@ -374,8 +386,16 @@ var schema = `{
             "min": 0,
             "max": "unlimited"
           }
+        },
+        "name": {
+          "type": "string"
         }
-      }
+      },
+      "indexes": [
+        [
+          "name"
+        ]
+      ]
     },
     "DHCP_Options": {
       "columns": {

--- a/go-controller/pkg/ovn/gateway_copp.go
+++ b/go-controller/pkg/ovn/gateway_copp.go
@@ -1,0 +1,96 @@
+package ovn
+
+import (
+	"fmt"
+
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+)
+
+const (
+	// Default Meters created on GRs.
+	OVNARPRateLimiter              = "arp"
+	OVNARPResolveRateLimiter       = "arp-resolve"
+	OVNBFDRateLimiter              = "bfd"
+	OVNControllerEventsRateLimiter = "event-elb"
+	OVNICMPV4ErrorsRateLimiter     = "icmp4-error"
+	OVNICMPV6ErrorsRateLimiter     = "icmp6-error"
+	OVNRejectRateLimiter           = "reject"
+	OVNTCPRSTRateLimiter           = "tcp-reset"
+
+	// Default COPP object name
+	defaultCOPPName = "ovnkube-default"
+)
+
+var defaultProtocolNames = [...]string{
+	OVNARPRateLimiter,
+	OVNARPResolveRateLimiter,
+	OVNBFDRateLimiter,
+	OVNControllerEventsRateLimiter,
+	OVNICMPV4ErrorsRateLimiter,
+	OVNICMPV6ErrorsRateLimiter,
+	OVNRejectRateLimiter,
+	OVNTCPRSTRateLimiter,
+}
+
+func getMeterNameForProtocol(protocol string) string {
+	// format: <OVNSupportedProtocolName>-rate-limiter
+	return protocol + "-" + types.OvnRateLimitingMeter
+}
+
+// EnsureDefaultCOPP creates the default COPP that needs to be added to each GR
+// if not already present. Also cleans up old COPP entries if required.
+func EnsureDefaultCOPP(nbClient libovsdbclient.Client) (string, error) {
+	p := func(item *nbdb.Copp) bool {
+		return item.Name == ""
+	}
+	ops, err := libovsdbops.DeleteCOPPsWithPredicateOps(nbClient, nil, p)
+	if err != nil {
+		return "", fmt.Errorf("failed to delete duplicate COPPs: %w", err)
+	}
+
+	band := &nbdb.MeterBand{
+		Action: types.MeterAction,
+		Rate:   int(25), // hard-coding for now. TODO(tssurya): make this configurable if needed
+	}
+	ops, err = libovsdbops.CreateMeterBandOps(nbClient, ops, band)
+	if err != nil {
+		return "", fmt.Errorf("can't create meter band %v: %v", band, err)
+	}
+
+	meterNames := make(map[string]string, len(defaultProtocolNames))
+	meterFairness := true
+	for _, protocol := range defaultProtocolNames {
+		// format: <OVNSupportedProtocolName>-rate-limiter
+		meterName := getMeterNameForProtocol(protocol)
+		meterNames[protocol] = meterName
+
+		meter := &nbdb.Meter{
+			Name: meterName,
+			Fair: &meterFairness,
+			Unit: types.PacketsPerSecond,
+		}
+		ops, err = libovsdbops.CreateOrUpdateMeterOps(nbClient, ops, meter, band)
+		if err != nil {
+			return "", fmt.Errorf("can't create meter %v: %v", meter, err)
+		}
+	}
+
+	defaultCOPP := &nbdb.Copp{
+		Name:   defaultCOPPName,
+		Meters: meterNames,
+	}
+	ops, err = libovsdbops.CreateOrUpdateCOPPsOps(nbClient, ops, defaultCOPP)
+	if err != nil {
+		return "", fmt.Errorf("failed to create/update default COPP: %w", err)
+	}
+
+	if _, err := libovsdbops.TransactAndCheckAndSetUUIDs(nbClient, defaultCOPP, ops); err != nil {
+		return "", fmt.Errorf("failed to transact default COPP: %w", err)
+	}
+
+	return defaultCOPP.UUID, nil
+}

--- a/go-controller/pkg/ovn/gateway_copp_test.go
+++ b/go-controller/pkg/ovn/gateway_copp_test.go
@@ -1,0 +1,172 @@
+package ovn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+)
+
+func TestEnsureDefaultCOPP(t *testing.T) {
+	meterMap := make(map[string]string, len(defaultProtocolNames))
+	for _, protocol := range defaultProtocolNames {
+		// format: <OVNSupportedProtocolName>-rate-limiter
+		meterMap[protocol] = getMeterNameForProtocol(protocol)
+	}
+
+	meterBand := &nbdb.MeterBand{
+		UUID:   "meter-band-UUID",
+		Action: types.MeterAction,
+		Rate:   int(25), // hard-coding for now. TODO(tssurya): make this configurable if needed
+	}
+
+	var meters []*nbdb.Meter
+	meterFairness := true
+	for i := 0; i < len(defaultProtocolNames); i++ {
+		meters = append(meters, &nbdb.Meter{
+			UUID:  fmt.Sprintf("meter-%d-UUID", i),
+			Name:  getMeterNameForProtocol(defaultProtocolNames[i]),
+			Fair:  &meterFairness,
+			Unit:  types.PacketsPerSecond,
+			Bands: []string{meterBand.UUID},
+		})
+	}
+
+	expectedNBData := []libovsdbtest.TestData{
+		&nbdb.Copp{
+			Name:   "ovnkube-default",
+			UUID:   "copp-UUID",
+			Meters: meterMap,
+		},
+		meterBand,
+	}
+	for _, m := range meters {
+		expectedNBData = append(expectedNBData, m)
+	}
+
+	existingNamedCOPPNBData := []libovsdbtest.TestData{
+		&nbdb.Copp{
+			UUID:   "copp-UUID",
+			Name:   "ovnkube-default",
+			Meters: meterMap,
+		},
+		meterBand,
+	}
+	for _, m := range meters {
+		existingNamedCOPPNBData = append(existingNamedCOPPNBData, m)
+	}
+
+	multipleEmptyCOPPNameNBData := []libovsdbtest.TestData{
+		&nbdb.Copp{
+			UUID:   "copp-UUID-1",
+			Meters: meterMap,
+		},
+		&nbdb.Copp{
+			UUID:   "copp-UUID-2",
+			Meters: meterMap,
+		},
+		&nbdb.Copp{
+			UUID:   "copp-UUID-3",
+			Meters: meterMap,
+		},
+		meterBand,
+	}
+	for _, m := range meters {
+		multipleEmptyCOPPNameNBData = append(multipleEmptyCOPPNameNBData, m)
+	}
+
+	multipleEmptyAndNamedCOPPNBData := []libovsdbtest.TestData{
+		&nbdb.Copp{
+			Name:   "ovnkube-default",
+			UUID:   "copp-UUID-1",
+			Meters: meterMap,
+		},
+		&nbdb.Copp{
+			UUID:   "copp-UUID-2",
+			Meters: meterMap,
+		},
+		&nbdb.Copp{
+			UUID:   "copp-UUID-3",
+			Meters: meterMap,
+		},
+		&nbdb.Copp{
+			UUID:   "copp-UUID-4",
+			Meters: meterMap,
+		},
+		meterBand,
+	}
+	for _, m := range meters {
+		multipleEmptyAndNamedCOPPNBData = append(multipleEmptyAndNamedCOPPNBData, m)
+	}
+
+	tests := []struct {
+		desc         string
+		expectErr    bool
+		initialNbdb  libovsdbtest.TestSetup
+		expectedNbdb libovsdbtest.TestSetup
+	}{
+		{
+			desc:      "no existing COPP",
+			expectErr: false,
+			expectedNbdb: libovsdbtest.TestSetup{
+				NBData: expectedNBData,
+			},
+		},
+		{
+			desc:      "updates existing named COPP",
+			expectErr: false,
+			initialNbdb: libovsdbtest.TestSetup{
+				NBData: existingNamedCOPPNBData,
+			},
+			expectedNbdb: libovsdbtest.TestSetup{
+				NBData: expectedNBData,
+			},
+		},
+		{
+			desc:      "cleans multiple empty-name default COPPs and adds named COPP",
+			expectErr: false,
+			initialNbdb: libovsdbtest.TestSetup{
+				NBData: multipleEmptyCOPPNameNBData,
+			},
+			expectedNbdb: libovsdbtest.TestSetup{
+				NBData: expectedNBData,
+			},
+		},
+		{
+			desc:      "cleans multiple empty-name default COPPs when named COPP exists",
+			expectErr: false,
+			initialNbdb: libovsdbtest.TestSetup{
+				NBData: multipleEmptyAndNamedCOPPNBData,
+			},
+			expectedNbdb: libovsdbtest.TestSetup{
+				NBData: expectedNBData,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(tt.initialNbdb, nil)
+			if err != nil {
+				t.Fatalf("test: \"%s\" failed to set up test harness: %v", tt.desc, err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			_, err = EnsureDefaultCOPP(nbClient)
+			if err != nil && !tt.expectErr {
+				t.Fatal(fmt.Errorf("EnsureDefaultCOPP() error = %v", err))
+			}
+
+			matcher := libovsdbtest.HaveData(tt.expectedNbdb.NBData)
+			success, err := matcher.Match(nbClient)
+
+			if !success {
+				t.Fatal(fmt.Errorf("test: \"%s\" didn't match expected with actual, err: %v", tt.desc, matcher.FailureMessage(nbClient)))
+			}
+			if err != nil {
+				t.Fatal(fmt.Errorf("test: \"%s\" encountered error: %v", tt.desc, err))
+			}
+		})
+	}
+}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -174,6 +174,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 
 	copp := &nbdb.Copp{
 		UUID:   "copp-UUID",
+		Name:   "ovnkube-default",
 		Meters: meters,
 	}
 	testData = append(testData, copp)
@@ -331,7 +332,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			}
 			sctpSupport := false
 
-			err := fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
+			var err error
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			testData := []libovsdb.TestData{}
@@ -384,7 +389,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			}
 			sctpSupport := false
 
-			err := fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
+			var err error
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			testData := []libovsdb.TestData{}
@@ -436,7 +445,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			}
 			sctpSupport := false
 
-			err := fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
+			var err error
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			testData := []libovsdb.TestData{}
@@ -489,7 +502,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			sctpSupport := false
 			config.Gateway.DisableSNATMultipleGWs = true
 
-			err := fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
+			var err error
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			testData := []libovsdb.TestData{}
@@ -567,7 +584,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			}
 			sctpSupport := false
 
-			err := fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
+			var err error
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			err = fakeOvn.controller.gatewayInit(nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, sctpSupport, joinLRPIPs, defLRPIPs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			testData := []libovsdb.TestData{}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -453,6 +453,11 @@ func (oc *Controller) SetupMaster(existingNodeNames []string) error {
 		return fmt.Errorf("failed to create logical switch port %+v and switch %s: %v", logicalSwitchPort, types.OVNJoinSwitch, err)
 	}
 
+	// Create default gateway Control Plane Protection (COPP) entry for gateway routers
+	if oc.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(oc.nbClient); err != nil {
+		return fmt.Errorf("unable to create gateway router control plane protection: %w", err)
+	}
+
 	return nil
 }
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -981,6 +981,8 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				record.NewFakeRecorder(0))
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
+			clusterController.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			clusterController.SCTPSupport = true
 			clusterController.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(clusterController.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})
@@ -1178,6 +1180,8 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				record.NewFakeRecorder(0))
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
+			clusterController.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			clusterController.SCTPSupport = true
 			clusterController.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(clusterController.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})
@@ -1358,6 +1362,8 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				record.NewFakeRecorder(0))
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
+			clusterController.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			clusterController.SCTPSupport = true
 			clusterController.joinSwIPManager, _ = lsm.NewJoinLogicalSwitchIPManager(clusterController.nbClient, expectedNodeSwitch.UUID, []string{node1.Name})

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -230,6 +230,9 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			fakeOvn.controller.multicastSupport = false
 			fakeOvn.controller.SCTPSupport = true
 
+			fakeOvn.controller.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 			_, clusterNetwork, err := net.ParseCIDR(clusterCIDR)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			fakeOvn.controller.masterSubnetAllocator.AddNetworkRange(clusterNetwork, 24)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -153,6 +153,9 @@ type Controller struct {
 	// Cluster wide Load_Balancer_Group UUID.
 	loadBalancerGroupUUID string
 
+	// Cluster-wide gateway router default Control Plane Protection (COPP) UUID
+	defaultGatewayCOPPUUID string
+
 	// Controller used for programming OVN for egress IP
 	eIPC egressIPController
 

--- a/go-controller/pkg/sbdb/bfd.go
+++ b/go-controller/pkg/sbdb/bfd.go
@@ -10,10 +10,10 @@ type (
 )
 
 var (
-	BFDStatusAdminDown BFDStatus = "admin_down"
 	BFDStatusDown      BFDStatus = "down"
 	BFDStatusInit      BFDStatus = "init"
 	BFDStatusUp        BFDStatus = "up"
+	BFDStatusAdminDown BFDStatus = "admin_down"
 )
 
 // BFD defines an object in BFD table

--- a/go-controller/pkg/sbdb/dhcp_options.go
+++ b/go-controller/pkg/sbdb/dhcp_options.go
@@ -11,14 +11,14 @@ type (
 
 var (
 	DHCPOptionsTypeBool         DHCPOptionsType = "bool"
-	DHCPOptionsTypeDomains      DHCPOptionsType = "domains"
-	DHCPOptionsTypeHostID       DHCPOptionsType = "host_id"
+	DHCPOptionsTypeUint8        DHCPOptionsType = "uint8"
+	DHCPOptionsTypeUint16       DHCPOptionsType = "uint16"
+	DHCPOptionsTypeUint32       DHCPOptionsType = "uint32"
 	DHCPOptionsTypeIpv4         DHCPOptionsType = "ipv4"
 	DHCPOptionsTypeStaticRoutes DHCPOptionsType = "static_routes"
 	DHCPOptionsTypeStr          DHCPOptionsType = "str"
-	DHCPOptionsTypeUint16       DHCPOptionsType = "uint16"
-	DHCPOptionsTypeUint32       DHCPOptionsType = "uint32"
-	DHCPOptionsTypeUint8        DHCPOptionsType = "uint8"
+	DHCPOptionsTypeHostID       DHCPOptionsType = "host_id"
+	DHCPOptionsTypeDomains      DHCPOptionsType = "domains"
 )
 
 // DHCPOptions defines an object in DHCP_Options table

--- a/go-controller/pkg/sbdb/dhcpv6_options.go
+++ b/go-controller/pkg/sbdb/dhcpv6_options.go
@@ -11,8 +11,8 @@ type (
 
 var (
 	DHCPv6OptionsTypeIpv6 DHCPv6OptionsType = "ipv6"
-	DHCPv6OptionsTypeMAC  DHCPv6OptionsType = "mac"
 	DHCPv6OptionsTypeStr  DHCPv6OptionsType = "str"
+	DHCPv6OptionsTypeMAC  DHCPv6OptionsType = "mac"
 )
 
 // DHCPv6Options defines an object in DHCPv6_Options table

--- a/go-controller/pkg/sbdb/load_balancer.go
+++ b/go-controller/pkg/sbdb/load_balancer.go
@@ -10,9 +10,9 @@ type (
 )
 
 var (
-	LoadBalancerProtocolSCTP LoadBalancerProtocol = "sctp"
 	LoadBalancerProtocolTCP  LoadBalancerProtocol = "tcp"
 	LoadBalancerProtocolUDP  LoadBalancerProtocol = "udp"
+	LoadBalancerProtocolSCTP LoadBalancerProtocol = "sctp"
 )
 
 // LoadBalancer defines an object in Load_Balancer table

--- a/go-controller/pkg/sbdb/logical_flow.go
+++ b/go-controller/pkg/sbdb/logical_flow.go
@@ -10,8 +10,8 @@ type (
 )
 
 var (
-	LogicalFlowPipelineEgress  LogicalFlowPipeline = "egress"
 	LogicalFlowPipelineIngress LogicalFlowPipeline = "ingress"
+	LogicalFlowPipelineEgress  LogicalFlowPipeline = "egress"
 )
 
 // LogicalFlow defines an object in Logical_Flow table

--- a/go-controller/pkg/sbdb/model.go
+++ b/go-controller/pkg/sbdb/model.go
@@ -132,10 +132,10 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "admin_down",
                   "down",
                   "init",
-                  "up"
+                  "up",
+                  "admin_down"
                 ]
               ]
             }
@@ -159,6 +159,7 @@ var schema = `{
               "type": "uuid",
               "refTable": "Encap"
             },
+            "min": 1,
             "max": "unlimited"
           }
         },
@@ -229,7 +230,8 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "external_ids": {
@@ -279,7 +281,8 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "is_connected": {
@@ -292,7 +295,8 @@ var schema = `{
               "type": "integer",
               "minInteger": 1000
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "other_config": {
@@ -345,7 +349,8 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "event_info": {
@@ -395,14 +400,14 @@ var schema = `{
                 "set",
                 [
                   "bool",
-                  "domains",
-                  "host_id",
+                  "uint8",
+                  "uint16",
+                  "uint32",
                   "ipv4",
                   "static_routes",
                   "str",
-                  "uint16",
-                  "uint32",
-                  "uint8"
+                  "host_id",
+                  "domains"
                 ]
               ]
             }
@@ -432,8 +437,8 @@ var schema = `{
                 "set",
                 [
                   "ipv6",
-                  "mac",
-                  "str"
+                  "str",
+                  "mac"
                 ]
               ]
             }
@@ -449,6 +454,7 @@ var schema = `{
               "type": "uuid",
               "refTable": "Datapath_Binding"
             },
+            "min": 1,
             "max": "unlimited"
           }
         },
@@ -600,7 +606,8 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "external_ids": {
@@ -655,7 +662,8 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "external_ids": {
@@ -699,7 +707,8 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "HA_Chassis"
+              "refTable": "HA_Chassis",
+              "refType": "strong"
             },
             "min": 0,
             "max": "unlimited"
@@ -738,7 +747,8 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "datapath": {
@@ -748,7 +758,8 @@ var schema = `{
               "refTable": "Datapath_Binding",
               "refType": "weak"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "ports": {
@@ -787,7 +798,8 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "eth_src": {
@@ -798,7 +810,8 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "ip4_src": {
@@ -812,7 +825,8 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "query_interval": {
@@ -820,7 +834,8 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "query_max_resp": {
@@ -828,7 +843,8 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "seq_no": {
@@ -839,7 +855,8 @@ var schema = `{
             "key": {
               "type": "integer"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         }
       },
@@ -895,13 +912,14 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "sctp",
                   "tcp",
-                  "udp"
+                  "udp",
+                  "sctp"
                 ]
               ]
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "vips": {
@@ -943,7 +961,8 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "external_ids": {
@@ -964,7 +983,8 @@ var schema = `{
               "type": "uuid",
               "refTable": "Datapath_Binding"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "logical_dp_group": {
@@ -973,7 +993,8 @@ var schema = `{
               "type": "uuid",
               "refTable": "Logical_DP_Group"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "match": {
@@ -986,8 +1007,8 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "egress",
-                  "ingress"
+                  "ingress",
+                  "egress"
                 ]
               ]
             }
@@ -1058,8 +1079,10 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Meter_Band"
+              "refTable": "Meter_Band",
+              "refType": "strong"
             },
+            "min": 1,
             "max": "unlimited"
           }
         },
@@ -1171,7 +1194,8 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "datapath": {
@@ -1189,7 +1213,8 @@ var schema = `{
               "refTable": "Encap",
               "refType": "weak"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "external_ids": {
@@ -1208,7 +1233,8 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "Gateway_Chassis"
+              "refTable": "Gateway_Chassis",
+              "refType": "strong"
             },
             "min": 0,
             "max": "unlimited"
@@ -1218,9 +1244,11 @@ var schema = `{
           "type": {
             "key": {
               "type": "uuid",
-              "refTable": "HA_Chassis_Group"
+              "refTable": "HA_Chassis_Group",
+              "refType": "strong"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "logical_port": {
@@ -1261,7 +1289,8 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "requested_chassis": {
@@ -1271,7 +1300,8 @@ var schema = `{
               "refTable": "Chassis",
               "refType": "weak"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "tag": {
@@ -1281,7 +1311,8 @@ var schema = `{
               "minInteger": 1,
               "maxInteger": 4095
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "tunnel_key": {
@@ -1301,7 +1332,8 @@ var schema = `{
             "key": {
               "type": "boolean"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "virtual_parent": {
@@ -1309,7 +1341,8 @@ var schema = `{
             "key": {
               "type": "string"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         }
       },
@@ -1441,7 +1474,8 @@ var schema = `{
               "type": "uuid",
               "refTable": "SSL"
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         }
       }
@@ -1533,7 +1567,8 @@ var schema = `{
                 ]
               ]
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         },
         "src_ip": {
@@ -1549,13 +1584,14 @@ var schema = `{
               "enum": [
                 "set",
                 [
-                  "error",
+                  "online",
                   "offline",
-                  "online"
+                  "error"
                 ]
               ]
             },
-            "min": 0
+            "min": 0,
+            "max": 1
           }
         }
       },

--- a/go-controller/pkg/sbdb/service_monitor.go
+++ b/go-controller/pkg/sbdb/service_monitor.go
@@ -13,9 +13,9 @@ type (
 var (
 	ServiceMonitorProtocolTCP   ServiceMonitorProtocol = "tcp"
 	ServiceMonitorProtocolUDP   ServiceMonitorProtocol = "udp"
-	ServiceMonitorStatusError   ServiceMonitorStatus   = "error"
-	ServiceMonitorStatusOffline ServiceMonitorStatus   = "offline"
 	ServiceMonitorStatusOnline  ServiceMonitorStatus   = "online"
+	ServiceMonitorStatusOffline ServiceMonitorStatus   = "offline"
+	ServiceMonitorStatusError   ServiceMonitorStatus   = "error"
 )
 
 // ServiceMonitor defines an object in Service_Monitor table


### PR DESCRIPTION
22.03 has some schema changes so we need to bump CI as well.

22.03 added (at our request) a Copp.Name field and indexing on name, which wasn't in 21.12, so we do need to update any COPP item we've already added with a name to make the indexes happy.