### PR TITLE
Update YAMLs to support kubernetes (kubeadm) v1.24

### DIFF
--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -54,6 +54,25 @@ spec:
         type: infra
         kubernetes.io/os: "linux"
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - "linux"
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - "linux"
       priorityClassName: "system-cluster-critical"
       # Requires fairly broad permissions - ability to read all services and network functions as well
       # as all pods.
@@ -200,9 +219,6 @@ spec:
 
       # end of container
 
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-        kubernetes.io/os: "linux"
       volumes:
       - name: host-var-lib-ovs
         hostPath:

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -44,15 +44,21 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: In
-                    values:
-                      - ""
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - "linux"
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - "linux"
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - "linux"
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:


### PR DESCRIPTION
**- What this PR does and why is it needed**

With Kubernetes 1.24, master nodes are now labelled
and tainted as `node-role.kubernetes.io/control-plane`.

This means yamls by daemonset.sh does not work correctly a kind cluster
based on 1.24.x node images.

Template yamls have been updated to scheduling pods on the 
control-plane/master node based on node affinity instead of node selector.

This will continue to work with existing kind clusters built on v1.23 nodes.

This PR is useful for running ovn-kubernetes in 1.24 k8s clusters till  the work in 
PR https://github.com/ovn-org/ovn-kubernetes/pull/3001 is merged.

**- Special notes for reviewers**
Updated template yamls.

**- How to verify it**
Creating k8s clusters using 1.24.x version of kind node images
For example, 
`K8S_VERSION=v1.24.0 ./kind.sh`
