### PR TITLE
Update libovsdbops to use Where().List() instead of Get()

### DIFF
--- a/go-controller/pkg/libovsdbops/model_client.go
+++ b/go-controller/pkg/libovsdbops/model_client.go
@@ -15,6 +15,7 @@ import (
 )
 
 var errMultipleResults = errors.New("unexpectedly found multiple results for provided predicate")
+var errNoIndexes = errors.New("no indexes found for given model")
 
 type modelClient struct {
 	client client.Client
@@ -149,6 +150,9 @@ type operationModel struct {
 	BulkOp bool
 	// DoAfter is invoked at the end of the operation and allows to setup a
 	// subsequent operation with values obtained from this one.
+	// If model lookup was successful, or a new db entry was created,
+	// Model will have UUID set, and it can be used in DoAfter. This only works
+	// if BulkOp is false and Model != nil.
 	DoAfter func()
 }
 
@@ -385,53 +389,75 @@ func (m *modelClient) Lookup(opModels ...operationModel) error {
 	return err
 }
 
+// CreateOrUpdate, Delete and Lookup can be called to
+// 1. create or update a single model
+// Model should be set, bulkOp = false, errNotfound = false
+// 2. update/delete/lookup 0..n models (create can't be done for multiple models at the same time)
+// Model index or predicate should be set
+//
+// The allowed combination of operationModel fields is different for these cases.
+// Both Model db index, and ModelPredicate can only be empty for the first case
+func lookupRequired(opModel *operationModel) bool {
+	// we know create is not supposed to be performed, if these fields are set
+	if opModel.BulkOp || opModel.ErrNotFound {
+		return true
+	}
+	return false
+}
+
 // lookup the model in the cache prioritizing provided indexes over a
-// predicate unless bulkop is set
+// predicate
+// If lookup was successful, opModel.Model will have UUID set,
+// so that further user operations with the same model are indexed by UUID
 func (m *modelClient) lookup(opModel *operationModel) error {
 	if opModel.ExistingResult == nil && opModel.Model != nil {
 		opModel.ExistingResult = getListFromModel(opModel.Model)
 	}
 
 	var err error
-	if opModel.Model != nil && !opModel.BulkOp {
-		err = m.get(opModel)
-		if err == nil || err != client.ErrNotFound {
+	if opModel.Model != nil {
+		err = m.where(opModel)
+		if err != errNoIndexes {
+			// if index wasn't provided by the Model, try predicate search
+			// otherwise return where result
 			return err
 		}
 	}
-
+	// if index wasn't provided by the Model (errNoIndexes) or Model == nil, try predicate search
 	if opModel.ModelPredicate != nil {
-		err = m.whereCache(opModel)
-	} else if opModel.BulkOp {
-		panic("Expected a ModelPredicate with BulkOp==true")
+		return m.whereCache(opModel)
 	}
-
-	return err
+	// the only operation that can be performed without a lookup (it can have no db indexes and no ModelPredicate set)
+	// is Create.
+	if lookupRequired(opModel) {
+		return fmt.Errorf("missing model indixes or predicate when a lookup was required")
+	}
+	return nil
 }
 
-/*
-get copies the model, since this function ends up being called from update /
-mutate, and Get'ing the model will modify the object to the one currently
-existing in the DB, thus overridding all new fields we are trying to set. Do
-return the retrived object though, in case the caller needs to act on the
-object's UUID
-*/
-func (m *modelClient) get(opModel *operationModel) error {
-	copy := copyIndexes(opModel.Model)
-	if reflect.ValueOf(copy).Elem().IsZero() {
+func (m *modelClient) where(opModel *operationModel) error {
+	copyModel := copyIndexes(opModel.Model)
+	if reflect.ValueOf(copyModel).Elem().IsZero() {
 		// no indexes available
-		return client.ErrNotFound
+		return errNoIndexes
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 	defer cancel()
-	if err := m.client.Get(ctx, copy); err != nil {
+	var err error
+	if err = m.client.Where(copyModel).List(ctx, opModel.ExistingResult); err != nil {
 		return err
 	}
-	uuid := getUUID(opModel.Model)
-	if uuid == "" || isNamedUUID(uuid) {
-		setUUID(opModel.Model, getUUID(copy))
+	if opModel.Model == nil || opModel.BulkOp {
+		return nil
 	}
-	return addToExistingResult(copy, opModel.ExistingResult)
+	// for non-bulk op cases, copy (the one) uuid found to model provided.
+	// so that further user operations with the same model are indexed by UUID
+	err = onModels(opModel.ExistingResult, func(model interface{}) error {
+		uuid := getUUID(model)
+		setUUID(opModel.Model, uuid)
+		return nil
+	})
+	return err
 }
 
 func (m *modelClient) whereCache(opModel *operationModel) error {
@@ -446,40 +472,14 @@ func (m *modelClient) whereCache(opModel *operationModel) error {
 		return nil
 	}
 
-	// for non-bulk op cases, copy (the one) uuid found to model provided, for convenience
+	// for non-bulk op cases, copy (the one) uuid found to model provided.
+	// so that further user operations with the same model are indexed by UUID
 	err = onModels(opModel.ExistingResult, func(model interface{}) error {
 		uuid := getUUID(model)
 		setUUID(opModel.Model, uuid)
 		return nil
 	})
 	return err
-}
-
-func addToExistingResult(model interface{}, existingResult interface{}) error {
-	resultPtr := reflect.ValueOf(existingResult)
-	if resultPtr.Type().Kind() != reflect.Ptr {
-		return fmt.Errorf("expected existingResult as a pointer but got %s", resultPtr.Type().Kind())
-	}
-
-	resultVal := reflect.Indirect(resultPtr)
-	if resultVal.Type().Kind() != reflect.Slice {
-		return fmt.Errorf("expected existingResult as a pointer to a slice but got %s", resultVal.Type().Kind())
-	}
-
-	var v reflect.Value
-	if resultVal.Type().Elem().Kind() == reflect.Ptr {
-		v = reflect.ValueOf(model)
-	} else {
-		v = reflect.Indirect(reflect.ValueOf(model))
-	}
-
-	if v.Type() != resultVal.Type().Elem() {
-		return fmt.Errorf("expected existingResult as a pointer to a slice of %s but got %s", v.Type(), resultVal.Type().Elem())
-	}
-
-	resultVal.Set(reflect.Append(resultVal, v))
-
-	return nil
 }
 
 func isGuardOp(op *ovsdb.Operation) bool {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -3576,8 +3576,9 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						Items: []v1.Pod{egressPod1},
 					},
 				)
-
-				fakeOvn.controller.lsManager.AddNode(node1.Name, node1.Name+"-UUID", []*net.IPNet{ovntest.MustParseIPNet(v4NodeSubnet)})
+				// we don't know the real switch UUID in the db, but it can be found by name
+				swUUID := getLogicalSwitchUUID(fakeOvn.controller.nbClient, node1.Name)
+				fakeOvn.controller.lsManager.AddNode(node1.Name, swUUID, []*net.IPNet{ovntest.MustParseIPNet(v4NodeSubnet)})
 
 				err := fakeOvn.controller.WatchPods()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -1858,7 +1858,9 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 						Items: []v1.Pod{},
 					},
 				)
-				fakeOvn.controller.lsManager.AddNode("node1", "ls-uuid", []*net.IPNet{ovntest.MustParseIPNet("10.128.1.0/24")})
+				// we don't know the real switch UUID in the db, but it can be found by name
+				swUUID := getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1")
+				fakeOvn.controller.lsManager.AddNode("node1", swUUID, []*net.IPNet{ovntest.MustParseIPNet("10.128.1.0/24")})
 
 				err := fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1922,7 +1924,9 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 						Items: []v1.Pod{},
 					},
 				)
-				fakeOvn.controller.lsManager.AddNode("node1", "ls-uuid", []*net.IPNet{ovntest.MustParseIPNet("10.128.1.0/24")})
+				// we don't know the real switch UUID in the db, but it can be found by name
+				swUUID := getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1")
+				fakeOvn.controller.lsManager.AddNode("node1", swUUID, []*net.IPNet{ovntest.MustParseIPNet("10.128.1.0/24")})
 
 				err := fakeOvn.controller.WatchNamespaces()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
to do index-based search.
Update the logic for model lookup to
1. Use index if any provided
2. If no indices provided with the Model, use predicate search.

Update syncPods find logical switch to only set Model.UUID if it is not
empty, otherwise search will only be performed using given UUID, and no
attempt to use predicate will be made.

Update egress_ip test to set empty ls UUID, since we don't know the real
switch UUID in the db to make a search, but it can be done by name.

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>