### PR TITLE
Share eventRecorder when both master & node specified

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 	"time"
 
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
@@ -219,6 +220,7 @@ func runOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	wg := &sync.WaitGroup{}
 	var watchFactory factory.Shutdownable
 	var masterWatchFactory *factory.WatchFactory
+	var masterEventRecorder record.EventRecorder
 	if master != "" {
 		var err error
 		// create factory and start the controllers asked for
@@ -240,8 +242,9 @@ func runOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 		// register prometheus metrics that do not depend on becoming ovnkube-master leader
 		metrics.RegisterMasterBase()
 
+		masterEventRecorder = util.EventRecorder(ovnClientset.KubeClient)
 		ovnController := ovn.NewOvnController(ovnClientset, masterWatchFactory, stopChan, nil,
-			libovsdbOvnNBClient, libovsdbOvnSBClient, util.EventRecorder(ovnClientset.KubeClient))
+			libovsdbOvnNBClient, libovsdbOvnSBClient, masterEventRecorder)
 		if err := ovnController.Start(master, wg, ctx.Context, cancel); err != nil {
 			return err
 		}
@@ -249,6 +252,8 @@ func runOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 
 	if node != "" {
 		var nodeWatchFactory factory.NodeWatchFactory
+		var nodeEventRecorder record.EventRecorder
+
 		if masterWatchFactory == nil {
 			var err error
 			nodeWatchFactory, err = factory.NewNodeWatchFactory(ovnClientset, node)
@@ -258,6 +263,12 @@ func runOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 			watchFactory = nodeWatchFactory
 		} else {
 			nodeWatchFactory = masterWatchFactory
+		}
+
+		if masterEventRecorder == nil {
+			nodeEventRecorder = util.EventRecorder(ovnClientset.KubeClient)
+		} else {
+			nodeEventRecorder = masterEventRecorder
 		}
 
 		if config.Kubernetes.Token == "" {
@@ -270,7 +281,7 @@ func runOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 		if err != nil {
 			return fmt.Errorf("cannot initialize libovsdb SB client: %v", err)
 		}
-		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, sbClient, stopChan, util.EventRecorder(ovnClientset.KubeClient))
+		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, sbClient, stopChan, nodeEventRecorder)
 		if err := n.Start(ctx.Context, wg); err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -48,11 +49,15 @@ func newControllerWithDBSetup(dbSetup libovsdbtest.TestSetup) (*serviceControlle
 	}
 	client := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+	recorder := record.NewFakeRecorder(10)
+
 	controller := NewController(client,
 		nbClient,
 		informerFactory.Core().V1().Services(),
 		informerFactory.Discovery().V1().EndpointSlices(),
 		informerFactory.Core().V1().Nodes(),
+		recorder,
 	)
 	controller.servicesSynced = alwaysReady
 	controller.endpointSlicesSynced = alwaysReady

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -266,7 +266,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 	if addressSetFactory == nil {
 		addressSetFactory = addressset.NewOvnAddressSetFactory(libovsdbOvnNBClient)
 	}
-	svcController, svcFactory := newServiceController(ovnClient.KubeClient, libovsdbOvnNBClient)
+	svcController, svcFactory := newServiceController(ovnClient.KubeClient, libovsdbOvnNBClient, recorder)
 	return &Controller{
 		client: ovnClient.KubeClient,
 		kube: &kube.Kube{
@@ -789,7 +789,7 @@ func shouldUpdate(node, oldNode *kapi.Node) (bool, error) {
 	return true, nil
 }
 
-func newServiceController(client clientset.Interface, nbClient libovsdbclient.Client) (*svccontroller.Controller, informers.SharedInformerFactory) {
+func newServiceController(client clientset.Interface, nbClient libovsdbclient.Client, recorder record.EventRecorder) (*svccontroller.Controller, informers.SharedInformerFactory) {
 	// Create our own informers to start compartmentalizing the code
 	// filter server side the things we don't care about
 	noProxyName, err := labels.NewRequirement("service.kubernetes.io/service-proxy-name", selection.DoesNotExist, nil)
@@ -816,6 +816,7 @@ func newServiceController(client clientset.Interface, nbClient libovsdbclient.Cl
 		svcFactory.Core().V1().Services(),
 		svcFactory.Discovery().V1().EndpointSlices(),
 		svcFactory.Core().V1().Nodes(),
+		recorder,
 	)
 
 	return controller, svcFactory


### PR DESCRIPTION
eventRecorder creates both incoming and outgoing queues
with same length (1000), this commit saves ovnk memory
by approriately 2000*Event bytes.

Signed-off-by: Zenghui Shi <zshi@redhat.com>
