### PR TITLE
Don't warn on failure to create pod when it isn't scheduled

### DIFF
--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -630,7 +630,7 @@ func (oc *Controller) updateResource(objectsToRetry *retryObjs, oldObj, newObj i
 		if err != nil {
 			return err
 		}
-		return oc.ensurePod(oldPod, newPod, objectsToRetry.checkRetryObj(newKey))
+		return oc.ensurePod(oldPod, newPod, objectsToRetry.checkRetryObj(newKey) || util.PodScheduled(oldPod) != util.PodScheduled(newPod))
 
 	case factory.NodeType:
 		newNode, ok := newObj.(*kapi.Node)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -475,7 +475,7 @@ func networkStatusAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 func (oc *Controller) ensurePod(oldPod, pod *kapi.Pod, addPort bool) error {
 	// Try unscheduled pods later
 	if !util.PodScheduled(pod) {
-		return fmt.Errorf("failed to ensurePod %s/%s since it is not yet scheduled", pod.Namespace, pod.Name)
+		return nil
 	}
 
 	if oldPod != nil && (exGatewayAnnotationsChanged(oldPod, pod) || networkStatusAnnotationsChanged(oldPod, pod)) {


### PR DESCRIPTION
If the pod isn't yet scheduled, we should just ignore the event and try again later.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>