### PR TITLE
remove the requirement that hybrid overlay needs subnet .3 address

### DIFF
--- a/go-controller/hybrid-overlay/pkg/types/types.go
+++ b/go-controller/hybrid-overlay/pkg/types/types.go
@@ -11,6 +11,8 @@ const (
 	HybridOverlayNodeSubnet = HybridOverlayAnnotationBase + "node-subnet"
 	// HybridOverlayDRMAC holds the MAC address of the Distributed Router/gateway
 	HybridOverlayDRMAC = HybridOverlayAnnotationBase + "distributed-router-gateway-mac"
+	// HybridOverlayDRIP holds the port address to redirect traffic to get to the hybrid overlay
+	HybridOverlayDRIP = HybridOverlayAnnotationBase + "distributed-router-gateway-ip"
 	// HybridOverlayVNI is the VNI for VXLAN tunnels between nodes/endpoints
 	HybridOverlayVNI = 4097
 )

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -528,6 +528,16 @@ func (n *OvnNode) Start(ctx context.Context, wg *sync.WaitGroup) error {
 			defer wg.Done()
 			nodeController.Run(n.stopChan)
 		}()
+	} else {
+		// attempt to cleanup the possibly stale bridge
+		_, stderr, err := util.RunOVSVsctl("--if-exists", "del-br", "br-ext")
+		if err != nil {
+			klog.Errorf("Deletion of bridge br-ext failed: %v (%v)", err, stderr)
+		}
+		_, stderr, err = util.RunOVSVsctl("--if-exists", "del-port", "br-int", "int")
+		if err != nil {
+			klog.Errorf("Deletion of port int on  br-int failed: %v (%v)", err, stderr)
+		}
 	}
 
 	if err := level.Set(strconv.Itoa(config.Logging.Level)); err != nil {

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -323,7 +323,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 
 			skipSnat := false
 			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{nodeSubnet}, l3Config, []*net.IPNet{joinLRPIPs}, []*net.IPNet{dLRPIPs}, skipSnat, node1.NodeMgmtPortIP)
-			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+			gomega.Eventually(fakeOvn.nbClient, 2).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			// check the namespace again and ensure the address set
 			// being created with the right set of IPs in it.

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -3,8 +3,10 @@ package ovn
 import (
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
+	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
@@ -108,6 +110,31 @@ func (oc *Controller) syncPodsRetriable(pods []interface{}) error {
 		ops, err = libovsdbops.DeleteLogicalSwitchPortsWithPredicateOps(oc.nbClient, ops, &sw, p)
 		if err != nil {
 			return fmt.Errorf("could not generate ops to delete stale ports from logical switch %s (%+v)", n.Name, err)
+		}
+
+		// have to set up the hybrid Overlay interface address here because all the pod IPs have been allocated above
+		if config.HybridOverlay.Enabled {
+			// check the annotation
+			nodeHybridOverlayDRIP := n.Annotations[hotypes.HybridOverlayDRIP]
+			var hybridOverlayDRIP []string
+			if len(nodeHybridOverlayDRIP) > 0 {
+				hybridOverlayDRIP = strings.Split(nodeHybridOverlayDRIP, ",")
+
+			}
+			AllocatedHybridOverlayDRIPes, err := oc.lsManager.AllocateHybridOverlay(n.Name, hybridOverlayDRIP)
+			if err != nil {
+				return fmt.Errorf("cannot allocate hybrid overlay interface addresses: %v", err)
+			}
+			var sliceHybridOverlayDRIP []string
+			for _, ip := range AllocatedHybridOverlayDRIPes {
+				sliceHybridOverlayDRIP = append(sliceHybridOverlayDRIP, ip.IP.String())
+			}
+			err = oc.kube.SetAnnotationsOnNode(n.Name, map[string]interface{}{hotypes.HybridOverlayDRIP: strings.Join(sliceHybridOverlayDRIP, ",")})
+			if err != nil {
+				return fmt.Errorf("cannot set hybrid annotations on node %s - %v", n.Name, err)
+
+			}
+
 		}
 	}
 

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	ovstypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -1771,6 +1772,224 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+		ginkgo.It("correctly configures hybridOverlay: allocates the address on the node annotation", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.HybridOverlay.Enabled = true
+				namespaceT := *newNamespace("namespace1")
+				initialDB = libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitch{
+							UUID:  "ls-uuid",
+							Name:  "node1",
+							Ports: []string{},
+						},
+					},
+				}
+
+				testNode := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Annotations: map[string]string{
+							hotypes.HybridOverlayDRIP: "10.128.1.53"},
+					},
+				}
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							testNode,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{},
+					},
+				)
+				fakeOvn.controller.lsManager.AddNode("node1", "ls-uuid", []*net.IPNet{ovntest.MustParseIPNet("10.128.1.0/24")})
+
+				err := fakeOvn.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectData := []libovsdbtest.TestData{
+					&nbdb.LogicalSwitch{
+						UUID:  "ls-uuid",
+						Name:  "node1",
+						Ports: []string{},
+					},
+				}
+
+				gomega.Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(expectData))
+				err = fakeOvn.controller.lsManager.AllocateIPs("node1", []*net.IPNet{ovntest.MustParseIPNet("10.128.1.53/32")})
+				gomega.Expect(err).To(gomega.Equal(ipallocator.ErrAllocated))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			node, err := fakeOvn.controller.kube.GetNode("node1")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(node.Annotations[hotypes.HybridOverlayDRIP]).To(gomega.Equal("10.128.1.53"))
+
+		})
+		ginkgo.It("correctly configures hybridOverlay: allocates the .3 address because it is available", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.HybridOverlay.Enabled = true
+				namespaceT := *newNamespace("namespace1")
+				initialDB = libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitch{
+							UUID:  "ls-uuid",
+							Name:  "node1",
+							Ports: []string{},
+						},
+					},
+				}
+
+				testNode := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				}
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							testNode,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{},
+					},
+				)
+				fakeOvn.controller.lsManager.AddNode("node1", "ls-uuid", []*net.IPNet{ovntest.MustParseIPNet("10.128.1.0/24")})
+
+				err := fakeOvn.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				expectData := []libovsdbtest.TestData{
+					&nbdb.LogicalSwitch{
+						UUID:  "ls-uuid",
+						Name:  "node1",
+						Ports: []string{},
+					},
+				}
+
+				gomega.Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(expectData))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			node, err := fakeOvn.controller.kube.GetNode("node1")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(node.Annotations[hotypes.HybridOverlayDRIP]).To(gomega.Equal("10.128.1.3"))
+			err = fakeOvn.controller.lsManager.AllocateIPs("node1", []*net.IPNet{ovntest.MustParseIPNet("10.128.1.3/32")})
+			gomega.Expect(err).To(gomega.Equal(ipallocator.ErrAllocated))
+
+		})
+		ginkgo.It("correctly configures hybridOverlay: allocates an address because the .3 is not available", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.HybridOverlay.Enabled = true
+				namespaceT := *newNamespace("namespace1")
+				t1 := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod1",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+				testNode := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				}
+				initialDB = libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						&nbdb.LogicalSwitchPort{
+							UUID:      t1.portUUID,
+							Name:      util.GetLogicalPortName(t1.namespace, t1.podName),
+							Addresses: []string{t1.podMAC, t1.podIP},
+							ExternalIDs: map[string]string{
+								"pod":       "true",
+								"namespace": t1.namespace,
+							},
+							Options: map[string]string{
+								"requested-chassis": t1.nodeName,
+							},
+							PortSecurity: []string{fmt.Sprintf("%s %s", t1.podMAC, t1.podIP)},
+						},
+						&nbdb.LogicalSwitch{
+							Name:  "node1",
+							Ports: []string{t1.portUUID},
+						},
+					},
+				}
+				// update TestPod to check nbdb lsp later
+				t1.noIfaceIdVer = true
+
+				pod1 := newPod(t1.namespace, t1.podName, t1.nodeName, t1.podIP)
+				setPodAnnotations(pod1, t1)
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*pod1,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							testNode,
+						},
+					},
+				)
+				t1.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, "node1"))
+				// pod annotations and lsp exist now
+
+				err := fakeOvn.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				fakeOvn.controller.WatchPods()
+
+				// check db values are updated to correlate with test pods settings
+				gomega.Eventually(fakeOvn.nbClient).Should(
+					libovsdbtest.HaveData(getExpectedDataPodsAndSwitches([]testPod{t1}, []string{"node1"})))
+				// check annotations are preserved
+				// makes sense only when handling is finished, therefore check after nbdb is updated
+				annotations := getPodAnnotations(fakeOvn.fakeClient.KubeClient, t1.namespace, t1.podName)
+				gomega.Expect(annotations).To(gomega.MatchJSON(t1.getAnnotationsJson()))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			node, err := fakeOvn.controller.kube.GetNode("node1")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(node.Annotations[hotypes.HybridOverlayDRIP]).To(gomega.Equal("10.128.1.4"))
+			err = fakeOvn.controller.lsManager.AllocateIPs("node1", []*net.IPNet{ovntest.MustParseIPNet("10.128.1.4/32")})
+			gomega.Expect(err).To(gomega.Equal(ipallocator.ErrAllocated))
 		})
 	})
 })


### PR DESCRIPTION
Change the hybrid overlay so that it can use any ipv4 address in the nodes subnet to setup. This will remove the requirement that hybrid overlay be on during cluster setup. hybrid overlay does require a restart to enable but not a clean cluster

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

cli.ContextTrivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->