### PR TITLE
Add nosprintfhostport linter config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Verify
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.45.2
+        version: v1.46
         working-directory: go-controller
         args: --modules-download-mode=vendor --timeout=15m0s --verbose
   build-master:

--- a/go-controller/.golangci.yml
+++ b/go-controller/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - nosprintfhostport
     - staticcheck
     - structcheck
     - typecheck

--- a/go-controller/hack/lint.sh
+++ b/go-controller/hack/lint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# pin golangci-lint version to 1.45.2
-VERSION=v1.45.2
+# pin golangci-lint version to 1.46.0
+VERSION=v1.46.0
 if [ "$#" -ne 1 ]; then
     echo "Expected command line argument - container runtime (docker/podman) got $# arguments: $@"
     exit 1


### PR DESCRIPTION
**- What this PR does and why is it needed**

Update golangci-lint to v1.46.0 and enable nosprintfhostport linter to prevent URL constructions that are incompatible with IPv6.

**- Special notes for reviewers**

None

**- How to verify it**

Run `make lint`, notice nosprintfhostport linter passes.

**- Description for the changelog**

Update golangci-lint to v1.46.0 and enable nosprintfhostport linter to prevent URL constructions that are incompatible with IPv6.