### PR TITLE
enable `exportloopref` linter and fix violations

### DIFF
--- a/go-controller/.golangci.yml
+++ b/go-controller/.golangci.yml
@@ -22,3 +22,4 @@ linters:
     - typecheck
     - unused
     - varcheck
+    - exportloopref

--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -303,7 +303,8 @@ func getPodInfo(coreclient *corev1client.CoreV1Client, restconfig *rest.Config, 
 
 	var ovnkubePod *kapi.Pod
 	// Find ovnkube-node-xxx pod running on the same node as Pod
-	for _, podOvn := range podsOvn.Items {
+	for index := 0; index < len(podsOvn.Items); index++ {
+		podOvn := podsOvn.Items[index]
 		if podOvn.Spec.NodeName == node.Name {
 			if !strings.HasPrefix(podOvn.Name, "ovnkube-node-metrics") {
 				if strings.HasPrefix(podOvn.Name, "ovnkube-node") {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -510,7 +510,8 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	if len(routingExternalGWs.gws) > 0 {
 		gateways = append(gateways, routingExternalGWs)
 	}
-	for _, gw := range routingPodGWs {
+	for key := range routingPodGWs {
+		gw := routingPodGWs[key]
 		if len(gw.gws) > 0 {
 			if err = validateRoutingPodGWs(routingPodGWs); err != nil {
 				klog.Error(err)


### PR DESCRIPTION
`exportloopref` golangci linter finds pointers exported from within
for-range loop, see https://github.com/kyoh86/exportloopref for details.

The linter does expose 2 violations, the one in `pkg/ovn/pods.go` is a
real bug.

Signed-off-by: xqu <xqu@nvidia.com>