### PR TITLE
fix new added pod, its ovs port maybe deleted by staleOVSInterfaces c…

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -535,9 +535,13 @@ func (n *OvnNode) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	mgmtPort.CheckManagementPortHealth(mgmtPortConfig, n.stopChan)
 
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+		kclient, ok := n.Kube.(*kube.Kube)
+		if !ok {
+			return fmt.Errorf("cannot get kubeclient for starting check stale ovs interfaces")
+		}
 		// start health check to ensure there are no stale OVS internal ports
 		go wait.Until(func() {
-			checkForStaleOVSInterfaces(n.name, n.watchFactory.(*factory.WatchFactory))
+			checkForStaleOVSInterfaces(n.name, n.watchFactory.(*factory.WatchFactory), kclient.KClient)
 		}, time.Minute, n.stopChan)
 		err := n.WatchEndpoints()
 		if err != nil {


### PR DESCRIPTION
In the gap when the network link between ovnkube-node and apiserver is disconnected，a new pod is created；the list-watch former cannot get the new added pod because apiserver unreachable in this moment。
In function checkForStaleOVSRepresentorInterfaces，wf.GetPods("") fetch pods from cache without returning an error when apiserver unreachable，but the new added pod not in cache；cause the ovs interface to be deleted

Signed-off-by: xuhao <xuhao@cestc.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->