### PR TITLE
Bug 2074009: Delete ChassisPrivate along with Chassis

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20211201215911-5a82bae32e46
 	github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366
-	github.com/ovn-org/libovsdb v0.6.1-0.20220328142833-2cbe2d093e12
+	github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/afero v1.4.1

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -399,8 +399,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mo
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366 h1:/llKlbXC7F6rqTkAl2GE//9GDR0iDsqJEFvvJ1kLJXg=
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366/go.mod h1:HJeHsH6mPyrrOVS/2j1zcztGAJG9ETKbqtlyohs84yY=
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
-github.com/ovn-org/libovsdb v0.6.1-0.20220328142833-2cbe2d093e12 h1:0omm+gRCOGkS2JyFoMYAF4NUrd8b4A+wnbooJZKH02g=
-github.com/ovn-org/libovsdb v0.6.1-0.20220328142833-2cbe2d093e12/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
+github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4 h1:atUIOA34Cg9GVFn/8rmIsmnOIbi0D82x+xfhV2UuF1Q=
+github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -94,14 +94,17 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 	}()
 
 	// Only Monitor Required SBDB tables to reduce memory overhead
+	chassisPrivate := sbdb.ChassisPrivate{}
 	_, err = c.Monitor(ctx,
 		c.NewMonitor(
 			// used by unidling controller
 			client.WithTable(&sbdb.ControllerEvent{}),
 			// used for gateway
 			client.WithTable(&sbdb.MACBinding{}),
-			// used by libovsdbops
+			// used by node sync
 			client.WithTable(&sbdb.Chassis{}),
+			// used by node sync, only interested in names
+			client.WithTable(&chassisPrivate, &chassisPrivate.Name),
 			// used for metrics
 			client.WithTable(&sbdb.SBGlobal{}),
 			// used for metrics

--- a/go-controller/pkg/libovsdbops/chassis_test.go
+++ b/go-controller/pkg/libovsdbops/chassis_test.go
@@ -1,0 +1,125 @@
+package libovsdbops
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+)
+
+func TestDeleteChassis(t *testing.T) {
+	uuid := "b9998337-2498-4d1e-86e6-fc0417abb2f0"
+	tests := []struct {
+		desc             string
+		chassis          *sbdb.Chassis
+		chassisPredicate chassisPredicate
+		initialDB        []libovsdbtest.TestData
+		expectedDB       []libovsdbtest.TestData
+	}{
+		{
+			desc:    "delete chassis and chassis private",
+			chassis: &sbdb.Chassis{Name: "test"},
+			initialDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "test"},
+				&sbdb.ChassisPrivate{Name: "test"},
+				&sbdb.Chassis{Name: "test2"},
+				&sbdb.ChassisPrivate{Name: "test2"},
+			},
+			expectedDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "test2"},
+				&sbdb.ChassisPrivate{Name: "test2"},
+			},
+		},
+		{
+			desc:    "delete chassis and chassis private by UUID",
+			chassis: &sbdb.Chassis{UUID: uuid},
+			initialDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{UUID: uuid, Name: "test"},
+				&sbdb.ChassisPrivate{Name: "test"},
+			},
+			expectedDB: []libovsdbtest.TestData{},
+		},
+		{
+			desc:    "delete chassis when chassis private does not exist",
+			chassis: &sbdb.Chassis{Name: "test"},
+			initialDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "test"},
+				&sbdb.Chassis{Name: "test2"},
+				&sbdb.ChassisPrivate{Name: "test2"},
+			},
+			expectedDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "test2"},
+				&sbdb.ChassisPrivate{Name: "test2"},
+			},
+		},
+		{
+			desc:    "delete chassis private when chassis does not exist",
+			chassis: &sbdb.Chassis{Name: "test"},
+			initialDB: []libovsdbtest.TestData{
+				&sbdb.ChassisPrivate{Name: "test"},
+				&sbdb.Chassis{Name: "test2"},
+				&sbdb.ChassisPrivate{Name: "test2"},
+			},
+			expectedDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "test2"},
+				&sbdb.ChassisPrivate{Name: "test2"},
+			},
+		},
+		{
+			desc:             "delete chassis and chassis private by predicate",
+			chassisPredicate: func(c *sbdb.Chassis) bool { return c.Hostname == "testNode" },
+			initialDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "test", Hostname: "testNode"},
+				&sbdb.ChassisPrivate{Name: "test"},
+				&sbdb.Chassis{Name: "test2", Hostname: "testNode"},
+				&sbdb.ChassisPrivate{Name: "test2"},
+				&sbdb.Chassis{Name: "test3", Hostname: "testNode3"},
+				&sbdb.ChassisPrivate{Name: "test3"},
+			},
+			expectedDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "test3", Hostname: "testNode3"},
+				&sbdb.ChassisPrivate{Name: "test3"},
+			},
+		},
+		{
+			desc:             "delete chassis by predicate when chassis private does not exist",
+			chassisPredicate: func(c *sbdb.Chassis) bool { return c.Hostname == "testNode" },
+			initialDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "test", Hostname: "testNode"},
+			},
+			expectedDB: []libovsdbtest.TestData{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			dbSetup := libovsdbtest.TestSetup{
+				SBData: tt.initialDB,
+			}
+			sbClient, cleanup, err := libovsdbtest.NewSBTestHarness(dbSetup, nil)
+			if err != nil {
+				t.Fatalf("%s: failed to set up test harness: %v", tt.desc, err)
+			}
+			t.Cleanup(cleanup.Cleanup)
+
+			if tt.chassis != nil {
+				err = DeleteChassis(sbClient, tt.chassis)
+			} else if tt.chassisPredicate != nil {
+				err = DeleteChassisWithPredicate(sbClient, tt.chassisPredicate)
+			}
+
+			if err != nil {
+				t.Fatal(fmt.Errorf("%s: got unexpected error: %v", tt.desc, err))
+			}
+
+			matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedDB)
+			match, err := matcher.Match(sbClient)
+			if err != nil {
+				t.Fatalf("%s: matcher error: %v", tt.desc, err)
+			}
+			if !match {
+				t.Fatalf("%s: DB state did not match: %s", tt.desc, matcher.FailureMessage(sbClient))
+			}
+		})
+	}
+}

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -52,6 +52,8 @@ func getUUID(model model.Model) string {
 		return t.UUID
 	case *sbdb.Chassis:
 		return t.UUID
+	case *sbdb.ChassisPrivate:
+		return t.UUID
 	case *sbdb.MACBinding:
 		return t.UUID
 	case *sbdb.SBGlobal:
@@ -100,6 +102,8 @@ func setUUID(model model.Model, uuid string) {
 	case *nbdb.Meter:
 		t.UUID = uuid
 	case *sbdb.Chassis:
+		t.UUID = uuid
+	case *sbdb.ChassisPrivate:
 		t.UUID = uuid
 	case *sbdb.MACBinding:
 		t.UUID = uuid
@@ -199,6 +203,11 @@ func copyIndexes(model model.Model) model.Model {
 			UUID: t.UUID,
 			Name: t.Name,
 		}
+	case *sbdb.ChassisPrivate:
+		return &sbdb.ChassisPrivate{
+			UUID: t.UUID,
+			Name: t.Name,
+		}
 	case *sbdb.MACBinding:
 		return &sbdb.MACBinding{
 			UUID:        t.UUID,
@@ -254,6 +263,8 @@ func getListFromModel(model model.Model) interface{} {
 		return &[]*nbdb.Meter{}
 	case *sbdb.Chassis:
 		return &[]*sbdb.Chassis{}
+	case *sbdb.ChassisPrivate:
+		return &[]*sbdb.ChassisPrivate{}
 	case *sbdb.MACBinding:
 		return &[]*sbdb.MACBinding{}
 	default:

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -1922,6 +1923,91 @@ func TestController_allocateNodeSubnets(t *testing.T) {
 
 			if len(allocated) != tt.allocated {
 				t.Errorf("Expected %d subnets allocated, received %d", tt.allocated, len(allocated))
+			}
+		})
+	}
+}
+
+func TestController_syncNodesRetriable(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialSBDB  []libovsdbtest.TestData
+		expectedSBDB []libovsdbtest.TestData
+	}{
+		{
+			name: "removes stale chassis and chassis private",
+			initialSBDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "chassis-node1", Hostname: "node1"},
+				&sbdb.ChassisPrivate{Name: "chassis-node1"},
+				&sbdb.Chassis{Name: "chassis-node2", Hostname: "node2"},
+				&sbdb.ChassisPrivate{Name: "chassis-node2"},
+				&sbdb.ChassisPrivate{Name: "chassis-node3"},
+			},
+			expectedSBDB: []libovsdbtest.TestData{
+				&sbdb.Chassis{Name: "chassis-node1", Hostname: "node1"},
+				&sbdb.ChassisPrivate{Name: "chassis-node1"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stopChan := make(chan struct{})
+			defer close(stopChan)
+
+			testNode := v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			}
+
+			kubeFakeClient := fake.NewSimpleClientset()
+			egressFirewallFakeClient := &egressfirewallfake.Clientset{}
+			egressIPFakeClient := &egressipfake.Clientset{}
+			fakeClient := &util.OVNClientset{
+				KubeClient:           kubeFakeClient,
+				EgressIPClient:       egressIPFakeClient,
+				EgressFirewallClient: egressFirewallFakeClient,
+			}
+			f, err := factory.NewMasterWatchFactory(fakeClient)
+			if err != nil {
+				t.Fatalf("%s: Error creating master watch factory: %v", tt.name, err)
+			}
+
+			dbSetup := libovsdbtest.TestSetup{
+				SBData: tt.initialSBDB,
+			}
+			nbClient, sbClient, libovsdbCleanup, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
+			if err != nil {
+				t.Fatalf("Error creating libovsdb test harness: %v", err)
+			}
+			t.Cleanup(libovsdbCleanup.Cleanup)
+
+			controller := NewOvnController(
+				fakeClient,
+				f,
+				stopChan,
+				addressset.NewFakeAddressSetFactory(),
+				nbClient,
+				sbClient,
+				record.NewFakeRecorder(0))
+
+			controller.joinSwIPManager, err = lsm.NewJoinLogicalSwitchIPManager(nbClient, "", []string{})
+			if err != nil {
+				t.Fatalf("%s: Error creating joinSwIPManager: %v", tt.name, err)
+			}
+
+			err = controller.syncNodesRetriable([]interface{}{&testNode})
+			if err != nil {
+				t.Fatalf("%s: Error on syncNodesRetriable: %v", tt.name, err)
+			}
+
+			matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedSBDB)
+			match, err := matcher.Match(sbClient)
+			if err != nil {
+				t.Fatalf("%s: matcher error: %v", tt.name, err)
+			}
+			if !match {
+				t.Fatalf("%s: DB state did not match: %s", tt.name, matcher.FailureMessage(sbClient))
 			}
 		})
 	}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/mapper/mapper.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/mapper/mapper.go
@@ -319,16 +319,10 @@ func (m Mapper) equalIndexes(one, other *Info, indexes ...string) (bool, error) 
 // NewMonitorRequest returns a monitor request for the provided tableName
 // If fields is provided, the request will be constrained to the provided columns
 // If no fields are provided, all columns will be used
-func (m *Mapper) NewMonitorRequest(data *Info, fields []interface{}) (*ovsdb.MonitorRequest, error) {
+func (m *Mapper) NewMonitorRequest(data *Info, fields []string) (*ovsdb.MonitorRequest, error) {
 	var columns []string
 	if len(fields) > 0 {
-		for _, f := range fields {
-			column, err := data.ColumnByPtr(f)
-			if err != nil {
-				return nil, err
-			}
-			columns = append(columns, column)
-		}
+		columns = append(columns, fields...)
 	} else {
 		for c := range data.Metadata.TableSchema.Columns {
 			columns = append(columns, c)

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -232,7 +232,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220328142833-2cbe2d093e12
+# github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4
 ## explicit; go 1.16
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client


### PR DESCRIPTION
When SBDB chassis rows are deleted, remove the associated chassis
private row as well.

Remove stale chassis private rows on initial node synchronization.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
