### PR TITLE
Refactor hybrid-overlay-node for linux nodes

### DIFF
--- a/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
+++ b/go-controller/hybrid-overlay/cmd/hybrid-overlay-node/hybrid-overlay-node.go
@@ -108,7 +108,7 @@ func runHybridOverlay(ctx *cli.Context) error {
 	defer close(stopChan)
 	f := informers.NewSharedInformerFactory(clientset, informer.DefaultResyncInterval)
 
-	n, err := controller.NewNode(
+	n, err := controller.NewHONode(
 		&kube.Kube{KClient: clientset},
 		nodeName,
 		f.Core().V1().Nodes().Informer(),

--- a/go-controller/hybrid-overlay/pkg/controller/honode_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/honode_linux.go
@@ -1,0 +1,123 @@
+package controller
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	"github.com/vishvananda/netlink"
+	kapi "k8s.io/api/core/v1"
+	listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// HONodeController is the node hybrid overlay controller
+type HONodeController struct {
+	kube            kube.Interface
+	machineID       string
+	nodeName        string
+	localNodeCIDR   *net.IPNet
+	localNodeIP     net.IP
+	remoteSubnetMap map[string]string // Maps a remote node to its remote subnet
+}
+
+// newHONodeController returns a node handler that listens for node events
+// so that Add/Update/Delete events are appropriately handled.
+func newHONodeController(kube kube.Interface,
+	nodeName string,
+	nodeLister listers.NodeLister,
+) (nodeController, error) {
+
+	node, err := kube.GetNode(nodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &HONodeController{
+		kube:            kube,
+		machineID:       node.Status.NodeInfo.MachineID,
+		nodeName:        node.Name,
+		remoteSubnetMap: make(map[string]string),
+	}, nil
+}
+
+// AddNode set annotations about its VTEP and gateway MAC address to its own node object
+func (n *HONodeController) AddNode(node *kapi.Node) error {
+	if node.Name == n.nodeName {
+		cidr, nodeIP := getNodeSubnetAndIP(node)
+		if (cidr != nil && !houtil.SameIPNet(cidr, n.localNodeCIDR)) || (nodeIP != nil && nodeIP.Equal(n.localNodeIP)) {
+			n.localNodeCIDR = cidr
+			n.localNodeIP = nodeIP
+
+			var drMAC string
+
+			links, err := util.GetNetLinkOps().LinkList()
+			if err != nil {
+				return err
+			}
+		out:
+			for _, link := range links {
+				addrs, err := util.GetNetLinkOps().AddrList(link, netlink.FAMILY_ALL)
+				if err != nil {
+					return fmt.Errorf("failed to get IP address for link %s: %v", link.Attrs().Name, err)
+				}
+				for _, add := range addrs {
+					if add.IP.Equal(n.localNodeIP) {
+						drMAC = link.Attrs().HardwareAddr.String()
+						break out
+					}
+				}
+			}
+
+			if drMAC == "" {
+				return fmt.Errorf("cannot to find the hybrid overlay distributed router gateway MAC address")
+			}
+
+			klog.Infof("Set hybrid overlay DRMAC annotation: %s", drMAC)
+			if err := n.kube.SetAnnotationsOnNode(node.Name, map[string]interface{}{
+				types.HybridOverlayDRMAC: drMAC,
+			}); err != nil {
+				return fmt.Errorf("failed to set DRMAC annotation on node: %v", err)
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+// Delete handles node deletions
+func (n *HONodeController) DeleteNode(node *kapi.Node) error {
+	return nil
+}
+
+// AddPod remove the ovnkube annotation from the pods running on its own node
+func (n *HONodeController) AddPod(pod *kapi.Pod) error {
+	if pod.Spec.NodeName != n.nodeName {
+		return nil
+	}
+
+	_, ok := pod.Annotations[util.OvnPodAnnotationName]
+	if ok {
+		klog.Infof("Remove the ovnkube pod annotation from pod %s", pod.Name)
+		delete(pod.Annotations, util.OvnPodAnnotationName)
+		if err := n.kube.UpdatePod(pod); err != nil {
+			return fmt.Errorf("failed to remove ovnkube pod annotation from pod %s: %v", pod.Name, err)
+		}
+		return nil
+	}
+	return nil
+}
+
+func (n *HONodeController) DeletePod(pod *kapi.Pod) error {
+	return nil
+}
+
+func (n *HONodeController) RunFlowSync(stopCh <-chan struct{}) {}
+
+func (n *HONodeController) EnsureHybridOverlayBridge(node *kapi.Node) error {
+	return nil
+}

--- a/go-controller/hybrid-overlay/pkg/controller/honode_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/honode_linux_test.go
@@ -1,0 +1,207 @@
+package controller
+
+import (
+	"context"
+	"sync"
+
+	"github.com/urfave/cli/v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/mocks"
+
+	"github.com/vishvananda/netlink"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	hoNodeName   string = "worker-1"
+	hoNodeIP     string = "10.0.0.1"
+	hoNodeSubnet string = "20.0.0.0/24"
+	hoNodeDRMAC  string = "22:33:44:55:66:77"
+)
+
+func appHONRun(app *cli.App) {
+	err := app.Run([]string{
+		app.Name,
+		"-no-hostsubnet-nodes=" + v1.LabelOSStable + "=linux",
+	})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func addHybridOverlayAddNodeMocks(nlMock *mocks.NetLinkOps) {
+	mockEth0IP := netlink.Addr{IPNet: ovntest.MustParseIPNet(hoNodeIP + "/24")}
+	mockEth0 := &fakeLink{
+		attrs: &netlink.LinkAttrs{
+			Index:        777,
+			HardwareAddr: ovntest.MustParseMAC(hoNodeDRMAC),
+		},
+	}
+
+	nlMocks := []ovntest.TestifyMockHelper{
+		{
+			OnCallMethodName: "LinkList",
+			RetArgList:       []interface{}{[]netlink.Link{mockEth0}, nil},
+		},
+		{
+			OnCallMethodName: "AddrList",
+			OnCallMethodArgs: []interface{}{mockEth0, netlink.FAMILY_ALL},
+			RetArgList: []interface{}{
+				[]netlink.Addr{
+					mockEth0IP,
+				},
+				nil,
+			},
+		},
+	}
+	ovntest.ProcessMockFnList(&nlMock.Mock, nlMocks)
+}
+
+var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
+
+	var (
+		app      *cli.App
+		stopChan chan struct{}
+		wg       *sync.WaitGroup
+		nlMock   *mocks.NetLinkOps
+	)
+
+	BeforeEach(func() {
+		// Restore global default values before each testcase
+		Expect(config.PrepareTestConfig()).To(Succeed())
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+
+		stopChan = make(chan struct{})
+		wg = &sync.WaitGroup{}
+
+		// prepare eth0 in netlink mock
+		nlMock = &mocks.NetLinkOps{}
+		util.SetNetLinkOpMockInst(nlMock)
+	})
+
+	AfterEach(func() {
+		close(stopChan)
+		wg.Wait()
+		util.ResetNetLinkOpMockInst()
+	})
+
+	ovntest.OnSupportedPlatformsIt("Set VTEP and gateway MAC address to its own node object annotations", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			addHybridOverlayAddNodeMocks(nlMock)
+
+			testNode := createNode(hoNodeName, "linux", hoNodeIP, map[string]string{
+				types.HybridOverlayNodeSubnet: hoNodeSubnet,
+			})
+
+			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
+				Items: []v1.Node{
+					*testNode,
+				},
+			})
+
+			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
+
+			n, err := NewHONode(
+				&kube.Kube{KClient: fakeClient},
+				hoNodeName,
+				f.Core().V1().Nodes().Informer(),
+				f.Core().V1().Pods().Informer(),
+				informer.NewTestEventHandler,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = n.controller.AddNode(testNode)
+			Expect(err).NotTo(HaveOccurred())
+			f.WaitForCacheSync(stopChan)
+
+			Eventually(func() (map[string]string, error) {
+				updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.TODO(), hoNodeName, metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return updatedNode.Annotations, nil
+			}, 2).Should(HaveKeyWithValue(types.HybridOverlayDRMAC, hoNodeDRMAC))
+			return nil
+		}
+		appHONRun(app)
+	})
+
+	ovntest.OnSupportedPlatformsIt("Remove ovnkube annotations for pod on Hybrid Overlay node", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			addHybridOverlayAddNodeMocks(nlMock)
+
+			testPod1 := createPod("default", "testpod-1", hoNodeName, "2.2.3.5/24", "aa:bb:cc:dd:ee:ff")
+			testPod2 := createPod("default", "testpod-2", "other-worker", "2.2.3.6/24", "ab:bb:cc:dd:ee:ff")
+			testNode := createNode(hoNodeName, "linux", hoNodeIP, map[string]string{
+				types.HybridOverlayNodeSubnet: hoNodeSubnet,
+			})
+
+			fakeClient := fake.NewSimpleClientset(&v1.PodList{
+				Items: []v1.Pod{
+					*testPod1,
+					*testPod2,
+				},
+			}, &v1.NodeList{
+				Items: []v1.Node{
+					*testNode,
+				},
+			})
+
+			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
+
+			n, err := NewHONode(
+				&kube.Kube{KClient: fakeClient},
+				hoNodeName,
+				f.Core().V1().Nodes().Informer(),
+				f.Core().V1().Pods().Informer(),
+				informer.NewTestEventHandler,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = n.controller.AddNode(testNode)
+			Expect(err).NotTo(HaveOccurred())
+			err = n.controller.AddPod(testPod1)
+			Expect(err).NotTo(HaveOccurred())
+			err = n.controller.AddPod(testPod2)
+			Expect(err).NotTo(HaveOccurred())
+			f.WaitForCacheSync(stopChan)
+
+			Eventually(func() (map[string]string, error) {
+				updatedPod, err := fakeClient.CoreV1().Pods("default").Get(context.TODO(), "testpod-1", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return updatedPod.Annotations, nil
+			}, 2).ShouldNot(HaveKey(util.OvnPodAnnotationName))
+
+			Eventually(func() (map[string]string, error) {
+				updatedPod, err := fakeClient.CoreV1().Pods("default").Get(context.TODO(), "testpod-2", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				return updatedPod.Annotations, nil
+			}, 2).Should(HaveKey(util.OvnPodAnnotationName))
+			return nil
+		}
+		appHONRun(app)
+	})
+})

--- a/go-controller/hybrid-overlay/pkg/controller/node.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node.go
@@ -79,18 +79,17 @@ func podChanged(old, new interface{}) bool {
 	return false
 }
 
-// NewNode Returns a new Node
-func NewNode(
+// NewHONode Returns a new HO Node
+func NewHONode(
 	kube kube.Interface,
 	nodeName string,
 	nodeInformer cache.SharedIndexInformer,
 	podInformer cache.SharedIndexInformer,
 	eventHandlerCreateFunction informer.EventHandlerCreateFunction,
 ) (*Node, error) {
-
 	nodeLister := listers.NewNodeLister(nodeInformer.GetIndexer())
 
-	controller, err := newNodeController(kube, nodeName, nodeLister)
+	controller, err := newHONodeController(kube, nodeName, nodeLister)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -247,7 +247,7 @@ func addEnsureHybridOverlayBridgeMocks(nlMock *mocks.NetLinkOps) {
 	ovntest.ProcessMockFnList(&nlMock.Mock, nlMocks)
 }
 
-var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
+var _ = Describe("Non-Hybrid Overlay Node Linux Operations", func() {
 	var (
 		app        *cli.App
 		fexec      *ovntest.FakeExec


### PR DESCRIPTION
**- What this PR does and why is it needed**
Currenly, the hybrid-overly-node binary only runs on windows nodes.
The linux binary used to be for testing long ago and is not
used anymore.

This patch refactors the linux code of hybrid-overly-node. So we can
run this binary on linux nodes which are not managed by ovnkube.
This is for the SDN live migration usecase, where we will have a
cluster with SDN and OVN-K nodes running in parallel, being connected
by Hybrid Overlay. The hybrid-overly-node on linux nodes will be
responsible for:
  1. Add Hybrid Overlay DRMAC annotation to its own node object;
  2. Remove the ovnkube pod annotations from the pods running on this
  node.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
Build hybrid-overlay-node Linux binary. Run this binary on a Linux worker which is not managed by ovnkube.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->