### PR TITLE
Refactor hybrid-overlay-node for linux nodes

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -1,652 +1,117 @@
 package controller
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"net"
-	"os"
 	"strings"
-	"sync"
-	"time"
 
-	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	"github.com/vishvananda/netlink"
-
 	kapi "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 )
 
-const (
-	extBridgeName string = "br-ext"
-	extVXLANName  string = "ext-vxlan"
-)
-
-type flowCacheEntry struct {
-	flows []string
-	// special table 20 flow if it has been learned from the switch
-	learnedFlow string
-	// ignore learn on next flow sync for this entry
-	ignoreLearn bool
-}
-
 // NodeController is the node hybrid overlay controller
 type NodeController struct {
-	nodeName    string
-	initialized bool
-	drMAC       net.HardwareAddr
-	drIP        net.IP
-	gwLRPIP     net.IP
-	vxlanPort   uint16
-	// contains a map of pods to corresponding tunnels
-	flowCache map[string]*flowCacheEntry
-	flowMutex sync.Mutex
-	// channel to indicate we need to update flows immediately
-	flowChan chan struct{}
-
-	nodeLister listers.NodeLister
+	kube            kube.Interface
+	machineID       string
+	nodeName        string
+	localNodeCIDR   *net.IPNet
+	localNodeIP     net.IP
+	remoteSubnetMap map[string]string // Maps a remote node to its remote subnet
 }
 
 // newNodeController returns a node handler that listens for node events
 // so that Add/Update/Delete events are appropriately handled.
-// It initializes the node it is currently running on. On Linux, this means:
-//  1. Setting up a VXLAN gateway and hooking to the OVN gateway
-//  2. Setting back annotations about its VTEP and gateway MAC address to its own object
-func newNodeController(
-	_ kube.Interface,
+func newNodeController(kube kube.Interface,
 	nodeName string,
 	nodeLister listers.NodeLister,
 ) (nodeController, error) {
 
-	node := &NodeController{
-		nodeName:   nodeName,
-		vxlanPort:  uint16(config.HybridOverlay.VXLANPort),
-		flowCache:  make(map[string]*flowCacheEntry),
-		flowMutex:  sync.Mutex{},
-		flowChan:   make(chan struct{}, 1),
-		nodeLister: nodeLister,
-	}
-	return node, nil
-}
-
-func podIPToCookie(podIP net.IP) string {
-	//TODO add ipv6 support
-	ip4 := podIP.To4()
-	if ip4 == nil {
-		return ""
-	}
-	return fmt.Sprintf("%02x%02x%02x%02x", ip4[0], ip4[1], ip4[2], ip4[3])
-}
-
-// AddPod handles the pod add event
-func (n *NodeController) AddPod(pod *kapi.Pod) error {
-	// nothing to do for hostnetworked pod
-	if !util.PodWantsNetwork(pod) {
-		return nil
-	}
-	if util.PodCompleted(pod) {
-		klog.Infof("Cleaning up hybrid overlay pod %s/%s because it has completed", pod.Namespace, pod.Name)
-		return n.DeletePod(pod)
-	}
-	podIPs, podMAC, err := getPodDetails(pod)
+	node, err := kube.GetNode(nodeName)
 	if err != nil {
-		klog.Warningf("Cleaning up hybrid overlay pod %s/%s because it has no OVN annotation %v", pod.Namespace, pod.Name, err)
-		return n.DeletePod(pod)
+		return nil, err
 	}
 
-	// It's always safe to ignore the learn flow as we only process and add or update
-	// if the IP/MAC or Annotations have changed
-	ignoreLearn := true
-
-	if !n.initialized {
-		node, err := n.nodeLister.Get(n.nodeName)
-		if err != nil {
-			return fmt.Errorf("hybrid overlay not initialized on %s, and failed to get node data: %v",
-				n.nodeName, err)
-		}
-		if err = n.EnsureHybridOverlayBridge(node); err != nil {
-			return fmt.Errorf("failed to ensure hybrid overlay in pod handler: %v", err)
-		}
-	}
-	if n.drMAC == nil || n.drIP == nil {
-		return fmt.Errorf("empty values for DR MAC: %s or DR IP: %s on node %s", n.drMAC, n.drIP, n.nodeName)
-	}
-
-	for _, podIP := range podIPs {
-		var flows []string
-		cookie := podIPToCookie(podIP.IP)
-		if cookie == "" {
-			continue
-		}
-		// table 10 is pod dispatch - Incoming vxlan traffic towards pods
-		flows = append(flows, fmt.Sprintf(
-			"table=10,cookie=0x%s,priority=100,ip,nw_dst=%s,"+
-				"actions=set_field:%s->eth_src,set_field:%s->eth_dst,output:ext",
-			cookie, podIP.IP, n.drMAC.String(), podMAC))
-
-		n.updateFlowCacheEntry(cookie, flows, ignoreLearn)
-	}
-	n.requestFlowSync()
-	klog.Infof("Pod %s wired for Hybrid Overlay", pod.Name)
-	return nil
+	return &NodeController{
+		kube:            kube,
+		machineID:       node.Status.NodeInfo.MachineID,
+		nodeName:        node.Name,
+		remoteSubnetMap: make(map[string]string),
+	}, nil
 }
 
-// DeletePod handles the pod delete event
-func (n *NodeController) DeletePod(pod *kapi.Pod) error {
-	// nothing to do for hostnetworked pods
-	if !util.PodWantsNetwork(pod) {
-		return nil
-	}
-	podIPs, _, err := getPodDetails(pod)
-	if err != nil {
-		return fmt.Errorf("error getting pod details: %v", err)
-	}
-	for _, podIP := range podIPs {
-		cookie := podIPToCookie(podIP.IP)
-		if cookie == "" {
-			continue
-		}
-		n.deleteFlowsByCookie(cookie)
-	}
-	return nil
-}
-
-// Sync is not needed but must be implemented to fulfill the interface
-func (n *NodeController) Sync(objs []*kapi.Node) {}
-
-func nameToCookie(nodeName string) string {
-	hash := sha256.Sum256([]byte(nodeName))
-	return fmt.Sprintf("%02x%02x%02x%02x", hash[0], hash[1], hash[2], hash[3])
-}
-
-// hybridOverlayNodeUpdate sets up or tears down VXLAN tunnels to hybrid overlay
-// nodes in the cluster
-func (n *NodeController) hybridOverlayNodeUpdate(node *kapi.Node) error {
-	if !houtil.IsHybridOverlayNode(node) {
-		return nil
-	}
-
-	cidr, nodeIP, drMAC, err := getNodeDetails(node)
-	if cidr == nil || nodeIP == nil || drMAC == nil {
-		klog.V(5).Infof("Cleaning up hybrid overlay resources for node %q because: %v", node.Name, err)
-		return n.DeleteNode(node)
-	}
-
-	klog.Infof("Setting up hybrid overlay tunnel to node %s", node.Name)
-
-	// (re)add flows for the node
-	cookie := nameToCookie(node.Name)
-	drMACRaw := strings.Replace(drMAC.String(), ":", "", -1)
-
-	var flows []string
-	// Distributed Router MAC ARP responder flow; responds to ARP requests by OVN for
-	// any IP address within this node's assigned subnet and returns our hybrid overlay
-	// port's MAC address.
-	flows = append(flows,
-		fmt.Sprintf("cookie=0x%s,table=0,priority=100,arp,in_port=ext,arp_tpa=%s,"+
-			"actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],"+
-			"mod_dl_src:%s,"+
-			"load:0x2->NXM_OF_ARP_OP[],"+
-			"move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],"+
-			"load:0x%s->NXM_NX_ARP_SHA[],"+
-			"move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],"+
-			"move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],"+
-			"move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],"+
-			"IN_PORT",
-			cookie, cidr.String(), drMAC.String(), drMACRaw))
-	// Send all flows for the remote node's assigned subnet to that node via the VXLAN tunnel.
-	// Windows hybrid overlay implementation requires that we set the destination MAC address
-	// to the node's Distributed Router MAC.
-	flows = append(flows,
-		fmt.Sprintf("cookie=0x%s,table=0,priority=100,ip,nw_dst=%s,"+
-			"actions=load:%d->NXM_NX_TUN_ID[0..31],"+
-			"set_field:%s->tun_dst,"+
-			"set_field:%s->eth_dst,"+
-			"output:"+extVXLANName,
-			cookie, cidr.String(), hotypes.HybridOverlayVNI, nodeIP.String(), drMAC.String()))
-
-	flows = append(flows,
-		fmt.Sprintf("cookie=0x%s,table=0,priority=101,ip,nw_dst=%s,nw_src=%s"+
-			"actions=load:%d->NXM_NX_TUN_ID[0..31],"+
-			"set_field:%s->nw_src,"+
-			"set_field:%s->tun_dst,"+
-			"set_field:%s->eth_dst,"+
-			"output:"+extVXLANName,
-			cookie, cidr.String(), n.gwLRPIP.String(), hotypes.HybridOverlayVNI, n.drIP, nodeIP.String(), drMAC.String()))
-
-	if len(config.HybridOverlay.ClusterSubnets) == 0 {
-		// No static cluster subnet is provided in config. Try to detect the hybrid overlay node subnet dynamically
-		// Add a route via the hybrid overlay port IP through the management port
-		// interface for each hybrid overlay cluster subnet
-		mgmtPortLink, err := netlink.LinkByName(types.K8sMgmtIntfName)
-		if err != nil {
-			return fmt.Errorf("failed to lookup link %s: %v", types.K8sMgmtIntfName, err)
-		}
-
-		route := &netlink.Route{
-			Dst:       cidr,
-			LinkIndex: mgmtPortLink.Attrs().Index,
-			Scope:     netlink.SCOPE_UNIVERSE,
-			Gw:        n.drIP,
-		}
-		err = netlink.RouteAdd(route)
-		if err != nil && !os.IsExist(err) {
-			return fmt.Errorf("failed to add route for subnet %s via gateway %s: %v",
-				route.Dst, route.Gw, err)
-		}
-	}
-
-	n.updateFlowCacheEntry(cookie, flows, false)
-	n.requestFlowSync()
-	return nil
-}
-
-// AddNode handles node additions and updates
+// AddNode set annotations about its VTEP and gateway MAC address to its own node object
 func (n *NodeController) AddNode(node *kapi.Node) error {
-	klog.Info("Add Node ", node.Name)
-	var err error
-	if n.drIP == nil {
-		subnet, err := getLocalNodeSubnet(n.nodeName)
-		if err != nil {
-			return err
-		}
-		// n.drIP is always 3rd address in the subnet
-		hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(subnet)
-		n.drIP = hybridOverlayIfAddr.IP
-	}
-	localNode, err := n.nodeLister.Get(n.nodeName)
-	if err != nil {
-		return fmt.Errorf("failed to get local node: %v", err)
-	}
-	if n.gwLRPIP == nil {
-		n.gwLRPIP, err = util.ParseNodeGatewayRouterLRPAddr(localNode)
-		if err != nil {
-			return fmt.Errorf("invalid Gateway Router LRP IP: %v", err)
-		}
-	}
 	if node.Name == n.nodeName {
-		// Retry hybrid overlay initialization if the master was
-		// slow to add the hybrid overlay logical network elements
-		err = n.EnsureHybridOverlayBridge(node)
-	} else {
-		klog.Infof("Add hybridOverlay Node %s", node.Name)
-		err = n.hybridOverlayNodeUpdate(node)
+		cidr, nodeIP := getNodeSubnetAndIP(node)
+		if (cidr != nil && !houtil.SameIPNet(cidr, n.localNodeCIDR)) || (nodeIP != nil && nodeIP.Equal(n.localNodeIP)) {
+			n.localNodeCIDR = cidr
+			n.localNodeIP = nodeIP
+
+			var drMAC string
+			interfaces, _ := net.Interfaces()
+			ip := n.localNodeIP.To4().String()
+		out:
+			for _, interf := range interfaces {
+				if addrs, err := interf.Addrs(); err == nil {
+					for _, addr := range addrs {
+						if strings.Contains(addr.String(), ip) {
+							netInterface, err := net.InterfaceByName(interf.Name)
+							if err != nil {
+								return fmt.Errorf("failed to get interface by name: %s: %v", interf.Name, err)
+							}
+							drMAC = netInterface.HardwareAddr.String()
+							break out
+						}
+					}
+				}
+			}
+			klog.Info("Set hybrid overlay DRMAC annotation")
+			if err := n.kube.SetAnnotationsOnNode(node.Name, map[string]interface{}{
+				types.HybridOverlayDRMAC: drMAC,
+			}); err != nil {
+				return fmt.Errorf("failed to set DRMAC annotation on node: %v", err)
+			}
+		}
+		return nil
 	}
-	return err
+	return nil
 }
 
-func (n *NodeController) deleteFlowsByCookie(cookie string) {
-	n.flowMutex.Lock()
-	defer n.flowMutex.Unlock()
-	delete(n.flowCache, cookie)
-}
-
-// DeleteNode handles node deletions
+// Delete handles node deletions
 func (n *NodeController) DeleteNode(node *kapi.Node) error {
-	if node.Name == n.nodeName || !houtil.IsHybridOverlayNode(node) {
+	return nil
+}
+
+// AddPod remove the ovnkube annotation from the pods running on its own node
+func (n *NodeController) AddPod(pod *kapi.Pod) error {
+	if pod.Spec.NodeName != n.nodeName {
 		return nil
 	}
 
-	n.deleteFlowsByCookie(nameToCookie(node.Name))
-
-	cidr, _, _, err := getNodeDetails(node)
-	if cidr == nil || err != nil {
-		return fmt.Errorf("failed to lookup hybrid overlay node cidr for node %s: %v", node.Name, err)
-	}
-	if len(config.HybridOverlay.ClusterSubnets) == 0 {
-		// No static cluster subnet is provided in config. Try to detect the hybrid overlay node subnet dynamically
-		// Add a route via the hybrid overlay port IP through the management port
-		// interface for each hybrid overlay cluster subnet
-		mgmtPortLink, err := netlink.LinkByName(types.K8sMgmtIntfName)
-		if err != nil {
-			return fmt.Errorf("failed to lookup link %s: %v", types.K8sMgmtIntfName, err)
+	_, ok := pod.Annotations[util.OvnPodAnnotationName]
+	if ok {
+		klog.Infof("Remove the ovnkube pod annotation from pod %s", pod.Name)
+		delete(pod.Annotations, util.OvnPodAnnotationName)
+		if err := n.kube.UpdatePod(pod); err != nil {
+			return fmt.Errorf("failed to remove ovnkube pod annotation from pod %s: %v", pod.Name, err)
 		}
-
-		route := &netlink.Route{
-			Dst:       cidr,
-			LinkIndex: mgmtPortLink.Attrs().Index,
-			Scope:     netlink.SCOPE_UNIVERSE,
-			Gw:        n.drIP,
-		}
-		err = netlink.RouteDel(route)
-		if err != nil && !os.IsExist(err) {
-			return fmt.Errorf("failed to delete route for subnet %s via gateway %s: %v",
-				route.Dst, route.Gw, err)
-		}
+		return nil
 	}
 	return nil
 }
 
-func getLocalNodeSubnet(nodeName string) (*net.IPNet, error) {
-	var cidr string
-	var err error
-
-	// First wait for the node logical switch to be created by the Master, timeout is 300s.
-	if err := wait.PollImmediate(500*time.Millisecond, 300*time.Second, func() (bool, error) {
-		if cidr, _, err = util.RunOVNNbctl("get", "logical_switch", nodeName, "other-config:subnet"); err != nil {
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
-		return nil, fmt.Errorf("timed out waiting for node %q logical switch: %v", nodeName, err)
-	}
-
-	_, subnet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid hostsubnet found for node %s - %v", nodeName, err)
-	}
-
-	klog.Infof("Found node %s subnet %s", nodeName, subnet.String())
-	return subnet, nil
+func (n *NodeController) DeletePod(pod *kapi.Pod) error {
+	return nil
 }
 
-func getIPAsHexString(ip net.IP) string {
-	if ip.To4() != nil {
-		ip = ip.To4()
-	}
-	asHex := ""
-	for i := 0; i < len(ip); i++ {
-		asHex += fmt.Sprintf("%02x", ip[i])
-	}
-	return asHex
-}
+func (n *NodeController) RunFlowSync(stopCh <-chan struct{}) {}
 
-// EnsureHybridOverlayBridge sets up the hybrid overlay bridge
 func (n *NodeController) EnsureHybridOverlayBridge(node *kapi.Node) error {
-	if n.initialized {
-		return nil
-	}
-
-	subnet, err := getLocalNodeSubnet(n.nodeName)
-	if err != nil {
-		return err
-	}
-
-	portName := util.GetHybridOverlayPortName(n.nodeName)
-	portMACString, haveDRMACAnnotation := node.Annotations[hotypes.HybridOverlayDRMAC]
-	if !haveDRMACAnnotation {
-		klog.Infof("Node %s does not have DRMAC annotation yet, failed to ensure hybrid overlay"+
-			"and will retry later", n.nodeName)
-		// node must not be annotated yet, retry later
-		return nil
-	}
-
-	portMAC, err := net.ParseMAC(portMACString)
-	if err != nil {
-		return fmt.Errorf("failed to parse DRMAC: %s", portMACString)
-	}
-	n.drMAC = portMAC
-
-	// n.drIP is always 3rd address in the subnet
-	hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(subnet)
-	n.drIP = hybridOverlayIfAddr.IP
-
-	_, stderr, err := util.RunOVSVsctl("--may-exist", "add-br", extBridgeName,
-		"--", "set", "Bridge", extBridgeName, "fail_mode=secure",
-		"--", "set", "Interface", extBridgeName, "mtu_request="+fmt.Sprintf("%d", config.Default.MTU))
-	if err != nil {
-		return fmt.Errorf("failed to create hybrid-overlay bridge %s"+
-			", stderr:%s: %v", extBridgeName, stderr, err)
-	}
-
-	// A OVS bridge's mac address can change when ports are added to it.
-	// We cannot let that happen, so make the bridge mac address permanent.
-	macAddress, err := util.GetOVSPortMACAddress(extBridgeName)
-	if err != nil {
-		return err
-	}
-	stdout, stderr, err := util.RunOVSVsctl("set", "bridge", extBridgeName, "other-config:hwaddr="+macAddress.String())
-	if err != nil {
-		return fmt.Errorf("failed to set bridge, stdout: %q, stderr: %q, "+
-			"error: %v", stdout, stderr, err)
-	}
-
-	if _, err := util.LinkSetUp(extBridgeName); err != nil {
-		return fmt.Errorf("failed to up %s: %v", extBridgeName, err)
-	}
-
-	const (
-		rampInt string = "int"
-		rampExt string = "ext"
-	)
-	// Create the connection between OVN's br-int and our hybrid overlay bridge br-ext
-	_, stderr, err = util.RunOVSVsctl("--may-exist", "add-port", "br-int", rampInt,
-		"--", "--may-exist", "add-port", extBridgeName, rampExt,
-		"--", "set", "Interface", rampInt, "type=patch", "options:peer="+rampExt, "external-ids:iface-id="+portName,
-		"--", "set", "Interface", rampExt, "type=patch", "options:peer="+rampInt)
-	if err != nil {
-		return fmt.Errorf("failed to create hybrid overlay bridge patch ports"+
-			", stderr:%s (%v)", stderr, err)
-	}
-
-	// Add the VXLAN port for sending/receiving traffic from hybrid overlay nodes
-	_, stderr, err = util.RunOVSVsctl("--may-exist", "add-port", extBridgeName, extVXLANName,
-		"--", "set", "interface", extVXLANName, "type=vxlan", `options:remote_ip="flow"`, `options:key="flow"`, fmt.Sprintf("options:dst_port=%d", n.vxlanPort))
-	if err != nil {
-		return fmt.Errorf("failed to add VXLAN port for ovs bridge %s"+
-			", stderr:%s: %v", extBridgeName, stderr, err)
-	}
-
-	flows := make([]string, 0, 10)
-	// Add default drop rule to tables for easier debugging via packet counters
-	for _, table := range []int{0, 1, 2, 10, 20} {
-		flows = append(flows, fmt.Sprintf("table=%d,priority=0,actions=drop", table))
-	}
-	// Handle ARP for gateway address internally towards pods
-	// resubmit to table 1 for gateway mode arp processing
-	portMACRaw := strings.Replace(n.drMAC.String(), ":", "", -1)
-	portIPRaw := getIPAsHexString(n.drIP)
-	flows = append(flows,
-		fmt.Sprintf("table=0,priority=100,in_port=%s,arp_op=1,arp,arp_tpa=%s,"+
-			"actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],"+
-			"mod_dl_src:%s,"+
-			"load:0x2->NXM_OF_ARP_OP[],"+
-			"move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],"+
-			"move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],"+
-			"load:0x%s->NXM_NX_ARP_SHA[],"+
-			"load:0x%s->NXM_OF_ARP_SPA[],"+
-			"IN_PORT,resubmit(,1)",
-			rampExt, n.drIP.String(), n.drMAC.String(), portMACRaw, portIPRaw))
-
-	// Send incoming VXLAN traffic to the pod dispatch table
-	flows = append(flows,
-		fmt.Sprintf("table=0,priority=100,in_port="+extVXLANName+",ip,nw_dst=%s,dl_dst=%s,actions=goto_table:10",
-			subnet.String(), n.drMAC.String()))
-
-	// Handle ARP requests from hybrid external gateway
-	// First flow is low priority flow to get to table 2 (arp response table)
-	// exgw will have flows that match for arp to build learn table 20, they need to be hit and then punt
-	// to table 2
-	// Therefore install a default low priority flow in case those flows are not installed via pod update
-	flows = append(flows,
-		fmt.Sprintf("table=0,priority=10,arp,in_port=%s,arp_op=1,arp_tpa=%s,"+
-			"actions=resubmit(,2)",
-			extVXLANName, subnet.String()))
-
-	// Install flow to handle the arp response from exgws
-	flows = append(flows,
-		fmt.Sprintf("table=2,priority=100,arp,in_port=%s,arp_op=1,arp_tpa=%s,"+
-			"actions=move:tun_src->tun_dst,"+
-			"load:%d->NXM_NX_TUN_ID[0..31],"+
-			"move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],"+
-			"mod_dl_src:%s,"+
-			"load:0x2->NXM_OF_ARP_OP[],"+
-			"move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],"+
-			"load:0x%s->NXM_NX_ARP_SHA[],"+
-			"move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],"+
-			"move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],"+
-			"move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],"+
-			"IN_PORT",
-			extVXLANName, subnet.String(), hotypes.HybridOverlayVNI, n.drMAC.String(), portMACRaw))
-
-	// Add a route via the hybrid overlay port IP through the management port
-	// interface for each hybrid overlay cluster subnet
-	mgmtPortLink, err := netlink.LinkByName(types.K8sMgmtIntfName)
-	if err != nil {
-		return fmt.Errorf("failed to lookup link %s: %v", types.K8sMgmtIntfName, err)
-	}
-	mgmtPortMAC := mgmtPortLink.Attrs().HardwareAddr
-	if len(config.HybridOverlay.ClusterSubnets) > 0 {
-		for _, clusterEntry := range config.HybridOverlay.ClusterSubnets {
-			route := &netlink.Route{
-				Dst:       clusterEntry.CIDR,
-				LinkIndex: mgmtPortLink.Attrs().Index,
-				Scope:     netlink.SCOPE_UNIVERSE,
-				Gw:        n.drIP,
-			}
-			err := netlink.RouteAdd(route)
-			if err != nil && !os.IsExist(err) {
-				return fmt.Errorf("failed to add route for subnet %s via gateway %s: %v",
-					route.Dst, route.Gw, err)
-			}
-		}
-	} else {
-		nodes, err := n.nodeLister.List(labels.Everything())
-		if err != nil {
-			return err
-		}
-		for _, node := range nodes {
-			if subnet, _ := houtil.ParseHybridOverlayHostSubnet(node); subnet != nil {
-				route := &netlink.Route{
-					Dst:       subnet,
-					LinkIndex: mgmtPortLink.Attrs().Index,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					Gw:        n.drIP,
-				}
-				err := netlink.RouteAdd(route)
-				if err != nil && !os.IsExist(err) {
-					return fmt.Errorf("failed to add route for subnet %s via gateway %s: %v",
-						route.Dst, route.Gw, err)
-				}
-			}
-		}
-	}
-
-	// Add a rule to fix up return host-network traffic
-	mgmtIfAddr := util.GetNodeManagementIfAddr(subnet)
-	flows = append(flows,
-		fmt.Sprintf("table=10,priority=100,ip,nw_dst=%s,"+
-			"actions=mod_dl_src:%s,mod_dl_dst:%s,output:ext",
-			mgmtIfAddr.IP.String(), portMAC.String(), mgmtPortMAC.String()))
-	// Add a rule to fix up return nodePort service traffic
-	gwIfAddr := util.GetNodeGatewayIfAddr(subnet)
-	gwPortMAC := util.IPAddrToHWAddr(gwIfAddr.IP)
-	flows = append(flows,
-		fmt.Sprintf("table=10,priority=100,ip,nw_dst=%s,"+
-			"actions=mod_nw_dst:%s,mod_dl_src:%s,mod_dl_dst:%s,output:ext",
-			n.drIP, n.gwLRPIP.String(), portMAC.String(), gwPortMAC.String()))
-
-	n.updateFlowCacheEntry("0x0", flows, false)
-	n.requestFlowSync()
-	n.initialized = true
-	klog.Infof("Hybrid overlay setup complete for node %s", node.Name)
 	return nil
-}
-
-// RunFlowSync runs flow synchronization
-// It runs once when the controller is started.
-// It will block until the stopCh is closed, running the sync periodically,
-// or when signalled via the flowChan
-func (n *NodeController) RunFlowSync(stopCh <-chan struct{}) {
-	klog.Info("Starting hybrid overlay OpenFlow sync thread")
-	klog.Info("Running initial OpenFlow sync")
-	n.syncFlows()
-	syncPeriod := 30 * time.Second
-	timer := time.NewTicker(syncPeriod)
-	defer timer.Stop()
-	for {
-		select {
-		case <-timer.C:
-			n.syncFlows()
-		case <-n.flowChan:
-			n.syncFlows()
-			timer.Reset(syncPeriod)
-		case <-stopCh:
-			klog.Info("Shutting down OpenFlow sync thread")
-			return
-		}
-	}
-}
-
-func (n *NodeController) syncFlows() {
-	n.flowMutex.Lock()
-	defer n.flowMutex.Unlock()
-	// any learned flows in table 20 we need to store for the update, as long as they correspond to a
-	// current pod in the cache
-	stdout, stderr, err := util.RunOVSOfctl("dump-flows", "--no-stats", extBridgeName, "table=20")
-	if err != nil {
-		klog.Errorf("Failed to dump flows for flow sync, stderr: %q, error: %v", stderr, err)
-		return
-	}
-	lines := strings.Split(stdout, "\n")
-	for _, line := range lines {
-		if len(line) == 0 {
-			continue
-		}
-		// Ignore the end-of-table drop rule
-		if strings.Contains(line, "actions=drop") {
-			continue
-		}
-		line = strings.TrimSpace(line)
-		cookie := strings.TrimPrefix(strings.Split(line, ",")[0], "cookie=0x")
-		// the cookie from OVS will remove leading zeros, and we know the cookie length for learned flow (IP to hex)
-		// is always 8, so pack with extra 0s
-		for len(cookie) < 8 {
-			cookie = "0" + cookie
-		}
-		if cacheEntry, ok := n.flowCache[cookie]; ok {
-			// we ignore certain cookies for learning to avoid a case where a NS was updated with a new vtep
-			// and we accidentally pick up the old vtep flow and cache it. This should only ever happen on a pod update
-			// with an NS annotation VTEP change. We only need to ignore it for one iteration of sync.
-			if cacheEntry.ignoreLearn {
-				klog.V(5).Infof("Ignoring learned flow to add to hybrid cache for this iteration: %s", line)
-				cacheEntry.ignoreLearn = false
-				cacheEntry.learnedFlow = ""
-				continue
-			}
-			// we only ever have one learned flow per pod IP
-			if cacheEntry.learnedFlow != line {
-				cacheEntry.learnedFlow = line
-				klog.Infof("Learned flow added to hybrid flow cache: %s", line)
-			}
-		} else {
-			klog.Warningf("Learned flow found with no matching cache entry: %s", line)
-		}
-	}
-
-	flows := make([]string, 0, 100)
-	for _, entry := range n.flowCache {
-		flows = append(flows, entry.flows...)
-		if len(entry.learnedFlow) > 0 {
-			flows = append(flows, entry.learnedFlow)
-		}
-	}
-	_, _, err = util.ReplaceOFFlows(extBridgeName, flows)
-	if err != nil {
-		klog.Errorf("Failed to add flows, error: %v, flows: %s", err, flows)
-	}
-}
-
-func (n *NodeController) requestFlowSync() {
-	select {
-	case n.flowChan <- struct{}{}:
-		klog.V(5).Infof("Flow sync requested")
-	default:
-		klog.V(5).Infof("Sync already requested for flows")
-	}
-}
-
-func (n *NodeController) updateFlowCacheEntry(cookie string, flows []string, ignoreLearn bool) {
-	n.flowMutex.Lock()
-	defer n.flowMutex.Unlock()
-	n.flowCache[cookie] = &flowCacheEntry{flows: flows}
-	n.flowCache[cookie].ignoreLearn = ignoreLearn
 }

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -1,27 +1,22 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
-	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -33,54 +28,16 @@ import (
 )
 
 const (
-	testOVSMAC     string = "11:22:33:44:55:66"
-	testMgmtMAC    string = "06:05:04:03:02:01"
+	testNodeName   string = "worker-1"
 	testDRMAC      string = "00:00:00:7a:af:04"
-	testNodeSubnet string = "1.2.3.0/24"
-	testNodeIP     string = "1.2.3.3"
+	testNodeSubnet string = "2.2.3.0/24"
+	testNodeIP     string = "1.2.3.3/24"
 )
 
-// returns a fake node IP and DR MAC
-func addNodeSetupCmds(fexec *ovntest.FakeExec, nodeName string) (string, string) {
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 get logical_switch mynode other-config:subnet",
-		Output: testNodeSubnet,
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface ovn-k8s-mp0 mac_in_use",
-		Output: testMgmtMAC,
-	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-vsctl --timeout=15 --may-exist add-br br-ext -- set Bridge br-ext fail_mode=secure -- set Interface br-ext mtu_request=1400",
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface br-ext mac_in_use",
-		Output: testOVSMAC,
-	})
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-vsctl --timeout=15 set bridge br-ext other-config:hwaddr=" + testOVSMAC,
-		"ovs-vsctl --timeout=15 --may-exist add-port br-int int -- --may-exist add-port br-ext ext -- set Interface int type=patch options:peer=ext external-ids:iface-id=int-" + nodeName + " -- set Interface ext type=patch options:peer=int",
-		"ovs-ofctl add-flow br-ext table=0,priority=0,actions=drop",
-	})
-	testDRMACRaw := strings.Replace(testDRMAC, ":", "", -1)
-	testNodeIPRaw := getIPAsHexString(ovntest.MustParseIP(testNodeIP))
-	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-ofctl add-flow br-ext table=0,priority=100,in_port=ext,arp,arp_tpa=" + testNodeIP + ",actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:" + testDRMAC + ",load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0x" + testDRMACRaw + "->NXM_NX_ARP_SHA[],load:0x" + testNodeIPRaw + "->NXM_OF_ARP_SPA[],IN_PORT",
-		`ovs-vsctl --timeout=15 --may-exist add-port br-ext ext-vxlan -- set interface ext-vxlan type=vxlan options:remote_ip="flow" options:key="flow" options:dst_port=4789`,
-		"ovs-ofctl add-flow br-ext table=0,priority=100,in_port=ext-vxlan,ip,nw_dst=" + testNodeSubnet + ",dl_dst=" + testDRMAC + ",actions=goto_table:10",
-		"ovs-ofctl add-flow br-ext table=0,priority=100,arp,in_port=ext-vxlan,arp_tpa=" + testNodeSubnet + ",actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:" + testDRMAC + ",load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0x" + testDRMACRaw + "->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT",
-		"ovs-ofctl add-flow br-ext table=10,priority=0,actions=drop",
-	})
-	return testNodeIP, testDRMAC
-}
-
-func createNode(name, os, ip string, annotations map[string]string) *v1.Node {
+func createNode(name, ip string, annotations map[string]string) *v1.Node {
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				v1.LabelOSStable: os,
-			},
+			Name:        name,
 			Annotations: annotations,
 		},
 		Status: v1.NodeStatus{
@@ -114,106 +71,49 @@ func createPod(namespace, name, node, podIP, podMAC string) *v1.Pod {
 	}
 }
 
-func expectRouteForSubnet(routes []netlink.Route, subnet *net.IPNet, hoIfAddr net.IP) {
-	found := false
-	for _, route := range routes {
-		if route.Dst.String() == subnet.String() && route.Gw.String() == hoIfAddr.String() {
-			found = true
-			break
-		}
-	}
-	Expect(found).To(BeTrue(), fmt.Sprintf("failed to find hybrid overlay host route %s via %s", subnet, hoIfAddr))
-}
-
-func validateNetlinkState(nodeSubnet string) {
-	link, err := netlink.LinkByName(extBridgeName)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(link.Attrs().Flags & net.FlagUp).To(Equal(net.FlagUp))
-
-	link, err = netlink.LinkByName(types.K8sMgmtIntfName)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(link.Attrs().Flags & net.FlagUp).To(Equal(net.FlagUp))
-
-	routes, err := netlink.RouteList(link, netlink.FAMILY_ALL)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Expect a route to the hybrid overlay CIDR via the .3 address
-	// through the management port
-	_, ipnet, err := net.ParseCIDR(nodeSubnet)
-	Expect(err).NotTo(HaveOccurred())
-	hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(ipnet)
-	Expect(len(config.HybridOverlay.ClusterSubnets)).ToNot(BeZero())
-	for _, hoSubnet := range config.HybridOverlay.ClusterSubnets {
-		expectRouteForSubnet(routes, hoSubnet.CIDR, hybridOverlayIfAddr.IP)
-	}
-}
-
 func appRun(app *cli.App, netns ns.NetNS) {
-	_ = netns.Do(func(ns.NetNS) error {
+	_ = netns.Do(func(netns ns.NetNS) error {
 		defer GinkgoRecover()
 		err := app.Run([]string{
 			app.Name,
-			"-enable-hybrid-overlay",
-			"-no-hostsubnet-nodes=" + v1.LabelOSStable + "=windows",
-			"-cluster-subnets=10.130.0.0/15/24",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		return nil
 	})
 }
 
-func createNodeAnnotationsForSubnet(subnet string) map[string]string {
-	subnetAnnotations, err := util.CreateNodeHostSubnetAnnotation(ovntest.MustParseIPNets(subnet))
-	Expect(err).NotTo(HaveOccurred())
-	annotations := make(map[string]string)
-	for k, v := range subnetAnnotations {
-		annotations[k] = fmt.Sprintf("%s", v)
-	}
-	return annotations
-}
-
 var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 	var (
 		app      *cli.App
-		fexec    *ovntest.FakeExec
 		netns    ns.NetNS
 		stopChan chan struct{}
 		wg       *sync.WaitGroup
-	)
-	const (
-		thisNode   string = "mynode"
-		thisSubnet string = "1.2.3.0/24"
+		err      error
 	)
 
 	BeforeEach(func() {
-		// Restore global default values before each testcase
-		config.PrepareTestConfig()
-
 		app = cli.NewApp()
 		app.Name = "test"
-		app.Flags = config.Flags
 
 		stopChan = make(chan struct{})
 		wg = &sync.WaitGroup{}
 
-		fexec = ovntest.NewLooseCompareFakeExec()
-		err := util.SetExec(fexec)
-		Expect(err).NotTo(HaveOccurred())
-
 		netns, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
 
-		// prepare br-ext and ovn-k8s-mp0 in original namespace
+		// prepare eth0 in original namespace
 		_ = netns.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
-			ovntest.AddLink(extBridgeName)
 
-			// Set up management interface with its address
-			link := ovntest.AddLink(types.K8sMgmtIntfName)
-			_, thisNet, err := net.ParseCIDR(thisSubnet)
+			// Set up default interface
+			link := ovntest.AddLink("eth0")
+			drMAC, err := net.ParseMAC(testDRMAC)
 			Expect(err).NotTo(HaveOccurred())
-			mgmtIfAddr := util.GetNodeManagementIfAddr(thisNet)
-			err = netlink.AddrAdd(link, &netlink.Addr{IPNet: mgmtIfAddr})
+			netlink.LinkSetHardwareAddr(link, drMAC)
+			Expect(err).NotTo(HaveOccurred())
+			nodeIP, err := netlink.ParseAddr(testNodeIP)
+			Expect(err).NotTo(HaveOccurred())
+			netlink.AddrAdd(link, nodeIP)
 			Expect(err).NotTo(HaveOccurred())
 			return nil
 		})
@@ -226,433 +126,100 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		Expect(testutils.UnmountNS(netns)).To(Succeed())
 	})
 
-	ovntest.OnSupportedPlatformsIt("does not set up tunnels for non-hybrid-overlay nodes without annotations", func() {
+	FIt("Set VTEP and gateway MAC address to its own node object annotations", func() {
 		app.Action = func(ctx *cli.Context) error {
-			const (
-				node1Name string = "node1"
-			)
+			ip := strings.Split(testNodeIP, "/")
+			testNode := createNode(testNodeName, ip[0], map[string]string{
+				types.HybridOverlayNodeSubnet: testNodeSubnet,
+			})
 
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
 				Items: []v1.Node{
-					*createNode(node1Name, "linux", "10.0.0.1", nil),
+					*testNode,
 				},
 			})
-
-			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Assume fresh OVS bridge
-				Output: "",
-			})
-
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
 
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
-				thisNode,
+				testNodeName,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.nodeEventHandler.Run(1, stopChan)
-			}()
+			err = n.controller.AddNode(testNode)
+			Expect(err).NotTo(HaveOccurred())
+			f.WaitForCacheSync(stopChan)
 
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			Eventually(func() (map[string]string, error) {
+				updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), testNodeName, metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return updatedNode.Annotations, nil
+			}, 2).Should(HaveKeyWithValue(types.HybridOverlayDRMAC, testDRMAC))
 			return nil
 		}
 		appRun(app, netns)
 	})
 
-	ovntest.OnSupportedPlatformsIt("does not set up tunnels for non-hybrid-overlay nodes with subnet annotations", func() {
+	FIt("Remove ovnkube annotations for pod on Hybrid Overlay node", func() {
 		app.Action = func(ctx *cli.Context) error {
-			const (
-				node1Name   string = "node1"
-				node1Subnet string = "1.2.4.0/24"
-				node1IP     string = "10.0.0.2"
-			)
+			testPod1 := createPod("default", "testpod-1", testNodeName, "2.2.3.5/24", "aa:bb:cc:dd:ee:ff")
+			testPod2 := createPod("default", "testpod-2", "other-worker", "2.2.3.6/24", "ab:bb:cc:dd:ee:ff")
+			ip := strings.Split(testNodeIP, "/")
+			testNode := createNode(testNodeName, ip[0], map[string]string{
+				types.HybridOverlayNodeSubnet: testNodeSubnet,
+			})
 
-			annotations := createNodeAnnotationsForSubnet(node1Subnet)
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
+			fakeClient := fake.NewSimpleClientset(&v1.PodList{
+				Items: []v1.Pod{
+					*testPod1,
+					*testPod2,
+				},
+			}, &v1.NodeList{
 				Items: []v1.Node{
-					*createNode(node1Name, "linux", node1IP, annotations),
+					*testNode,
 				},
 			})
 
-			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Assume fresh OVS bridge
-				Output: "",
-			})
-
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
 
 			n, err := NewNode(
 				&kube.Kube{KClient: fakeClient},
-				thisNode,
+				testNodeName,
 				f.Core().V1().Nodes().Informer(),
 				f.Core().V1().Pods().Informer(),
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.nodeEventHandler.Run(1, stopChan)
-			}()
-
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
-		appRun(app, netns)
-	})
-
-	ovntest.OnSupportedPlatformsIt("sets up local node hybrid overlay bridge", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				thisDrMAC string = "22:33:44:55:66:77"
-			)
-
-			annotations := createNodeAnnotationsForSubnet(thisSubnet)
-			annotations[hotypes.HybridOverlayDRMAC] = thisDrMAC
-			node := createNode(thisNode, "linux", "10.0.0.1", annotations)
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{*node},
-			})
-
-			// Node setup from initial node sync
-			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Assume fresh OVS bridge
-				Output: "",
-			})
-			config.HybridOverlay.RawClusterSubnets = "10.0.0.1/16/23"
-			_, err := config.InitConfig(ctx, fexec, nil)
+			err = n.controller.AddNode(testNode)
 			Expect(err).NotTo(HaveOccurred())
-			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
-
-			n, err := NewNode(
-				&kube.Kube{KClient: fakeClient},
-				thisNode,
-				f.Core().V1().Nodes().Informer(),
-				f.Core().V1().Pods().Informer(),
-				informer.NewTestEventHandler,
-			)
+			err = n.controller.AddPod(testPod1)
 			Expect(err).NotTo(HaveOccurred())
-
-			err = n.controller.EnsureHybridOverlayBridge(node)
+			err = n.controller.AddPod(testPod2)
 			Expect(err).NotTo(HaveOccurred())
+			f.WaitForCacheSync(stopChan)
 
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			validateNetlinkState(thisSubnet)
-			return nil
-		}
-		appRun(app, netns)
-	})
-	ovntest.OnSupportedPlatformsIt("sets up local linux pod", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				thisDrMAC string = "22:33:44:55:66:77"
-				pod1IP    string = "1.2.3.5"
-				pod1CIDR  string = pod1IP + "/24"
-				pod1MAC   string = "aa:bb:cc:dd:ee:ff"
-			)
+			Eventually(func() (map[string]string, error) {
+				updatedPod, err := fakeClient.CoreV1().Pods("default").Get(context.TODO(), "testpod-1", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return updatedPod.Annotations, nil
+			}, 2).ShouldNot(HaveKey(util.OvnPodAnnotationName))
 
-			annotations := createNodeAnnotationsForSubnet(thisSubnet)
-			annotations[hotypes.HybridOverlayDRMAC] = thisDrMAC
-			node := createNode(thisNode, "linux", "10.0.0.1", annotations)
-			testPod := createPod("test", "pod1", thisNode, pod1CIDR, pod1MAC)
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{*node},
-			})
-
-			// Node setup from initial node sync
-			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Assume fresh OVS bridge
-				Output: "",
-			})
-			config.HybridOverlay.RawClusterSubnets = "10.0.0.1/16/23"
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-
-			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
-
-			n, err := NewNode(
-				&kube.Kube{KClient: fakeClient},
-				thisNode,
-				f.Core().V1().Nodes().Informer(),
-				f.Core().V1().Pods().Informer(),
-				informer.NewTestEventHandler,
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = n.controller.EnsureHybridOverlayBridge(node)
-			Expect(err).NotTo(HaveOccurred())
-
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			validateNetlinkState(thisSubnet)
-			err = n.controller.AddPod(testPod)
-			Expect(err).NotTo(HaveOccurred())
-			return nil
-		}
-		appRun(app, netns)
-	})
-
-	ovntest.OnSupportedPlatformsIt("sets up tunnels for Windows nodes", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				node1Name   string = "node1"
-				node1IP     string = "10.0.0.2"
-				node1DrMAC  string = "22:33:44:55:66:77"
-				node1Subnet string = "5.6.7.0/24"
-			)
-
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{
-					*createNode(node1Name, "windows", node1IP, map[string]string{
-						hotypes.HybridOverlayNodeSubnet: node1Subnet,
-						hotypes.HybridOverlayDRMAC:      node1DrMAC,
-					}),
-				},
-			})
-
-			node1DrMACRaw := strings.Replace(node1DrMAC, ":", "", -1)
-
-			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-ofctl dump-flows br-ext table=0",
-				// Adds flows for existing node1
-				"ovs-ofctl add-flow br-ext cookie=0xca12f31b,table=0,priority=100,arp,in_port=ext,arp_tpa=" + node1Subnet + ",actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:" + node1DrMAC + ",load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0x" + node1DrMACRaw + "->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT",
-				"ovs-ofctl add-flow br-ext cookie=0xca12f31b,table=0,priority=100,ip,nw_dst=5.6.7.0/24,actions=load:4097->NXM_NX_TUN_ID[0..31],set_field:10.0.0.2->tun_dst,set_field:22:33:44:55:66:77->eth_dst,output:ext-vxlan",
-			})
-
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-
-			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
-
-			n, err := NewNode(
-				&kube.Kube{KClient: fakeClient},
-				thisNode,
-				f.Core().V1().Nodes().Informer(),
-				f.Core().V1().Pods().Informer(),
-				informer.NewTestEventHandler,
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.nodeEventHandler.Run(1, stopChan)
-			}()
-
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
-		appRun(app, netns)
-	})
-
-	ovntest.OnSupportedPlatformsIt("removes stale node flows on initial sync", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				node1Name string = "node1"
-				node1IP   string = "10.0.0.2"
-			)
-
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{*createNode(node1Name, "linux", node1IP, nil)},
-			})
-
-			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Return output for a stale node
-				Output: ` cookie=0x0, duration=137014.498s, table=0, n_packets=20, n_bytes=2605, priority=100,ip,in_port="ext-vxlan",dl_dst=00:00:00:4d:d9:c1,nw_dst=10.128.1.0/24 actions=resubmit(,10)
- cookie=0x1f40e27c, duration=61107.432s, table=0, n_packets=0, n_bytes=0, priority=100,arp,in_port=ext,arp_tpa=10.132.0.0/24 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:00:00:00:33:65:d0,load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0x3365d0->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT
- cookie=0x1f40e27c, duration=61107.417s, table=0, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.132.0.0/24 actions=load:0x1001->NXM_NX_TUN_ID[0..31],load:0xac110003->NXM_NX_TUN_IPV4_DST[],mod_dl_dst:00:00:00:33:65:d0,output:"ext-vxlan"
- cookie=0x0, duration=61107.658s, table=0, n_packets=50, n_bytes=3576, priority=0 actions=drop`,
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				// Deletes flows for stale node in OVS
-				"ovs-ofctl del-flows br-ext cookie=0x1f40e27c/0xffffffff",
-			})
-
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
-
-			n, err := NewNode(
-				&kube.Kube{KClient: fakeClient},
-				thisNode,
-				f.Core().V1().Nodes().Informer(),
-				f.Core().V1().Pods().Informer(),
-				informer.NewTestEventHandler,
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.nodeEventHandler.Run(1, stopChan)
-			}()
-
-			//FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
-		appRun(app, netns)
-	})
-
-	ovntest.OnSupportedPlatformsIt("removes stale pod flows on initial sync", func() {
-		app.Action = func(ctx *cli.Context) error {
-			fakeClient := fake.NewSimpleClientset()
-
-			addNodeSetupCmds(fexec, thisNode)
-
-			// Put one live pod and one stale pod into the OVS bridge flows
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=10",
-				Output: ` cookie=0xaabbccdd, duration=29398.539s, table=10, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=1.2.3.4 actions=mod_dl_src:ab:cd:ef:ab:cd:ef,mod_dl_dst:ef:cd:ab:ef:cd:ab,output:ext
- cookie=0x0, duration=29398.687s, table=10, n_packets=0, n_bytes=0, priority=0 actions=drop`,
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				// Deletes flows for pod in OVS that is not in Kube
-				"ovs-ofctl del-flows br-ext cookie=0xaabbccdd/0xffffffff",
-				// provide cover for up to 3 runs of flows thread
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
-			})
-
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
-
-			n, err := NewNode(
-				&kube.Kube{KClient: fakeClient},
-				thisNode,
-				f.Core().V1().Nodes().Informer(),
-				f.Core().V1().Pods().Informer(),
-				informer.NewTestEventHandler,
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.Run(stopChan)
-			}()
-
-			// Wait for the controller to start
-			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.IsReady() == true, nil })
-			Expect(err).NotTo(HaveOccurred())
-
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
-		appRun(app, netns)
-	})
-
-	ovntest.OnSupportedPlatformsIt("sets up local pod flows", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				pod1IP   string = "1.2.3.5"
-				pod1CIDR string = pod1IP + "/24"
-				pod1MAC  string = "aa:bb:cc:dd:ee:ff"
-			)
-
-			ns := &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					UID:  k8stypes.UID("test"),
-					Name: "test",
-					Annotations: map[string]string{
-						hotypes.HybridOverlayDRMAC: "00:11:22:33:44:55:66",
-					},
-				},
-				Spec:   v1.NamespaceSpec{},
-				Status: v1.NamespaceStatus{},
-			}
-			fakeClient := fake.NewSimpleClientset([]runtime.Object{
-				ns,
-				createPod("test", "pod1", thisNode, pod1CIDR, pod1MAC),
-			}...)
-
-			_, hybMAC := addNodeSetupCmds(fexec, thisNode)
-
-			// Put one live pod and one stale pod into the OVS bridge flows
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=10",
-				Output: ` cookie=0x7fdcde17, duration=29398.539s, table=10, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=` + pod1CIDR + ` actions=mod_dl_src:` + hybMAC + `,mod_dl_dst:` + pod1MAC + `,output:ext
- cookie=0x0, duration=29398.687s, table=10, n_packets=0, n_bytes=0, priority=0 actions=drop`,
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				// provide cover for up to 3 runs of flows thread
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
-			})
-
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
-
-			n, err := NewNode(
-				&kube.Kube{KClient: fakeClient},
-				thisNode,
-				f.Core().V1().Nodes().Informer(),
-				f.Core().V1().Pods().Informer(),
-				informer.NewTestEventHandler,
-			)
-			Expect(err).NotTo(HaveOccurred())
-			// FIXME: DT Why are these needed?
-			// n.drIP = net.ParseIP(hybIP)
-			// n.drMAC, err = net.ParseMAC(hybMAC)
-			// Expect(err).NotTo(HaveOccurred())
-
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.Run(stopChan)
-			}()
-
-			// Wait for the controller to start
-			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.IsReady() == true, nil })
-			Expect(err).NotTo(HaveOccurred())
-
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			Eventually(func() (map[string]string, error) {
+				updatedPod, err := fakeClient.CoreV1().Pods("default").Get(context.TODO(), "testpod-2", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return updatedPod.Annotations, nil
+			}, 2).Should(HaveKey(util.OvnPodAnnotationName))
 			return nil
 		}
 		appRun(app, netns)

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -46,6 +46,7 @@ type Interface interface {
 	CreateCloudPrivateIPConfig(cloudPrivateIPConfig *ocpcloudnetworkapi.CloudPrivateIPConfig) (*ocpcloudnetworkapi.CloudPrivateIPConfig, error)
 	UpdateCloudPrivateIPConfig(cloudPrivateIPConfig *ocpcloudnetworkapi.CloudPrivateIPConfig) (*ocpcloudnetworkapi.CloudPrivateIPConfig, error)
 	DeleteCloudPrivateIPConfig(name string) error
+	UpdatePod(pod *kapi.Pod) error
 	Events() kv1core.EventInterface
 }
 
@@ -81,6 +82,12 @@ func (k *Kube) SetAnnotationsOnPod(namespace, podName string, annotations map[st
 	if err != nil {
 		klog.Errorf("Error in setting annotation on pod %s: %v", podDesc, err)
 	}
+	return err
+}
+
+// UpdatePod updates the pod with the provided pod data
+func (k *Kube) UpdatePod(pod *kapi.Pod) error {
+	_, err := k.KClient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
 	return err
 }
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
Currenly, the hybrid-overly-node binary only runs on windows nodes.
The linux binary used to be for testing long ago, and is not
used any more.

This patch refactor the linux code of hybrid-overly-node. So we can
run this binary on linux nodes which are not managed by ovnkube.
This is for the SDN live migration usecase, where we will have a
cluster with SDN and OVN-K nodes running in parallel, being connected
by Hybrid Overlay. The hybrid-overly-node on linux nodes will be
responsible for:
  1. Add Hybrid Overlay DRMAC annotation to its own node object;
  2. Remove the ovnkube pod annotations from the pods running on this
  node.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->