### PR TITLE
kube: use paging when List-ing API objects directly

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/ho_node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ho_node_windows.go
@@ -349,7 +349,8 @@ func (n *NodeController) initSelf(node *kapi.Node, nodeSubnet *net.IPNet) error 
 		return fmt.Errorf("error in initializing/fetching nodes: %v", err)
 	}
 
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
+		node := *node
 		// Add VXLAN tunnel to the remote nodes
 		if node.Status.NodeInfo.MachineID != n.machineID {
 			n.AddNode(&node)
@@ -374,7 +375,8 @@ func (n *NodeController) uninitSelf(node *kapi.Node) error {
 	}
 
 	// Delete VXLAN tunnel to the remote nodes
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
+		node := *node
 		if node.Status.NodeInfo.MachineID != n.machineID {
 			n.DeleteNode(&node)
 		}

--- a/go-controller/pkg/kube/mocks/Interface.go
+++ b/go-controller/pkg/kube/mocks/Interface.go
@@ -97,15 +97,15 @@ func (_m *Interface) GetAnnotationsOnPod(namespace string, name string) (map[str
 }
 
 // GetNamespaces provides a mock function with given fields: labelSelector
-func (_m *Interface) GetNamespaces(labelSelector metav1.LabelSelector) (*apicorev1.NamespaceList, error) {
+func (_m *Interface) GetNamespaces(labelSelector metav1.LabelSelector) ([]*apicorev1.Namespace, error) {
 	ret := _m.Called(labelSelector)
 
-	var r0 *apicorev1.NamespaceList
-	if rf, ok := ret.Get(0).(func(metav1.LabelSelector) *apicorev1.NamespaceList); ok {
+	var r0 []*apicorev1.Namespace
+	if rf, ok := ret.Get(0).(func(metav1.LabelSelector) []*apicorev1.Namespace); ok {
 		r0 = rf(labelSelector)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*apicorev1.NamespaceList)
+			r0 = ret.Get(0).([]*apicorev1.Namespace)
 		}
 	}
 
@@ -143,15 +143,15 @@ func (_m *Interface) GetNode(name string) (*apicorev1.Node, error) {
 }
 
 // GetNodes provides a mock function with given fields:
-func (_m *Interface) GetNodes() (*apicorev1.NodeList, error) {
+func (_m *Interface) GetNodes() ([]*apicorev1.Node, error) {
 	ret := _m.Called()
 
-	var r0 *apicorev1.NodeList
-	if rf, ok := ret.Get(0).(func() *apicorev1.NodeList); ok {
+	var r0 []*apicorev1.Node
+	if rf, ok := ret.Get(0).(func() []*apicorev1.Node); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*apicorev1.NodeList)
+			r0 = ret.Get(0).([]*apicorev1.Node)
 		}
 	}
 
@@ -188,22 +188,22 @@ func (_m *Interface) GetPod(namespace string, name string) (*apicorev1.Pod, erro
 	return r0, r1
 }
 
-// GetPods provides a mock function with given fields: namespace, labelSelector
-func (_m *Interface) GetPods(namespace string, labelSelector metav1.LabelSelector) (*apicorev1.PodList, error) {
-	ret := _m.Called(namespace, labelSelector)
+// GetPods provides a mock function with given fields: namespace, opts
+func (_m *Interface) GetPods(namespace string, opts metav1.ListOptions) ([]*apicorev1.Pod, error) {
+	ret := _m.Called(namespace, opts)
 
-	var r0 *apicorev1.PodList
-	if rf, ok := ret.Get(0).(func(string, metav1.LabelSelector) *apicorev1.PodList); ok {
-		r0 = rf(namespace, labelSelector)
+	var r0 []*apicorev1.Pod
+	if rf, ok := ret.Get(0).(func(string, metav1.ListOptions) []*apicorev1.Pod); ok {
+		r0 = rf(namespace, opts)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*apicorev1.PodList)
+			r0 = ret.Get(0).([]*apicorev1.Pod)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, metav1.LabelSelector) error); ok {
-		r1 = rf(namespace, labelSelector)
+	if rf, ok := ret.Get(1).(func(string, metav1.ListOptions) error); ok {
+		r1 = rf(namespace, opts)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/go-controller/pkg/kube/mocks/InterfaceOVN.go
+++ b/go-controller/pkg/kube/mocks/InterfaceOVN.go
@@ -98,15 +98,15 @@ func (_m *InterfaceOVN) GetAnnotationsOnPod(namespace string, name string) (map[
 }
 
 // GetEgressFirewalls provides a mock function with given fields:
-func (_m *InterfaceOVN) GetEgressFirewalls() (*egressfirewallv1.EgressFirewallList, error) {
+func (_m *InterfaceOVN) GetEgressFirewalls() ([]*egressfirewallv1.EgressFirewall, error) {
 	ret := _m.Called()
 
-	var r0 *egressfirewallv1.EgressFirewallList
-	if rf, ok := ret.Get(0).(func() *egressfirewallv1.EgressFirewallList); ok {
+	var r0 []*egressfirewallv1.EgressFirewall
+	if rf, ok := ret.Get(0).(func() []*egressfirewallv1.EgressFirewall); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*egressfirewallv1.EgressFirewallList)
+			r0 = ret.Get(0).([]*egressfirewallv1.EgressFirewall)
 		}
 	}
 
@@ -144,15 +144,15 @@ func (_m *InterfaceOVN) GetEgressIP(name string) (*egressipv1.EgressIP, error) {
 }
 
 // GetEgressIPs provides a mock function with given fields:
-func (_m *InterfaceOVN) GetEgressIPs() (*egressipv1.EgressIPList, error) {
+func (_m *InterfaceOVN) GetEgressIPs() ([]*egressipv1.EgressIP, error) {
 	ret := _m.Called()
 
-	var r0 *egressipv1.EgressIPList
-	if rf, ok := ret.Get(0).(func() *egressipv1.EgressIPList); ok {
+	var r0 []*egressipv1.EgressIP
+	if rf, ok := ret.Get(0).(func() []*egressipv1.EgressIP); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*egressipv1.EgressIPList)
+			r0 = ret.Get(0).([]*egressipv1.EgressIP)
 		}
 	}
 
@@ -167,15 +167,15 @@ func (_m *InterfaceOVN) GetEgressIPs() (*egressipv1.EgressIPList, error) {
 }
 
 // GetNamespaces provides a mock function with given fields: labelSelector
-func (_m *InterfaceOVN) GetNamespaces(labelSelector metav1.LabelSelector) (*apicorev1.NamespaceList, error) {
+func (_m *InterfaceOVN) GetNamespaces(labelSelector metav1.LabelSelector) ([]*apicorev1.Namespace, error) {
 	ret := _m.Called(labelSelector)
 
-	var r0 *apicorev1.NamespaceList
-	if rf, ok := ret.Get(0).(func(metav1.LabelSelector) *apicorev1.NamespaceList); ok {
+	var r0 []*apicorev1.Namespace
+	if rf, ok := ret.Get(0).(func(metav1.LabelSelector) []*apicorev1.Namespace); ok {
 		r0 = rf(labelSelector)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*apicorev1.NamespaceList)
+			r0 = ret.Get(0).([]*apicorev1.Namespace)
 		}
 	}
 
@@ -213,15 +213,15 @@ func (_m *InterfaceOVN) GetNode(name string) (*apicorev1.Node, error) {
 }
 
 // GetNodes provides a mock function with given fields:
-func (_m *InterfaceOVN) GetNodes() (*apicorev1.NodeList, error) {
+func (_m *InterfaceOVN) GetNodes() ([]*apicorev1.Node, error) {
 	ret := _m.Called()
 
-	var r0 *apicorev1.NodeList
-	if rf, ok := ret.Get(0).(func() *apicorev1.NodeList); ok {
+	var r0 []*apicorev1.Node
+	if rf, ok := ret.Get(0).(func() []*apicorev1.Node); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*apicorev1.NodeList)
+			r0 = ret.Get(0).([]*apicorev1.Node)
 		}
 	}
 
@@ -258,22 +258,22 @@ func (_m *InterfaceOVN) GetPod(namespace string, name string) (*apicorev1.Pod, e
 	return r0, r1
 }
 
-// GetPods provides a mock function with given fields: namespace, labelSelector
-func (_m *InterfaceOVN) GetPods(namespace string, labelSelector metav1.LabelSelector) (*apicorev1.PodList, error) {
-	ret := _m.Called(namespace, labelSelector)
+// GetPods provides a mock function with given fields: namespace, opts
+func (_m *InterfaceOVN) GetPods(namespace string, opts metav1.ListOptions) ([]*apicorev1.Pod, error) {
+	ret := _m.Called(namespace, opts)
 
-	var r0 *apicorev1.PodList
-	if rf, ok := ret.Get(0).(func(string, metav1.LabelSelector) *apicorev1.PodList); ok {
-		r0 = rf(namespace, labelSelector)
+	var r0 []*apicorev1.Pod
+	if rf, ok := ret.Get(0).(func(string, metav1.ListOptions) []*apicorev1.Pod); ok {
+		r0 = rf(namespace, opts)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*apicorev1.PodList)
+			r0 = ret.Get(0).([]*apicorev1.Pod)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, metav1.LabelSelector) error); ok {
-		r1 = rf(namespace, labelSelector)
+	if rf, ok := ret.Get(1).(func(string, metav1.ListOptions) error); ok {
+		r1 = rf(namespace, opts)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/go-controller/pkg/metrics/ovnkube_controller.go
+++ b/go-controller/pkg/metrics/ovnkube_controller.go
@@ -1328,7 +1328,7 @@ func getNodeCount(kube kube.Interface) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("unable to retrieve node list: %v", err)
 	}
-	return len(nodes.Items), nil
+	return len(nodes), nil
 }
 
 // setNbE2eTimestamp return true if setting timestamp to NB global options is successful

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -878,7 +878,8 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 					err1 = fmt.Errorf("upgrade hack: error retrieving node %s: %v", nc.name, err)
 					return false, nil
 				}
-				for _, node := range nodes.Items {
+				for _, node := range nodes {
+					node := *node
 					if nc.name != node.Name && util.GetNodeZone(&node) != config.Default.Zone && !util.NoHostSubnet(&node) {
 						nodeSubnets, err := util.ParseNodeHostSubnetAnnotation(&node, types.DefaultNetworkName)
 						if err != nil {

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -343,7 +343,7 @@ func (oc *DefaultNetworkController) Init(ctx context.Context) error {
 		klog.Errorf("Error in fetching nodes: %v", err)
 		return err
 	}
-	klog.V(5).Infof("Existing number of nodes: %d", len(existingNodes.Items))
+	klog.V(5).Infof("Existing number of nodes: %d", len(existingNodes))
 	err = oc.upgradeOVNTopology(existingNodes)
 	if err != nil {
 		klog.Errorf("Failed to upgrade OVN topology to version %d: %v", ovntypes.OvnCurrentTopologyVersion, err)
@@ -388,7 +388,8 @@ func (oc *DefaultNetworkController) Init(ctx context.Context) error {
 
 	networkID := util.InvalidNetworkID
 	nodeNames := []string{}
-	for _, node := range existingNodes.Items {
+	for _, node := range existingNodes {
+		node := *node
 		nodeNames = append(nodeNames, node.Name)
 
 		if config.OVNKubernetesFeature.EnableInterconnect && networkID == util.InvalidNetworkID {

--- a/go-controller/pkg/ovn/external_ids_syncer/acl/acl_sync_test.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/acl/acl_sync_test.go
@@ -30,7 +30,7 @@ type aclSync struct {
 }
 
 func testSyncerWithData(data []aclSync, controllerName string, initialDbState, finalDbState []libovsdbtest.TestData,
-	existingNodes []v1.Node) {
+	existingNodes []*v1.Node) {
 	// create initial db setup
 	dbSetup := libovsdbtest.TestSetup{NBData: initialDbState}
 	for _, asSync := range data {
@@ -61,7 +61,7 @@ func testSyncerWithData(data []aclSync, controllerName string, initialDbState, f
 	}
 	// run sync
 	syncer := NewACLSyncer(libovsdbOvnNBClient, controllerName)
-	err = syncer.SyncACLs(&v1.NodeList{Items: existingNodes})
+	err = syncer.SyncACLs(existingNodes)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	// check results
 	gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDbState))
@@ -292,7 +292,7 @@ var _ = ginkgo.Describe("OVN ACL Syncer", func() {
 		hostSubnets := map[string][]string{types.DefaultNetworkName: {"10.244.0.0/24", "fd02:0:0:2::2895/64"}}
 		bytes, err := json.Marshal(hostSubnets)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		existingNodes := []v1.Node{{
+		existingNodes := []*v1.Node{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        nodeName,
 				Annotations: map[string]string{"k8s.ovn.org/node-subnets": string(bytes)},

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -255,10 +255,11 @@ func (oc *DefaultNetworkController) removeLRPolicies(nodeName string, priorities
 }
 
 // removes DGP, snat_and_dnat entries, and LRPs
-func (oc *DefaultNetworkController) cleanupDGP(nodes *kapi.NodeList) error {
+func (oc *DefaultNetworkController) cleanupDGP(nodes []*kapi.Node) error {
 	klog.Infof("Removing DGP %v", nodes)
 	// remove dnat_snat entries as well as LRPs
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
+		node := *node
 		oc.delPbrAndNatRules(node.Name, []string{types.InterNodePolicyPriority, types.MGMTPortPolicyPriority})
 	}
 	// remove SBDB MAC bindings for DGP

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -169,7 +169,8 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 			if err != nil {
 				return err
 			}
-			for _, node := range nodes.Items {
+			for _, node := range nodes {
+				node := *node
 				if util.NoHostSubnet(&node) {
 					if subnet, _ := houtil.ParseHybridOverlayHostSubnet(&node); subnet != nil {
 						hybridCIDRs[node.Name] = subnet
@@ -398,7 +399,8 @@ func (oc *DefaultNetworkController) removeRoutesToHONodeSubnet(nodeSubnet *net.I
 	if err != nil {
 		return err
 	}
-	for _, node := range nodes.Items {
+	for _, node := range nodes {
+		node := *node
 		// Check existence of Gateway Router before removing the static route from it.
 		if _, err := libovsdbops.GetLogicalRouter(oc.nbClient, &nbdb.LogicalRouter{Name: ovntypes.GWRouterPrefix + node.Name}); err != nil {
 			if err == libovsdbclient.ErrNotFound {

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -198,7 +198,7 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 
 	existingNodes, err := o.controller.kube.GetNodes()
 	if err == nil {
-		for _, node := range existingNodes.Items {
+		for _, node := range existingNodes {
 			o.controller.localZoneNodes.Store(node.Name, true)
 			for _, secondaryController := range o.secondaryControllers {
 				if secondaryController.bnc.localZoneNodes != nil {

--- a/go-controller/pkg/ovndbmanager/ovndbmanager.go
+++ b/go-controller/pkg/ovndbmanager/ovndbmanager.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -224,11 +225,9 @@ func ensureClusterRaftMembership(db *util.OvsDbProperties, kclient kube.Interfac
 	r = regexp.MustCompile(`([a-z0-9]{4}) at ` + dbServerRegexp)
 	members := r.FindAllStringSubmatch(out, -1)
 	kickedMembersCount := 0
-	dbAppLabel := map[string]string{"ovn-db-pod": "true"}
-	dbPods, err := kclient.GetPods(config.Kubernetes.OVNConfigNamespace,
-		metav1.LabelSelector{
-			MatchLabels: dbAppLabel,
-		})
+	dbPods, err := kclient.GetPods(config.Kubernetes.OVNConfigNamespace, metav1.ListOptions{
+		LabelSelector: labels.Set(map[string]string{"ovn-db-pod": "true"}).String(),
+	})
 	if err != nil {
 		return fmt.Errorf("unable to get db pod list from kubeclient: %v", err)
 	}
@@ -251,7 +250,7 @@ func ensureClusterRaftMembership(db *util.OvsDbProperties, kclient kube.Interfac
 		}
 		// check if there's a db pod with the same IP address, then it's a match
 		if !memberFound {
-			for _, dbPod := range dbPods.Items {
+			for _, dbPod := range dbPods {
 				for _, ip := range dbPod.Status.PodIPs {
 					if ip.IP == matchedServer || utilnet.ParseIPSloppy(ip.IP).String() == matchedServer {
 						memberFound = true


### PR DESCRIPTION
Listing when there's a bunch of API objects puts lots of load on the apiserver. Be nice and use paging.

Thankfully most of our accesses are from the informer.