### PR TITLE
contrib: fix generated yaml file in gitignore

### DIFF
--- a/contrib/.gitignore
+++ b/contrib/.gitignore
@@ -1,2 +1,2 @@
-kind.yaml
-
+# the j2 file will be converted to kind-${CLUSTER_NAME}.yaml which is ovn
+kind-ovn.yaml


### PR DESCRIPTION
Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>

**- What this PR does and why is it needed**
Fix the name for the file in gitignore. Avoid showing it in `git status`

**- How to verify it**
run `contrib/kind.sh` and execute git status, no generated file should show up. 

**- Description for the changelog**
- contrib: fix gitignore for including the kind-CLUSTERNAME