### PR TITLE
Modification of kind.md document

### DIFF
--- a/docs/kind.md
+++ b/docs/kind.md
@@ -26,7 +26,8 @@ For OVN kubernetes KIND deployment, use the `kind.sh` script.
 First Download and build the OVN-Kubernetes repo: 
 
 ```
-$ go get github.com/ovn-org/ovn-kubernetes; cd GOPATH/src/github.com/ovn-org/ovn-kubernetes
+$ go env -w GO111MODULE=auto
+$ go get github.com/ovn-org/ovn-kubernetes; cd $(go env GOPATH)/src/github.com/ovn-org/ovn-kubernetes
 ```
 
 The `kind.sh` script builds OVN-Kubernetes into a container image. To verify


### PR DESCRIPTION
Hey, I found that `kind.md` has two problems.

We could not execute `go get` to get `src` folder unless executing `go env -w GO111MODULE=auto` first.
Second, we need `go env GOPATH` to get `GOPATH` environment rather than only `GOPATH`.

I fix them, and they run well on my laptop.