### PR TITLE
BZ2111362: ACL logging: rename and rewrite oc.aclLoggingCanEnable 

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	ktypes "k8s.io/apimachinery/pkg/types"
+	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
@@ -681,40 +682,59 @@ func (oc *Controller) WatchNodes() error {
 	return err
 }
 
-// Verify if controller can support ACL logging and validate annotation
-func (oc *Controller) aclLoggingCanEnable(annotation string, nsInfo *namespaceInfo) bool {
-	if !oc.aclLoggingEnabled || annotation == "" {
-		nsInfo.aclLogging.Deny = ""
-		nsInfo.aclLogging.Allow = ""
-		return false
-	}
+// aclLoggingUpdateNsInfo parses the provided annotation values and sets nsInfo.aclLogging.Deny and
+// nsInfo.aclLogging.Allow. If errors are encountered parsing the annotation, disable logging completely. If either
+// value contains invalid input, disable logging for the respective key. This is needed to ensure idempotency.
+// More details:
+// *) If the provided annotation cannot be unmarshaled: Disable both Deny and Allow logging. Return an error.
+// *) Valid values for "allow" and "deny" are  "alert", "warning", "notice", "info", "debug", "".
+// *) Invalid values will return an error, and logging will be disabled for the respective key.
+// *) In the following special cases, nsInfo.aclLogging.Deny and nsInfo.aclLogging.Allow. will both be reset to ""
+//    without logging an error, meaning that logging will be switched off:
+//    i) oc.aclLoggingEnabled == false
+//    ii) annotation == ""
+//    iii) annotation == "{}"
+// *) If one of "allow" or "deny" can be parsed and has a valid value, but the other key is not present in the
+//    annotation, then assume that this key should be disabled by setting its nsInfo value to "".
+func (oc *Controller) aclLoggingUpdateNsInfo(annotation string, nsInfo *namespaceInfo) error {
 	var aclLevels ACLLoggingLevels
-	err := json.Unmarshal([]byte(annotation), &aclLevels)
-	if err != nil {
-		return false
+	var errors []error
+
+	// If logging is disabled or if the annotation is "" or "{}", use empty strings. Otherwise, parse the annotation.
+	if oc.aclLoggingEnabled && annotation != "" && annotation != "{}" {
+		err := json.Unmarshal([]byte(annotation), &aclLevels)
+		if err != nil {
+			// Disable Allow and Deny logging to ensure idempotency.
+			nsInfo.aclLogging.Allow = ""
+			nsInfo.aclLogging.Deny = ""
+			return fmt.Errorf("could not unmarshal namespace ACL annotation '%s', disabling logging, err: %q",
+				annotation, err)
+		}
 	}
 
-	// Using newDenyLoggingLevel and newAllowLoggingLevel allows resetting nsinfo state.
-	// This is important if a user sets either the allow level or the deny level flag to an
-	// invalid value or after they remove either the allow or the deny annotation.
-	// If either of the 2 (allow or deny logging level) is set with a valid level, return true.
-	newDenyLoggingLevel := ""
-	newAllowLoggingLevel := ""
-	okCnt := 0
-	for _, s := range []string{nbdb.ACLSeverityAlert, nbdb.ACLSeverityWarning, nbdb.ACLSeverityNotice,
-		nbdb.ACLSeverityInfo, nbdb.ACLSeverityDebug} {
-		if s == aclLevels.Deny {
-			newDenyLoggingLevel = aclLevels.Deny
-			okCnt++
-		}
-		if s == aclLevels.Allow {
-			newAllowLoggingLevel = aclLevels.Allow
-			okCnt++
-		}
+	// Valid log levels are the various preestablished levels or the empty string.
+	validLogLevels := sets.NewString(nbdb.ACLSeverityAlert, nbdb.ACLSeverityWarning, nbdb.ACLSeverityNotice,
+		nbdb.ACLSeverityInfo, nbdb.ACLSeverityDebug, "")
+
+	// Set Deny logging.
+	if validLogLevels.Has(aclLevels.Deny) {
+		nsInfo.aclLogging.Deny = aclLevels.Deny
+	} else {
+		errors = append(errors, fmt.Errorf("disabling deny logging due to invalid deny annotation. "+
+			"%q is not a valid log severity", aclLevels.Deny))
+		nsInfo.aclLogging.Deny = ""
 	}
-	nsInfo.aclLogging.Deny = newDenyLoggingLevel
-	nsInfo.aclLogging.Allow = newAllowLoggingLevel
-	return okCnt > 0
+
+	// Set Allow logging.
+	if validLogLevels.Has(aclLevels.Allow) {
+		nsInfo.aclLogging.Allow = aclLevels.Allow
+	} else {
+		errors = append(errors, fmt.Errorf("disabling allow logging due to an invalid allow annotation. "+
+			"%q is not a valid log severity", aclLevels.Allow))
+		nsInfo.aclLogging.Allow = ""
+	}
+
+	return apierrors.NewAggregate(errors)
 }
 
 // gatewayChanged() compares old annotations to new and returns true if something has changed.

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -711,22 +711,22 @@ func ExecCommandInContainerWithFullOutput(f *framework.Framework, namespace, pod
 	return f.ExecWithOptions(options)
 }
 
-func assertAclLogs(targetNodeName string, policyNameRegex string, expectedAclVerdict string, expectedAclSeverity string) (bool, error) {
+func assertACLLogs(targetNodeName string, policyNameRegex string, expectedACLVerdict string, expectedACLSeverity string) (bool, error) {
 	framework.Logf("collecting the ovn-controller logs for node: %s", targetNodeName)
 	targetNodeLog, err := runCommand([]string{"docker", "exec", targetNodeName, "grep", "acl_log", ovnControllerLogPath}...)
 	if err != nil {
 		return false, fmt.Errorf("error accessing logs in node %s: %v", targetNodeName, err)
 	}
 
-	framework.Logf("Ensuring the audit log contains: 'name=\"%s\"', 'verdict=%s' AND 'severity=%s'", policyNameRegex, expectedAclVerdict, expectedAclSeverity)
+	framework.Logf("Ensuring the audit log contains: 'name=\"%s\"', 'verdict=%s' AND 'severity=%s'", policyNameRegex, expectedACLVerdict, expectedACLSeverity)
 	for _, logLine := range strings.Split(targetNodeLog, "\n") {
 		matched, err := regexp.MatchString(fmt.Sprintf("name=\"%s\"", policyNameRegex), logLine)
 		if err != nil {
 			return false, err
 		}
 		if matched &&
-			strings.Contains(logLine, fmt.Sprintf("verdict=%s", expectedAclVerdict)) &&
-			strings.Contains(logLine, fmt.Sprintf("severity=%s", expectedAclSeverity)) {
+			strings.Contains(logLine, fmt.Sprintf("verdict=%s", expectedACLVerdict)) &&
+			strings.Contains(logLine, fmt.Sprintf("severity=%s", expectedACLSeverity)) {
 			return true, nil
 		}
 	}
@@ -836,10 +836,10 @@ func newPrivelegedTestFramework(basename string) *framework.Framework {
 	return f
 }
 
-// countAclLogs connects to <targetNodeName> (ovn-control-plane, ovn-worker or ovn-worker2 in kind environments) via the docker exec
+// countACLLogs connects to <targetNodeName> (ovn-control-plane, ovn-worker or ovn-worker2 in kind environments) via the docker exec
 // command and it greps for the string "acl_log" inside the OVN controller logs. It then checks if the line contains name=<policyNameRegex>
 // and if it does, it increases the counter if both the verdict and the severity for this line match what's expected.
-func countAclLogs(targetNodeName string, policyNameRegex string, expectedAclVerdict string, expectedAclSeverity string) (int, error) {
+func countACLLogs(targetNodeName string, policyNameRegex string, expectedACLVerdict string, expectedACLSeverity string) (int, error) {
 	count := 0
 
 	framework.Logf("collecting the ovn-controller logs for node: %s", targetNodeName)
@@ -851,8 +851,8 @@ func countAclLogs(targetNodeName string, policyNameRegex string, expectedAclVerd
 	stringToMatch := fmt.Sprintf(
 		".*acl_log.*name=\"%s\".*verdict=%s.*severity=%s.*",
 		policyNameRegex,
-		expectedAclVerdict,
-		expectedAclSeverity)
+		expectedACLVerdict,
+		expectedACLSeverity)
 
 	for _, logLine := range strings.Split(targetNodeLog, "\n") {
 		matched, err := regexp.MatchString(stringToMatch, logLine)


### PR DESCRIPTION
commit 150d9b71f2bfb6630cbfe4775cd19885755fef95 (HEAD -> 2111362, origin/2111362)
Author: Andreas Karis <ak.karis@gmail.com>
Date:   Mon Aug 1 20:05:42 2022 +0000

    ACL logging: rename and rewrite oc.aclLoggingCanEnable
    
    Rename oc.aclLoggingCanEnable to aclLoggingUpdateNsInfo and make some
    changes to this method and how it is being called.
    
    When a namespace's ACL logging annotation is updated to either {}
    or {"allow": "", "deny": ""}, make sure to disable ACL logging
    completely.
    
    When "" or an invalid value is provided for "allow" or "deny", reset
    the key's value to "", always.
    
    Signed-off-by: Andreas Karis <ak.karis@gmail.com>

commit 194963e512bbcdeb8d15f0c22fb7f90c1e2b42cb
Author: Andreas Karis <ak.karis@gmail.com>
Date:   Mon Aug 1 15:00:48 2022 +0200

    E2E tests: Improve EgressFW and NetworkPolicy ACL logging tests
    
    When a namespace's ACL logging annotation is updated to either {}
    or {"allow": "", "deny": ""}, make sure to disable ACL logging
    completely. Add E2E tests for these scenarios.
    
    Add E2E tests for invalid values.
    
    Add an additional test for NetworkPolicy.
    
    ACL E2E: Remove ineffectual Gets of namespace objects
    
    Make the linter complain a bit less.
    
    Signed-off-by: Andreas Karis <ak.karis@gmail.com>



How to test:
~~~
make -C test control-plane WHAT="ACL Logging for EgressFirewall"
make -C test control-plane WHAT="ACL Logging for NetworkPolicy"
~~~