### PR TITLE
BZ2117255 append instead of overwrite logicalSwitch other-config

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -664,6 +664,7 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 	var v4Gateway, v6Gateway net.IP
 	var hostNetworkPolicyIPs []net.IP
 	logicalRouterPortNetwork := []string{}
+	logicalSwitch.OtherConfig = map[string]string{}
 	for _, hostSubnet := range hostSubnets {
 		gwIfAddr := util.GetNodeGatewayIfAddr(hostSubnet)
 		mgmtIfAddr := util.GetNodeManagementIfAddr(hostSubnet)
@@ -673,9 +674,8 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 		if utilnet.IsIPv6CIDR(hostSubnet) {
 			v6Gateway = gwIfAddr.IP
 
-			logicalSwitch.OtherConfig = map[string]string{
-				"ipv6_prefix": hostSubnet.IP.String(),
-			}
+			logicalSwitch.OtherConfig["ipv6_prefix"] =
+				hostSubnet.IP.String()
 		} else {
 			v4Gateway = gwIfAddr.IP
 			excludeIPs := mgmtIfAddr.IP.String()
@@ -683,10 +683,8 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 				hybridOverlayIfAddr := util.GetNodeHybridOverlayIfAddr(hostSubnet)
 				excludeIPs += ".." + hybridOverlayIfAddr.IP.String()
 			}
-			logicalSwitch.OtherConfig = map[string]string{
-				"subnet":      hostSubnet.String(),
-				"exclude_ips": excludeIPs,
-			}
+			logicalSwitch.OtherConfig["subnet"] = hostSubnet.String()
+			logicalSwitch.OtherConfig["exclude_ips"] = excludeIPs
 		}
 	}
 


### PR DESCRIPTION
Commit 16ea40be changed the logical switch other-config to be overwriten this needs to be changed so that the hostsubnet values are appended.

https://bugzilla.redhat.com/show_bug.cgi?id=2117255

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->