### PR TITLE
Tmp fix for retry_obj cache deadlocks.

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1004,7 +1004,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				gomega.Expect(retryEntry.oldObj).To(gomega.BeNil())
 				gomega.Expect(retryEntry.ignore).To(gomega.BeTrue())
 			}
-			clusterController.retryNodes.deleteRetryObj(testNode.Name, true)
+			clusterController.retryNodes.deleteRetryObj(testNode.Name, nil)
 			gomega.Expect(clusterController.retryNodes.entries[testNode.Name]).To(gomega.BeNil())
 			var clusterSubnets []*net.IPNet
 			for _, clusterSubnet := range config.Default.ClusterSubnets {

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -359,7 +359,7 @@ func (oc *Controller) deleteNamespace(ns *kapi.Namespace) {
 			klog.Errorf("Failed to delete network policy: %s, error: %v", key, err)
 			oc.retryNetworkPolicies.unSkipRetryObj(key)
 		} else {
-			oc.retryNetworkPolicies.deleteRetryObj(key, true)
+			oc.retryNetworkPolicies.deleteRetryObj(key, nil)
 			delete(nsInfo.networkPolicies, np.name)
 		}
 	}

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -747,7 +747,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				fakeOvn.controller.retryPods.unSkipRetryObj(key)
 				gomega.Expect(fakeOvn.controller.retryPods.entries[key].ignore).To(gomega.BeFalse())
 
-				fakeOvn.controller.retryPods.deleteRetryObj(key, true)
+				fakeOvn.controller.retryPods.deleteRetryObj(key, nil)
 				gomega.Expect(fakeOvn.controller.retryPods.entries[key]).To(gomega.BeNil())
 				return nil
 			}


### PR DESCRIPTION
Always take retryMutex first, then entry lock.
This is bad parallelization, since the whole cache is locked while
waiting for a single entry lock, but the fix is temporary - it is only
needed to fix CI failure and will be properly reworked soon.

Mutexes order (based on https://github.com/ovn-org/ovn-kubernetes/pull/3097#pullrequestreview-1054582891):
Add:
lock cache
lock entry
if entry.deleted, unlock entry and cache, return nil
unlock cache, and return entry

Get
lock cache
lock entry
if entry.deleted, unlock entry and cache, return nil
unlock cache and return entry

Delete
mark as deleted
unlock entry
lock cache
lock entry
delete entry from cache
unlock entry
unlock cache

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>

Real fix should be here https://github.com/ovn-org/ovn-kubernetes/pull/3097