### PR TITLE
Revert "Remove stale chassis for hosts that run ovnkube-node on DPU"

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -277,11 +277,7 @@ func runOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 		// register ovnkube node specific prometheus metrics exported by the node
 		metrics.RegisterNodeMetrics()
 		start := time.Now()
-		sbClient, err := libovsdb.NewSBClient(stopChan)
-		if err != nil {
-			return fmt.Errorf("cannot initialize libovsdb SB client: %v", err)
-		}
-		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, sbClient, stopChan, nodeEventRecorder)
+		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, stopChan, nodeEventRecorder)
 		if err := n.Start(ctx.Context, wg); err != nil {
 			return err
 		}

--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -111,8 +111,6 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, stopCh <-chan struct{}) (cl
 			client.WithTable(&sbdb.PortBinding{}),
 			// used for hybrid-overlay
 			client.WithTable(&sbdb.DatapathBinding{}),
-			// used for dpu-host mode
-			client.WithTable(&sbdb.Encap{}),
 		),
 	)
 	if err != nil {

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -6,11 +6,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/urfave/cli/v2"
@@ -145,11 +143,7 @@ var _ = Describe("Node Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 		fExec = ovntest.NewFakeExec()
-		dbSetup := libovsdbtest.TestSetup{}
-		var libovsdbOvnSBClient libovsdbclient.Client
-		_, libovsdbOvnSBClient, _, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
-		Expect(err).NotTo(HaveOccurred())
-		fakeOvnNode = NewFakeOVNNode(fExec, libovsdbOvnSBClient)
+		fakeOvnNode = NewFakeOVNNode(fExec)
 
 		iptV4, iptV6 = util.SetFakeIPTablesHelpers()
 		_, nodeNet, err := net.ParseCIDR("10.1.1.0/24")

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
@@ -26,9 +25,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/informer"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/upgrade"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/vishvananda/netlink"
@@ -43,11 +40,10 @@ type OvnNode struct {
 	stopChan     chan struct{}
 	recorder     record.EventRecorder
 	gateway      Gateway
-	sbClient     libovsdbclient.Client
 }
 
 // NewNode creates a new controller for node management
-func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name string, dbclient libovsdbclient.Client, stopChan chan struct{}, eventRecorder record.EventRecorder) *OvnNode {
+func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name string, stopChan chan struct{}, eventRecorder record.EventRecorder) *OvnNode {
 	return &OvnNode{
 		name:         name,
 		client:       kubeClient,
@@ -55,7 +51,6 @@ func NewNode(kubeClient clientset.Interface, wf factory.NodeWatchFactory, name s
 		watchFactory: wf,
 		stopChan:     stopChan,
 		recorder:     eventRecorder,
-		sbClient:     dbclient,
 	}
 }
 
@@ -362,11 +357,6 @@ func (n *OvnNode) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		}
 
 		err = setupOVNNode(node)
-		if err != nil {
-			return err
-		}
-	} else {
-		err = removeStaleChassisByNodeIP(n.sbClient, nodeAddr)
 		if err != nil {
 			return err
 		}
@@ -812,27 +802,6 @@ func upgradeServiceRoute(bridgeName string) error {
 		rules := getLocalGatewayNATRules(types.LocalnetGatewayNextHopPort, IPNet)
 		if err := delIptRules(rules); err != nil {
 			klog.Errorf("Failed to LocalGatewayNATRules: %v", err)
-		}
-	}
-	return nil
-}
-
-func removeStaleChassisByNodeIP(sbClient libovsdbclient.Client, ip net.IP) error {
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
-	defer cancel()
-	encaps := []*sbdb.Encap{}
-	if err := sbClient.List(ctx, &encaps); err != nil {
-		return err
-	}
-
-	for _, encap := range encaps {
-		if encap.IP == ip.String() {
-			klog.V(2).Infof("Remove stale chassis: %s", encap.ChassisName)
-			if err := libovsdbops.DeleteChassisWithPredicate(sbClient, func(item *sbdb.Chassis) bool {
-				return item.Name == encap.ChassisName
-			}); err != nil {
-				return err
-			}
 		}
 	}
 	return nil

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -7,13 +7,10 @@ import (
 	"github.com/urfave/cli/v2"
 	"github.com/vishvananda/netlink"
 
-	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/mocks"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
-	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	netlink_mocks "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/mocks/github.com/vishvananda/netlink"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -603,58 +600,6 @@ var _ = Describe("Node", func() {
 			}
 			err := app.Run([]string{app.Name})
 			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Describe("DPU host mode", func() {
-		var (
-			initialSBDB, expectedSBDB []libovsdbtest.TestData
-			hostIP                    net.IP
-			dpuIP                     net.IP
-			libovsdbCleanup           *libovsdbtest.Cleanup
-			err                       error
-			sbClient                  client.Client
-		)
-
-		BeforeEach(func() {
-			hostIP, _, _ = net.ParseCIDR("1.2.3.4/24")
-			dpuIP, _, _ = net.ParseCIDR("1.2.3.5/24")
-			initialSBDB = []libovsdbtest.TestData{
-				&sbdb.Chassis{Name: "chassis-node1-host", Hostname: "node1", Encaps: []string{"encap-node1-host"}},
-				&sbdb.Chassis{Name: "chassis-node1-dpu", Hostname: "node1", Encaps: []string{"encap-node1-dpu"}},
-				&sbdb.Encap{UUID: "encap-node1-host", ChassisName: "chassis-node1-host", IP: hostIP.String()},
-				&sbdb.Encap{UUID: "encap-node1-dpu", ChassisName: "chassis-node1-dpu", IP: dpuIP.String()},
-			}
-			expectedSBDB = []libovsdbtest.TestData{
-				&sbdb.Chassis{Name: "chassis-node1-dpu", Hostname: "node1", Encaps: []string{"encap-node1-dpu"}},
-				// OVN shall also remove the corresponding Encap when the chassis is deleted, but in the mock DB it will be still there
-				&sbdb.Encap{UUID: "encap-node1-host", ChassisName: "chassis-node1-host", IP: hostIP.String()},
-				&sbdb.Encap{UUID: "encap-node1-dpu", ChassisName: "chassis-node1-dpu", IP: dpuIP.String()},
-			}
-		})
-
-		AfterEach(func() {
-			if libovsdbCleanup != nil {
-				libovsdbCleanup.Cleanup()
-			}
-		})
-
-		It("remove stale host chassis", func() {
-
-			stopChan := make(chan struct{})
-			defer close(stopChan)
-
-			dbSetup := libovsdbtest.TestSetup{
-				SBData: initialSBDB,
-			}
-			_, sbClient, libovsdbCleanup, err = libovsdbtest.NewNBSBTestHarness(dbSetup)
-			Expect(err).NotTo(HaveOccurred())
-			err = removeStaleChassisByNodeIP(sbClient, net.IP(hostIP))
-			Expect(err).NotTo(HaveOccurred())
-			matcher := libovsdbtest.HaveDataIgnoringUUIDs(expectedSBDB)
-			match, err := matcher.Match(sbClient)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(match).To(BeTrue())
 		})
 	})
 })

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	. "github.com/onsi/gomega"
-	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
@@ -26,10 +25,9 @@ type FakeOVNNode struct {
 	fakeClient *util.OVNClientset
 	fakeExec   *ovntest.FakeExec
 	wg         *sync.WaitGroup
-	sbClient   libovsdbclient.Client
 }
 
-func NewFakeOVNNode(fexec *ovntest.FakeExec, sbclient libovsdbclient.Client) *FakeOVNNode {
+func NewFakeOVNNode(fexec *ovntest.FakeExec) *FakeOVNNode {
 	err := util.SetExec(fexec)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -37,7 +35,6 @@ func NewFakeOVNNode(fexec *ovntest.FakeExec, sbclient libovsdbclient.Client) *Fa
 		fakeExec: fexec,
 		recorder: record.NewFakeRecorder(1),
 		wg:       &sync.WaitGroup{},
-		sbClient: sbclient,
 	}
 }
 
@@ -73,6 +70,6 @@ func (o *FakeOVNNode) init() {
 	o.watcher, err = factory.NewNodeWatchFactory(o.fakeClient, fakeNodeName)
 	Expect(err).NotTo(HaveOccurred())
 
-	o.node = NewNode(o.fakeClient.KubeClient, o.watcher, fakeNodeName, o.sbClient, o.stopChan, o.recorder)
+	o.node = NewNode(o.fakeClient.KubeClient, o.watcher, fakeNodeName, o.stopChan, o.recorder)
 	o.node.Start(context.TODO(), o.wg)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
This reverts commit 9086e574a8e73a27a827524a45badb427d8863d2.
As the community decided not to add any DB client to the node, revert
the commit first. A new fix will be proposed later.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->