### PR TITLE
NodePort services DualStack tests refactor and failure toleration

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -462,6 +462,26 @@ func addressIsIP(address v1.NodeAddress) bool {
 	return true
 }
 
+// addressIsIPv4 tells whether the given address is an
+// IPv4 address.
+func addressIsIPv4(address v1.NodeAddress) bool {
+	addr := net.ParseIP(address.Address)
+	if addr == nil {
+		return false
+	}
+	return utilnet.IsIPv4String(addr.String())
+}
+
+// addressIsIPv6 tells whether the given address is an
+// IPv6 address.
+func addressIsIPv6(address v1.NodeAddress) bool {
+	addr := net.ParseIP(address.Address)
+	if addr == nil {
+		return false
+	}
+	return utilnet.IsIPv6String(addr.String())
+}
+
 // Returns pod's ipv4 and ipv6 addresses IN ORDER
 func getPodAddresses(pod *v1.Pod) (string, string) {
 	var ipv4Res, ipv6Res string


### PR DESCRIPTION
Refactor the DualStack service IPFamily upgrade test for node ports.
Tolerate initial failure of the IPv4 endpoints (workaround iss #2868)

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->