### PR TITLE
Add Egress QoS E2E and fix panic

### DIFF
--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -301,8 +301,25 @@ func (as *fakeAddressSets) GetIPs() ([]string, []string) {
 }
 
 func (as *fakeAddressSets) SetIPs(ips []net.IP) error {
-	// NOOP
-	return nil
+	allIPs := []net.IP{}
+	if as.ipv4 != nil {
+		for _, ip := range as.ipv4.ips {
+			allIPs = append(allIPs, ip)
+		}
+	}
+
+	if as.ipv6 != nil {
+		for _, ip := range as.ipv6.ips {
+			allIPs = append(allIPs, ip)
+		}
+	}
+
+	err := as.DeleteIPs(allIPs)
+	if err != nil {
+		return err
+	}
+
+	return as.AddIPs(ips)
 }
 
 func (as *fakeAddressSets) DeleteIPs(ips []net.IP) error {

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -123,7 +123,7 @@ func (oc *Controller) createASForEgressQoSRule(podSelector metav1.LabelSelector,
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot ensure that addressSet for namespace %s exists %v", namespace, err)
 		}
-		return addrSet, nil, nil
+		return addrSet, &sync.Map{}, nil
 	}
 
 	podsCache := sync.Map{}

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -657,16 +657,16 @@ func (oc *Controller) syncEgressQoSPod(key string) error {
 		return err
 	}
 
-	klog.Infof("Processing sync for EgressQoS pod %s/%s", namespace, name)
-
-	defer func() {
-		klog.V(4).Infof("Finished syncing EgressQoS pod %s on namespace %s : %v", name, namespace, time.Since(startTime))
-	}()
-
 	obj, loaded := oc.egressQoSCache.Load(namespace)
 	if !loaded { // no EgressQoS in the namespace
 		return nil
 	}
+
+	klog.V(5).Infof("Processing sync for EgressQoS pod %s/%s", namespace, name)
+
+	defer func() {
+		klog.V(4).Infof("Finished syncing EgressQoS pod %s on namespace %s : %v", name, namespace, time.Since(startTime))
+	}()
 
 	eq := obj.(*egressQoS)
 	eq.RLock() // allow multiple pods to sync
@@ -774,7 +774,6 @@ func (oc *Controller) onEgressQoSPodAdd(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
 		return
 	}
-	klog.V(4).Infof("Adding EgressQoS pod %s", key)
 	oc.egressQoSPodQueue.Add(key)
 }
 

--- a/test/e2e/egressqos.go
+++ b/test/e2e/egressqos.go
@@ -1,0 +1,268 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/onsi/ginkgo"
+	ginkgotable "github.com/onsi/ginkgo/extensions/table"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+)
+
+var _ = ginkgo.Describe("e2e EgressQoS validation", func() {
+	const (
+		egressQoSYaml = "egressqos.yaml"
+		srcPodName    = "src-dscp-pod"
+		dstPod1Name   = "dst-dscp-pod1"
+		dstPod2Name   = "dst-dscp-pod2"
+		// tcpdump args: http://darenmatthews.com/blog/?p=1199 , https://www.tucny.com/home/dscp-tos
+		tcpdumpIPv4 = "icmp and (ip and (ip[1] & 0xfc) >> 2 == %d)"
+		tcpdumpIPv6 = "icmp6 and (ip6 and (ip6[0:2] & 0xfc0) >> 6 == %d)"
+	)
+
+	var (
+		dstPod1IPv4 string
+		dstPod1IPv6 string
+		dstPod2IPv4 string
+		dstPod2IPv6 string
+		srcNode     string
+	)
+
+	f := framework.NewDefaultFramework("egressqos")
+
+	ginkgo.BeforeEach(func() {
+		clientSet := f.ClientSet
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(clientSet, 3)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 3 {
+			framework.Failf(
+				"Test requires >= 3 Ready nodes, but there are only %v nodes",
+				len(nodes.Items))
+		}
+
+		srcNode = nodes.Items[0].Name
+
+		dstPod1, err := createPod(f, dstPod1Name, nodes.Items[1].Name, f.Namespace.Name, []string{"bash", "-c", "apk update; apk add tcpdump; sleep 20000"}, map[string]string{}, func(p *v1.Pod) {
+			p.Spec.HostNetwork = true
+		})
+		framework.ExpectNoError(err)
+		dstPod1IPv4, dstPod1IPv6 = getPodAddresses(dstPod1)
+
+		dstPod2, err := createPod(f, dstPod2Name, nodes.Items[2].Name, f.Namespace.Name, []string{"bash", "-c", "apk update; apk add tcpdump; sleep 20000"}, map[string]string{}, func(p *v1.Pod) {
+			p.Spec.HostNetwork = true
+		})
+		framework.ExpectNoError(err)
+
+		dstPod2IPv4, dstPod2IPv6 = getPodAddresses(dstPod2)
+
+		gomega.Eventually(func() error {
+			_, err := framework.RunKubectl(f.Namespace.Name, "exec", dstPod1Name, "--", "which", "tcpdump")
+			if err != nil {
+				return err
+			}
+
+			_, err = framework.RunKubectl(f.Namespace.Name, "exec", dstPod2Name, "--", "which", "tcpdump")
+			return err
+		}, 60*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())
+	})
+
+	// Validate a pod's egress traffic heading to different CIDRs is marked with correct DSCP
+	// values corresponding to the EgressQoS resource. Updating the resource should change these values.
+	// We also validate that both current pods and new pods are affected by the EgressQoS resource by
+	// creating the pod before or after it (podBeforeQoS param).
+	ginkgotable.DescribeTable("Should validate correct DSCP value on EgressQoS resource changes",
+		func(tcpDumpTpl string, dst1IP *string, prefix1 string, dst2IP *string, podBeforeQoS bool) {
+			dscpValue := 50
+			if podBeforeQoS {
+				_, err := createPod(f, srcPodName, srcNode, f.Namespace.Name, []string{}, map[string]string{"app": "test"})
+				framework.ExpectNoError(err)
+			}
+
+			egressQoSConfig := fmt.Sprintf(`
+apiVersion: k8s.ovn.org/v1
+kind: EgressQoS
+metadata:
+  name: default
+  namespace: ` + f.Namespace.Name + `
+spec:
+  egress:
+  - dscp: ` + strconv.Itoa(dscpValue-1) + `
+    dstCIDR: ` + *dst1IP + prefix1 + `
+  - dscp: ` + strconv.Itoa(dscpValue-2) + `
+    podSelector:
+      matchLabels:
+        app: test
+`)
+
+			if err := ioutil.WriteFile(egressQoSYaml, []byte(egressQoSConfig), 0644); err != nil {
+				framework.Failf("Unable to write CRD config to disk: %v", err)
+			}
+			defer func() {
+				if err := os.Remove(egressQoSYaml); err != nil {
+					framework.Logf("Unable to remove the CRD config from disk: %v", err)
+				}
+			}()
+
+			framework.Logf("Create the EgressQoS configuration")
+			framework.RunKubectlOrDie(f.Namespace.Name, "create", "-f", egressQoSYaml)
+
+			if !podBeforeQoS {
+				_, err := createPod(f, srcPodName, srcNode, f.Namespace.Name, []string{}, map[string]string{"app": "test"})
+				framework.ExpectNoError(err)
+			}
+
+			pingAndCheckDSCP(f, srcPodName, dstPod1Name, *dst1IP, dstPod2Name, *dst2IP, tcpDumpTpl, dscpValue-1, dscpValue-2)
+
+			egressQoSConfig = fmt.Sprintf(`
+apiVersion: k8s.ovn.org/v1
+kind: EgressQoS
+metadata:
+  name: default
+  namespace: ` + f.Namespace.Name + `
+spec:
+  egress:
+  - dscp: ` + strconv.Itoa(dscpValue-10) + `
+    dstCIDR: ` + *dst1IP + prefix1 + `
+  - dscp: ` + strconv.Itoa(dscpValue-20) + `
+    podSelector:
+      matchLabels:
+        app: test
+`)
+
+			if err := ioutil.WriteFile(egressQoSYaml, []byte(egressQoSConfig), 0644); err != nil {
+				framework.Failf("Unable to write CRD config to disk: %v", err)
+			}
+			framework.Logf("Update the EgressQoS configuration")
+			framework.RunKubectlOrDie(f.Namespace.Name, "apply", "-f", egressQoSYaml)
+
+			pingAndCheckDSCP(f, srcPodName, dstPod1Name, *dst1IP, dstPod2Name, *dst2IP, tcpDumpTpl, dscpValue-10, dscpValue-20)
+
+			framework.RunKubectlOrDie(f.Namespace.Name, "delete", "-f", egressQoSYaml)
+
+			pingAndCheckDSCP(f, srcPodName, dstPod1Name, *dst1IP, dstPod2Name, *dst2IP, tcpDumpTpl, 0, 0)
+
+		},
+		ginkgotable.Entry("ipv4 pod before resource", tcpdumpIPv4, &dstPod1IPv4, "/32", &dstPod2IPv4, true),
+		ginkgotable.Entry("ipv4 pod after resource", tcpdumpIPv4, &dstPod1IPv4, "/32", &dstPod2IPv4, false),
+		ginkgotable.Entry("ipv6 pod before resource", tcpdumpIPv6, &dstPod1IPv6, "/128", &dstPod2IPv6, true),
+		ginkgotable.Entry("ipv6 pod after resource", tcpdumpIPv6, &dstPod1IPv6, "/128", &dstPod2IPv6, false))
+
+	ginkgotable.DescribeTable("Should validate correct DSCP value on pod labels changes",
+		func(tcpDumpTpl string, dst1IP *string, prefix1 string, dst2IP *string, prefix2 string) {
+			dscpValue := 50
+
+			// create without labels, no packets should be marked
+			pod, err := createPod(f, srcPodName, srcNode, f.Namespace.Name, []string{}, nil)
+			framework.ExpectNoError(err)
+
+			egressQoSConfig := fmt.Sprintf(`
+apiVersion: k8s.ovn.org/v1
+kind: EgressQoS
+metadata:
+  name: default
+  namespace: ` + f.Namespace.Name + `
+spec:
+  egress:
+  - dscp: ` + strconv.Itoa(dscpValue-1) + `
+    dstCIDR: ` + *dst1IP + prefix1 + `
+    podSelector:
+      matchLabels:
+        test1: test1
+  - dscp: ` + strconv.Itoa(dscpValue-2) + `
+    dstCIDR: ` + *dst2IP + prefix2 + `
+    podSelector:
+      matchLabels:
+        test2: test2
+`)
+
+			if err := ioutil.WriteFile(egressQoSYaml, []byte(egressQoSConfig), 0644); err != nil {
+				framework.Failf("Unable to write CRD config to disk: %v", err)
+			}
+			defer func() {
+				if err := os.Remove(egressQoSYaml); err != nil {
+					framework.Logf("Unable to remove the CRD config from disk: %v", err)
+				}
+			}()
+
+			framework.Logf("Create the EgressQoS configuration")
+			framework.RunKubectlOrDie(f.Namespace.Name, "create", "-f", egressQoSYaml)
+
+			pingAndCheckDSCP(f, srcPodName, dstPod1Name, *dst1IP, dstPod2Name, *dst2IP, tcpDumpTpl, 0, 0)
+
+			// match the first rule only
+			pod.Labels = map[string]string{"test1": "test1"}
+			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(context.Background(), pod, metav1.UpdateOptions{})
+			framework.ExpectNoError(err, "unable to update pod labels")
+
+			pingAndCheckDSCP(f, srcPodName, dstPod1Name, *dst1IP, dstPod2Name, *dst2IP, tcpDumpTpl, dscpValue-1, 0)
+
+			// match the second rule only
+			pod.Labels = map[string]string{"test2": "test2"}
+			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(context.Background(), pod, metav1.UpdateOptions{})
+			framework.ExpectNoError(err, "unable to update pod labels")
+
+			pingAndCheckDSCP(f, srcPodName, dstPod1Name, *dst1IP, dstPod2Name, *dst2IP, tcpDumpTpl, 0, dscpValue-2)
+
+			// match both rules
+			pod.Labels = map[string]string{"test1": "test1", "test2": "test2"}
+			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(context.Background(), pod, metav1.UpdateOptions{})
+			framework.ExpectNoError(err, "unable to update pod labels")
+
+			pingAndCheckDSCP(f, srcPodName, dstPod1Name, *dst1IP, dstPod2Name, *dst2IP, tcpDumpTpl, dscpValue-1, dscpValue-2)
+
+			// match no rules again
+			pod.Labels = map[string]string{"unrelated": "unrelated"}
+			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(context.Background(), pod, metav1.UpdateOptions{})
+			framework.ExpectNoError(err, "unable to update pod labels")
+
+			pingAndCheckDSCP(f, srcPodName, dstPod1Name, *dst1IP, dstPod2Name, *dst2IP, tcpDumpTpl, 0, 0)
+		},
+		ginkgotable.Entry("ipv4 pod", tcpdumpIPv4, &dstPod1IPv4, "/32", &dstPod2IPv4, "/32"),
+		ginkgotable.Entry("ipv6 pod", tcpdumpIPv6, &dstPod1IPv6, "/128", &dstPod2IPv6, "/128"))
+})
+
+func pingAndCheckDSCP(f *framework.Framework, srcPod, dstPod1, dstPod1IP, dstPod2, dstPod2IP, tcpDumpTpl string, dscp1, dscp2 int) {
+	tcpDumpSync := errgroup.Group{}
+	pingSync := errgroup.Group{}
+
+	checkDSCPOnPod := func(pod string, dscp int) error {
+		_, err := framework.RunKubectl(f.Namespace.Name, "exec", pod, "--", "timeout", "10",
+			"tcpdump", "-i", "any", "-c", "1", "-v", fmt.Sprintf(tcpDumpTpl, dscp))
+		return err
+	}
+
+	pingFromSrcPod := func(pod, dst string) error {
+		_, err := framework.RunKubectl(f.Namespace.Name, "exec", pod, "--", "ping", "-c", "3", dst)
+		return err
+	}
+
+	tcpDumpSync.Go(func() error {
+		return checkDSCPOnPod(dstPod1, dscp1)
+	})
+	tcpDumpSync.Go(func() error {
+		return checkDSCPOnPod(dstPod2, dscp2)
+	})
+
+	pingSync.Go(func() error {
+		return pingFromSrcPod(srcPod, dstPod1IP)
+	})
+	pingSync.Go(func() error {
+		return pingFromSrcPod(srcPod, dstPod2IP)
+	})
+
+	err := pingSync.Wait()
+	framework.ExpectNoError(err, "Failed to ping dst pod")
+	err = tcpDumpSync.Wait()
+	framework.ExpectNoError(err, "Failed to detect ping with correct DSCP on pod")
+
+}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -682,6 +682,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -11,7 +11,8 @@ export KUBECONFIG=${HOME}/ovn.conf
 IPV6_SKIPPED_TESTS="Should be allowed by externalip services|\
 should provide connection to external host by DNS name from a pod|\
 Should validate flow data of br-int is sent to an external gateway with netflow v5|\
-test tainting a node according to its defaults interface MTU size"
+test tainting a node according to its defaults interface MTU size|\
+ipv4 pod"
 
 SKIPPED_TESTS=""
 
@@ -22,7 +23,7 @@ if [ "$KIND_IPV4_SUPPORT" == true ]; then
     else
 	# Skip sflow in IPv4 since it's a long test (~5 minutes)
 	# We're validating netflow v5 with an ipv4 cluster, sflow with an ipv6 cluster
-	SKIPPED_TESTS="Should validate flow data of br-int is sent to an external gateway with sflow"
+	SKIPPED_TESTS="Should validate flow data of br-int is sent to an external gateway with sflow|ipv6 pod"
     fi
 fi
 


### PR DESCRIPTION
When using the namespace's address_set for the
EgressQoS rule we should return an empty map rather
than nil, otherwise when we try to load from it
in the pod sync path we get a nil pointer dereference.

Using an empty map is fine since we don't want to
change anything in the namespace's address_set here.

---

Adding E2E tests that cover EgressQoS functionality for both
IPv4 and IPv6:
* First table verifies that a pod's egress traffic is marked with
the correct DSCP value on EgressQoS resource updates regardless
if it was created before or after the resource.

* Second table verifies that updating a pod's labels results
in the right QoS rules being applied to its egress traffic.