### PR TITLE
[hybrid-overlay] Forward routes for link-local addresses to vNIC in Windows

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_windows.go
@@ -141,6 +141,11 @@ func ensureBaseNetwork() error {
 	if err = DuplicatePersistentIPRoutes(); err != nil {
 		return fmt.Errorf("unable to refresh the persistent IP routes, error: %v", err)
 	}
+	// Duplicate link-local addresses to the newly created host vNIC
+	klog.Infof("Forwarding routes associated with link-local addresses in the physical interface to the vNIC")
+	if err = DuplicateLinkLocalIPRoutes(); err != nil {
+		return fmt.Errorf("unable to refresh the link-local IP routes, error: %v", err)
+	}
 
 	return nil
 }

--- a/go-controller/hybrid-overlay/pkg/controller/overlay_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/overlay_windows.go
@@ -266,30 +266,53 @@ func EnsureExistingNetworkIsValid(networkName string, expectedAddressPrefix stri
 	return nil
 }
 
-func DuplicatePersistentIPRoutes() error {
+// duplicateIPv4Routes duplicates all the IPv4 network routes associated with the physical interface to the host vNIC,
+// where parameters policyStore and destinationPrefix are optional and could be used as filtering criteria.
+// Otherwise, all IPv4 routes will be forwarded from the physical interface to the host vNIC.
+func duplicateIPv4Routes(policyStore, destinationPrefix string) error {
 	shell, err := ps.New(&psBackend.Local{})
 	if err != nil {
 		return err
 	}
 	defer shell.Exit()
 
+	// build filter options for Get-NetRoute command. See https://docs.microsoft.com/en-us/powershell/module/nettcpip/get-netroute
+	var opts string
+	if policyStore != "" {
+		opts += fmt.Sprintf(" -PolicyStore %s", policyStore)
+	}
+	if destinationPrefix != "" {
+		opts += fmt.Sprintf(" -DestinationPrefix \"%s\"", destinationPrefix)
+	}
+
 	script := `
 	# Find physical adapters whose interfaces are bound to a vswitch (i.e. the MAC addresses match)
 	$boundAdapters = (Get-NetAdapter -Physical | where { (Get-NetAdapter -Name "*vEthernet*").MacAddress -eq $_.MacAddress })
 
-	# Forward all the persistent routes associated with the physical interface to the associated vNIC
+	# Forward all the matching routes associated with the physical interface to the associated vNIC
 	foreach ($boundAdapter in $boundAdapters) {
 		$associatedVNic = Get-NetAdapter -Name "*vEthernet*" | where { $_.MacAddress -eq $boundAdapter.MacAddress }
-		$routes = Get-NetRoute -PolicyStore PersistentStore -InterfaceIndex $boundAdapter.IfIndex -ErrorAction SilentlyContinue
+		$routes = Get-NetRoute` + opts + ` -AddressFamily IPv4 -InterfaceIndex $boundAdapter.IfIndex -ErrorAction SilentlyContinue
 		foreach ($route in $routes) {
-			netsh.exe int ipv4 add route interface=$($associatedVNic.ifIndex) prefix=$($route.DestinationPrefix) nexthop=$($route.NextHop) metric=$($route.RouteMetric) store=persistent
+			netsh.exe int ipv4 add route interface=$($associatedVNic.ifIndex) prefix=$($route.DestinationPrefix) nexthop=$($route.NextHop) metric=$($route.RouteMetric) store=$($route.PolicyStore)
 		}
 	}
 	`
 
 	if _, stderr, err := shell.Execute(script + "\r\n\r\n"); err != nil {
-		return fmt.Errorf("falied to refresh the network persistent routes, %v: %v", stderr, err)
+		return fmt.Errorf("falied to duplicate network routes to the associated vNIC, %v: %v", stderr, err)
 	}
 
 	return nil
+}
+
+func DuplicatePersistentIPRoutes() error {
+	return duplicateIPv4Routes("PersistentStore", "")
+}
+
+// DuplicateLinkLocalIPRoutes copies the routes for link-local addresses, that is 169.254.0.0/16 (169.254.0.0
+// through 169.254.255.255) for IPv4, that used to be on the physical network interface to the newly created host vNIC
+// See https://datatracker.ietf.org/doc/html/rfc3927
+func DuplicateLinkLocalIPRoutes() error {
+	return duplicateIPv4Routes("", "169.254.")
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->
**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Before, AWS EC2 initial instance boot used [EC2Launch](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch.html#ec2launch-tasks) to set `persistent` static routes to reach the [metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html). With [EC2Launch v2](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2.html) the routes to reach the metadata service are set as `non-persistent` static routes, making the [DuplicatePersistentIPRoutes](https://github.com/ovn-org/ovn-kubernetes/blob/fadfcd6112b4207c8fafacf8e719f2806d9bb421/go-controller/hybrid-overlay/pkg/controller/overlay_windows.go#L269) function an instruction that specifies no operation since there are no persistent routes in the Windows instance.

The new EC2Launch v2 is the default launch agent for all Windows AMIs since the `2022.05.05` release. See [AWS Windows AMI version history](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-windows-ami-version-history.html).

The Windows Machine Config Operator ([WMCO](https://github.com/openshift/windows-machine-config-operator)) consumes the metadata service to fetch the EC2 instance name, to properly configure the Windows node.

This PR ensures the EC2 metadata service is available in the host vNIC, by adding a new step in the configuration process of the base network in hybrid-overlay for Windows to forward all the routes that match link-local addresses from the physical network interface to the newly created vNIC. The link-local addresses subnet for IPv4 is 169.254.0.0/16. See https://datatracker.ietf.org/doc/html/rfc3927

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
For hybrid-overlay in Windows:
- overlay_windows.go: Add a function to copy the routes for link-local addresses from the physical network interface to the newly created host vNIC.
- node_windows.go: Log information and invoke the function to forward the routes to link-local addresses, after the duplication of the persistent IP routes.


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Run the following PowerShell cmdlet to verify the default routes in a Windows instance include the link-local addresses.
```
PS C:\> Get-NetRoute
```
Sample output showing the route with a link-local address for the [AWS EC2 instance metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)

```
ifIndex DestinationPrefix                              NextHop                                  RouteMetric ifMetric PolicyStore
------- -----------------                              -------                                  ----------- -------- -----------
5       169.254.169.254/32                             10.0.128.1                                        15 15       ActiveStore
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Routes for link-local addresses are now forwarded to the vNIC in Windows