### PR TITLE
Cleanup stale acls as part of syncNetworkPolicies on startup

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,6 +47,8 @@ const (
 	ingressDefaultDenySuffix = "ingressDefaultDeny"
 	// egressDefaultDenySuffix is the suffix used when creating the ingress port group for a namespace
 	egressDefaultDenySuffix = "egressDefaultDeny"
+	// arpAllowPolicySuffix is the suffix used when creating default ACLs for a namespace
+	arpAllowPolicySuffix = "ARPallowPolicy"
 )
 
 var NetworkPolicyNotCreated error
@@ -110,6 +113,45 @@ func getACLLoggingSeverity(aclLogging string) string {
 // hash the provided input to make it a valid portGroup name.
 func hashedPortGroup(s string) string {
 	return util.HashForOVN(s)
+}
+
+// updateStaleDefaultDenyACLNames updates the naming of the default ingress and egress deny ACLs per namespace
+// oldName: <namespace>_<policyname> (lucky winner will be first policy created in the namespace)
+// newName: <namespace>_egressDefaultDeny OR <namespace>_ingressDefaultDeny
+func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gressSuffix string) error {
+	cleanUpDefaultDeny := make(map[string][]*nbdb.ACL)
+	p := func(item *nbdb.ACL) bool {
+		return item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] == string(npType) && // default-deny-policy-type:Egress or default-deny-policy-type:Ingress
+			strings.Contains(item.Match, gressSuffix) && // Match:inport ==	@ablah80448_egressDefaultDeny or Match:inport == @ablah80448_ingressDefaultDeny
+			!strings.Contains(*item.Name, arpAllowPolicySuffix) && // != name: namespace_ARPallowPolicy
+			!strings.Contains(*item.Name, gressSuffix) // filter out already converted ACLs
+	}
+	gressACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
+	if err != nil {
+		return fmt.Errorf("cannot find NetworkPolicy default deny ACLs: %v", err)
+	}
+	for _, acl := range gressACLs {
+		acl := acl
+		namespace := strings.Split(*acl.Name, "_")[0] // parse the namespace from the ACL name
+		cleanUpDefaultDeny[namespace] = append(cleanUpDefaultDeny[namespace], acl)
+	}
+	// loop through the cleanUp map and per namespace update the first ACL's name and delete the rest
+	for namespace, aclList := range cleanUpDefaultDeny {
+		newName := namespacePortGroupACLName(namespace, "", gressSuffix)
+		if len(aclList) > 1 {
+			// this should never be the case but delete everything except 1st ACL
+			err := libovsdbops.DeleteACLs(oc.nbClient, aclList[1:]...)
+			if err != nil {
+				return err
+			}
+		}
+		aclList[0].Name = &newName
+		err := libovsdbops.CreateOrUpdateACLs(oc.nbClient, aclList[0])
+		if err != nil {
+			return fmt.Errorf("cannot update old NetworkPolicy ACLs for namespace %s: %v", namespace, err)
+		}
+	}
+	return nil
 }
 
 func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
@@ -186,6 +228,28 @@ func (oc *Controller) syncNetworkPolicies(networkPolicies []interface{}) error {
 		if err != nil {
 			return fmt.Errorf("cannot update old Egress NetworkPolicy ACLs: %v", err)
 		}
+	}
+
+	if err := oc.updateStaleDefaultDenyACLNames(knet.PolicyTypeEgress, egressDefaultDenySuffix); err != nil {
+		return fmt.Errorf("cannot clean up egress default deny ACL name: %v", err)
+	}
+	if err := oc.updateStaleDefaultDenyACLNames(knet.PolicyTypeIngress, ingressDefaultDenySuffix); err != nil {
+		return fmt.Errorf("cannot clean up ingress default deny ACL name: %v", err)
+	}
+
+	// remove stale egress and ingress allow arp ACLs that were leftover as a result
+	// of ACL migration for "ARPallowPolicy" when the match changed from "arp" to "(arp || nd)"
+	p = func(item *nbdb.ACL) bool {
+		return strings.Contains(item.Match, " && arp") &&
+			strings.Contains(*item.Name, arpAllowPolicySuffix)
+	}
+	gressACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
+	if err != nil {
+		return fmt.Errorf("cannot find stale arp allow ACLs: %v", err)
+	}
+	err = libovsdbops.DeleteACLs(oc.nbClient, gressACLs...)
+	if err != nil {
+		return fmt.Errorf("cannot delete stale arp allow ACLs: %v", err)
 	}
 
 	return nil
@@ -274,11 +338,11 @@ func buildDenyACLs(namespace, policy, pg, aclLogging string, policyType knet.Pol
 	denyMatch := getACLMatch(pg, "", policyType)
 	allowMatch := getACLMatch(pg, "(arp || nd)", policyType)
 	if policyType == knet.PolicyTypeIngress {
-		denyACL = buildACL(namespace, pg, policy, nbdb.ACLDirectionToLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
-		allowACL = buildACL(namespace, pg, "ARPallowPolicy", nbdb.ACLDirectionToLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
+		denyACL = buildACL(namespace, pg, ingressDefaultDenySuffix, nbdb.ACLDirectionToLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
+		allowACL = buildACL(namespace, pg, arpAllowPolicySuffix, nbdb.ACLDirectionToLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
 	} else {
-		denyACL = buildACL(namespace, pg, policy, nbdb.ACLDirectionFromLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
-		allowACL = buildACL(namespace, pg, "ARPallowPolicy", nbdb.ACLDirectionFromLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
+		denyACL = buildACL(namespace, pg, egressDefaultDenySuffix, nbdb.ACLDirectionFromLport, types.DefaultDenyPriority, denyMatch, nbdb.ACLActionDrop, aclLogging, policyType)
+		allowACL = buildACL(namespace, pg, arpAllowPolicySuffix, nbdb.ACLDirectionFromLport, types.DefaultAllowPriority, allowMatch, nbdb.ACLActionAllow, "", policyType)
 	}
 	return
 }

--- a/test/e2e/acl_logging.go
+++ b/test/e2e/acl_logging.go
@@ -33,6 +33,7 @@ var _ = Describe("ACL Logging for NetworkPolicy", func() {
 		namespacePrefix         = "acl-logging-netpol"
 		pokerPodIndex           = 0
 		pokedPodIndex           = 1
+		egressDefaultDenySuffix = "egressDefaultDeny"
 	)
 
 	fr := wrappedTestFramework(namespacePrefix)
@@ -83,7 +84,7 @@ var _ = Describe("ACL Logging for NetworkPolicy", func() {
 	It("the logs have the expected log level", func() {
 		clientPodScheduledPodName := pods[pokerPodIndex].Spec.NodeName
 		// Retry here in the case where OVN acls have not been programmed yet
-		composedPolicyNameRegex := fmt.Sprintf("%s_%s", nsName, denyAllPolicyName)
+		composedPolicyNameRegex := fmt.Sprintf("%s_%s", nsName, egressDefaultDenySuffix)
 		Eventually(func() (bool, error) {
 			return assertAclLogs(
 				clientPodScheduledPodName,
@@ -123,7 +124,7 @@ var _ = Describe("ACL Logging for NetworkPolicy", func() {
 
 		It("the ACL logs are updated accordingly", func() {
 			clientPodScheduledPodName := pods[pokerPodIndex].Spec.NodeName
-			composedPolicyNameRegex := fmt.Sprintf("%s_%s", nsName, denyAllPolicyName)
+			composedPolicyNameRegex := fmt.Sprintf("%s_%s", nsName, egressDefaultDenySuffix)
 			Eventually(func() (bool, error) {
 				return assertAclLogs(
 					clientPodScheduledPodName,


### PR DESCRIPTION
 Update and cleanup older stale ACLs upon startup
    
    This PR does two things:
    
    1) Loops through all the ACLs that have `ARPallowPolicy`
    in their names and have " && arp" in their match expression
    and deletes it. This is because we did
    https://github.com/openshift/ovn-kubernetes/pull/1043/files where
    we changed the match but didn't remove acls on the older match which
    causes problems like:
    
    2022-06-01T08:17:44.635401164Z E0601 08:17:44.634509       1 ovn.go:753]
    Failed to create network policy mdh-old/allow-from-other-namespaces,
    error: failed to create default port groups and acls for policy:
    mdh-old/allow-from-other-namespaces, error: unexpectedly found multiple
    equivalent ACLs: [{UUID:3bc36c0e-ee1a-4609-a240-c211f14f379b
    Action:allow Direction:to-lport
    ExternalIDs:map[default-deny-policy-type:Ingress] Label:0 Log:false
    Match:outport == @a13985064446031893020_ingressDefaultDeny && arp
    Meter:0xc003245210 Name:0xc003245220 Options:map[] Priority:1001
    Severity:0xc003245230} {UUID:41702278-fb49-4418-abca-6425912d1e63
    Action:allow Direction:to-lport
    ExternalIDs:map[default-deny-policy-type:Ingress] Label:0 Log:false
    Match:outport == @a13985064446031893020_ingressDefaultDeny && (arp ||
    nd) Meter:0xc0032452a0 Name:0xc0032452b0 Options:map[] Priority:1001
    Severity:0xc0032452c0}]
    
    on upgrades
    
    2) When we create the default deny ACLs for a namespace with at least
    one network policy, we name it "namespace_np-name". This doesn't make
    sense since the ACL is applicable to all the network policies in that
    namespace. The policy that get's created first becomes the lucky winner.
    This PR updates the names of default deny ACLs to
    "namespace_egressDefaultDeny" OR "namespace_ingressDefaultDeny" so that
    "we can stop being stupid" :) and stop errors like:

    2022-06-09T17:15:00.952174381Z E0609 17:15:00.952154       1 ovn.go:753]
    Failed to create network policy oit-ssi-fluentd/fluentd-input, error:
    failed to create default port groups and acls for policy:
    oit-ssi-fluentd/fluentd-input, error: unexpectedly found multiple
    equivalent ACLs: [{UUID:5b98f17d-789f-4de1-9beb-36741bfa40d1 Action:drop
    Direction:from-lport ExternalIDs:map[default-deny-policy-type:Egress]
    Label:0 Log:false Match:inport ==
    @a12933912868060780448_egressDefaultDeny Meter:0xc001388aa0
    Name:0xc001388ab0 Options:map[apply-after-lb:true] Priority:1000
    Severity:0xc001388ac0} {UUID:b9349cb8-99b0-4130-92cf-ab11b4874a11
    Action:drop Direction:from-lport
    ExternalIDs:map[default-deny-policy-type:Egress] Label:0 Log:false
    Match:inport == @a12933912868060780448_egressDefaultDeny
    Meter:0xc001388c90 Name:0xc001388ca0 Options:map[apply-after-lb:true]
    Priority:1000 Severity:0xc001388cb0}]
    
    (NOTE: not sure how the user ended up with two default ACLs in the same
    namespace, but they did!)
    
    Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
