### PR TITLE
Add single-node config option

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -307,6 +307,9 @@ type KubernetesConfig struct {
 	HostNetworkNamespace string `gcfg:"host-network-namespace"`
 	PlatformType         string `gcfg:"platform-type"`
 
+	// SingeNode indicates the cluster only has one node
+	SingleNode bool `gcfg:"single-node"`
+
 	// CompatMetricsBindAddress is overridden by the corresponding option in MetricsConfig
 	CompatMetricsBindAddress string `gcfg:"metrics-bind-address"`
 	// CompatOVNMetricsBindAddress is overridden by the corresponding option in MetricsConfig
@@ -959,6 +962,12 @@ var K8sFlags = []cli.Flag{
 			"Valid values can be found in: https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/vendor/github.com/openshift/api/config/v1/types_infrastructure.go#L130-L172",
 		Destination: &cliConfig.Kubernetes.PlatformType,
 		Value:       Kubernetes.PlatformType,
+	},
+	&cli.BoolFlag{
+		Name: "single-node",
+		Usage: "Enable single node optimizations. " +
+			"Single node indicates a one node cluster and simplifies ovn-kubernetes feature logic to reduce overall cpu and memory footprints which are required in small form factor deployment",
+		Destination: &cliConfig.Kubernetes.SingleNode,
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -148,6 +148,7 @@ tokenFile=/path/to/token
 cacert=/path/to/kubeca.crt
 service-cidrs=172.18.0.0/24
 no-hostsubnet-nodes=label=another-test-label
+single-node=true
 
 [metrics]
 bind-address=1.1.1.1:8080
@@ -285,6 +286,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal(DefaultAPIServer))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.16.1.0/24"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal(""))
+			gomega.Expect(Kubernetes.SingleNode).To(gomega.Equal(false))
 			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal(""))
 			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal(""))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
@@ -563,6 +565,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/path/to/token"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://1.2.3.4:6443"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.18.0.0/24"))
+			gomega.Expect(Kubernetes.SingleNode).To(gomega.Equal(true))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.132.0.0/14"), 23},
 			}))
@@ -646,6 +649,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://4.4.3.2:8080"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.15.0.0/24"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal("test=pass"))
+			gomega.Expect(Kubernetes.SingleNode).To(gomega.Equal(true))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.130.0.0/15"), 24},
 			}))
@@ -732,6 +736,7 @@ var _ = Describe("Config Operations", func() {
 			"-ovn-metrics-bind-address=2.2.2.3:8081",
 			"-export-ovs-metrics=false",
 			"-metrics-enable-pprof=false",
+			"-single-node=false",
 			"-ofctrl-wait-before-clear=5000",
 			"-metrics-enable-config-duration=true",
 			"-egressip-reachability-total-timeout=5",

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -146,6 +147,10 @@ func (c *addressManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) {
 					c.OnChanged()
 				}
 			case <-addressSyncTimer.C:
+				// skip periodic sync since there is no egress or ingress IP rotation in single node
+				if config.Kubernetes.SingleNode {
+					continue
+				}
 				if subscribed {
 					klog.V(5).Info("Node IP manager calling sync() explicitly")
 					c.sync()


### PR DESCRIPTION
Single node indicates a one node cluster and allows to
simplify ovn-kubernetes feature logic to reduce overall
cpu and memory footprints which are required in small
form factor deployment.
    
This change enable future work to have optimized logic
for single node ovnk deployment.