### PR TITLE
Add support for enabling UDP packet aggregation on veth interfaces

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
+	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1
 	github.com/spf13/afero v1.4.1
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.2.0
@@ -75,7 +76,6 @@ require (
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
-	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
-	github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8 // indirect
+	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -433,8 +433,9 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8 h1:2c1EFnZHIPCW8qKWgHMH/fX2PkSabFc5mrVzfUNdg5U=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1 h1:ZFfeKAhIQiiOrQaI3/znw0gOmYpO28Tcu1YaqMa/jtQ=
+github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -400,8 +400,6 @@ github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mo
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366 h1:/llKlbXC7F6rqTkAl2GE//9GDR0iDsqJEFvvJ1kLJXg=
 github.com/openshift/client-go v0.0.0-20211202194848-d3f186f2d366/go.mod h1:HJeHsH6mPyrrOVS/2j1zcztGAJG9ETKbqtlyohs84yY=
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
-github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4 h1:atUIOA34Cg9GVFn/8rmIsmnOIbi0D82x+xfhV2UuF1Q=
-github.com/ovn-org/libovsdb v0.6.1-0.20220427123326-d7b273399db4/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/ovn-org/libovsdb v0.6.1-0.20220513144310-50ec17900991 h1:EsMLPWOIRgB9WFTt5+L99LaX4H1Nm6yL2S6zsx4TSzY=
 github.com/ovn-org/libovsdb v0.6.1-0.20220513144310-50ec17900991/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -40,14 +40,15 @@ type KubeAPIAuth struct {
 type PodInterfaceInfo struct {
 	util.PodAnnotation
 
-	MTU           int    `json:"mtu"`
-	RoutableMTU   int    `json:"routable-mtu"`
-	Ingress       int64  `json:"ingress"`
-	Egress        int64  `json:"egress"`
-	CheckExtIDs   bool   `json:"check-external-ids"`
-	IsDPUHostMode bool   `json:"is-dpu-host-mode"`
-	PodUID        string `json:"pod-uid"`
-	VfNetdevName  string `json:"vf-netdev-name"`
+	MTU                  int    `json:"mtu"`
+	RoutableMTU          int    `json:"routable-mtu"`
+	Ingress              int64  `json:"ingress"`
+	Egress               int64  `json:"egress"`
+	CheckExtIDs          bool   `json:"check-external-ids"`
+	IsDPUHostMode        bool   `json:"is-dpu-host-mode"`
+	PodUID               string `json:"pod-uid"`
+	VfNetdevName         string `json:"vf-netdev-name"`
+	EnableUDPAggregation bool   `json:"enable-udp-aggregation"`
 }
 
 // Explicit type for CNI commands the server handles

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -119,15 +119,16 @@ func PodAnnotation2PodInfo(podAnnotation map[string]string, checkExtIDs bool, po
 	}
 
 	podInterfaceInfo := &PodInterfaceInfo{
-		PodAnnotation: *podAnnotSt,
-		MTU:           config.Default.MTU,
-		RoutableMTU:   config.Default.RoutableMTU,
-		Ingress:       ingress,
-		Egress:        egress,
-		CheckExtIDs:   checkExtIDs,
-		IsDPUHostMode: config.OvnKubeNode.Mode == types.NodeModeDPUHost,
-		PodUID:        podUID,
-		VfNetdevName:  vfNetdevname,
+		PodAnnotation:        *podAnnotSt,
+		MTU:                  config.Default.MTU,
+		RoutableMTU:          config.Default.RoutableMTU,
+		Ingress:              ingress,
+		Egress:               egress,
+		CheckExtIDs:          checkExtIDs,
+		IsDPUHostMode:        config.OvnKubeNode.Mode == types.NodeModeDPUHost,
+		PodUID:               podUID,
+		VfNetdevName:         vfNetdevname,
+		EnableUDPAggregation: config.Default.EnableUDPAggregation,
 	}
 	return podInterfaceInfo, nil
 }

--- a/go-controller/pkg/cni/utils_test.go
+++ b/go-controller/pkg/cni/utils_test.go
@@ -243,5 +243,19 @@ var _ = Describe("CNI Utils tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.CheckExtIDs).To(BeTrue())
 		})
+
+		It("Creates PodInterfaceInfo with EnableUDPAggregation", func() {
+			config.Default.EnableUDPAggregation = true
+			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pif.EnableUDPAggregation).To(BeTrue())
+		})
+
+		It("Creates PodInterfaceInfo without EnableUDPAggregation", func() {
+			config.Default.EnableUDPAggregation = false
+			pif, err := PodAnnotation2PodInfo(podAnnot, false, podUID, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pif.EnableUDPAggregation).To(BeFalse())
+		})
 	})
 })

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -219,6 +219,11 @@ type DefaultConfig struct {
 	// ClusterSubnets holds parsed cluster subnet entries and may be used
 	// outside the config module.
 	ClusterSubnets []CIDRNetworkEntry
+	// EnableUDPAggregation is true if ovn-kubernetes should use UDP Generic Receive
+	// Offload forwarding to improve the performance of containers that transmit lots
+	// of small UDP packets by allowing them to be aggregated before passing through
+	// the kernel network stack. This requires a new-enough kernel (5.15 or RHEL 8.5).
+	EnableUDPAggregation bool `gcfg:"enable-udp-aggregation"`
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -263,6 +263,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Default.LFlowCacheEnable).To(gomega.BeTrue())
 			gomega.Expect(Default.LFlowCacheLimit).To(gomega.Equal(uint(0)))
 			gomega.Expect(Default.LFlowCacheLimitKb).To(gomega.Equal(uint(0)))
+			gomega.Expect(Default.EnableUDPAggregation).To(gomega.BeFalse())
 			gomega.Expect(Logging.File).To(gomega.Equal(""))
 			gomega.Expect(Logging.Level).To(gomega.Equal(5))
 			gomega.Expect(Monitoring.RawNetFlowTargets).To(gomega.Equal(""))

--- a/go-controller/vendor/github.com/safchain/ethtool/.travis.yml
+++ b/go-controller/vendor/github.com/safchain/ethtool/.travis.yml
@@ -1,1 +1,7 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
+
+before_script:
+  - go get golang.org/x/sys/unix

--- a/go-controller/vendor/github.com/safchain/ethtool/ethtool.go
+++ b/go-controller/vendor/github.com/safchain/ethtool/ethtool.go
@@ -30,8 +30,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // Maximum size of an interface name
@@ -53,12 +54,15 @@ const (
 	ETHTOOL_GSTRINGS = 0x0000001b
 	ETHTOOL_GSTATS   = 0x0000001d
 	// other CMDs from ethtool-copy.h of ethtool-3.5 package
-	ETHTOOL_GSET          = 0x00000001 /* Get settings. */
-	ETHTOOL_SSET          = 0x00000002 /* Set settings. */
-	ETHTOOL_GMSGLVL       = 0x00000007 /* Get driver message level */
-	ETHTOOL_SMSGLVL       = 0x00000008 /* Set driver msg level. */
+	ETHTOOL_GSET      = 0x00000001 /* Get settings. */
+	ETHTOOL_SSET      = 0x00000002 /* Set settings. */
+	ETHTOOL_GMSGLVL   = 0x00000007 /* Get driver message level */
+	ETHTOOL_SMSGLVL   = 0x00000008 /* Set driver msg level. */
+	ETHTOOL_GCHANNELS = 0x0000003c /* Get no of channels */
+	ETHTOOL_SCHANNELS = 0x0000003d /* Set no of channels */
+	ETHTOOL_GCOALESCE = 0x0000000e /* Get coalesce config */
 	/* Get link status for host, i.e. whether the interface *and* the
- * physical port (if there is one) are up (ethtool_value). */
+	 * physical port (if there is one) are up (ethtool_value). */
 	ETHTOOL_GLINK         = 0x0000000a
 	ETHTOOL_GMODULEINFO   = 0x00000042 /* Get plug-in module information */
 	ETHTOOL_GMODULEEEPROM = 0x00000043 /* Get plug-in module eeprom */
@@ -72,7 +76,7 @@ const (
 // MAX_GSTRINGS maximum number of stats entries that ethtool can
 // retrieve currently.
 const (
-	MAX_GSTRINGS       = 1000
+	MAX_GSTRINGS       = 16384
 	MAX_FEATURE_BLOCKS = (MAX_GSTRINGS + 32 - 1) / 32
 	EEPROM_LEN         = 640
 	PERMADDR_LEN       = 32
@@ -130,6 +134,63 @@ type ethtoolDrvInfo struct {
 	regdump_len  uint32
 }
 
+// DrvInfo contains driver information
+// ethtool.h v3.5: struct ethtool_drvinfo
+type DrvInfo struct {
+	Cmd         uint32
+	Driver      string
+	Version     string
+	FwVersion   string
+	BusInfo     string
+	EromVersion string
+	Reserved2   string
+	NPrivFlags  uint32
+	NStats      uint32
+	TestInfoLen uint32
+	EedumpLen   uint32
+	RegdumpLen  uint32
+}
+
+// Channels contains the number of channels for a given interface.
+type Channels struct {
+	Cmd           uint32
+	MaxRx         uint32
+	MaxTx         uint32
+	MaxOther      uint32
+	MaxCombined   uint32
+	RxCount       uint32
+	TxCount       uint32
+	OtherCount    uint32
+	CombinedCount uint32
+}
+
+// Coalesce is a coalesce config for an interface
+type Coalesce struct {
+	Cmd                      uint32
+	RxCoalesceUsecs          uint32
+	RxMaxCoalescedFrames     uint32
+	RxCoalesceUsecsIrq       uint32
+	RxMaxCoalescedFramesIrq  uint32
+	TxCoalesceUsecs          uint32
+	TxMaxCoalescedFrames     uint32
+	TxCoalesceUsecsIrq       uint32
+	TxMaxCoalescedFramesIrq  uint32
+	StatsBlockCoalesceUsecs  uint32
+	UseAdaptiveRxCoalesce    uint32
+	UseAdaptiveTxCoalesce    uint32
+	PktRateLow               uint32
+	RxCoalesceUsecsLow       uint32
+	RxMaxCoalescedFramesLow  uint32
+	TxCoalesceUsecsLow       uint32
+	TxMaxCoalescedFramesLow  uint32
+	PktRateHigh              uint32
+	RxCoalesceUsecsHigh      uint32
+	RxMaxCoalescedFramesHigh uint32
+	TxCoalesceUsecsHigh      uint32
+	TxMaxCoalescedFramesHigh uint32
+	RateSampleInterval       uint32
+}
+
 type ethtoolGStrings struct {
 	cmd        uint32
 	string_set uint32
@@ -159,8 +220,8 @@ type ethtoolModInfo struct {
 }
 
 type ethtoolLink struct {
-	cmd        uint32
-	data       uint32
+	cmd  uint32
+	data uint32
 }
 
 type ethtoolPermAddr struct {
@@ -212,13 +273,58 @@ func (e *Ethtool) ModuleEepromHex(intf string) (string, error) {
 }
 
 // DriverInfo returns driver information of the given interface name.
-func (e *Ethtool) DriverInfo(intf string) (ethtoolDrvInfo, error) {
-	drvInfo, err := e.getDriverInfo(intf)
+func (e *Ethtool) DriverInfo(intf string) (DrvInfo, error) {
+	i, err := e.getDriverInfo(intf)
 	if err != nil {
-		return ethtoolDrvInfo{}, err
+		return DrvInfo{}, err
+	}
+
+	drvInfo := DrvInfo{
+		Cmd:         i.cmd,
+		Driver:      string(bytes.Trim(i.driver[:], "\x00")),
+		Version:     string(bytes.Trim(i.version[:], "\x00")),
+		FwVersion:   string(bytes.Trim(i.fw_version[:], "\x00")),
+		BusInfo:     string(bytes.Trim(i.bus_info[:], "\x00")),
+		EromVersion: string(bytes.Trim(i.erom_version[:], "\x00")),
+		Reserved2:   string(bytes.Trim(i.reserved2[:], "\x00")),
+		NPrivFlags:  i.n_priv_flags,
+		NStats:      i.n_stats,
+		TestInfoLen: i.testinfo_len,
+		EedumpLen:   i.eedump_len,
+		RegdumpLen:  i.regdump_len,
 	}
 
 	return drvInfo, nil
+}
+
+// GetChannels returns the number of channels for the given interface name.
+func (e *Ethtool) GetChannels(intf string) (Channels, error) {
+	channels, err := e.getChannels(intf)
+	if err != nil {
+		return Channels{}, err
+	}
+
+	return channels, nil
+}
+
+// SetChannels sets the number of channels for the given interface name and
+// returns the new number of channels.
+func (e *Ethtool) SetChannels(intf string, channels Channels) (Channels, error) {
+	channels, err := e.setChannels(intf, channels)
+	if err != nil {
+		return Channels{}, err
+	}
+
+	return channels, nil
+}
+
+// GetCoalesce returns the coalesce config for the given interface name.
+func (e *Ethtool) GetCoalesce(intf string) (Coalesce, error) {
+	coalesce, err := e.getCoalesce(intf)
+	if err != nil {
+		return Coalesce{}, err
+	}
+	return coalesce, nil
 }
 
 // PermAddr returns permanent address of the given interface name.
@@ -253,9 +359,9 @@ func (e *Ethtool) ioctl(intf string, data uintptr) error {
 		ifr_data: data,
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd), SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd), SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return syscall.Errno(ep)
+		return ep
 	}
 
 	return nil
@@ -271,6 +377,40 @@ func (e *Ethtool) getDriverInfo(intf string) (ethtoolDrvInfo, error) {
 	}
 
 	return drvinfo, nil
+}
+
+func (e *Ethtool) getChannels(intf string) (Channels, error) {
+	channels := Channels{
+		Cmd: ETHTOOL_GCHANNELS,
+	}
+
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&channels))); err != nil {
+		return Channels{}, err
+	}
+
+	return channels, nil
+}
+
+func (e *Ethtool) setChannels(intf string, channels Channels) (Channels, error) {
+	channels.Cmd = ETHTOOL_SCHANNELS
+
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&channels))); err != nil {
+		return Channels{}, err
+	}
+
+	return channels, nil
+}
+
+func (e *Ethtool) getCoalesce(intf string) (Coalesce, error) {
+	coalesce := Coalesce{
+		Cmd: ETHTOOL_GCOALESCE,
+	}
+
+	if err := e.ioctl(intf, uintptr(unsafe.Pointer(&coalesce))); err != nil {
+		return Coalesce{}, err
+	}
+
+	return coalesce, nil
 }
 
 func (e *Ethtool) getPermAddr(intf string) (ethtoolPermAddr, error) {
@@ -423,7 +563,7 @@ func (e *Ethtool) Change(intf string, config map[string]bool) error {
 	return e.ioctl(intf, uintptr(unsafe.Pointer(&features)))
 }
 
-// Get state of a link. 
+// Get state of a link.
 func (e *Ethtool) LinkState(intf string) (uint32, error) {
 	x := ethtoolLink{
 		cmd: ETHTOOL_GLINK,
@@ -474,7 +614,11 @@ func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
 	var result = make(map[string]uint64)
 	for i := 0; i != int(drvinfo.n_stats); i++ {
 		b := gstrings.data[i*ETH_GSTRING_LEN : i*ETH_GSTRING_LEN+ETH_GSTRING_LEN]
-		key := string(b[:strings.Index(string(b), "\x00")])
+		strEnd := strings.Index(string(b), "\x00")
+		if strEnd == -1 {
+			strEnd = ETH_GSTRING_LEN
+		}
+		key := string(b[:strEnd])
 		if len(key) != 0 {
 			result[key] = stats.data[i]
 		}
@@ -485,12 +629,12 @@ func (e *Ethtool) Stats(intf string) (map[string]uint64, error) {
 
 // Close closes the ethool handler
 func (e *Ethtool) Close() {
-	syscall.Close(e.fd)
+	unix.Close(e.fd)
 }
 
 // NewEthtool returns a new ethtool handler
 func NewEthtool() (*Ethtool, error) {
-	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_IP)
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, unix.IPPROTO_IP)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/vendor/github.com/safchain/ethtool/ethtool_cmd.go
+++ b/go-controller/vendor/github.com/safchain/ethtool/ethtool_cmd.go
@@ -28,8 +28,9 @@ package ethtool
 import (
 	"math"
 	"reflect"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 type EthtoolCmd struct { /* ethtool.c: struct ethtool_cmd */
@@ -121,10 +122,10 @@ func (e *Ethtool) CmdGet(ecmd *EthtoolCmd, intf string) (uint32, error) {
 		ifr_data: uintptr(unsafe.Pointer(ecmd)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, syscall.Errno(ep)
+		return 0, ep
 	}
 
 	var speedval uint32 = (uint32(ecmd.Speed_hi) << 16) |
@@ -149,10 +150,10 @@ func (e *Ethtool) CmdSet(ecmd *EthtoolCmd, intf string) (uint32, error) {
 		ifr_data: uintptr(unsafe.Pointer(ecmd)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, syscall.Errno(ep)
+		return 0, unix.Errno(ep)
 	}
 
 	var speedval uint32 = (uint32(ecmd.Speed_hi) << 16) |
@@ -178,10 +179,10 @@ func (e *Ethtool) CmdGetMapped(intf string) (map[string]uint64, error) {
 		ifr_data: uintptr(unsafe.Pointer(&ecmd)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return nil, syscall.Errno(ep)
+		return nil, ep
 	}
 
 	var result = make(map[string]uint64)

--- a/go-controller/vendor/github.com/safchain/ethtool/ethtool_msglvl.go
+++ b/go-controller/vendor/github.com/safchain/ethtool/ethtool_msglvl.go
@@ -26,8 +26,9 @@
 package ethtool
 
 import (
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 type ethtoolValue struct { /* ethtool.c: struct ethtool_value */
@@ -49,10 +50,10 @@ func (e *Ethtool) MsglvlGet(intf string) (uint32, error) {
 		ifr_data: uintptr(unsafe.Pointer(&edata)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, syscall.Errno(ep)
+		return 0, ep
 	}
 
 	return edata.data, nil
@@ -72,10 +73,10 @@ func (e *Ethtool) MsglvlSet(intf string, valset uint32) (uint32, uint32, error) 
 		ifr_data: uintptr(unsafe.Pointer(&edata)),
 	}
 
-	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep := unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, 0, syscall.Errno(ep)
+		return 0, 0, ep
 	}
 
 	readval := edata.data
@@ -83,10 +84,10 @@ func (e *Ethtool) MsglvlSet(intf string, valset uint32) (uint32, uint32, error) 
 	edata.cmd = ETHTOOL_SMSGLVL
 	edata.data = valset
 
-	_, _, ep = syscall.Syscall(syscall.SYS_IOCTL, uintptr(e.fd),
+	_, _, ep = unix.Syscall(unix.SYS_IOCTL, uintptr(e.fd),
 		SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
 	if ep != 0 {
-		return 0, 0, syscall.Errno(ep)
+		return 0, 0, ep
 	}
 
 	return readval, edata.data, nil

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -269,7 +269,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/russross/blackfriday/v2 v2.0.1
 ## explicit
 github.com/russross/blackfriday/v2
-# github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8
+# github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1
 ## explicit
 github.com/safchain/ethtool
 # github.com/shurcooL/sanitized_anchor_name v1.0.0


### PR DESCRIPTION
With recent kernels it is possible to improve the performance of pods that transmit lots of small UDP packets by allowing multiple packets to traverse the kernel network stack as a single large aggregate packet. For various reasons, this functionality is not enabled by default (in particular, aggregating multiple packets implies _not sending the first packet right away_, so enabling this functionality would be bad on systems that care more about having very low latency than about having good bandwidth.)

More details [in this blog post](https://developers.redhat.com/articles/2021/11/05/improve-udp-performance-rhel-85). The graphs there are for bare metal, and the performance improvements are not as impressive in virtualized/cloud environments (more like 1.3x rather than 2x), but it's still an improvement.

So, this adds a config option, and if it's set, it enables the relevant options on the NIC and all pod veths. `"github.com/safchain/ethtool"` is a dependency that is already used by `"github.com/containernetworking/plugins"`, but the version pulled in by the version of CNI that we vendor is old so I needed to update that. (I was originally going to put this code into `containernetworking/plugins` and have ovn-k just pass an option to `SetupVeth`, but we're currently vendoring a fairly old version of that repo so that didn't really work. But I'll probably submit patches there as well and in the future ovn-k could get the functionality from there rather than doing it itself.)