### PR TITLE
Improve default deny port groups logic for network policy

### DIFF
--- a/go-controller/pkg/ovn/obj_retry.go
+++ b/go-controller/pkg/ovn/obj_retry.go
@@ -95,7 +95,7 @@ func (r *RetryObjs) DoWithLock(key string, f func(key string)) {
 
 func (r *RetryObjs) initRetryObjWithAddBackoff(obj interface{}, lockedKey string, backoff time.Duration) *retryObjEntry {
 	// even if the object was loaded and changed before with the same lock, LoadOrStore will return reference to the same object
-	entry := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{backoffSec: backoff})
+	entry, _ := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{backoffSec: backoff})
 	entry.timeStamp = time.Now()
 	entry.newObj = obj
 	entry.failedAttempts = 0
@@ -111,7 +111,7 @@ func (r *RetryObjs) initRetryObjWithAdd(obj interface{}, lockedKey string) *retr
 
 // initRetryObjWithUpdate tracks objects that failed to be updated to potentially retry later
 func (r *RetryObjs) initRetryObjWithUpdate(oldObj, newObj interface{}, lockedKey string) *retryObjEntry {
-	entry := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: oldObj, backoffSec: initialBackoff})
+	entry, _ := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: oldObj, backoffSec: initialBackoff})
 	// even if the object was loaded and changed before with the same lock, LoadOrStore will return reference to the same object
 	entry.timeStamp = time.Now()
 	entry.newObj = newObj
@@ -131,7 +131,7 @@ func (r *RetryObjs) initRetryObjWithUpdate(oldObj, newObj interface{}, lockedKey
 // The noRetryAdd boolean argument is to indicate whether to retry for addition
 func (r *RetryObjs) initRetryObjWithDelete(obj interface{}, lockedKey string, config interface{}, noRetryAdd bool) *retryObjEntry {
 	// even if the object was loaded and changed before with the same lock, LoadOrStore will return reference to the same object
-	entry := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: config, backoffSec: initialBackoff})
+	entry, _ := r.retryEntries.LoadOrStore(lockedKey, &retryObjEntry{config: config, backoffSec: initialBackoff})
 	entry.timeStamp = time.Now()
 	entry.oldObj = obj
 	if entry.config == nil {
@@ -335,7 +335,7 @@ func getResourceKey(objType reflect.Type, obj interface{}) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("could not cast %T object to *knet.NetworkPolicy", obj)
 		}
-		return getPolicyNamespacedName(np), nil
+		return getPolicyKey(np), nil
 
 	case factory.NodeType,
 		factory.EgressNodeType:
@@ -688,10 +688,8 @@ func (oc *Controller) addResource(objectsToRetry *RetryObjs, obj interface{}, fr
 	case factory.LocalPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
 		return oc.handleLocalPodSelectorAddFunc(
-			extraParameters.policy,
 			extraParameters.np,
-			extraParameters.portGroupIngressDenyName,
-			extraParameters.portGroupEgressDenyName,
+			false,
 			obj)
 
 	case factory.EgressFirewallType:
@@ -807,10 +805,8 @@ func (oc *Controller) updateResource(objectsToRetry *RetryObjs, oldObj, newObj i
 	case factory.LocalPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
 		return oc.handleLocalPodSelectorAddFunc(
-			extraParameters.policy,
 			extraParameters.np,
-			extraParameters.portGroupIngressDenyName,
-			extraParameters.portGroupEgressDenyName,
+			false,
 			newObj)
 
 	case factory.EgressIPType:
@@ -981,10 +977,7 @@ func (oc *Controller) deleteResource(objectsToRetry *RetryObjs, obj, cachedObj i
 	case factory.LocalPodSelectorType:
 		extraParameters := objectsToRetry.extraParameters.(*NetworkPolicyExtraParameters)
 		return oc.handleLocalPodSelectorDelFunc(
-			extraParameters.policy,
 			extraParameters.np,
-			extraParameters.portGroupIngressDenyName,
-			extraParameters.portGroupEgressDenyName,
 			obj)
 
 	case factory.EgressFirewallType:

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -60,42 +60,6 @@ type ACLLoggingLevels struct {
 	Deny  string `json:"deny,omitempty"`
 }
 
-// namespaceInfo contains information related to a Namespace. Use oc.getNamespaceLocked()
-// or oc.waitForNamespaceLocked() to get a locked namespaceInfo for a Namespace, and call
-// nsInfo.Unlock() on it when you are done with it. (No code outside of the code that
-// manages the oc.namespaces map is ever allowed to hold an unlocked namespaceInfo.)
-type namespaceInfo struct {
-	sync.RWMutex
-
-	// addressSet is an address set object that holds the IP addresses
-	// of all pods in the namespace.
-	addressSet addressset.AddressSet
-
-	// map from NetworkPolicy name to networkPolicy. You must hold the
-	// namespaceInfo's mutex to add/delete/lookup policies, but must hold the
-	// networkPolicy's mutex (and not necessarily the namespaceInfo's) to work with
-	// the policy itself.
-	networkPolicies map[string]*networkPolicy
-
-	// routingExternalGWs is a slice of net.IP containing the values parsed from
-	// annotation k8s.ovn.org/routing-external-gws
-	routingExternalGWs gatewayInfo
-
-	// routingExternalPodGWs contains a map of all pods serving as exgws as well as their
-	// exgw IPs
-	// key is <namespace>_<pod name>
-	routingExternalPodGWs map[string]gatewayInfo
-
-	multicastEnabled bool
-
-	// If not empty, then it has to be set to a logging a severity level, e.g. "notice", "alert", etc
-	aclLogging ACLLoggingLevels
-
-	// Per-namespace port group default deny UUIDs
-	portGroupIngressDenyName string // Port group Name for ingress deny rule
-	portGroupEgressDenyName  string // Port group Name for egress deny rule
-}
-
 // Controller structure is the object which holds the controls for starting
 // and reacting upon the watched resources (e.g. pods, endpoints)
 type Controller struct {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -12,26 +12,24 @@ import (
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	egressqoslisters "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1/apis/listers/egressqos/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	egresssvc "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/egress_services"
 	svccontroller "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/unidling"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
-	corev1listers "k8s.io/client-go/listers/core/v1"
-
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/subnetallocator"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
-	utilnet "k8s.io/utils/net"
-
-	egressqoslisters "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1/apis/listers/egressqos/v1"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -42,12 +40,13 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/client-go/util/workqueue"
-
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 )
 
 const (
@@ -114,16 +113,12 @@ type Controller struct {
 	// An address set factory that creates address sets
 	addressSetFactory addressset.AddressSetFactory
 
-	// For each logical port, the number of network policies that want
-	// to add an ingress deny rule.
-	lspIngressDenyCache map[string]int
-
-	// For each logical port, the number of network policies that want
-	// to add an egress deny rule.
-	lspEgressDenyCache map[string]int
-
-	// A mutex for lspIngressDenyCache and lspEgressDenyCache
-	lspMutex *sync.Mutex
+	// map of existing shared port groups for network policies
+	// port group exists in the db if and only if port group key is present in this map
+	// key is namespace
+	// allowed locking order is namespace Lock -> networkPolicy.Lock -> sharedNetpolPortGroups key Lock
+	// make sure to keep this order to avoid deadlocks
+	sharedNetpolPortGroups *syncmap.SyncMap[*defaultDenyPortGroups]
 
 	// Supports multicast?
 	multicastSupport bool
@@ -263,9 +258,7 @@ func NewOvnController(ovnClient *util.OVNClientset, wf *factory.WatchFactory, st
 		externalGWCache:              make(map[ktypes.NamespacedName]*externalRouteInfo),
 		exGWCacheMutex:               sync.RWMutex{},
 		addressSetFactory:            addressSetFactory,
-		lspIngressDenyCache:          make(map[string]int),
-		lspEgressDenyCache:           make(map[string]int),
-		lspMutex:                     &sync.Mutex{},
+		sharedNetpolPortGroups:       syncmap.NewSyncMap[*defaultDenyPortGroups](),
 		eIPC: egressIPController{
 			egressIPAssignmentMutex:           &sync.Mutex{},
 			podAssignmentMutex:                &sync.Mutex{},

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"time"
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	ovsdb "github.com/ovn-org/libovsdb/ovsdb"
@@ -15,15 +14,14 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	kerrorsutil "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
@@ -51,6 +49,83 @@ const (
 	arpAllowPolicySuffix = "ARPallowPolicy"
 )
 
+// defaultDenyPortGroups is a shared object and should be used by only 1 thread at a time
+type defaultDenyPortGroups struct {
+	// portName: map[portName]sets.String(policyNames)
+	// store policies that are using every port in the map
+	// these maps should be atomically updated with db operations
+	// if adding a port to db for a policy fails, map shouldn't be changed
+	ingressPortToPolicies map[string]sets.String
+	egressPortToPolicies  map[string]sets.String
+	// policies is a map of policies that use this port group
+	// policy keys must be unique, and it can be retrieved with (np *networkPolicy) getKey()
+	policies map[string]bool
+}
+
+// addPortsForPolicy adds port-policy association for default deny port groups and
+// returns lists of new ports to add to the default deny port groups.
+// If port should be added to ingress and/or egress default deny port group depends on policy spec.
+func (sharedPGs *defaultDenyPortGroups) addPortsForPolicy(np *networkPolicy,
+	portNamesToUUIDs map[string]string) (ingressDenyPorts, egressDenyPorts []string) {
+	ingressDenyPorts = []string{}
+	egressDenyPorts = []string{}
+
+	if np.isIngress {
+		for portName, portUUID := range portNamesToUUIDs {
+			// if this is the first NP referencing this pod, then we
+			// need to add it to the port group.
+			if sharedPGs.ingressPortToPolicies[portName].Len() == 0 {
+				ingressDenyPorts = append(ingressDenyPorts, portUUID)
+				sharedPGs.ingressPortToPolicies[portName] = sets.String{}
+			}
+			// increment the reference count.
+			sharedPGs.ingressPortToPolicies[portName].Insert(np.getKey())
+		}
+	}
+	if np.isEgress {
+		for portName, portUUID := range portNamesToUUIDs {
+			if sharedPGs.egressPortToPolicies[portName].Len() == 0 {
+				// again, reference count is 0, so add to port
+				egressDenyPorts = append(egressDenyPorts, portUUID)
+				sharedPGs.egressPortToPolicies[portName] = sets.String{}
+			}
+			// bump reference count
+			sharedPGs.egressPortToPolicies[portName].Insert(np.getKey())
+		}
+	}
+	return
+}
+
+// deletePortsForPolicy deletes port-policy association for default deny port groups,
+// and returns lists of port UUIDs to delete from the default deny port groups.
+// If port should be deleted from ingress and/or egress default deny port group depends on policy spec.
+func (sharedPGs *defaultDenyPortGroups) deletePortsForPolicy(np *networkPolicy,
+	portNamesToUUIDs map[string]string) (ingressDenyPorts, egressDenyPorts []string) {
+	ingressDenyPorts = []string{}
+	egressDenyPorts = []string{}
+
+	if np.isIngress {
+		for portName, portUUID := range portNamesToUUIDs {
+			// Delete and Len can be used for zero-value nil set
+			sharedPGs.ingressPortToPolicies[portName].Delete(np.getKey())
+			if sharedPGs.ingressPortToPolicies[portName].Len() == 0 {
+				ingressDenyPorts = append(ingressDenyPorts, portUUID)
+				delete(sharedPGs.ingressPortToPolicies, portName)
+			}
+		}
+	}
+	if np.isEgress {
+		for portName, portUUID := range portNamesToUUIDs {
+			sharedPGs.egressPortToPolicies[portName].Delete(np.getKey())
+			if sharedPGs.egressPortToPolicies[portName].Len() == 0 {
+				egressDenyPorts = append(egressDenyPorts, portUUID)
+				delete(sharedPGs.egressPortToPolicies, portName)
+			}
+		}
+	}
+	return
+}
+
 type networkPolicy struct {
 	// RWMutex synchronizes operations on the policy.
 	// Operations that change local and peer pods take a RLock,
@@ -61,13 +136,19 @@ type networkPolicy struct {
 	policy          *knet.NetworkPolicy
 	ingressPolicies []*gressPolicy
 	egressPolicies  []*gressPolicy
+	isIngress       bool
+	isEgress        bool
 	podHandlerList  []*factory.Handler
 	svcHandlerList  []*factory.Handler
 	nsHandlerList   []*factory.Handler
 
-	// localPods is a list of pods affected by this policy
-	// this is a sync map so we can handle multiple pods at once
-	// map of string -> *lpInfo
+	// localPods is a map of pods affected by this policy.
+	// It is used to update defaultDeny port group port counters, when deleting network policy.
+	// Port should only be added here if it was successfully added to default deny port group,
+	// and local port group in db.
+	// localPods may be updated by multiple pod handlers at the same time,
+	// therefore it uses a sync map to handle simultaneous access.
+	// map of portName(string): portUUID(string)
 	localPods sync.Map
 
 	portGroupName string
@@ -75,12 +156,15 @@ type networkPolicy struct {
 }
 
 func NewNetworkPolicy(policy *knet.NetworkPolicy) *networkPolicy {
+	policyTypeIngress, policyTypeEgress := getPolicyType(policy)
 	np := &networkPolicy{
 		name:            policy.Name,
 		namespace:       policy.Namespace,
 		policy:          policy,
 		ingressPolicies: make([]*gressPolicy, 0),
 		egressPolicies:  make([]*gressPolicy, 0),
+		isIngress:       policyTypeIngress,
+		isEgress:        policyTypeEgress,
 		podHandlerList:  make([]*factory.Handler, 0),
 		svcHandlerList:  make([]*factory.Handler, 0),
 		nsHandlerList:   make([]*factory.Handler, 0),
@@ -128,8 +212,8 @@ func (oc *Controller) updateStaleDefaultDenyACLNames(npType knet.PolicyType, gre
 		newName := namespacePortGroupACLName(namespace, "", gressSuffix)
 		if len(aclList) > 1 {
 			// this should never be the case but delete everything except 1st ACL
-			ingressPGName := defaultDenyPortGroup(namespace, ingressDefaultDenySuffix)
-			egressPGName := defaultDenyPortGroup(namespace, egressDefaultDenySuffix)
+			ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
+			egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
 			err := libovsdbops.DeleteACLs(oc.nbClient, []string{ingressPGName, egressPGName}, nil, aclList[1:]...)
 			if err != nil {
 				return err
@@ -345,7 +429,7 @@ func buildACL(namespace, portGroup, name, direction string, priority int, match,
 	return BuildACL(aclName, direction, priority, match, action, logLevels, externalIds, options)
 }
 
-func defaultDenyPortGroup(namespace, gressSuffix string) string {
+func defaultDenyPortGroupName(namespace, gressSuffix string) string {
 	return hashedPortGroup(namespace) + "_" + gressSuffix
 }
 
@@ -366,14 +450,50 @@ func buildDenyACLs(namespace, policy, pg string, aclLogging *ACLLoggingLevels, p
 	return
 }
 
-// must be called with a write lock on nsInfo
-func (oc *Controller) createDefaultDenyPGAndACLs(namespace, policy string, nsInfo *namespaceInfo) error {
-	aclLogging := nsInfo.aclLogging
+func (oc *Controller) addPolicyToDefaultPortGroups(np *networkPolicy, aclLogging *ACLLoggingLevels) error {
+	return oc.sharedNetpolPortGroups.DoWithLock(np.namespace, func(pgKey string) error {
+		sharedPGs, loaded := oc.sharedNetpolPortGroups.LoadOrStore(pgKey, &defaultDenyPortGroups{
+			ingressPortToPolicies: map[string]sets.String{},
+			egressPortToPolicies:  map[string]sets.String{},
+			policies:              map[string]bool{},
+		})
+		if !loaded {
+			// create port groups with acls
+			err := oc.createDefaultDenyPGAndACLs(np.namespace, np.name, aclLogging)
+			if err != nil {
+				oc.sharedNetpolPortGroups.Delete(pgKey)
+				return fmt.Errorf("failed to create default deny port groups: %v", err)
+			}
+		}
+		sharedPGs.policies[np.getKey()] = true
+		return nil
+	})
+}
 
-	ingressPGName := defaultDenyPortGroup(namespace, ingressDefaultDenySuffix)
-	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, policy, ingressPGName, &aclLogging, knet.PolicyTypeIngress)
-	egressPGName := defaultDenyPortGroup(namespace, egressDefaultDenySuffix)
-	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, policy, egressPGName, &aclLogging, knet.PolicyTypeEgress)
+func (oc *Controller) delPolicyFromDefaultPortGroups(np *networkPolicy) error {
+	return oc.sharedNetpolPortGroups.DoWithLock(np.namespace, func(pgKey string) error {
+		sharedPGs, found := oc.sharedNetpolPortGroups.Load(pgKey)
+		if !found {
+			return nil
+		}
+		delete(sharedPGs.policies, np.getKey())
+		if len(sharedPGs.policies) == 0 {
+			// last policy was deleted, delete port group
+			err := oc.deleteDefaultDenyPGAndACLs(np.namespace, np.name)
+			if err != nil {
+				return fmt.Errorf("failed to delete defaul deny port group: %v", err)
+			}
+			oc.sharedNetpolPortGroups.Delete(pgKey)
+		}
+		return nil
+	})
+}
+
+func (oc *Controller) createDefaultDenyPGAndACLs(namespace, policy string, aclLogging *ACLLoggingLevels) error {
+	ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
+	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, policy, ingressPGName, aclLogging, knet.PolicyTypeIngress)
+	egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
+	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, policy, egressPGName, aclLogging, knet.PolicyTypeEgress)
 	ops, err := libovsdbops.CreateOrUpdateACLsOps(oc.nbClient, nil, ingressDenyACL, ingressAllowACL, egressDenyACL, egressAllowACL)
 	if err != nil {
 		return err
@@ -398,23 +518,18 @@ func (oc *Controller) createDefaultDenyPGAndACLs(namespace, policy string, nsInf
 	}
 	txOkCallBack()
 
-	nsInfo.portGroupEgressDenyName = egressPGName
-	nsInfo.portGroupIngressDenyName = ingressPGName
-
 	return nil
 }
 
 // deleteDefaultDenyPGAndACLs deletes the default port groups and acls for a ns/policy
-// must be called with a write lock on nsInfo
-func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string, nsInfo *namespaceInfo) error {
-	aclLogging := nsInfo.aclLogging
+func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string) error {
 	var aclsToBeDeleted []*nbdb.ACL
 
-	ingressPGName := defaultDenyPortGroup(namespace, ingressDefaultDenySuffix)
-	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, policy, ingressPGName, &aclLogging, knet.PolicyTypeIngress)
+	ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
+	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, policy, ingressPGName, nil, knet.PolicyTypeIngress)
 	aclsToBeDeleted = append(aclsToBeDeleted, ingressDenyACL, ingressAllowACL)
-	egressPGName := defaultDenyPortGroup(namespace, egressDefaultDenySuffix)
-	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, policy, egressPGName, &aclLogging, knet.PolicyTypeEgress)
+	egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
+	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, policy, egressPGName, nil, knet.PolicyTypeEgress)
 	aclsToBeDeleted = append(aclsToBeDeleted, egressDenyACL, egressAllowACL)
 
 	ops, err := libovsdbops.DeletePortGroupsOps(oc.nbClient, nil, ingressPGName, egressPGName)
@@ -431,8 +546,6 @@ func (oc *Controller) deleteDefaultDenyPGAndACLs(namespace, policy string, nsInf
 	if err != nil {
 		return fmt.Errorf("failed to transact deleteDefaultDenyPGAndACLs: %v", err)
 	}
-	nsInfo.portGroupEgressDenyName = ""
-	nsInfo.portGroupIngressDenyName = ""
 
 	return nil
 }
@@ -453,15 +566,21 @@ func (oc *Controller) updateACLLoggingForPolicy(np *networkPolicy, aclLogging *A
 }
 
 func (oc *Controller) updateACLLoggingForDefaultACLs(ns string, nsInfo *namespaceInfo) error {
-	// update namespace-scoped default deny ACLs
-	denyEgressACL, _ := buildDenyACLs(ns, "", defaultDenyPortGroup(ns, egressDefaultDenySuffix),
-		&nsInfo.aclLogging, knet.PolicyTypeEgress)
-	denyIngressACL, _ := buildDenyACLs(ns, "", defaultDenyPortGroup(ns, ingressDefaultDenySuffix),
-		&nsInfo.aclLogging, knet.PolicyTypeIngress)
-	if err := UpdateACLLogging(oc.nbClient, []*nbdb.ACL{denyIngressACL, denyEgressACL}, &nsInfo.aclLogging); err != nil {
-		return fmt.Errorf("unable to update ACL logging for namespace %s: %w", ns, err)
-	}
-	return nil
+	return oc.sharedNetpolPortGroups.DoWithLock(ns, func(pgKey string) error {
+		_, loaded := oc.sharedNetpolPortGroups.Load(pgKey)
+		if !loaded {
+			// shared port group doesn't exist
+			return fmt.Errorf("shared port group doesn't exist for ns %s", ns)
+		}
+		denyEgressACL, _ := buildDenyACLs(ns, "", defaultDenyPortGroupName(ns, egressDefaultDenySuffix),
+			&nsInfo.aclLogging, knet.PolicyTypeEgress)
+		denyIngressACL, _ := buildDenyACLs(ns, "", defaultDenyPortGroupName(ns, ingressDefaultDenySuffix),
+			&nsInfo.aclLogging, knet.PolicyTypeIngress)
+		if err := UpdateACLLogging(oc.nbClient, []*nbdb.ACL{denyIngressACL, denyEgressACL}, &nsInfo.aclLogging); err != nil {
+			return fmt.Errorf("unable to update ACL logging for namespace %s: %w", ns, err)
+		}
+		return nil
+	})
 }
 
 func (oc *Controller) setNetworkPolicyACLLoggingForNamespace(ns string, nsInfo *namespaceInfo) error {
@@ -694,8 +813,8 @@ func podDeleteAllowMulticastPolicy(nbClient libovsdbclient.Client, ns string, po
 	return libovsdbops.DeletePortsFromPortGroup(nbClient, hashedPortGroup(ns), portUUID)
 }
 
-// policyType returns whether the policy is of type ingress and/or egress
-func policyType(policy *knet.NetworkPolicy) (bool, bool) {
+// getPolicyType returns whether the policy is of type ingress and/or egress
+func getPolicyType(policy *knet.NetworkPolicy) (bool, bool) {
 	var policyTypeIngress bool
 	var policyTypeEgress bool
 
@@ -710,160 +829,15 @@ func policyType(policy *knet.NetworkPolicy) (bool, bool) {
 	return policyTypeIngress, policyTypeEgress
 }
 
-// localPodAddDefaultDeny ensures ports (i.e. pods) are in the correct
-// default-deny portgroups. Whether or not pods are in default-deny depends
-// on whether or not any policies select this pod, so there is a reference
-// count to ensure we don't accidentally open up a pod.
-func (oc *Controller) localPodAddDefaultDeny(policy *knet.NetworkPolicy,
-	ports ...*lpInfo) (ingressDenyPorts, egressDenyPorts []string) {
-	oc.lspMutex.Lock()
+// getNewLocalPolicyPorts will find and return port info for every given pod obj, that is not found in
+// np.localPods.
+// if there are problems with fetching port info from logicalPortCache, pod will be added to errObjs.
+func (oc *Controller) getNewLocalPolicyPorts(np *networkPolicy,
+	objs ...interface{}) (policyPortsToUUIDs map[string]string, policyPortUUIDs []string, errObjs []interface{}) {
 
-	ingressDenyPorts = []string{}
-	egressDenyPorts = []string{}
-
-	policyTypeIngress, policyTypeEgress := policyType(policy)
-
-	if policyTypeIngress {
-		for _, portInfo := range ports {
-			// if this is the first NP referencing this pod, then we
-			// need to add it to the port group.
-			if oc.lspIngressDenyCache[portInfo.name] == 0 {
-				ingressDenyPorts = append(ingressDenyPorts, portInfo.uuid)
-			}
-
-			// increment the reference count.
-			oc.lspIngressDenyCache[portInfo.name]++
-		}
-	}
-
-	// Handle condition 2 above.
-	if policyTypeEgress {
-		for _, portInfo := range ports {
-			if oc.lspEgressDenyCache[portInfo.name] == 0 {
-				// again, reference count is 0, so add to port
-				egressDenyPorts = append(egressDenyPorts, portInfo.uuid)
-			}
-
-			// bump reference count
-			oc.lspEgressDenyCache[portInfo.name]++
-		}
-	}
-	oc.lspMutex.Unlock()
-
-	return
-}
-
-// localPodDelDefaultDeny decrements a pod's policy reference count and removes a pod
-// from the default-deny portgroups if the reference count for the pod is 0
-func (oc *Controller) localPodDelDefaultDeny(
-	np *networkPolicy, ports ...*lpInfo) (ingressDenyPorts, egressDenyPorts []string) {
-	oc.lspMutex.Lock()
-
-	ingressDenyPorts = []string{}
-	egressDenyPorts = []string{}
-
-	policyTypeIngress, policyTypeEgress := policyType(np.policy)
-
-	// Remove port from ingress deny port-group for [Ingress] and [ingress,egress] PolicyTypes
-	// If NOT [egress] PolicyType
-	if policyTypeIngress {
-		for _, portInfo := range ports {
-			if oc.lspIngressDenyCache[portInfo.name] > 0 {
-				oc.lspIngressDenyCache[portInfo.name]--
-				if oc.lspIngressDenyCache[portInfo.name] == 0 {
-					ingressDenyPorts = append(ingressDenyPorts, portInfo.uuid)
-					delete(oc.lspIngressDenyCache, portInfo.name)
-				}
-			}
-		}
-	}
-
-	// Remove port from egress deny port group for [egress] and [ingress,egress] PolicyTypes
-	// if [egress] PolicyType OR there are any egress rules OR [ingress,egress] PolicyType
-	if policyTypeEgress {
-		for _, portInfo := range ports {
-			if oc.lspEgressDenyCache[portInfo.name] > 0 {
-				oc.lspEgressDenyCache[portInfo.name]--
-				if oc.lspEgressDenyCache[portInfo.name] == 0 {
-					egressDenyPorts = append(egressDenyPorts, portInfo.uuid)
-					delete(oc.lspEgressDenyCache, portInfo.name)
-				}
-			}
-		}
-	}
-	oc.lspMutex.Unlock()
-
-	return
-}
-
-func (oc *Controller) processLocalPodSelectorSetPods(policy *knet.NetworkPolicy,
-	np *networkPolicy, objs ...interface{}) (policyPorts, ingressDenyPorts, egressDenyPorts []string) {
 	klog.Infof("Processing NetworkPolicy %s/%s to have %d local pods...", np.namespace, np.name, len(objs))
-
-	// get list of pods and their logical ports to add
-	// theoretically this should never filter any pods but it's always good to be
-	// paranoid.
-	policyPorts = make([]string, 0, len(objs))
-	policyPortsInfo := make([]*lpInfo, 0, len(objs))
-
-	// thread safe helper vars used by the `getPortInfo` go-routine
-	getPortsInfoMap := sync.Map{}
-	getPolicyPortsWg := &sync.WaitGroup{}
-
-	getPortInfo := func(pod *kapi.Pod) {
-		defer getPolicyPortsWg.Done()
-
-		if pod.Spec.NodeName == "" {
-			return
-		}
-
-		logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
-		var portInfo *lpInfo
-
-		// Get the logical port info from the cache, if that fails, retry.
-		// If the gotten LSP is scheduled for removal, retry (stateful-sets).
-		//
-		// 24ms is chosen because gomega.Eventually default timeout is 50ms
-		// libovsdb transactions take less than 50ms usually as well so pod create
-		// should be done within a couple iterations
-		retryErr := wait.PollImmediate(24*time.Millisecond, 1*time.Second, func() (bool, error) {
-			var err error
-
-			// Retry if getting pod LSP from the cache fails
-			portInfo, err = oc.logicalPortCache.get(logicalPort)
-			if err != nil {
-				klog.Warningf("Failed to get LSP for pod %s/%s for networkPolicy %s refetching err: %v",
-					pod.Namespace, pod.Name, policy.Name, err)
-				return false, nil
-			}
-
-			// Retry if LSP is scheduled for deletion
-			if !portInfo.expires.IsZero() {
-				klog.Warningf("Stale LSP %s for network policy %s found in cache refetching",
-					portInfo.name, policy.Name)
-				return false, nil
-			}
-
-			// LSP get succeeded and LSP is up to fresh, exit and continue
-			klog.V(5).Infof("Fresh LSP %s for network policy %s found in cache",
-				portInfo.name, policy.Name)
-			return true, nil
-
-		})
-		if retryErr != nil {
-			// Failed to get an up to date version of the LSP from the cache
-			klog.Warningf("Failed to get LSP after multiple retries for pod %s/%s for networkPolicy %s err: %v",
-				pod.Namespace, pod.Name, policy.Name, retryErr)
-			return
-		}
-
-		// if this pod is somehow already added to this policy, then skip
-		if _, ok := np.localPods.LoadOrStore(portInfo.name, portInfo); ok {
-			return
-		}
-
-		getPortsInfoMap.Store(portInfo.uuid, portInfo)
-	}
+	policyPortUUIDs = make([]string, 0, len(objs))
+	policyPortsToUUIDs = map[string]string{}
 
 	for _, obj := range objs {
 		pod := obj.(*kapi.Pod)
@@ -872,140 +846,268 @@ func (oc *Controller) processLocalPodSelectorSetPods(policy *knet.NetworkPolicy,
 			// if pod is completed, do not add it to NP port group
 			continue
 		}
+		if pod.Spec.NodeName == "" {
+			// pod is not yet scheduled, will receive update event for it
+			continue
+		}
 
-		getPolicyPortsWg.Add(1)
-		go getPortInfo(pod)
+		logicalPortName := util.GetLogicalPortName(pod.Namespace, pod.Name)
+
+		if _, ok := np.localPods.Load(logicalPortName); ok {
+			// port is already added for this policy
+			continue
+		}
+
+		// Add pod to errObjs for retry if
+		// 1. getting pod LSP from the cache fails,
+		// 2. the gotten LSP is scheduled for removal (stateful-sets).
+		portInfo, err := oc.logicalPortCache.get(logicalPortName)
+		if err != nil {
+			klog.Warningf("Failed to get LSP for pod %s/%s for networkPolicy %s, err: %v",
+				pod.Namespace, pod.Name, np.name, err)
+			errObjs = append(errObjs, pod)
+			continue
+		}
+
+		// Add pod to errObjs if LSP is scheduled for deletion
+		if !portInfo.expires.IsZero() {
+			klog.Warningf("Stale LSP %s for network policy %s found in cache",
+				portInfo.name, np.name)
+			errObjs = append(errObjs, pod)
+			continue
+		}
+
+		// LSP get succeeded and LSP is up to fresh
+		klog.V(5).Infof("Fresh LSP %s for network policy %s found in cache",
+			portInfo.name, np.name)
+
+		policyPortUUIDs = append(policyPortUUIDs, portInfo.uuid)
+		policyPortsToUUIDs[portInfo.name] = portInfo.uuid
 	}
-
-	getPolicyPortsWg.Wait()
-
-	// build usable atomic structures from the sync.Map() populated by the getPortInfo threads
-	// add to backup policyPorts array
-	getPortsInfoMap.Range(func(key interface{}, value interface{}) bool {
-		policyPorts = append(policyPorts, key.(string))
-		policyPortsInfo = append(policyPortsInfo, value.(*lpInfo))
-		return true
-	})
-
-	ingressDenyPorts, egressDenyPorts = oc.localPodAddDefaultDeny(policy, policyPortsInfo...)
-
 	return
 }
 
-func (oc *Controller) processLocalPodSelectorDelPods(np *networkPolicy,
-	objs ...interface{}) (policyPorts, ingressDenyPorts, egressDenyPorts []string) {
+// getExistingLocalPolicyPorts will find and return port info for every given pod obj, that is present in np.localPods.
+// if there are problems with fetching port info from logicalPortCache, pod will be added to errObjs.
+func (oc *Controller) getExistingLocalPolicyPorts(np *networkPolicy,
+	objs ...interface{}) (policyPortsToUUIDs map[string]string, policyPortUUIDs []string, errObjs []interface{}) {
 	klog.Infof("Processing NetworkPolicy %s/%s to delete %d local pods...", np.namespace, np.name, len(objs))
 
-	policyPorts = make([]string, 0, len(objs))
-	policyPortsInfo := make([]*lpInfo, 0, len(objs))
+	policyPortUUIDs = make([]string, 0, len(objs))
+	policyPortsToUUIDs = map[string]string{}
 	for _, obj := range objs {
 		pod := obj.(*kapi.Pod)
 
-		if pod.Spec.NodeName == "" {
+		logicalPortName := util.GetLogicalPortName(pod.Namespace, pod.Name)
+		if _, ok := np.localPods.Load(logicalPortName); !ok {
+			// port is already deleted for this policy
 			continue
 		}
 
-		logicalPort := util.GetLogicalPortName(pod.Namespace, pod.Name)
-		portInfo, err := oc.logicalPortCache.get(logicalPort)
+		portInfo, err := oc.logicalPortCache.get(logicalPortName)
 		if err != nil {
-			klog.Errorf(err.Error())
+			klog.Warningf("Failed to get LSP for pod %s/%s for networkPolicy %s refetching err: %v",
+				pod.Namespace, pod.Name, np.name, err)
+			errObjs = append(errObjs, pod)
 			return
 		}
 
-		// If we never saw this pod, short-circuit
-		if _, ok := np.localPods.LoadAndDelete(logicalPort); !ok {
-			continue
-		}
-
-		policyPortsInfo = append(policyPortsInfo, portInfo)
-		policyPorts = append(policyPorts, portInfo.uuid)
+		policyPortsToUUIDs[portInfo.name] = portInfo.uuid
+		policyPortUUIDs = append(policyPortUUIDs, portInfo.uuid)
 	}
-
-	ingressDenyPorts, egressDenyPorts = oc.localPodDelDefaultDeny(np, policyPortsInfo...)
-
 	return
 }
 
-// handleLocalPodSelectorAddFunc adds a new pod to an existing NetworkPolicy
-func (oc *Controller) handleLocalPodSelectorAddFunc(policy *knet.NetworkPolicy, np *networkPolicy,
-	portGroupIngressDenyName, portGroupEgressDenyName string, obj interface{}) error {
+// denyPGAddPorts adds ports to default deny port groups.
+func (oc *Controller) denyPGAddPorts(np *networkPolicy, portNamesToUUIDs map[string]string) error {
+	var err error
+	var ops []ovsdb.Operation
+	ingressDenyPGName := defaultDenyPortGroupName(np.namespace, ingressDefaultDenySuffix)
+	egressDenyPGName := defaultDenyPortGroupName(np.namespace, egressDefaultDenySuffix)
+
+	pgKey := np.namespace
+	// this lock guarantees that sharedPortGroup counters will be updated atomically
+	// with adding port to port group in db.
+	oc.sharedNetpolPortGroups.LockKey(pgKey)
+	defer oc.sharedNetpolPortGroups.UnlockKey(pgKey)
+	sharedPGs, ok := oc.sharedNetpolPortGroups.Load(pgKey)
+	if !ok {
+		// Port group doesn't exist
+		return fmt.Errorf("port groups for ns %s don't exist", np.namespace)
+	}
+
+	ingressDenyPorts, egressDenyPorts := sharedPGs.addPortsForPolicy(np, portNamesToUUIDs)
+	// counters were updated, update back to initial values on error
+	defer func() {
+		if err != nil {
+			sharedPGs.deletePortsForPolicy(np, portNamesToUUIDs)
+		}
+	}()
+
+	if len(ingressDenyPorts) != 0 || len(egressDenyPorts) != 0 {
+		// db changes required
+		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, ingressDenyPGName, ingressDenyPorts...)
+		if err != nil {
+			return fmt.Errorf("unable to get add ports to %s port group ops: %v", ingressDenyPGName, err)
+		}
+
+		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, egressDenyPGName, egressDenyPorts...)
+		if err != nil {
+			return fmt.Errorf("unable to get add ports to %s port group ops: %v", egressDenyPGName, err)
+		}
+
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("unable to transact add ports to default deny port groups: %v", err)
+		}
+	}
+	return nil
+}
+
+// denyPGDeletePorts deletes ports from default deny port groups.
+// Set useLocalPods = true, when deleting networkPolicy to remove all its ports from defaultDeny port groups.
+func (oc *Controller) denyPGDeletePorts(np *networkPolicy, portNamesToUUIDs map[string]string, useLocalPods bool) error {
+	var err error
+	var ops []ovsdb.Operation
+	if useLocalPods {
+		portNamesToUUIDs = map[string]string{}
+		np.localPods.Range(func(key, value interface{}) bool {
+			portNamesToUUIDs[key.(string)] = value.(string)
+			return true
+		})
+	}
+	if len(portNamesToUUIDs) == 0 {
+		return nil
+	}
+
+	ingressDenyPGName := defaultDenyPortGroupName(np.namespace, ingressDefaultDenySuffix)
+	egressDenyPGName := defaultDenyPortGroupName(np.namespace, egressDefaultDenySuffix)
+
+	pgKey := np.namespace
+	// this lock guarantees that sharedPortGroup counters will be updated atomically
+	// with adding port to port group in db.
+	oc.sharedNetpolPortGroups.LockKey(pgKey)
+	defer oc.sharedNetpolPortGroups.UnlockKey(pgKey)
+	sharedPGs, ok := oc.sharedNetpolPortGroups.Load(pgKey)
+	if !ok {
+		// Port group doesn't exist, nothing to clean up
+		klog.Infof("Skip delete ports from default deny port group: port group doesn't exist")
+		return nil
+	}
+
+	ingressDenyPorts, egressDenyPorts := sharedPGs.deletePortsForPolicy(np, portNamesToUUIDs)
+	// counters were updated, update back to initial values on error
+	defer func() {
+		if err != nil {
+			sharedPGs.addPortsForPolicy(np, portNamesToUUIDs)
+		}
+	}()
+
+	if len(ingressDenyPorts) != 0 || len(egressDenyPorts) != 0 {
+		// db changes required
+		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, ingressDenyPGName, ingressDenyPorts...)
+		if err != nil {
+			return fmt.Errorf("unable to get del ports from %s port group ops: %v", ingressDenyPGName, err)
+		}
+
+		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, egressDenyPGName, egressDenyPorts...)
+		if err != nil {
+			return fmt.Errorf("unable to get del ports from %s port group ops: %v", egressDenyPGName, err)
+		}
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("unable to transact del ports from default deny port groups: %v", err)
+		}
+	}
+	return nil
+}
+
+// handleLocalPodSelectorAddFunc adds a new pod to an existing NetworkPolicy, should be retriable.
+// ignoreErr=true should only be used for initial objects handling, relying on per-object handlers to retry.
+func (oc *Controller) handleLocalPodSelectorAddFunc(np *networkPolicy, ignoreErr bool, objs ...interface{}) error {
+	np.RLock()
+	defer np.RUnlock()
+	if np.deleted {
+		return nil
+	}
+	// get info for new pods that are not listed in np.localPods
+	portNamesToUUIDs, policyPortUUIDs, errPods := oc.getNewLocalPolicyPorts(np, objs...)
+
+	if len(portNamesToUUIDs) > 0 {
+		var err error
+		// add pods to policy port group
+		var ops []ovsdb.Operation
+		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, nil, np.portGroupName, policyPortUUIDs...)
+		if err != nil {
+			return fmt.Errorf("unable to get ops to add new pod to policy port group: %v", err)
+		}
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("unable to transact add new pod to policy port group: %v", err)
+		}
+		// add pods to default deny port group
+		// make sure to only pass newly added pods
+		if err = oc.denyPGAddPorts(np, portNamesToUUIDs); err != nil {
+			// we don't need to delete policy ports from policy port group,
+			// because adding ports to port group is idempotent and can be retried
+			return fmt.Errorf("unable to add new pod to default deny port group: %v", err)
+		}
+		// all operations were successful, update np.localPods
+		for portName, portUUID := range portNamesToUUIDs {
+			np.localPods.Store(portName, portUUID)
+		}
+	}
+
+	if !ignoreErr && len(errPods) > 0 {
+		pod := errPods[0].(*kapi.Pod)
+		return fmt.Errorf("unable to get port info for pod %s/%s", pod.Namespace, pod.Name)
+	}
+
+	return nil
+}
+
+// handleLocalPodSelectorDelFunc handles delete event for local pod, should be retriable
+func (oc *Controller) handleLocalPodSelectorDelFunc(np *networkPolicy, objs ...interface{}) error {
 	np.RLock()
 	defer np.RUnlock()
 	if np.deleted {
 		return nil
 	}
 
-	policyPorts, ingressDenyPorts, egressDenyPorts := oc.processLocalPodSelectorSetPods(policy, np, obj)
+	portNamesToUUIDs, policyPortUUIDs, errPods := oc.getExistingLocalPolicyPorts(np, objs...)
 
-	var errs []error
-
-	ops, err := libovsdbops.AddPortsToPortGroupOps(oc.nbClient, nil, portGroupIngressDenyName, ingressDenyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, obj)
-		errs = append(errs, err)
+	if len(portNamesToUUIDs) > 0 {
+		var err error
+		// del pods from policy port group
+		var ops []ovsdb.Operation
+		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, nil, np.portGroupName, policyPortUUIDs...)
+		if err != nil {
+			return fmt.Errorf("unable to get ops to add new pod to policy port group: %v", err)
+		}
+		_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("unable to transact add new pod to policy port group: %v", err)
+		}
+		// delete pods from default deny port group
+		if err = oc.denyPGDeletePorts(np, portNamesToUUIDs, false); err != nil {
+			// we don't need to add policy ports back to policy port group,
+			// because delete ports from port group is idempotent and can be retried
+			return fmt.Errorf("unable to add new pod to default deny port group: %v", err)
+		}
+		// all operations were successful, update np.localPods
+		for portName := range portNamesToUUIDs {
+			np.localPods.Delete(portName)
+		}
 	}
 
-	ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, portGroupEgressDenyName, egressDenyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, obj)
-		errs = append(errs, err)
+	if len(errPods) > 0 {
+		pod := errPods[0].(*kapi.Pod)
+		return fmt.Errorf("unable to get port info for pod %s/%s", pod.Namespace, pod.Name)
 	}
-
-	ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, np.portGroupName, policyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, obj)
-		errs = append(errs, err)
-	}
-
-	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, obj)
-		errs = append(errs, err)
-	}
-	return kerrorsutil.NewAggregate(errs)
+	return nil
 }
 
-func (oc *Controller) handleLocalPodSelectorDelFunc(policy *knet.NetworkPolicy, np *networkPolicy,
-	portGroupIngressDenyName, portGroupEgressDenyName string, obj interface{}) error {
-	np.RLock()
-	defer np.RUnlock()
-	if np.deleted {
-		return nil
-	}
-
-	policyPorts, ingressDenyPorts, egressDenyPorts := oc.processLocalPodSelectorDelPods(np, obj)
-
-	ops, err := libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, nil, portGroupIngressDenyName, ingressDenyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorSetPods(policy, np, obj)
-		return err
-	}
-
-	ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, portGroupEgressDenyName, egressDenyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorSetPods(policy, np, obj)
-		return err
-	}
-
-	var errs []error
-
-	ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, np.portGroupName, policyPorts...)
-	if err != nil {
-		oc.processLocalPodSelectorSetPods(policy, np, obj)
-		errs = append(errs, err)
-	}
-
-	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
-	if err != nil {
-		oc.processLocalPodSelectorSetPods(policy, np, obj)
-		errs = append(errs, err)
-	}
-
-	return kerrorsutil.NewAggregate(errs)
-}
-
-func (oc *Controller) addLocalPodHandler(
-	policy *knet.NetworkPolicy, np *networkPolicy, portGroupIngressDenyName, portGroupEgressDenyName string,
+func (oc *Controller) addLocalPodHandler(policy *knet.NetworkPolicy, np *networkPolicy,
 	handleInitialItems func([]interface{}) error) error {
 
 	// NetworkPolicy is validated by the apiserver
@@ -1021,10 +1123,7 @@ func (oc *Controller) addLocalPodHandler(
 		sel,
 		handleInitialItems,
 		&NetworkPolicyExtraParameters{
-			policy:                   policy,
-			np:                       np,
-			portGroupIngressDenyName: portGroupIngressDenyName,
-			portGroupEgressDenyName:  portGroupEgressDenyName,
+			np: np,
 		})
 
 	podHandler, err := oc.WatchResource(retryLocalPods)
@@ -1050,8 +1149,7 @@ func hasAnyLabelSelector(peers []knet.NetworkPolicyPeer) bool {
 }
 
 // createNetworkPolicy creates a network policy
-func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.NetworkPolicy, aclLogging *ACLLoggingLevels,
-	portGroupIngressDenyName, portGroupEgressDenyName string) error {
+func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.NetworkPolicy, aclLogging *ACLLoggingLevels) error {
 
 	np.Lock()
 
@@ -1192,25 +1290,24 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 	// Add a handler to update the policy and deny port groups with the pods
 	// this policy applies to.
 	// Handle initial items locally to minimize DB ops.
-	var selectedPods []interface{}
 	handleInitialSelectedPods := func(objs []interface{}) error {
-		var errs []error
-		selectedPods = objs
-		policyPorts, ingressDenyPorts, egressDenyPorts := oc.processLocalPodSelectorSetPods(policy, np, selectedPods...)
-		pg.Ports = append(pg.Ports, policyPorts...)
-		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, portGroupIngressDenyName, ingressDenyPorts...)
-		if err != nil {
-			oc.processLocalPodSelectorDelPods(np, selectedPods...)
-			errs = append(errs, err)
+		// get info for new pods that are not listed in np.localPods
+		portNamesToUUIDs, policyPortUUIDs, _ := oc.getNewLocalPolicyPorts(np, objs...)
+		pg.Ports = append(pg.Ports, policyPortUUIDs...)
+		// add pods to default deny port group
+		// make sure to only pass newly added pods
+		if err = oc.denyPGAddPorts(np, portNamesToUUIDs); err != nil {
+			// we don't need to delete policy ports from policy port group,
+			// because adding ports to port group is idempotent and can be retried
+			return fmt.Errorf("unable to add new pod to default deny port group: %v", err)
 		}
-		ops, err = libovsdbops.AddPortsToPortGroupOps(oc.nbClient, ops, portGroupEgressDenyName, egressDenyPorts...)
-		if err != nil {
-			oc.processLocalPodSelectorDelPods(np, selectedPods...)
-			errs = append(errs, err)
+		// all operations were successful, update np.localPods
+		for portName, portUUID := range portNamesToUUIDs {
+			np.localPods.Store(portName, portUUID)
 		}
-		return kerrorsutil.NewAggregate(errs)
+		return nil
 	}
-	err = oc.addLocalPodHandler(policy, np, portGroupIngressDenyName, portGroupEgressDenyName, handleInitialSelectedPods)
+	err = oc.addLocalPodHandler(policy, np, handleInitialSelectedPods)
 	if err != nil {
 		return fmt.Errorf("failed to handle local pod selector: %v", err)
 	}
@@ -1218,13 +1315,13 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 	np.Lock()
 	defer np.Unlock()
 	if np.deleted {
-		oc.processLocalPodSelectorDelPods(np, selectedPods...)
+		_ = oc.denyPGDeletePorts(np, nil, true)
 		return nil
 	}
 
 	ops, err = libovsdbops.CreateOrUpdatePortGroupsOps(oc.nbClient, ops, pg)
 	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, selectedPods...)
+		_ = oc.denyPGDeletePorts(np, nil, true)
 		return fmt.Errorf("failed to create ops to add port to a port group: %v", err)
 	}
 
@@ -1237,7 +1334,7 @@ func (oc *Controller) createNetworkPolicy(np *networkPolicy, policy *knet.Networ
 
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
 	if err != nil {
-		oc.processLocalPodSelectorDelPods(np, selectedPods...)
+		_ = oc.denyPGDeletePorts(np, nil, true)
 		return fmt.Errorf("failed to run ovsdb txn to add ports to port group: %v", err)
 	}
 	txOkCallBack()
@@ -1268,40 +1365,26 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 	np := NewNetworkPolicy(policy)
 
 	if len(nsInfo.networkPolicies) == 0 {
-		err = oc.createDefaultDenyPGAndACLs(policy.Namespace, policy.Name, nsInfo)
+		err := oc.addPolicyToDefaultPortGroups(np, &nsInfo.aclLogging)
 		if err != nil {
 			nsUnlock()
-			return fmt.Errorf("failed to create default port groups and acls for policy: %s/%s, error: %v",
+			return fmt.Errorf("adding network policy %s/%s failed: %v",
 				policy.Namespace, policy.Name, err)
 		}
 		defer func() {
 			if err != nil {
-				nsInfo, nsUnlock, errDelete := oc.ensureNamespaceLocked(policy.Namespace, false, nil)
+				errDelete := oc.delPolicyFromDefaultPortGroups(np)
 				// rollback failed, best effort cleanup; won't add to retry mechanism since item doesn't exist in cache yet.
 				if errDelete != nil {
 					klog.Warningf("Rollback of default port groups and acls for policy: %s/%s failed, Unable to ensure namespace for network policy: error %v", policy.Namespace, policy.Name, errDelete)
 					return
 				}
-				if len(nsInfo.networkPolicies) == 0 {
-					// try rolling-back since creation of default acls/pgs failed
-					errDelete = oc.deleteDefaultDenyPGAndACLs(policy.Namespace, policy.Name, nsInfo)
-					nsUnlock()
-					if errDelete != nil {
-						// rollback failed, best effort cleanup; won't add to retry mechanism since item doesn't exist in cache yet.
-						klog.Warningf("Rollback of default port groups and acls for policy: %s/%s failed: error %v", policy.Namespace, policy.Name, errDelete)
-					}
-				} else {
-					nsUnlock()
-				}
 			}
 		}()
 	}
 	aclLogging := nsInfo.aclLogging
-	portGroupIngressDenyName := nsInfo.portGroupIngressDenyName
-	portGroupEgressDenyName := nsInfo.portGroupEgressDenyName
 	nsUnlock()
-	if err := oc.createNetworkPolicy(np, policy, &aclLogging,
-		portGroupIngressDenyName, portGroupEgressDenyName); err != nil {
+	if err := oc.createNetworkPolicy(np, policy, &aclLogging); err != nil {
 		return fmt.Errorf("failed to create Network Policy: %s/%s, error: %v",
 			policy.Namespace, policy.Name, err)
 	}
@@ -1312,7 +1395,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 		// rollback network policy
 		if err := oc.deleteNetworkPolicy(policy, np); err != nil {
 			// rollback failed, add to retry to cleanup
-			key := getPolicyNamespacedName(policy)
+			key := getPolicyKey(policy)
 			oc.retryNetworkPolicies.DoWithLock(key, func(key string) {
 				oc.retryNetworkPolicies.initRetryObjWithDelete(policy, key, np, false)
 			})
@@ -1328,7 +1411,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
-				getPolicyNamespacedName(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
+				getPolicyKey(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
 		}
 	}
 	// The allow logging level was updated while we were creating the policy if
@@ -1340,7 +1423,7 @@ func (oc *Controller) addNetworkPolicy(policy *knet.NetworkPolicy) error {
 			klog.Warningf(err.Error())
 		} else {
 			klog.Infof("Policy %s: ACL logging setting updated to deny=%s allow=%s",
-				getPolicyNamespacedName(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
+				getPolicyKey(policy), nsInfo.aclLogging.Deny, nsInfo.aclLogging.Allow)
 		}
 	}
 	nsInfo.networkPolicies[policy.Name] = np
@@ -1378,7 +1461,7 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 			return nil
 		}
 
-		if err := oc.destroyNetworkPolicy(np, false); err != nil {
+		if err := oc.destroyNetworkPolicy(np); err != nil {
 			return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
 		}
 		return nil
@@ -1389,18 +1472,15 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 	// try to use the more official np found in nsInfo
 	// also, if this is called during the process of the policy creation, the current network policy
 	// may not be added to nsInfo.networkPolicies yet.
-	expectedLastPolicyNum := 0
 	foundNp, ok := nsInfo.networkPolicies[policy.Name]
 	if ok {
-		expectedLastPolicyNum = 1
 		np = foundNp
 	}
 	if np == nil {
 		klog.Warningf("Unable to delete network policy: %s/%s since its not found in cache", policy.Namespace, policy.Name)
 		return nil
 	}
-	isLastPolicyInNamespace := len(nsInfo.networkPolicies) == expectedLastPolicyNum
-	if err := oc.destroyNetworkPolicy(np, isLastPolicyInNamespace); err != nil {
+	if err := oc.destroyNetworkPolicy(np); err != nil {
 		return fmt.Errorf("failed to destroy network policy: %s/%s", policy.Namespace, policy.Name)
 	}
 
@@ -1411,58 +1491,19 @@ func (oc *Controller) deleteNetworkPolicy(policy *knet.NetworkPolicy, np *networ
 // destroys a particular network policy
 // if nsInfo is provided, the entire port group will be deleted for ingress/egress directions
 // lastPolicy indicates if no other policies are using the respective portgroup anymore
-func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) error {
+func (oc *Controller) destroyNetworkPolicy(np *networkPolicy) error {
 	np.Lock()
 	defer np.Unlock()
 	np.deleted = true
 	oc.shutdownHandlers(np)
-
-	ports := []*lpInfo{}
-	np.localPods.Range(func(_, value interface{}) bool {
-		portInfo := value.(*lpInfo)
-		ports = append(ports, portInfo)
-		return true
-	})
-
 	var err error
-	ingressPGName := defaultDenyPortGroup(np.namespace, ingressDefaultDenySuffix)
-	egressPGName := defaultDenyPortGroup(np.namespace, egressDefaultDenySuffix)
 
-	ingressDenyPorts, egressDenyPorts := oc.localPodDelDefaultDeny(np, ports...)
-	defer func() {
-		// In case of error, undo localPodDelDefaultDeny() and restore lspIngressDenyCache/lspEgressDenyCache refcnt.
-		// Deletion will be retried.
-		if err != nil {
-			oc.localPodAddDefaultDeny(np.policy, ports...)
-		}
-	}()
+	err = oc.denyPGDeletePorts(np, nil, true)
+	if err != nil {
+		return fmt.Errorf("unable to delete ports from defaultDeny port group: %v", err)
+	}
 
 	ops := []ovsdb.Operation{}
-	// we haven't deleted our np from the namespace yet so there should be 1 policy
-	// if there are no more policies left on the namespace
-	if lastPolicy {
-		ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, ingressPGName)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for delete ingress port group: %s, for policy: %s/%s, error: %v",
-				ingressPGName, np.namespace, np.name, err)
-		}
-		ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, egressPGName)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for delete egress port group: %s, for policy: %s/%s, error: %v",
-				egressPGName, np.namespace, np.name, err)
-		}
-	} else {
-		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, ingressPGName, ingressDenyPorts...)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for ingress port group: %s, for policy: %s/%s, to remove ports: %#v,"+
-				" error: %v", ingressPGName, np.namespace, np.name, ingressDenyPorts, err)
-		}
-		ops, err = libovsdbops.DeletePortsFromPortGroupOps(oc.nbClient, ops, egressPGName, egressDenyPorts...)
-		if err != nil {
-			return fmt.Errorf("failed to make ops for egress port group: %s, for policy: %s/%s, to remove ports: %#v,"+
-				" error: %v", egressPGName, np.namespace, np.name, egressDenyPorts, err)
-		}
-	}
 
 	// Delete the port group
 	ops, err = libovsdbops.DeletePortGroupsOps(oc.nbClient, ops, np.portGroupName)
@@ -1500,6 +1541,12 @@ func (oc *Controller) destroyNetworkPolicy(np *networkPolicy, lastPolicy bool) e
 				np.namespace, np.name, err)
 		}
 	}
+
+	err = oc.delPolicyFromDefaultPortGroups(np)
+	if err != nil {
+		return fmt.Errorf("unable to delete policy from default deny port groups: %v", err)
+	}
+
 	return nil
 }
 
@@ -1553,12 +1600,9 @@ func (oc *Controller) handlePeerServiceDelete(gp *gressPolicy, service *kapi.Ser
 }
 
 type NetworkPolicyExtraParameters struct {
-	policy                   *knet.NetworkPolicy
-	np                       *networkPolicy
-	gp                       *gressPolicy
-	podSelector              labels.Selector
-	portGroupIngressDenyName string
-	portGroupEgressDenyName  string
+	np          *networkPolicy
+	gp          *gressPolicy
+	podSelector labels.Selector
 }
 
 // Watch services that are in the same Namespace as the NP
@@ -1713,6 +1757,11 @@ func (oc *Controller) shutdownHandlers(np *networkPolicy) {
 	}
 }
 
-func getPolicyNamespacedName(policy *knet.NetworkPolicy) string {
+// The following 2 function should return the same key for network policy based on k8s on internal networkPolicy object
+func getPolicyKey(policy *knet.NetworkPolicy) string {
 	return fmt.Sprintf("%v/%v", policy.Namespace, policy.Name)
+}
+
+func (np *networkPolicy) getKey() string {
+	return fmt.Sprintf("%v/%v", np.namespace, np.name)
 }


### PR DESCRIPTION
 No need to save and pass portGroupIngressDenyName,

portGroupEgressDenyName. Some time ago its name was unpredictable, but
now it can be just retrieved with defaultDenyPortGroupName.

Sort ovn.go imports

Move logic to define if policy need egress/ingress isolation from update
counters function to networkPolicy object

Stop counting nsInfo.networkPolicies to decide if defaultDeny port group
should be created/deleted: for shared resources like this counter should
be updated atomically together with db.
An example of race with previous implementation: 2 network policies are
being created, nsInfo.networkPolicies will only be updated at the end.
Both network policies will call createDefaultDenyPGAndACLs, which in
turn creates port group with empty ports list, so one policy can drop
ports added by another policy.
For this purpose syncMap oc.sharedNetpolPortGroups was added.
defaultDenyPortGroups has a map of policies using it, that is only
updated together with successful db operation. Also, new functions
addPolicyToDefaultPortGroups and delPolicyFromDefaultPortGroups were
added to make sure default deny port groups are up to date.
policy_tests were updated to delete defaultDeny port groups ACLs, since
deleteDefaultDenyPGAndACLs always deleted them, but it wasn't called
from destroyNetworkPolicy, now there is only 1 way to delete port group.

lspXgressDenyCache had some problems:
1. it uses cluster-wide lock, while default deny port groups are only
shared within the same namespace
2. counters updates were racy and not idempotent: e.g.
destroyNetworkPolicy decrements counters and deletes ports from port
group, but uses oc.localPodAddDefaultDeny as a rollback in case of
error. Thus pod can be deleted from port group, but its counter
will = 1, because rollback doesn't add successfully deleted port back

What was implemented: defaultDenyPortGroups struct has policy set instead
of oc.lspXgressDenyCache that will only be updated together with db
operation success and is idemponent because it's not a counter anymore.
networkPolicy.localPods is used to delete ports from default deny port
group, therefore it also should only be updated together with
defaultDenyPortGroups counters update. That allows to retry delete,
because we know ports that are listed in networkPolicy.localPods are
also recorded in defaultDenyPortGroups.

localPodAddDefaultDeny and localPodDelDefaultDeny were replaced with
defaultDenyPortGroups methods

processLocalPodSelectorSetPods was renamed to getNewLocalPolicyPorts
and doesn't retry getting lsp info from cache, instead it returns a list
failed pods allowing caller to deal with it. Now adding local pod
failures will be retried (we caught this bug in our CI, where pod
wasn't found in the cache, and was never retried, even though it was
added to the cache later)

Fixes https://issues.redhat.com/browse/OCPBUGS-1008
