### PR TITLE
Don't add ITP specific gw setup for DPU mode

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -404,18 +404,6 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 get interface " + hostRep + " ofport",
 			Output: "9",
 		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ip route replace table 7 172.16.1.0/24 via 10.1.1.1 dev ovn-k8s-mp0",
-			Output: "0",
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ip -4 rule",
-			Output: "0",
-		})
-		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-			Cmd:    "ip -4 rule add fwmark 0x1745ec lookup 7 prio 30",
-			Output: "0",
-		})
 		// cleanup flows
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovs-ofctl -O OpenFlow13 --bundle replace-flows " + brphys + " -",

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -103,8 +103,11 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 		}
 
 		if config.Gateway.NodeportEnable {
-			if err := initSvcViaMgmPortRoutingRules(hostSubnets); err != nil {
-				return err
+			if config.OvnKubeNode.Mode == types.NodeModeFull {
+				// (TODO): Internal Traffic Policy is not supported in DPU mode
+				if err := initSvcViaMgmPortRoutingRules(hostSubnets); err != nil {
+					return err
+				}
 			}
 			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge.patchPort, gwBridge.bridgeName, gwBridge.uplinkName, gwBridge.ips, gw.openflowManager, gw.nodeIPManager, watchFactory)
 			if err != nil {

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1352,8 +1352,11 @@ func newSharedGateway(nodeName string, subnets []*net.IPNet, gwNextHops []net.IP
 		}
 
 		if config.Gateway.NodeportEnable {
-			if err := initSvcViaMgmPortRoutingRules(subnets); err != nil {
-				return err
+			if config.OvnKubeNode.Mode == types.NodeModeFull {
+				// (TODO): Internal Traffic Policy is not supported in DPU mode
+				if err := initSvcViaMgmPortRoutingRules(subnets); err != nil {
+					return err
+				}
 			}
 			klog.Info("Creating Shared Gateway Node Port Watcher")
 			gw.nodePortWatcher, err = newNodePortWatcher(gwBridge.patchPort, gwBridge.bridgeName, gwBridge.uplinkName, gwBridge.ips, gw.openflowManager, gw.nodeIPManager, watchFactory)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Since DPU mode doesn't have a hostSubnet IP for `ovn-k8s-mp0` interface, we shouldn't be doing gateway setup for ITP specific things in DPU mode as ETP/ITP aren't really supported in DPU mode.

**- Special notes for reviewers**
@cathy-zhou pointed out that we were running into:
```
I0510 01:13:49.793882      80 ovs.go:205] Exec(53): /usr/sbin/ip route replace table 7 10.96.0.0/12 via 10.192.0.1 dev ovn-k8s-mp0
I0510 01:13:49.798029      80 ovs.go:208] Exec(53): stdout: ""
I0510 01:13:49.798103      80 ovs.go:209] Exec(53): stderr: "Error: Nexthop has invalid gateway.\n"
I0510 01:13:49.798129      80 ovs.go:211] Exec(53): err: exit status 2
F0510 01:13:49.798314      80 ovnkube.go:132] error waiting for node readiness: error adding routing table entry into custom routing table: 7: stdout: , stderr: Error: Nexthop has invalid gateway.
```

**- How to verify it**
I've changed DPU mode unit tests as well to reflect this.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
