### PR TITLE
Don't addRetryPods during node updates

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1348,7 +1348,7 @@ func (oc *Controller) addUpdateNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) err
 	pods, err := oc.client.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
 	if err != nil {
 		klog.Errorf("Unable to list existing pods on node: %s, existing pods on this node may not function")
-	} else {
+	} else if nSyncs.syncNode { // do this only if its a new node add
 		klog.V(5).Infof("When adding node %s, found %d pods to add to retryPods", node.Name, len(pods.Items))
 		for _, pod := range pods.Items {
 			pod := pod


### PR DESCRIPTION
Since we combined add and update node functions
into addUpdateNodeEvent, we end up calling oc.addRetryPods(pods.Items)
and trigger oc.requestRetryPods() for every node update which happens
every 5 mins. This means we are retrying all the existing pods on
a given node every 5mins. Let's call addRetryPods only if syncNode=true
which signifies its a nodeAdd and not nodeUpdate.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
Closes: #2942

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->