### PR TITLE
Auto detect hybrid overlay node subnets

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -142,6 +142,11 @@ func (m *MasterController) hybridOverlayNodeEnsureSubnet(node *kapi.Node, annota
 }
 
 func (m *MasterController) releaseNodeSubnet(nodeName string, subnet *net.IPNet) error {
+	if len(config.HybridOverlay.ClusterSubnets) == 0 {
+		// skip releasing node subnet if hybrid-overlay-cluster-subnets is unset.
+		return nil
+	}
+
 	if err := m.allocator.ReleaseNetwork(subnet); err != nil {
 		return fmt.Errorf("error deleting hybrid overlay HostSubnet %s for node %q: %s", subnet, nodeName, err)
 	}
@@ -216,11 +221,9 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 
 	// we need to setup a reroute policy for hybrid overlay subnet
 	// this is so hybrid pod -> service -> hybrid endpoint will reroute to the DR IP
-	if len(config.HybridOverlay.ClusterSubnets) > 0 {
-		if err := m.setupHybridLRPolicySharedGw(subnets, node.Name, portMAC); err != nil {
-			return fmt.Errorf("unable to setup Hybrid Subnet Logical Route Policy for node: %s, error: %v",
-				node.Name, err)
-		}
+	if err := m.setupHybridLRPolicySharedGw(subnets, node.Name, portMAC); err != nil {
+		return fmt.Errorf("unable to setup Hybrid Subnet Logical Route Policy for node: %s, error: %v",
+			node.Name, err)
 	}
 
 	if !lspOK {
@@ -321,110 +324,128 @@ func (m *MasterController) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet,
 		} else {
 			L3Prefix = "ip4"
 		}
-		var hybridCIDR *net.IPNet
-		for _, hybridSubnet := range config.HybridOverlay.ClusterSubnets {
-			if utilnet.IsIPv6CIDR(hybridSubnet.CIDR) == utilnet.IsIPv6CIDR(nodeSubnet) {
-				hybridCIDR = hybridSubnet.CIDR
-				break
+		var hybridCIDRs []*net.IPNet
+		if len(config.HybridOverlay.ClusterSubnets) > 0 {
+			for _, hybridSubnet := range config.HybridOverlay.ClusterSubnets {
+				if utilnet.IsIPv6CIDR(hybridSubnet.CIDR) == utilnet.IsIPv6CIDR(nodeSubnet) {
+					hybridCIDRs = append(hybridCIDRs, hybridSubnet.CIDR)
+					break
+				}
+			}
+		} else {
+			nodes, err := m.kube.GetNodes()
+			if err != nil {
+				return err
+			}
+			for _, node := range nodes.Items {
+				if subnet, _ := houtil.ParseHybridOverlayHostSubnet(&node); subnet != nil {
+					hybridCIDRs = append(hybridCIDRs, subnet)
+				}
 			}
 		}
 
-		drIP := util.GetNodeHybridOverlayIfAddr(nodeSubnet).IP
-		matchStr := fmt.Sprintf(`inport == "%s%s" && %s.dst == %s`,
-			ovntypes.RouterToSwitchPrefix, nodeName, L3Prefix, hybridCIDR)
+		for _, hybridCIDR := range hybridCIDRs {
+			if utilnet.IsIPv6CIDR(hybridCIDR) != utilnet.IsIPv6CIDR(nodeSubnet) {
+				// skip if the IP family is not match
+				continue
+			}
+			drIP := util.GetNodeHybridOverlayIfAddr(nodeSubnet).IP
+			matchStr := fmt.Sprintf(`inport == "%s%s" && %s.dst == %s`,
+				ovntypes.RouterToSwitchPrefix, nodeName, L3Prefix, hybridCIDR)
 
-		// Logic route policy to steer packet from pod to hybrid overlay nodes
-		logicalRouterPolicy := nbdb.LogicalRouterPolicy{
-			Priority: ovntypes.HybridOverlaySubnetPriority,
-			ExternalIDs: map[string]string{
-				"name": ovntypes.HybridSubnetPrefix + nodeName,
-			},
-			Action:   nbdb.LogicalRouterPolicyActionReroute,
-			Nexthops: []string{drIP.String()},
-			Match:    matchStr,
-		}
+			// Logic route policy to steer packet from pod to hybrid overlay nodes
+			logicalRouterPolicy := nbdb.LogicalRouterPolicy{
+				Priority: ovntypes.HybridOverlaySubnetPriority,
+				ExternalIDs: map[string]string{
+					"name": ovntypes.HybridSubnetPrefix + nodeName,
+				},
+				Action:   nbdb.LogicalRouterPolicyActionReroute,
+				Nexthops: []string{drIP.String()},
+				Match:    matchStr,
+			}
 
-		if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &logicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
-			return item.Priority == logicalRouterPolicy.Priority &&
-				item.ExternalIDs["name"] == logicalRouterPolicy.ExternalIDs["name"]
-		}); err != nil {
-			return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
-		}
+			if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &logicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
+				return item.Priority == logicalRouterPolicy.Priority &&
+					item.ExternalIDs["name"] == logicalRouterPolicy.ExternalIDs["name"]
+			}); err != nil {
+				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
+			}
 
-		logicalPort := ovntypes.RouterToSwitchPrefix + nodeName
-		if err := util.CreateMACBinding(m.sbClient, logicalPort, ovntypes.OVNClusterRouter, portMac, drIP); err != nil {
-			return fmt.Errorf("failed to create MAC Binding for hybrid overlay: %v", err)
-		}
+			logicalPort := ovntypes.RouterToSwitchPrefix + nodeName
+			if err := util.CreateMACBinding(m.sbClient, logicalPort, ovntypes.OVNClusterRouter, portMac, drIP); err != nil {
+				return fmt.Errorf("failed to create MAC Binding for hybrid overlay: %v", err)
+			}
 
-		// Logic route policy to steer packet from external to nodePort service backed by non-ovnkube pods to hybrid overlay nodes
-		gwLRPIfAddrs, err := util.GetLRPAddrs(m.nbClient, ovntypes.GWRouterToJoinSwitchPrefix+ovntypes.GWRouterPrefix+nodeName)
-		if err != nil {
-			return err
-		}
-		gwLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), gwLRPIfAddrs)
-		if err != nil {
-			return err
-		}
-		grMatchStr := fmt.Sprintf(`%s.src == %s && %s.dst == %s`,
-			L3Prefix, gwLRPIfAddr.IP.String(), L3Prefix, hybridCIDR)
-		grLogicalRouterPolicy := nbdb.LogicalRouterPolicy{
-			Priority: ovntypes.HybridOverlaySubnetPriority,
-			ExternalIDs: map[string]string{
-				"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
-			},
-			Action:   nbdb.LogicalRouterPolicyActionReroute,
-			Nexthops: []string{drIP.String()},
-			Match:    grMatchStr,
-		}
+			// Logic route policy to steer packet from external to nodePort service backed by non-ovnkube pods to hybrid overlay nodes
+			gwLRPIfAddrs, err := util.GetLRPAddrs(m.nbClient, ovntypes.GWRouterToJoinSwitchPrefix+ovntypes.GWRouterPrefix+nodeName)
+			if err != nil {
+				return err
+			}
+			gwLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), gwLRPIfAddrs)
+			if err != nil {
+				return err
+			}
+			grMatchStr := fmt.Sprintf(`%s.src == %s && %s.dst == %s`,
+				L3Prefix, gwLRPIfAddr.IP.String(), L3Prefix, hybridCIDR)
+			grLogicalRouterPolicy := nbdb.LogicalRouterPolicy{
+				Priority: ovntypes.HybridOverlaySubnetPriority,
+				ExternalIDs: map[string]string{
+					"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
+				},
+				Action:   nbdb.LogicalRouterPolicyActionReroute,
+				Nexthops: []string{drIP.String()},
+				Match:    grMatchStr,
+			}
 
-		if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &grLogicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
-			return item.Priority == grLogicalRouterPolicy.Priority &&
-				item.ExternalIDs["name"] == grLogicalRouterPolicy.ExternalIDs["name"]
-		}); err != nil {
-			return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
-		}
-		klog.Infof("Created hybrid overlay logical route policies for node %s", nodeName)
+			if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &grLogicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
+				return item.Priority == grLogicalRouterPolicy.Priority &&
+					item.ExternalIDs["name"] == grLogicalRouterPolicy.ExternalIDs["name"]
+			}); err != nil {
+				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
+			}
+			klog.Infof("Created hybrid overlay logical route policies for node %s", nodeName)
 
-		// Static route to steer packets from external to nodePort service backed by pods on hybrid overlay node.
-		// This route is to used for triggering above route policy
-		clutsterRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
-			IPPrefix: hybridCIDR.String(),
-			Nexthop:  drIP.String(),
-			ExternalIDs: map[string]string{
-				"name": ovntypes.HybridSubnetPrefix + nodeName,
-			},
-		}
-		if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &clutsterRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.IPPrefix == clutsterRouterStaticRoutes.IPPrefix && item.Nexthop == clutsterRouterStaticRoutes.Nexthop &&
-				item.ExternalIDs["name"] == clutsterRouterStaticRoutes.ExternalIDs["name"]
-		}); err != nil {
-			return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", clutsterRouterStaticRoutes.IPPrefix, clutsterRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
-		}
-		klog.Infof("Created hybrid overlay logical route static route at cluster router for node %s", nodeName)
+			// Static route to steer packets from external to nodePort service backed by pods on hybrid overlay node.
+			// This route is to used for triggering above route policy
+			clutsterRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
+				IPPrefix: hybridCIDR.String(),
+				Nexthop:  drIP.String(),
+				ExternalIDs: map[string]string{
+					"name": ovntypes.HybridSubnetPrefix + nodeName,
+				},
+			}
+			if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &clutsterRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == clutsterRouterStaticRoutes.IPPrefix && item.Nexthop == clutsterRouterStaticRoutes.Nexthop &&
+					item.ExternalIDs["name"] == clutsterRouterStaticRoutes.ExternalIDs["name"]
+			}); err != nil {
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", clutsterRouterStaticRoutes.IPPrefix, clutsterRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
+			}
+			klog.Infof("Created hybrid overlay logical route static route at cluster router for node %s", nodeName)
 
-		// Static route to steer packets from external to nodePort service backed by pods on hybrid overlay node to cluster router.
-		drLRPIfAddrs, err := util.GetLRPAddrs(m.nbClient, ovntypes.GWRouterToJoinSwitchPrefix+ovntypes.OVNClusterRouter)
-		if err != nil {
-			return err
+			// Static route to steer packets from external to nodePort service backed by pods on hybrid overlay node to cluster router.
+			drLRPIfAddrs, err := util.GetLRPAddrs(m.nbClient, ovntypes.GWRouterToJoinSwitchPrefix+ovntypes.OVNClusterRouter)
+			if err != nil {
+				return err
+			}
+			drLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), drLRPIfAddrs)
+			if err != nil {
+				return fmt.Errorf("failed to match cluster router join interface IPs: %v, err: %v", drLRPIfAddr, err)
+			}
+			nodeGWRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
+				IPPrefix: hybridCIDR.String(),
+				Nexthop:  drLRPIfAddr.IP.String(),
+				ExternalIDs: map[string]string{
+					"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
+				},
+			}
+			if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(m.nbClient, ovntypes.GWRouterPrefix+nodeName, &nodeGWRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
+				return item.IPPrefix == nodeGWRouterStaticRoutes.IPPrefix && item.Nexthop == nodeGWRouterStaticRoutes.Nexthop &&
+					item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"]
+			}); err != nil {
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
+			}
+			klog.Infof("Created hybrid overlay logical route static route at gateway router for node %s", nodeName)
 		}
-		drLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), drLRPIfAddrs)
-		if err != nil {
-			return fmt.Errorf("failed to match cluster router join interface IPs: %v, err: %v", drLRPIfAddr, err)
-		}
-		nodeGWRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
-			IPPrefix: hybridCIDR.String(),
-			Nexthop:  drLRPIfAddr.IP.String(),
-			ExternalIDs: map[string]string{
-				"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
-			},
-		}
-		if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(m.nbClient, ovntypes.GWRouterPrefix+nodeName, &nodeGWRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
-			return item.IPPrefix == nodeGWRouterStaticRoutes.IPPrefix && item.Nexthop == nodeGWRouterStaticRoutes.Nexthop &&
-				item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"]
-		}); err != nil {
-			return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
-		}
-		klog.Infof("Created hybrid overlay logical route static route at gateway router for node %s", nodeName)
 	}
 	return nil
 }

--- a/go-controller/hybrid-overlay/pkg/controller/master_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master_test.go
@@ -52,6 +52,30 @@ func newTestNode(name, os, ovnHostSubnet, hybridHostSubnet, drMAC string) v1.Nod
 	}
 }
 
+func newTestWinNode(name, os, ovnHostSubnet, hybridHostSubnet, drMAC string) v1.Node {
+	annotations := make(map[string]string)
+	if ovnHostSubnet != "" {
+		subnetAnnotations, err := util.CreateNodeHostSubnetAnnotation(ovntest.MustParseIPNets(ovnHostSubnet))
+		Expect(err).NotTo(HaveOccurred())
+		for k, v := range subnetAnnotations {
+			annotations[k] = fmt.Sprintf("%s", v)
+		}
+	}
+	if hybridHostSubnet != "" {
+		annotations[hotypes.HybridOverlayNodeSubnet] = hybridHostSubnet
+	}
+	if drMAC != "" {
+		annotations[hotypes.HybridOverlayDRMAC] = drMAC
+	}
+	return v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      map[string]string{v1.LabelOSStable: os},
+			Annotations: annotations,
+		},
+	}
+}
+
 var _ = Describe("Hybrid SDN Master Operations", func() {
 	var (
 		app             *cli.App
@@ -591,6 +615,250 @@ var _ = Describe("Hybrid SDN Master Operations", func() {
 			"-loglevel=5",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=" + hybridOverlayClusterCIDR,
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("cluster handles a linux node when hybridOverlayClusterCIDR in unset but the HO annotations are available on windows nodes", func() {
+		app.Action = func(ctx *cli.Context) error {
+			const (
+				linNodeName   string = "node-linux"
+				winNodeName   string = "node-windows"
+				linNodeSubnet string = "10.1.2.0/24"
+				winNodeSubnet string = "10.1.3.0/24"
+				linNodeHOIP   string = "10.1.2.3"
+				linNodeHOMAC  string = "0a:58:0a:01:02:03"
+			)
+
+			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
+				Items: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   winNodeName,
+							Labels: map[string]string{v1.LabelOSStable: "windows"},
+							Annotations: map[string]string{
+								hotypes.HybridOverlayNodeSubnet: winNodeSubnet,
+							},
+						},
+					},
+					newTestNode(linNodeName, "linux", linNodeSubnet, "", ""),
+				},
+			})
+
+			_, err := config.InitConfig(ctx, fexec, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			// pre-existing nbdb objects
+			nodeSwitch := &nbdb.LogicalSwitch{
+				Name: linNodeName,
+				UUID: linNodeName + "-UUID",
+			}
+
+			ovnClusterRouter := &nbdb.LogicalRouter{
+				Name: types.OVNClusterRouter,
+				UUID: types.OVNClusterRouter + "-UUID",
+			}
+
+			ovnClusterRouterLRP := &nbdb.LogicalRouterPort{
+				Name:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter,
+				Networks: []string{"100.64.0.1/16"},
+				UUID:     types.GWRouterToJoinSwitchPrefix + types.OVNClusterRouter + "-UUID",
+			}
+			ovnClusterRouter.Ports = []string{ovnClusterRouterLRP.UUID}
+
+			nodeGWRouter := &nbdb.LogicalRouter{
+				Name: types.GWRouterPrefix + linNodeName,
+				UUID: types.GWRouterPrefix + linNodeName + "-UUID",
+			}
+
+			nodeGWLRP := &nbdb.LogicalRouterPort{
+				Name:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + linNodeName,
+				Networks: []string{"100.64.0.2/16"},
+				UUID:     types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + linNodeName + "-UUID",
+			}
+
+			nodeGWRouter.Ports = []string{nodeGWLRP.UUID}
+
+			initialNBDB := []libovsdbtest.TestData{
+				nodeSwitch,
+				ovnClusterRouter,
+				ovnClusterRouterLRP,
+				nodeGWRouter,
+				nodeGWLRP,
+			}
+
+			// pre-existing sbdb objects
+			clusterRouterDatapath := &sbdb.DatapathBinding{
+				UUID:        types.OVNClusterRouter + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": ovnClusterRouter.UUID, "name": types.OVNClusterRouter},
+			}
+
+			initialSBDB := []libovsdbtest.TestData{
+				clusterRouterDatapath,
+			}
+
+			dbSetup := libovsdbtest.TestSetup{
+				NBData: initialNBDB,
+				SBData: initialSBDB,
+			}
+
+			var libovsdbOvnNBClient libovsdbclient.Client
+			var libovsdbOvnSBClient libovsdbclient.Client
+
+			libovsdbOvnNBClient, libovsdbOvnSBClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
+			Expect(err).NotTo(HaveOccurred())
+
+			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
+			m, err := NewMaster(
+				&kube.Kube{KClient: fakeClient},
+				f.Core().V1().Nodes().Informer(),
+				f.Core().V1().Namespaces().Informer(),
+				f.Core().V1().Pods().Informer(),
+				libovsdbOvnNBClient,
+				libovsdbOvnSBClient,
+				informer.NewTestEventHandler,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// make sure the expected LSP is created and added to the node
+			expectedLSP := &nbdb.LogicalSwitchPort{
+				UUID:      types.HybridOverlayPrefix + linNodeName + "-UUID",
+				Name:      types.HybridOverlayPrefix + linNodeName,
+				Addresses: []string{linNodeHOMAC},
+			}
+
+			// make sure the expected LRP is created and added to cluster router
+			expectedLRP1 := &nbdb.LogicalRouterPolicy{
+				Priority: 1002,
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node-linux-gr",
+				},
+				Action:   nbdb.LogicalRouterPolicyActionReroute,
+				Nexthops: []string{linNodeHOIP},
+				Match:    fmt.Sprintf("ip4.src == 100.64.0.2 && ip4.dst == %s", winNodeSubnet),
+				UUID:     "expectedLRP-1-UUID",
+			}
+
+			expectedLRP2 := &nbdb.LogicalRouterPolicy{
+				Priority: 1002,
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node-linux",
+				},
+				Action:   nbdb.LogicalRouterPolicyActionReroute,
+				Nexthops: []string{linNodeHOIP},
+				Match:    fmt.Sprintf("inport == \"rtos-node-linux\" && ip4.dst == %s", winNodeSubnet),
+				UUID:     "expectedLRP-2-UUID",
+			}
+
+			expectedLRSR := &nbdb.LogicalRouterStaticRoute{
+				IPPrefix: winNodeSubnet,
+				Nexthop:  linNodeHOIP,
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node-linux",
+				},
+				UUID: "expectedLRSR-UUID",
+			}
+
+			nodeSwitch.Ports = []string{expectedLSP.UUID}
+			ovnClusterRouter.Policies = []string{expectedLRP1.UUID, expectedLRP2.UUID}
+			ovnClusterRouter.StaticRoutes = []string{expectedLRSR.UUID}
+
+			expectedGRLRSR := &nbdb.LogicalRouterStaticRoute{
+				IPPrefix: winNodeSubnet,
+				Nexthop:  "100.64.0.1",
+				ExternalIDs: map[string]string{
+					"name": "hybrid-subnet-node-linux-gr",
+				},
+				UUID: "expectedGRLRSR-UUID",
+			}
+			nodeGWRouter.StaticRoutes = []string{expectedGRLRSR.UUID}
+
+			expectedMACBinding := &sbdb.MACBinding{
+				Datapath:    clusterRouterDatapath.UUID,
+				IP:          linNodeHOIP,
+				LogicalPort: types.RouterToSwitchPrefix + linNodeName,
+				MAC:         linNodeHOMAC,
+			}
+
+			f.Start(stopChan)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				m.Run(stopChan)
+			}()
+			f.WaitForCacheSync(stopChan)
+
+			Eventually(func() (map[string]string, error) {
+				updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), linNodeName, metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return updatedNode.Annotations, nil
+			}, 2).Should(HaveKeyWithValue(hotypes.HybridOverlayDRMAC, linNodeHOMAC))
+
+			nodeSwitch.OtherConfig = map[string]string{"exclude_ips": "10.1.2.2"}
+
+			expectedNBDatabaseState := []libovsdbtest.TestData{
+				nodeSwitch,
+				ovnClusterRouter,
+				ovnClusterRouterLRP,
+				nodeGWRouter,
+				nodeGWLRP,
+				expectedLSP,
+				expectedLRP1,
+				expectedLRP2,
+				expectedLRSR,
+				expectedGRLRSR,
+			}
+
+			expectedSBDatabaseState := []libovsdbtest.TestData{
+				clusterRouterDatapath,
+				expectedMACBinding,
+			}
+
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedNBDatabaseState))
+			Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedSBDatabaseState))
+
+			err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), linNodeName, *metav1.NewDeleteOptions(0))
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+
+			// LRP should have been deleted and removed
+			ovnClusterRouter.Policies = []string{}
+
+			// LSP should have been deleted and removed
+			nodeSwitch.Ports = []string{}
+
+			// Static Route should have been deleted and removed
+			ovnClusterRouter.StaticRoutes = []string{}
+			nodeGWRouter.StaticRoutes = []string{}
+
+			expectedNBDatabaseState = []libovsdbtest.TestData{
+				ovnClusterRouter,
+				nodeSwitch,
+				nodeGWRouter,
+				nodeGWLRP,
+				ovnClusterRouterLRP,
+			}
+
+			// in a real db, deleting the HO LSP would result in the Mac Binding being removed as well
+			expectedSBDatabaseState = []libovsdbtest.TestData{
+				clusterRouterDatapath,
+				expectedMACBinding,
+			}
+
+			Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedNBDatabaseState))
+			Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveDataIgnoringUUIDs(expectedSBDatabaseState))
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-loglevel=5",
+			"-enable-hybrid-overlay",
+			"--no-hostsubnet-nodes=kubernetes.io/os=windows",
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
With this patch, when '--hybrid-overlay-cluster-subnets' is absent, and
the hybrider overlay node annotation exists on non-ovnkube nodes,
ovnkube-master will try to derive the hybrid-overlay-node-subnet for each
non-ovnkube node and setup the static routes and route policies for the
traffic to the hybrid overlay nodes accordingly.

We need this ability for the SDN live migration case, where we use hybrid
overlay to connect the node managed by ovnkube and openshift-sdn. To
reuse the node subnet, we need to skip the ip allocation for hybrid
overlady nodes by setting the node annotation by other tools (e.g
cluster-network-operator). As we don't cannot use the same value for
both '--hybrid-overlay-cluster-subnets' and '--cluster-subnets', I think
we shall use the per-node subnet instead.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
Spin up a cluster with ovnkube hybrid overlay enabled, but without setting
 '--hybrid-overlay-cluster-subnets'. Adding windows nodes to the cluster,
Setting the hybrid overlay node annotation manually for the windows nodes.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->