### PR TITLE
node: start CNIServer before writing out CNI config and log when initialized

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -561,6 +561,7 @@ func (n *OvnNode) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		}
 	}
 
+	klog.Infof("OVN Kube Node initialized and ready.")
 	return nil
 }
 


### PR DESCRIPTION
Start the CNI server before we indicate we're ready to process requests by writing the CNI config file out.

Also log when the node is initialized and ready which helps debugging.