### PR TITLE
Fix pod retries

### DIFF
--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -1,6 +1,7 @@
 package addressset
 
 import (
+	"k8s.io/klog/v2"
 	"net"
 	"strings"
 	"sync"
@@ -149,7 +150,21 @@ func (f *FakeAddressSetFactory) ExpectAddressSetWithIPs(name string, ips []strin
 			gomega.Expect(as4.ips).To(gomega.HaveKey(ip))
 		}
 	}
+	if lenAddressSet != len(ips) {
+		var addrs []string
+		if as4 != nil {
+			for _, v := range as4.ips {
+				addrs = append(addrs, v.String())
+			}
+		}
+		if as6 != nil {
+			for _, v := range as6.ips {
+				addrs = append(addrs, v.String())
+			}
+		}
 
+		klog.Errorf("IPv4 addresses mismatch in cache: %#v, expected: %#v", addrs, ips)
+	}
 	gomega.Expect(lenAddressSet).To(gomega.Equal(len(ips)))
 }
 

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"context"
 	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"net"
 	"time"
 
@@ -830,6 +831,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 				connCtx, cancel := context.WithTimeout(context.Background(), t.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOVN.controller.nbClient)
+				fakeOVN.controller.retryPods.setRetryObjWithNoBackoff(key)
 				fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
 
 				// ACL should be removed from switches after egfw is deleted
@@ -957,7 +959,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 				// sleep long enough for TransactWithRetry to fail, causing egress firewall Add to fail
 				time.Sleep(t.OVSDBTimeout + time.Second)
 				// check to see if the retry cache has an entry for this egress firewall
-				key := getEgressFirewallNamespacedName(egressFirewall)
+				key, err := getResourceKey(factory.EgressFirewallType, egressFirewall)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(func() *retryObjEntry {
 					return fakeOVN.controller.retryEgressFirewalls.getObjRetryEntry(key)
 				}).ShouldNot(gomega.BeNil())
@@ -968,7 +971,9 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 				gomega.Expect(retryEntry.oldObj).NotTo(gomega.BeNil())
 				connCtx, cancel := context.WithTimeout(context.Background(), t.OVSDBTimeout)
 				defer cancel()
+				ginkgo.By("bringing up NBDB and requesting retry of entry")
 				resetNBClient(connCtx, fakeOVN.controller.nbClient)
+				fakeOVN.controller.retryEgressFirewalls.setRetryObjWithNoBackoff(key)
 				fakeOVN.controller.retryEgressFirewalls.requestRetryObjs()
 				// check the cache no longer has the entry
 				gomega.Eventually(func() *retryObjEntry {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -635,6 +635,8 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
+				fakeOvn.controller.retryEgressNodes.setRetryObjWithNoBackoff(key1)
+				fakeOvn.controller.retryEgressNodes.setRetryObjWithNoBackoff(key2)
 				fakeOvn.controller.retryEgressNodes.requestRetryObjs()
 				// check the cache no longer has the entry
 				gomega.Eventually(func() *retryObjEntry {
@@ -1653,6 +1655,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
+				fakeOvn.controller.retryEgressIPPods.setRetryObjWithNoBackoff(key)
 				fakeOvn.controller.retryEgressIPPods.requestRetryObjs()
 				// check the cache no longer has the entry
 				gomega.Eventually(func() *retryObjEntry {
@@ -2256,6 +2259,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
+				fakeOvn.controller.retryPods.setRetryObjWithNoBackoff(key)
 				fakeOvn.controller.retryEgressIPs.requestRetryObjs()
 				// check the cache no longer has the entry
 				gomega.Eventually(func() *retryObjEntry {

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1401,7 +1401,7 @@ func (oc *Controller) addUpdateNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) err
 					continue
 				}
 				klog.V(5).Infof("Adding pod %s/%s to retryPods", pod.Namespace, pod.Name)
-				oc.retryPods.addRetryObjWithAdd(&pod)
+				oc.retryPods.addRetryObjWithAddNoBackoff(&pod)
 			}
 			oc.retryPods.requestRetryObjs()
 		}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1292,6 +1292,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			defer cancel()
 			ginkgo.By("bring up NBDB")
 			resetNBClient(connCtx, clusterController.nbClient)
+			clusterController.retryNodes.setRetryObjWithNoBackoff(node1.Name)
 			clusterController.retryNodes.requestRetryObjs() // retry the failed entry
 			ginkgo.By("should be no retry entry after update completes")
 			gomega.Eventually(func() *retryObjEntry {
@@ -1440,6 +1441,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Expect(retryEntry.oldObj).NotTo(gomega.BeNil())
 			// allocate subnet to allow delete to continue
 			gomega.Expect(clusterController.masterSubnetAllocator.AddNetworkRange(subnet, 24)).To(gomega.Succeed())
+			clusterController.retryNodes.setRetryObjWithNoBackoff(node1.Name)
 			clusterController.retryNodes.requestRetryObjs() // retry the failed entry
 
 			gomega.Eventually(func() *retryObjEntry {

--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -679,7 +679,7 @@ func (oc *Controller) addResource(objectsToRetry *retryObjs, obj interface{}, fr
 		}
 
 		if err = oc.addNetworkPolicy(np); err != nil {
-			klog.Infof("Network Policy retry delete failed for %s/%s, will try again later: %v",
+			klog.Infof("Network Policy add failed for %s/%s, will try again later: %v",
 				np.Namespace, np.Name, err)
 			return err
 		}
@@ -705,7 +705,7 @@ func (oc *Controller) addResource(objectsToRetry *retryObjs, obj interface{}, fr
 		}
 
 		if err = oc.addUpdateNodeEvent(node, nodeParams); err != nil {
-			klog.Infof("Node retry delete failed for %s, will try again later: %v",
+			klog.Infof("Node add failed for %s, will try again later: %v",
 				node.Name, err)
 			return err
 		}
@@ -744,7 +744,7 @@ func (oc *Controller) addResource(objectsToRetry *retryObjs, obj interface{}, fr
 		// on existing pods so we can't be holding the lock at this point
 		podHandler, err := oc.WatchResource(retryPeerPods)
 		if err != nil {
-			klog.Errorf("Failed WatchResource for PeerNamespaceAndPodSelectorTypeVar: %v", err)
+			klog.Errorf("Failed WatchResource for PeerNamespaceAndPodSelectorType: %v", err)
 			return err
 		}
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1438,6 +1438,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
+				fakeOvn.controller.retryPods.setRetryObjWithNoBackoff(key)
 				fakeOvn.controller.retryNetworkPolicies.requestRetryObjs()
 
 				gressPolicy2ExpectedData := npTest.getPolicyData(networkPolicy2, []string{nPodTest.portUUID}, nil, []int32{portNum + 1}, nbdb.ACLSeverityInfo, false)
@@ -2445,6 +2446,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
+				fakeOvn.controller.retryPods.setRetryObjWithNoBackoff(key)
 				fakeOvn.controller.retryNetworkPolicies.requestRetryObjs()
 
 				eventuallyExpectNoAddressSets(fakeOvn, networkPolicy)


### PR DESCRIPTION
Includes multiple fixes for pod retries:

1. When disable-snat-multiple-gateways is true, we need to get l3 gateway info of a node when we addLogicalPort (to add the SNAT entry). However, we were requesting the pod to be retried during node add, before the l3gateway config had been validated. This would end up requesting a pod to be retried from the node handler, which would end up failing anyway due to lack of l3gateway config.

2. Fixes for various error logs that were wrong.
3. When the node was requesting immediate retry of pods for a node, it was actually signalling to retry all pods on the entire cluster that were in the retry cache. This is now fixed so that only the requested pods are immediately retried, while the backoff is respected for all other pods during the next retry iteration.