### PR TITLE
Fix go version in lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,20 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      id: go
+
     - name: Verify
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.46
         working-directory: go-controller
         args: --modules-download-mode=vendor --timeout=15m0s --verbose
+        skip-go-installation: true
+
   build-master:
     name: Build-master
     runs-on: ubuntu-latest
@@ -50,8 +58,8 @@ jobs:
         path: |
           ${{ env.CI_IMAGE_CACHE }}
         key: ${{ github.run_id }}-image-cache-master
-    # if CI_IMAGE_MASTER_TAR isn't in cache, try pulling it and saving to the cache rather 
-    # than building, resort back to building if the cache isn't populated and 
+    # if CI_IMAGE_MASTER_TAR isn't in cache, try pulling it and saving to the cache rather
+    # than building, resort back to building if the cache isn't populated and
     # pulling the image fails.
     - name: Check if master image build is needed
       id: is_master_image_build_needed
@@ -63,9 +71,9 @@ jobs:
             gunzip ${CI_IMAGE_MASTER_TAR}.gz
             echo "::set-output name=MASTER_IMAGE_RESTORED_FROM_CACHE::true"
             exit 0
-        fi 
-        
-        if docker pull ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master; then 
+        fi
+
+        if docker pull ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master; then
             docker tag ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master ovn-daemonset-f:dev
 
             echo "::set-output name=MASTER_IMAGE_RESTORED_FROM_GHCR::true"
@@ -101,7 +109,7 @@ jobs:
           sudo cp -f ../../go-controller/_output/go/bin/ovn* .
           echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
           docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
-        popd 
+        popd
 
     - name: Cache master image
       if: steps.is_master_image_build_needed.outputs.MASTER_IMAGE_RESTORED_FROM_CACHE != 'true' && success()
@@ -282,11 +290,11 @@ jobs:
     - name: Load docker image
       run: |
         docker load --input ${CI_IMAGE_MASTER_TAR}
-        
+
     - name: Check out code into the Go module directory - from Master branch
       if: steps.last_run_status.outputs.STATUS != 'completed' && success()
       uses: actions/checkout@v2
-      with: 
+      with:
           ref: master
 
     - name: kind setup
@@ -301,9 +309,9 @@ jobs:
         kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
         set -x
         docker ps -a
-        docker exec ovn-control-plane crictl images 
+        docker exec ovn-control-plane crictl images
         docker exec ovn-worker crictl images
-        docker exec ovn-worker2 crictl images 
+        docker exec ovn-worker2 crictl images
 
     - name: Upload kind logs
       if: always()
@@ -320,7 +328,7 @@ jobs:
     - name: Load docker image
       run: |
         docker load --input ${CI_IMAGE_PR_TAR}
-    
+
     - name: Check out code into the Go module directory - from PR branch
       uses: actions/checkout@v2
 


### PR DESCRIPTION
Add golang installation step to lint job, since `golangci-lint` might install a later version by design: https://github.com/golangci/golangci-lint-action/issues/75

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
