### PR TITLE
Cleanup ACL UUID references from switch or port group when deleting ACL

### DIFF
--- a/go-controller/pkg/libovsdbops/portgroup.go
+++ b/go-controller/pkg/libovsdbops/portgroup.go
@@ -1,10 +1,25 @@
 package libovsdbops
 
 import (
+	"context"
+
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
+
+type portGroupPredicate func(group *nbdb.PortGroup) bool
+
+// FindPortGroupsWithPredicate looks up port groups from the cache based on a
+// given predicate
+func FindPortGroupsWithPredicate(nbClient libovsdbclient.Client, p portGroupPredicate) ([]*nbdb.PortGroup, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	defer cancel()
+	found := []*nbdb.PortGroup{}
+	err := nbClient.WhereCache(p).List(ctx, &found)
+	return found, err
+}
 
 // BuildPortGroup builds a port group referencing the provided ports and ACLs
 func BuildPortGroup(hashName, name string, ports []*nbdb.LogicalSwitchPort, acls []*nbdb.ACL) *nbdb.PortGroup {

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -398,15 +398,10 @@ func (oc *Controller) deleteEgressFirewallRules(externalID string) error {
 		return nil
 	}
 
-	// delete egress firewall acls off any logical switch which has it
+	// delete egress firewall acls off any logical switch which has it,
+	// then manually remove the egressFirewall ACLs instead of relying on ovsdb garbage collection to do so
 	pSwitch := func(item *nbdb.LogicalSwitch) bool { return true }
-	err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(oc.nbClient, pSwitch, egressFirewallACLs...)
-	if err != nil {
-		return fmt.Errorf("failed to remove reject acl from logical switches: %v", err)
-	}
-
-	// Manually remove the egressFirewall ACLs instead of relying on ovsdb garbage collection to do so
-	err = libovsdbops.DeleteACLs(oc.nbClient, egressFirewallACLs...)
+	err = libovsdbops.DeleteACLs(oc.nbClient, nil, pSwitch, egressFirewallACLs...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To make sure we don't forget about that, add port group and switch refs
to DeleteACLs as args. UUIDs don't need to be cleaned up only if
port group or switch is completely deleted.
Update all DeleteACLs calls to cleanup refs.

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>
