### PR TITLE
Allow make check without root

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -21,6 +21,12 @@ CONTAINER_RUNTIME=docker
 endif
 CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1; echo $$?)
 OVN_VERSION ?= v22.03.0
+ifeq ($(NOROOT),TRUE)
+C_ARGS = -e NOROOT=TRUE
+else
+C_ARGS = --cap-add=NET_ADMIN --cap-add=SYS_ADMIN
+endif
+export NOROOT
 
 .PHONY: all build check test
 
@@ -41,7 +47,7 @@ windows:
 # tests in a container. Refer: https://www.projectatomic.io/blog/2016/03/dwalsh_selinux_containers/ for additional context
 check test:
 ifeq ($(CONTAINER_RUNNABLE), 0)
-	$(CONTAINER_RUNTIME) run -it --rm --security-opt label=disable --cap-add=NET_ADMIN --cap-add=SYS_ADMIN -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller -e COVERALLS=${COVERALLS} -e GINKGO_FOCUS="${GINKGO_FOCUS}" $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 COVERALLS=${COVERALLS} PKGS="${PKGS}" hack/test-go.sh focus \"${GINKGO_FOCUS}\" "
+	$(CONTAINER_RUNTIME) run -it --rm --security-opt label=disable ${C_ARGS} -v $(shell dirname $(PWD)):/go/src/github.com/ovn-org/ovn-kubernetes -w /go/src/github.com/ovn-org/ovn-kubernetes/go-controller -e COVERALLS=${COVERALLS} -e GINKGO_FOCUS="${GINKGO_FOCUS}" $(GO_DOCKER_IMG) sh -c "RACE=1 DOCKER_TEST=1 COVERALLS=${COVERALLS} PKGS="${PKGS}" hack/test-go.sh focus \"${GINKGO_FOCUS}\" "
 else
 	RACE=1 hack/test-go.sh
 endif

--- a/go-controller/hack/test-go.sh
+++ b/go-controller/hack/test-go.sh
@@ -36,7 +36,11 @@ function testrun {
             go test -mod=vendor -covermode set -c "${pkg}" -o "${testfile}"
         fi
         args=""
-        go_test="sudo ${testfile}"
+        if [ "$NOROOT" = "TRUE" ]; then
+            go_test="${testfile}"
+        else
+            go_test="sudo ${testfile}"
+        fi
     fi
     if [[ -n "$gingko_focus" ]]; then
         local ginkgoargs=${ginkgo_focus:-}
@@ -57,7 +61,7 @@ function testrun {
     ${go_test} -test.v ${args} ${ginkgoargs} 2>&1
 }
 
-# These packages requires root for network namespace maniuplation in unit tests
+# These packages requires root for network namespace manipulation in unit tests
 root_pkgs=("github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node" "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller")
 
 i=0

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		Expect(testutils.UnmountNS(netns)).To(Succeed())
 	})
 
-	It("does not set up tunnels for non-hybrid-overlay nodes without annotations", func() {
+	ovntest.OnSupportedPlatformsIt("does not set up tunnels for non-hybrid-overlay nodes without annotations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				node1Name string = "node1"
@@ -273,7 +273,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		appRun(app, netns)
 	})
 
-	It("does not set up tunnels for non-hybrid-overlay nodes with subnet annotations", func() {
+	ovntest.OnSupportedPlatformsIt("does not set up tunnels for non-hybrid-overlay nodes with subnet annotations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				node1Name   string = "node1"
@@ -322,7 +322,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		appRun(app, netns)
 	})
 
-	It("sets up local node hybrid overlay bridge", func() {
+	ovntest.OnSupportedPlatformsIt("sets up local node hybrid overlay bridge", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				thisDrMAC string = "22:33:44:55:66:77"
@@ -366,7 +366,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		}
 		appRun(app, netns)
 	})
-	It("sets up local linux pod", func() {
+	ovntest.OnSupportedPlatformsIt("sets up local linux pod", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				thisDrMAC string = "22:33:44:55:66:77"
@@ -418,7 +418,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		appRun(app, netns)
 	})
 
-	It("sets up tunnels for Windows nodes", func() {
+	ovntest.OnSupportedPlatformsIt("sets up tunnels for Windows nodes", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				node1Name   string = "node1"
@@ -474,7 +474,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		appRun(app, netns)
 	})
 
-	It("removes stale node flows on initial sync", func() {
+	ovntest.OnSupportedPlatformsIt("removes stale node flows on initial sync", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				node1Name string = "node1"
@@ -526,7 +526,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		appRun(app, netns)
 	})
 
-	It("removes stale pod flows on initial sync", func() {
+	ovntest.OnSupportedPlatformsIt("removes stale pod flows on initial sync", func() {
 		app.Action = func(ctx *cli.Context) error {
 			fakeClient := fake.NewSimpleClientset()
 
@@ -581,7 +581,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		appRun(app, netns)
 	})
 
-	It("sets up local pod flows", func() {
+	ovntest.OnSupportedPlatformsIt("sets up local pod flows", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				pod1IP   string = "1.2.3.5"

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -982,7 +982,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("newLocalGateway sets up a local interface gateway", func() {
+		ovntest.OnSupportedPlatformsIt("newLocalGateway sets up a local interface gateway", func() {
 			localGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0IP, eth0GWIP, eth0CIDR)
 		})
 
@@ -1031,20 +1031,20 @@ var _ = Describe("Gateway Init Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("sets up a shared interface gateway", func() {
+		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway", func() {
 			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0IP, eth0GWIP, eth0CIDR, 0)
 		})
 
-		It("sets up a shared interface gateway with tagged VLAN", func() {
+		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway with tagged VLAN", func() {
 			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0IP, eth0GWIP, eth0CIDR, 3000)
 		})
 
 		config.Gateway.Interface = eth0Name
-		It("sets up a shared interface gateway with predetermined gateway interface", func() {
+		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway with predetermined gateway interface", func() {
 			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0IP, eth0GWIP, eth0CIDR, 0)
 		})
 
-		It("sets up a shared interface gateway with tagged VLAN + predetermined gateway interface", func() {
+		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway with tagged VLAN + predetermined gateway interface", func() {
 			shareGatewayInterfaceTest(app, testNS, eth0Name, eth0MAC, eth0IP, eth0GWIP, eth0CIDR, 3000)
 		})
 	})
@@ -1115,7 +1115,7 @@ var _ = Describe("Gateway Operations DPU", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("sets up a shared interface gateway DPU", func() {
+		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway DPU", func() {
 			shareGatewayInterfaceDPUTest(app, testNS, brphys, hostMAC, hostCIDR)
 		})
 	})
@@ -1158,7 +1158,7 @@ var _ = Describe("Gateway Operations DPU", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("sets up a shared interface gateway DPU host", func() {
+		ovntest.OnSupportedPlatformsIt("sets up a shared interface gateway DPU host", func() {
 			shareGatewayInterfaceDPUHostTest(app, testNS, uplinkName, hostIP, gwIP)
 		})
 	})

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -450,7 +450,7 @@ var _ = Describe("Management Port Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("sets up the management port for IPv4 clusters", func() {
+		ovntest.OnSupportedPlatformsIt("sets up the management port for IPv4 clusters", func() {
 			app.Action = func(ctx *cli.Context) error {
 				testManagementPort(ctx, fexec, testNS,
 					[]managementPortTestConfig{
@@ -474,7 +474,7 @@ var _ = Describe("Management Port Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("sets up the management port for IPv6 clusters", func() {
+		ovntest.OnSupportedPlatformsIt("sets up the management port for IPv6 clusters", func() {
 			app.Action = func(ctx *cli.Context) error {
 				testManagementPort(ctx, fexec, testNS,
 					[]managementPortTestConfig{
@@ -500,7 +500,7 @@ var _ = Describe("Management Port Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("sets up the management port for dual-stack clusters", func() {
+		ovntest.OnSupportedPlatformsIt("sets up the management port for dual-stack clusters", func() {
 			app.Action = func(ctx *cli.Context) error {
 				testManagementPort(ctx, fexec, testNS,
 					[]managementPortTestConfig{
@@ -551,7 +551,7 @@ var _ = Describe("Management Port Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("sets up the management port for IPv4 dpu clusters", func() {
+		ovntest.OnSupportedPlatformsIt("sets up the management port for IPv4 dpu clusters", func() {
 			app.Action = func(ctx *cli.Context) error {
 				testManagementPortDPU(ctx, fexec, testNS,
 					[]managementPortTestConfig{
@@ -592,7 +592,7 @@ var _ = Describe("Management Port Operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("sets up the management port for IPv4 dpu-host clusters", func() {
+		ovntest.OnSupportedPlatformsIt("sets up the management port for IPv4 dpu-host clusters", func() {
 			app.Action = func(ctx *cli.Context) error {
 				testManagementPortDPUHost(ctx, fexec, testNS,
 					[]managementPortTestConfig{

--- a/go-controller/pkg/node/management-port_test.go
+++ b/go-controller/pkg/node/management-port_test.go
@@ -1,11 +1,12 @@
 package node
 
 import (
+	"reflect"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	"reflect"
 )
 
 var _ = Describe("Mananagement port tests", func() {

--- a/go-controller/pkg/testing/testing.go
+++ b/go-controller/pkg/testing/testing.go
@@ -1,9 +1,26 @@
 package testing
 
 import (
+	"os"
+
+	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega/format"
+
 	kruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
+
+// OnSupportedPlatformsIt is a wrapper around ginkgo.It to determine if running
+// the test is applicable for the current test environment. This is used to skip
+// tests that are unable to execute in certain environments. Such as those without
+// root or cap_net_admin privileges
+func OnSupportedPlatformsIt(description string, f interface{}) {
+	if os.Getenv("NOROOT") != "TRUE" {
+		ginkgo.It(description, f)
+	} else {
+		defer ginkgo.GinkgoRecover()
+		ginkgo.Skip(description)
+	}
+}
 
 func init() {
 	// Gomega's default string diff behavior makes it impossible to figure


### PR DESCRIPTION
Skips tests that require sudo or special capabilities to execute. To
run, use "make check NOROOT=TRUE"

Signed-off-by: Tim Rozet <trozet@redhat.com>

