### PR TITLE
Move egress firewall ACLs to port groups, change ACL priorities for Network Policy, Multicast and Egress Firewall

### DIFF
--- a/go-controller/pkg/ovn/acl.go
+++ b/go-controller/pkg/ovn/acl.go
@@ -1,0 +1,80 @@
+package ovn
+
+import (
+	"fmt"
+
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+
+	"k8s.io/klog/v2"
+)
+
+// GetNamespaceACLLogging retrieves ACL policy logging setting for the Namespace
+func (oc *Controller) GetNamespaceACLLogging(ns string) *ACLLoggingLevels {
+	nsInfo, nsUnlock := oc.getNamespaceLocked(ns, true)
+	if nsInfo == nil {
+		return &ACLLoggingLevels{
+			Allow: "",
+			Deny:  "",
+		}
+	}
+	defer nsUnlock()
+	return &nsInfo.aclLogging
+}
+
+func getLogSeverity(action string, aclLogging *ACLLoggingLevels) (log bool, severity string) {
+	severity = ""
+	if aclLogging != nil {
+		if action == nbdb.ACLActionAllow || action == nbdb.ACLActionAllowRelated || action == nbdb.ACLActionAllowStateless {
+			severity = aclLogging.Allow
+		} else if action == nbdb.ACLActionDrop || action == nbdb.ACLActionReject {
+			severity = aclLogging.Deny
+		}
+	}
+	log = severity != ""
+	return log, severity
+}
+
+func UpdateACLLoggingWithPredicate(nbClient libovsdbclient.Client, p func(*nbdb.ACL) bool, aclLogging *ACLLoggingLevels) error {
+	ACLs, err := libovsdbops.FindACLsWithPredicate(nbClient, p)
+	if err != nil {
+		return fmt.Errorf("unable to list ACLs with predicate, err: %v", err)
+	}
+	if len(ACLs) == 0 {
+		klog.Warningf("No ACLs to update")
+		return nil
+	}
+	for i := range ACLs {
+		// Set logging and severity
+		log, logSeverity := getLogSeverity(ACLs[i].Action, aclLogging)
+		libovsdbops.UpdateACLLogging(ACLs[i], logSeverity, log)
+	}
+	ops, err := libovsdbops.UpdateACLsLoggingOps(nbClient, nil, ACLs...)
+	if err != nil {
+		return fmt.Errorf("unable to get ACL logging ops: %v", err)
+	}
+	if _, err := libovsdbops.TransactAndCheck(nbClient, ops); err != nil {
+		return fmt.Errorf("unable to update ACL logging: %v", err)
+	}
+	return nil
+}
+
+func BuildACL(name string, direction nbdb.ACLDirection, priority int, match string, action nbdb.ACLAction,
+	logLevels *ACLLoggingLevels, externalIds map[string]string, options map[string]string) *nbdb.ACL {
+	log, logSeverity := getLogSeverity(action, logLevels)
+	ACL := libovsdbops.BuildACL(
+		name,
+		direction,
+		priority,
+		match,
+		action,
+		types.OvnACLLoggingMeter,
+		logSeverity,
+		log,
+		externalIds,
+		options,
+	)
+	return ACL
+}

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewallapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
 	kapi "k8s.io/api/core/v1"
@@ -25,6 +24,10 @@ import (
 const (
 	egressFirewallAppliedCorrectly = "EgressFirewall Rules applied"
 	egressFirewallAddError         = "EgressFirewall Rules not correctly added"
+	// egressFirewallPortGroupSuffix is the suffix used when creating
+	egressFirewallPortGroupSuffix = "egress_firewall"
+	// egressFirewallACLExtIdKey external ID key for egress firewall ACLs
+	egressFirewallACLExtIdKey = "egressFirewall"
 )
 
 type egressFirewall struct {
@@ -32,6 +35,7 @@ type egressFirewall struct {
 	name        string
 	namespace   string
 	egressRules []*egressFirewallRule
+	hasDNS      bool
 }
 
 type egressFirewallRule struct {
@@ -69,7 +73,6 @@ func newEgressFirewallRule(rawEgressFirewallRule egressfirewallapi.EgressFirewal
 	if rawEgressFirewallRule.To.DNSName != "" {
 		efr.to.dnsName = rawEgressFirewallRule.To.DNSName
 	} else {
-
 		_, _, err := net.ParseCIDR(rawEgressFirewallRule.To.CIDRSelector)
 		if err != nil {
 			return nil, err
@@ -81,139 +84,299 @@ func newEgressFirewallRule(rawEgressFirewallRule egressfirewallapi.EgressFirewal
 	return efr, nil
 }
 
-// This function is used to sync egress firewall setup. It does three "cleanups"
+func (oc *Controller) deleteLegacyACLsFromDb(egressFirewallACLs []*nbdb.ACL) error {
+	// egress firewall ACLs were moved from switches to port groups
+	// delete ACLs from all switches
+	p := func(item *nbdb.LogicalSwitch) bool {
+		return true
+	}
+	err := libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(oc.nbClient, p, egressFirewallACLs...)
+	if err != nil {
+		return fmt.Errorf("failed to remove ACLs from node logical switches: %v", err)
+	}
+	// Delete ACLs
+	err = libovsdbops.DeleteACLs(oc.nbClient, egressFirewallACLs...)
+	if err != nil {
+		return fmt.Errorf("failed to delete ACLs: %v", err)
+	}
+	return nil
+}
 
-// - 	Cleanup the old implementation (using LRP) in local GW mode -> new implementation (using ACLs) local GW mode
-//  	For this it just deletes all LRP setup done for egress firewall
-//  	And also convert all old ACLs which specifed from-lport to specifying to-lport
-
-// -	Cleanup the new local GW mode implementation (using ACLs on the node switch) -> shared GW mode implementation (using ACLs on the join switch)
-//  	For this it just deletes all ACL setup done for egress firewall on the node switches
-
-// -	Cleanup the old implementation (using LRP) in local GW mode -> shared GW mode implementation (using ACLs on the join switch)
-//  	For this it just deletes all LRP setup done for egress firewall
-
-// -    Cleanup for migration from shared GW mode -> local GW mode
-//      For this it just deletes all the ACLs on the distributed join switch
-
-// NOTE: Utilize the fact that we know that all egress firewall related setup must have a priority: types.MinimumReservedEgressFirewallPriority <= priority <= types.EgressFirewallStartPriority
+// This function is used to sync egress firewall setup. Egress firewall implementation had many versions,
+// the latest one makes no difference for gateway modes, and moves EF ACLs from switches to port groups.
+// Together with that, match was changed to use port_group and also priority range was changed to ensure
+// proper priorities between features using ACLs (multicast, network policy, egress firewall).
+// Therefore, the easiest way to sync egress firewalls is to delete the old rules and create them from scratch
+//
+// 1. Delete stale EF ACLs and their references from switches with deleteLegacyACLsFromDb function that knows old db structure
+// 2. Delete EFs that are not present in the k8s anymore
+// 3. Keep track of address sets referenced by EF ACLs, delete the ones that don't have references after ACL cleanup
+// This is required, because EgressDNS after restart doesn't know which address sets were created for dns entries before
+// 4. Cleanup the old implementation (using LRP) in local GW mode
+// For this it just deletes all LRP setup done for egress firewall
+//
 // Upon failure, it may be invoked multiple times in order to avoid a pod restart.
 func (oc *Controller) syncEgressFirewall(egressFirewalls []interface{}) error {
-	// Lookup all ACLs used for egress Firewalls
-	aclPred := func(item *nbdb.ACL) bool {
-		return item.Priority >= types.MinimumReservedEgressFirewallPriority && item.Priority <= types.EgressFirewallStartPriority
+	k8sEgressFirewalls := map[string]*egressfirewallapi.EgressFirewall{}
+	for _, efInterface := range egressFirewalls {
+		ef, ok := efInterface.(*egressfirewallapi.EgressFirewall)
+		if !ok {
+			return fmt.Errorf("spurious object in syncEgressFirewall: %v", efInterface)
+		}
+		k8sEgressFirewalls[ef.Namespace] = ef
 	}
-	egressFirewallACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, aclPred)
+	// remember all DNS address sets referenced by EF ACLs in the db before any cleanup
+	efAclPred := func(item *nbdb.ACL) bool {
+		return item.ExternalIDs[egressFirewallACLExtIdKey] != ""
+	}
+	egressFirewallACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, efAclPred)
 	if err != nil {
-		return fmt.Errorf("unable to list egress firewall ACLs, cannot cleanup old stale data, err: %v", err)
+		return fmt.Errorf("unable to find egress firewall ACLs, err: %v", err)
+	}
+	referencedASBefore := oc.getReferencedDNSAddressSets(egressFirewallACLs)
+
+	// find and delete legacy ACLs and their references.
+	// priority range for egress firewall was moved, but the ranges intersect.
+	// use the fact, that old ef ACL priority start at LegacyEgressFirewallStartPriority
+	// (skipping priorities was not possible before nodeSelector) and every old ef will have ACL with that priority.
+	// then find ef namespace, and try to recreate ef
+	staleEFAclPred := func(item *nbdb.ACL) bool {
+		_, ok := item.ExternalIDs[egressFirewallACLExtIdKey]
+		if !ok {
+			return false
+		}
+		return item.Priority == types.LegacyEgressFirewallStartPriority
+	}
+	egressFirewallACLs, err = libovsdbops.FindACLsWithPredicate(oc.nbClient, staleEFAclPred)
+	if err != nil {
+		return fmt.Errorf("unable to find stale egress firewall ACLs, err: %v", err)
 	}
 
 	if len(egressFirewallACLs) != 0 {
-		var p func(item *nbdb.LogicalSwitch) bool
-		if config.Gateway.Mode == config.GatewayModeShared {
-			p = func(item *nbdb.LogicalSwitch) bool {
-				// Ignore external and Join switches(both legacy and current)
-				return !(strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == "join" || strings.HasPrefix(item.Name, types.ExternalSwitchPrefix))
+		// only 1 ACL for an ef can be present here, because every ef can have no more than 1 rule with specified priority
+		// to allow applying this function again in case of error, fist save stale ACLs for ef
+		// then try to create new ACLs for it
+		// delete stale ACLs only if creating a new ones succeeds
+		for _, ef := range egressFirewallACLs {
+			if ns := ef.ExternalIDs[egressFirewallACLExtIdKey]; ns != "" {
+				// Find and save stale ACLs for a given egressFirewall
+				pACL := func(item *nbdb.ACL) bool {
+					return item.ExternalIDs[egressFirewallACLExtIdKey] == ns
+				}
+				staleACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, pACL)
+				if err != nil {
+					return fmt.Errorf("unable to find ACLs for stale egress firewall in namespace %s, err: %v", ns, err)
+				}
+				if _, ok := k8sEgressFirewalls[ns]; ok {
+					// ef still exists in k8s, update
+					klog.Infof("re-create stale egress firewall in namespace %s", ns)
+					// create new ACLs
+					// ensureEgressFirewall doesn't clean up db in case of error, so stale ACLs should stay
+					err = oc.ensureEgressFirewall(k8sEgressFirewalls[ns])
+					if err != nil {
+						return fmt.Errorf("failed to recreate stale egress firewall in namespace %s: %v", ns, err)
+					}
+					// delete saved stale ACLs only if update succeeds
+					err = oc.deleteLegacyACLsFromDb(staleACLs)
+					if err != nil {
+						return fmt.Errorf("failed to delete stale egress firewall in namespace %s: %v", ns, err)
+					}
+				} else {
+					klog.Infof("Delete stale egress firewall in namespace %s", ns)
+					// ef doesn't exist in k8s, just delete
+					err = oc.deleteLegacyACLsFromDb(staleACLs)
+					if err != nil {
+						return fmt.Errorf("failed to delete stale egress firewall in namespace %s: %v", ns, err)
+					}
+				}
 			}
-		} else if config.Gateway.Mode == config.GatewayModeLocal {
-			p = func(item *nbdb.LogicalSwitch) bool {
-				// Return only join switch (the per node ones if its old topology & distributed one if its new topology)
-				return (strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == "join")
-			}
-		}
-		err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(oc.nbClient, p, egressFirewallACLs...)
-		if err != nil {
-			return fmt.Errorf("failed to remove reject acl from node logical switches: %v", err)
 		}
 	}
 
-	// Update the direction of each egressFirewallACL if needed.
-	// Update the egressFirewallACL name if needed.
-	// Update logging related information if needed.
-	for i := range egressFirewallACLs {
-		egressFirewallACLs[i].Direction = types.DirectionToLPort
-		if namespace, ok := egressFirewallACLs[i].ExternalIDs["egressFirewall"]; ok && namespace != "" {
-			aclName := buildEgressFwAclName(namespace, egressFirewallACLs[i].Priority)
-			log, meterName, logSeverity := oc.getLogMeterSeverity(namespace, egressFirewallACLs[i].Action)
-			egressFirewallACLs[i].Meter = &meterName
-			egressFirewallACLs[i].Name = &aclName
-			egressFirewallACLs[i].Log = log
-			egressFirewallACLs[i].Severity = &logSeverity
-		} else {
-			klog.Warningf("Could not find namespace for egress firewall ACL during refresh operation: %v", egressFirewallACLs[i])
+	// delete egressFirewalls that are present in ovn but deleted from k8s
+	// represents the namespaces that have firewalls according to ovn
+	// don't touch default ACL for cluster network
+	klog.Infof("Sync egress firewalls")
+	egressFirewallACLs, err = libovsdbops.FindACLsWithPredicate(oc.nbClient, efAclPred)
+	if err != nil {
+		return fmt.Errorf("unable to find existing egress firewall ACLs, err: %v", err)
+	}
+	ovnEgressFirewalls := make(map[string]bool)
+	for _, egressFirewallACL := range egressFirewallACLs {
+		if ns := egressFirewallACL.ExternalIDs[egressFirewallACLExtIdKey]; ns != "" {
+			// Most egressFirewalls will have more than one ACL, but we only need to know if there is one for the namespace
+			// so a map is fine, and we will add an entry every iteration but because it is a map will overwrite the previous
+			// entry if it already existed
+			ovnEgressFirewalls[ns] = true
 		}
 	}
-	err = libovsdbops.CreateOrUpdateACLs(oc.nbClient, egressFirewallACLs...)
+
+	// delete entries from the map that exist in k8s and ovn
+	for k8sEgressFirewallNamespace := range k8sEgressFirewalls {
+		delete(ovnEgressFirewalls, k8sEgressFirewallNamespace)
+	}
+	// any that are left are spurious and should be cleaned up
+	if len(ovnEgressFirewalls) > 0 {
+		klog.Infof("Cleanup deleted egress firewalls: %+v", ovnEgressFirewalls)
+	}
+	for spuriousEF := range ovnEgressFirewalls {
+		// stale egressFirewalls should already be deleted/update on the previous step
+		// use deleteEgressFirewallFromDb that can only clear new-style egress firewalls
+		err := oc.deleteEgressFirewallFromDb(spuriousEF)
+		if err != nil {
+			return fmt.Errorf("cannot fully reconcile the state of egressfirewalls ACLs for namespace %s still exist in ovn db: %v", spuriousEF, err)
+		}
+	}
+
+	// now see which DNS address sets are references after cleanup
+	egressFirewallACLs, err = libovsdbops.FindACLsWithPredicate(oc.nbClient, efAclPred)
 	if err != nil {
-		return fmt.Errorf("unable to update ACL information (direction and logging) during resync operation, err: %v", err)
+		return fmt.Errorf("unable to find egress firewall ACLs after cleanup, err: %v", err)
+	}
+	referencedASAfter := oc.getReferencedDNSAddressSets(egressFirewallACLs)
+
+	// delete all DNS address sets that are not referenced anymore
+	for asName := range referencedASAfter {
+		delete(referencedASBefore, asName)
+	}
+	asPred := func(item *nbdb.AddressSet) bool {
+		for staleAsName := range referencedASBefore {
+			if item.Name == staleAsName {
+				return true
+			}
+		}
+		return false
+	}
+	klog.Infof("Deleting stale DNS address sets %v", referencedASBefore)
+	err = libovsdbops.DeleteAddressSetsWithPredicate(oc.nbClient, asPred)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup DNS address sets: %v", err)
 	}
 
 	// In any gateway mode, make sure to delete all LRPs on ovn_cluster_router.
 	// This covers migration from LGW mode that used LRPs for EFW to using ACLs in SGW/LGW modes
+	// Using Legacy priorities is safe, since this is applied to LRP Policy and not to ACLs
 	p := func(item *nbdb.LogicalRouterPolicy) bool {
-		return item.Priority <= types.EgressFirewallStartPriority && item.Priority >= types.MinimumReservedEgressFirewallPriority
+		return types.LegacyMinimumReservedEgressFirewallPriority <= item.Priority && item.Priority <= types.LegacyEgressFirewallStartPriority
 	}
 	err = libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, types.OVNClusterRouter, p)
 	if err != nil {
 		return fmt.Errorf("error deleting egress firewall policies on router %s: %v", types.OVNClusterRouter, err)
 	}
-
-	// sync the ovn and k8s egressFirewall states
-	// represents the namespaces that have firewalls according to  ovn
-	ovnEgressFirewalls := make(map[string]struct{})
-
-	for _, egressFirewallACL := range egressFirewallACLs {
-		if ns, ok := egressFirewallACL.ExternalIDs["egressFirewall"]; ok {
-			// Most egressFirewalls will have more then one ACL but we only need to know if there is one for the namespace
-			// so a map is fine and we will add an entry every iteration but because it is a map will overwrite the previous
-			// entry if it already existed
-			ovnEgressFirewalls[ns] = struct{}{}
-		}
-	}
-
-	// get all the k8s EgressFirewall Objects
-	egressFirewallList, err := oc.kube.GetEgressFirewalls()
-	if err != nil {
-		return fmt.Errorf("cannot reconcile the state of egressfirewalls in ovn database and k8s. err: %v", err)
-	}
-	// delete entries from the map that exist in k8s and ovn
-	for _, egressFirewall := range egressFirewallList.Items {
-		delete(ovnEgressFirewalls, egressFirewall.Namespace)
-	}
-	// any that are left are spurious and should be cleaned up
-	for spuriousEF := range ovnEgressFirewalls {
-		err := oc.deleteEgressFirewallRules(spuriousEF)
-		if err != nil {
-			return fmt.Errorf("cannot fully reconcile the state of egressfirewalls ACLs for namespace %s still exist in ovn db: %v", spuriousEF, err)
-		}
-	}
+	klog.Infof("Sync egress firewalls: done")
 	return nil
 }
 
-func (oc *Controller) addEgressFirewall(egressFirewall *egressfirewallapi.EgressFirewall) error {
-	klog.Infof("Adding egressFirewall %s in namespace %s", egressFirewall.Name, egressFirewall.Namespace)
+func (oc *Controller) getReferencedDNSAddressSets(egressFirewallACLs []*nbdb.ACL) map[string]bool {
+	usedASNames := map[string]bool{}
+	for _, acl := range egressFirewallACLs {
+		// address sets in match used as $<hashed as name>
+		// egress firewall only uses address sets for dns
+		asStartIdx := strings.Index(acl.Match, "$")
+		if asStartIdx >= 0 {
+			var hashedASName string
+			// address set match has a format "(ip<x>.dst == $<address set>)"
+			asEndIdx := strings.Index(acl.Match[asStartIdx+1:], ")")
+			if asEndIdx < 0 {
+				// shouldn't happen, just in case
+				hashedASName = acl.Match[asStartIdx+1:]
+			} else {
+				hashedASName = acl.Match[asStartIdx+1 : asStartIdx+1+asEndIdx]
+			}
+			usedASNames[hashedASName] = true
+		}
+	}
+	return usedASNames
+}
 
-	ef := cloneEgressFirewall(egressFirewall)
-	ef.Lock()
-	defer ef.Unlock()
-	// there should not be an item already in egressFirewall map for the given Namespace
-	if _, loaded := oc.egressFirewalls.Load(egressFirewall.Namespace); loaded {
-		return fmt.Errorf("error attempting to add egressFirewall %s to namespace %s when it already has an egressFirewall",
-			egressFirewall.Name, egressFirewall.Namespace)
+func (oc *Controller) disableEgressFirewall() error {
+	// delete all EF ACLs, port groups and DNS address sets
+	pACL := func(item *nbdb.ACL) bool {
+		return item.ExternalIDs[egressFirewallACLExtIdKey] != ""
+	}
+	egressFirewallACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, pACL)
+	if err != nil {
+		return fmt.Errorf("unable to list egress firewall ACLs, err: %v", err)
+	}
+	// find and delete all referenced address sets
+	referencedAS := oc.getReferencedDNSAddressSets(egressFirewallACLs)
+	asPred := func(item *nbdb.AddressSet) bool {
+		for staleAsName := range referencedAS {
+			if item.Name == staleAsName {
+				return true
+			}
+		}
+		return false
+	}
+	err = libovsdbops.DeleteAddressSetsWithPredicate(oc.nbClient, asPred)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup DNS address sets: %v", err)
+	}
+	// find and delete all EF port groups
+	var pgNames []string
+	for _, ef := range egressFirewallACLs {
+		if ns := ef.ExternalIDs[egressFirewallACLExtIdKey]; ns != "" {
+			pgNames = append(pgNames, getEgressFirewallPortGroupName(ns))
+		}
+	}
+	ops, err := libovsdbops.DeletePortGroupsOps(oc.nbClient, nil, pgNames...)
+	if err != nil {
+		return fmt.Errorf("unable to get deleting port group ops: %v", err)
 	}
 
+	// finally, delete all ACLs
+	ops, err = libovsdbops.DeleteACLsOps(oc.nbClient, ops, egressFirewallACLs...)
+	if err != nil {
+		return fmt.Errorf("unable to get deleting ACL ops: %v", err)
+	}
+
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	return err
+}
+
+// getEgressFirewallLocked loads egress firewall by namespace and locks it.
+// When errIfNotFound is false and egress firewall is not found, `nil, nil` will be returned
+// Egress Firewall can be unlocked just by calling Unlock() on returned object
+func (oc *Controller) getEgressFirewallLocked(namespace string, errIfNotFound bool) (*egressFirewall, error) {
+	obj, loaded := oc.egressFirewalls.Load(namespace)
+	if loaded {
+		ef, ok := obj.(*egressFirewall)
+		if !ok {
+			return nil, fmt.Errorf("type assertion to *egressFirewall failed for EgressFirewall in namespace %s",
+				namespace)
+		}
+		ef.Lock()
+		// make sure ef wasn't deleted while we waited for lock
+		if _, loaded = oc.egressFirewalls.Load(namespace); loaded {
+			return ef, nil
+		} else {
+			ef.Unlock()
+		}
+	}
+	// not found
+	if errIfNotFound {
+		return nil, fmt.Errorf("there is no egressFirewall found in namespace %s",
+			namespace)
+	} else {
+		return nil, nil
+	}
+}
+
+func (oc *Controller) ensureEgressFirewall(egressFirewallObj *egressfirewallapi.EgressFirewall) error {
+	klog.Infof("Adding egressFirewall %s in namespace %s", egressFirewallObj.Name, egressFirewallObj.Namespace)
+	ef := cloneEgressFirewall(egressFirewallObj)
 	var addErrors error
-	for i, egressFirewallRule := range egressFirewall.Spec.Egress {
+	for i, egressFirewallRule := range egressFirewallObj.Spec.Egress {
 		// process Rules into egressFirewallRules for egressFirewall struct
 		if i > types.EgressFirewallStartPriority-types.MinimumReservedEgressFirewallPriority {
 			klog.Warningf("egressFirewall for namespace %s has too many rules, the rest will be ignored",
-				egressFirewall.Namespace)
+				egressFirewallObj.Namespace)
 			break
 		}
 		efr, err := newEgressFirewallRule(egressFirewallRule, i)
 		if err != nil {
 			addErrors = errors.Wrapf(addErrors, "error: cannot create EgressFirewall Rule to destination %s for namespace %s - %v",
-				egressFirewallRule.To.CIDRSelector, egressFirewall.Namespace, err)
+				egressFirewallRule.To.CIDRSelector, egressFirewallObj.Namespace, err)
 			continue
 
 		}
@@ -223,56 +386,85 @@ func (oc *Controller) addEgressFirewall(egressFirewall *egressfirewallapi.Egress
 		return addErrors
 	}
 
-	// EgressFirewall needs to make sure that the address_set for the namespace exists independently of the namespace object
-	// so that OVN doesn't get unresolved references to the address_set.
-	// TODO: This should go away once we do something like refcounting for address_sets.
-	_, err := oc.addressSetFactory.EnsureAddressSet(egressFirewall.Namespace)
+	var ops []ovsdb.Operation
+	// err is used in defer, make sure not to reassign
+	var err error
+	var acls []*nbdb.ACL
+	var lsps []*nbdb.LogicalSwitchPort
+	// no db transactions for now, just build ops
+	pgName := getEgressFirewallPortGroupName(ef.namespace)
+	aclLoggingLevels := oc.GetNamespaceACLLogging(ef.namespace)
+	// create ACLs referencing port group first
+	if ops, acls, err = oc.updateEgressFirewallRulesOps(ef, pgName, types.EgressFirewallStartPriority, aclLoggingLevels, ops); err != nil {
+		return fmt.Errorf("error getting acls create ops: %v", err)
+	}
+	// lock and expose ef object before getting namespace ports for ef port group.
+	// newly added pods will hold that lock to update port group
+	ef.Lock()
+	defer ef.Unlock()
+	// there should not be an item already in egressFirewall map for the given Namespace
+	if obj, loaded := oc.egressFirewalls.LoadOrStore(egressFirewallObj.Namespace, ef); loaded {
+		existingEF, ok := obj.(*egressFirewall)
+		if !ok {
+			return fmt.Errorf("type assertion to *egressFirewall failed for EgressFirewall in namespace %s",
+				egressFirewallObj.Namespace)
+		}
+		if existingEF.name != ef.name {
+			return fmt.Errorf("error attempting to add egressFirewall %s to namespace %s when it already has an egressFirewall",
+				egressFirewallObj.Name, egressFirewallObj.Namespace)
+		}
+	}
+	defer func() {
+		if err != nil {
+			// no need to clear db, since it's the last operation in this function
+			_ = oc.cleanupEgressFirewall(ef, false, true)
+		}
+	}()
+
+	lsps, err = oc.getNamespacePorts(ef.namespace)
 	if err != nil {
-		return fmt.Errorf("cannot Ensure that addressSet for namespace %s exists %v", egressFirewall.Namespace, err)
+		return fmt.Errorf("failed to get logical ports for ns %s: %v", ef.namespace, err)
 	}
-	ipv4HashedAS, ipv6HashedAS := addressset.MakeAddressSetHashNames(egressFirewall.Namespace)
-	if err := oc.addEgressFirewallRules(ef, ipv4HashedAS, ipv6HashedAS, types.EgressFirewallStartPriority); err != nil {
-		return err
+	// now create port group with acls and ports
+	pg := libovsdbops.BuildPortGroup(pgName, getEgressFirewallPortGroupExternalIdName(ef.namespace), lsps, acls)
+	if ops, err = libovsdbops.CreateOrUpdatePortGroupsOps(oc.nbClient, ops, pg); err != nil {
+		return fmt.Errorf("error getting create port group ops: %v", err)
 	}
-	oc.egressFirewalls.Store(egressFirewall.Namespace, ef)
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	return err
+}
+
+func (oc *Controller) cleanupEgressFirewall(ef *egressFirewall, clearDb, ignoreErr bool) error {
+	if clearDb {
+		if err := oc.deleteEgressFirewallFromDb(ef.namespace); err != nil {
+			if ignoreErr {
+				klog.Warningf("Failed deleting egress firewall for namespace %s from db: %v", ef.namespace, err)
+			} else {
+				return err
+			}
+		}
+	}
+	if ef.hasDNS {
+		if err := oc.egressFirewallDNS.DeleteNamespace(ef.namespace); err != nil {
+			if ignoreErr {
+				klog.Warningf("Failed deleting DNS entries for ns %s: %v", ef.namespace, err)
+			} else {
+				return err
+			}
+		}
+	}
+	oc.egressFirewalls.Delete(ef.namespace)
 	return nil
 }
 
 func (oc *Controller) deleteEgressFirewall(egressFirewallObj *egressfirewallapi.EgressFirewall) error {
 	klog.Infof("Deleting egress Firewall %s in namespace %s", egressFirewallObj.Name, egressFirewallObj.Namespace)
-	deleteDNS := false
-	obj, loaded := oc.egressFirewalls.Load(egressFirewallObj.Namespace)
-	if !loaded {
-		return fmt.Errorf("there is no egressFirewall found in namespace %s",
-			egressFirewallObj.Namespace)
-	}
-
-	ef, ok := obj.(*egressFirewall)
-	if !ok {
-		return fmt.Errorf("deleteEgressFirewall failed: type assertion to *egressFirewall"+
-			" failed for EgressFirewall %s of type %T in namespace %s",
-			egressFirewallObj.Name, obj, egressFirewallObj.Namespace)
-	}
-
-	ef.Lock()
-	defer ef.Unlock()
-	for _, rule := range ef.egressRules {
-		if len(rule.to.dnsName) > 0 {
-			deleteDNS = true
-			break
-		}
-	}
-	if deleteDNS {
-		if err := oc.egressFirewallDNS.Delete(egressFirewallObj.Namespace); err != nil {
-			return err
-		}
-	}
-
-	if err := oc.deleteEgressFirewallRules(egressFirewallObj.Namespace); err != nil {
+	ef, err := oc.getEgressFirewallLocked(egressFirewallObj.Namespace, true)
+	if err != nil {
 		return err
 	}
-	oc.egressFirewalls.Delete(egressFirewallObj.Namespace)
-	return nil
+	defer ef.Unlock()
+	return oc.cleanupEgressFirewall(ef, true, false)
 }
 
 func (oc *Controller) updateEgressFirewallStatusWithRetry(egressfirewall *egressfirewallapi.EgressFirewall) error {
@@ -286,132 +478,166 @@ func (oc *Controller) updateEgressFirewallStatusWithRetry(egressfirewall *egress
 	return nil
 }
 
-func (oc *Controller) addEgressFirewallRules(ef *egressFirewall, hashedAddressSetNameIPv4, hashedAddressSetNameIPv6 string, efStartPriority int) error {
+func (oc *Controller) createDefaultACLs(namespace, portGroupName string, aclLogging *ACLLoggingLevels,
+	ops []ovsdb.Operation) ([]ovsdb.Operation, []*nbdb.ACL, error) {
+	var err error
+	// Management ports will be blocked by egress firewall rules.
+	// To block pod to node traffic in case such traffic is forbidden by egress firewall rules via node ips.
+	// The priority should be higher than EgressFirewallAllowClusterSubnetsPriority to exclude management ports
+	// from cluster subnets.
+	// All management ports are added to the ClusterPortGroupName when created, use it.
+	defaultDenyMgmtPortACL := BuildACL(
+		buildEgressFwAclName(namespace, types.EgressFirewallDenyMgmtPortsPriority),
+		nbdb.ACLDirectionFromLport,
+		types.EgressFirewallDenyMgmtPortsPriority,
+		fmt.Sprintf("outport == @%s && inport == @%s", types.ClusterPortGroupName, portGroupName),
+		nbdb.ACLActionDrop,
+		aclLogging,
+		map[string]string{egressFirewallACLExtIdKey: namespace},
+		map[string]string{"apply-after-lb": "true"},
+	)
+	acls := []*nbdb.ACL{defaultDenyMgmtPortACL}
+	ops, err = libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, ops, defaultDenyMgmtPortACL)
+	if err != nil {
+		return ops, acls, err
+	}
+	allowClusterSubnetACL := BuildACL(
+		buildEgressFwAclName(namespace, types.EgressFirewallAllowClusterSubnetsPriority),
+		nbdb.ACLDirectionFromLport,
+		types.EgressFirewallAllowClusterSubnetsPriority,
+		fmt.Sprintf("%s && inport == @%s", getDstClusterSubnetsMatch(), portGroupName),
+		nbdb.ACLActionAllowRelated,
+		aclLogging,
+		map[string]string{egressFirewallACLExtIdKey: namespace},
+		map[string]string{"apply-after-lb": "true"},
+	)
+	acls = append(acls, allowClusterSubnetACL)
+	ops, err = libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, ops, allowClusterSubnetACL)
+	if err != nil {
+		return ops, acls, err
+	}
+	return ops, acls, nil
+}
+
+func (oc *Controller) updateEgressFirewallRulesOps(ef *egressFirewall, portGroupName string, efStartPriority int,
+	aclLogging *ACLLoggingLevels, ops []ovsdb.Operation) ([]ovsdb.Operation, []*nbdb.ACL, error) {
+	var err error
+	var acls []*nbdb.ACL
+	var priority int
+	// create 2 default ACLs to handle clusterSubnet traffic first
+	ops, acls, err = oc.createDefaultACLs(ef.namespace, portGroupName, aclLogging, ops)
+	if err != nil {
+		return ops, acls, fmt.Errorf("failed to create default EF acls: %v", err)
+	}
+	dnsNames := map[string]bool{}
 	for _, rule := range ef.egressRules {
 		var action string
-		var matchTargets []matchTarget
+		var matchTar matchTarget
 		if rule.access == egressfirewallapi.EgressFirewallRuleAllow {
-			action = "allow"
+			action = nbdb.ACLActionAllowRelated
 		} else {
-			action = "drop"
+			action = nbdb.ACLActionDrop
 		}
 		if rule.to.cidrSelector != "" {
 			if utilnet.IsIPv6CIDRString(rule.to.cidrSelector) {
-				matchTargets = []matchTarget{{matchKindV6CIDR, rule.to.cidrSelector}}
+				matchTar = matchTarget{matchKindV6CIDR, rule.to.cidrSelector}
 			} else {
-				matchTargets = []matchTarget{{matchKindV4CIDR, rule.to.cidrSelector}}
+				matchTar = matchTarget{matchKindV4CIDR, rule.to.cidrSelector}
 			}
 		} else {
 			// rule based on DNS NAME
 			dnsNameAddressSets, err := oc.egressFirewallDNS.Add(ef.namespace, rule.to.dnsName)
 			if err != nil {
-				return fmt.Errorf("error with EgressFirewallDNS - %v", err)
+				return ops, acls, fmt.Errorf("error with EgressFirewallDNS - %v", err)
 			}
+			dnsNames[rule.to.dnsName] = true
 			dnsNameIPv4ASHashName, dnsNameIPv6ASHashName := dnsNameAddressSets.GetASHashNames()
 			if dnsNameIPv4ASHashName != "" {
-				matchTargets = append(matchTargets, matchTarget{matchKindV4AddressSet, dnsNameIPv4ASHashName})
+				matchTar = matchTarget{matchKindV4AddressSet, dnsNameIPv4ASHashName}
 			}
 			if dnsNameIPv6ASHashName != "" {
-				matchTargets = append(matchTargets, matchTarget{matchKindV6AddressSet, dnsNameIPv6ASHashName})
+				matchTar = matchTarget{matchKindV6AddressSet, dnsNameIPv6ASHashName}
 			}
 		}
-		match := generateMatch(hashedAddressSetNameIPv4, hashedAddressSetNameIPv6, matchTargets, rule.ports)
-		err := oc.createEgressFirewallRules(efStartPriority-rule.id, match, action, ef.namespace)
+		match := generateMatch(portGroupName, matchTar, rule.ports)
+		priority = efStartPriority - rule.id
+		// a name is needed for logging purposes - the name must be unique, so make it
+		// egressFirewall_<namespace name>_<priority>
+		aclName := buildEgressFwAclName(ef.namespace, priority)
+		egressFirewallACL := BuildACL(
+			aclName,
+			nbdb.ACLDirectionFromLport,
+			priority,
+			match,
+			action,
+			aclLogging,
+			map[string]string{egressFirewallACLExtIdKey: ef.namespace},
+			map[string]string{"apply-after-lb": "true"},
+		)
+		acls = append(acls, egressFirewallACL)
+		ops, err = libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, ops, egressFirewallACL)
 		if err != nil {
-			return err
+			return ops, acls, err
 		}
 	}
-	return nil
+
+	// now cleanup stale DNS
+	if len(dnsNames) > 0 {
+		// hasDNS is needed for cleanup on add failure
+		ef.hasDNS = true
+		if err = oc.egressFirewallDNS.UpdateNamespace(ef.namespace, dnsNames); err != nil {
+			return ops, acls, fmt.Errorf("update egress firewall (ns %s) ACLs failed: "+
+				"DNS entry cleanup failed: %v", ef.namespace, err)
+		}
+	}
+	// find and delete old ACLs with lower priorities that won't be updated
+	// the lowest priority for updated ef is saved in `priority` variable
+	staleEFAclPred := func(item *nbdb.ACL) bool {
+		id, ok := item.ExternalIDs[egressFirewallACLExtIdKey]
+		return ok && id == ef.namespace && item.Priority < priority
+	}
+	staleACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, staleEFAclPred)
+	if err != nil {
+		return ops, acls, fmt.Errorf("update egress firewall (ns %s) ACLs failed: "+
+			"cannot cleanup stale ACLs, err: %v", ef.namespace, err)
+	}
+	if len(staleACLs) > 0 {
+		ops, err = libovsdbops.DeleteACLsFromPortGroupOps(oc.nbClient, ops, getEgressFirewallPortGroupName(ef.namespace), staleACLs...)
+		if err != nil {
+			return ops, acls, fmt.Errorf("update egress firewall (ns %s) ACLs failed: "+
+				"unable to get deleting ACL from port group ops: %v", ef.namespace, err)
+		}
+		ops, err = libovsdbops.DeleteACLsOps(oc.nbClient, ops, staleACLs...)
+		if err != nil {
+			return ops, acls, fmt.Errorf("update egress firewall (ns %s) ACLs failed: "+
+				"unable to get deleting ACL ops: %v", ef.namespace, err)
+		}
+	}
+	return ops, acls, nil
 }
 
-// createEgressFirewallRules uses the previously generated elements and creates the
-// logical_router_policy/join_switch_acl for a specific egressFirewallRouter
-func (oc *Controller) createEgressFirewallRules(priority int, match, action, externalID string) error {
-	logicalSwitches := []string{}
-	if config.Gateway.Mode == config.GatewayModeLocal {
-		// Find all node switches
-		p := func(item *nbdb.LogicalSwitch) bool {
-			// Ignore external and Join switches(both legacy and current)
-			return !(strings.HasPrefix(item.Name, types.JoinSwitchPrefix) || item.Name == "join" || strings.HasPrefix(item.Name, types.ExternalSwitchPrefix))
-		}
-		nodeLocalSwitches, err := libovsdbops.FindLogicalSwitchesWithPredicate(oc.nbClient, p)
-		if err != nil {
-			return fmt.Errorf("unable to setup egress firewall ACLs on cluster nodes, err: %v", err)
-		}
-		for _, nodeLocalSwitch := range nodeLocalSwitches {
-			logicalSwitches = append(logicalSwitches, nodeLocalSwitch.Name)
-		}
-	} else {
-		logicalSwitches = append(logicalSwitches, types.OVNJoinSwitch)
-	}
-
-	// a name is needed for logging purposes - the name must be unique, so make it
-	// egressFirewall_<namespace name>_<priority>
-	aclName := buildEgressFwAclName(externalID, priority)
-	log, meter, severity := oc.getLogMeterSeverity(externalID, action)
-
-	egressFirewallACL := libovsdbops.BuildACL(
-		aclName,
-		types.DirectionToLPort,
-		priority,
-		match,
-		action,
-		meter,
-		severity,
-		log,
-		map[string]string{"egressFirewall": externalID},
-		nil,
-	)
-	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, egressFirewallACL)
+// deleteEgressFirewallFromDb delete egress firewall acls and port group
+func (oc *Controller) deleteEgressFirewallFromDb(externalID string) error {
+	// Delete port group
+	ops, err := libovsdbops.DeletePortGroupsOps(oc.nbClient, nil, getEgressFirewallPortGroupName(externalID))
 	if err != nil {
-		return fmt.Errorf("failed to create egressFirewall ACL %v: %v", egressFirewallACL, err)
+		return fmt.Errorf("unable to get deleting port group ops: %v", err)
 	}
-
-	for _, logicalSwitchName := range logicalSwitches {
-		ops, err = libovsdbops.AddACLsToLogicalSwitchOps(oc.nbClient, ops, logicalSwitchName, egressFirewallACL)
-		if err != nil {
-			return fmt.Errorf("failed to add egressFirewall ACL %v to switch %s: %v", egressFirewallACL, logicalSwitchName, err)
-		}
-	}
-
-	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-	if err != nil {
-		return fmt.Errorf("failed to transact egressFirewall ACL: %v", err)
-	}
-
-	return nil
-}
-
-// deleteEgressFirewallRules delete the specific logical router policy/join switch Acls
-func (oc *Controller) deleteEgressFirewallRules(externalID string) error {
 	// Find ACLs for a given egressFirewall
 	pACL := func(item *nbdb.ACL) bool {
-		return item.ExternalIDs["egressFirewall"] == externalID
+		return item.ExternalIDs[egressFirewallACLExtIdKey] == externalID
 	}
 	egressFirewallACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, pACL)
 	if err != nil {
 		return fmt.Errorf("unable to list egress firewall ACLs, cannot cleanup old stale data, err: %v", err)
 	}
-
-	if len(egressFirewallACLs) == 0 {
-		klog.Warningf("No egressFirewall ACLs to delete in ns: %s", externalID)
-		return nil
-	}
-
-	// delete egress firewall acls off any logical switch which has it
-	pSwitch := func(item *nbdb.LogicalSwitch) bool { return true }
-	err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(oc.nbClient, pSwitch, egressFirewallACLs...)
+	// Delete ACLs
+	ops, err = libovsdbops.DeleteACLsOps(oc.nbClient, ops, egressFirewallACLs...)
 	if err != nil {
-		return fmt.Errorf("failed to remove reject acl from logical switches: %v", err)
+		return fmt.Errorf("unable to get deleting ACL ops: %v", err)
 	}
-
-	// Manually remove the egressFirewall ACLs instead of relying on ovsdb garbage collection to do so
-	err = libovsdbops.DeleteACLs(oc.nbClient, egressFirewallACLs...)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	return err
 }
 
 type matchTarget struct {
@@ -451,47 +677,22 @@ func (m *matchTarget) toExpr() (string, error) {
 // generateMatch generates the "match" section of ACL generation for egressFirewallRules.
 // It is referentially transparent as all the elements have been validated before this function is called
 // sample output:
-// match=\"(ip4.dst == 1.2.3.4/32) && ip4.src == $testv4 && ip4.dst != 10.128.0.0/14\
-func generateMatch(ipv4Source, ipv6Source string, destinations []matchTarget, dstPorts []egressfirewallapi.EgressFirewallPort) string {
+// match=\"(ip4.dst == 1.2.3.4/32) && inport == @portGroup\
+// Be careful about updating match - getReferencedDNSAddressSets() depends on it for parsing address set name
+func generateMatch(inportPortGroup string, destination matchTarget, dstPorts []egressfirewallapi.EgressFirewallPort) string {
 	var src string
 	var dst string
-	var extraMatch string
-	switch {
-	case config.IPv4Mode && config.IPv6Mode:
-		src = fmt.Sprintf("(ip4.src == $%s || ip6.src == $%s)", ipv4Source, ipv6Source)
-	case config.IPv4Mode:
-		src = fmt.Sprintf("ip4.src == $%s", ipv4Source)
-	case config.IPv6Mode:
-		src = fmt.Sprintf("ip6.src == $%s", ipv6Source)
-	}
+	src = fmt.Sprintf("inport == @%s", inportPortGroup)
 
-	for _, entry := range destinations {
-		if entry.value == "" {
-			continue
-		}
-		ipDst, err := entry.toExpr()
-		if err != nil {
-			klog.Error(err)
-			continue
-		}
-		if dst == "" {
-			dst = ipDst
-		} else {
-			dst = strings.Join([]string{dst, ipDst}, " || ")
-		}
+	dst, err := destination.toExpr()
+	if err != nil {
+		klog.Error(err)
 	}
-
 	match := fmt.Sprintf("(%s) && %s", dst, src)
 	if len(dstPorts) > 0 {
 		match = fmt.Sprintf("%s && %s", match, egressGetL4Match(dstPorts))
 	}
-
-	if config.Gateway.Mode == config.GatewayModeLocal {
-		extraMatch = getClusterSubnetsExclusion()
-	} else {
-		extraMatch = fmt.Sprintf("inport == \"%s%s\"", types.JoinSwitchToGWRouterPrefix, types.OVNClusterRouter)
-	}
-	return fmt.Sprintf("%s && %s", match, extraMatch)
+	return match
 }
 
 // egressGetL4Match generates the rules for when ports are specified in an egressFirewall Rule
@@ -561,98 +762,85 @@ func egressGetL4Match(ports []egressfirewallapi.EgressFirewallPort) string {
 	return fmt.Sprintf("(%s)", l4Match)
 }
 
-func getClusterSubnetsExclusion() string {
-	var exclusion string
+func getDstClusterSubnetsMatch() string {
+	var match string
 	for _, clusterSubnet := range config.Default.ClusterSubnets {
-		if exclusion != "" {
-			exclusion += " && "
+		if match != "" {
+			match += " && "
 		}
 		if utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
-			exclusion += fmt.Sprintf("%s.dst != %s", "ip6", clusterSubnet.CIDR)
+			match += fmt.Sprintf("%s.dst == %s", "ip6", clusterSubnet.CIDR)
 		} else {
-			exclusion += fmt.Sprintf("%s.dst != %s", "ip4", clusterSubnet.CIDR)
+			match += fmt.Sprintf("%s.dst == %s", "ip4", clusterSubnet.CIDR)
 		}
 	}
-	return exclusion
+	return match
 }
 
 func getEgressFirewallNamespacedName(egressFirewall *egressfirewallapi.EgressFirewall) string {
 	return fmt.Sprintf("%v/%v", egressFirewall.Namespace, egressFirewall.Name)
 }
 
-// getLogMeterSeverity determines if logging shall be enabled for a given ACL, what the name of the meter is and the
-// severity level for logging.
-func (oc *Controller) getLogMeterSeverity(namespaceName, action string) (log bool, meter string, severity string) {
-	aclLogging := ""
-	// ok should always be true. However, to avoid nil pointer derefence panics here, it's
-	// best to add this verification and in the worst case to resort to sane default values.
-	if nsInfo, ok := oc.namespaces[namespaceName]; ok {
-		if action == "allow" || action == "allow-related" {
-			aclLogging = nsInfo.aclLogging.Allow
-		} else if action == "drop" || action == "drop-related" {
-			aclLogging = nsInfo.aclLogging.Deny
-		}
-	} else {
-		klog.Warningf("No nsInfo object found for namespace %s", namespaceName)
-	}
-	log = aclLogging != ""
-	severity = getACLLoggingSeverity(aclLogging)
-	meter = types.OvnACLLoggingMeter
-
-	return
-}
-
-// refreshEgressFirewallLogging updates logging related configuration for all rules of this specific firewall in OVN.
+// updateACLLoggingForEgressFirewall updates logging related configuration for all rules of this specific firewall in OVN.
 // This method can be called for example from the Namespaces Watcher methods to reload firewall rules' logging  when
 // namespace annotations change.
 // Return values are: bool - if the egressFirewall's ACL was updated or not, error in case of errors. If a namespace
 // does not contain an egress firewall ACL, then this returns false, nil instead of a NotFound error.
-func (oc *Controller) refreshEgressFirewallLogging(egressFirewallNamespace string) (bool, error) {
+func (oc *Controller) updateACLLoggingForEgressFirewall(egressFirewallNamespace string, nsInfo *namespaceInfo) (bool, error) {
 	// Retrieve the egress firewall object from cache and lock it.
-	obj, loaded := oc.egressFirewalls.Load(egressFirewallNamespace)
-	if !loaded {
+	ef, err := oc.getEgressFirewallLocked(egressFirewallNamespace, false)
+	if err != nil {
+		return false, err
+	}
+	if ef == nil {
 		return false, nil
 	}
-
-	ef, ok := obj.(*egressFirewall)
-	if !ok {
-		return false, fmt.Errorf("refreshEgressFirewallLogging failed: type assertion to *egressFirewall"+
-			" failed for EgressFirewall of type %T in namespace %s",
-			obj, ef.namespace)
-	}
-
-	ef.Lock()
 	defer ef.Unlock()
 
-	// Find ACLs for a given egressFirewall
+	// Predicate for given egress firewall ACLs
 	p := func(item *nbdb.ACL) bool {
-		return item.ExternalIDs["egressFirewall"] == ef.namespace
+		return item.ExternalIDs[egressFirewallACLExtIdKey] == ef.namespace
 	}
-	egressFirewallACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
-	if err != nil {
-		return false, fmt.Errorf("unable to list egress firewall ACLs, err: %v", err)
-	}
-	if len(egressFirewallACLs) == 0 {
-		klog.Warningf("No egressFirewall ACLs to update in ns: %s", ef.namespace)
-		return false, nil
-	}
-
-	for i := range egressFirewallACLs {
-		// Set logging and severity
-		log, meterName, logSeverity := oc.getLogMeterSeverity(ef.namespace, egressFirewallACLs[i].Action)
-		egressFirewallACLs[i].Log = log
-		egressFirewallACLs[i].Severity = &logSeverity
-		egressFirewallACLs[i].Meter = &meterName
-	}
-	// CreateOrUpdateACLs will update all provided (non zero value) fields
-	err = libovsdbops.CreateOrUpdateACLs(oc.nbClient, egressFirewallACLs...)
-	if err != nil {
+	if err := UpdateACLLoggingWithPredicate(oc.nbClient, p, &nsInfo.aclLogging); err != nil {
 		return false, fmt.Errorf("unable to update ACL logging in ns %s, err: %v", ef.namespace, err)
 	}
-
 	return true, nil
+}
+
+func (oc *Controller) podAddEgressFirewall(namespace, portUUID string, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+	ef, _ := oc.getEgressFirewallLocked(namespace, false)
+	if ef != nil {
+		defer ef.Unlock()
+		var err error
+		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, getEgressFirewallPortGroupName(namespace), portUUID)
+		if err != nil {
+			return ops, fmt.Errorf("failed to get add ports to port group ops: %v", err)
+		}
+	}
+	return ops, nil
+}
+
+func (oc *Controller) podDeleteEgressFirewall(namespace, portUUID string, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+	ef, _ := oc.getEgressFirewallLocked(namespace, false)
+	if ef != nil {
+		defer ef.Unlock()
+		var err error
+		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, getEgressFirewallPortGroupName(namespace), portUUID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ops, nil
 }
 
 func buildEgressFwAclName(namespace string, priority int) string {
 	return fmt.Sprintf("egressFirewall_%s_%d", namespace, priority)
+}
+
+func getEgressFirewallPortGroupName(ns string) string {
+	return hashedPortGroup(ns) + "_" + egressFirewallPortGroupSuffix
+}
+
+func getEgressFirewallPortGroupExternalIdName(ns string) string {
+	return ns + "_" + egressFirewallPortGroupSuffix
 }

--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -400,7 +400,7 @@ func TestDelete(t *testing.T) {
 				}
 			}
 			_, dnsResolves, _ := res.getDNSEntry(tc.dnsName)
-			res.Delete("addNamespace")
+			res.DeleteNamespace("addNamespace")
 			for stay, timeout := true, time.After(10*time.Second); stay; {
 				_, dnsResolves, _ = res.getDNSEntry(tc.dnsName)
 				if dnsResolves == nil {

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
@@ -305,7 +304,7 @@ func (gp *gressPolicy) delNamespaceAddressSet(name string) bool {
 // buildLocalPodACLs builds the ACLs that implement the gress policy's rules to the
 // given Port Group (which should contain all pod logical switch ports selected
 // by the parent NetworkPolicy)
-func (gp *gressPolicy) buildLocalPodACLs(portGroupName, aclLogging string) []*nbdb.ACL {
+func (gp *gressPolicy) buildLocalPodACLs(portGroupName string, aclLogging *ACLLoggingLevels) []*nbdb.ACL {
 	l3Match := gp.getL3MatchFromAddressSet()
 	var lportMatch string
 	var cidrMatches []string
@@ -358,8 +357,8 @@ func (gp *gressPolicy) buildLocalPodACLs(portGroupName, aclLogging string) []*nb
 	return acls
 }
 
-// buildACLAllow builds an allow-related ACL for a given given match
-func (gp *gressPolicy) buildACLAllow(match, l4Match string, ipBlockCIDR int, aclLogging string) *nbdb.ACL {
+// buildACLAllow builds an allow-related ACL for a given match
+func (gp *gressPolicy) buildACLAllow(match, l4Match string, ipBlockCIDR int, aclLogging *ACLLoggingLevels) *nbdb.ACL {
 	var direction string
 	var options map[string]string
 	if gp.policyType == knet.PolicyTypeIngress {
@@ -396,8 +395,7 @@ func (gp *gressPolicy) buildACLAllow(match, l4Match string, ipBlockCIDR int, acl
 		policyTypeACLExtIdKey:  string(gp.policyType),
 		policyTypeNum:          policyTypeIndex,
 	}
-
-	acl := libovsdbops.BuildACL(aclName, direction, priority, match, action, types.OvnACLLoggingMeter, getACLLoggingSeverity(aclLogging), aclLogging != "", externalIds, options)
+	acl := BuildACL(aclName, direction, priority, match, action, aclLogging, externalIds, options)
 	return acl
 }
 

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -802,7 +802,7 @@ func (oc *Controller) addResource(objectsToRetry *retryObjs, obj interface{}, fr
 	case factory.EgressFirewallType:
 		var err error
 		egressFirewall := obj.(*egressfirewall.EgressFirewall).DeepCopy()
-		if err = oc.addEgressFirewall(egressFirewall); err != nil {
+		if err = oc.ensureEgressFirewall(egressFirewall); err != nil {
 			egressFirewall.Status.Status = egressFirewallAddError
 		} else {
 			egressFirewall.Status.Status = egressFirewallAppliedCorrectly
@@ -990,6 +990,9 @@ func (oc *Controller) updateResource(objectsToRetry *retryObjs, oldObj, newObj i
 		oldCloudPrivateIPConfig := oldObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
 		newCloudPrivateIPConfig := newObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
 		return oc.reconcileCloudPrivateIPConfig(oldCloudPrivateIPConfig, newCloudPrivateIPConfig)
+	case factory.EgressFirewallType:
+		newEF := newObj.(*egressfirewall.EgressFirewall)
+		return oc.ensureEgressFirewall(newEF)
 	}
 
 	return fmt.Errorf("no update function for object type %s", objectsToRetry.oType)
@@ -1446,12 +1449,12 @@ func (oc *Controller) WatchResource(objectsToRetry *retryObjs) (*factory.Handler
 	addHandlerFunc, err := oc.watchFactory.GetResourceHandlerFunc(objectsToRetry.oType)
 	if err != nil {
 		return nil, fmt.Errorf("no resource handler function found for resource %v. "+
-			"Cannot watch this resource.", objectsToRetry.oType)
+			"Cannot watch this resource", objectsToRetry.oType)
 	}
 	syncFunc, err := oc.getSyncResourcesFunc(objectsToRetry)
 	if err != nil {
 		return nil, fmt.Errorf("no sync function found for resource %v. "+
-			"Cannot watch this resource.", objectsToRetry.oType)
+			"Cannot watch this resource", objectsToRetry.oType)
 	}
 
 	// create the actual watcher

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -43,33 +43,38 @@ const (
 
 	NodeLocalSwitch = "node_local_switch"
 
-	// ACL directions
-	DirectionToLPort   = "to-lport"
-	DirectionFromLPort = "from-lport"
-
 	// ACL Priorities
 
-	// Default routed multicast allow acl rule priority
-	DefaultRoutedMcastAllowPriority = 1013
 	// Default multicast allow acl rule priority
-	DefaultMcastAllowPriority = 1012
+	DefaultMcastAllowPriority = 9112
 	// Default multicast deny acl rule priority
-	DefaultMcastDenyPriority = 1011
+	DefaultMcastDenyPriority = 9111
 	// Default allow acl rule priority
-	DefaultAllowPriority = 1001
+	DefaultAllowPriority = 9101
 	// Default deny acl rule priority
-	DefaultDenyPriority = 1000
+	DefaultDenyPriority = 9100
+	//Egress Firewall acl rule priority
+	EgressFirewallDenyMgmtPortsPriority       = 9002
+	EgressFirewallAllowClusterSubnetsPriority = 9001
+	EgressFirewallStartPriority               = 9000
+	MinimumReservedEgressFirewallPriority     = 1000
+
+	//Legacy ACL priorities
+	LegacyDefaultMcastAllowPriority             = 1012
+	LegacyDefaultMcastDenyPriority              = 1011
+	LegacyDefaultAllowPriority                  = 1001
+	LegacyDefaultDenyPriority                   = 1000
+	LegacyEgressFirewallStartPriority           = 10000
+	LegacyMinimumReservedEgressFirewallPriority = 2000
 
 	// priority of logical router policies on the OVNClusterRouter
-	EgressFirewallStartPriority           = 10000
-	MinimumReservedEgressFirewallPriority = 2000
-	MGMTPortPolicyPriority                = "1005"
-	NodeSubnetPolicyPriority              = "1004"
-	InterNodePolicyPriority               = "1003"
-	HybridOverlaySubnetPriority           = 1002
-	HybridOverlayReroutePriority          = 501
-	DefaultNoRereoutePriority             = 101
-	EgressIPReroutePriority               = 100
+	MGMTPortPolicyPriority       = "1005"
+	NodeSubnetPolicyPriority     = "1004"
+	InterNodePolicyPriority      = "1003"
+	HybridOverlaySubnetPriority  = 1002
+	HybridOverlayReroutePriority = 501
+	DefaultNoRereoutePriority    = 101
+	EgressIPReroutePriority      = 100
 
 	V6NodeLocalNATSubnet           = "fd99::/64"
 	V6NodeLocalNATSubnetPrefix     = 64

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1837,7 +1837,7 @@ spec:
 		if err == nil {
 			framework.Failf("Succeeded in connecting the implicitly denied remote host %s from container %s on node %s", exFWDenyTcpDnsDest, ovnContainer, serverNodeInfo.name)
 		}
-		// Verify the the explicitly allowed host/port tcp port 80 rule is functional
+		// Verify the explicitly allowed host/port tcp port 80 rule is functional
 		ginkgo.By(fmt.Sprintf("Verifying connectivity to an explicitly allowed host %s is permitted as defined by the external firewall policy", exFWPermitTcpWwwDest))
 		_, err = framework.RunKubectl(f.Namespace.Name, "exec", srcPodName, testContainerFlag, "--", "nc", "-vz", "-w", testTimeout, exFWPermitTcpWwwDest, "80")
 		if err != nil {


### PR DESCRIPTION
Change priorities for all ACLs to ensure the following priority order:
    1. Multicast Priority
    2. Network Policy (Default Allow/Deny) Priority
    3. Allow all service traffic priority
    4. Egress firewall Priority
    
Egress firewall refactoring:
1. Same implementation for shared and local gw mode
2. For every egress firewall
  - create port group with all pods from the namespace
  (pods will add themselves to that port group with ef lock)
  - add default ACL to always allow cluster subnets traffic
  - add default ACL to deny management port with the highest
  ef ACL priority
  - apply ef ACLs to the port group and add match `inport=@<portgroup>`
3. Change addEgressFirewall to ensureEgressFirewall that can update
given egress firewall with appropriate cleanup
4. Use ensureEgressFirewall as OnUpdate for egress firewall
5. Add dns address sets to all cleanup functions

    
Other changes:
- Move getNamespacePorts functionality from policy.go to pods.go,
use this function for network policy and egress firewall.
- Use nbdb constants instead of strings.
- Unify ACL logging setup (ovn/acl.go).
- Remove default ACL severity, use nil to reset.
- Add cleanup when egress firewall is disabled.
- Simplify egress firewall generateMatch, since only 1 destination can be
used per 1 rule.
 
Add e2e test for egress firewall
1. to verify inbound connections are allowed
2. to verify local traffic is not affected by egress firewall,
but hostNetwork pods are affected.