### PR TITLE
Build all ovnk binaries with cgo disabled

### DIFF
--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -23,11 +23,7 @@ build_binaries() {
     set -x
     for bin in "$@"; do
         binbase=$(basename ${bin})
-        CGO_ENABLED=1
-        if [ "$binbase" = "ovn-k8s-cni-overlay" ]; then
-            CGO_ENABLED=0
-        fi
-        env CGO_ENABLED=$CGO_ENABLED go build -v \
+        env CGO_ENABLED=0 go build -v \
             -mod vendor \
             -gcflags "${GCFLAGS}" \
             -ldflags "-B ${BUILDID} \


### PR DESCRIPTION
remove runtime dependencies for c libraries

Signed-off-by: Zenghui Shi <zshi@redhat.com>
