### PR TITLE
iterateRetryResources: Lock the entry in the loop

### DIFF
--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -1258,6 +1258,7 @@ func (oc *Controller) iterateRetryResources(r *retryObjs) {
 	var kObj interface{}
 	var err error
 	for objKey, entry := range r.entries {
+		entry.Lock()
 		// check if we need to create the object
 		if entry.newObj != nil {
 			// get the latest version of the object from the informer;
@@ -1277,6 +1278,7 @@ func (oc *Controller) iterateRetryResources(r *retryObjs) {
 		}
 		klog.Infof("Gathered %v resource %s for retry", r.oType, objKey)
 		localRetryEntries = append(localRetryEntries, &localRetryEntry{objKey, entry.newObj, entry.oldObj, kObj})
+		entry.Unlock()
 	}
 	r.retryMutex.Unlock()
 


### PR DESCRIPTION
We weren't locking individual entries while looping through
them, this was causing races when same entry was changed or
accessed elsewhere in the code.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
Closes: #3080

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->