### PR TITLE
Remove stale chassis for hosts that run ovnkube-node on DPU

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -268,7 +268,11 @@ func runOvnKube(ctx *cli.Context) error {
 		// register ovnkube node specific prometheus metrics exported by the node
 		metrics.RegisterNodeMetrics()
 		start := time.Now()
-		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, stopChan, util.EventRecorder(ovnClientset.KubeClient))
+		sbClient, err := libovsdb.NewSBClient(stopChan)
+		if err != nil {
+			return fmt.Errorf("cannot initialize libovsdb SB client: %v", err)
+		}
+		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, sbClient, stopChan, util.EventRecorder(ovnClientset.KubeClient))
 		if err := n.Start(ctx.Context, wg); err != nil {
 			return err
 		}

--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -111,6 +111,8 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 			client.WithTable(&sbdb.PortBinding{}),
 			// used for hybrid-overlay
 			client.WithTable(&sbdb.DatapathBinding{}),
+			// used for dpu-host mode
+			client.WithTable(&sbdb.Encap{}),
 		),
 	)
 	if err != nil {

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -6,9 +6,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
@@ -142,7 +144,11 @@ var _ = Describe("Node Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 		fExec = ovntest.NewFakeExec()
-		fakeOvnNode = NewFakeOVNNode(fExec)
+		dbSetup := libovsdbtest.TestSetup{}
+		var libovsdbOvnSBClient libovsdbclient.Client
+		_, libovsdbOvnSBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
+		Expect(err).NotTo(HaveOccurred())
+		fakeOvnNode = NewFakeOVNNode(fExec, libovsdbOvnSBClient)
 
 		iptV4, iptV6 = util.SetFakeIPTablesHelpers()
 		_, nodeNet, err := net.ParseCIDR("10.1.1.0/24")


### PR DESCRIPTION
**- What this PR does and why is it needed**
In the DPU 2-clusters design, a host with DPU will join the cluster
with ovn-controller running in the host first, then it will be  moved
to the DPU. Therefore, we will have 2 chassis with the same hostname
in the ovn sbdb.

This patch removes the stale chassis from the ovn sbdb if ovnkube-node
is running at the dpu-host mode.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
Create a cluster with hosts having BF-2 DPU installed. Check the sbdb of OVN.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->