### PR TITLE
libovsdbops: fix mis-use of BulkOp=true

### DIFF
--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -357,7 +357,7 @@ func DeleteLogicalSwitchPortsWithPredicateOps(nbClient libovsdbclient.Client, op
 		opModel := operationModel{
 			Model:       lsp,
 			ErrNotFound: false,
-			BulkOp:      true,
+			BulkOp:      false,
 		}
 		opModels = append(opModels, opModel)
 	}


### PR DESCRIPTION
BulkOps:true requires a ModelPredicate; but the function has
alredy done what ModelPredicate would do by building
the list of LSPs manually.

Fixes: 6d607414 ("libovsdb: cleanup ModelClient usage for switch & ports")

@trozet @jcaamano 

```
I0421 19:58:41.338284       1 kube.go:73] Setting annotations map[k8s.ovn.org/pod-networks:{"default":{"ip_addresses":["10.129.2.3/23"],"mac_address":"0a:58:0a:81:02:03","gateway_ips":["10.129.2.1"],"ip_address":"10.129.2.3/23","gateway_ip":"10.129.2.1"}}] on pod openshift-image-registry/image-registry-5f6d9b4cb4-cd7t4
E0421 19:58:41.338556       1 pods.go:53] Already allocated IPs: 10.130.0.4 for pod: openshift-kube-scheduler_openshift-kube-scheduler-guard-ip-10-0-180-228.us-west-2.compute.internal on node: ip-10-0-180-228.us-west-2.compute.internal
E0421 19:58:41.338590       1 pods.go:53] Already allocated IPs: 10.128.0.3 for pod: openshift-kube-apiserver_revision-pruner-6-ip-10-0-133-31.us-west-2.compute.internal on node: ip-10-0-133-31.us-west-2.compute.internal
E0421 19:58:41.338598       1 pods.go:53] Already allocated IPs: 10.130.0.3 for pod: openshift-kube-controller-manager_installer-5-ip-10-0-180-228.us-west-2.compute.internal on node: ip-10-0-180-228.us-west-2.compute.internal
E0421 19:58:41.340577       1 runtime.go:76] Observed a panic: Expected a ModelPredicate with BulkOp==true
goroutine 147 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x18cf8e0, 0x1e72b30})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x7d
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xb7cf60})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
panic({0x18cf8e0, 0x1e72b30})
	/usr/lib/golang/src/runtime/panic.go:1038 +0x215
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops.(*modelClient).lookup(0xc002b7cf30, 0xc002c90000)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/libovsdbops/model_client.go:393 +0x11b
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops.(*modelClient).buildOps(0x7ff6ef10ba68, {0x2e51a80, 0x0, 0x0}, 0xc001f87540, 0x0, {0xc00054a380, 0x2, 0x10})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/libovsdbops/model_client.go:257 +0x1a7
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops.(*modelClient).DeleteOps(0xc002c8b980, {0x2e51a80, 0xc002c8b8c0, 0x7ff6ef10ba68}, {0xc00054a380, 0xc000071000, 0xc002b7a540})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/libovsdbops/model_client.go:244 +0x4e
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops.DeleteLogicalSwitchPortsWithPredicateOps({0x1f06ac8, 0xc000322270}, {0x2e51a80, 0x0, 0x0}, 0x1, 0xc001f87868)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/libovsdbops/switch.go:373 +0x7db
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).syncPodsRetriable(0xc0001c4840, {0xc00207a000, 0xcd, 0x10})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/pods.go:85 +0x35a
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).syncPods.func1()
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/pods.go:25 +0x29
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).syncWithRetry.func1()
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/master.go:1161 +0x42
k8s.io/apimachinery/pkg/util/wait.ConditionFunc.WithContext.func1({0x7ff6c41ac240, 0x0})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:220 +0x1b
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext({0x1eb83c8, 0xc00019a000}, 0xc001f87b20)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:233 +0x7c
k8s.io/apimachinery/pkg/util/wait.poll({0x1eb83c8, 0xc00019a000}, 0x60, 0xb752a5, 0x20)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:580 +0x38
k8s.io/apimachinery/pkg/util/wait.PollImmediateWithContext({0x1eb83c8, 0xc00019a000}, 0xc0001aa0c0, 0xc001f87bb0, 0x4135a7)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:526 +0x4a
k8s.io/apimachinery/pkg/util/wait.PollImmediate(0x7ff6c40e3a28, 0x18, 0x28)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:512 +0x50
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).syncWithRetry(0x1952f40, {0x1c034c4, 0x8}, 0xc001eda3c0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/master.go:1160 +0xbc
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).syncPods(0xc0001c4840, {0xc00207a000, 0xcd, 0x100})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/pods.go:25 +0xb2
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory.(*WatchFactory).addHandler(0xc000100ba0, {0x1f0d030, 0x1bda9e0}, {0x0, 0x0}, {0x0, 0x0}, {0x1eaef30, 0xc001e27da0}, 0xc001f87e38)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/factory/factory.go:367 +0x328
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory.(*WatchFactory).AddPodHandler(...)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/factory/factory.go:382
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).WatchPods(0xc0001c4840)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/ovn.go:532 +0x1f5
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).Run(0xc0001c4840, {0x1eb8390, 0xc0004df9c0}, 0xc00001fdb0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/ovn.go:358 +0x13b
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).Start.func1({0x1eb8390, 0xc0004df9c0})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/master.go:102 +0x10f
created by k8s.io/client-go/tools/leaderelection.(*LeaderElector).Run
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:211 +0x154
panic: Expected a ModelPredicate with BulkOp==true [recovered]
	panic: Expected a ModelPredicate with BulkOp==true
```