### PR TITLE
Fix flaky egress IP test

### DIFF
--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -1493,7 +1493,7 @@ func (oc *Controller) WatchResource(objectsToRetry *retryObjs) (*factory.Handler
 						objectsToRetry.oType, err)
 					return
 				}
-				klog.V(5).Infof("Update event received for resource %s, old object is equal to new: %s",
+				klog.V(5).Infof("Update event received for resource %s, old object is equal to new: %t",
 					objectsToRetry.oType, areEqual)
 				if areEqual {
 					return


### PR DESCRIPTION
Fix flaky test: using EgressNode retry should re-assign EgressIPs andperform proper OVN transactions when pod is created after node egress label switch

In `OVN master EgressIP Operations/using EgressNode retry should re-assign EgressIPs and perform proper OVN transactions when pod is created after node egress label switch` test we are using a sleep to wait for TransactWithRetry timeout.
There is a chance that both egressnode events(node1 removal and node2 update) will end up in the same event queue which means we need to wait double the time.

Addresses: https://github.com/ovn-org/ovn-kubernetes/issues/2988
Signed-off-by: Patryk Diak <pdiak@redhat.com>