### PR TITLE
Delete stale egress ip before assigning new ip

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -230,21 +230,6 @@ func (oc *Controller) reconcileEgressIP(old, new *egressipv1.EgressIP) (err erro
 				return err
 			}
 		}
-		// If running on a public cloud we should not program OVN just yet for assignment
-		// operations. We need confirmation from the cloud-network-config-controller that
-		// it can assign the IPs. reconcileCloudPrivateIPConfig will take care of
-		// processing the answer from the requests we make here, and update OVN
-		// accordingly when we know what the outcome is.
-		if len(ipsToAssign) > 0 {
-			statusToAdd = oc.assignEgressIPs(name, ipsToAssign.UnsortedList())
-			statusToKeep = append(statusToKeep, statusToAdd...)
-		}
-		// Same as above: Add all assignments which are to be kept to the
-		// allocator cache, allowing us to track all assignments which have been
-		// performed and avoid incorrect future assignments due to a
-		// de-synchronized cache.
-		oc.addAllocatorEgressIPAssignments(name, statusToKeep)
-
 		// When egress IP is not fully assigned to a node, then statusToRemove may not
 		// have those entries, hence retrieve it from staleEgressIPs for removing
 		// the item from cloudprivateipconfig.
@@ -260,6 +245,20 @@ func (oc *Controller) reconcileEgressIP(old, new *egressipv1.EgressIP) (err erro
 					egressipv1.EgressIPStatusItem{EgressIP: staleEgressIP, Node: nodeName})
 			}
 		}
+		// If running on a public cloud we should not program OVN just yet for assignment
+		// operations. We need confirmation from the cloud-network-config-controller that
+		// it can assign the IPs. reconcileCloudPrivateIPConfig will take care of
+		// processing the answer from the requests we make here, and update OVN
+		// accordingly when we know what the outcome is.
+		if len(ipsToAssign) > 0 {
+			statusToAdd = oc.assignEgressIPs(name, ipsToAssign.UnsortedList())
+			statusToKeep = append(statusToKeep, statusToAdd...)
+		}
+		// Same as above: Add all assignments which are to be kept to the
+		// allocator cache, allowing us to track all assignments which have been
+		// performed and avoid incorrect future assignments due to a
+		// de-synchronized cache.
+		oc.addAllocatorEgressIPAssignments(name, statusToKeep)
 
 		// Execute CloudPrivateIPConfig changes for assignments which need to be
 		// added/removed, assignments which don't change do not require any


### PR DESCRIPTION
This deletes any stale ip from node allocations map before assignment
so that update on same egress ip object would assign new ip address
on a particular assignable node in any timing scenarios.

For Example:
1. Label a node with `k8s.ovn.org/egress-assignable='' `
2. Create egress ip entry like below.
  ```
  apiVersion: k8s.ovn.org/v1
  kind: EgressIP
  metadata:
    name: egressips-peri-test
  spec:
    egressIPs:
    - 10.0.128.10
    namespaceSelector:
      matchLabels:
        team: red
  ```
   For this EgressIP object, ovn-k populates egressNode#allocations cache with an entry for labeled node and then invokes 
   CreateCloudPrivateIPConfig for given ip address. In some clouds like Azure, this op takes a while and delay in populating 
   EgressIP object with status containing node and ip.
3. While cloud op is in progress, Update EgressIP object by replacing ip address 10.0.128.10 with 10.0.128.11.

Expected Result:
Egress IP status should get populated with node and new ip address 10.0.128.11.

Actual Result:
Egress IP status still containing old ip address 10.0.128.10.

Reason:
The entry in allocations cache is not removed for old ip, because of this new ip is ignored for assignment on this node.

Fix:
Delete entry from allocations cache before assignment happens.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>