### PR TITLE
kube: pass ResourceVersion:"0" for direct List() calls

### DIFF
--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -265,20 +265,24 @@ func (k *Kube) GetAnnotationsOnPod(namespace, name string) (map[string]string, e
 // GetNamespaces returns the list of all Namespace objects matching the labelSelector
 func (k *Kube) GetNamespaces(labelSelector metav1.LabelSelector) (*kapi.NamespaceList, error) {
 	return k.KClient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+		LabelSelector:   labels.Set(labelSelector.MatchLabels).String(),
+		ResourceVersion: "0",
 	})
 }
 
 // GetPods returns the list of all Pod objects in a namespace matching the labelSelector
 func (k *Kube) GetPods(namespace string, labelSelector metav1.LabelSelector) (*kapi.PodList, error) {
 	return k.KClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+		LabelSelector:   labels.Set(labelSelector.MatchLabels).String(),
+		ResourceVersion: "0",
 	})
 }
 
 // GetNodes returns the list of all Node objects from kubernetes
 func (k *Kube) GetNodes() (*kapi.NodeList, error) {
-	return k.KClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	return k.KClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+		ResourceVersion: "0",
+	})
 }
 
 // GetNode returns the Node resource from kubernetes apiserver, given its name
@@ -293,12 +297,16 @@ func (k *Kube) GetEgressIP(name string) (*egressipv1.EgressIP, error) {
 
 // GetEgressIPs returns the list of all EgressIP objects from kubernetes
 func (k *Kube) GetEgressIPs() (*egressipv1.EgressIPList, error) {
-	return k.EIPClient.K8sV1().EgressIPs().List(context.TODO(), metav1.ListOptions{})
+	return k.EIPClient.K8sV1().EgressIPs().List(context.TODO(), metav1.ListOptions{
+		ResourceVersion: "0",
+	})
 }
 
 // GetEgressFirewalls returns the list of all EgressFirewall objects from kubernetes
 func (k *Kube) GetEgressFirewalls() (*egressfirewall.EgressFirewallList, error) {
-	return k.EgressFirewallClient.K8sV1().EgressFirewalls(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	return k.EgressFirewallClient.K8sV1().EgressFirewalls(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
+		ResourceVersion: "0",
+	})
 }
 
 func (k *Kube) CreateCloudPrivateIPConfig(cloudPrivateIPConfig *ocpcloudnetworkapi.CloudPrivateIPConfig) (*ocpcloudnetworkapi.CloudPrivateIPConfig, error) {

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -365,7 +365,8 @@ func checkPodRunsOnGivenNode(clientset kubernetes.Interface, labels []string, k8
 	keepTrying bool) (bool, error) {
 	for _, label := range labels {
 		pods, err := clientset.CoreV1().Pods(config.Kubernetes.OVNConfigNamespace).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: label,
+			LabelSelector:   label,
+			ResourceVersion: "0",
 		})
 		if err != nil {
 			klog.V(5).Infof("Failed to list Pods with label %q: %v. Retrying..", label, err)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -1390,7 +1390,10 @@ func (oc *Controller) addUpdateNodeEvent(node *kapi.Node, nSyncs *nodeSyncs) err
 	// if per pod SNAT is being used, then l3 gateway config is required to be able to add pods
 	if _, gwFailed := oc.gatewaysFailed.Load(node.Name); !gwFailed || !config.Gateway.DisableSNATMultipleGWs {
 		if nSyncs.syncNode || nSyncs.syncGw { // do this only if it is a new node add or a gateway sync happened
-			options := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector("spec.nodeName", node.Name).String()}
+			options := metav1.ListOptions{
+				FieldSelector:   fields.OneTermEqualSelector("spec.nodeName", node.Name).String(),
+				ResourceVersion: "0",
+			}
 			pods, err := oc.client.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
 			if err != nil {
 				errs = append(errs, err)


### PR DESCRIPTION
Antonio says that if you don't pass ResourceVersion:"0" the call goes directly
through to etcd, while if you pass "0" it gets pulled from the apiserver's
cache. Pulling from the cache can greatly reduce load on etcd.

@aojea 

See: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go#L637

```
    // GetList implements storage.Interface
    func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
    	recursive := opts.Recursive
    	resourceVersion := opts.ResourceVersion
    	pred := opts.Predicate
    	if shouldDelegateList(opts) {
    		return c.storage.GetList(ctx, key, opts, listObj)
    	}
    	<...>
    }
    
    func shouldDelegateList(opts storage.ListOptions) bool {
    	resourceVersion := opts.ResourceVersion
    	pred := opts.Predicate
    	pagingEnabled := utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
    	hasContinuation := pagingEnabled && len(pred.Continue) > 0
    	hasLimit := pagingEnabled && pred.Limit > 0 && resourceVersion != "0"
    
    	// If resourceVersion is not specified, serve it from underlying
    	// storage (for backward compatibility). If a continuation is
    	// requested, serve it from the underlying storage as well.
    	// Limits are only sent to storage when resourceVersion is non-zero
    	// since the watch cache isn't able to perform continuations, and
    	// limits are ignored when resource version is zero
    	return resourceVersion == "" || hasContinuation || hasLimit || opts.ResourceVersionMatch == metav1.ResourceVersionMatchExact
    }
```