### PR TITLE
master: don't list node pods on add/update unless necessary

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1389,27 +1389,27 @@ func (oc *Controller) addUpdateNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) err
 	// ensure pods that already exist on this node have their logical ports created
 	// if per pod SNAT is being used, then l3 gateway config is required to be able to add pods
 	if _, gwFailed := oc.gatewaysFailed.Load(node.Name); !gwFailed || !config.Gateway.DisableSNATMultipleGWs {
-		options := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector("spec.nodeName", node.Name).String()}
-		pods, err := oc.client.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
-		if err != nil {
-			klog.Errorf("Unable to list existing pods on node: %s, existing pods on this node may not function")
-		} else if nSyncs.syncNode || nSyncs.syncGw { // do this only if it is a new node add or a gateway sync happened
-			klog.V(5).Infof("When adding node %s, found %d pods to add to retryPods", node.Name, len(pods.Items))
-			for _, pod := range pods.Items {
-				pod := pod
-				if util.PodCompleted(&pod) {
-					continue
+		if nSyncs.syncNode || nSyncs.syncGw { // do this only if it is a new node add or a gateway sync happened
+			options := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector("spec.nodeName", node.Name).String()}
+			pods, err := oc.client.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
+			if err != nil {
+				errs = append(errs, err)
+				klog.Errorf("Unable to list existing pods on node: %s, existing pods on this node may not function")
+			} else {
+				klog.V(5).Infof("When adding node %s, found %d pods to add to retryPods", node.Name, len(pods.Items))
+				for _, pod := range pods.Items {
+					pod := pod
+					if util.PodCompleted(&pod) {
+						continue
+					}
+					klog.V(5).Infof("Adding pod %s/%s to retryPods", pod.Namespace, pod.Name)
+					oc.retryPods.addRetryObjWithAddNoBackoff(&pod)
 				}
-				klog.V(5).Infof("Adding pod %s/%s to retryPods", pod.Namespace, pod.Name)
-				oc.retryPods.addRetryObjWithAddNoBackoff(&pod)
 			}
 			oc.retryPods.requestRetryObjs()
 		}
 	}
 
-	if len(errs) == 0 {
-		return nil
-	}
 	return kerrors.NewAggregate(errs)
 }
 


### PR DESCRIPTION
Instead of always listing all pods on a node even when we don't use
the result, just list them if we are going to iterate the pods to
ensure they are set up.

This fixes a performance regression where ovnkube-master puts more
pressure on the apiserver/etcd when node update events occur.

@tssurya @trozet @jtaleric