### PR TITLE
Bump libovsdb to include https://github.com/ovn-org/libovsdb/pull/321

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
-	github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1
+	github.com/ovn-org/libovsdb v0.6.1-0.20220809122511-83fdc64a4613
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -415,8 +415,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mo
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a h1:ylsEgoC8Dlg4A0C1TLH0A4x/TZao7k1YveLwROhRUdk=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
 github.com/ory/dockertest/v3 v3.8.0/go.mod h1:9zPATATlWQru+ynXP+DytBQrsXV7Tmlx7K86H6fQaDo=
-github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1 h1:ZXVHrW4b7RK/emoqTNL58IWUuK0dD8PVb93fbfh9cMs=
-github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
+github.com/ovn-org/libovsdb v0.6.1-0.20220809122511-83fdc64a4613 h1:qWujUoskFI9z/UU4ehzdzZxHEg/Uz/+f4GLMMkLI2ds=
+github.com/ovn-org/libovsdb v0.6.1-0.20220809122511-83fdc64a4613/go.mod h1:BQPdnSM2QOKxPwxl7wHJDSPP4B/CDKq3+vzgFW3J5gE=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/cache/cache.go
@@ -1136,7 +1136,7 @@ type event struct {
 
 // eventProcessor handles the queueing and processing of cache events
 type eventProcessor struct {
-	events chan event
+	events chan *event
 	// handlersMutex locks the handlers array when we add a handler or dispatch events
 	// we don't need a RWMutex in this case as we only have one thread reading and the write
 	// volume is very low (i.e only when AddEventHandler is called)
@@ -1147,7 +1147,7 @@ type eventProcessor struct {
 
 func newEventProcessor(capacity int, logger *logr.Logger) *eventProcessor {
 	return &eventProcessor{
-		events:   make(chan event, capacity),
+		events:   make(chan *event, capacity),
 		handlers: []EventHandler{},
 		logger:   logger,
 	}
@@ -1174,7 +1174,7 @@ func (e *eventProcessor) AddEvent(eventType string, table string, old model.Mode
 		new:       new,
 	}
 	select {
-	case e.events <- event:
+	case e.events <- &event:
 		// noop
 		return
 	default:

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/server/mutate.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/server/mutate.go
@@ -164,7 +164,7 @@ func mutateDelete(current, value interface{}) (interface{}, interface{}) {
 			vvk := iter.Key()
 			vvv := iter.Value()
 			vcv := vc.MapIndex(vvk)
-			if reflect.DeepEqual(vcv.Interface(), vvv.Interface()) {
+			if vcv.IsValid() && reflect.DeepEqual(vcv.Interface(), vvv.Interface()) {
 				diff.SetMapIndex(vvk, vcv)
 				vc.SetMapIndex(vvk, reflect.Value{})
 			}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -157,12 +157,12 @@ github.com/gorilla/mux
 # github.com/imdario/mergo v0.3.12
 ## explicit; go 1.13
 github.com/imdario/mergo
-# github.com/josharian/intern v1.0.0
-## explicit; go 1.5
-github.com/josharian/intern
 # github.com/j-keck/arping v1.0.2
 ## explicit; go 1.12
 github.com/j-keck/arping
+# github.com/josharian/intern v1.0.0
+## explicit; go 1.5
+github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
@@ -267,7 +267,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220603151050-98c0bad3cff1
+# github.com/ovn-org/libovsdb v0.6.1-0.20220809122511-83fdc64a4613
 ## explicit; go 1.16
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client


### PR DESCRIPTION
Signed-off-by: Zenghui Shi <zshi@redhat.com>
