### PR TITLE
Partial Revert of onModelUpdatesAll

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20211201215911-5a82bae32e46
 	github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366
-	github.com/ovn-org/libovsdb v0.6.1-0.20220513144310-50ec17900991
+	github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -404,6 +404,8 @@ github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4 h1:atUIOA34Cg9G
 github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/ovn-org/libovsdb v0.6.1-0.20220513144310-50ec17900991 h1:EsMLPWOIRgB9WFTt5+L99LaX4H1Nm6yL2S6zsx4TSzY=
 github.com/ovn-org/libovsdb v0.6.1-0.20220513144310-50ec17900991/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
+github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1 h1:ZXVHrW4b7RK/emoqTNL58IWUuK0dD8PVb93fbfh9cMs=
+github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/hybrid-overlay/pkg/controller/master.go
+++ b/go-controller/hybrid-overlay/pkg/controller/master.go
@@ -371,7 +371,7 @@ func (m *MasterController) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet,
 			if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &logicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
 				return item.Priority == logicalRouterPolicy.Priority &&
 					item.ExternalIDs["name"] == logicalRouterPolicy.ExternalIDs["name"]
-			}); err != nil {
+			}, &logicalRouterPolicy.Nexthops, &logicalRouterPolicy.Match, &logicalRouterPolicy.Action); err != nil {
 				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
 			}
 
@@ -404,7 +404,7 @@ func (m *MasterController) setupHybridLRPolicySharedGw(nodeSubnets []*net.IPNet,
 			if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(m.nbClient, ovntypes.OVNClusterRouter, &grLogicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
 				return item.Priority == grLogicalRouterPolicy.Priority &&
 					item.ExternalIDs["name"] == grLogicalRouterPolicy.ExternalIDs["name"]
-			}); err != nil {
+			}, &grLogicalRouterPolicy.Nexthops, &grLogicalRouterPolicy.Match, &grLogicalRouterPolicy.Action); err != nil {
 				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
 			}
 			klog.Infof("Created hybrid overlay logical route policies for node %s", nodeName)

--- a/go-controller/pkg/libovsdbops/acl.go
+++ b/go-controller/pkg/libovsdbops/acl.go
@@ -95,7 +95,7 @@ func CreateOrUpdateACLsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operat
 		opModel := operationModel{
 			Model:          acl,
 			ModelPredicate: func(item *nbdb.ACL) bool { return isEquivalentACL(item, acl) },
-			OnModelUpdates: onModelUpdatesAll(),
+			OnModelUpdates: onModelUpdatesAllNonDefault(),
 			ErrNotFound:    false,
 			BulkOp:         false,
 		}

--- a/go-controller/pkg/libovsdbops/copp.go
+++ b/go-controller/pkg/libovsdbops/copp.go
@@ -18,7 +18,7 @@ func CreateOrUpdateCOPPsOps(nbClient libovsdbclient.Client, ops []ovsdb.Operatio
 		copp := copps[i]
 		opModel := operationModel{
 			Model:          copp,
-			OnModelUpdates: onModelUpdatesAll(),
+			OnModelUpdates: onModelUpdatesAllNonDefault(),
 			ErrNotFound:    false,
 			BulkOp:         false,
 		}

--- a/go-controller/pkg/libovsdbops/lbgroup.go
+++ b/go-controller/pkg/libovsdbops/lbgroup.go
@@ -13,9 +13,10 @@ import (
 // CreateOrUpdateLoadBalancerGroup creates or updates the provided load balancer
 // group
 func CreateOrUpdateLoadBalancerGroup(nbClient libovsdbclient.Client, group *nbdb.LoadBalancerGroup) error {
+	// lb group has no fields other than name, safe to update just with non-default values
 	opModel := operationModel{
 		Model:          group,
-		OnModelUpdates: onModelUpdatesAll(),
+		OnModelUpdates: onModelUpdatesAllNonDefault(),
 		ErrNotFound:    false,
 		BulkOp:         false,
 	}

--- a/go-controller/pkg/libovsdbops/mac_binding.go
+++ b/go-controller/pkg/libovsdbops/mac_binding.go
@@ -7,10 +7,14 @@ import (
 )
 
 // CreateOrUpdateMacBinding creates or updates the provided mac binding
-func CreateOrUpdateMacBinding(sbClient libovsdbclient.Client, mb *sbdb.MACBinding) error {
+func CreateOrUpdateMacBinding(sbClient libovsdbclient.Client, mb *sbdb.MACBinding, fields ...interface{}) error {
+	if len(fields) == 0 {
+		fields = onModelUpdatesAllNonDefault()
+	}
+
 	opModel := operationModel{
 		Model:          mb,
-		OnModelUpdates: onModelUpdatesAll(),
+		OnModelUpdates: fields,
 		ErrNotFound:    false,
 		BulkOp:         false,
 	}

--- a/go-controller/pkg/libovsdbops/meter.go
+++ b/go-controller/pkg/libovsdbops/meter.go
@@ -46,14 +46,17 @@ func CreateMeterBandOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, m
 
 // CreateOrUpdateMeterOps creates or updates the provided meter associated to
 // the provided meter bands and returns the corresponding ops
-func CreateOrUpdateMeterOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, meter *nbdb.Meter, meterBands ...*nbdb.MeterBand) ([]ovsdb.Operation, error) {
+func CreateOrUpdateMeterOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, meter *nbdb.Meter, meterBands []*nbdb.MeterBand, fields ...interface{}) ([]ovsdb.Operation, error) {
+	if len(fields) == 0 {
+		fields = onModelUpdatesAllNonDefault()
+	}
 	meter.Bands = make([]string, 0, len(meterBands))
 	for _, band := range meterBands {
 		meter.Bands = append(meter.Bands, band.UUID)
 	}
 	opModel := operationModel{
 		Model:          meter,
-		OnModelUpdates: onModelUpdatesAll(),
+		OnModelUpdates: fields,
 		ErrNotFound:    false,
 		BulkOp:         false,
 	}

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -390,3 +390,15 @@ func buildFailOnDuplicateOps(c client.Client, m model.Model) ([]ovsdb.Operation,
 	}
 	return c.Where(m, cond).Wait(ovsdb.WaitConditionNotEqual, &timeout, m, field)
 }
+
+// getAllUpdatableFields returns a list of all of the columns/fields that can be updated for a model
+func getAllUpdatableFields(model model.Model) []interface{} {
+	switch t := model.(type) {
+	case *nbdb.LogicalSwitchPort:
+		return []interface{}{&t.Addresses, &t.Type, &t.TagRequest, &t.Options, &t.PortSecurity}
+	case *nbdb.PortGroup:
+		return []interface{}{&t.ACLs, &t.Ports, &t.ExternalIDs}
+	default:
+		panic(fmt.Sprintf("getAllUpdatableFields: unknown model %T", t))
+	}
+}

--- a/go-controller/pkg/libovsdbops/model_client.go
+++ b/go-controller/pkg/libovsdbops/model_client.go
@@ -156,7 +156,7 @@ func onModelUpdatesNone() []interface{} {
 	return nil
 }
 
-func onModelUpdatesAll() []interface{} {
+func onModelUpdatesAllNonDefault() []interface{} {
 	return []interface{}{}
 }
 
@@ -198,6 +198,7 @@ func (m *modelClient) createOrUpdateOps(ops []ovsdb.Operation, opModels ...opera
 	hasGuardOp := len(ops) > 0 && isGuardOp(&ops[0])
 	guardOp := []ovsdb.Operation{}
 	doWhenFound := func(model interface{}, opModel *operationModel) ([]ovsdb.Operation, error) {
+		// nil represents onModelUpdatesNone
 		if opModel.OnModelUpdates != nil {
 			return m.update(model, opModel)
 		} else if opModel.OnModelMutations != nil {

--- a/go-controller/pkg/libovsdbops/portgroup.go
+++ b/go-controller/pkg/libovsdbops/portgroup.go
@@ -38,7 +38,7 @@ func CreateOrUpdatePortGroupsOps(nbClient libovsdbclient.Client, ops []libovsdb.
 		pg := pgs[i]
 		opModel := operationModel{
 			Model:          pg,
-			OnModelUpdates: onModelUpdatesAll(),
+			OnModelUpdates: getAllUpdatableFields(pg),
 			ErrNotFound:    false,
 			BulkOp:         false,
 		}

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -45,12 +45,15 @@ func GetLogicalSwitch(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch) (*
 	return found[0], nil
 }
 
-// CreateOrUpdateLogicalRouter creates or updates the provided logical switch
-func CreateOrUpdateLogicalSwitch(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch) error {
+// CreateOrUpdateLogicalSwitch creates or updates the provided logical switch
+func CreateOrUpdateLogicalSwitch(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch, fields ...interface{}) error {
+	if len(fields) == 0 {
+		fields = onModelUpdatesAllNonDefault()
+	}
 	opModel := operationModel{
 		Model:          sw,
 		ModelPredicate: func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
-		OnModelUpdates: onModelUpdatesAll(),
+		OnModelUpdates: fields,
 		ErrNotFound:    false,
 		BulkOp:         false,
 	}
@@ -225,7 +228,7 @@ func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []l
 		lsp := lsps[i]
 		opModel := operationModel{
 			Model:          lsp,
-			OnModelUpdates: onModelUpdatesAll(),
+			OnModelUpdates: getAllUpdatableFields(lsp),
 			DoAfter:        func() { sw.Ports = append(sw.Ports, lsp.UUID) },
 			ErrNotFound:    false,
 			BulkOp:         false,

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -66,7 +66,7 @@ func (oc *Controller) gatewayCleanup(nodeName string) error {
 		return fmt.Errorf("failed to delete external switch %s: %v", externalSwitch, err)
 	}
 
-	exGWexternalSwitch := types.ExternalSwitchPrefix + types.ExternalSwitchPrefix + nodeName
+	exGWexternalSwitch := types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeName
 	err = libovsdbops.DeleteLogicalSwitch(oc.nbClient, exGWexternalSwitch)
 	if err != nil {
 		return fmt.Errorf("failed to delete external switch %s: %v", exGWexternalSwitch, err)

--- a/go-controller/pkg/ovn/gateway_copp.go
+++ b/go-controller/pkg/ovn/gateway_copp.go
@@ -73,7 +73,8 @@ func EnsureDefaultCOPP(nbClient libovsdbclient.Client) (string, error) {
 			Fair: &meterFairness,
 			Unit: types.PacketsPerSecond,
 		}
-		ops, err = libovsdbops.CreateOrUpdateMeterOps(nbClient, ops, meter, band)
+		ops, err = libovsdbops.CreateOrUpdateMeterOps(nbClient, ops, meter, []*nbdb.MeterBand{band},
+			&meter.Bands, &meter.Fair, &meter.Unit)
 		if err != nil {
 			return "", fmt.Errorf("can't create meter %v: %v", meter, err)
 		}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -678,8 +678,8 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 						UUID: types.ExternalSwitchPrefix + nodeName + "-UUID ",
 					},
 					&nbdb.LogicalSwitch{
-						Name: types.ExternalSwitchPrefix + types.ExternalSwitchPrefix + nodeName,
-						UUID: types.ExternalSwitchPrefix + types.ExternalSwitchPrefix + nodeName + "-UUID",
+						Name: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeName,
+						UUID: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeName + "-UUID",
 					},
 				},
 			})
@@ -807,8 +807,8 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 						UUID: types.ExternalSwitchPrefix + nodeName + "-UUID ",
 					},
 					&nbdb.LogicalSwitch{
-						Name: types.ExternalSwitchPrefix + types.ExternalSwitchPrefix + nodeName,
-						UUID: types.ExternalSwitchPrefix + types.ExternalSwitchPrefix + nodeName + "-UUID",
+						Name: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeName,
+						UUID: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeName + "-UUID",
 					},
 				},
 			})

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -1307,7 +1307,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 								// check old value for iface-id-ver will be updated to pod.UID
 								"iface-id-ver": "wrong_value",
 							},
-							PortSecurity: []string{t1.podMAC, t1.podIP},
+							PortSecurity: []string{fmt.Sprintf("%s %s", t1.podMAC, t1.podIP)},
 						},
 						&nbdb.LogicalSwitchPort{
 							UUID:      t2.portUUID,
@@ -1321,7 +1321,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 								"requested-chassis": t2.nodeName,
 								//"iface-id-ver": is empty to check that it won't be set on update
 							},
-							PortSecurity: []string{t2.podMAC, t2.podIP},
+							PortSecurity: []string{fmt.Sprintf("%s %s", t2.podMAC, t2.podIP)},
 						},
 						&nbdb.LogicalSwitch{
 							Name:  "node1",

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1960,7 +1960,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				expectedData := []libovsdb.TestData{}
 				expectedData = append(expectedData, gressPolicyExpectedData...)
 				expectedData = append(expectedData, defaultDenyExpectedData...)
-				expectedData = append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
+				expectedData1 := append(expectedData, getExpectedDataPodsAndSwitches([]testPod{nPodTest}, []string{"node1"})...)
 
 				fakeOvn.startWithDBSetup(initialDB,
 					&v1.NamespaceList{
@@ -1992,11 +1992,12 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 
 				_, err = fakeOvn.fakeClient.KubeClient.NetworkingV1().NetworkPolicies(networkPolicy.Namespace).Get(context.TODO(), networkPolicy.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData1...))
 
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(nPodTest.namespace).Delete(context.TODO(), nPodTest.podName, *metav1.NewDeleteOptions(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData...))
+				expectedData2 := append(expectedData, getExpectedDataPodsAndSwitches([]testPod{}, []string{"node1"})...)
+				gomega.Eventually(fakeOvn.nbClient).Should(libovsdb.HaveData(expectedData2...))
 
 				// After deleting the pod all address sets should be empty
 				eventuallyExpectEmptyAddressSetsExist(fakeOvn, networkPolicy)

--- a/go-controller/pkg/util/ovn.go
+++ b/go-controller/pkg/util/ovn.go
@@ -34,7 +34,7 @@ func CreateMACBinding(sbClient libovsdbclient.Client, logicalPort, datapathName 
 		IP:          nextHop.String(),
 	}
 
-	err = libovsdbops.CreateOrUpdateMacBinding(sbClient, &mb)
+	err = libovsdbops.CreateOrUpdateMacBinding(sbClient, &mb, &mb.Datapath, &mb.LogicalPort, &mb.IP, &mb.MAC)
 	if err != nil {
 		return fmt.Errorf("failed to create mac binding %+v: %v", mb, err)
 	}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 
@@ -25,6 +26,7 @@ const (
 	deleteEvent     = "delete"
 	bufferSize      = 65536
 	columnDelimiter = ","
+	keyDelimiter    = "|"
 )
 
 // ErrCacheInconsistent is an error that can occur when an operation
@@ -68,32 +70,84 @@ func NewIndexExistsError(table string, value interface{}, index string, new, exi
 }
 
 // map of unique values to uuids
-type valueToUUID map[interface{}]string
+type valueToUUIDs map[interface{}]uuidset
 
-// map of column name(s) to a unique values, to UUIDs
-type columnToValue map[index]valueToUUID
+// map of column name(s) to unique values, to UUIDs
+type columnToValue map[index]valueToUUIDs
 
 // index is the type used to implement multiple cache indexes
 type index string
 
-// columns returns the columns that conform the index
-func (i index) columns() []string {
-	return strings.Split(string(i), columnDelimiter)
+// indexType is the type of index
+type indexType uint
+
+const (
+	schemaIndexType indexType = iota
+	clientIndexType
+)
+
+// indexSpec contains details about an index
+type indexSpec struct {
+	index     index
+	columns   []model.ColumnKey
+	indexType indexType
+}
+
+func (s indexSpec) isClientIndex() bool {
+	return s.indexType == clientIndexType
+}
+
+func (s indexSpec) isSchemaIndex() bool {
+	return s.indexType == schemaIndexType
 }
 
 // newIndex builds a index from a list of columns
-func newIndex(columns ...string) index {
+func newIndexFromColumns(columns ...string) index {
+	sort.Strings(columns)
 	return index(strings.Join(columns, columnDelimiter))
+}
+
+// newIndexFromColumnKeys builds a index from a list of column keys
+func newIndexFromColumnKeys(columnsKeys ...model.ColumnKey) index {
+	// RFC 7047 says that Indexes is a [<column-set>] and "Each <column-set> is a set of
+	// columns whose values, taken together within any given row, must be
+	// unique within the table". We'll store the column names, separated by comma
+	// as we'll assume (RFC is not clear), that comma isn't valid in a <id>
+	columns := make([]string, 0, len(columnsKeys))
+	columnsMap := map[string]struct{}{}
+	for _, columnKey := range columnsKeys {
+		var column string
+		if columnKey.Key != nil {
+			column = fmt.Sprintf("%s%s%v", columnKey.Column, keyDelimiter, columnKey.Key)
+		} else {
+			column = columnKey.Column
+		}
+		if _, found := columnsMap[column]; !found {
+			columns = append(columns, column)
+			columnsMap[column] = struct{}{}
+		}
+	}
+	return newIndexFromColumns(columns...)
+}
+
+// newColumnKeysFromColumns builds a list of column keys from a list of columns
+func newColumnKeysFromColumns(columns ...string) []model.ColumnKey {
+	columnKeys := make([]model.ColumnKey, len(columns))
+	for i, column := range columns {
+		columnKeys[i] = model.ColumnKey{Column: column}
+	}
+	return columnKeys
 }
 
 // RowCache is a collections of Models hashed by UUID
 type RowCache struct {
-	name     string
-	dbModel  model.DatabaseModel
-	dataType reflect.Type
-	cache    map[string]model.Model
-	indexes  columnToValue
-	mutex    sync.RWMutex
+	name       string
+	dbModel    model.DatabaseModel
+	dataType   reflect.Type
+	cache      map[string]model.Model
+	indexSpecs []indexSpec
+	indexes    columnToValue
+	mutex      sync.RWMutex
 }
 
 // rowByUUID returns one model from the cache by UUID. Caller must hold the row
@@ -112,31 +166,71 @@ func (r *RowCache) Row(uuid string) model.Model {
 	return r.rowByUUID(uuid)
 }
 
-// RowByModel searches the cache using a the indexes for a provided model
-func (r *RowCache) RowByModel(m model.Model) model.Model {
+func (r *RowCache) rowsByModel(m model.Model, useClientIndexes bool) map[string]model.Model {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 	if reflect.TypeOf(m) != r.dataType {
 		return nil
 	}
 	info, _ := r.dbModel.NewModelInfo(m)
-	uuid, err := info.FieldByColumn("_uuid")
+	field, err := info.FieldByColumn("_uuid")
 	if err != nil {
 		return nil
 	}
-	if uuid.(string) != "" {
-		return r.rowByUUID(uuid.(string))
+	uuid := field.(string)
+	if uuid != "" {
+		row := r.rowByUUID(uuid)
+		if row != nil {
+			return map[string]model.Model{uuid: row}
+		}
 	}
-	for index, vals := range r.indexes {
-		val, err := valueFromIndex(info, index)
+	// indexSpecs are ordered, schema indexes go first, then client indexes
+	for _, indexSpec := range r.indexSpecs {
+		if indexSpec.isClientIndex() && !useClientIndexes {
+			// Given the ordered indexSpecs, we can break here if we reach the
+			// first client index
+			break
+		}
+		val, err := valueFromIndex(info, indexSpec.columns)
 		if err != nil {
 			continue
 		}
-		if uuid, ok := vals[val]; ok {
-			return r.rowByUUID(uuid)
+		vals := r.indexes[indexSpec.index]
+		uuids, ok := vals[val]
+		if !ok || uuids.empty() {
+			continue
 		}
+		results := make(map[string]model.Model, len(uuids))
+		for uuid := range uuids {
+			results[uuid] = r.rowByUUID(uuid)
+		}
+		return results
 	}
 	return nil
+}
+
+// RowByModel searches the cache by UUID and schema indexes. UUID search is
+// performed first. Then schema indexes are evaluated in turn by the same order
+// with which they are defined in the schema. The model for the first matching
+// index is returned along with its UUID. An empty string and nil is returned if
+// no Model is found.
+func (r *RowCache) RowByModel(m model.Model) (string, model.Model) {
+	models := r.rowsByModel(m, false)
+	for uuid, model := range models {
+		return uuid, model
+	}
+	return "", nil
+}
+
+// RowsByModel searches the cache by UUID, schema indexes and client indexes.
+// UUID search is performed first. Schema indexes are evaluated next in turn by
+// the same order with which they are defined in the schema. Finally, client
+// indexes are evaluated in turn by the same order with which they are defined
+// in the client DB model. The models for the first matching index are returned,
+// which might be more than 1 if they were found through a client index since in
+// that case uniqueness is not enforced. Nil is returned if no Model is found.
+func (r *RowCache) RowsByModel(m model.Model) map[string]model.Model {
+	return r.rowsByModel(m, true)
 }
 
 // Create writes the provided content to the cache
@@ -153,60 +247,65 @@ func (r *RowCache) Create(uuid string, m model.Model, checkIndexes bool) error {
 	if err != nil {
 		return err
 	}
-	newIndexes := newColumnToValue(r.dbModel.Schema.Table(r.name).Indexes)
-	for index, vals := range r.indexes {
-		val, err := valueFromIndex(info, index)
+	newIndexes := r.newIndexes()
+	for _, indexSpec := range r.indexSpecs {
+		index := indexSpec.index
+		val, err := valueFromIndex(info, indexSpec.columns)
 		if err != nil {
 			return err
 		}
 
-		if existing, ok := vals[val]; ok && checkIndexes {
-			return NewIndexExistsError(r.name, val, string(index), uuid, existing)
+		vals := r.indexes[index]
+		if existing, ok := vals[val]; ok && !existing.empty() && checkIndexes && indexSpec.isSchemaIndex() {
+			return NewIndexExistsError(r.name, val, string(index), uuid, existing.getAny())
 		}
 
-		newIndexes[index][val] = uuid
+		uuidset := newUUIDSet(uuid)
+		if indexSpec.isSchemaIndex() {
+			newIndexes[index][val] = uuidset
+		} else {
+			newIndexes[index][val] = addUUIDSet(r.indexes[index][val], uuidset)
+		}
 	}
 
 	// write indexes
 	for k1, v1 := range newIndexes {
-		vals := r.indexes[k1]
 		for k2, v2 := range v1 {
-			vals[k2] = v2
+			r.indexes[k1][k2] = v2
 		}
 	}
 	r.cache[uuid] = model.Clone(m)
 	return nil
 }
 
-// Update updates the content in the cache
-func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
+// Update updates the content in the cache and returns the original (pre-update) model
+func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) (model.Model, error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	if _, ok := r.cache[uuid]; !ok {
-		return NewErrCacheInconsistent(fmt.Sprintf("cannot update row %s as it does not exist in the cache", uuid))
+		return nil, NewErrCacheInconsistent(fmt.Sprintf("cannot update row %s as it does not exist in the cache", uuid))
 	}
 	oldRow := model.Clone(r.cache[uuid])
 	oldInfo, err := r.dbModel.NewModelInfo(oldRow)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	newInfo, err := r.dbModel.NewModelInfo(m)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	indexes := r.dbModel.Schema.Table(r.name).Indexes
-	newIndexes := newColumnToValue(indexes)
-	oldIndexes := newColumnToValue(indexes)
+	newIndexes := r.newIndexes()
 	var errs []error
-	for index, vals := range r.indexes {
+	for _, indexSpec := range r.indexSpecs {
+		index := indexSpec.index
 		var err error
-		oldVal, err := valueFromIndex(oldInfo, index)
+		oldVal, err := valueFromIndex(oldInfo, indexSpec.columns)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		newVal, err := valueFromIndex(newInfo, index)
+		newVal, err := valueFromIndex(newInfo, indexSpec.columns)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// if old and new values are the same, don't worry
@@ -216,38 +315,41 @@ func (r *RowCache) Update(uuid string, m model.Model, checkIndexes bool) error {
 		// old and new values are NOT the same
 
 		// check that there are no conflicts
-		if conflict, ok := vals[newVal]; ok && checkIndexes && conflict != uuid {
+		vals := r.indexes[index]
+		if existing, ok := vals[newVal]; ok && indexSpec.isSchemaIndex() && checkIndexes && !existing.empty() && !existing.has(uuid) {
 			errs = append(errs, NewIndexExistsError(
 				r.name,
 				newVal,
 				string(index),
 				uuid,
-				conflict,
+				existing.getAny(),
 			))
 		}
 
-		newIndexes[index][newVal] = uuid
-		oldIndexes[index][oldVal] = ""
+		uuidset := newUUIDSet(uuid)
+		if indexSpec.isSchemaIndex() {
+			newIndexes[index][newVal] = uuidset
+			newIndexes[index][oldVal] = nil
+		} else {
+			newIndexes[index][newVal] = addUUIDSet(r.indexes[index][newVal], uuidset)
+			newIndexes[index][oldVal] = substractUUIDSet(r.indexes[index][oldVal], uuidset)
+		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%+v", errs)
+		return nil, fmt.Errorf("%+v", errs)
 	}
 	// write indexes
 	for k1, v1 := range newIndexes {
-		vals := r.indexes[k1]
 		for k2, v2 := range v1 {
-			vals[k2] = v2
-		}
-	}
-	// delete old indexes
-	for k1, v1 := range oldIndexes {
-		vals := r.indexes[k1]
-		for k2 := range v1 {
-			delete(vals, k2)
+			if len(v2) == 0 {
+				delete(r.indexes[k1], k2)
+			} else {
+				r.indexes[k1][k2] = v2
+			}
 		}
 	}
 	r.cache[uuid] = model.Clone(m)
-	return nil
+	return oldRow, nil
 }
 
 func (r *RowCache) IndexExists(row model.Model) error {
@@ -255,22 +357,30 @@ func (r *RowCache) IndexExists(row model.Model) error {
 	if err != nil {
 		return err
 	}
-	uuid, err := info.FieldByColumn("_uuid")
+	field, err := info.FieldByColumn("_uuid")
 	if err != nil {
 		return nil
 	}
-	for index, vals := range r.indexes {
-		val, err := valueFromIndex(info, index)
+	uuid := field.(string)
+	for _, indexSpec := range r.indexSpecs {
+		if !indexSpec.isSchemaIndex() {
+			// Given the ordered indexSpecs, we can break here if we reach the
+			// first non schema index
+			break
+		}
+		index := indexSpec.index
+		val, err := valueFromIndex(info, indexSpec.columns)
 		if err != nil {
 			continue
 		}
-		if existing, ok := vals[val]; ok && existing != uuid.(string) {
+		vals := r.indexes[index]
+		if existing := vals[val]; !existing.empty() && !existing.has(uuid) {
 			return NewIndexExistsError(
 				r.name,
 				val,
 				string(index),
-				uuid.(string),
-				existing,
+				uuid,
+				existing.getAny(),
 			)
 		}
 	}
@@ -289,16 +399,22 @@ func (r *RowCache) Delete(uuid string) error {
 	if err != nil {
 		return err
 	}
-	for index, vals := range r.indexes {
-		oldVal, err := valueFromIndex(oldInfo, index)
+	for _, indexSpec := range r.indexSpecs {
+		index := indexSpec.index
+		oldVal, err := valueFromIndex(oldInfo, indexSpec.columns)
 		if err != nil {
 			return err
 		}
 		// only remove the index if it is pointing to this uuid
 		// otherwise we can cause a consistency issue if we've processed
 		// updates out of order
-		if vals[oldVal] == uuid {
-			delete(vals, oldVal)
+		vals := r.indexes[index]
+		existing, ok := vals[oldVal]
+		if ok {
+			existing.remove(uuid)
+			if len(existing) == 0 {
+				delete(vals, oldVal)
+			}
 		}
 	}
 	delete(r.cache, uuid)
@@ -331,73 +447,277 @@ func (r *RowCache) RowsShallow() map[string]model.Model {
 	return result
 }
 
+// uuidsByConditionsAsIndexes checks possible indexes that can be built with a
+// subset of the provided conditions and returns the uuids for the models that
+// match that subset of conditions. If no conditions could be used as indexes,
+// returns nil. Note that this method does not necessarily match all the
+// provided conditions. Thus the caller is required to evaluate all the
+// conditions against the returned candidates. This is only useful to obtain, as
+// quick as possible, via indexes, a reduced list of candidate models that might
+// match all conditions, which should be better than just evaluating all
+// conditions against all rows of a table.
+//nolint:gocyclo // warns overall function is complex but ignores inner functions
+func (r *RowCache) uuidsByConditionsAsIndexes(conditions []ovsdb.Condition, nativeValues []interface{}) (uuidset, error) {
+	type indexableCondition struct {
+		column      string
+		keys        []interface{}
+		nativeValue interface{}
+	}
+
+	// build an indexable condition, more appropriate for our processing, from
+	// an ovsdb condition. Only equality based conditions can be used as indexes
+	// (or `includes` conditions on map values).
+	toIndexableCondition := func(condition ovsdb.Condition, nativeValue interface{}) *indexableCondition {
+		if condition.Column == "_uuid" {
+			return nil
+		}
+		if condition.Function != ovsdb.ConditionEqual && condition.Function != ovsdb.ConditionIncludes {
+			return nil
+		}
+		v := reflect.ValueOf(nativeValue)
+		if !v.IsValid() {
+			return nil
+		}
+		isSet := v.Kind() == reflect.Slice || v.Kind() == reflect.Array
+		if condition.Function == ovsdb.ConditionIncludes && isSet {
+			return nil
+		}
+		keys := []interface{}{}
+		if v.Kind() == reflect.Map && condition.Function == ovsdb.ConditionIncludes {
+			for _, key := range v.MapKeys() {
+				keys = append(keys, key.Interface())
+			}
+		}
+		return &indexableCondition{
+			column:      condition.Column,
+			keys:        keys,
+			nativeValue: nativeValue,
+		}
+	}
+
+	// for any given set of conditions, we need to check if an index uses the
+	// same fields as the conditions
+	indexMatchesConditions := func(spec indexSpec, conditions []*indexableCondition) bool {
+		columnKeys := []model.ColumnKey{}
+		for _, condition := range conditions {
+			if len(condition.keys) == 0 {
+				columnKeys = append(columnKeys, model.ColumnKey{Column: condition.column})
+				continue
+			}
+			for _, key := range condition.keys {
+				columnKeys = append(columnKeys, model.ColumnKey{Column: condition.column, Key: key})
+			}
+		}
+		index := newIndexFromColumnKeys(columnKeys...)
+		return index == spec.index
+	}
+
+	// for a specific set of conditions, check if an index can be built from
+	// them and return the associated UUIDs
+	evaluateConditionSetAsIndex := func(conditions []*indexableCondition) (uuidset, error) {
+		// build a model with the values from the conditions
+		m, err := r.dbModel.NewModel(r.name)
+		if err != nil {
+			return nil, err
+		}
+		info, err := r.dbModel.NewModelInfo(m)
+		if err != nil {
+			return nil, err
+		}
+		for _, conditions := range conditions {
+			err := info.SetField(conditions.column, conditions.nativeValue)
+			if err != nil {
+				return nil, err
+			}
+		}
+		for _, spec := range r.indexSpecs {
+			if !indexMatchesConditions(spec, conditions) {
+				continue
+			}
+			// if we have an index for those conditions, calculate the index
+			// value. The models mapped to that value match the conditions.
+			v, err := valueFromIndex(info, spec.columns)
+			if err != nil {
+				return nil, err
+			}
+			if v != nil {
+				uuids := r.indexes[spec.index][v]
+				if uuids == nil {
+					// this set of conditions was represented by an index but
+					// had no matches, return an empty set
+					uuids = uuidset{}
+				}
+				return uuids, nil
+			}
+		}
+		return nil, nil
+	}
+
+	// set of uuids that match the conditions as we evaluate them
+	var matching uuidset
+
+	// attempt to evaluate a set of conditions via indexes and intersect the
+	// results against matches of previous sets
+	intersectUUIDsFromConditionSet := func(indexableConditions []*indexableCondition) (bool, error) {
+		uuids, err := evaluateConditionSetAsIndex(indexableConditions)
+		if err != nil {
+			return true, err
+		}
+		if matching == nil {
+			matching = uuids
+		} else if uuids != nil {
+			matching = intersectUUIDSets(matching, uuids)
+		}
+		if matching != nil && len(matching) <= 1 {
+			// if we had no matches or a single match, no point in continuing
+			// searching for additional indexes. If we had a single match, it's
+			// cheaper to just evaluate all conditions on it.
+			return true, nil
+		}
+		return false, nil
+	}
+
+	// First, filter out conditions that cannot be matched against indexes. With
+	// the remaining conditions build all possible subsets (the power set of all
+	// conditions) and for any subset that is an index, intersect the obtained
+	// uuids with the ones obtained from previous subsets
+	matchUUIDsFromConditionsPowerSet := func() error {
+		ps := [][]*indexableCondition{}
+		// prime the power set with a first empty subset
+		ps = append(ps, []*indexableCondition{})
+		for i, condition := range conditions {
+			nativeValue := nativeValues[i]
+			iCondition := toIndexableCondition(condition, nativeValue)
+			// this is not a condition we can use as an index, skip it
+			if iCondition == nil {
+				continue
+			}
+			// the power set is built appending the subsets that result from
+			// adding each item to each of the previous subsets
+			ss := make([][]*indexableCondition, len(ps))
+			for j := range ss {
+				ss[j] = make([]*indexableCondition, len(ps[j]), len(ps[j])+1)
+				copy(ss[j], ps[j])
+				ss[j] = append(ss[j], iCondition)
+				// as we add them to the power set, attempt to evaluate this
+				// subset of conditions as indexes
+				stop, err := intersectUUIDsFromConditionSet(ss[j])
+				if stop || err != nil {
+					return err
+				}
+			}
+			ps = append(ps, ss...)
+		}
+		return nil
+	}
+
+	// finally
+	err := matchUUIDsFromConditionsPowerSet()
+	return matching, err
+}
+
+// RowsByCondition searches models in the cache that match all conditions
 func (r *RowCache) RowsByCondition(conditions []ovsdb.Condition) (map[string]model.Model, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
 	results := make(map[string]model.Model)
 	schema := r.dbModel.Schema.Table(r.name)
+
+	// no conditions matches all rows
 	if len(conditions) == 0 {
-		for uuid, row := range r.Rows() {
-			results[uuid] = row
+		for uuid := range r.cache {
+			results[uuid] = r.rowByUUID(uuid)
 		}
 		return results, nil
 	}
 
+	// one pass to obtain the native values
+	nativeValues := make([]interface{}, 0, len(conditions))
 	for _, condition := range conditions {
-		if condition.Column == "_uuid" {
-			ovsdbUUID, ok := condition.Value.(ovsdb.UUID)
+		tSchema := schema.Column(condition.Column)
+		nativeValue, err := ovsdb.OvsToNative(tSchema, condition.Value)
+		if err != nil {
+			return nil, err
+		}
+		nativeValues = append(nativeValues, nativeValue)
+	}
+
+	// obtain all possible matches using conditions as indexes
+	matching, err := r.uuidsByConditionsAsIndexes(conditions, nativeValues)
+	if err != nil {
+		return nil, err
+	}
+
+	// From the matches obtained with indexes, which might have not used all
+	// conditions, continue trimming down the list explicitly evaluating the
+	// conditions.
+	for i, condition := range conditions {
+		matchingCondition := uuidset{}
+
+		if condition.Column == "_uuid" && (condition.Function == ovsdb.ConditionEqual || condition.Function == ovsdb.ConditionIncludes) {
+			uuid, ok := nativeValues[i].(string)
 			if !ok {
-				panic(fmt.Sprintf("%+v is not an ovsdb uuid", ovsdbUUID))
+				panic(fmt.Sprintf("%+v is not a uuid", nativeValues[i]))
 			}
-			uuid := ovsdbUUID.GoUUID
-			for rowUUID, row := range r.Rows() {
-				ok, err := condition.Function.Evaluate(rowUUID, uuid)
-				if err != nil {
-					return nil, err
-				}
-				if ok {
-					results[rowUUID] = row
-				}
-			}
-		} else if index, err := r.Index(condition.Column); err == nil {
-			for k, rowUUID := range index {
-				tSchema := schema.Columns[condition.Column]
-				nativeValue, err := ovsdb.OvsToNative(tSchema, condition.Value)
-				if err != nil {
-					return nil, err
-				}
-				ok, err := condition.Function.Evaluate(k, nativeValue)
-				if err != nil {
-					return nil, err
-				}
-				if ok {
-					row := r.Row(rowUUID)
-					results[rowUUID] = row
-				}
+			if _, found := r.cache[uuid]; found {
+				matchingCondition.add(uuid)
 			}
 		} else {
-			for uuid, row := range r.Rows() {
+			matchCondition := func(uuid string) error {
+				row := r.cache[uuid]
 				info, err := r.dbModel.NewModelInfo(row)
 				if err != nil {
-					return nil, err
+					return err
 				}
 				value, err := info.FieldByColumn(condition.Column)
 				if err != nil {
-					return nil, err
+					return err
 				}
-				tSchema := schema.Columns[condition.Column]
-				nativeValue, err := ovsdb.OvsToNative(tSchema, condition.Value)
+				ok, err := condition.Function.Evaluate(value, nativeValues[i])
 				if err != nil {
-					return nil, err
-				}
-				ok, err := condition.Function.Evaluate(value, nativeValue)
-				if err != nil {
-					return nil, err
+					return err
 				}
 				if ok {
-					results[uuid] = row
+					matchingCondition.add(uuid)
+				}
+				return nil
+			}
+			if matching != nil {
+				// we just need to consider rows that matched previous
+				// conditions
+				for uuid := range matching {
+					err = matchCondition(uuid)
+					if err != nil {
+						return nil, err
+					}
+				}
+			} else {
+				// If this is the first condition we are able to check, just run
+				// it by whole table
+				for uuid := range r.cache {
+					err = matchCondition(uuid)
+					if err != nil {
+						return nil, err
+					}
 				}
 			}
 		}
+		if matching == nil {
+			matching = matchingCondition
+		} else {
+			matching = intersectUUIDSets(matching, matchingCondition)
+		}
+		if matching.empty() {
+			// no models match the conditions checked up to now, no need to
+			// check remaining conditions
+			break
+		}
 	}
+
+	for uuid := range matching {
+		results[uuid] = r.rowByUUID(uuid)
+	}
+
 	return results, nil
 }
 
@@ -408,14 +728,19 @@ func (r *RowCache) Len() int {
 	return len(r.cache)
 }
 
-func (r *RowCache) Index(columns ...string) (map[interface{}]string, error) {
+func (r *RowCache) Index(columns ...string) (map[interface{}][]string, error) {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	index, ok := r.indexes[newIndex(columns...)]
+	spec := newIndexFromColumns(columns...)
+	index, ok := r.indexes[spec]
 	if !ok {
-		return nil, fmt.Errorf("%s is not an index", index)
+		return nil, fmt.Errorf("%v is not an index", columns)
 	}
-	return index, nil
+	dbIndex := make(map[interface{}][]string, len(index))
+	for k, v := range index {
+		dbIndex[k] = v.list()
+	}
+	return dbIndex, nil
 }
 
 // EventHandler can handle events when the contents of the cache changes
@@ -595,8 +920,8 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 		}
 		tCache := t.cache[table]
 		for uuid, row := range updates {
-			logger := t.logger.WithValues("uuid", uuid, "table", table)
-			logger.V(5).Info("processing update")
+			dbgLogger := t.logger.WithValues("uuid", uuid, "table", table).V(5)
+			dbgLogger.Info("processing update")
 			if row.New != nil {
 				newModel, err := t.CreateModel(table, row.New, uuid)
 				if err != nil {
@@ -604,16 +929,20 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 				}
 				if existing := tCache.Row(uuid); existing != nil {
 					if !model.Equal(newModel, existing) {
-						logger.V(5).Info("updating row", "old:", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", newModel))
-						if err := tCache.Update(uuid, newModel, false); err != nil {
+						if _, err := tCache.Update(uuid, newModel, false); err != nil {
 							return err
+						}
+						if dbgLogger.Enabled() {
+							dbgLogger.Info("updated row", "old:", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", newModel))
 						}
 						t.eventProcessor.AddEvent(updateEvent, table, existing, newModel)
 					}
 					// no diff
 					continue
 				}
-				logger.V(5).Info("creating row", "model", fmt.Sprintf("%+v", newModel))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("creating row", "model", fmt.Sprintf("%+v", newModel))
+				}
 				if err := tCache.Create(uuid, newModel, false); err != nil {
 					return err
 				}
@@ -624,7 +953,9 @@ func (t *TableCache) Populate(tableUpdates ovsdb.TableUpdates) error {
 				if err != nil {
 					return err
 				}
-				logger.V(5).Info("deleting row", "model", fmt.Sprintf("%+v", oldModel))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("deleting row", "model", fmt.Sprintf("%+v", oldModel))
+				}
 				if err := tCache.Delete(uuid); err != nil {
 					return err
 				}
@@ -647,15 +978,17 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 		}
 		tCache := t.cache[table]
 		for uuid, row := range updates {
-			logger := t.logger.WithValues("uuid", uuid, "table", table)
-			logger.V(5).Info("processing update")
+			dbgLogger := t.logger.WithValues("uuid", uuid, "table", table).V(5)
+			dbgLogger.Info("processing update")
 			switch {
 			case row.Initial != nil:
 				m, err := t.CreateModel(table, row.Initial, uuid)
 				if err != nil {
 					return err
 				}
-				logger.V(5).Info("creating row", "model", fmt.Sprintf("%+v", m))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("creating row", "model", fmt.Sprintf("%+v", m))
+				}
 				if err := tCache.Create(uuid, m, false); err != nil {
 					return err
 				}
@@ -665,25 +998,29 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				if err != nil {
 					return err
 				}
-				logger.V(5).Info("inserting row", "model", fmt.Sprintf("%+v", m))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("inserting row", "model", fmt.Sprintf("%+v", m))
+				}
 				if err := tCache.Create(uuid, m, false); err != nil {
 					return err
 				}
 				t.eventProcessor.AddEvent(addEvent, table, nil, m)
 			case row.Modify != nil:
-				existing := tCache.Row(uuid)
-				if existing == nil {
+				modified := tCache.Row(uuid)
+				if modified == nil {
 					return NewErrCacheInconsistent(fmt.Sprintf("row with uuid %s does not exist", uuid))
 				}
-				modified := model.Clone(existing)
-				err := t.ApplyModifications(table, modified, *row.Modify)
+				changed, err := t.ApplyModifications(table, modified, *row.Modify)
 				if err != nil {
 					return fmt.Errorf("unable to apply row modifications: %w", err)
 				}
-				if !model.Equal(modified, existing) {
-					logger.V(5).Info("updating row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))
-					if err := tCache.Update(uuid, modified, false); err != nil {
+				if changed {
+					existing, err := tCache.Update(uuid, modified, false)
+					if err != nil {
 						return err
+					}
+					if dbgLogger.Enabled() {
+						dbgLogger.Info("updated row", "old", fmt.Sprintf("%+v", existing), "new", fmt.Sprintf("%+v", modified))
 					}
 					t.eventProcessor.AddEvent(updateEvent, table, existing, modified)
 				}
@@ -696,7 +1033,9 @@ func (t *TableCache) Populate2(tableUpdates ovsdb.TableUpdates2) error {
 				if m == nil {
 					return NewErrCacheInconsistent(fmt.Sprintf("row with uuid %s does not exist", uuid))
 				}
-				logger.V(5).Info("deleting row", "model", fmt.Sprintf("%+v", m))
+				if dbgLogger.Enabled() {
+					dbgLogger.Info("deleting row", "model", fmt.Sprintf("%+v", m))
+				}
 				if err := tCache.Delete(uuid); err != nil {
 					return err
 				}
@@ -740,29 +1079,49 @@ func (t *TableCache) Run(stopCh <-chan struct{}) {
 // newRowCache creates a new row cache with the provided data
 // if the data is nil, and empty RowCache will be created
 func newRowCache(name string, dbModel model.DatabaseModel, dataType reflect.Type) *RowCache {
+	schemaIndexes := dbModel.Schema.Table(name).Indexes
+	clientIndexes := dbModel.Client().Indexes(name)
+
 	r := &RowCache{
-		name:     name,
-		dbModel:  dbModel,
-		indexes:  newColumnToValue(dbModel.Schema.Table(name).Indexes),
-		dataType: dataType,
-		cache:    make(map[string]model.Model),
-		mutex:    sync.RWMutex{},
+		name:       name,
+		dbModel:    dbModel,
+		indexSpecs: make([]indexSpec, 0, len(schemaIndexes)+len(clientIndexes)),
+		dataType:   dataType,
+		cache:      make(map[string]model.Model),
+		mutex:      sync.RWMutex{},
 	}
+
+	// respect the order of indexes, add first schema indexes, then client
+	// indexes
+	indexes := map[index]indexSpec{}
+	for _, columns := range schemaIndexes {
+		columnKeys := newColumnKeysFromColumns(columns...)
+		index := newIndexFromColumnKeys(columnKeys...)
+		spec := indexSpec{index: index, columns: columnKeys, indexType: schemaIndexType}
+		r.indexSpecs = append(r.indexSpecs, spec)
+		indexes[index] = spec
+	}
+	for _, clientIndex := range clientIndexes {
+		columnKeys := clientIndex.Columns
+		index := newIndexFromColumnKeys(columnKeys...)
+		// if this is already a DB index, ignore
+		if _, ok := indexes[index]; ok {
+			continue
+		}
+		spec := indexSpec{index: index, columns: columnKeys, indexType: clientIndexType}
+		r.indexSpecs = append(r.indexSpecs, spec)
+		indexes[index] = spec
+	}
+
+	r.indexes = r.newIndexes()
 	return r
 }
 
-func newColumnToValue(schemaIndexes [][]string) columnToValue {
-	// RFC 7047 says that Indexes is a [<column-set>] and "Each <column-set> is a set of
-	// columns whose values, taken together within any given row, must be
-	// unique within the table". We'll store the column names, separated by comma
-	// as we'll assume (RFC is not clear), that comma isn't valid in a <id>
-	var indexes []index
-	for i := range schemaIndexes {
-		indexes = append(indexes, newIndex(schemaIndexes[i]...))
-	}
+func (r *RowCache) newIndexes() columnToValue {
 	c := make(columnToValue)
-	for _, index := range indexes {
-		c[index] = make(valueToUUID)
+	for _, indexSpec := range r.indexSpecs {
+		index := indexSpec.index
+		c[index] = make(valueToUUIDs)
 	}
 	return c
 }
@@ -881,24 +1240,26 @@ func (t *TableCache) CreateModel(tableName string, row *ovsdb.Row, uuid string) 
 	return model, nil
 }
 
-// ApplyModifications applies the contents of a RowUpdate2.Modify to a model
+// ApplyModifications applies the contents of a RowUpdate2.Modify to a model.
+// It returns true if any changes were actually applied.
 // nolint: gocyclo
-func (t *TableCache) ApplyModifications(tableName string, base model.Model, update ovsdb.Row) error {
+func (t *TableCache) ApplyModifications(tableName string, base model.Model, update ovsdb.Row) (bool, error) {
 	if !t.dbModel.Valid() {
-		return fmt.Errorf("database model not valid")
+		return false, fmt.Errorf("database model not valid")
 	}
 	table := t.dbModel.Schema.Table(tableName)
 	if table == nil {
-		return fmt.Errorf("table %s not found", tableName)
+		return false, fmt.Errorf("table %s not found", tableName)
 	}
 	schema := t.dbModel.Schema.Table(tableName)
 	if schema == nil {
-		return fmt.Errorf("no schema for table %s", tableName)
+		return false, fmt.Errorf("no schema for table %s", tableName)
 	}
 	info, err := t.dbModel.NewModelInfo(base)
 	if err != nil {
-		return err
+		return false, err
 	}
+	modified := false
 	for k, v := range update {
 		if k == "_uuid" {
 			continue
@@ -906,7 +1267,7 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 
 		current, err := info.FieldByColumn(k)
 		if err != nil {
-			return err
+			return modified, err
 		}
 
 		var value interface{}
@@ -917,31 +1278,34 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 			value, err = ovsdb.OvsToNativeSlice(schema.Column(k).TypeObj.Key.Type, v)
 		}
 		if err != nil {
-			return err
+			return modified, err
 		}
 		nv := reflect.ValueOf(value)
 
 		switch reflect.ValueOf(current).Kind() {
 		case reflect.Slice, reflect.Array:
 			// The difference between two sets are all elements that only belong to one of the sets.
-			// Iterate new values
+			// If a value in the update set exists in the set, it will be removed from the base set.
+			// If a value in the update set does not exist in the set, it will be added to the base set.
 			for i := 0; i < nv.Len(); i++ {
 				// search for match in base values
 				baseValue, err := info.FieldByColumn(k)
 				if err != nil {
-					return err
+					return modified, err
 				}
 				bv := reflect.ValueOf(baseValue)
 				var found bool
+				newVal := nv.Index(i).Interface()
 				for j := 0; j < bv.Len(); j++ {
-					if bv.Index(j).Interface() == nv.Index(i).Interface() {
+					if bv.Index(j).Interface() == newVal {
 						// found a match, delete from slice
 						found = true
 						newValue := reflect.AppendSlice(bv.Slice(0, j), bv.Slice(j+1, bv.Len()))
 						err = info.SetField(k, newValue.Interface())
 						if err != nil {
-							return err
+							return modified, err
 						}
+						modified = true
 						break
 					}
 				}
@@ -949,35 +1313,39 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 					newValue := reflect.Append(bv, nv.Index(i))
 					err = info.SetField(k, newValue.Interface())
 					if err != nil {
-						return err
+						return modified, err
 					}
+					modified = true
 				}
 			}
 		case reflect.Ptr:
 			// if NativeToOVS was successful, then simply assign
-			if nv.Type() == reflect.ValueOf(current).Type() {
+			bv := reflect.ValueOf(current)
+			if (nv.Type() == bv.Type()) && !reflect.DeepEqual(nv.Interface(), bv.Interface()) {
 				err = info.SetField(k, nv.Interface())
 				if err != nil {
-					return err
+					return modified, err
 				}
+				modified = true
 				break
 			}
 			// With a pointer type, an update value could be a set with 2 elements [old, new]
 			if nv.Len() != 2 {
-				return fmt.Errorf("expected a slice with 2 elements for update: %+v", update)
+				return modified, fmt.Errorf("expected a slice with 2 elements for update: %+v", update)
 			}
 			// the new value is the value in the slice which isn't equal to the existing string
 			for i := 0; i < nv.Len(); i++ {
 				baseValue, err := info.FieldByColumn(k)
 				if err != nil {
-					return err
+					return modified, err
 				}
 				bv := reflect.ValueOf(baseValue)
-				if nv.Index(i) != bv {
+				if !reflect.DeepEqual(nv.Index(i).Addr().Interface(), bv.Interface()) {
 					err = info.SetField(k, nv.Index(i).Addr().Interface())
 					if err != nil {
-						return err
+						return modified, err
 					}
+					modified = true
 				}
 			}
 		case reflect.Map:
@@ -988,9 +1356,8 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 
 			baseValue, err := info.FieldByColumn(k)
 			if err != nil {
-				return err
+				return modified, err
 			}
-
 			bv := reflect.ValueOf(baseValue)
 			if bv.IsNil() {
 				bv = reflect.MakeMap(nv.Type())
@@ -1005,12 +1372,15 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 				// key does not exist, add it
 				if !existingValue.IsValid() {
 					bv.SetMapIndex(mk, mv)
+					modified = true
 				} else if reflect.DeepEqual(mv.Interface(), existingValue.Interface()) {
 					// delete it
 					bv.SetMapIndex(mk, reflect.Value{})
+					modified = true
 				} else {
 					// set new value
 					bv.SetMapIndex(mk, mv)
+					modified = true
 				}
 			}
 			if len(bv.MapKeys()) == 0 {
@@ -1018,27 +1388,30 @@ func (t *TableCache) ApplyModifications(tableName string, base model.Model, upda
 			}
 			err = info.SetField(k, bv.Interface())
 			if err != nil {
-				return err
+				return modified, err
 			}
 
 		default:
 			// For columns with single value, the difference is the value of the new column.
-			err = info.SetField(k, value)
-			if err != nil {
-				return err
+			bv := reflect.ValueOf(current)
+			if !reflect.DeepEqual(nv.Interface(), bv.Interface()) {
+				err = info.SetField(k, value)
+				if err != nil {
+					return modified, err
+				}
+				modified = true
 			}
 		}
 	}
-	return nil
+	return modified, nil
 }
 
-func valueFromIndex(info *mapper.Info, index index) (interface{}, error) {
-	columns := index.columns()
-	if len(columns) > 1 {
+func valueFromIndex(info *mapper.Info, columnKeys []model.ColumnKey) (interface{}, error) {
+	if len(columnKeys) > 1 {
 		var buf bytes.Buffer
 		enc := gob.NewEncoder(&buf)
-		for _, column := range columns {
-			val, err := info.FieldByColumn(column)
+		for _, columnKey := range columnKeys {
+			val, err := valueFromColumnKey(info, columnKey)
 			if err != nil {
 				return "", err
 			}
@@ -1051,9 +1424,37 @@ func valueFromIndex(info *mapper.Info, index index) (interface{}, error) {
 		val := hex.EncodeToString(h.Sum(buf.Bytes()))
 		return val, nil
 	}
-	val, err := info.FieldByColumn(columns[0])
+	val, err := valueFromColumnKey(info, columnKeys[0])
+	if err != nil {
+		return "", err
+	}
+	return val, err
+}
+
+func valueFromColumnKey(info *mapper.Info, columnKey model.ColumnKey) (interface{}, error) {
+	val, err := info.FieldByColumn(columnKey.Column)
 	if err != nil {
 		return nil, err
 	}
+	if columnKey.Key != nil {
+		val, err = valueFromMap(val, columnKey.Key)
+		if err != nil {
+			return "", fmt.Errorf("can't get key value from map: %v", err)
+		}
+	}
 	return val, err
+}
+
+func valueFromMap(aMap interface{}, key interface{}) (interface{}, error) {
+	m := reflect.ValueOf(aMap)
+	if m.Kind() != reflect.Map {
+		return nil, fmt.Errorf("expected map but got %s", m.Kind())
+	}
+	v := m.MapIndex(reflect.ValueOf(key))
+	if !v.IsValid() {
+		// return the zero value for the map value type
+		return reflect.Indirect(reflect.New(m.Type().Elem())).Interface(), nil
+	}
+
+	return v.Interface(), nil
 }

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/cache/uuidset.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/cache/uuidset.go
@@ -1,0 +1,89 @@
+package cache
+
+type void struct{}
+type uuidset map[string]void
+
+func newUUIDSet(uuids ...string) uuidset {
+	s := uuidset{}
+	for _, uuid := range uuids {
+		s[uuid] = void{}
+	}
+	return s
+}
+
+func (s uuidset) add(uuid string) {
+	s[uuid] = void{}
+}
+
+func (s uuidset) remove(uuid string) {
+	delete(s, uuid)
+}
+
+func (s uuidset) has(uuid string) bool {
+	_, ok := s[uuid]
+	return ok
+}
+
+func (s uuidset) getAny() string {
+	for k := range s {
+		return k
+	}
+	return ""
+}
+
+func (s uuidset) list() []string {
+	uuids := make([]string, 0, len(s))
+	for uuid := range s {
+		uuids = append(uuids, uuid)
+	}
+	return uuids
+}
+
+func (s uuidset) empty() bool {
+	return len(s) == 0
+}
+
+func addUUIDSet(s1, s2 uuidset) uuidset {
+	if len(s2) == 0 {
+		return s1
+	}
+	if s1 == nil {
+		s1 = uuidset{}
+	}
+	for uuid := range s2 {
+		s1.add(uuid)
+	}
+	return s1
+}
+
+func substractUUIDSet(s1, s2 uuidset) uuidset {
+	if len(s1) == 0 || len(s2) == 0 {
+		return s1
+	}
+	for uuid := range s2 {
+		s1.remove(uuid)
+	}
+	return s1
+}
+
+func intersectUUIDSets(s1, s2 uuidset) uuidset {
+	if len(s1) == 0 || len(s2) == 0 {
+		return nil
+	}
+	var big uuidset
+	var small uuidset
+	if len(s1) > len(s2) {
+		big = s1
+		small = s2
+	} else {
+		big = s2
+		small = s1
+	}
+	f := uuidset{}
+	for uuid := range small {
+		if big.has(uuid) {
+			f.add(uuid)
+		}
+	}
+	return f
+}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
@@ -322,7 +322,7 @@ func (o *ovsdbClient) connect(ctx context.Context, reconnect bool) error {
 // tryEndpoint connects to a single database endpoint. Returns the
 // server ID (if clustered) on success, or an error.
 func (o *ovsdbClient) tryEndpoint(ctx context.Context, u *url.URL) (string, error) {
-	o.logger.V(5).Info("trying to connect", "endpoint", fmt.Sprintf("%v", u))
+	o.logger.V(3).Info("trying to connect", "endpoint", fmt.Sprintf("%v", u))
 	var dialer net.Dialer
 	var err error
 	var c net.Conn
@@ -778,7 +778,7 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, operation ...
 	if o.rpcClient == nil {
 		return nil, ErrNotConnected
 	}
-	o.logger.V(5).Info("transacting operations", "database", dbName, "operations", fmt.Sprintf("%+v", operation))
+	o.logger.V(4).Info("transacting operations", "database", dbName, "operations", fmt.Sprintf("%+v", operation))
 	err := o.rpcClient.CallWithContext(ctx, "transact", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/condition.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/condition.go
@@ -16,118 +16,147 @@ type Conditional interface {
 	// Generate returns a list of lists of conditions to be used in Operations
 	// Each element in the (outer) list corresponds to an operation
 	Generate() ([][]ovsdb.Condition, error)
-	// matches returns true if a model matches the condition
-	Matches(m model.Model) (bool, error)
+	// Returns the models that match the conditions
+	Matches() (map[string]model.Model, error)
 	// returns the table that this condition is associated with
 	Table() string
 }
 
-// equalityConditional uses the information available in a model to generate conditions
-// The conditions are based on the equality of the first available index.
-// The priority of indexes is: uuid, {schema index}
-type equalityConditional struct {
-	dbModel   model.DatabaseModel
-	tableName string
-	info      *mapper.Info
-	singleOp  bool
+func generateConditionsFromModels(dbModel model.DatabaseModel, models map[string]model.Model) ([][]ovsdb.Condition, error) {
+	anyConditions := make([][]ovsdb.Condition, 0, len(models))
+	for _, model := range models {
+		info, err := dbModel.NewModelInfo(model)
+		if err != nil {
+			return nil, err
+		}
+		allConditions, err := dbModel.Mapper.NewEqualityCondition(info)
+		if err != nil {
+			return nil, err
+		}
+		anyConditions = append(anyConditions, allConditions)
+	}
+	return anyConditions, nil
 }
 
-func (c *equalityConditional) Matches(m model.Model) (bool, error) {
-	info, err := c.dbModel.NewModelInfo(m)
-	if err != nil {
-		return false, err
+func generateOvsdbConditionsFromModelConditions(dbModel model.DatabaseModel, info *mapper.Info, conditions []model.Condition, singleOp bool) ([][]ovsdb.Condition, error) {
+	anyConditions := [][]ovsdb.Condition{}
+	if singleOp {
+		anyConditions = append(anyConditions, []ovsdb.Condition{})
 	}
-	return c.dbModel.Mapper.EqualFields(c.info, info)
+	for _, condition := range conditions {
+		ovsdbCond, err := dbModel.Mapper.NewCondition(info, condition.Field, condition.Function, condition.Value)
+		if err != nil {
+			return nil, err
+		}
+		allConditions := []ovsdb.Condition{*ovsdbCond}
+		if singleOp {
+			anyConditions[0] = append(anyConditions[0], allConditions...)
+		} else {
+			anyConditions = append(anyConditions, allConditions)
+		}
+	}
+	return anyConditions, nil
+}
+
+// equalityConditional uses the indexes available in a provided model to find a
+// matching model in the database.
+type equalityConditional struct {
+	tableName string
+	model     model.Model
+	cache     *cache.TableCache
 }
 
 func (c *equalityConditional) Table() string {
 	return c.tableName
 }
 
-// Generate returns a condition based on the model and the field pointers
-func (c *equalityConditional) Generate() ([][]ovsdb.Condition, error) {
-	var result [][]ovsdb.Condition
+// Returns the models that match the indexes available through the provided
+// model.
+func (c *equalityConditional) Matches() (map[string]model.Model, error) {
+	tableCache := c.cache.Table(c.tableName)
+	if tableCache == nil {
+		return nil, ErrNotFound
+	}
+	return tableCache.RowsByModel(c.model), nil
+}
 
-	conds, err := c.dbModel.Mapper.NewEqualityCondition(c.info)
-	if err != nil {
-		return nil, err
+// Generate conditions based on the equality of the first available index. If
+// the index can be matched against a model in the cache, the condition will be
+// based on the UUID of the found model. Otherwise, the conditions will be based
+// on the index.
+func (c *equalityConditional) Generate() ([][]ovsdb.Condition, error) {
+	models, _ := c.Matches()
+	if len(models) == 0 {
+		// no cache hits, generate condition from model we were given
+		return generateConditionsFromModels(c.cache.DatabaseModel(), map[string]model.Model{"": c.model})
 	}
-	if c.singleOp {
-		result = append(result, conds)
-	} else {
-		for _, c := range conds {
-			result = append(result, []ovsdb.Condition{c})
-		}
-	}
-	return result, nil
+	return generateConditionsFromModels(c.cache.DatabaseModel(), models)
 }
 
 // NewEqualityCondition creates a new equalityConditional
-func newEqualityConditional(dbModel model.DatabaseModel, table string, all bool, model model.Model, fields ...interface{}) (Conditional, error) {
-	info, err := dbModel.NewModelInfo(model)
-	if err != nil {
-		return nil, err
-	}
+func newEqualityConditional(table string, cache *cache.TableCache, model model.Model) (Conditional, error) {
 	return &equalityConditional{
-		dbModel:   dbModel,
 		tableName: table,
-		info:      info,
-		singleOp:  all,
+		model:     model,
+		cache:     cache,
 	}, nil
 }
 
 // explicitConditional generates conditions based on the provided Condition list
 type explicitConditional struct {
-	dbModel    model.DatabaseModel
-	tableName  string
-	info       *mapper.Info
-	conditions []model.Condition
-	singleOp   bool
-}
-
-func (c *explicitConditional) Matches(m model.Model) (bool, error) {
-	return false, fmt.Errorf("cannot perform cache comparisons using explicit conditions")
+	tableName     string
+	anyConditions [][]ovsdb.Condition
+	cache         *cache.TableCache
 }
 
 func (c *explicitConditional) Table() string {
 	return c.tableName
 }
 
-// Generate returns a condition based on the model and the field pointers
-func (c *explicitConditional) Generate() ([][]ovsdb.Condition, error) {
-	var result [][]ovsdb.Condition
-	var conds []ovsdb.Condition
-
-	for _, cond := range c.conditions {
-		ovsdbCond, err := c.dbModel.Mapper.NewCondition(c.info, cond.Field, cond.Function, cond.Value)
+// Returns the models that match the conditions
+func (c *explicitConditional) Matches() (map[string]model.Model, error) {
+	tableCache := c.cache.Table(c.tableName)
+	if tableCache == nil {
+		return nil, ErrNotFound
+	}
+	found := map[string]model.Model{}
+	for _, allConditions := range c.anyConditions {
+		models, err := tableCache.RowsByCondition(allConditions)
 		if err != nil {
 			return nil, err
 		}
-		if c.singleOp {
-			conds = append(conds, *ovsdbCond)
-		} else {
-			result = append(result, []ovsdb.Condition{*ovsdbCond})
+		for uuid, model := range models {
+			found[uuid] = model
 		}
-
 	}
-	if c.singleOp {
-		result = append(result, conds)
-	}
-	return result, nil
+	return found, nil
 }
 
-// newIndexCondition creates a new equalityConditional
-func newExplicitConditional(dbModel model.DatabaseModel, table string, all bool, model model.Model, cond ...model.Condition) (Conditional, error) {
+// Generate returns conditions based on the provided Condition list
+func (c *explicitConditional) Generate() ([][]ovsdb.Condition, error) {
+	models, _ := c.Matches()
+	if len(models) == 0 {
+		// no cache hits, return conditions we were given
+		return c.anyConditions, nil
+	}
+	return generateConditionsFromModels(c.cache.DatabaseModel(), models)
+}
+
+// newExplicitConditional creates a new explicitConditional
+func newExplicitConditional(table string, cache *cache.TableCache, all bool, model model.Model, cond ...model.Condition) (Conditional, error) {
+	dbModel := cache.DatabaseModel()
 	info, err := dbModel.NewModelInfo(model)
 	if err != nil {
 		return nil, err
 	}
+	anyConditions, err := generateOvsdbConditionsFromModelConditions(dbModel, info, cond, all)
+	if err != nil {
+		return nil, err
+	}
 	return &explicitConditional{
-		dbModel:    dbModel,
-		tableName:  table,
-		info:       info,
-		conditions: cond,
-		singleOp:   all,
+		tableName:     table,
+		anyConditions: anyConditions,
+		cache:         cache,
 	}, nil
 }
 
@@ -141,9 +170,22 @@ type predicateConditional struct {
 
 // matches returns the result of the execution of the predicate
 // Type verifications are not performed
-func (c *predicateConditional) Matches(model model.Model) (bool, error) {
-	ret := reflect.ValueOf(c.predicate).Call([]reflect.Value{reflect.ValueOf(model)})
-	return ret[0].Bool(), nil
+// Returns the models that match the conditions
+func (c *predicateConditional) Matches() (map[string]model.Model, error) {
+	tableCache := c.cache.Table(c.tableName)
+	if tableCache == nil {
+		return nil, ErrNotFound
+	}
+	found := map[string]model.Model{}
+	// run the predicate on a shallow copy of the models for speed and only
+	// clone the matches
+	for u, m := range tableCache.RowsShallow() {
+		ret := reflect.ValueOf(c.predicate).Call([]reflect.Value{reflect.ValueOf(m)})
+		if ret[0].Bool() {
+			found[u] = model.Clone(m)
+		}
+	}
+	return found, nil
 }
 
 func (c *predicateConditional) Table() string {
@@ -153,29 +195,8 @@ func (c *predicateConditional) Table() string {
 // generate returns a list of conditions that match, by _uuid equality, all the objects that
 // match the predicate
 func (c *predicateConditional) Generate() ([][]ovsdb.Condition, error) {
-	allConditions := make([][]ovsdb.Condition, 0)
-	tableCache := c.cache.Table(c.tableName)
-	if tableCache == nil {
-		return nil, ErrNotFound
-	}
-	for _, row := range tableCache.Rows() {
-		match, err := c.Matches(row)
-		if err != nil {
-			return nil, err
-		}
-		if match {
-			info, err := c.cache.DatabaseModel().NewModelInfo(row)
-			if err != nil {
-				return nil, err
-			}
-			elemCond, err := c.cache.Mapper().NewEqualityCondition(info)
-			if err != nil {
-				return nil, err
-			}
-			allConditions = append(allConditions, elemCond)
-		}
-	}
-	return allConditions, nil
+	models, _ := c.Matches()
+	return generateConditionsFromModels(c.cache.DatabaseModel(), models)
 }
 
 // newPredicateConditional creates a new predicateConditional
@@ -193,8 +214,8 @@ type errorConditional struct {
 	err error
 }
 
-func (e *errorConditional) Matches(model.Model) (bool, error) {
-	return false, e.err
+func (e *errorConditional) Matches() (map[string]model.Model, error) {
+	return nil, e.err
 }
 
 func (e *errorConditional) Table() string {

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/doc.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/doc.go
@@ -61,9 +61,8 @@ Conditions must refer to fields of the provided Model (via pointer to fields). E
 		Value: []string{"portUUID"},
 	    })
 
-If no client.Condition is provided, the client will create a default Condition based on the Model's data.
-The first non-null field that corresponds to a database index will be used. Therefore the following
-two statements are equivalent:
+If no client.Condition is provided, the client will use any of fields that correspond to indexes to
+generate an appropriate condition. Therefore the following two statements are equivalent:
 
 	ls = &MyLogicalSwitch {UUID:"myUUID"}
 
@@ -92,8 +91,11 @@ For example, the following operation will delete all the Logical Switches named 
 
 To create a Condition that matches all of the conditions simultaneously (i.e: AND semantics), use WhereAll().
 
-Where() and WhereAll() inject conditions into operations that will be evaluated by the server.
-However, to perform searches on the local cache, a more flexible mechanism is available: WhereCache()
+Where() or WhereAll() evaluate the provided index values or explicit conditions against the cache and generate
+conditions based on the UUIDs of matching models. If no matches are found in the cache, the generated conditions
+will be based on the index or condition fields themselves.
+
+A more flexible mechanism to search the cache is available: WhereCache()
 
 WhereCache() accepts a function that takes any Model as argument and returns a boolean.
 It is used to search the cache so commonly used with List() function. For example:
@@ -111,7 +113,7 @@ same condition using Where() or WhereAll() which will be more efficient.
 
 Get
 
-Get() operation is a simple operation capable of retrieving one Model based on some of its indexes. E.g:
+Get() operation is a simple operation capable of retrieving one Model based on some of its schema indexes. E.g:
 
 	ls := &LogicalSwitch{UUID:"myUUID"}
 	err := ovs.Get(ls)

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/model/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/model/client.go
@@ -8,10 +8,22 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
+// ColumnKey addresses a column and optionally a key within a column
+type ColumnKey struct {
+	Column string
+	Key    interface{}
+}
+
+// ClientIndex defines a client index by a set of columns
+type ClientIndex struct {
+	Columns []ColumnKey
+}
+
 // ClientDBModel contains the client information needed to build a DatabaseModel
 type ClientDBModel struct {
-	name  string
-	types map[string]reflect.Type
+	name    string
+	types   map[string]reflect.Type
+	indexes map[string][]ClientIndex
 }
 
 // NewModel returns a new instance of a model from a specific string
@@ -29,6 +41,28 @@ func (db ClientDBModel) Name() string {
 	return db.name
 }
 
+// Indexes returns the client indexes for a model
+func (db ClientDBModel) Indexes(table string) []ClientIndex {
+	if len(db.indexes) == 0 {
+		return nil
+	}
+	if _, ok := db.indexes[table]; ok {
+		return copyIndexes(db.indexes)[table]
+	}
+	return nil
+}
+
+// SetIndexes sets the client indexes. Client indexes are optional, similar to
+// schema indexes and are only tracked in the specific client instances that are
+// provided with this client model. A client index may point to multiple models
+// as uniqueness is not enforced. They are defined per table and multiple
+// indexes can be defined for a table. Each index consists of a set of columns.
+// If the column is a map, specific keys of that map can be addressed for the
+// index.
+func (db *ClientDBModel) SetIndexes(indexes map[string][]ClientIndex) {
+	db.indexes = copyIndexes(indexes)
+}
+
 // Validate validates the DatabaseModel against the input schema
 // Returns all the errors detected
 func (db ClientDBModel) validate(schema ovsdb.DatabaseSchema) []error {
@@ -38,6 +72,7 @@ func (db ClientDBModel) validate(schema ovsdb.DatabaseSchema) []error {
 			db.name, schema.Name))
 	}
 
+	infos := make(map[string]*mapper.Info, len(db.types))
 	for tableName := range db.types {
 		tableSchema := schema.Table(tableName)
 		if tableSchema == nil {
@@ -49,8 +84,41 @@ func (db ClientDBModel) validate(schema ovsdb.DatabaseSchema) []error {
 			errors = append(errors, err)
 			continue
 		}
-		if _, err := mapper.NewInfo(tableName, tableSchema, model); err != nil {
+		info, err := mapper.NewInfo(tableName, tableSchema, model)
+		if err != nil {
 			errors = append(errors, err)
+			continue
+		}
+		infos[tableName] = info
+	}
+
+	for tableName, indexSets := range db.indexes {
+		info, ok := infos[tableName]
+		if !ok {
+			errors = append(errors, fmt.Errorf("database model contains a client index for table %s that does not exist in schema", tableName))
+			continue
+		}
+		for _, indexSet := range indexSets {
+			for _, indexColumn := range indexSet.Columns {
+				f, err := info.FieldByColumn(indexColumn.Column)
+				if err != nil {
+					errors = append(
+						errors,
+						fmt.Errorf("database model contains a client index for column %s that does not exist in table %s",
+							indexColumn.Column,
+							tableName))
+					continue
+				}
+				if indexColumn.Key != nil && reflect.ValueOf(f).Kind() != reflect.Map {
+					errors = append(
+						errors,
+						fmt.Errorf("database model contains a client index for key %s in column %s of table %s that is not a map",
+							indexColumn.Key,
+							indexColumn.Column,
+							tableName))
+					continue
+				}
+			}
 		}
 	}
 	return errors
@@ -82,4 +150,22 @@ func NewClientDBModel(name string, models map[string]Model) (ClientDBModel, erro
 		types: types,
 		name:  name,
 	}, nil
+}
+
+func copyIndexes(src map[string][]ClientIndex) map[string][]ClientIndex {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string][]ClientIndex, len(src))
+	for table, indexSets := range src {
+		dst[table] = make([]ClientIndex, 0, len(indexSets))
+		for _, indexSet := range indexSets {
+			indexSetCopy := ClientIndex{
+				Columns: make([]ColumnKey, len(indexSet.Columns)),
+			}
+			copy(indexSetCopy.Columns, indexSet.Columns)
+			dst[table] = append(dst[table], indexSetCopy)
+		}
+	}
+	return dst
 }

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/set.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/set.go
@@ -19,13 +19,18 @@ type OvsSet struct {
 
 // NewOvsSet creates a new OVSDB style set from a Go interface (object)
 func NewOvsSet(obj interface{}) (OvsSet, error) {
+	ovsSet := make([]interface{}, 0)
 	var v reflect.Value
 	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
 		v = reflect.ValueOf(obj).Elem()
+		if v.Kind() == reflect.Invalid {
+			// must be a nil pointer, so just return an empty set
+			return OvsSet{ovsSet}, nil
+		}
 	} else {
 		v = reflect.ValueOf(obj)
 	}
-	ovsSet := make([]interface{}, 0)
+
 	switch v.Kind() {
 	case reflect.Slice, reflect.Array:
 		for i := 0; i < v.Len(); i++ {

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -232,7 +232,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220513144310-50ec17900991
+# github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1
 ## explicit; go 1.16
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client


### PR DESCRIPTION
Reverts part of https://github.com/ovn-org/ovn-kubernetes/pull/2800

onModelUpdatesAll was not really updating all...only things that had non
default values. Therefore if there was an update operation using
onModelUpdatesAll, where the desired update was to set a column back to
its default state, it would be ignored. This true for specific types
like maps, slices and pointers.

This commit reverts the behavior to its previous state before
onModelUpdatesAll was added. Additionally for those models which used
the same behavior of only updating default previously, onModelUpdatesAll
is renamed to onModelUpdatesAllNonDefault.

In the future, someone may want to implement a real onModelUpdatesAll
function which would dynamically figure out all of the fields of a model
to update and return that list. For now the code is commented with TODOs
and reverted back to its previous state.

Signed-off-by: Tim Rozet <trozet@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->