### PR TITLE
Fix UpdateService healthport checks

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -266,7 +266,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	var portClaimWatcher *portClaimWatcher
 
 	if config.Gateway.NodeportEnable && config.OvnKubeNode.Mode == types.NodeModeFull {
-		loadBalancerHealthChecker = newLoadBalancerHealthChecker(n.name)
+		loadBalancerHealthChecker = newLoadBalancerHealthChecker(n.name, n.watchFactory)
 		portClaimWatcher, err = newPortClaimWatcher(n.recorder)
 		if err != nil {
 			return err
@@ -424,7 +424,7 @@ func (n *OvnNode) initGatewayDPUHost(kubeNodeIP net.IP) error {
 			return err
 		}
 		gw.nodePortWatcherIptables = newNodePortWatcherIptables()
-		gw.loadBalancerHealthChecker = newLoadBalancerHealthChecker(n.name)
+		gw.loadBalancerHealthChecker = newLoadBalancerHealthChecker(n.name, n.watchFactory)
 		portClaimWatcher, err := newPortClaimWatcher(n.recorder)
 		if err != nil {
 			return err


### PR DESCRIPTION
We were not creating healthchecks for service updates when the etp changed from local to cluster or back. This PR fixes this. It also fixes some endpoint slice code on node side where we seem to assume service:endpointslice is 1:1 ? o_o

No use of adding e2e's here since this only effects cloud load balancer offerings, KIND clusters don't have that luxury, real e2e needs to go into sig-network, will see if I can submit a PR for this there.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>
