### PR TITLE
Fix retry_obj retryMutex vs retryEntry.Mutex deadlocks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 env:
-  GO_VERSION: 1.17.6
+  GO_VERSION: 1.18.4
   REGISTRY: ghcr.io 
   OWNER: ovn-org
   REPOSITORY: ovn-kubernetes 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 */12 * * *'
 
 env:
-  GO_VERSION: "1.17.6"
+  GO_VERSION: "1.18.4"
   K8S_VERSION: v1.24.0
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.17.6"
+  GO_VERSION: "1.18.4"
   K8S_VERSION: v1.24.0
   KIND_CLUSTER_NAME: ovn
   KIND_INSTALL_INGRESS: true

--- a/README_MANUAL.md
+++ b/README_MANUAL.md
@@ -26,8 +26,8 @@ this repository. To compile it, you will need golang installed.  You can
 install golang with:
 
 ```
-wget -nv https://go.dev/dl/go1.17.6.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz
+wget -nv https://go.dev/dl/go1.18.4.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.18.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -9,7 +9,7 @@ PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
 TEST_REPORT_DIR?=$(CURDIR)/_artifacts
 export TEST_REPORT_DIR
-GO_VERSION ?= 1.17.6
+GO_VERSION ?= 1.18.4
 GO_DOCKER_IMG = quay.io/giantswarm/golang:${GO_VERSION}
 # CONTAINER_RUNNABLE determines if the tests can be run inside a container. It checks to see if
 # podman/docker is installed on the system.

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/ovn-org/ovn-kubernetes/go-controller
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Mellanox/sriovnet v1.0.3

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -304,9 +304,9 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/j-keck/arping v1.0.2 h1:hlLhuXgQkzIJTZuhMigvG/CuSkaspeaD9hRDk2zuiMI=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -486,7 +486,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
@@ -960,7 +959,6 @@ k8s.io/code-generator v0.24.0/go.mod h1:dpVhs00hTuTdTY6jvVxvTFCk6gSMrtfRydbhZwHI
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/gengo v0.0.0-20211129171323-c02415ce4185/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
-k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92 h1:PgoMI/L1Nu5Vmvgm+vGheLuxKST8h6FMOqggyAFtHPc=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -392,6 +392,9 @@ func (oc *Controller) deletePodGWRoutesForNamespace(pod *kapi.Pod, namespace str
 	if err := oc.deleteGWRoutesForNamespace(namespace, foundGws.gws); err != nil {
 		// add the entry back to nsInfo for retrying later
 		nsInfo, nsUnlock := oc.getNamespaceLocked(namespace, false)
+		if nsInfo == nil {
+			return fmt.Errorf("failed to get nsInfo %s to add back all the gw routes: %w", namespace, err)
+		}
 		// we add back all the gw routes as we don't know which specific route for which pod error-ed out
 		nsInfo.routingExternalPodGWs[podGWKey] = foundGws
 		nsUnlock()

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -622,19 +622,17 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				time.Sleep(2 * (types.OVSDBTimeout + time.Second))
 				// check to see if the retry cache has an entry
 				key1 := node1.Name
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressNodes.getObjRetryEntry(key1)
-				}).ShouldNot(gomega.BeNil())
-				retryEntry := fakeOvn.controller.retryEgressNodes.getObjRetryEntry(key1)
+				checkRetryObjectEventually(key1, true, fakeOvn.controller.retryEgressNodes)
+				retryEntry, found := getRetryObj(key1, fakeOvn.controller.retryEgressNodes)
+				gomega.Expect(found).To(gomega.BeTrue())
 				ginkgo.By("retry entry new obj be nil")
 				gomega.Expect(retryEntry.newObj).To(gomega.BeNil())
 				ginkgo.By("retry entry old obj should not be nil")
 				gomega.Expect(retryEntry.oldObj).NotTo(gomega.BeNil())
 				key2 := node2.Name
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressNodes.getObjRetryEntry(key2)
-				}).ShouldNot(gomega.BeNil())
-				retryEntry = fakeOvn.controller.retryEgressNodes.getObjRetryEntry(key2)
+				checkRetryObjectEventually(key2, true, fakeOvn.controller.retryEgressNodes)
+				retryEntry, found = getRetryObj(key2, fakeOvn.controller.retryEgressNodes)
+				gomega.Expect(found).To(gomega.BeTrue())
 				ginkgo.By("retry entry new obj should not be nil")
 				gomega.Expect(retryEntry.newObj).NotTo(gomega.BeNil())
 				ginkgo.By("retry entry config should not be nil")
@@ -642,16 +640,12 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
-				fakeOvn.controller.retryEgressNodes.setRetryObjWithNoBackoff(key1)
-				fakeOvn.controller.retryEgressNodes.setRetryObjWithNoBackoff(key2)
-				fakeOvn.controller.retryEgressNodes.requestRetryObjs()
+				setRetryObjWithNoBackoff(key1, fakeOvn.controller.retryEgressNodes)
+				setRetryObjWithNoBackoff(key2, fakeOvn.controller.retryEgressNodes)
+				fakeOvn.controller.retryEgressNodes.RequestRetryObjs()
 				// check the cache no longer has the entry
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressNodes.getObjRetryEntry(key1)
-				}).Should(gomega.BeNil())
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressNodes.getObjRetryEntry(key2)
-				}).Should(gomega.BeNil())
+				checkRetryObjectEventually(key1, false, fakeOvn.controller.retryEgressNodes)
+				checkRetryObjectEventually(key2, false, fakeOvn.controller.retryEgressNodes)
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				gomega.Eventually(nodeSwitch).Should(gomega.Equal(node2.Name))
 				egressIPs, _ = getEgressIPStatus(egressIPName)
@@ -1651,10 +1645,11 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				time.Sleep(types.OVSDBTimeout + time.Second)
 				// check to see if the retry cache has an entry
 				key := getNamespacedName(podUpdate.Namespace, podUpdate.Name)
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressIPPods.getObjRetryEntry(key)
-				}, inspectTimeout).ShouldNot(gomega.BeNil())
-				retryEntry := fakeOvn.controller.retryEgressIPPods.getObjRetryEntry(key)
+				gomega.Eventually(func() bool {
+					return checkRetryObj(key, fakeOvn.controller.retryEgressIPPods)
+				}, inspectTimeout).Should(gomega.BeTrue())
+				retryEntry, found := getRetryObj(key, fakeOvn.controller.retryEgressIPPods)
+				gomega.Expect(found).To(gomega.BeTrue())
 				ginkgo.By("retry entry new obj should not be nil")
 				gomega.Expect(retryEntry.newObj).NotTo(gomega.BeNil())
 				ginkgo.By("retry entry config should not be nil")
@@ -1662,12 +1657,13 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
-				fakeOvn.controller.retryEgressIPPods.setRetryObjWithNoBackoff(key)
-				fakeOvn.controller.retryEgressIPPods.requestRetryObjs()
+
+				setRetryObjWithNoBackoff(key, fakeOvn.controller.retryEgressIPPods)
+				fakeOvn.controller.retryEgressIPPods.RequestRetryObjs()
 				// check the cache no longer has the entry
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressIPPods.getObjRetryEntry(key)
-				}, inspectTimeout).Should(gomega.BeNil())
+				gomega.Eventually(func() bool {
+					return checkRetryObj(key, fakeOvn.controller.retryEgressIPPods)
+				}, inspectTimeout).Should(gomega.BeFalse())
 				gomega.Eventually(getEgressIPStatusLen(eIP.Name)).Should(gomega.Equal(1))
 
 				return nil
@@ -2243,9 +2239,12 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				n.IP = i
 				fakeOvn.controller.logicalPortCache.add("", util.GetLogicalPortName(egressPod.Namespace, egressPod.Name), "", nil, []*net.IPNet{n})
 
-				fakeOvn.controller.WatchEgressIPNamespaces()
-				fakeOvn.controller.WatchEgressIPPods()
-				fakeOvn.controller.WatchEgressIP()
+				err := fakeOvn.controller.WatchEgressIPNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchEgressIPPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				ginkgo.By("Bringing down NBDB")
 				// inject transient problem, nbdb is down
@@ -2254,24 +2253,24 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 					return fakeOvn.controller.nbClient.Connected()
 				}).Should(gomega.BeFalse())
 
-				_, err := fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
+				_, err = fakeOvn.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// sleep long enough for TransactWithRetry to fail, causing egressnode operations to fail
 				time.Sleep(types.OVSDBTimeout + time.Second)
 				// check to see if the retry cache has an entry
 				key := eIP.Name
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressIPs.getObjRetryEntry(key)
-				}, inspectTimeout).ShouldNot(gomega.BeNil())
+				gomega.Eventually(func() bool {
+					return checkRetryObj(key, fakeOvn.controller.retryEgressIPs)
+				}, inspectTimeout).Should(gomega.BeTrue())
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
-				fakeOvn.controller.retryPods.setRetryObjWithNoBackoff(key)
-				fakeOvn.controller.retryEgressIPs.requestRetryObjs()
+				setRetryObjWithNoBackoff(key, fakeOvn.controller.retryEgressIPs)
+				fakeOvn.controller.retryEgressIPs.RequestRetryObjs()
 				// check the cache no longer has the entry
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressIPs.getObjRetryEntry(key)
-				}, inspectTimeout).Should(gomega.BeNil())
+				gomega.Eventually(func() bool {
+					return checkRetryObj(key, fakeOvn.controller.retryEgressIPs)
+				}, inspectTimeout).Should(gomega.BeFalse())
 				gomega.Eventually(getEgressIPStatusLen(eIP.Name)).Should(gomega.Equal(1))
 
 				expectedNatLogicalPort := "k8s-node2"
@@ -3320,10 +3319,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				time.Sleep(2 * (types.OVSDBTimeout + time.Second))
 				// check to see if the retry cache has an entry
 				key := node.Name
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressNodes.getObjRetryEntry(key)
-				}).ShouldNot(gomega.BeNil())
-				retryEntry := fakeOvn.controller.retryEgressNodes.getObjRetryEntry(key)
+				checkRetryObjectEventually(key, true, fakeOvn.controller.retryEgressNodes)
+				retryEntry, found := getRetryObj(key, fakeOvn.controller.retryEgressNodes)
+				gomega.Expect(found).To(gomega.BeTrue())
 				ginkgo.By("retry entry new obj should not be nil")
 				gomega.Expect(retryEntry.newObj).NotTo(gomega.BeNil())
 				ginkgo.By("retry entry old obj should be nil")
@@ -3335,12 +3333,10 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 				defer cancel()
 				resetNBClient(connCtx, fakeOvn.controller.nbClient)
-				fakeOvn.controller.retryEgressNodes.setRetryObjWithNoBackoff(key)
-				fakeOvn.controller.retryEgressNodes.requestRetryObjs()
+				setRetryObjWithNoBackoff(key, fakeOvn.controller.retryEgressNodes)
+				fakeOvn.controller.retryEgressNodes.RequestRetryObjs()
 				// check the cache no longer has the entry
-				gomega.Eventually(func() *retryObjEntry {
-					return fakeOvn.controller.retryEgressNodes.getObjRetryEntry(key)
-				}).Should(gomega.BeNil())
+				checkRetryObjectEventually(key, false, fakeOvn.controller.retryEgressNodes)
 				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(1))
 				gomega.Expect(fakeOvn.controller.eIPC.allocator.cache).To(gomega.HaveKey(node.Name))
 				gomega.Expect(fakeOvn.controller.eIPC.allocator.cache[node.Name].egressIPConfig.V4.Net).To(gomega.Equal(ipV4Sub))

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1403,10 +1403,14 @@ func (oc *Controller) addUpdateNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) err
 						continue
 					}
 					klog.V(5).Infof("Adding pod %s/%s to retryPods", pod.Namespace, pod.Name)
-					oc.retryPods.addRetryObjWithAddNoBackoff(&pod)
+					err = oc.retryPods.AddRetryObjWithAddNoBackoff(&pod)
+					if err != nil {
+						errs = append(errs, err)
+						klog.Errorf("Failed to add pod %s/%s to retryPods: %v", pod.Namespace, pod.Name, err)
+					}
 				}
 			}
-			oc.retryPods.requestRetryObjs()
+			oc.retryPods.RequestRetryObjs()
 		}
 	}
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -996,16 +996,15 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
 			err = clusterController.syncGatewayLogicalNetwork(updatedNode, l3GatewayConfig, []*net.IPNet{subnet}, hostAddrs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			clusterController.retryNodes.initRetryObjWithAdd(testNode, testNode.Name)
-			gomega.Expect(len(clusterController.retryNodes.entries)).To(gomega.Equal(1))
-			if retryEntry := clusterController.retryNodes.getObjRetryEntry(testNode.Name); retryEntry != nil {
+			initRetryObjWithAdd(testNode, testNode.Name, clusterController.retryNodes)
+			gomega.Expect(retryObjsLen(clusterController.retryNodes)).To(gomega.Equal(1))
+			if retryEntry, found := getRetryObj(testNode.Name, clusterController.retryNodes); found {
 				gomega.Expect(retryEntry).ToNot(gomega.BeNil())
 				gomega.Expect(retryEntry.newObj).ToNot(gomega.BeNil())
 				gomega.Expect(retryEntry.oldObj).To(gomega.BeNil())
-				gomega.Expect(retryEntry.ignore).To(gomega.BeTrue())
 			}
-			clusterController.retryNodes.deleteRetryObj(testNode.Name, true)
-			gomega.Expect(clusterController.retryNodes.entries[testNode.Name]).To(gomega.BeNil())
+			deleteRetryObj(testNode.Name, clusterController.retryNodes)
+			gomega.Expect(checkRetryObj(testNode.Name, clusterController.retryNodes)).To(gomega.BeFalse())
 			var clusterSubnets []*net.IPNet
 			for _, clusterSubnet := range config.Default.ClusterSubnets {
 				clusterSubnets = append(clusterSubnets, clusterSubnet.CIDR)
@@ -1418,10 +1417,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.By("update should have failed with a retry present")
 			// check to see if the retry cache has an entry for this node
-			gomega.Eventually(func() *retryObjEntry {
-				return clusterController.retryNodes.getObjRetryEntry(testNode.Name)
-			}, "60s").ShouldNot(gomega.BeNil())
-			retryEntry := clusterController.retryNodes.getObjRetryEntry(testNode.Name)
+			checkRetryObjectEventually(testNode.Name, true, clusterController.retryNodes)
+			retryEntry, found := getRetryObj(testNode.Name, clusterController.retryNodes)
+			gomega.Expect(found).To(gomega.BeTrue())
 			ginkgo.By("retry entry new obj should not be nil")
 			gomega.Expect(retryEntry.newObj).NotTo(gomega.BeNil())
 			ginkgo.By("retry entry old obj should be nil")
@@ -1431,12 +1429,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			defer cancel()
 			ginkgo.By("bring up NBDB")
 			resetNBClient(connCtx, clusterController.nbClient)
-			clusterController.retryNodes.setRetryObjWithNoBackoff(node1.Name)
-			clusterController.retryNodes.requestRetryObjs() // retry the failed entry
+			setRetryObjWithNoBackoff(node1.Name, clusterController.retryNodes)
+			clusterController.retryNodes.RequestRetryObjs() // retry the failed entry
 			ginkgo.By("should be no retry entry after update completes")
-			gomega.Eventually(func() *retryObjEntry {
-				return clusterController.retryNodes.getObjRetryEntry(testNode.Name)
-			}).Should(gomega.BeNil())
+			checkRetryObjectEventually(testNode.Name, false, clusterController.retryNodes)
 			for _, data := range expectedDatabaseState {
 				if route, ok := data.(*nbdb.LogicalRouterStaticRoute); ok {
 					if route.Nexthop == "172.16.16.1" {
@@ -1569,23 +1565,19 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// check to see if the retry cache has an entry for this node
-			clusterController.retryNodes.getObjRetryEntry(testNode.Name)
-			gomega.Eventually(func() *retryObjEntry {
-				return clusterController.retryNodes.getObjRetryEntry(testNode.Name)
-			}).ShouldNot(gomega.BeNil())
-			retryEntry := clusterController.retryNodes.getObjRetryEntry(testNode.Name)
+			checkRetryObjectEventually(testNode.Name, true, clusterController.retryNodes)
+			retryEntry, found := getRetryObj(testNode.Name, clusterController.retryNodes)
+			gomega.Expect(found).To(gomega.BeTrue())
 			ginkgo.By("retry entry new obj should be nil")
 			gomega.Expect(retryEntry.newObj).To(gomega.BeNil())
 			ginkgo.By("retry entry old obj should not be nil")
 			gomega.Expect(retryEntry.oldObj).NotTo(gomega.BeNil())
 			// allocate subnet to allow delete to continue
 			gomega.Expect(clusterController.masterSubnetAllocator.AddNetworkRange(subnet, 24)).To(gomega.Succeed())
-			clusterController.retryNodes.setRetryObjWithNoBackoff(node1.Name)
-			clusterController.retryNodes.requestRetryObjs() // retry the failed entry
+			setRetryObjWithNoBackoff(node1.Name, clusterController.retryNodes)
+			clusterController.retryNodes.RequestRetryObjs() // retry the failed entry
 
-			gomega.Eventually(func() *retryObjEntry {
-				return clusterController.retryNodes.getObjRetryEntry(testNode.Name)
-			}).Should(gomega.BeNil())
+			checkRetryObjectEventually(testNode.Name, false, clusterController.retryNodes)
 			return nil
 		}
 

--- a/go-controller/pkg/ovn/obj_retry_test.go
+++ b/go-controller/pkg/ovn/obj_retry_test.go
@@ -1,0 +1,63 @@
+package ovn
+
+import (
+	"github.com/onsi/gomega"
+)
+
+// help functions to lock retryObj properly
+func checkRetryObj(key string, r *RetryObjs) bool {
+	r.retryEntries.LockKey(key)
+	defer r.retryEntries.UnlockKey(key)
+	_, found := r.getRetryObj(key)
+	return found
+}
+
+func getRetryObj(key string, r *RetryObjs) (*retryObjEntry, bool) {
+	r.retryEntries.LockKey(key)
+	defer r.retryEntries.UnlockKey(key)
+	return r.getRetryObj(key)
+}
+
+func setFailedAttemptsCounterForTestingOnly(key string, val uint8, r *RetryObjs) {
+	r.DoWithLock(key, func(key string) {
+		entry, found := r.getRetryObj(key)
+		if found {
+			entry.failedAttempts = val
+		}
+	})
+}
+
+func setRetryObjWithNoBackoff(key string, r *RetryObjs) {
+	r.DoWithLock(key, func(key string) {
+		entry, found := r.getRetryObj(key)
+		if found {
+			r.setRetryObjWithNoBackoff(entry)
+		}
+	})
+}
+
+func initRetryObjWithAdd(obj interface{}, key string, r *RetryObjs) {
+	r.DoWithLock(key, func(key string) {
+		r.initRetryObjWithAdd(obj, key)
+	})
+}
+
+func deleteRetryObj(key string, r *RetryObjs) {
+	r.DoWithLock(key, func(key string) {
+		r.deleteRetryObj(key)
+	})
+}
+
+func checkRetryObjectEventually(key string, shouldExist bool, r *RetryObjs) {
+	expectedValue := gomega.BeTrue()
+	if !shouldExist {
+		expectedValue = gomega.BeFalse()
+	}
+	gomega.Eventually(func() bool {
+		return checkRetryObj(key, r)
+	}).Should(expectedValue)
+}
+
+func retryObjsLen(r *RetryObjs) int {
+	return len(r.retryEntries.GetKeys())
+}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -199,28 +199,28 @@ type Controller struct {
 	v6HostSubnetsUsed float64
 
 	// Objects for pods that need to be retried
-	retryPods *retryObjs
+	retryPods *RetryObjs
 
 	// Objects for network policies that need to be retried
-	retryNetworkPolicies *retryObjs
+	retryNetworkPolicies *RetryObjs
 
 	// Objects for egress firewall that need to be retried
-	retryEgressFirewalls *retryObjs
+	retryEgressFirewalls *RetryObjs
 
 	// Objects for egress IP that need to be retried
-	retryEgressIPs *retryObjs
+	retryEgressIPs *RetryObjs
 	// Objects for egress IP Namespaces that need to be retried
-	retryEgressIPNamespaces *retryObjs
+	retryEgressIPNamespaces *RetryObjs
 	// Objects for egress IP Pods that need to be retried
-	retryEgressIPPods *retryObjs
+	retryEgressIPPods *RetryObjs
 	// Objects for Egress nodes that need to be retried
-	retryEgressNodes *retryObjs
+	retryEgressNodes *RetryObjs
 	// EgressIP Node-specific syncMap used by egressip node event handler
 	addEgressNodeFailed sync.Map
 	// Objects for nodes that need to be retried
-	retryNodes *retryObjs
+	retryNodes *RetryObjs
 	// Objects for Cloud private IP config that need to be retried
-	retryCloudPrivateIPConfig *retryObjs
+	retryCloudPrivateIPConfig *RetryObjs
 	// Node-specific syncMap used by node event handler
 	gatewaysFailed              sync.Map
 	mgmtPortFailed              sync.Map

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1320,8 +1320,9 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 		if err := oc.deleteNetworkPolicy(policy, np); err != nil {
 			// rollback failed, add to retry to cleanup
 			key := getPolicyNamespacedName(policy)
-			oc.retryNetworkPolicies.initRetryObjWithDelete(policy, key, np, false)
-			oc.retryNetworkPolicies.unSkipRetryObj(key)
+			oc.retryNetworkPolicies.DoWithLock(key, func(key string) {
+				oc.retryNetworkPolicies.initRetryObjWithDelete(policy, key, np, false)
+			})
 		}
 		return fmt.Errorf("unable to ensure namespace for network policy: %s, namespace: %s, error: %v",
 			policy.Name, policy.Namespace, err)

--- a/go-controller/pkg/syncmap/syncmap.go
+++ b/go-controller/pkg/syncmap/syncmap.go
@@ -1,0 +1,161 @@
+package syncmap
+
+import (
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+type keyLock struct {
+	mutex      sync.Mutex
+	refCounter int
+}
+
+func (m *keyLock) addRef() {
+	m.refCounter++
+}
+
+func (m *keyLock) delRef() {
+	m.refCounter--
+}
+
+func newKeyLock() *keyLock {
+	c := keyLock{
+		sync.Mutex{},
+		0,
+	}
+	return &c
+}
+
+// SyncMap is a map with lockable keys. It allows to lock the key regardless of whether the entry for
+// given key exists. When key is locked other threads can't read/write the key.
+type SyncMap[T any] struct {
+	// keyLocksMutex needs to be locked for every read/write operation with keyLocks.
+	// refCounter should be updated for keyLock before keyLocksMutex lock is released.
+	// to avoid deadlocks make sure no other locks are acquired when keyLocksMutex is locked.
+	keyLocksMutex sync.Mutex
+	// map of key mutexes, should only be accessed with keyLocksMutex lock
+	// keyLock exists for a key that was locked with LockKey and until all threads that called LockKey
+	// execute UnlockKey
+	keyLocks map[string]*keyLock
+	// entriesMutex needs to be locked for every read/write operation with entries
+	// to avoid deadlocks make sure no other locks are acquired when entriesMutex is locked
+	entriesMutex sync.Mutex
+	// cache entries
+	// should only be accessed with entriesMutex, also
+	// read/write for a given key is only allowed with keyLock
+	entries map[string]T
+}
+
+func NewSyncMap[T any]() *SyncMap[T] {
+	c := SyncMap[T]{
+		sync.Mutex{},
+		make(map[string]*keyLock),
+		sync.Mutex{},
+		make(map[string]T),
+	}
+	return &c
+}
+
+// UnlockKey unlocks previously locked key. Call it when all the operations with the given key are done.
+func (c *SyncMap[T]) UnlockKey(lockedKey string) {
+	c.keyLocksMutex.Lock()
+	defer c.keyLocksMutex.Unlock()
+	kLock, ok := c.keyLocks[lockedKey]
+	if !ok {
+		// this should never happen, since UnlockKey should only be called when the key is Locked
+		// and when the key is Locked, c.keyLocks[key] will always have its keyLock.
+		// similar to calling Unlock() on unlocked mutex
+		klog.Errorf("Unlocking non-existing key %s", lockedKey)
+		return
+	}
+	kLock.delRef()
+	// keyLock can be deleted when the last request is being shut down (that is refCount=0)
+	// next load request for this key will create a new keyLock
+	if kLock.refCounter == 0 {
+		delete(c.keyLocks, lockedKey)
+	}
+	kLock.mutex.Unlock()
+}
+
+// loadOrStoreKeyLock returns the existing value for keyLock if present.
+// Otherwise, it stores and returns the given value.
+// The loaded result is true if the value was loaded, false if stored.
+// loadOrStoreKeyLock will increase refCounter for returned value
+func (c *SyncMap[T]) loadOrStoreKeyLock(lockedKey string, value *keyLock) (*keyLock, bool) {
+	c.keyLocksMutex.Lock()
+	defer c.keyLocksMutex.Unlock()
+	if kLock, ok := c.keyLocks[lockedKey]; ok {
+		kLock.addRef()
+		return kLock, true
+	} else {
+		c.keyLocks[lockedKey] = value
+		value.addRef()
+		return value, false
+	}
+}
+
+// LockKey should be called before reading/writing entry value,
+// it guarantees exclusive access to the key.
+// Unlock(key) should be called once the work for this key is done to unlock other threads
+// After the key is unlocked there are no guarantees for the entry for given key
+func (c *SyncMap[T]) LockKey(key string) {
+	// if the kLock is not present, we create a new one
+	// lock it before adding, to prevent other threads from getting the key lock after we add it
+	newKLock := newKeyLock()
+	newKLock.mutex.Lock()
+	kLock, loaded := c.loadOrStoreKeyLock(key, newKLock)
+	// loadOrStoreKeyLock will increase refCounter for the returned kLock,
+	// meaning that other threads won't be able to delete this kLock until we decrease refCounter
+	// with UnlockKey().
+	// if newKLock was stored (!loaded), we already have it locked
+	if !loaded {
+		return
+	}
+	// existing kLock was loaded, unlock newKLock since we didn't use it
+	newKLock.mutex.Unlock()
+	// lock the key
+	kLock.mutex.Lock()
+}
+
+// Load returns the value stored in the map for a key, or nil if no value is present.
+// The loaded result indicates whether value was found in the map.
+func (c *SyncMap[T]) Load(lockedKey string) (value T, loaded bool) {
+	c.entriesMutex.Lock()
+	defer c.entriesMutex.Unlock()
+	entry, ok := c.entries[lockedKey]
+	return entry, ok
+}
+
+// LoadOrStore gets the key value if it's present or creates a new one if it isn't.
+func (c *SyncMap[T]) LoadOrStore(lockedKey string, newEntry T) T {
+	c.entriesMutex.Lock()
+	defer c.entriesMutex.Unlock()
+	if entry, ok := c.entries[lockedKey]; ok {
+		return entry
+	} else {
+		c.entries[lockedKey] = newEntry
+		return newEntry
+	}
+}
+
+// Delete deletes object from the entries map
+func (c *SyncMap[T]) Delete(lockedKey string) {
+	c.entriesMutex.Lock()
+	defer c.entriesMutex.Unlock()
+	delete(c.entries, lockedKey)
+}
+
+// GetKeys returns a snapshot of all keys from entries map.
+// After this function returns there are no guarantees that the keys in the real entries map are still the same
+func (c *SyncMap[T]) GetKeys() []string {
+	c.entriesMutex.Lock()
+	defer c.entriesMutex.Unlock()
+	keys := make([]string, len(c.entries))
+	i := 0
+	for k := range c.entries {
+		keys[i] = k
+		i++
+	}
+	return keys
+}


### PR DESCRIPTION
Implmenet syncCache for retryObjects with lockable keys.

Isolate cache implementation from the retry logic:
  - retryObjEntry doesn't need to have mutex anymore
  - retryObjs doesn't work with cache mutexes, only calls methods

SyncCache is a map with lockable keys. It allows to lock the key
regardless of whether the entry for given key exists.
When key is locked other threads can't read/write the entry with
the key.

Split ensureRetryEntryLocked into loadOrStore that will
make sure newEntry is present and locked, and load that was
previously called as ensureRetryEntryLocked with nil newRetryEntry.
Change iterateRetryResources to only lock every entry once and not use
cache mutex. Create a snapshot of keys that will be retried instead
of holding map lock.

Lock retyrObject key until work for this key is completed.
That also removes the need for .ignore field - retry loop
will wait until key is unlocked.

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>