### PR TITLE
policy: Fix multicast allow policy type.

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -569,7 +569,7 @@ func (oc *Controller) createDefaultAllowMulticastPolicy() error {
 	egressACL := buildACL("", types.ClusterRtrPortGroupName, "DefaultAllowMulticastEgress", nbdb.ACLDirectionFromLport, types.DefaultMcastAllowPriority, egressMatch, nbdb.ACLActionAllow, "", knet.PolicyTypeEgress)
 
 	ingressMatch := getACLMatch(types.ClusterRtrPortGroupName, mcastMatch, knet.PolicyTypeIngress)
-	ingressACL := buildACL("", types.ClusterRtrPortGroupName, "DefaultAllowMulticastIngress", nbdb.ACLDirectionToLport, types.DefaultMcastAllowPriority, ingressMatch, nbdb.ACLActionAllow, "", knet.PolicyTypeEgress)
+	ingressACL := buildACL("", types.ClusterRtrPortGroupName, "DefaultAllowMulticastIngress", nbdb.ACLDirectionToLport, types.DefaultMcastAllowPriority, ingressMatch, nbdb.ACLActionAllow, "", knet.PolicyTypeIngress)
 
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressACL, ingressACL)
 	if err != nil {


### PR DESCRIPTION
**- What this PR does and why is it needed**
This PR fixes ACLs that allow POD ip multicast traffic to pass towards the ovn_cluster_router. IP multicast traffic between pods that are on different nodes was otherwise dropped.

**- How to verify it**
The following e2e test is now passing:
```
Multicast 
  should be able to send multicast UDP traffic between nodes
```

**- Description for the changelog**
There was a typo for multicast ingress allow policies causing their ACLs
to be turned into "from-lport" ACLs that would never be matched.
