### PR TITLE
pods: don't look up LSP twice

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -183,8 +183,12 @@ func (m *MasterController) handleOverlayPort(node *kapi.Node, annotator kube.Ann
 		return nil
 	}
 
-	// retrieve port configuration. If port isn't set up, portMAC will be nil
-	portMAC, _, _ = util.GetPortAddresses(portName, m.nbClient)
+	// Retrieve port MAC address; if the port isn't set up, portMAC will be nil
+	lsp := &nbdb.LogicalSwitchPort{Name: portName}
+	lsp, err = libovsdbops.GetLogicalSwitchPort(m.nbClient, lsp)
+	if err == nil {
+		portMAC, _, _ = util.ExtractPortAddresses(lsp)
+	}
 
 	// compare port configuration to annotation MAC, reconcile as needed
 	lspOK := false

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -426,13 +426,16 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) (err error) {
 	}
 
 	if needsIP {
-		// try to get the IP from existing port in OVN first
-		podMac, podIfAddrs, err = oc.getPortAddresses(logicalSwitch, portName)
-		if err != nil {
-			return fmt.Errorf("failed to get pod addresses for pod %s on node: %s, err: %v",
-				portName, logicalSwitch, err)
+		if existingLSP != nil {
+			// try to get the MAC and IPs from existing OVN port first
+			podMac, podIfAddrs, err = oc.getPortAddresses(logicalSwitch, existingLSP)
+			if err != nil {
+				return fmt.Errorf("failed to get pod addresses for pod %s on node: %s, err: %v",
+					portName, logicalSwitch, err)
+			}
 		}
 		needsNewAllocation := false
+
 		// ensure we have reserved the IPs found in OVN
 		if len(podIfAddrs) == 0 {
 			needsNewAllocation = true
@@ -623,15 +626,13 @@ func (oc *Controller) assignPodAddresses(nodeName string) (net.HardwareAddr, []*
 	return podMAC, podCIDRs, nil
 }
 
-// Given a pod and the node on which it is scheduled, get all addresses currently assigned
-// to it from the nbdb.
-func (oc *Controller) getPortAddresses(nodeName, portName string) (net.HardwareAddr, []*net.IPNet, error) {
-	podMac, podIPs, err := util.GetPortAddresses(portName, oc.nbClient)
+// Given a logical switch port and the node on which it is scheduled, get all
+// addresses currently assigned to it including subnet masks.
+func (oc *Controller) getPortAddresses(nodeName string, existingLSP *nbdb.LogicalSwitchPort) (net.HardwareAddr, []*net.IPNet, error) {
+	podMac, podIPs, err := util.ExtractPortAddresses(existingLSP)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if podMac == nil || len(podIPs) == 0 {
+	} else if podMac == nil || len(podIPs) == 0 {
 		return nil, nil, nil
 	}
 

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -35,16 +35,8 @@ func intToIP(i *big.Int) net.IP {
 	return net.IP(i.Bytes())
 }
 
-// GetPortAddresses returns the MAC and IPs of the given logical switch port
-func GetPortAddresses(portName string, nbClient client.Client) (net.HardwareAddr, []net.IP, error) {
-	lsp := &nbdb.LogicalSwitchPort{Name: portName}
-	lsp, err := libovsdbops.GetLogicalSwitchPort(nbClient, lsp)
-	if err == client.ErrNotFound {
-		return nil, nil, nil
-	} else if err != nil {
-		return nil, nil, err
-	}
-
+// ExtractPortAddresses returns the MAC and IPs of the given logical switch port
+func ExtractPortAddresses(lsp *nbdb.LogicalSwitchPort) (net.HardwareAddr, []net.IP, error) {
 	var addresses []string
 
 	if lsp.DynamicAddresses == nil {
@@ -63,13 +55,13 @@ func GetPortAddresses(portName string, nbClient client.Client) (net.HardwareAddr
 
 	mac, err := net.ParseMAC(addresses[0])
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse logical switch port %q MAC %q: %v", portName, addresses[0], err)
+		return nil, nil, fmt.Errorf("failed to parse logical switch port %q MAC %q: %v", lsp.Name, addresses[0], err)
 	}
 	var ips []net.IP
 	for _, addr := range addresses[1:] {
 		ip := net.ParseIP(addr)
 		if ip == nil {
-			return nil, nil, fmt.Errorf("failed to parse logical switch port %q IP %q is not a valid ip address", portName, addr)
+			return nil, nil, fmt.Errorf("failed to parse logical switch port %q IP %q is not a valid ip address", lsp.Name, addr)
 		}
 		ips = append(ips, ip)
 	}


### PR DESCRIPTION
addLogicalPort() looks up the LSP early and then looks it up again
if the pod had no IP/MAC annotations. This is kinda pointless and
just costs time and lock contention in libovsdb since if the port
was found early we can just use that one to get the MAC/IPs.

Since the only other user of GetPortAddresses() was the hybrid
overlay code move the port lookup into the hybrid overlay code
and just keep the address extraction code common.