### PR TITLE
dist: Makefile use podman for fedora-dev

### DIFF
--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -19,7 +19,14 @@ ifeq ($(ARCH),arm64)
 endif
 OVS_BRANCH ?= master
 OVN_BRANCH ?= main
-OCI_BIN ?= docker
+
+# Check if the system contain podman or docker
+PODMAN ?= $(shell podman -v > /dev/null 2>&1; echo $$?)
+ifeq ($(PODMAN), 0)
+OCI_BIN=podman
+else
+OCI_BIN=docker
+endif
 
 # The image of ovnkube/ovn-daemonset-u should be multi-arched before using it on arm64
 ubuntu: bld


### PR DESCRIPTION
Fedora do not ship anymore docker. We should support
out of box podman.

Resolves: https://github.com/ovn-org/ovn-kubernetes/issues/2781
Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

**- What this PR does and why is it needed**
- remove dependency of docker for `dist/images` makefile
 
**- Special notes for reviewers**
Nothing fancy, just found this when testing some bits in the repo.

**- How to verify it**
On a recent Fedora system, do not install docker from external repos and install podman.
```
sudo dnf install podman -y
cd dist/images
make fedora-dev
```

**- Description for the changelog**
- dist/images: fedora-dev do not depend on docker anymore