### PR TITLE
add support for creating stateless OVN ACLs for K8s Network Policies

### DIFF
--- a/go-controller/pkg/ovn/gress_policy_test.go
+++ b/go-controller/pkg/ovn/gress_policy_test.go
@@ -109,7 +109,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		gressPolicy := newGressPolicy(knet.PolicyTypeIngress, 5, "testing", "test")
+		gressPolicy := newGressPolicy(knet.PolicyTypeIngress, 5, "testing", "test", false)
 		for _, ipBlock := range tc.ipBlocks {
 			gressPolicy.addIPBlock(ipBlock)
 		}


### PR DESCRIPTION
All K8s Network Policies are implemented as OVN ACLs and they are
stateful by default. With stateful ACLs, the reply packets for an
outbound connection are automatically matched and those packets are let
in since the connection was started from within the Pod. There is no
need to author additional network policy to match the reply packets.

This means that the Kernel needs to track connection state and match
the incoming packets with that state to ascertain whether they are
‘reply’ packets or ‘new’ packets. This can be used to overwhelm the DPU
by creating millions of connections and making the kernel track
the state for each one of them and forcing the incoming packets to match
those states thereby overwhelming the DPU CPU.

To mitigate this, the K8s Network Policies can be created as
stateless OVN ACLs by annotating the K8s Network Policy with

ovnStatelessACLAnnotationName = "k8s.ovn.org/acl-stateless"

However, this means that we need to add additional network policy in
the opposite direction otherwise connections will not complete.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>