### PR TITLE
Add EgressQoS DstCIDR kubebuilder validation

### DIFF
--- a/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
@@ -57,6 +57,7 @@ spec:
                         traffic heading to this CIDR will be marked with the DSCP
                         value. This field is optional, and in case it is not set the
                         rule is applied to all egress traffic regardless of the destination.
+                      format: cidr
                       type: string
                     podSelector:
                       description: PodSelector applies the QoS rule only to the pods

--- a/go-controller/pkg/crd/egressqos/v1/types.go
+++ b/go-controller/pkg/crd/egressqos/v1/types.go
@@ -59,6 +59,7 @@ type EgressQoSRule struct {
 	// This field is optional, and in case it is not set the rule is applied
 	// to all egress traffic regardless of the destination.
 	// +optional
+	// +kubebuilder:validation:Format="cidr"
 	DstCIDR *string `json:"dstCIDR,omitempty"`
 
 	// PodSelector applies the QoS rule only to the pods in the namespace whose label


### PR DESCRIPTION
This denies resources that specify an invalid cidr.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>

thanks @andreaskaris :)
