### PR TITLE
cni pod deployment performance imrovements

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -301,13 +301,8 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 		}
 	}
 
-	ofPort, err := getIfaceOFPort(hostIfaceName)
-	if err != nil {
-		return err
-	}
-
-	if err = waitForPodInterface(ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIfaceName,
-		ifaceID, ofPort, ifInfo.CheckExtIDs, podLister, kclient, namespace, podName,
+	if err := waitForPodInterface(ctx, ifInfo.MAC.String(), ifInfo.IPs, hostIfaceName,
+		ifaceID, ifInfo.CheckExtIDs, podLister, kclient, namespace, podName,
 		initialPodUID); err != nil {
 		// Ensure the error shows up in node logs, rather than just
 		// being reported back to the runtime.

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -379,26 +379,9 @@ func TestSetupInterface(t *testing.T) {
 			},
 			errExp: true,
 			cniPluginMockHelper: []ovntest.TestifyMockHelper{
-				{"SetupVeth",[]string{"string", "int", "*ns.NetNS"}, []interface{}{nil, nil, fmt.Errorf("mock error")}},
+				{"SetupVeth",[]string{"string", "string", "int", "*ns.NetNS"}, []interface{}{nil, nil, fmt.Errorf("mock error")}},
 			},
 		},*/
-		{
-			desc:         "test code path when renameLink() returns error",
-			inpNetNS:     mockNS,
-			inpContID:    "35b82dbe2c39768d9874861aee38cf569766d4855b525ae02bff2bfbda73392a",
-			inpIfaceName: "eth0",
-			inpPodIfaceInfo: &PodInterfaceInfo{
-				PodAnnotation: util.PodAnnotation{},
-				MTU:           1500,
-			},
-			errMatch: fmt.Errorf("failed to rename"),
-			netLinkOpsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "LinkByName", OnCallMethodArgType: []string{"string", "string"}, RetArgList: []interface{}{nil, fmt.Errorf("mock error")}},
-			},
-			nsMockHelper: []ovntest.TestifyMockHelper{
-				{OnCallMethodName: "Do", OnCallMethodArgType: []string{"func(ns.NetNS) error"}, RetArgList: []interface{}{nil}},
-			},
-		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {

--- a/go-controller/pkg/cni/mocks/CNIPluginLibOps.go
+++ b/go-controller/pkg/cni/mocks/CNIPluginLibOps.go
@@ -32,26 +32,26 @@ func (_m *CNIPluginLibOps) AddRoute(ipn *net.IPNet, gw net.IP, dev netlink.Link,
 }
 
 // SetupVeth provides a mock function with given fields: contVethName, mtu, hostNS
-func (_m *CNIPluginLibOps) SetupVeth(contVethName string, mtu int, hostNS ns.NetNS) (net.Interface, net.Interface, error) {
-	ret := _m.Called(contVethName, mtu, hostNS)
+func (_m *CNIPluginLibOps) SetupVeth(contVethName string, hostVethName string, mtu int, hostNS ns.NetNS) (net.Interface, net.Interface, error) {
+	ret := _m.Called(contVethName, hostVethName, mtu, hostNS)
 
 	var r0 net.Interface
-	if rf, ok := ret.Get(0).(func(string, int, ns.NetNS) net.Interface); ok {
-		r0 = rf(contVethName, mtu, hostNS)
+	if rf, ok := ret.Get(0).(func(string, string, int, ns.NetNS) net.Interface); ok {
+		r0 = rf(contVethName, hostVethName, mtu, hostNS)
 	} else {
 		r0 = ret.Get(0).(net.Interface)
 	}
 
 	var r1 net.Interface
-	if rf, ok := ret.Get(1).(func(string, int, ns.NetNS) net.Interface); ok {
-		r1 = rf(contVethName, mtu, hostNS)
+	if rf, ok := ret.Get(1).(func(string, string, int, ns.NetNS) net.Interface); ok {
+		r1 = rf(contVethName, hostVethName, mtu, hostNS)
 	} else {
 		r1 = ret.Get(1).(net.Interface)
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(string, int, ns.NetNS) error); ok {
-		r2 = rf(contVethName, mtu, hostNS)
+	if rf, ok := ret.Get(2).(func(string, string, int, ns.NetNS) error); ok {
+		r2 = rf(contVethName, hostVethName, mtu, hostNS)
 	} else {
 		r2 = ret.Error(2)
 	}


### PR DESCRIPTION
**- What this PR does and why is it needed**
During Single-node cluster testing cpu usage spikes were noticed, e.g. when deploying a large daemonset.
ovnkube-master container doesn't affect master pod cpu usage too much (example from the cluster with 3 master nodes, sorted by total cpu usage for master pods containers). Therefore optimizing master code won't make a big difference here.
```
container_cpu_usage_seconds_total    northd                 127.704829389    
container_cpu_usage_seconds_total    sbdb                    70.024377485
container_cpu_usage_seconds_total    nbdb                    42.733104665
container_cpu_usage_seconds_total    sbdb                     35.589553931
container_cpu_usage_seconds_total    nbdb                     34.340587309
container_cpu_usage_seconds_total    sbdb                     34.148023649
container_cpu_usage_seconds_total    ovnkube-master    33.954528192
container_cpu_usage_seconds_total    nbdb                      33.792159644
container_cpu_usage_seconds_total    ovnkube-master    12.026705725
container_cpu_usage_seconds_total    ovnkube-master    11.724290895
```
For ovnkube-node pod, ovnkube-node container consumes the most part of total cpu usage (see total vs ovnkube-node):
```
container_cpu_usage_seconds_total   total                    31.772949887
container_cpu_usage_seconds_total   ovnkube-node    28.263941918
container_cpu_usage_seconds_total   ovn-controller      1.378608245
```
therefore some minor performance improvements for ovnkube-node were made, using pprof during a 50-pod daemonset deployment.

The following profiles are for a single run and can differ between runs based on pprof sampling times, therefore it's difficult to tell exactly what is the performance improvement, but it helps to find places for improvements. We mostly look at `cum` value for pprof, which means the value of the location plus all its descendants https://github.com/google/pprof/blob/master/doc/README.md#details
## initial profile
<pre>
(pprof) top100 --cum
      flat  flat%   sum%        cum   cum%
         0     0%     0%      0.84s 53.50%  net/http.(*conn).serve
         0     0%     0%      0.83s 52.87%  net/http.HandlerFunc.ServeHTTP
         0     0%     0%      0.83s 52.87%  net/http.serverHandler.ServeHTTP
         0     0%     0%      0.81s 51.59%  github.com/gorilla/mux.(*Router).ServeHTTP
         0     0%     0%      0.81s 51.59%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.NewCNIServer.func1
         <b>0     0%     0%      0.80s 50.96%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).ConfigureInterface</b>
         0     0%     0%      0.80s 50.96%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).cmdAdd
         0     0%     0%      0.80s 50.96%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).getCNIResult
         0     0%     0%      0.80s 50.96%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*Server).handleCNIRequest
         0     0%     0%      0.80s 50.96%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.HandleCNIRequest
     0.70s 44.59% 44.59%      0.71s 45.22%  syscall.Syscall6
         0     0% 44.59%      0.59s 37.58%  github.com/vishvananda/netlink/nl.(*NetlinkRequest).Execute
         0     0% 44.59%      0.48s 30.57%  github.com/vishvananda/netlink/nl.(*NetlinkSocket).Send
         0     0% 44.59%      0.48s 30.57%  golang.org/x/sys/unix.Sendto
         0     0% 44.59%      0.48s 30.57%  golang.org/x/sys/unix.sendto
         0     0% 44.59%      0.42s 26.75%  github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func1
         0     0% 44.59%      0.42s 26.75%  github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func2
         <b>0     0% 44.59%      0.41s 26.11%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.renameLink</b>
         0     0% 44.59%      0.41s 26.11%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.setupInterface
         0     0% 44.59%      0.39s 24.84%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util.defaultNetLinkOps.LinkSetDown
         0     0% 44.59%      0.39s 24.84%  github.com/vishvananda/netlink.(*Handle).LinkSetDown
         0     0% 44.59%      0.39s 24.84%  github.com/vishvananda/netlink.LinkSetDown (inline)
         0     0% 44.59%      0.39s 24.84%  os/exec.(*Cmd).Run
         0     0% 44.59%      0.38s 24.20%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.ConfigureOVS
         0     0% 44.59%      0.38s 24.20%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.ovsExec
         0     0% 44.59%      0.37s 23.57%  k8s.io/utils/exec.(*cmdWrapper).CombinedOutput
         0     0% 44.59%      0.37s 23.57%  os/exec.(*Cmd).CombinedOutput
</pre>

renameLink call consumes ~26.11% (I've seen up to 40% for different runs) of all ovnkube-node cpu usage, and it was not necessary since the name can be set up on creation.

## renameLink removed profile
After removing renameLink, you can see that `(*PodRequest).ConfigureInterface` cpu usage decreased form ~50.96% to ~15.38%. Also, distribution between different function as more equeal now (no functions that take e.g. 50%)
<pre>
(pprof) top100 --cum
      flat  flat%   sum%        cum   cum%
         0     0%     0%      180ms 27.69%  github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func1
         0     0%     0%      180ms 27.69%  github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func2
         0     0%     0%      140ms 21.54%  net/http.(*conn).serve
     140ms 21.54% 21.54%      140ms 21.54%  syscall.Syscall6
         0     0% 21.54%      120ms 18.46%  github.com/vishvananda/netlink/nl.(*NetlinkRequest).Execute
         0     0% 21.54%      120ms 18.46%  os/exec.(*Cmd).Run
         0     0% 21.54%      110ms 16.92%  net/http.HandlerFunc.ServeHTTP
         0     0% 21.54%      110ms 16.92%  net/http.serverHandler.ServeHTTP
         0     0% 21.54%      110ms 16.92%  runtime.mcall
      10ms  1.54% 23.08%      110ms 16.92%  runtime.schedule
         0     0% 23.08%      100ms 15.38%  github.com/gorilla/mux.(*Router).ServeHTTP
         <b>0     0% 23.08%      100ms 15.38%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).ConfigureInterface</b>
         0     0% 23.08%      100ms 15.38%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).cmdAdd
         0     0% 23.08%      100ms 15.38%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).getCNIResult
         0     0% 23.08%      100ms 15.38%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*Server).handleCNIRequest
        <b> 0     0% 23.08%      100ms 15.38%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.ConfigureOVS</b>
...
         0     0% 63.08%       20ms  3.08%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.waitForPodInterface
...
         0     0% 70.77%       10ms  1.54%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.getIfaceOFPort
</pre>

For further improvements, we can see that a lot of cpu is consumed by netlink and ip libraries (which we can't help, working with host networking is not very fast), but we can try to improve `cni.ConfigureOVS` which now consumes almost all cpu for `(*PodRequest).ConfigureInterface` and equals to ~15.38%. Looking deeper almost all the cpu is spent for `ovsExec` (same as for other workflows, calling ovs commands take most of the cpu and can be improved by minimizing the amount of calls).

Not going into further details, I removed unnecessary call for `cni.getIfaceOFPort` and improved `cni.waitForPodInterface` to have a single `ovs-vsctl get` call for every iteration instead of two.

## remove getIfaceOFPort + change waitForPodInterface profile
Since the numbers here may vary a lot, cpu usage improvement for `cni.ConfigureOVS` was in range 3.5-8% for different runs, worst-case is drop from ~15.38% to ~11.86%.

<pre>
(pprof) top100 --cum
      flat  flat%   sum%        cum   cum%
         0     0%     0%      290ms 49.15%  github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func1
         0     0%     0%      290ms 49.15%  github.com/containernetworking/plugins/pkg/ns.(*netNS).Do.func2
         0     0%     0%      230ms 38.98%  github.com/vishvananda/netlink/nl.(*NetlinkRequest).Execute
     220ms 37.29% 37.29%      220ms 37.29%  syscall.Syscall6
         0     0% 37.29%      170ms 28.81%  github.com/vishvananda/netlink/nl.(*NetlinkSocket).Send
         0     0% 37.29%      170ms 28.81%  golang.org/x/sys/unix.Sendto
         0     0% 37.29%      170ms 28.81%  golang.org/x/sys/unix.sendto
         0     0% 37.29%      150ms 25.42%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.setupInterface.func1
         0     0% 37.29%      130ms 22.03%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).ConfigureInterface.func1
         0     0% 37.29%      130ms 22.03%  net/http.(*conn).serve
         0     0% 37.29%      120ms 20.34%  net/http.HandlerFunc.ServeHTTP
         0     0% 37.29%      120ms 20.34%  net/http.serverHandler.ServeHTTP
         0     0% 37.29%      110ms 18.64%  os/exec.(*Cmd).Run
         0     0% 37.29%       80ms 13.56%  github.com/containernetworking/plugins/pkg/ip.SettleAddresses
         0     0% 37.29%       80ms 13.56%  github.com/containernetworking/plugins/pkg/ip.SetupVethWithName
         0     0% 37.29%       80ms 13.56%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.defaultCNIPluginLibOps.SetupVeth
         0     0% 37.29%       70ms 11.86%  github.com/gorilla/mux.(*Router).ServeHTTP
         0     0% 37.29%       70ms 11.86%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).ConfigureInterface
         0     0% 37.29%       70ms 11.86%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).cmdAdd
         0     0% 37.29%       70ms 11.86%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*PodRequest).getCNIResult
         0     0% 37.29%       70ms 11.86%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.(*Server).handleCNIRequest
         <b>0     0% 37.29%       70ms 11.86%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni.ConfigureOVS</b>
</pre>

More scale testing is needed to get the exact numbers for performance improvements, but this PR should improve cpu usage by at least 30% (for pod creation workflow).