### PR TITLE
cni: don't settle addresses or set IPv6 parameters for IPv4

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -428,28 +428,40 @@ func (pr *PodRequest) ConfigureInterface(podLister corev1listers.PodLister, kcli
 		}
 	}
 
-	err = netns.Do(func(hostNS ns.NetNS) error {
-		// deny IPv6 neighbor solicitations
-		dadSysctlIface := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/dad_transmits", contIface.Name)
-		if _, err := os.Stat(dadSysctlIface); !os.IsNotExist(err) {
-			err = setSysctl(dadSysctlIface, 0)
-			if err != nil {
-				klog.Warningf("Failed to disable IPv6 DAD: %q", err)
-			}
+	// Only configure IPv6 specific stuff and wait for addresses to become usable
+	// if there are any IPv6 addresses to assign. v4 doesn't have the concept
+	// of tentative addresses so it doesn't need any of this.
+	haveV6 := false
+	for _, ip := range ifInfo.IPs {
+		if ip.IP.To4() == nil {
+			haveV6 = true
+			break
 		}
-		// generate address based on EUI64
-		genSysctlIface := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/addr_gen_mode", contIface.Name)
-		if _, err := os.Stat(genSysctlIface); !os.IsNotExist(err) {
-			err = setSysctl(genSysctlIface, 0)
-			if err != nil {
-				klog.Warningf("Failed to set IPv6 address generation mode to EUI64: %q", err)
+	}
+	if haveV6 {
+		err = netns.Do(func(hostNS ns.NetNS) error {
+			// deny IPv6 neighbor solicitations
+			dadSysctlIface := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/dad_transmits", contIface.Name)
+			if _, err := os.Stat(dadSysctlIface); !os.IsNotExist(err) {
+				err = setSysctl(dadSysctlIface, 0)
+				if err != nil {
+					klog.Warningf("Failed to disable IPv6 DAD: %q", err)
+				}
 			}
-		}
+			// generate address based on EUI64
+			genSysctlIface := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/addr_gen_mode", contIface.Name)
+			if _, err := os.Stat(genSysctlIface); !os.IsNotExist(err) {
+				err = setSysctl(genSysctlIface, 0)
+				if err != nil {
+					klog.Warningf("Failed to set IPv6 address generation mode to EUI64: %q", err)
+				}
+			}
 
-		return ip.SettleAddresses(contIface.Name, 10)
-	})
-	if err != nil {
-		klog.Warningf("Failed to settle addresses: %q", err)
+			return ip.SettleAddresses(contIface.Name, 10)
+		})
+		if err != nil {
+			klog.Warningf("Failed to settle addresses: %q", err)
+		}
 	}
 
 	return []*current.Interface{hostIface, contIface}, nil


### PR DESCRIPTION
If the pod only has IPv4 addresses, we don't need to do any IPv6
stuff because it won't matter anyway. The sysctls take the RTNL
lock which under heavy load contends with other users (metrics,
cadvisor, node exporter), and SettleAddresses() does netlink
operations every 50ms.

Even with all that, this doesn't have a huge affect in heavy
load cases because the OVS operations and waiting for ovn-installed
take way more time, and waiting for addresses to settle actually
runs in parallel with ovn-installed.

But let's not make the netlink problem worse, and let's credit
the time taken for operations to the rigth place instead of
masking it.

Sample of some timings to call SettleAddresses during a scale test:

```
/tmp/logs2/bdd1ffe1-node-density-heavy-20220827-perfapp-1-126-84f65fb45c-nx6hb-2022-08-27T01:00:53.462980471Z:      Settle: 1.413036157s
/tmp/logs2/bdd1ffe1-node-density-heavy-20220827-perfapp-1-2067-7dccbfc695-zcsst-2022-08-27T01:06:40.546517756Z:      Settle: 1.0603518s
/tmp/logs2/bdd1ffe1-node-density-heavy-20220827-perfapp-1-2085-6bd677b4f9-wjn5f-2022-08-27T01:06:44.268710266Z:      Settle: 1.422142652s
/tmp/logs2/bdd1ffe1-node-density-heavy-20220827-perfapp-1-2104-5b99c9ffbc-hpjdc-2022-08-27T01:06:48.807482699Z:      Settle: 1.570140468s
/tmp/logs2/bdd1ffe1-node-density-heavy-20220827-perfapp-1-2127-5bcc9f86f7-ss49s-2022-08-27T01:06:54.492646444Z:      Settle: 638.673498ms
/tmp/logs2/bdd1ffe1-node-density-heavy-20220827-perfapp-1-2128-6dd5d658cf-6txbc-2022-08-27T01:06:54.673787319Z:      Settle: 620.961692ms
/tmp/logs2/bdd1ffe1-node-density-heavy-20220827-perfapp-1-2146-8687f4c495-sm682-2022-08-27T01:06:58.790797957Z:      Settle: 856.226311ms
```

@trozet @jcaamano 