### PR TITLE
Add libovsdb metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,6 +17,7 @@ Measurement accuracy can be impacted by other parallel processing that might be 
 ## Change log
 This list is to help notify if there are additions, changes or removals to metrics.
 
+- Add libovsdb metrics - ovnkube_master_libovsdb_disconnects_total and ovnkube_master_libovsdb_monitors.
 - Add ovn_controller_southbound_database_connected metric (https://github.com/ovn-org/ovn-kubernetes/pull/3117).
 - Stopwatch metrics now report in seconds instead of milliseconds.
 - Rename (https://github.com/ovn-org/ovn-kubernetes/pull/3022):

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/bhendo/go-powershell v0.0.0-20190719160123-219e7fb4e41e
-	github.com/cenkalti/backoff/v4 v4.1.1
+	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.8.7
 	github.com/coreos/go-iptables v0.4.5
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
-	github.com/ovn-org/libovsdb v0.6.1-0.20220826133223-e4d2d8648be7
+	github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0
@@ -45,7 +45,7 @@ require (
 )
 
 require (
-	github.com/Microsoft/go-winio v0.5.0 // indirect
+	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -50,8 +50,8 @@ github.com/Mellanox/sriovnet v1.0.3 h1:Nlmxr2mkp16aIP4CJcsnqCczxQQgOuzNDm/nu9qTB
 github.com/Mellanox/sriovnet v1.0.3/go.mod h1:8TlYc3iOTEvUM+WAbC7MU6U6JXqIfhl2DcWIGVUsjIE=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
-github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
-github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
+github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990 h1:1xpVY4dSUSbW3PcSGxZJhI8Z+CJiqbd933kM7HIinTc=
 github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990/go.mod h1:ay/0dTb7NsG8QMDfsRfLHgZo/6xAJShLe1+ePPflihk=
@@ -82,8 +82,8 @@ github.com/bhendo/go-powershell v0.0.0-20190719160123-219e7fb4e41e h1:KCjb01YiNo
 github.com/bhendo/go-powershell v0.0.0-20190719160123-219e7fb4e41e/go.mod h1:f7vw6ObmmNcyFQLhZX9eUGBJGpnwTJFDvVjqZxIxHWY=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cenk/hub v1.0.1 h1:RBwXNOF4a8KjD8BJ08XqN8KbrqaGiQLDrgvUGJSHuPA=
-github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
-github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/hub v1.0.1 h1:UMtjc6dHSaOQTO15SVA50MBIR9zQwvsukQupDrkIRtg=
 github.com/cenkalti/hub v1.0.1/go.mod h1:tcYwtS3a2d9NO/0xDXVJWx3IedurUjYCqFCmpi0lpHs=
 github.com/cenkalti/rpc2 v0.0.0-20210604223624-c1acbc6ec984 h1:CNwZyGS6KpfaOWbh2yLkSy3rSTUh3jub9CzpFpP6PVQ=
@@ -387,8 +387,8 @@ github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68/go.mod h1:LEnw1IVscI
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a h1:ylsEgoC8Dlg4A0C1TLH0A4x/TZao7k1YveLwROhRUdk=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
-github.com/ovn-org/libovsdb v0.6.1-0.20220826133223-e4d2d8648be7 h1:5QygTHBNvCe3A78OAl9UqllaIGX4TL00te/OIBiHHEo=
-github.com/ovn-org/libovsdb v0.6.1-0.20220826133223-e4d2d8648be7/go.mod h1:j6GV+8zVENVmWFxHg5nNcn88ge67sq35yyoAEso7TD8=
+github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a h1:fcKT5QPXQfNURcy4QddDFnI8f2GTNVlJrQMwJ+pZbI8=
+github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a/go.mod h1:S/+Hux9//oB7yLaPsUKnXTzZc6S1C4a9HP0UifXfKz0=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go-controller/pkg/testing/libovsdb/libovsdb.go
+++ b/go-controller/pkg/testing/libovsdb/libovsdb.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/libovsdb/ovsdb/serverdb"
 	"github.com/ovn-org/libovsdb/server"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -139,7 +140,7 @@ func newOVSDBTestHarness(serverData []TestData, newServer serverBuilderFn, newCl
 
 func newNBClient(cfg config.OvnAuthConfig, cleanup *Cleanup) (libovsdbclient.Client, error) {
 	stopChan := make(chan struct{})
-	libovsdbOvnNBClient, err := libovsdb.NewNBClientWithConfig(cfg, stopChan)
+	libovsdbOvnNBClient, err := libovsdb.NewNBClientWithConfig(cfg, prometheus.NewRegistry(), stopChan)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func newNBClient(cfg config.OvnAuthConfig, cleanup *Cleanup) (libovsdbclient.Cli
 
 func newSBClient(cfg config.OvnAuthConfig, cleanup *Cleanup) (libovsdbclient.Client, error) {
 	stopChan := make(chan struct{})
-	libovsdbOvnSBClient, err := libovsdb.NewSBClientWithConfig(cfg, stopChan)
+	libovsdbOvnSBClient, err := libovsdb.NewSBClientWithConfig(cfg, prometheus.NewRegistry(), stopChan)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/vendor/github.com/Microsoft/go-winio/README.md
+++ b/go-controller/vendor/github.com/Microsoft/go-winio/README.md
@@ -11,12 +11,27 @@ package.
 
 Please see the LICENSE file for licensing information.
 
-This project has adopted the [Microsoft Open Source Code of
-Conduct](https://opensource.microsoft.com/codeofconduct/). For more information
-see the [Code of Conduct
-FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
-[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
-questions or comments.
+## Contributing
 
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA)
+declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR
+appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+We also require that contributors sign their commits using git commit -s or git commit --signoff to certify they either authored the work themselves
+or otherwise have permission to use it in this project. Please see https://developercertificate.org/ for more info, as well as to make sure that you can
+attest to the rules listed. Our CI uses the DCO Github app to ensure that all commits in a given PR are signed-off.
+
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+
+
+## Special Thanks
 Thanks to natefinch for the inspiration for this library. See https://github.com/natefinch/npipe
 for another named pipe implementation.

--- a/go-controller/vendor/github.com/Microsoft/go-winio/file.go
+++ b/go-controller/vendor/github.com/Microsoft/go-winio/file.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio
@@ -141,6 +142,11 @@ func (f *win32File) closeHandle() {
 func (f *win32File) Close() error {
 	f.closeHandle()
 	return nil
+}
+
+// IsClosed checks if the file has been closed
+func (f *win32File) IsClosed() bool {
+	return f.closing.isSet()
 }
 
 // prepareIo prepares for a new IO operation.

--- a/go-controller/vendor/github.com/Microsoft/go-winio/pkg/guid/guid.go
+++ b/go-controller/vendor/github.com/Microsoft/go-winio/pkg/guid/guid.go
@@ -14,8 +14,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strconv"
-
-	"golang.org/x/sys/windows"
 )
 
 // Variant specifies which GUID variant (or "type") of the GUID. It determines
@@ -40,13 +38,6 @@ type Version uint8
 
 var _ = (encoding.TextMarshaler)(GUID{})
 var _ = (encoding.TextUnmarshaler)(&GUID{})
-
-// GUID represents a GUID/UUID. It has the same structure as
-// golang.org/x/sys/windows.GUID so that it can be used with functions expecting
-// that type. It is defined as its own type so that stringification and
-// marshaling can be supported. The representation matches that used by native
-// Windows code.
-type GUID windows.GUID
 
 // NewV4 returns a new version 4 (pseudorandom) GUID, as defined by RFC 4122.
 func NewV4() (GUID, error) {

--- a/go-controller/vendor/github.com/Microsoft/go-winio/pkg/guid/guid_nonwindows.go
+++ b/go-controller/vendor/github.com/Microsoft/go-winio/pkg/guid/guid_nonwindows.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package guid
+
+// GUID represents a GUID/UUID. It has the same structure as
+// golang.org/x/sys/windows.GUID so that it can be used with functions expecting
+// that type. It is defined as its own type as that is only available to builds
+// targeted at `windows`. The representation matches that used by native Windows
+// code.
+type GUID struct {
+	Data1 uint32
+	Data2 uint16
+	Data3 uint16
+	Data4 [8]byte
+}

--- a/go-controller/vendor/github.com/Microsoft/go-winio/pkg/guid/guid_windows.go
+++ b/go-controller/vendor/github.com/Microsoft/go-winio/pkg/guid/guid_windows.go
@@ -1,0 +1,10 @@
+package guid
+
+import "golang.org/x/sys/windows"
+
+// GUID represents a GUID/UUID. It has the same structure as
+// golang.org/x/sys/windows.GUID so that it can be used with functions expecting
+// that type. It is defined as its own type so that stringification and
+// marshaling can be supported. The representation matches that used by native
+// Windows code.
+type GUID windows.GUID

--- a/go-controller/vendor/github.com/Microsoft/go-winio/vhd/vhd.go
+++ b/go-controller/vendor/github.com/Microsoft/go-winio/vhd/vhd.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package vhd
@@ -7,17 +8,16 @@ import (
 	"syscall"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 
 //go:generate go run mksyscall_windows.go -output zvhd_windows.go vhd.go
 
-//sys createVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, securityDescriptor *uintptr, createVirtualDiskFlags uint32, providerSpecificFlags uint32, parameters *CreateVirtualDiskParameters, overlapped *syscall.Overlapped, handle *syscall.Handle) (err error) [failretval != 0] = virtdisk.CreateVirtualDisk
-//sys openVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, openVirtualDiskFlags uint32, parameters *OpenVirtualDiskParameters, handle *syscall.Handle) (err error) [failretval != 0] = virtdisk.OpenVirtualDisk
-//sys attachVirtualDisk(handle syscall.Handle, securityDescriptor *uintptr, attachVirtualDiskFlag uint32, providerSpecificFlags uint32, parameters *AttachVirtualDiskParameters, overlapped *syscall.Overlapped) (err error) [failretval != 0] = virtdisk.AttachVirtualDisk
-//sys detachVirtualDisk(handle syscall.Handle, detachVirtualDiskFlags uint32, providerSpecificFlags uint32) (err error) [failretval != 0] = virtdisk.DetachVirtualDisk
-//sys getVirtualDiskPhysicalPath(handle syscall.Handle, diskPathSizeInBytes *uint32, buffer *uint16) (err error) [failretval != 0] = virtdisk.GetVirtualDiskPhysicalPath
+//sys createVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, securityDescriptor *uintptr, createVirtualDiskFlags uint32, providerSpecificFlags uint32, parameters *CreateVirtualDiskParameters, overlapped *syscall.Overlapped, handle *syscall.Handle) (win32err error) = virtdisk.CreateVirtualDisk
+//sys openVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, openVirtualDiskFlags uint32, parameters *openVirtualDiskParameters, handle *syscall.Handle) (win32err error) = virtdisk.OpenVirtualDisk
+//sys attachVirtualDisk(handle syscall.Handle, securityDescriptor *uintptr, attachVirtualDiskFlag uint32, providerSpecificFlags uint32, parameters *AttachVirtualDiskParameters, overlapped *syscall.Overlapped) (win32err error) = virtdisk.AttachVirtualDisk
+//sys detachVirtualDisk(handle syscall.Handle, detachVirtualDiskFlags uint32, providerSpecificFlags uint32) (win32err error) = virtdisk.DetachVirtualDisk
+//sys getVirtualDiskPhysicalPath(handle syscall.Handle, diskPathSizeInBytes *uint32, buffer *uint16) (win32err error) = virtdisk.GetVirtualDiskPhysicalPath
 
 type (
 	CreateVirtualDiskFlag uint32
@@ -62,13 +62,27 @@ type OpenVirtualDiskParameters struct {
 	Version2 OpenVersion2
 }
 
+// The higher level `OpenVersion2` struct uses bools to refer to `GetInfoOnly` and `ReadOnly` for ease of use. However,
+// the internal windows structure uses `BOOLS` aka int32s for these types. `openVersion2` is used for translating
+// `OpenVersion2` fields to the correct windows internal field types on the `Open____` methods.
+type openVersion2 struct {
+	getInfoOnly    int32
+	readOnly       int32
+	resiliencyGUID guid.GUID
+}
+
+type openVirtualDiskParameters struct {
+	version  uint32
+	version2 openVersion2
+}
+
 type AttachVersion2 struct {
 	RestrictedOffset uint64
 	RestrictedLength uint64
 }
 
 type AttachVirtualDiskParameters struct {
-	Version  uint32 // Must always be set to 2
+	Version  uint32
 	Version2 AttachVersion2
 }
 
@@ -146,16 +160,13 @@ func CreateVhdx(path string, maxSizeInGb, blockSizeInMb uint32) error {
 		return err
 	}
 
-	if err := syscall.CloseHandle(handle); err != nil {
-		return err
-	}
-	return nil
+	return syscall.CloseHandle(handle)
 }
 
 // DetachVirtualDisk detaches a virtual hard disk by handle.
 func DetachVirtualDisk(handle syscall.Handle) (err error) {
 	if err := detachVirtualDisk(handle, 0, 0); err != nil {
-		return errors.Wrap(err, "failed to detach virtual disk")
+		return fmt.Errorf("failed to detach virtual disk: %w", err)
 	}
 	return nil
 }
@@ -185,7 +196,7 @@ func AttachVirtualDisk(handle syscall.Handle, attachVirtualDiskFlag AttachVirtua
 		parameters,
 		nil,
 	); err != nil {
-		return errors.Wrap(err, "failed to attach virtual disk")
+		return fmt.Errorf("failed to attach virtual disk: %w", err)
 	}
 	return nil
 }
@@ -209,7 +220,7 @@ func AttachVhd(path string) (err error) {
 		AttachVirtualDiskFlagNone,
 		&params,
 	); err != nil {
-		return errors.Wrap(err, "failed to attach virtual disk")
+		return fmt.Errorf("failed to attach virtual disk: %w", err)
 	}
 	return nil
 }
@@ -234,19 +245,35 @@ func OpenVirtualDiskWithParameters(vhdPath string, virtualDiskAccessMask Virtual
 	var (
 		handle      syscall.Handle
 		defaultType VirtualStorageType
+		getInfoOnly int32
+		readOnly    int32
 	)
 	if parameters.Version != 2 {
 		return handle, fmt.Errorf("only version 2 VHDs are supported, found version: %d", parameters.Version)
+	}
+	if parameters.Version2.GetInfoOnly {
+		getInfoOnly = 1
+	}
+	if parameters.Version2.ReadOnly {
+		readOnly = 1
+	}
+	params := &openVirtualDiskParameters{
+		version: parameters.Version,
+		version2: openVersion2{
+			getInfoOnly,
+			readOnly,
+			parameters.Version2.ResiliencyGUID,
+		},
 	}
 	if err := openVirtualDisk(
 		&defaultType,
 		vhdPath,
 		uint32(virtualDiskAccessMask),
 		uint32(openVirtualDiskFlags),
-		parameters,
+		params,
 		&handle,
 	); err != nil {
-		return 0, errors.Wrap(err, "failed to open virtual disk")
+		return 0, fmt.Errorf("failed to open virtual disk: %w", err)
 	}
 	return handle, nil
 }
@@ -272,7 +299,7 @@ func CreateVirtualDisk(path string, virtualDiskAccessMask VirtualDiskAccessMask,
 		nil,
 		&handle,
 	); err != nil {
-		return handle, errors.Wrap(err, "failed to create virtual disk")
+		return handle, fmt.Errorf("failed to create virtual disk: %w", err)
 	}
 	return handle, nil
 }
@@ -290,7 +317,7 @@ func GetVirtualDiskPhysicalPath(handle syscall.Handle) (_ string, err error) {
 		&diskPathSizeInBytes,
 		&diskPhysicalPathBuf[0],
 	); err != nil {
-		return "", errors.Wrap(err, "failed to get disk physical path")
+		return "", fmt.Errorf("failed to get disk physical path: %w", err)
 	}
 	return windows.UTF16ToString(diskPhysicalPathBuf[:]), nil
 }
@@ -314,10 +341,10 @@ func CreateDiffVhd(diffVhdPath, baseVhdPath string, blockSizeInMB uint32) error 
 		createParams,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create differencing vhd: %s", err)
+		return fmt.Errorf("failed to create differencing vhd: %w", err)
 	}
 	if err := syscall.CloseHandle(vhdHandle); err != nil {
-		return fmt.Errorf("failed to close differencing vhd handle: %s", err)
+		return fmt.Errorf("failed to close differencing vhd handle: %w", err)
 	}
 	return nil
 }

--- a/go-controller/vendor/github.com/Microsoft/go-winio/vhd/zvhd_windows.go
+++ b/go-controller/vendor/github.com/Microsoft/go-winio/vhd/zvhd_windows.go
@@ -47,60 +47,60 @@ var (
 	procOpenVirtualDisk            = modvirtdisk.NewProc("OpenVirtualDisk")
 )
 
-func attachVirtualDisk(handle syscall.Handle, securityDescriptor *uintptr, attachVirtualDiskFlag uint32, providerSpecificFlags uint32, parameters *AttachVirtualDiskParameters, overlapped *syscall.Overlapped) (err error) {
-	r1, _, e1 := syscall.Syscall6(procAttachVirtualDisk.Addr(), 6, uintptr(handle), uintptr(unsafe.Pointer(securityDescriptor)), uintptr(attachVirtualDiskFlag), uintptr(providerSpecificFlags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(overlapped)))
-	if r1 != 0 {
-		err = errnoErr(e1)
+func attachVirtualDisk(handle syscall.Handle, securityDescriptor *uintptr, attachVirtualDiskFlag uint32, providerSpecificFlags uint32, parameters *AttachVirtualDiskParameters, overlapped *syscall.Overlapped) (win32err error) {
+	r0, _, _ := syscall.Syscall6(procAttachVirtualDisk.Addr(), 6, uintptr(handle), uintptr(unsafe.Pointer(securityDescriptor)), uintptr(attachVirtualDiskFlag), uintptr(providerSpecificFlags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(overlapped)))
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
 	}
 	return
 }
 
-func createVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, securityDescriptor *uintptr, createVirtualDiskFlags uint32, providerSpecificFlags uint32, parameters *CreateVirtualDiskParameters, overlapped *syscall.Overlapped, handle *syscall.Handle) (err error) {
+func createVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, securityDescriptor *uintptr, createVirtualDiskFlags uint32, providerSpecificFlags uint32, parameters *CreateVirtualDiskParameters, overlapped *syscall.Overlapped, handle *syscall.Handle) (win32err error) {
 	var _p0 *uint16
-	_p0, err = syscall.UTF16PtrFromString(path)
-	if err != nil {
+	_p0, win32err = syscall.UTF16PtrFromString(path)
+	if win32err != nil {
 		return
 	}
 	return _createVirtualDisk(virtualStorageType, _p0, virtualDiskAccessMask, securityDescriptor, createVirtualDiskFlags, providerSpecificFlags, parameters, overlapped, handle)
 }
 
-func _createVirtualDisk(virtualStorageType *VirtualStorageType, path *uint16, virtualDiskAccessMask uint32, securityDescriptor *uintptr, createVirtualDiskFlags uint32, providerSpecificFlags uint32, parameters *CreateVirtualDiskParameters, overlapped *syscall.Overlapped, handle *syscall.Handle) (err error) {
-	r1, _, e1 := syscall.Syscall9(procCreateVirtualDisk.Addr(), 9, uintptr(unsafe.Pointer(virtualStorageType)), uintptr(unsafe.Pointer(path)), uintptr(virtualDiskAccessMask), uintptr(unsafe.Pointer(securityDescriptor)), uintptr(createVirtualDiskFlags), uintptr(providerSpecificFlags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(handle)))
-	if r1 != 0 {
-		err = errnoErr(e1)
+func _createVirtualDisk(virtualStorageType *VirtualStorageType, path *uint16, virtualDiskAccessMask uint32, securityDescriptor *uintptr, createVirtualDiskFlags uint32, providerSpecificFlags uint32, parameters *CreateVirtualDiskParameters, overlapped *syscall.Overlapped, handle *syscall.Handle) (win32err error) {
+	r0, _, _ := syscall.Syscall9(procCreateVirtualDisk.Addr(), 9, uintptr(unsafe.Pointer(virtualStorageType)), uintptr(unsafe.Pointer(path)), uintptr(virtualDiskAccessMask), uintptr(unsafe.Pointer(securityDescriptor)), uintptr(createVirtualDiskFlags), uintptr(providerSpecificFlags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(overlapped)), uintptr(unsafe.Pointer(handle)))
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
 	}
 	return
 }
 
-func detachVirtualDisk(handle syscall.Handle, detachVirtualDiskFlags uint32, providerSpecificFlags uint32) (err error) {
-	r1, _, e1 := syscall.Syscall(procDetachVirtualDisk.Addr(), 3, uintptr(handle), uintptr(detachVirtualDiskFlags), uintptr(providerSpecificFlags))
-	if r1 != 0 {
-		err = errnoErr(e1)
+func detachVirtualDisk(handle syscall.Handle, detachVirtualDiskFlags uint32, providerSpecificFlags uint32) (win32err error) {
+	r0, _, _ := syscall.Syscall(procDetachVirtualDisk.Addr(), 3, uintptr(handle), uintptr(detachVirtualDiskFlags), uintptr(providerSpecificFlags))
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
 	}
 	return
 }
 
-func getVirtualDiskPhysicalPath(handle syscall.Handle, diskPathSizeInBytes *uint32, buffer *uint16) (err error) {
-	r1, _, e1 := syscall.Syscall(procGetVirtualDiskPhysicalPath.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(diskPathSizeInBytes)), uintptr(unsafe.Pointer(buffer)))
-	if r1 != 0 {
-		err = errnoErr(e1)
+func getVirtualDiskPhysicalPath(handle syscall.Handle, diskPathSizeInBytes *uint32, buffer *uint16) (win32err error) {
+	r0, _, _ := syscall.Syscall(procGetVirtualDiskPhysicalPath.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(diskPathSizeInBytes)), uintptr(unsafe.Pointer(buffer)))
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
 	}
 	return
 }
 
-func openVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, openVirtualDiskFlags uint32, parameters *OpenVirtualDiskParameters, handle *syscall.Handle) (err error) {
+func openVirtualDisk(virtualStorageType *VirtualStorageType, path string, virtualDiskAccessMask uint32, openVirtualDiskFlags uint32, parameters *openVirtualDiskParameters, handle *syscall.Handle) (win32err error) {
 	var _p0 *uint16
-	_p0, err = syscall.UTF16PtrFromString(path)
-	if err != nil {
+	_p0, win32err = syscall.UTF16PtrFromString(path)
+	if win32err != nil {
 		return
 	}
 	return _openVirtualDisk(virtualStorageType, _p0, virtualDiskAccessMask, openVirtualDiskFlags, parameters, handle)
 }
 
-func _openVirtualDisk(virtualStorageType *VirtualStorageType, path *uint16, virtualDiskAccessMask uint32, openVirtualDiskFlags uint32, parameters *OpenVirtualDiskParameters, handle *syscall.Handle) (err error) {
-	r1, _, e1 := syscall.Syscall6(procOpenVirtualDisk.Addr(), 6, uintptr(unsafe.Pointer(virtualStorageType)), uintptr(unsafe.Pointer(path)), uintptr(virtualDiskAccessMask), uintptr(openVirtualDiskFlags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(handle)))
-	if r1 != 0 {
-		err = errnoErr(e1)
+func _openVirtualDisk(virtualStorageType *VirtualStorageType, path *uint16, virtualDiskAccessMask uint32, openVirtualDiskFlags uint32, parameters *openVirtualDiskParameters, handle *syscall.Handle) (win32err error) {
+	r0, _, _ := syscall.Syscall6(procOpenVirtualDisk.Addr(), 6, uintptr(unsafe.Pointer(virtualStorageType)), uintptr(unsafe.Pointer(path)), uintptr(virtualDiskAccessMask), uintptr(openVirtualDiskFlags), uintptr(unsafe.Pointer(parameters)), uintptr(unsafe.Pointer(handle)))
+	if r0 != 0 {
+		win32err = syscall.Errno(r0)
 	}
 	return
 }

--- a/go-controller/vendor/github.com/cenkalti/backoff/v4/exponential.go
+++ b/go-controller/vendor/github.com/cenkalti/backoff/v4/exponential.go
@@ -147,6 +147,9 @@ func (b *ExponentialBackOff) incrementCurrentInterval() {
 // Returns a random value from the following interval:
 // 	[currentInterval - randomizationFactor * currentInterval, currentInterval + randomizationFactor * currentInterval].
 func getRandomValueFromInterval(randomizationFactor, random float64, currentInterval time.Duration) time.Duration {
+	if randomizationFactor == 0 {
+		return currentInterval // make sure no randomness is used when randomizationFactor is 0.
+	}
 	var delta = randomizationFactor * float64(currentInterval)
 	var minInterval = float64(currentInterval) - delta
 	var maxInterval = float64(currentInterval) + delta

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/metrics.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/metrics.go
@@ -13,9 +13,8 @@ type metrics struct {
 	numTableUpdates *prometheus.CounterVec
 	numDisconnects  prometheus.Counter
 	numMonitors     prometheus.Gauge
+	registerOnce    sync.Once
 }
-
-var regMetricsOnce sync.Once
 
 func (m *metrics) init(modelName string, namespace, subsystem string) {
 	// labels that are the same across all metrics
@@ -70,7 +69,7 @@ func (m *metrics) init(modelName string, namespace, subsystem string) {
 }
 
 func (m *metrics) register(r prometheus.Registerer) {
-	regMetricsOnce.Do(func() {
+	m.registerOnce.Do(func() {
 		r.MustRegister(
 			m.numUpdates,
 			m.numTableUpdates,

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -3,8 +3,8 @@
 github.com/Mellanox/sriovnet
 github.com/Mellanox/sriovnet/pkg/utils/filesystem
 github.com/Mellanox/sriovnet/pkg/utils/netlinkops
-# github.com/Microsoft/go-winio v0.5.0
-## explicit; go 1.12
+# github.com/Microsoft/go-winio v0.5.2
+## explicit; go 1.13
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/vhd
@@ -45,7 +45,7 @@ github.com/beorn7/perks/quantile
 github.com/bhendo/go-powershell
 github.com/bhendo/go-powershell/backend
 github.com/bhendo/go-powershell/utils
-# github.com/cenkalti/backoff/v4 v4.1.1
+# github.com/cenkalti/backoff/v4 v4.1.3
 ## explicit; go 1.13
 github.com/cenkalti/backoff/v4
 # github.com/cenkalti/hub v1.0.1
@@ -267,7 +267,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220826133223-e4d2d8648be7
+# github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a
 ## explicit; go 1.18
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client


### PR DESCRIPTION
depends on ovn-org/libovsdb/pull/328

See docs/metrics.md for metric names.

I want libovsdb monitor connection metrics to create an alert if we aren't connected to SB and NB DBs.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

Also,
Go mod vendor for vishvananda/netlink has custom modifications. When I perform go mod vendor, I need to remove the overwrites of the custom mods. It seems surya made the mods.

~~Also, fedora dockerfile is rejecting updates because of gpg check. Needed to add `--nogpgcheck` to install the packages locally.~~
Resolved - very old f36 image locally.

Testing with CI.

/cc @npinaeva 