### PR TITLE
Add nil pointer check to destroyNetworkPolicy

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1272,7 +1272,7 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 	}
 	isLastPolicyInNamespace := len(nsInfo.networkPolicies) == expectedLastPolicyNum
 	if err := oc.destroyNetworkPolicy(np, isLastPolicyInNamespace); err != nil {
-		return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
+		return fmt.Errorf("failed to destroy network policy: %s/%s, err: %q", policy.Namespace, policy.Name, err)
 	}
 
 	delete(nsInfo.networkPolicies, policy.Name)
@@ -1283,6 +1283,9 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 // if nsInfo is provided, the entire port group will be deleted for ingress/egress directions
 // lastPolicy indicates if no other policies are using the respective portgroup anymore
 func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) error {
+	if np == nil {
+		return fmt.Errorf("failed to run destroyNetworkPolicy, received a nil pointer")
+	}
 	np.Lock()
 	defer np.Unlock()
 	np.deleted = true


### PR DESCRIPTION
If for any reason destroyNetworkPolicy is called with a nil pointer,
make sure to report such an error instead of causing a nil pointer
dereference exception. For example, this might happen if
deleteNetworkPolicy is fed a nil pointer network policy and if no entry
is found inside nsInfo for the policy.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->