### PR TITLE
Improve memory efficiency when checking stale VF representor

### DIFF
--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -172,7 +172,7 @@ func checkForStaleOVSInternalPorts() {
 func checkForStaleOVSRepresentorInterfaces(nodeName string, wf factory.ObjectCacheInterface) {
 	// Get all ovn-kuberntes Pod interfaces. these are OVS interfaces that have their external_ids:sandbox set.
 	out, stderr, err := util.RunOVSVsctl("--columns=name,external_ids", "--data=bare", "--no-headings",
-		"--format=csv", "find", "Interface", "external_ids:sandbox!=\"\"")
+		"--format=csv", "find", "Interface", "external_ids:sandbox!=\"\"", "external_ids:vf-netdev-name!=\"\"")
 	if err != nil {
 		klog.Errorf("Failed to list ovn-k8s OVS interfaces:, stderr: %q, error: %v", stderr, err)
 		return
@@ -231,10 +231,6 @@ func checkForStaleOVSRepresentorInterfaces(nodeName string, wf factory.ObjectCac
 
 	// Remove any stale representor ports
 	for _, ifaceInfo := range interfaceInfos {
-		// ignore non-vf representor ports
-		if _, ok := ifaceInfo.Attributes["vf-netdev-name"]; !ok {
-			continue
-		}
 		ifaceId, ok := ifaceInfo.Attributes["iface-id"]
 		if !ok {
 			klog.Warningf("iface-id attribute was not found for OVS interface %s. "+

--- a/go-controller/pkg/node/healthcheck_test.go
+++ b/go-controller/pkg/node/healthcheck_test.go
@@ -34,7 +34,7 @@ func genDeleteStaleRepPortCmd(iface string) string {
 
 func genFindInterfaceWithSandboxCmd() string {
 	return fmt.Sprintf("ovs-vsctl --timeout=15 --columns=name,external_ids --data=bare --no-headings " +
-		"--format=csv find Interface external_ids:sandbox!=\"\"")
+		"--format=csv find Interface external_ids:sandbox!=\"\" external_ids:vf-netdev-name!=\"\"")
 }
 
 var _ = Describe("Healthcheck tests", func() {


### PR DESCRIPTION
checkForStaleOVSRepresentorInterfaces was found to run
in non-SRIOV deployment which causes memory spike every
minute with extra 512kB memory allocated in the heap.
This could be a problem when running ovnk in a small
form factor deployment.

The following is observed via pprof:
512.14kB 14.17% 57.50%   512.14kB 14.17%  github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node.checkForStaleOVSRepresentorInterfaces

this commit filters "ovs-vsctl find" output with "vf-netdev-name"
external-ids so it takes much less memory in non-SRIOV case.

Signed-off-by: Zenghui Shi <zshi@redhat.com>
