### PR TITLE
Add RBAC coordination.k8s.io leases

### DIFF
--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -115,6 +115,15 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "watch", "list"]
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
 
 ---
 


### PR DESCRIPTION
necessary for leader election in kubernetes v1.24, required for https://github.com/ovn-org/ovn-kubernetes/pull/3001

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>