### PR TITLE
util: remove unused arping binary checking

### DIFF
--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -36,7 +36,6 @@ const (
 	ovnAppctlCommand   = "ovn-appctl"
 	ovsdbClientCommand = "ovsdb-client"
 	ovsdbToolCommand   = "ovsdb-tool"
-	arpingCommand      = "arping"
 	ipCommand          = "ip"
 	powershellCommand  = "powershell"
 	netshCommand       = "netsh"
@@ -164,7 +163,6 @@ type execHelper struct {
 	ovsdbToolPath   string
 	ovnRunDir       string
 	ipPath          string
-	arpingPath      string
 	powershellPath  string
 	netshPath       string
 	routePath       string
@@ -287,10 +285,6 @@ func SetExecWithoutOVS(exec kexec.Interface) error {
 		}
 	} else {
 		runner.ipPath, err = exec.LookPath(ipCommand)
-		if err != nil {
-			return err
-		}
-		runner.arpingPath, err = exec.LookPath(arpingCommand)
 		if err != nil {
 			return err
 		}
@@ -620,12 +614,6 @@ func RunOvsVswitchdAppCtl(args ...string) (string, string, error) {
 // RunIP runs a command via the iproute2 "ip" utility
 func RunIP(args ...string) (string, string, error) {
 	stdout, stderr, err := run(runner.ipPath, args...)
-	return strings.TrimSpace(stdout.String()), stderr.String(), err
-}
-
-// RunArping runs a command via the "arping" utility
-func RunArping(args ...string) (string, string, error) {
-	stdout, stderr, err := run(runner.arpingPath, args...)
 	return strings.TrimSpace(stdout.String()), stderr.String(), err
 }
 

--- a/go-controller/pkg/util/ovs_unit_test.go
+++ b/go-controller/pkg/util/ovs_unit_test.go
@@ -527,13 +527,13 @@ func TestSetExec(t *testing.T) {
 		{
 			desc:         "positive, test when 'runner' is nil",
 			expectedErr:  nil,
-			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil, "arping", nil}, CallTimes: 10},
+			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil}, CallTimes: 9},
 			setRunnerNil: true,
 		},
 		{
 			desc:         "positive, test when 'runner' is not nil",
 			expectedErr:  nil,
-			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", nil, "", nil}, CallTimes: 10},
+			onRetArgs:    &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", nil}, CallTimes: 9},
 			setRunnerNil: false,
 		},
 	}
@@ -560,14 +560,14 @@ func TestSetExecWithoutOVS(t *testing.T) {
 		onRetArgs   *ovntest.TestifyMockHelper
 	}{
 		{
-			desc:        "positive, ip and arping path found",
+			desc:        "positive, ip path found",
 			expectedErr: nil,
-			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil, "arping", nil}, CallTimes: 2},
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"ip", nil}, CallTimes: 1},
 		},
 		{
 			desc:        "negative, ip path not found",
 			expectedErr: fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`),
-			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`), "arping", nil}},
+			onRetArgs:   &ovntest.TestifyMockHelper{OnCallMethodName: "LookPath", OnCallMethodArgType: []string{"string"}, RetArgList: []interface{}{"", fmt.Errorf(`exec: \"ip:\" executable file not found in $PATH`)}},
 		},
 	}
 


### PR DESCRIPTION
We don't use it anywhere, and the code will error out if it doesn't exist, which is kinda pointless.