### PR TITLE
Dump OVN databases on e2e-control-plane failure

### DIFF
--- a/test/e2e/acl_logging.go
+++ b/test/e2e/acl_logging.go
@@ -31,7 +31,7 @@ var _ = Describe("ACL Logging", func() {
 		pokedPodIndex           = 1
 	)
 
-	fr := framework.NewDefaultFramework(namespacePrefix)
+	fr := wrappedTestFramework(namespacePrefix)
 
 	var (
 		nsName string

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe("e2e non-vxlan external gateway through a gateway pod", 
 		clientSet                kubernetes.Interface
 	)
 
-	f := framework.NewDefaultFramework(svcname)
+	f := wrappedTestFramework(svcname)
 
 	ginkgo.BeforeEach(func() {
 		clientSet = f.ClientSet // so it can be used in AfterEach
@@ -232,7 +232,7 @@ var _ = ginkgo.Describe("e2e multiple external gateway validation", func() {
 		externalUDPPort        = 90
 	)
 
-	f := framework.NewDefaultFramework(svcname)
+	f := wrappedTestFramework(svcname)
 
 	var addressesv4, addressesv6 gatewayTestIPs
 
@@ -399,7 +399,7 @@ var _ = ginkgo.Context("BFD", func() {
 			clientSet                kubernetes.Interface
 		)
 
-		f := framework.NewDefaultFramework(svcname)
+		f := wrappedTestFramework(svcname)
 
 		ginkgo.BeforeEach(func() {
 			clientSet = f.ClientSet // so it can be used in AfterEach
@@ -603,7 +603,7 @@ var _ = ginkgo.Context("BFD", func() {
 		testContainer := fmt.Sprintf("%s-container", srcPodName)
 		testContainerFlag := fmt.Sprintf("--container=%s", testContainer)
 
-		f := framework.NewDefaultFramework(svcname)
+		f := wrappedTestFramework(svcname)
 
 		var addressesv4, addressesv6 gatewayTestIPs
 

--- a/test/e2e/multicast.go
+++ b/test/e2e/multicast.go
@@ -95,7 +95,7 @@ var _ = ginkgo.Describe("Multicast", func() {
 		// Start a multicast listener on the same groups and verify it received the traffic (iperf server is the multicast listener)
 		// join multicast group (-B 224.3.3.3), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
 		ginkgo.By("creating first multicast listener pod in node " + serverNodeInfo.name)
-		iperf = fmt.Sprintf("iperf -s -B %s -u -t 30 -i 5", mcastGroup)
+		iperf = fmt.Sprintf("iperf -s -B %s -u -t 180 -i 5", mcastGroup)
 		if IsIPv6Cluster(cs) {
 			iperf = iperf + " -V"
 		}
@@ -107,7 +107,7 @@ var _ = ginkgo.Describe("Multicast", func() {
 		// Start a multicast listener on on other group and verify it does not receive the traffic (iperf server is the multicast listener)
 		// join multicast group (-B 224.4.4.4), UDP (-u), during (-t 30) seconds, report every (-i 1) seconds
 		ginkgo.By("creating second multicast listener pod in node " + serverNodeInfo.name)
-		iperf = fmt.Sprintf("iperf -s -B %s -u -t 30 -i 5", mcastGroupBad)
+		iperf = fmt.Sprintf("iperf -s -B %s -u -t 180 -i 5", mcastGroupBad)
 		if IsIPv6Cluster(cs) {
 			iperf = iperf + " -V"
 		}

--- a/test/e2e/multicast.go
+++ b/test/e2e/multicast.go
@@ -24,7 +24,7 @@ const (
 
 var _ = ginkgo.Describe("Multicast", func() {
 
-	fr := framework.NewDefaultFramework("multicast")
+	fr := wrappedTestFramework("multicast")
 
 	type nodeInfo struct {
 		name   string

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -27,7 +27,7 @@ var _ = ginkgo.Describe("Services", func() {
 		serviceName = "testservice"
 	)
 
-	f := framework.NewDefaultFramework("services")
+	f := wrappedTestFramework("services")
 
 	var cs clientset.Interface
 

--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -42,7 +42,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 		port              = 80
 	)
 
-	f := framework.NewDefaultFramework("unidling")
+	f := wrappedTestFramework("unidling")
 
 	var cs clientset.Interface
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -694,4 +695,58 @@ func isDualStackCluster(nodes *v1.NodeList) bool {
 		}
 	}
 	return false
+}
+
+// used to inject OVN specific test actions
+func wrappedTestFramework(basename string) *framework.Framework{
+	f := framework.NewDefaultFramework(basename)
+	// inject dumping dbs on failure
+	ginkgo.JustAfterEach(func() {
+		if ! ginkgo.CurrentGinkgoTestDescription().Failed {
+			return
+		}
+
+		ovnDocker := "ovn-control-plane"
+
+		logLocation := "/var/log"
+		dbLocation := "/var/lib/openvswitch"
+		ovsdbLocation := "/etc/origin/openvswitch"
+		dbs := []string{"ovnnb_db.db", "ovnsb_db.db"}
+		ovsdb := "conf.db"
+
+		testName :=  strings.Replace(ginkgo.CurrentGinkgoTestDescription().TestText, " ", "_", -1)
+		logDir := fmt.Sprintf("%s/e2e-dbs/%s-%s", logLocation, testName, f.UniqueName)
+
+		var args []string
+
+		// grab all OVS dbs
+		nodes, err := f.ClientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		framework.ExpectNoError(err)
+		for _, node := range nodes.Items {
+			// ensure e2e-dbs directory with test case exists
+			args = []string{"docker", "exec", node.Name, "mkdir", "-p", logDir}
+			_, err = runCommand(args...)
+			framework.ExpectNoError(err)
+
+			// node name is the same in kapi and docker
+			args = []string{"docker", "exec", node.Name, "cp", "-f", fmt.Sprintf("%s/%s", ovsdbLocation, ovsdb),
+				fmt.Sprintf("%s/%s", logDir, fmt.Sprintf("%s-%s", node.Name, ovsdb))}
+			_, err = runCommand(args...)
+			framework.ExpectNoError(err)
+		}
+
+		args = []string{"docker", "exec", ovnDocker, "stat", fmt.Sprintf("%s/%s", dbLocation, dbs[0])}
+		_, err = runCommand(args...)
+		framework.ExpectNoError(err)
+
+		// grab the OVN dbs
+		for _, db := range dbs {
+			args = []string{"docker", "exec", ovnDocker, "cp", "-f", fmt.Sprintf("%s/%s", dbLocation, db),
+				fmt.Sprintf("%s/%s", logDir, db)}
+			_, err = runCommand(args...)
+			framework.ExpectNoError(err)
+		}
+	})
+
+	return f
 }


### PR DESCRIPTION
Now when a test case fails, the DBs will be copied before cleanup to the
/var/logs/e2e-dbs/<test case>_<test namespace>/

This makes it easier to debug OVN failures.

Example output on ovn-control-plane node:

```
root@ovn-control-plane:/var/log/e2e-dbs# ls
should_be_able_to_send_multicast_UDP_traffic_between_nodes-multicast-1847  should_be_able_to_send_multicast_UDP_traffic_between_nodes-multicast-4425
should_be_able_to_send_multicast_UDP_traffic_between_nodes-multicast-2540  should_be_able_to_send_multicast_UDP_traffic_between_nodes-multicast-7887
root@ovn-control-plane:/var/log/e2e-dbs# ls should_be_able_to_send_multicast_UDP_traffic_between_nodes-multicast-1847
ovn-control-plane-conf.db  ovnnb_db.db  ovnsb_db.db

```
