### PR TITLE
Lock the cdr global variable

### DIFF
--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -843,7 +843,12 @@ type ConfigDurationRecorder struct {
 // global variable is needed because this functionality is accessed in many functions
 var cdr *ConfigDurationRecorder
 
+// lock for accessing the cdr global variable
+var cdrMutex sync.Mutex
+
 func GetConfigDurationRecorder() *ConfigDurationRecorder {
+	cdrMutex.Lock()
+	defer cdrMutex.Unlock()
 	if cdr == nil {
 		cdr = &ConfigDurationRecorder{}
 	}


### PR DESCRIPTION
GetConfigDurationRecorder is called from two paths. 1) nodeTracker detects a switch or GR has been added for the node and does a full RequestFullSync which calls onServiceAdd 2) onServiceAdd is called from the service handler for adds.

If we don't lock the cdr variable we access it from two routines while one routine edits it; the other tries to read it for example. Let's lock this variable to prevent races.

```
2022-09-09T14:33:01.6982688Z WARNING: DATA RACE
2022-09-09T14:33:01.6982976Z Read at 0x000004402a78 by goroutine 1044:
2022-09-09T14:33:01.6983629Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics.GetConfigDurationRecorder()
2022-09-09T14:33:01.6984387Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics/master.go:847 +0x29b
2022-09-09T14:33:01.6985239Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services.(*Controller).onServiceAdd()
2022-09-09T14:33:01.6986069Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/services/services_controller.go:366 +0x33f
2022-09-09T14:33:01.6986732Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services.(*Controller).RequestFullSync()
2022-09-09T14:33:01.6988638Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/services/services_controller.go:351 +0x2b2
2022-09-09T14:33:01.6989314Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services.(*Controller).RequestFullSync-fm()
2022-09-09T14:33:01.6989705Z       <autogenerated>:1 +0x39
2022-09-09T14:33:01.6990287Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services.(*nodeTracker).updateNodeInfo()
2022-09-09T14:33:01.6991204Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/services/node_tracker.go:150 +0x67b
2022-09-09T14:33:01.6993403Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services.(*nodeTracker).updateNode()
2022-09-09T14:33:01.6994200Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/services/node_tracker.go:201 +0x709
2022-09-09T14:33:01.6996051Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services.newNodeTracker.func1()
2022-09-09T14:33:01.6996855Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/services/node_tracker.go:78 +0x55
2022-09-09T14:33:01.6998163Z   k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd()
```

versus

```
2022-09-09T14:33:01.7016687Z Previous write at 0x000004402a78 by goroutine 1070:
2022-09-09T14:33:01.7017329Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics.GetConfigDurationRecorder()
2022-09-09T14:33:01.7018197Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/metrics/master.go:848 +0x310
2022-09-09T14:33:01.7018912Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services.(*Controller).onServiceAdd()
2022-09-09T14:33:01.7019866Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/services/services_controller.go:366 +0x33f
2022-09-09T14:33:01.7020529Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services.(*Controller).onServiceAdd-fm()
2022-09-09T14:33:01.7020900Z       <autogenerated>:1 +0x4d
2022-09-09T14:33:01.7021431Z   k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd()
2022-09-09T14:33:01.7022328Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/k8s.io/client-go/tools/cache/controller.go:232 +0x74
2022-09-09T14:33:01.7022857Z   k8s.io/client-go/tools/cache.(*ResourceEventHandlerFuncs).OnAdd()
```

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
Closes #3154 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"



Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->