### PR TITLE
Fix possible retryEntry deadlock in iterateRetryResources

### DIFF
--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -1272,6 +1272,7 @@ func (oc *Controller) iterateRetryResources(r *retryObjs) {
 				} else {
 					klog.Errorf("Failed to look up %s %s in the informers cache,"+
 						" will retry later: %v", r.oType, objKey, err)
+					entry.Unlock()
 					continue
 				}
 			}


### PR DESCRIPTION
Randomly found this during debugging unit test failures

Introduced here https://github.com/ovn-org/ovn-kubernetes/pull/3081