### PR TITLE
Clean only unknown rules on mgmt chain on node add

### DIFF
--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -6,13 +6,12 @@ package node
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
+
 	kapi "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/cache"
@@ -28,87 +27,12 @@ const (
 	iptableESVCChain       = "OVN-KUBE-EGRESS-SVC" // called from nat-POSTROUTING
 )
 
-func clusterIPTablesProtocols() []iptables.Protocol {
-	var protocols []iptables.Protocol
-	if config.IPv4Mode {
-		protocols = append(protocols, iptables.ProtocolIPv4)
-	}
-	if config.IPv6Mode {
-		protocols = append(protocols, iptables.ProtocolIPv6)
-	}
-	return protocols
-}
-
-// getIPTablesProtocol returns the IPTables protocol matching the protocol (v4/v6) of provided IP string
-func getIPTablesProtocol(ip string) iptables.Protocol {
-	if utilnet.IsIPv6String(ip) {
-		return iptables.ProtocolIPv6
-	}
-	return iptables.ProtocolIPv4
-}
-
 // getMasqueradeVIP returns the .3 masquerade VIP based on the protocol (v4/v6) of provided IP string
 func getMasqueradeVIP(ip string) string {
 	if utilnet.IsIPv6String(ip) {
 		return types.V6HostETPLocalMasqueradeIP
 	}
 	return types.V4HostETPLocalMasqueradeIP
-}
-
-type iptRule struct {
-	table    string
-	chain    string
-	args     []string
-	protocol iptables.Protocol
-}
-
-func addIptRules(rules []iptRule) error {
-	var addErrors, err error
-	var ipt util.IPTablesHelper
-	for _, r := range rules {
-		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
-			r.table, r.chain, strings.Join(r.args, " "), r.protocol)
-		if ipt, err = util.GetIPTablesHelper(r.protocol); err != nil {
-			addErrors = errors.Wrapf(addErrors,
-				"Failed to add iptables %s/%s rule %q: %v", r.table, r.chain, strings.Join(r.args, " "), err)
-			continue
-		}
-		if err = ipt.NewChain(r.table, r.chain); err != nil {
-			klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v",
-				r.chain, r.table, err)
-		}
-		exists, err := ipt.Exists(r.table, r.chain, r.args...)
-		if !exists && err == nil {
-			err = ipt.Insert(r.table, r.chain, 1, r.args...)
-		}
-		if err != nil {
-			addErrors = errors.Wrapf(addErrors, "failed to add iptables %s/%s rule %q: %v",
-				r.table, r.chain, strings.Join(r.args, " "), err)
-		}
-	}
-	return addErrors
-}
-
-func delIptRules(rules []iptRule) error {
-	var delErrors, err error
-	var ipt util.IPTablesHelper
-	for _, r := range rules {
-		klog.V(5).Infof("Deleting rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
-			r.table, r.chain, strings.Join(r.args, " "), r.protocol)
-		if ipt, err = util.GetIPTablesHelper(r.protocol); err != nil {
-			delErrors = errors.Wrapf(delErrors,
-				"Failed to delete iptables %s/%s rule %q: %v", r.table, r.chain, strings.Join(r.args, " "), err)
-			continue
-		}
-		if exists, err := ipt.Exists(r.table, r.chain, r.args...); err == nil && exists {
-			err := ipt.Delete(r.table, r.chain, r.args...)
-			if err != nil {
-				delErrors = errors.Wrapf(delErrors, "failed to delete iptables %s/%s rule %q: %v",
-					r.table, r.chain, strings.Join(r.args, " "), err)
-			}
-		}
-	}
-	return delErrors
 }
 
 func getGatewayInitRules(chain string, proto iptables.Protocol) []iptRule {

--- a/go-controller/pkg/node/iptables.go
+++ b/go-controller/pkg/node/iptables.go
@@ -134,3 +134,15 @@ func getIPTablesProtocol(ip string) iptables.Protocol {
 	}
 	return iptables.ProtocolIPv4
 }
+
+type rulesFilteringPredicate func(rule iptRule) bool
+
+func filterRulesByPredicate(p rulesFilteringPredicate, rules ...iptRule) []iptRule {
+	var filteredRules []iptRule
+	for _, rule := range rules {
+		if p(rule) {
+			filteredRules = append(filteredRules, rule)
+		}
+	}
+	return filteredRules
+}

--- a/go-controller/pkg/node/iptables.go
+++ b/go-controller/pkg/node/iptables.go
@@ -1,0 +1,151 @@
+package node
+
+import (
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/pkg/errors"
+
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+type iptRule struct {
+	table    string
+	chain    string
+	args     []string
+	protocol iptables.Protocol
+}
+
+//
+//
+//func addIptRules(rules []iptRule) error {
+//	var addErrors, err error
+//	var ipt util.IPTablesHelper
+//	for _, r := range rules {
+//		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
+//			r.table, r.chain, strings.Join(r.args, " "), r.protocol)
+//		if ipt, err = util.GetIPTablesHelper(r.protocol); err != nil {
+//			addErrors = errors.Wrapf(addErrors,
+//				"Failed to add iptables %s/%s rule %q: %v", r.table, r.chain, strings.Join(r.args, " "), err)
+//			continue
+//		}
+//		if err = ipt.NewChain(r.table, r.chain); err != nil {
+//			klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v",
+//				r.chain, r.table, err)
+//		}
+//		exists, err := ipt.Exists(r.table, r.chain, r.args...)
+//		if !exists && err == nil {
+//			err = ipt.Insert(r.table, r.chain, 1, r.args...)
+//		}
+//		if err != nil {
+//			addErrors = errors.Wrapf(addErrors, "failed to add iptables %s/%s rule %q: %v",
+//				r.table, r.chain, strings.Join(r.args, " "), err)
+//		}
+//	}
+//	return addErrors
+//}
+//
+//func delIptRules(rules []iptRule) error {
+//	var delErrors, err error
+//	var ipt util.IPTablesHelper
+//	for _, r := range rules {
+//		klog.V(5).Infof("Deleting rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ",
+//			r.table, r.chain, strings.Join(r.args, " "), r.protocol)
+//		if ipt, err = util.GetIPTablesHelper(r.protocol); err != nil {
+//			delErrors = errors.Wrapf(delErrors,
+//				"Failed to delete iptables %s/%s rule %q: %v", r.table, r.chain, strings.Join(r.args, " "), err)
+//			continue
+//		}
+//		if exists, err := ipt.Exists(r.table, r.chain, r.args...); err == nil && exists {
+//			err := ipt.Delete(r.table, r.chain, r.args...)
+//			if err != nil {
+//				delErrors = errors.Wrapf(delErrors, "failed to delete iptables %s/%s rule %q: %v",
+//					r.table, r.chain, strings.Join(r.args, " "), err)
+//			}
+//		}
+//	}
+//	return delErrors
+//}
+
+func addIptRules(rules []iptRule) error {
+	var addErrors error
+	for _, r := range rules {
+		klog.V(5).Infof("Adding rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ", r.table, r.chain, strings.Join(r.args, " "), r.protocol)
+		ipt, _ := util.GetIPTablesHelper(r.protocol)
+		if err := ipt.NewChain(r.table, r.chain); err != nil {
+			klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v", r.chain, r.table, err)
+		}
+		exists, err := ipt.Exists(r.table, r.chain, r.args...)
+		if !exists && err == nil {
+			err = ipt.Insert(r.table, r.chain, 1, r.args...)
+		}
+		if err != nil {
+			addErrors = errors.Wrapf(addErrors, "failed to add iptables %s/%s rule %q: %v",
+				r.table, r.chain, strings.Join(r.args, " "), err)
+		}
+	}
+	return addErrors
+}
+
+// ensureIptRules adds the rules passed to it *in the order* defined in the
+// slice - i.e. unlike it `addIptRules` it *appends* the rules to the chain
+// instead of inserting at the beginning.
+func ensureIptRules(rules []iptRule) error {
+	var addErrors error
+	for _, r := range rules {
+		klog.V(5).Infof("Appending rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ", r.table, r.chain, strings.Join(r.args, " "), r.protocol)
+		ipt, _ := util.GetIPTablesHelper(r.protocol)
+		if err := ipt.NewChain(r.table, r.chain); err != nil {
+			klog.V(5).Infof("Chain: \"%s\" in table: \"%s\" already exists, skipping creation: %v", r.chain, r.table, err)
+		}
+		exists, err := ipt.Exists(r.table, r.chain, r.args...)
+		if !exists && err == nil {
+			err = ipt.Append(r.table, r.chain, r.args...)
+		}
+		if err != nil {
+			addErrors = errors.Wrapf(addErrors, "failed to add iptables %s/%s rule %q: %v",
+				r.table, r.chain, strings.Join(r.args, " "), err)
+		}
+		klog.V(5).Infof("Rule \"%s\" *already* found in table: %s, chain: %s for protocol: %v. Skipped adding it.", strings.Join(r.args, " "), r.table, r.chain, r.protocol)
+	}
+	return addErrors
+}
+
+func delIptRules(rules []iptRule) error {
+	var delErrors error
+	for _, r := range rules {
+		klog.V(5).Infof("Deleting rule in table: %s, chain: %s with args: \"%s\" for protocol: %v ", r.table, r.chain, strings.Join(r.args, " "), r.protocol)
+		ipt, _ := util.GetIPTablesHelper(r.protocol)
+		if exists, err := ipt.Exists(r.table, r.chain, r.args...); err == nil && exists {
+			err := ipt.Delete(r.table, r.chain, r.args...)
+			if err != nil {
+				delErrors = errors.Wrapf(delErrors, "failed to delete iptables %s/%s rule %q: %v",
+					r.table, r.chain, strings.Join(r.args, " "), err)
+			}
+		}
+	}
+	return delErrors
+}
+
+func clusterIPTablesProtocols() []iptables.Protocol {
+	var protocols []iptables.Protocol
+	if config.IPv4Mode {
+		protocols = append(protocols, iptables.ProtocolIPv4)
+	}
+	if config.IPv6Mode {
+		protocols = append(protocols, iptables.ProtocolIPv6)
+	}
+	return protocols
+}
+
+// getIPTablesProtocol returns the IPTables protocol matching the protocol (v4/v6) of provided IP string
+func getIPTablesProtocol(ip string) iptables.Protocol {
+	if utilnet.IsIPv6String(ip) {
+		return iptables.ProtocolIPv6
+	}
+	return iptables.ProtocolIPv4
+}

--- a/go-controller/pkg/node/iptables_test.go
+++ b/go-controller/pkg/node/iptables_test.go
@@ -1,0 +1,62 @@
+package node
+
+import (
+	"fmt"
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/onsi/ginkgo/extensions/table"
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IPTables rules helpers", func() {
+	const (
+		ifaceIP   = "10.10.11.12"
+		ifaceName = "eth0"
+	)
+
+	table.DescribeTable("equal rules are compared", func(expectedRule iptRule, kernelRule string) {
+		Expect(expectedRule.IsEqual(kernelRule)).To(BeTrue())
+	},
+		table.Entry(
+			"SNAT management port rule",
+			generateNATMgmtChainSNATRule(ifaceName, net.ParseIP(ifaceIP)),
+			snatRuleForMgmtChainFromKernel(ifaceName, ifaceIP),
+		),
+		table.Entry(
+			"SNAT management port rule",
+			generateNATPostRoutingJumpToMgmtPortChain(ifaceName, iptables.ProtocolIPv4),
+			jumpToMnmtChainFromKernel(ifaceName),
+		),
+	)
+
+	table.DescribeTable("different rules are identified", func(inputIfaceName, inputIP string) {
+		Expect(
+			generateNATMgmtChainSNATRule(ifaceName, net.ParseIP(ifaceIP)).IsEqual(
+				snatRuleForMgmtChainFromKernel(inputIfaceName, inputIP))).To(BeFalse())
+	},
+		table.Entry("Successfully compares a different rule as false", "fake-iface-name", ifaceIP),
+		table.Entry("Successfully compares a different rule as false", ifaceName, "10.11.12.13"),
+	)
+
+	It("Parse rules from the kernel iptables", func() {
+		const (
+			ifaceIP   = "10.10.11.12"
+			ifaceName = "eth0"
+		)
+
+		Expect(
+			parseRule(
+				snatRuleForMgmtChainFromKernel(ifaceName, ifaceIP))).To(
+			ConsistOf("-o", ifaceName, "-m", "comment", "--comment", "OVN SNAT to Management Port", "-j", "SNAT", "--to-source", ifaceIP))
+	})
+})
+
+func snatRuleForMgmtChainFromKernel(ifaceName string, ifaceIP string) string {
+	return fmt.Sprintf("-A OVN-KUBE-SNAT-MGMTPORT -o %s -m comment --comment \"OVN SNAT to Management Port\" -j SNAT --to-source %s", ifaceName, net.ParseIP(ifaceIP))
+}
+
+func jumpToMnmtChainFromKernel(ifaceName string) string {
+	return fmt.Sprintf("-I POSTROUTING -o %s -j %s", ifaceName, iptableMgmPortChain)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->
closes https://bugzilla.redhat.com/show_bug.cgi?id=2107309

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Currently, whenever the node is restarted, the management port IPTables chain is flushed,
and its rules re-created.

This - as correctly reported in the bug linked above - causes some traffic interruption. 
... and is not necessary at all, since these rules **never** change. 

This PR changes this behavior by not doing any of that - instead of clearing up the mgmt port chain
on reboot, it makes sure the desired rules are present, while deleting all others.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
This is still a draft: I think this naive solution will impose performance degradation on boot-up.
Just want some early feedback.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
TODO. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
TODO dear bot. Hold your horses.
