### PR TITLE
OVN-K Metrics: Ensure stopwatch metrics are reported in seconds

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,6 +17,7 @@ Measurement accuracy can be impacted by other parallel processing that might be 
 ## Change log
 This list is to help notify if there are additions, changes or removals to metrics.
 
+- Stopwatch metrics now report in seconds instead of milliseconds.
 - Rename (https://github.com/ovn-org/ovn-kubernetes/pull/3022):
   - `ovs_vswitchd_interface_link_resets` -> `ovs_vswitchd_interface_resets_total`
   - `ovs_vswitchd_interface_rx_dropped` -> `ovs_vswitchd_interface_rx_dropped_total`

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -347,11 +347,11 @@ func stopwatchShowMetricsUpdater(component string, stopChan <-chan struct{}) {
 				}
 
 				metricInfo.metrics.totalSamples.Set(totalSamplesMetricValue)
-				metricInfo.metrics.min.Set(minMetricValue)
-				metricInfo.metrics.max.Set(maxMetricValue)
-				metricInfo.metrics.percentile95th.Set(percentile95thMetricValue)
-				metricInfo.metrics.shortTermAvg.Set(shortTermAvgMetricValue)
-				metricInfo.metrics.longTermAvg.Set(longTermAvgMetricValue)
+				metricInfo.metrics.min.Set(minMetricValue / 1000)
+				metricInfo.metrics.max.Set(maxMetricValue / 1000)
+				metricInfo.metrics.percentile95th.Set(percentile95thMetricValue / 1000)
+				metricInfo.metrics.shortTermAvg.Set(shortTermAvgMetricValue / 1000)
+				metricInfo.metrics.longTermAvg.Set(longTermAvgMetricValue / 1000)
 			}
 		case <-stopChan:
 			return


### PR DESCRIPTION
Currently, they are reported in milliseconds.
Prometheus mandates time values are reported in seconds.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

/cc @creydr && @npinaeva 