### PR TITLE
WIP: Shutdown event broadcaster and rename event sources

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -16,6 +16,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -46,14 +47,15 @@ type OvnNode struct {
 }
 
 // NewNode creates a new controller for node management
-func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name string, stopChan chan struct{}, eventRecorder record.EventRecorder) *OvnNode {
+func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name string, eventBroadcaster record.EventBroadcaster,
+	stopChan chan struct{}) *OvnNode {
 	return &OvnNode{
 		name:         name,
 		client:       kubeClient,
 		Kube:         &kube.Kube{KClient: kubeClient},
 		watchFactory: wf,
 		stopChan:     stopChan,
-		recorder:     eventRecorder,
+		recorder:     eventBroadcaster.NewRecorder(scheme.Scheme, kapi.EventSource{Component: "controlplane"}),
 	}
 }
 

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -55,7 +55,7 @@ func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name s
 		Kube:         &kube.Kube{KClient: kubeClient},
 		watchFactory: wf,
 		stopChan:     stopChan,
-		recorder:     eventBroadcaster.NewRecorder(scheme.Scheme, kapi.EventSource{Component: "controlplane"}),
+		recorder:     eventBroadcaster.NewRecorder(scheme.Scheme, kapi.EventSource{Component: "ovn-node-controller"}),
 	}
 }
 

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -3425,7 +3425,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
 				gomega.Expect(fakeOvn.controller.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
 				gomega.Expect(fakeOvn.controller.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
-
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(0))
 				gomega.Eventually(fakeOvn.fakeRecorder.Events).Should(gomega.HaveLen(3))
 				return nil

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -980,9 +980,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState := []libovsdbtest.TestData{}
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
-			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+			broadcaster := record.NewBroadcaster()
+			defer broadcaster.Shutdown()
+			clusterController := NewOvnController(fakeClient, f, addressset.NewFakeAddressSetFactory(), broadcaster,
+				libovsdbOvnNBClient, libovsdbOvnSBClient, stopChan)
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 			clusterController.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
@@ -1181,9 +1182,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState := []libovsdbtest.TestData{}
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
-			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+			broadcaster := record.NewBroadcaster()
+			defer broadcaster.Shutdown()
+			clusterController := NewOvnController(fakeClient, f, addressset.NewFakeAddressSetFactory(), broadcaster,
+				libovsdbOvnNBClient, libovsdbOvnSBClient, stopChan)
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 			clusterController.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
@@ -1363,9 +1365,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState := []libovsdbtest.TestData{}
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
-			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+			broadcaster := record.NewBroadcaster()
+			defer broadcaster.Shutdown()
+			clusterController := NewOvnController(fakeClient, f, addressset.NewFakeAddressSetFactory(), broadcaster,
+				libovsdbOvnNBClient, libovsdbOvnSBClient, stopChan)
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 			clusterController.defaultGatewayCOPPUUID, err = EnsureDefaultCOPP(libovsdbOvnNBClient)
@@ -1597,9 +1600,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			expectedDatabaseState := []libovsdbtest.TestData{}
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
 
-			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+			broadcaster := record.NewBroadcaster()
+			defer broadcaster.Shutdown()
+			clusterController := NewOvnController(fakeClient, f, addressset.NewFakeAddressSetFactory(), broadcaster,
+				libovsdbOvnNBClient, libovsdbOvnSBClient, stopChan)
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 			gomega.Expect(clusterController).NotTo(gomega.BeNil())
 
@@ -1895,10 +1899,10 @@ func TestController_allocateNodeSubnets(t *testing.T) {
 				t.Fatalf("Error creating libovsdb test harness %v", err)
 			}
 			t.Cleanup(libovsdbCleanup.Cleanup)
-
-			clusterController := NewOvnController(fakeClient, f, stopChan, addressset.NewFakeAddressSetFactory(),
-				libovsdbOvnNBClient, libovsdbOvnSBClient,
-				record.NewFakeRecorder(0))
+			broadcaster := record.NewBroadcaster()
+			defer broadcaster.Shutdown()
+			clusterController := NewOvnController(fakeClient, f, addressset.NewFakeAddressSetFactory(), broadcaster,
+				libovsdbOvnNBClient, libovsdbOvnSBClient, stopChan)
 			clusterController.loadBalancerGroupUUID = expectedClusterLBGroup.UUID
 
 			// configure the cluster allocators
@@ -1988,15 +1992,16 @@ func TestController_syncNodesRetriable(t *testing.T) {
 				t.Fatalf("Error creating libovsdb test harness: %v", err)
 			}
 			t.Cleanup(libovsdbCleanup.Cleanup)
-
+			broadcaster := record.NewBroadcaster()
+			defer broadcaster.Shutdown()
 			controller := NewOvnController(
 				fakeClient,
 				f,
-				stopChan,
 				addressset.NewFakeAddressSetFactory(),
+				broadcaster,
 				nbClient,
 				sbClient,
-				record.NewFakeRecorder(0))
+				stopChan)
 
 			controller.joinSwIPManager, err = lsm.NewJoinLogicalSwitchIPManager(nbClient, "", []string{})
 			if err != nil {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -312,7 +312,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, ad
 		retryEgressIPPods:         NewRetryObjs(factory.EgressIPPodType, "", nil, nil, nil),
 		retryEgressNodes:          NewRetryObjs(factory.EgressNodeType, "", nil, nil, nil),
 		retryCloudPrivateIPConfig: NewRetryObjs(factory.CloudPrivateIPConfigType, "", nil, nil, nil),
-		recorder:                  eventBroadcaster.NewRecorder(scheme.Scheme, kapi.EventSource{Component: "controlplane"}),
+		recorder:                  eventBroadcaster.NewRecorder(scheme.Scheme, kapi.EventSource{Component: "ovn-master-controller"}),
 		nbClient:                  libovsdbOvnNBClient,
 		sbClient:                  libovsdbOvnSBClient,
 		svcController:             svcController,

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -15,11 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 
@@ -256,21 +254,6 @@ func PodCompleted(pod *kapi.Pod) bool {
 // PodScheduled returns if the given pod is scheduled
 func PodScheduled(pod *kapi.Pod) bool {
 	return pod.Spec.NodeName != ""
-}
-
-// EventRecorder returns an EventRecorder type that can be
-// used to post Events to different object's lifecycles.
-func EventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(klog.Infof)
-	eventBroadcaster.StartRecordingToSink(
-		&typedcorev1.EventSinkImpl{
-			Interface: kubeClient.CoreV1().Events(""),
-		})
-	recorder := eventBroadcaster.NewRecorder(
-		scheme.Scheme,
-		kapi.EventSource{Component: "controlplane"})
-	return recorder
 }
 
 // UseEndpointSlices detect if Endpoints Slices are enabled in the cluster


### PR DESCRIPTION
Pass event broadcaster to consumers. 
Shut down broadcaster when component is terminating.
Rename event source component name.