### PR TITLE
Support AllocateLoadBalancerNodePorts=False with ETP=local, LGW mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -383,6 +383,7 @@ jobs:
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' }}"
       OVN_HA: "${{ matrix.ha == 'HA' }}"
       OVN_DISABLE_SNAT_MULTIPLE_GWS: "${{ matrix.disable-snat-multiple-gws == 'noSnatGW' }}"
+      KIND_INSTALL_METALLB: "${{ matrix.target == 'control-plane' }}"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
       OVN_SECOND_BRIDGE: "${{ matrix.second-bridge == '2br' }}"
       KIND_IPV4_SUPPORT: "${{ matrix.ipfamily == 'IPv4' || matrix.ipfamily == 'dualstack' }}"

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -274,6 +274,51 @@ func getNodePortETPLocalIPTRules(svcPort kapi.ServicePort, targetIP string) []ip
 	}
 }
 
+func computeProbability(n, i int) string {
+	return fmt.Sprintf("%0.10f", 1.0/float64(n-i+1))
+}
+
+func generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort kapi.ServicePort, externalIP string, service *kapi.Service, localEndpoints []string) []iptRule {
+	var iptRules []iptRule
+	if len(localEndpoints) == 0 {
+		// either its smart nic mode; etp&itp not implemented, OR
+		// fetching endpointSlices error-ed out prior to reaching here so nothing to do
+		return iptRules
+	}
+	numLocalEndpoints := len(localEndpoints)
+	for i, ip := range localEndpoints {
+		iptRules = append([]iptRule{
+			{
+				table: "nat",
+				chain: iptableETPChain,
+				args: []string{
+					"-p", string(svcPort.Protocol),
+					"-d", externalIP,
+					"--dport", fmt.Sprintf("%v", svcPort.Port),
+					"-j", "DNAT",
+					"--to-destination", util.JoinHostPortInt32(ip, int32(svcPort.TargetPort.IntValue())),
+					"-m", "statistic",
+					"--mode", "random",
+					"--probability", computeProbability(numLocalEndpoints, i+1),
+				},
+				protocol: getIPTablesProtocol(externalIP),
+			},
+			{
+				table: "nat",
+				chain: iptableMgmPortChain,
+				args: []string{
+					"-p", string(svcPort.Protocol),
+					"-d", ip,
+					"--dport", fmt.Sprintf("%v", int32(svcPort.TargetPort.IntValue())),
+					"-j", "RETURN",
+				},
+				protocol: getIPTablesProtocol(externalIP),
+			},
+		}, iptRules...)
+	}
+	return iptRules
+}
+
 // getExternalIPTRules returns the IPTable DNAT rules for a service of type LB or ExternalIP
 // `svcPort` corresponds to port details for this service as specified in the service object
 // `externalIP` can either be the externalIP or LB.status.ingressIP
@@ -449,7 +494,7 @@ func recreateIPTRules(table, chain string, keepIPTRules []iptRule) error {
 // case3: if svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that redirects clusterIP traffic to host targetPort is added.
 //
 //	if !svcHasLocalHostNetEndPnt and svcTypeIsITPLocal, rule that marks clusterIP traffic to steer it to ovn-k8s-mp0 is added.
-func getGatewayIPTRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) []iptRule {
+func getGatewayIPTRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool) []iptRule {
 	rules := make([]iptRule, 0)
 	clusterIPs := util.GetClusterIPs(service)
 	svcTypeIsETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
@@ -492,7 +537,11 @@ func getGatewayIPTRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) []
 					// case1 (see function description for details)
 					// DNAT traffic to masqueradeIP:nodePort instead of clusterIP:Port. We are leveraging the existing rules for NODEPORT
 					// service so no need to add skip SNAT rule to OVN-KUBE-SNAT-MGMTPORT since the corresponding nodePort svc would have one.
-					rules = append(rules, getExternalIPTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					if !util.ServiceTypeHasNodePort(service) {
+						rules = append(rules, generateIPTRulesForLoadBalancersWithoutNodePorts(svcPort, externalIP, service, localEndpoints)...)
+					} else {
+						rules = append(rules, getExternalIPTRules(svcPort, externalIP, "", svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					}
 				}
 				// case2 (see function description for details)
 				rules = append(rules, getExternalIPTRules(svcPort, externalIP, clusterIP, svcHasLocalHostNetEndPnt, false)...)

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -88,6 +88,8 @@ type serviceConfig struct {
 	service *kapi.Service
 	// hasLocalHostNetworkEp will be true for a service if it has at least one endpoint which is "hostnetworked&local-to-this-node".
 	hasLocalHostNetworkEp bool
+	// localEndpoints stores all the local non-host-networked endpoints for this service
+	localEndpoints sets.String
 }
 
 type serviceEps struct {
@@ -371,7 +373,7 @@ func (npw *nodePortWatcher) getServiceInfo(index ktypes.NamespacedName) (out *se
 }
 
 // getAndSetServiceInfo creates and sets the serviceConfig, returns if it existed and whatever was there
-func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool) (old *serviceConfig, exists bool) {
+func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool, localEndpoints sets.String) (old *serviceConfig, exists bool) {
 	npw.serviceInfoLock.Lock()
 	defer npw.serviceInfoLock.Unlock()
 
@@ -380,18 +382,18 @@ func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, se
 	if exists {
 		ptrCopy = *old
 	}
-	npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp}
+	npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp, localEndpoints: localEndpoints}
 	return &ptrCopy, exists
 }
 
 // addOrSetServiceInfo creates and sets the serviceConfig if it doesn't exist
-func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool) (exists bool) {
+func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp bool, localEndpoints sets.String) (exists bool) {
 	npw.serviceInfoLock.Lock()
 	defer npw.serviceInfoLock.Unlock()
 
 	if _, exists := npw.serviceInfo[index]; !exists {
 		// Only set this if it doesn't exist
-		npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp}
+		npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp, localEndpoints: localEndpoints}
 		return false
 	}
 	return true
@@ -400,7 +402,7 @@ func (npw *nodePortWatcher) addOrSetServiceInfo(index ktypes.NamespacedName, ser
 
 // updateServiceInfo sets the serviceConfig for a service and returns the existing serviceConfig, if inputs are nil
 // do not update those fields, if it does not exist return nil.
-func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp *bool) (old *serviceConfig, exists bool) {
+func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, service *kapi.Service, hasLocalHostNetworkEp *bool, localEndpoints sets.String) (old *serviceConfig, exists bool) {
 
 	npw.serviceInfoLock.Lock()
 	defer npw.serviceInfoLock.Unlock()
@@ -418,12 +420,16 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 		npw.serviceInfo[index].hasLocalHostNetworkEp = *hasLocalHostNetworkEp
 	}
 
+	if localEndpoints != nil {
+		npw.serviceInfo[index].localEndpoints = localEndpoints
+	}
+
 	return &ptrCopy, exists
 }
 
 // addServiceRules ensures the correct iptables rules and OpenFlow physical
 // flows are programmed for a given service and endpoint configuration
-func addServiceRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, npw *nodePortWatcher) error {
+func addServiceRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool, npw *nodePortWatcher) error {
 	// For dpu or Full mode
 	var err error
 	var errors []error
@@ -434,7 +440,7 @@ func addServiceRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, npw *
 		npw.ofm.requestFlowSync()
 		if !npw.dpuMode {
 			// add iptable rules only in full mode
-			if err = addGatewayIptRules(service, svcHasLocalHostNetEndPnt); err != nil {
+			if err = addGatewayIptRules(service, localEndpoints, svcHasLocalHostNetEndPnt); err != nil {
 				errors = append(errors, err)
 			}
 			if err = updateEgressSVCIptRules(service, npw); err != nil {
@@ -443,7 +449,7 @@ func addServiceRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, npw *
 		}
 	} else {
 		// For Host Only Mode
-		if err = addGatewayIptRules(service, svcHasLocalHostNetEndPnt); err != nil {
+		if err = addGatewayIptRules(service, localEndpoints, svcHasLocalHostNetEndPnt); err != nil {
 			errors = append(errors, err)
 		}
 
@@ -454,7 +460,7 @@ func addServiceRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool, npw *
 
 // delServiceRules deletes all possible iptables rules and OpenFlow physical
 // flows for a service
-func delServiceRules(service *kapi.Service, npw *nodePortWatcher) error {
+func delServiceRules(service *kapi.Service, localEndpoints []string, npw *nodePortWatcher) error {
 	var err error
 	var errors []error
 	// full mode || dpu mode
@@ -490,10 +496,10 @@ func delServiceRules(service *kapi.Service, npw *nodePortWatcher) error {
 			// |                          |                       |                       |   + default dnat towards CIP   |
 			// +--------------------------+-----------------------+-----------------------+--------------------------------+
 
-			if err = delGatewayIptRules(service, true); err != nil {
+			if err = delGatewayIptRules(service, localEndpoints, true); err != nil {
 				errors = append(errors, fmt.Errorf("error updating service flow cache: %v", err))
 			}
-			if err = delGatewayIptRules(service, false); err != nil {
+			if err = delGatewayIptRules(service, localEndpoints, false); err != nil {
 				errors = append(errors, fmt.Errorf("error updating service flow cache: %v", err))
 			}
 			if err = delAllEgressSVCIptRules(service, npw); err != nil {
@@ -502,10 +508,10 @@ func delServiceRules(service *kapi.Service, npw *nodePortWatcher) error {
 		}
 	} else {
 
-		if err = delGatewayIptRules(service, true); err != nil {
+		if err = delGatewayIptRules(service, localEndpoints, true); err != nil {
 			errors = append(errors, fmt.Errorf("error updating service flow cache: %v", err))
 		}
-		if err = delGatewayIptRules(service, false); err != nil {
+		if err = delGatewayIptRules(service, localEndpoints, false); err != nil {
 			errors = append(errors, fmt.Errorf("error updating service flow cache: %v", err))
 		}
 	}
@@ -522,7 +528,9 @@ func serviceUpdateNotNeeded(old, new *kapi.Service) bool {
 		reflect.DeepEqual(new.Spec.ExternalTrafficPolicy, old.Spec.ExternalTrafficPolicy) &&
 		(new.Spec.InternalTrafficPolicy != nil && old.Spec.InternalTrafficPolicy != nil &&
 			reflect.DeepEqual(*new.Spec.InternalTrafficPolicy, *old.Spec.InternalTrafficPolicy)) &&
-		!util.EgressSVCHostChanged(old, new)
+		!util.EgressSVCHostChanged(old, new) &&
+		(new.Spec.AllocateLoadBalancerNodePorts != nil && old.Spec.AllocateLoadBalancerNodePorts != nil &&
+			reflect.DeepEqual(*new.Spec.AllocateLoadBalancerNodePorts, *old.Spec.AllocateLoadBalancerNodePorts))
 }
 
 // AddService handles configuring shared gateway bridge flows to steer External IP, Node Port, Ingress LB traffic into OVN
@@ -544,12 +552,12 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) error {
 		nodeIPs := npw.nodeIPManager.ListAddresses()
 		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(epSlices, nodeIPs)
 	}
-
+	localEndpoints := npw.GetLocalEndpointAddresses(epSlices)
 	// If something didn't already do it add correct Service rules
-	if exists := npw.addOrSetServiceInfo(name, service, hasLocalHostNetworkEp); !exists {
+	if exists := npw.addOrSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndpoints); !exists {
 		klog.V(5).Infof("Service Add %s event in namespace %s came before endpoint event setting svcConfig",
 			service.Name, service.Namespace)
-		if err := addServiceRules(service, hasLocalHostNetworkEp, npw); err != nil {
+		if err := addServiceRules(service, localEndpoints.List(), hasLocalHostNetworkEp, npw); err != nil {
 			return fmt.Errorf("AddService failed for nodePortWatcher: %v", err)
 		}
 	} else {
@@ -569,9 +577,9 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) error {
 			".Spec.ExternalTrafficPolicy, .Spec.InternalTrafficPolicy, Egress service host", new.Name)
 		return nil
 	}
-	// Update the service in svcConfig if we need to, so that other handler
-	// threads do the correct thing, leave hasLocalHostNetworkEp alone in the cache
-	svcConfig, exists := npw.updateServiceInfo(name, new, nil)
+	// Update the service in svcConfig if we need to so that other handler
+	// threads do the correct thing, leave hasLocalHostNetworkEp and localEndpoints alone in the cache
+	svcConfig, exists := npw.updateServiceInfo(name, new, nil, nil)
 	if !exists {
 		klog.V(5).Infof("Service %s in namespace %s was deleted during service Update", old.Name, old.Namespace)
 		return nil
@@ -581,14 +589,14 @@ func (npw *nodePortWatcher) UpdateService(old, new *kapi.Service) error {
 		// Delete old rules if needed, but don't delete svcConfig
 		// so that we don't miss any endpoint update events here
 		klog.V(5).Infof("Deleting old service rules for: %v", old)
-		if err = delServiceRules(old, npw); err != nil {
+		if err = delServiceRules(old, svcConfig.localEndpoints.List(), npw); err != nil {
 			errors = append(errors, err)
 		}
 	}
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
 		klog.V(5).Infof("Adding new service rules for: %v", new)
-		if err = addServiceRules(new, svcConfig.hasLocalHostNetworkEp, npw); err != nil {
+		if err = addServiceRules(new, svcConfig.localEndpoints.List(), svcConfig.hasLocalHostNetworkEp, npw); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -651,7 +659,7 @@ func (npw *nodePortWatcher) DeleteService(service *kapi.Service) error {
 	klog.V(5).Infof("Deleting service %s in namespace %s", service.Name, service.Namespace)
 	name := ktypes.NamespacedName{Namespace: service.Namespace, Name: service.Name}
 	if svcConfig, exists := npw.getAndDeleteServiceInfo(name); exists {
-		if err = delServiceRules(svcConfig.service, npw); err != nil {
+		if err = delServiceRules(svcConfig.service, svcConfig.localEndpoints.List(), npw); err != nil {
 			errors = append(errors, err)
 		}
 	} else {
@@ -692,7 +700,8 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		}
 		nodeIPs := npw.nodeIPManager.ListAddresses()
 		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(epSlices, nodeIPs)
-		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp)
+		localEndPoints := npw.GetLocalEndpointAddresses(epSlices)
+		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndPoints)
 		// Delete OF rules for service if they exist
 		if err = npw.updateServiceFlowCache(service, false, hasLocalHostNetworkEp); err != nil {
 			errors = append(errors, err)
@@ -702,7 +711,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		}
 		// Add correct iptables rules only for Full mode
 		if !npw.dpuMode {
-			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, hasLocalHostNetworkEp)...)
+			keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, localEndPoints.List(), hasLocalHostNetworkEp)...)
 		}
 
 		if !npw.dpuMode && shouldConfigureEgressSVC(service, npw) {
@@ -774,25 +783,31 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) e
 	nodeIPs := npw.nodeIPManager.ListAddresses()
 	hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{epSlice}, nodeIPs)
 
-	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice
-	// event is received, only alter flows if we need to, i.e if cache wasn't
-	// set or if it was and hasLocalHostNetworkEp state changed, to prevent flow churn
+	epSlices, err := npw.watchFactory.GetEndpointSlices(svc.Namespace, svc.Name)
+	if err != nil {
+		klog.V(5).Infof("Could not fetch endpointslices for service %s/%s during endpointSliceAdd", svc.Name, svc.Namespace)
+	}
+	localEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice event is
+	// received, only alter flows if we need to, i.e if cache wasn't set or if it was and
+	// hasLocalHostNetworkEp or localEndpoints state (for LB svc where NPs=0) changed, to prevent flow churn
 	namespacedName, err := namespacedNameFromEPSlice(epSlice)
 	if err != nil {
 		return fmt.Errorf("cannot add %s/%s to nodePortWatcher: %v", epSlice.Namespace, epSlice.Name, err)
 	}
-	out, exists := npw.getAndSetServiceInfo(namespacedName, svc, hasLocalHostNetworkEp)
+	out, exists := npw.getAndSetServiceInfo(namespacedName, svc, hasLocalHostNetworkEp, localEndpoints)
 	if !exists {
 		klog.V(5).Infof("Endpointslice %s ADD event in namespace %s is creating rules", epSlice.Name, epSlice.Namespace)
-		return addServiceRules(svc, hasLocalHostNetworkEp, npw)
+		return addServiceRules(svc, localEndpoints.List(), hasLocalHostNetworkEp, npw)
 	}
 
-	if out.hasLocalHostNetworkEp != hasLocalHostNetworkEp {
+	if out.hasLocalHostNetworkEp != hasLocalHostNetworkEp ||
+		(!util.LoadBalancerServiceHasNodePortAllocation(svc) && !reflect.DeepEqual(out.localEndpoints, localEndpoints)) {
 		klog.V(5).Infof("Endpointslice %s ADD event in namespace %s is updating rules", epSlice.Name, epSlice.Namespace)
-		if err = delServiceRules(svc, npw); err != nil {
+		if err = delServiceRules(svc, out.localEndpoints.List(), npw); err != nil {
 			errors = append(errors, err)
 		}
-		if err = addServiceRules(svc, hasLocalHostNetworkEp, npw); err != nil {
+		if err = addServiceRules(svc, localEndpoints.List(), hasLocalHostNetworkEp, npw); err != nil {
 			errors = append(errors, err)
 		}
 		return apierrors.NewAggregate(errors)
@@ -821,21 +836,39 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 	if err != nil {
 		return fmt.Errorf("cannot delete %s/%s from nodePortWatcher: %v", epSlice.Namespace, epSlice.Name, err)
 	}
-	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp); exists {
+	epSlices, err := npw.watchFactory.GetEndpointSlices(epSlice.Namespace, epSlice.Labels[discovery.LabelServiceName])
+	if err != nil {
+		return fmt.Errorf("could not fetch endpointslices for service %s during endpointSliceDelete", namespacedName)
+	}
+	localEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp, localEndpoints); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
 		// we have to do this because deleting and adding iptables rules is slow.
 		npw.serviceInfoLock.Lock()
 		defer npw.serviceInfoLock.Unlock()
 
-		if err = delServiceRules(svcConfig.service, npw); err != nil {
+		if err = delServiceRules(svcConfig.service, svcConfig.localEndpoints.List(), npw); err != nil {
 			errors = append(errors, err)
 		}
-		if err = addServiceRules(svcConfig.service, hasLocalHostNetworkEp, npw); err != nil {
+		if err = addServiceRules(svcConfig.service, localEndpoints.List(), hasLocalHostNetworkEp, npw); err != nil {
 			errors = append(errors, err)
 		}
 		return apierrors.NewAggregate(errors)
 	}
 	return nil
+}
+
+// GetLocalEndpointAddresses returns a list of endpoints that are local to the node
+func (npw *nodePortWatcher) GetLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice) sets.String {
+	localEndpoints := sets.NewString()
+	for _, endpointSlice := range endpointSlices {
+		for _, endpoint := range endpointSlice.Endpoints {
+			if isEndpointReady(endpoint) && endpoint.NodeName != nil && *endpoint.NodeName == npw.nodeIPManager.nodeName {
+				localEndpoints.Insert(endpoint.Addresses...)
+			}
+		}
+	}
+	return localEndpoints
 }
 
 func getEndpointAddresses(endpointSlice *discovery.EndpointSlice) []string {
@@ -851,6 +884,9 @@ func getEndpointAddresses(endpointSlice *discovery.EndpointSlice) []string {
 }
 
 func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice) error {
+	// TODO (tssurya): refactor bits in this function to ensure add and delete endpoint slices are not called repeatedly
+	// Context: Both add and delete endpointslice are calling delServiceRules followed by addServiceRules which makes double
+	// the number of calls than needed for an update endpoint slice
 	var err error
 	var errors []error
 
@@ -866,7 +902,9 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	if err != nil {
 		return fmt.Errorf("cannot update %s/%s in nodePortWatcher: %v", newEpSlice.Namespace, newEpSlice.Name, err)
 	}
-	if _, exists := npw.getServiceInfo(namespacedName); !exists {
+	var serviceInfo *serviceConfig
+	var exists bool
+	if serviceInfo, exists = npw.getServiceInfo(namespacedName); !exists {
 		// When a service is updated from externalName to nodeport type, it won't be
 		// in nodePortWatcher cache (npw): in this case, have the new nodeport IPtable rules
 		// installed.
@@ -881,11 +919,17 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 		}
 	}
 
-	// Update rules if hasHostNetworkEndpoints status changed
+	// Update rules and service cache if hasHostNetworkEndpoints status changed or localEndpoints changed
 	nodeIPs := npw.nodeIPManager.ListAddresses()
 	hasLocalHostNetworkEpOld := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{oldEpSlice}, nodeIPs)
 	hasLocalHostNetworkEpNew := hasLocalHostNetworkEndpoints([]*discovery.EndpointSlice{newEpSlice}, nodeIPs)
-	if hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew {
+	epSlices, err := npw.watchFactory.GetEndpointSlices(newEpSlice.Namespace, newEpSlice.Labels[discovery.LabelServiceName])
+	if err != nil {
+		klog.V(5).Infof("Could not fetch endpointslices for service %s during endpointSliceDelete", namespacedName)
+	}
+	newLocalEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+	if hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew ||
+		(serviceInfo != nil && !reflect.DeepEqual(serviceInfo.localEndpoints, newLocalEndpoints)) {
 		if err = npw.DeleteEndpointSlice(oldEpSlice); err != nil {
 			errors = append(errors, err)
 		}
@@ -918,7 +962,7 @@ func (npwipt *nodePortWatcherIptables) AddService(service *kapi.Service) error {
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
-	if err := addServiceRules(service, false, nil); err != nil {
+	if err := addServiceRules(service, nil, false, nil); err != nil {
 		return fmt.Errorf("AddService failed for nodePortWatcherIptables: %v", err)
 	}
 	return nil
@@ -935,13 +979,13 @@ func (npwipt *nodePortWatcherIptables) UpdateService(old, new *kapi.Service) err
 	}
 
 	if util.ServiceTypeHasClusterIP(old) && util.IsClusterIPSet(old) {
-		if err = delServiceRules(old, nil); err != nil {
+		if err = delServiceRules(old, nil, nil); err != nil {
 			errors = append(errors, err)
 		}
 	}
 
 	if util.ServiceTypeHasClusterIP(new) && util.IsClusterIPSet(new) {
-		if err = addServiceRules(new, false, nil); err != nil {
+		if err = addServiceRules(new, nil, false, nil); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -957,7 +1001,7 @@ func (npwipt *nodePortWatcherIptables) DeleteService(service *kapi.Service) erro
 	if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 		return nil
 	}
-	if err := delServiceRules(service, nil); err != nil {
+	if err := delServiceRules(service, nil, nil); err != nil {
 		return fmt.Errorf("DeleteService failed for nodePortWatcherIptables: %v", err)
 	}
 	return nil
@@ -976,7 +1020,7 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		}
 		// Add correct iptables rules.
 		// TODO: ETP and ITP is not implemented for smart NIC mode.
-		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, false)...)
+		keepIPTRules = append(keepIPTRules, getGatewayIPTRules(service, nil, false)...)
 	}
 
 	// sync IPtables rules once

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -376,8 +376,12 @@ func (npw *nodePortWatcher) getAndSetServiceInfo(index ktypes.NamespacedName, se
 	defer npw.serviceInfoLock.Unlock()
 
 	old, exists = npw.serviceInfo[index]
+	var ptrCopy serviceConfig
+	if exists {
+		ptrCopy = *old
+	}
 	npw.serviceInfo[index] = &serviceConfig{service: service, hasLocalHostNetworkEp: hasLocalHostNetworkEp}
-	return old, exists
+	return &ptrCopy, exists
 }
 
 // addOrSetServiceInfo creates and sets the serviceConfig if it doesn't exist
@@ -405,7 +409,7 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 		klog.V(5).Infof("No serviceConfig found for service %s in namespace %s", index.Name, index.Namespace)
 		return nil, exists
 	}
-
+	ptrCopy := *old
 	if service != nil {
 		npw.serviceInfo[index].service = service
 	}
@@ -414,7 +418,7 @@ func (npw *nodePortWatcher) updateServiceInfo(index ktypes.NamespacedName, servi
 		npw.serviceInfo[index].hasLocalHostNetworkEp = *hasLocalHostNetworkEp
 	}
 
-	return old, exists
+	return &ptrCopy, exists
 }
 
 // addServiceRules ensures the correct iptables rules and OpenFlow physical

--- a/go-controller/pkg/node/gateway_shared_intf_linux.go
+++ b/go-controller/pkg/node/gateway_shared_intf_linux.go
@@ -59,8 +59,8 @@ func deleteLocalNodeAccessBridge() error {
 }
 
 // addGatewayIptRules adds the necessary iptable rules for a service on the node
-func addGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) error {
-	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt)
+func addGatewayIptRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool) error {
+	rules := getGatewayIPTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 
 	if err := addIptRules(rules); err != nil {
 		return fmt.Errorf("failed to add iptables rules for service %s/%s: %v",
@@ -70,8 +70,8 @@ func addGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) er
 }
 
 // delGatewayIptRules removes the iptable rules for a service from the node
-func delGatewayIptRules(service *kapi.Service, svcHasLocalHostNetEndPnt bool) error {
-	rules := getGatewayIPTRules(service, svcHasLocalHostNetEndPnt)
+func delGatewayIptRules(service *kapi.Service, localEndpoints []string, svcHasLocalHostNetEndPnt bool) error {
+	rules := getGatewayIPTRules(service, localEndpoints, svcHasLocalHostNetEndPnt)
 
 	if err := delIptRules(rules); err != nil {
 		return fmt.Errorf("failed to delete iptables rules for service %s/%s: %v", service.Namespace, service.Name, err)

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -218,9 +218,14 @@ func ServiceTypeHasClusterIP(service *kapi.Service) bool {
 	return service.Spec.Type == kapi.ServiceTypeClusterIP || service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
 }
 
+func LoadBalancerServiceHasNodePortAllocation(service *kapi.Service) bool {
+	return service.Spec.AllocateLoadBalancerNodePorts == nil || *service.Spec.AllocateLoadBalancerNodePorts
+}
+
 // ServiceTypeHasNodePort checks if the service has an associated NodePort or not
 func ServiceTypeHasNodePort(service *kapi.Service) bool {
-	return service.Spec.Type == kapi.ServiceTypeNodePort || service.Spec.Type == kapi.ServiceTypeLoadBalancer
+	return service.Spec.Type == kapi.ServiceTypeNodePort ||
+		(service.Spec.Type == kapi.ServiceTypeLoadBalancer && LoadBalancerServiceHasNodePortAllocation(service))
 }
 
 // ServiceTypeHasLoadBalancer checks if the service has an associated LoadBalancer or not

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1541,7 +1541,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 			// Then, downgrade back to SingleStack and test endpoints.
 			for _, ipFamilyPolicy := range []string{"PreferDualStack", "SingleStack"} {
 				ginkgo.By(fmt.Sprintf("Changing the nodeport service to %s", ipFamilyPolicy))
-				err = patchService(f.ClientSet, np.Name, np.Namespace, "/spec/ipFamilyPolicy", ipFamilyPolicy)
+				err = patchServiceStringValue(f.ClientSet, np.Name, np.Namespace, "/spec/ipFamilyPolicy", ipFamilyPolicy)
 				framework.ExpectNoError(err)
 
 				// It is expected that endpoints take a bit of time to come up after conversion. We remove all iptables rules and all breth0 flows.

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -3,8 +3,10 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -544,7 +546,7 @@ var _ = ginkgo.Describe("Service Hairpin SNAT", func() {
 		framework.ExpectNoError(err, fmt.Sprintf("unable to create service: service-for-pods, err: %v", err))
 
 		err = framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, "service-for-pods", 1, time.Second, wait.ForeverTestTimeout)
-		framework.ExpectNoError(err, fmt.Sprintf("service: service-for-pods never had an enpoint, err: %v", err))
+		framework.ExpectNoError(err, fmt.Sprintf("service: service-for-pods never had an endpoint, err: %v", err))
 
 		ginkgo.By("by sending a TCP packet to service service-for-pods with type=ClusterIP in namespace " + namespaceName + " from backend pod " + backendName)
 
@@ -589,6 +591,228 @@ var _ = ginkgo.Describe("Service Hairpin SNAT", func() {
 		framework.ExpectNoError(err, "failed to parse client ip:port")
 
 		framework.ExpectEqual(clientIP, nodeIP, fmt.Sprintf("returned client: %v was not correct", clientIP))
+	})
+
+})
+
+var _ = ginkgo.Describe("Load Balancer Service Tests with MetalLB", func() {
+
+	const (
+		svcName          = "lbservice-test"
+		backendName      = "lb-backend-pod"
+		endpointHTTPPort = 80
+		nodeHTTPPort     = 32766
+		loadBalancerYaml = "loadbalancer.yaml"
+		namespaceName    = "default"
+		svcIP            = "192.168.10.0"
+		clientContainer  = "lbclient"
+		routerContainer  = "frr"
+	)
+
+	var (
+		backendNodeName string
+	)
+
+	f := newPrivelegedTestFramework(svcName)
+	ginkgo.BeforeEach(func() {
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 2)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 2 {
+			framework.Failf("Test requires >= 2 Ready nodes, but there are only %v nodes", len(nodes.Items))
+		}
+		backendNodeName = nodes.Items[0].Name
+		var loadBalancerServiceConfig = fmt.Sprintf(`
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dynamic-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 1000Mi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ` + backendName + `
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+           claimName: dynamic-claim
+      initContainers:
+      - name: get-big-file
+        image: quay.io/itssurya/dev-images:metallb-lbservice
+        command: ['sh', '-c', "dd if=/dev/zero of=/usr/share/nginx/html/big.iso  bs=1024 count=0 seek=102400"]
+        volumeMounts:
+        - name: data
+          mountPath: "/usr/share/nginx/html"
+      containers:
+      - name: nginx
+        image: nginx:1
+        volumeMounts:
+        - name: data
+          mountPath: "/usr/share/nginx/html"
+        ports:
+        - name: http
+          containerPort: 80
+      nodeSelector:
+        kubernetes.io/hostname: ` + backendNodeName + `
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ` + svcName + `
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: nginx
+  type: LoadBalancer
+`)
+		if err := ioutil.WriteFile(loadBalancerYaml, []byte(loadBalancerServiceConfig), 0644); err != nil {
+			framework.Failf("Unable to write CRD config to disk: %v", err)
+		}
+		framework.Logf("Create the Load Balancer configuration")
+		framework.RunKubectlOrDie("default", "create", "-f", loadBalancerYaml)
+
+	})
+
+	ginkgo.AfterEach(func() {
+		framework.Logf("Delete the Load Balancer configuration")
+		framework.RunKubectlOrDie("default", "delete", "-f", loadBalancerYaml)
+		defer func() {
+			if err := os.Remove(loadBalancerYaml); err != nil {
+				framework.Logf("Unable to remove the CRD config from disk: %v", err)
+			}
+		}()
+	})
+
+	ginkgo.It("Should ensure load balancer service works with pmtu", func() {
+
+		err := framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, svcName, 4, time.Second, time.Second*120)
+		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an endpoint, err: %v", svcName, err))
+
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+
+		numberOfETPRules := pokeIPTableRules(backendNodeName, "OVN-KUBE-EXTERNALIP")
+		framework.ExpectEqual(numberOfETPRules, 4)
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+
+		ginkgo.By("change MTU on intermediary router to force icmp related packets")
+		cmd := []string{containerRuntime, "exec", routerContainer}
+		mtuCommand := strings.Split("ip link set mtu 1200 dev eth1", " ")
+
+		cmd = append(cmd, mtuCommand...)
+		_, err = runCommand(cmd...)
+		framework.ExpectNoError(err, "failed to change MTU on intermediary router")
+
+		time.Sleep(time.Second * 5) // buffer to ensure MTU change took effect
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+	})
+
+	ginkgo.It("Should ensure load balancer service works with 0 node ports when ETP=local", func() {
+
+		err := framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, svcName, 4, time.Second, time.Second*120)
+		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an enpoint, err: %v", svcName, err))
+
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+
+		checkNumberOfETPRules := func(value int, pattern string) wait.ConditionFunc {
+			return func() (bool, error) {
+				numberOfETPRules := pokeIPTableRules(backendNodeName, pattern)
+				return (numberOfETPRules == value), nil
+			}
+		}
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(2, "OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(4, "OVN-KUBE-EXTERNALIP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(3, "OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+
+		ginkgo.By("patching service " + svcName + " to allocateLoadBalancerNodePorts=false and externalTrafficPolicy=local")
+
+		err = patchServiceBoolValue(f.ClientSet, svcName, "default", "/spec/allocateLoadBalancerNodePorts", false)
+		framework.ExpectNoError(err)
+
+		output := framework.RunKubectlOrDie("default", "get", "svc", svcName, "-o=jsonpath='{.spec.allocateLoadBalancerNodePorts}'")
+		framework.ExpectEqual(output, "'false'")
+
+		err = patchServiceStringValue(f.ClientSet, svcName, "default", "/spec/externalTrafficPolicy", "Local")
+		framework.ExpectNoError(err)
+
+		output = framework.RunKubectlOrDie("default", "get", "svc", svcName, "-o=jsonpath='{.spec.externalTrafficPolicy}'")
+		framework.ExpectEqual(output, "'Local'")
+
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(6, "OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(7, "OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(1, "[1:60] -A OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(1, "[1:60] -A OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
+		ginkgo.By("Scale down endpoints of service: " + svcName + " to ensure iptable rules are also getting recreated correctly")
+		framework.RunKubectlOrDie("default", "scale", "deployment", backendName, "--replicas=3")
+
+		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
+		// number of iptable rules should have decreased by 1
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(5, "OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(6, "OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
+		ginkgo.By("by sending a TCP packet to service " + svcName + " with type=LoadBalancer in namespace " + namespaceName + " from backend pod " + backendName)
+
+		_, err = curlInContainer(clientContainer, svcIP, endpointHTTPPort, "big.iso -o big.iso", 120)
+		framework.ExpectNoError(err, "failed to curl load balancer service")
+
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(1, "[1:60] -A OVN-KUBE-ETP"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+		err = wait.PollImmediate(retryInterval, retryTimeout, checkNumberOfETPRules(1, "[1:60] -A OVN-KUBE-SNAT-MGMTPORT"))
+		framework.ExpectNoError(err, "Couldn't fetch the correct number of iptable rules, err: %v", err)
+
 	})
 
 })

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -399,14 +399,14 @@ func isNeighborEntryStable(clientContainer, targetHost string, iterations int) b
 // curlInContainer leverages a container running the netexec command to send a request to a target running
 // netexec on the given target host / protocol / port.
 // Returns a pair of either result, nil or "", error in case of an error.
-func curlInContainer(clientContainer, protocol, targetHost string, targetPort int32, endPoint string, maxTime int) (string, error) {
+func curlInContainer(clientContainer, targetHost string, targetPort int32, endPoint string, maxTime int) (string, error) {
 	cmd := []string{containerRuntime, "exec", clientContainer}
 	if utilnet.IsIPv6String(targetHost) {
 		targetHost = fmt.Sprintf("[%s]", targetHost)
 	}
 
 	// we leverage the dial command from netexec, that is already supporting multiple protocols
-	curlCommand := strings.Split(fmt.Sprintf("curl -g -q -s --max-time %d http://%s:%d/%s",
+	curlCommand := strings.Split(fmt.Sprintf("curl --max-time %d http://%s:%d/%s",
 		maxTime,
 		targetHost,
 		targetPort,
@@ -765,8 +765,8 @@ func assertACLLogs(targetNodeName string, policyNameRegex string, expectedACLVer
 	return false, nil
 }
 
-// patchService patches service serviceName in namespace serviceNamespace.
-func patchService(c kubernetes.Interface, serviceName, serviceNamespace, jsonPath, value string) error {
+// patchServiceStringValue patches service serviceName in namespace serviceNamespace with provided string value.
+func patchServiceStringValue(c kubernetes.Interface, serviceName, serviceNamespace, jsonPath, value string) error {
 	patch := []struct {
 		Op    string `json:"op"`
 		Path  string `json:"path"`
@@ -778,6 +778,27 @@ func patchService(c kubernetes.Interface, serviceName, serviceNamespace, jsonPat
 	}}
 	patchBytes, _ := json.Marshal(patch)
 
+	return patchService(c, serviceName, serviceNamespace, jsonPath, patchBytes)
+}
+
+// patchServiceBoolValue patches service serviceName in namespace serviceNamespace with provided bool value.
+func patchServiceBoolValue(c kubernetes.Interface, serviceName, serviceNamespace, jsonPath string, value bool) error {
+	patch := []struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value bool   `json:"value"`
+	}{{
+		Op:    "replace",
+		Path:  jsonPath,
+		Value: value,
+	}}
+	patchBytes, _ := json.Marshal(patch)
+
+	return patchService(c, serviceName, serviceNamespace, jsonPath, patchBytes)
+}
+
+// patchService patches service serviceName in namespace serviceNamespace.
+func patchService(c kubernetes.Interface, serviceName, serviceNamespace, jsonPath string, patchBytes []byte) error {
 	_, err := c.CoreV1().Services(serviceNamespace).Patch(
 		context.TODO(),
 		serviceName,
@@ -789,6 +810,24 @@ func patchService(c kubernetes.Interface, serviceName, serviceNamespace, jsonPat
 	}
 
 	return nil
+}
+
+// pokeIPTableRules returns the number of iptable rules that match the provided pattern
+func pokeIPTableRules(clientContainer, pattern string) int {
+	cmd := []string{containerRuntime, "exec", clientContainer}
+	ipTCommand := strings.Split("iptables-save -c", " ")
+
+	cmd = append(cmd, ipTCommand...)
+	iptRules, err := runCommand(cmd...)
+	framework.ExpectNoError(err, "failed to get iptable rules from node %s", clientContainer)
+	numOfMatchRules := 0
+	for _, iptRule := range strings.Split(iptRules, "\n") {
+		match := strings.Contains(iptRule, pattern)
+		if match {
+			numOfMatchRules++
+		}
+	}
+	return numOfMatchRules
 }
 
 // isDualStackCluster returns 'true' if at least one of the nodes has more than one node subnet.

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -59,6 +59,13 @@ if [ "$OVN_DISABLE_SNAT_MULTIPLE_GWS" == false ]; then
   SKIPPED_TESTS+="e2e multiple external gateway stale conntrack entry deletion validation"
 fi
 
+if [ "$OVN_GATEWAY_MODE" == "shared" ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+    SKIPPED_TESTS+="|"
+  fi
+  SKIPPED_TESTS+="Should ensure load balancer service"
+fi
+
 # skipping the egress ip legacy health check test because it requires two
 # sequenced rollouts of both ovnkube-node and ovnkube-master that take a lot of
 # time.


### PR DESCRIPTION
**- What this PR does and why is it needed**
Curently in LGW mode, when using ETP=local, we use the masqueradeIP .3 and nodePort to DNAT LB VIPs and externalIPs and lure them into mp0. However there can be cases where nodeports don't exist on load balancer services. This PR takes care of this scenario by directly dnat-ing to pod backend in such situations using the IPT random probability algorithm.

**- Special notes for reviewers**
Unit test is added to catch the iptable rule changes, e2e's already exist for AllocateLoadBalancerNodePorts https://github.com/kubernetes/kubernetes/blob/00c0c9d880c1448f778bf892c43664081c80d11e/test/e2e/network/loadbalancer.go#L926 but not in combination with ETP=local. So a new one has been added downstream only using metalLB. 

**- How to verify it**
Following IPTable rules get created for this service.
```
[0:0] -A OVN-KUBE-ETP -d 192.168.10.0/32 -p tcp -m tcp --dport 80 -m statistic --mode random --probability 0.25000000000 -j DNAT --to-destination 10.244.0.10:80
[0:0] -A OVN-KUBE-ETP -d 192.168.10.0/32 -p tcp -m tcp --dport 80 -m statistic --mode random --probability 0.33333333349 -j DNAT --to-destination 10.244.0.11:80
[0:0] -A OVN-KUBE-ETP -d 192.168.10.0/32 -p tcp -m tcp --dport 80 -m statistic --mode random --probability 0.50000000000 -j DNAT --to-destination 10.244.0.8:80
[0:0] -A OVN-KUBE-ETP -d 192.168.10.0/32 -p tcp -m tcp --dport 80 -m statistic --mode random --probability 1.00000000000 -j DNAT --to-destination 10.244.0.9:80
[0:0] -A OVN-KUBE-EXTERNALIP -d 192.168.10.0/32 -p tcp -m tcp --dport 80 -j DNAT --to-destination 10.96.61.90:80
[0:0] -A OVN-KUBE-SNAT-MGMTPORT -d 10.244.0.10/32 -p tcp -m tcp --dport 80 -j RETURN
[0:0] -A OVN-KUBE-SNAT-MGMTPORT -d 10.244.0.11/32 -p tcp -m tcp --dport 80 -j RETURN
[0:0] -A OVN-KUBE-SNAT-MGMTPORT -d 10.244.0.8/32 -p tcp -m tcp --dport 80 -j RETURN
[0:0] -A OVN-KUBE-SNAT-MGMTPORT -d 10.244.0.9/32 -p tcp -m tcp --dport 80 -j RETURN
[0:0] -A OVN-KUBE-SNAT-MGMTPORT -o ovn-k8s-mp0 -m comment --comment "OVN SNAT to Management Port" -j SNAT --to-source 10.244.0.2

```
Have added a new e2e test using metalLB as load balancer provider since coverage in upstream k8s around ETP=local and allocateNodePorts=false is less outside of cloud envs.

**- Description for the changelog**
`This PR supports having AllocateLoadBalancerNodePorts=False along with etp=local services on lgw mode.`