### PR TITLE
Don't lookup LBs that don't exist in cache

### DIFF
--- a/go-controller/pkg/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/libovsdbops/loadbalancer.go
@@ -58,6 +58,25 @@ func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, selectio
 	}
 }
 
+// CreateLoadBalancersOps creates the provided load balancers returning the
+// corresponding ops
+func CreateLoadBalancersOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {
+	opModels := make([]operationModel, 0, len(lbs))
+	for i := range lbs {
+		lb := lbs[i]
+		opModel := operationModel{
+			Model:          lb,
+			OnModelUpdates: onModelUpdatesNone(),
+			ErrNotFound:    false,
+			BulkOp:         false,
+		}
+		opModels = append(opModels, opModel)
+	}
+
+	modelClient := newModelClient(nbClient)
+	return modelClient.CreateOrUpdateOps(ops, opModels...)
+}
+
 // CreateOrUpdateLoadBalancersOps creates or updates the provided load balancers
 // returning the corresponding ops
 func CreateOrUpdateLoadBalancersOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lbs ...*nbdb.LoadBalancer) ([]libovsdb.Operation, error) {


### PR DESCRIPTION
Running the LB predicate that matches on name takes a long time if the
LB table has many LBs. For example, looking up ~40 LBs in a table with
~200k rows took aproximately 3s.

The service controller has a second level cache and knows which LBs need
to be added and which need to be updated. Avoid this lookup for LBs that
are to be added.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->