### PR TITLE
Add support for Topology Aware Hints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -389,6 +389,7 @@ jobs:
       OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target == 'control-plane' }}"
       OVN_MULTICAST_ENABLE:  "${{ matrix.target == 'control-plane' }}"
       OVN_EMPTY_LB_EVENTS: "${{ matrix.target == 'control-plane' }}"
+      KIND_REMOVE_TAINT: "${{ !(matrix.target == 'shard-conformance' && matrix.ha == 'noHA') }}"
       OVN_HA: "${{ matrix.ha == 'HA' }}"
       OVN_DISABLE_SNAT_MULTIPLE_GWS: "${{ matrix.disable-snat-multiple-gws == 'noSnatGW' }}"
       OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -682,6 +682,12 @@ install_ovn() {
   run_kubectl apply -f k8s.ovn.org_egressips.yaml
   run_kubectl apply -f k8s.ovn.org_egressqoses.yaml
   run_kubectl apply -f ovn-setup.yaml
+  if [[ "${KIND_NUM_WORKER}" -ne 0 ]]; then
+    WORKER_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}" | sort | tail -n "${KIND_NUM_WORKER}")
+    for n in $WORKER_NODES; do
+      kubectl label node "$n" node-role.kubernetes.io/worker="" --overwrite
+    done
+  fi
   MASTER_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}" | sort | head -n "${KIND_NUM_MASTER}")
   # We want OVN HA not Kubernetes HA
   # leverage the kubeadm well-known label node-role.kubernetes.io/control-plane=

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -60,6 +60,12 @@ nodes:
  - role: worker
 {%- endfor %}
 {%- endif %}
-{%- for _ in range(ovn_num_worker | int) %}
+{%- for i in range(ovn_num_worker | int) %}
  - role: worker
+   kubeadmConfigPatches:
+   - |
+     kind: JoinConfiguration
+     nodeRegistration:
+       kubeletExtraArgs:
+         node-labels: "{{ "topology.kubernetes.io/zone=zone-" + i|string }}"
 {%- endfor %}

--- a/go-controller/pkg/ovn/controller/services/load_balancer_test.go
+++ b/go-controller/pkg/ovn/controller/services/load_balancer_test.go
@@ -14,6 +14,7 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -38,7 +39,7 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 	inport1 := int32(81)
 	outport1 := int32(8081)
 	outportstr := intstr.FromInt(int(outport))
-	emptyEPs := util.LbEndpoints{V4IPs: []string{}, V6IPs: []string{}, Port: 0}
+	emptyEPs := util.LbEndpoints{V4IPs: []string{}, V6IPs: []string{}, Port: 0, ZoneHints: make(map[string]util.PerZoneEPs)}
 	tcp := v1.ProtocolTCP
 	udp := v1.ProtocolUDP
 
@@ -185,9 +186,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
 				eps: util.LbEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{},
-					Port:  outport,
+					V4IPs:     []string{"10.128.0.2"},
+					V6IPs:     []string{},
+					Port:      outport,
+					ZoneHints: make(map[string]util.PerZoneEPs),
 				},
 			}},
 			resultsSame: true,
@@ -254,9 +256,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
-						Port:  outport,
+						V4IPs:     []string{"10.128.0.2", "10.128.1.2"},
+						V6IPs:     []string{},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 				{
@@ -264,9 +267,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport1,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
-						Port:  outport1,
+						V4IPs:     []string{"10.128.0.2", "10.128.1.2"},
+						V6IPs:     []string{},
+						Port:      outport1,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -333,9 +337,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
-						Port:  outport,
+						V4IPs:     []string{"10.128.0.2", "10.128.1.2"},
+						V6IPs:     []string{},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 				{
@@ -343,9 +348,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolUDP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.2", "10.128.1.2"},
-						V6IPs: []string{},
-						Port:  outport,
+						V4IPs:     []string{"10.128.0.2", "10.128.1.2"},
+						V6IPs:     []string{},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -374,9 +380,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
 				eps: util.LbEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{"fe00::1:1"},
-					Port:  outport,
+					V4IPs:     []string{"10.128.0.2"},
+					V6IPs:     []string{"fe00::1:1"},
+					Port:      outport,
+					ZoneHints: make(map[string]util.PerZoneEPs),
 				},
 			}},
 		},
@@ -412,9 +419,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
 				eps: util.LbEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{"fe00::1:1"},
-					Port:  outport,
+					V4IPs:     []string{"10.128.0.2"},
+					V6IPs:     []string{"fe00::1:1"},
+					Port:      outport,
+					ZoneHints: make(map[string]util.PerZoneEPs),
 				},
 			}},
 		},
@@ -452,9 +460,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						V6IPs: []string{"fe00::1:1"},
-						Port:  outport,
+						V4IPs:     []string{"10.128.0.2"},
+						V6IPs:     []string{"fe00::1:1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -465,9 +474,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					inport:               inport,
 					externalTrafficLocal: true,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"10.128.0.2"},
-						V6IPs: []string{"fe00::1:1"},
-						Port:  outport,
+						V4IPs:     []string{"10.128.0.2"},
+						V6IPs:     []string{"fe00::1:1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -497,9 +507,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				protocol: v1.ProtocolTCP,
 				inport:   inport,
 				eps: util.LbEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{"fe00::1:1"},
-					Port:  outport,
+					V4IPs:     []string{"10.128.0.2"},
+					V6IPs:     []string{"fe00::1:1"},
+					Port:      outport,
+					ZoneHints: make(map[string]util.PerZoneEPs),
 				},
 			}},
 			resultSharedGatewayNode: []lbConfig{{
@@ -507,9 +518,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 				protocol: v1.ProtocolTCP,
 				inport:   5,
 				eps: util.LbEndpoints{
-					V4IPs: []string{"10.128.0.2"},
-					V6IPs: []string{"fe00::1:1"},
-					Port:  outport,
+					V4IPs:     []string{"10.128.0.2"},
+					V6IPs:     []string{"fe00::1:1"},
+					Port:      outport,
+					ZoneHints: make(map[string]util.PerZoneEPs),
 				},
 				hasNodePort: true,
 			}},
@@ -541,9 +553,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   5,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 					hasNodePort: true,
 				},
@@ -552,9 +565,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -565,9 +579,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   5,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 					hasNodePort: true,
 				},
@@ -576,9 +591,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -611,9 +627,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   5,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
@@ -623,9 +640,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -635,9 +653,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   5,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 					externalTrafficLocal: true,
 					hasNodePort:          true,
@@ -647,9 +666,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -680,9 +700,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -692,9 +713,10 @@ func Test_buildServiceLBConfigs(t *testing.T) {
 					protocol: v1.ProtocolTCP,
 					inport:   inport,
 					eps: util.LbEndpoints{
-						V4IPs: []string{"192.168.0.1"},
-						V6IPs: []string{"2001::1"},
-						Port:  outport,
+						V4IPs:     []string{"192.168.0.1"},
+						V6IPs:     []string{"2001::1"},
+						Port:      outport,
+						ZoneHints: make(map[string]util.PerZoneEPs),
 					},
 				},
 			},
@@ -968,6 +990,9 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			gatewayRouterName: "gr-node-a",
 			switchName:        "switch-node-a",
 			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
+			nodeLabels: map[string]string{
+				v1.LabelTopologyZone: "zone-a",
+			},
 		},
 		{
 			name:              "node-b",
@@ -975,6 +1000,9 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			gatewayRouterName: "gr-node-b",
 			switchName:        "switch-node-b",
 			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+			nodeLabels: map[string]string{
+				v1.LabelTopologyZone: "zone-b",
+			},
 		},
 	}
 
@@ -992,6 +1020,7 @@ func Test_buildPerNodeLBs(t *testing.T) {
 		configs        []lbConfig
 		expectedShared []ovnlb.LB
 		expectedLocal  []ovnlb.LB
+		resultsSame    bool //if true, then just use the SharedGateway results for the LGW test
 	}{
 		{
 			name:    "host-network pod",
@@ -1477,6 +1506,119 @@ func Test_buildPerNodeLBs(t *testing.T) {
 			},
 		},
 		{
+			name:    "clusterIP + nodePort + externalIP service, standard pods, InternalTrafficPolicy=local, ExternalTrafficPolicy=cluster, TopologyAwareRouting=true",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"192.168.0.1"}, // clusterIP config
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					internalTrafficLocal: true,
+					topologyAwareRouting: true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.128.0.1", "10.128.1.1"}, // 1 ep on node-a and 1 ep on node-b
+						Port:  8080,
+						ZoneHints: map[string]util.PerZoneEPs{
+							"zone-a": {
+								V4IPs: sets.NewString("10.128.0.1"),
+								V6IPs: sets.NewString(),
+							},
+							"zone-b": {
+								V4IPs: sets.NewString("10.128.1.1"),
+								V6IPs: sets.NewString(),
+							},
+						},
+					},
+				},
+				{
+					vips:                 []string{"node"},
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					topologyAwareRouting: true,
+					hasNodePort:          true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
+						Port:  8080,
+						ZoneHints: map[string]util.PerZoneEPs{
+							"zone-a": {
+								V4IPs: sets.NewString("10.128.0.1"),
+								V6IPs: sets.NewString(),
+							},
+							"zone-b": {
+								V4IPs: sets.NewString("10.128.1.1"),
+								V6IPs: sets.NewString(),
+							},
+						},
+					},
+				},
+				{
+					vips:                 []string{"1.2.3.4"}, // externalIP config
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					topologyAwareRouting: true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.128.0.1", "10.128.1.1"},
+						Port:  8080,
+						ZoneHints: map[string]util.PerZoneEPs{
+							"zone-a": {
+								V4IPs: sets.NewString("10.128.0.1"),
+								V6IPs: sets.NewString(),
+							},
+							"zone-b": {
+								V4IPs: sets.NewString("10.128.1.1"),
+								V6IPs: sets.NewString(),
+							},
+						},
+					},
+				},
+			},
+			expectedShared: []ovnlb.LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-a"},
+					Routers:     []string{"gr-node-a"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.0.1", 80},
+							Targets: []ovnlb.Addr{{"10.128.0.1", 8080}}, // filters out the ep present only on node-a for ITP, clusterIP
+						},
+						{
+							Source:  ovnlb.Addr{"10.0.0.1", 80},
+							Targets: []ovnlb.Addr{{"10.128.0.1", 8080}}, // ITP is only applicable for clusterIPs but we have topologyAwareRouting enabled so it filters out endpoints on zone-a for nodePorts.
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{{"10.128.0.1", 8080}}, // ITP is only applicable for clusterIPs but we have topologyAwareRouting enabled so it filters out endpoints on zone-a for externalIPs.
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_router+switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-b"},
+					Routers:     []string{"gr-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.0.1", 80},
+							Targets: []ovnlb.Addr{{"10.128.1.1", 8080}}, // filters out the ep present only on node-b for ITP, clusterIP
+						},
+						{
+							Source:  ovnlb.Addr{"10.0.0.2", 80},
+							Targets: []ovnlb.Addr{{"10.128.1.1", 8080}}, // ITP is only applicable for clusterIPs but we have topologyAwareRouting enabled so it filters out endpoints on zone-b for nodePorts.
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{{"10.128.1.1", 8080}}, // ITP is only applicable for clusterIPs but we have topologyAwareRouting enabled so it filters out endpoints on zone-b for externalIPs.
+						},
+					},
+				},
+			},
+			resultsSame: true,
+		},
+		{
 			name:    "clusterIP + externalIP service, host-networked pods, InternalTrafficPolicy=local",
 			service: defaultService,
 			configs: []lbConfig{
@@ -1829,6 +1971,338 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				},
 			},
 		},
+		{
+			// topology aware routing will have no effect here since ETP and ITP are both local
+			name:    "clusterIP + nodeport + externalIP service, host-network pod, ExternalTrafficPolicy=local, InternalTrafficPolicy=local, TopologyAwareRouting=true",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"192.168.0.1"}, // clusterIP config
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					internalTrafficLocal: true,
+					externalTrafficLocal: false, // ETP is applicable only to nodePorts and LBs
+					topologyAwareRouting: true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+						Port:  8080,
+						ZoneHints: map[string]util.PerZoneEPs{
+							"zone-a": {
+								V4IPs: sets.NewString("10.0.0.1"),
+								V6IPs: sets.NewString(),
+							},
+						},
+					},
+				},
+				{
+					vips:                 []string{"node"}, // nodePort config
+					protocol:             v1.ProtocolTCP,
+					inport:               34345,
+					externalTrafficLocal: true,
+					internalTrafficLocal: false, // ITP is applicable only to clusterIPs
+					topologyAwareRouting: true,
+					hasNodePort:          true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+						Port:  8080,
+						ZoneHints: map[string]util.PerZoneEPs{
+							"zone-a": {
+								V4IPs: sets.NewString("10.0.0.1"),
+								V6IPs: sets.NewString(),
+							},
+						},
+					},
+				},
+				{
+					vips:                 []string{"1.2.3.4"}, // externalIP config
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					externalTrafficLocal: true,
+					internalTrafficLocal: false, // ITP is applicable only to clusterIPs
+					topologyAwareRouting: true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.0.0.1"}, // only one ep on node-a
+						Port:  8080,
+						ZoneHints: map[string]util.PerZoneEPs{
+							"zone-a": {
+								V4IPs: sets.NewString("10.0.0.1"),
+								V6IPs: sets.NewString(),
+							},
+						},
+					},
+				},
+			},
+			expectedShared: []ovnlb.LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_router_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.0.1", 80},
+							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // we don't filter clusterIPs at GR for ETP/ITP=local
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
+					Opts:        ovnlb.LBOpts{SkipSNAT: true},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"10.0.0.1", 34345},
+							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.0.1", 80},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}}, // filter out eps only on node-a for clusterIP
+						},
+						{
+							Source:  ovnlb.Addr{"169.254.169.3", 34345}, // add special masqueradeIP VIP for nodePort/LB traffic coming from node via mp0 when ETP=local
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}},   // filter out eps only on node-a for nodePorts
+						},
+						{
+							Source:  ovnlb.Addr{"10.0.0.1", 34345},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}}, // don't filter out eps for externalIPs on switches when ETP=local
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_router_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.0.1", 80},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}}, // we don't filter clusterIPs at GR for ETP/ITP=local
+						},
+						{
+							Source:  ovnlb.Addr{"10.0.0.2", 34345},
+							Targets: []ovnlb.Addr{}, // filter out eps only on node-b for nodePort on GR when ETP=local
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{}, // filter out eps only on node-b for nodePort on GR when ETP=local
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.0.1", 80},
+							Targets: []ovnlb.Addr{}, // filter out eps only on node-b for clusterIP
+						},
+						{
+							Source:  ovnlb.Addr{"169.254.169.3", 34345}, // add special masqueradeIP VIP for nodePort/LB traffic coming from node via mp0 when ETP=local
+							Targets: []ovnlb.Addr{},                     // filter out eps only on node-b for nodePorts
+						},
+						{
+							Source:  ovnlb.Addr{"10.0.0.2", 34345},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}}, // don't filter out eps for externalIPs on switches when ETP=local
+						},
+					},
+				},
+			},
+			resultsSame: true,
+		},
+		{
+			name:    "clusterIP + nodeport + externalIP service, host-network pod, ExternalTrafficPolicy=local, InternalTrafficPolicy=cluster, TopologyAwareRouting=true",
+			service: defaultService,
+			configs: []lbConfig{
+				{
+					vips:                 []string{"192.168.0.1"}, // clusterIP config
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					internalTrafficLocal: true,
+					externalTrafficLocal: false, // ETP is applicable only to nodePorts and LBs
+					topologyAwareRouting: true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
+						Port:  8080,
+						ZoneHints: map[string]util.PerZoneEPs{
+							"zone-a": {
+								V4IPs: sets.NewString("10.0.0.1"),
+								V6IPs: sets.NewString(),
+							},
+							"zone-b": {
+								V4IPs: sets.NewString("10.0.0.2"),
+								V6IPs: sets.NewString(),
+							},
+						},
+					},
+				},
+				{
+					vips:                 []string{"node"}, // nodePort config
+					protocol:             v1.ProtocolTCP,
+					inport:               34345,
+					externalTrafficLocal: true,
+					internalTrafficLocal: false, // ITP is applicable only to clusterIPs
+					topologyAwareRouting: true,
+					hasNodePort:          true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
+						Port:  8080,
+						ZoneHints: map[string]util.PerZoneEPs{
+							"zone-a": {
+								V4IPs: sets.NewString("10.0.0.1"),
+								V6IPs: sets.NewString(),
+							},
+							"zone-b": {
+								V4IPs: sets.NewString("10.0.0.2"),
+								V6IPs: sets.NewString(),
+							},
+						},
+					},
+				},
+				{
+					vips:                 []string{"1.2.3.4"}, // externalIP config
+					protocol:             v1.ProtocolTCP,
+					inport:               80,
+					externalTrafficLocal: true,
+					internalTrafficLocal: false, // ITP is applicable only to clusterIPs
+					topologyAwareRouting: true,
+					eps: util.LbEndpoints{
+						V4IPs: []string{"10.0.0.1", "10.0.0.2"},
+						Port:  8080,
+						ZoneHints: map[string]util.PerZoneEPs{
+							"zone-a": {
+								V4IPs: sets.NewString("10.0.0.1"),
+								V6IPs: sets.NewString(),
+							},
+							"zone-b": {
+								V4IPs: sets.NewString("10.0.0.2"),
+								V6IPs: sets.NewString(),
+							},
+						},
+					},
+				},
+			},
+			expectedShared: []ovnlb.LB{
+				{
+					Name:        "Service_testns/foo_TCP_node_router_node-a_merged",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a", "gr-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.0.1", 80},
+							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // we filter out eps in node zone for clusterIP
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-a"},
+					Opts:        ovnlb.LBOpts{SkipSNAT: true},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"10.0.0.1", 34345},
+							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-a",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-a"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.0.1", 80},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}}, // filter out eps only on zone-a for clusterIP (TAH)
+						},
+						{
+							Source:  ovnlb.Addr{"169.254.169.3", 34345}, // add special masqueradeIP VIP for nodePort/LB traffic coming from node via mp0 when ETP=local
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}},   // filter out eps only on node-a for nodePorts
+						},
+						{
+							Source:  ovnlb.Addr{"10.0.0.1", 34345},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}, {"10.0.0.2", 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}, {"10.0.0.2", 8080}}, // don't filter out eps for externalIPs on switches when ETP=local
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_local_router_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Routers:     []string{"gr-node-b"},
+					Opts:        ovnlb.LBOpts{SkipSNAT: true},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"10.0.0.2", 34345},
+							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{{"169.254.169.2", 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
+						},
+					},
+				},
+				{
+					Name:        "Service_testns/foo_TCP_node_switch_node-b",
+					ExternalIDs: defaultExternalIDs,
+					Switches:    []string{"switch-node-b"},
+					Protocol:    "TCP",
+					Rules: []ovnlb.LBRule{
+						{
+							Source:  ovnlb.Addr{"192.168.0.1", 80},
+							Targets: []ovnlb.Addr{{"10.0.0.2", 8080}}, // filter out eps only on zone-b for clusterIP (TAH)
+						},
+						{
+							Source:  ovnlb.Addr{"169.254.169.3", 34345}, // add special masqueradeIP VIP for nodePort/LB traffic coming from node via mp0 when ETP=local
+							Targets: []ovnlb.Addr{{"10.0.0.2", 8080}},   // filter out eps only on node-b for nodePorts
+						},
+						{
+							Source:  ovnlb.Addr{"10.0.0.2", 34345},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}, {"10.0.0.2", 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
+						},
+						{
+							Source:  ovnlb.Addr{"1.2.3.4", 80},
+							Targets: []ovnlb.Addr{{"10.0.0.1", 8080}, {"10.0.0.2", 8080}}, // don't filter out eps for externalIPs on switches when ETP=local
+						},
+					},
+				},
+			},
+			resultsSame: true,
+		},
 	}
 
 	for i, tt := range tc {
@@ -1844,6 +2318,12 @@ func Test_buildPerNodeLBs(t *testing.T) {
 				globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
 				actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
 				assert.Equal(t, tt.expectedLocal, actual, "local gateway mode not as expected")
+			}
+
+			if tt.resultsSame {
+				globalconfig.Gateway.Mode = globalconfig.GatewayModeLocal
+				actual := buildPerNodeLBs(tt.service, tt.configs, defaultNodes)
+				assert.Equal(t, tt.expectedShared, actual, "local gateway mode not as expected")
 			}
 
 		})

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -34,6 +34,8 @@ type nodeInfo struct {
 	name string
 	// The list of physical IPs the node has, as reported by the gatewayconf annotation
 	nodeIPs []string
+	// The list of labels on the node (service creation cares about the topology label)
+	nodeLabels map[string]string
 	// The pod network subnet(s)
 	podSubnets []net.IPNet
 	// the name of the node's GatewayRouter, or "" of non-existent
@@ -122,10 +124,11 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) *nodeTracker {
 
 // updateNodeInfo updates the node info cache, and syncs all services
 // if it changed.
-func (nt *nodeTracker) updateNodeInfo(nodeName, switchName, routerName string, nodeIPs []string, podSubnets []*net.IPNet) {
+func (nt *nodeTracker) updateNodeInfo(nodeName, switchName, routerName string, nodeIPs []string, podSubnets []*net.IPNet, nodeLabels map[string]string) {
 	ni := nodeInfo{
 		name:              nodeName,
 		nodeIPs:           nodeIPs,
+		nodeLabels:        nodeLabels,
 		podSubnets:        make([]net.IPNet, 0, len(podSubnets)),
 		gatewayRouterName: routerName,
 		switchName:        switchName,
@@ -204,6 +207,7 @@ func (nt *nodeTracker) updateNode(node *v1.Node) {
 		grName,
 		ips,
 		hsn,
+		node.Labels,
 	)
 }
 

--- a/go-controller/pkg/ovn/controller/services/topology.go
+++ b/go-controller/pkg/ovn/controller/services/topology.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* NOTE: This file is loosely based on https://github.com/kubernetes/kubernetes/blob/23a4920d83559ba803629512c8a02630e5fdc0a6/pkg/proxy/topology.go.
+We are picking up the parts we need to implement topology aware hints without having to vendor in the k8s code.
+Technically this should live in package kube, but we are using LB config structs here and thus it made sense to keep
+it in services package */
+
+package services
+
+import (
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/klog/v2"
+)
+
+// topologyAwareRoutingIsEnabledForService is true for the given service if:
+// * The "service.kubernetes.io/topology-aware-hints" annotation on this Service is set to "Auto"
+// * All of the endpoints for this Service have a topology hint
+func topologyAwareRoutingIsEnabledForService(service *v1.Service, endpointSlices []*discovery.EndpointSlice) bool {
+	hintsAnnotation := service.Annotations[v1.AnnotationTopologyAwareHints]
+	if hintsAnnotation != "Auto" && hintsAnnotation != "auto" {
+		if hintsAnnotation != "" && hintsAnnotation != "Disabled" && hintsAnnotation != "disabled" {
+			klog.Warningf("Skipping topology aware endpoint filtering since Service %s/%s has unexpected value in %s:%v", service.Namespace, service.Name, v1.AnnotationTopologyAwareHints, hintsAnnotation)
+		}
+		return false
+	}
+	for _, epSlice := range endpointSlices {
+		for _, endpoint := range epSlice.Endpoints {
+			if endpoint.Hints.Size() == 0 {
+				klog.Warningf("Skipping topology aware endpoint filtering since one or more endpoints is missing a zone hint for service %s/%s", service.Namespace, service.Name)
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// topologyAwareRoutingIsEnabledForLBConfig is true for the given LB config if:
+// * The node's labels include "topology.kubernetes.io/zone"
+// * At least one endpoint for this Service LB config is hinted for this node's zone.
+func topologyAwareRoutingIsEnabledForLBConfig(endpointsInfo util.LbEndpoints, nodeInfo nodeInfo) bool {
+	zone, ok := nodeInfo.nodeLabels[v1.LabelTopologyZone]
+	if !ok || zone == "" {
+		klog.Warningf("Skipping topology aware endpoint filtering since node %s is missing %s label", nodeInfo.name, v1.LabelTopologyZone)
+		return false
+	}
+	if _, ok := endpointsInfo.ZoneHints[zone]; !ok {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
**- What this PR does and why is it needed**
This PR implements the upstream K8s feature: Topology Aware Hints: https://kubernetes.io/docs/concepts/services-networking/topology-aware-hints/ 

**- Special notes for reviewers**
I plan to add an e2e into K8s for inter-interoperability between ITP&ETP&TAH which seems to have no coverage when used together.

**- How to verify it**
The non-HA lane runs the TAH e2e test when using multi-zone environments:
```
2022-09-24T12:16:59.2669822Z [BeforeEach] [sig-network] [Feature:Topology Hints]
2022-09-24T12:16:59.2670197Z   test/e2e/framework/framework.go:187
2022-09-24T12:16:59.2671148Z [1mSTEP[0m: Creating a kubernetes client
2022-09-24T12:16:59.2671491Z Sep 24 12:16:25.806: INFO: >>> kubeConfig: /home/runner/ovn.conf
2022-09-24T12:16:59.2671933Z [1mSTEP[0m: Building a namespace api object, basename topology-hints
2022-09-24T12:16:59.2672400Z [1mSTEP[0m: Waiting for a default service account to be provisioned in namespace
2022-09-24T12:16:59.2672844Z [1mSTEP[0m: Waiting for kube-root-ca.crt to be provisioned in namespace
2022-09-24T12:16:59.2673359Z [BeforeEach] [sig-network] [Feature:Topology Hints]
2022-09-24T12:16:59.2673702Z   test/e2e/network/topology_hints.go:50
2022-09-24T12:16:59.2673971Z [It] should distribute endpoints evenly
2022-09-24T12:16:59.2674251Z   test/e2e/network/topology_hints.go:55
2022-09-24T12:16:59.2675186Z Sep 24 12:16:30.896: INFO: DaemonSet pods can't tolerate node ovn-control-plane with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>} {Key:node-role.kubernetes.io/control-plane Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
2022-09-24T12:16:59.2676023Z Sep 24 12:16:30.926: INFO: Number of nodes with available pods controlled by daemonset topology-serve-hostname: 1
2022-09-24T12:16:59.2676525Z Sep 24 12:16:30.926: INFO: Node ovn-worker is running 0 daemon pod, expected 1
2022-09-24T12:16:59.2677466Z Sep 24 12:16:36.033: INFO: DaemonSet pods can't tolerate node ovn-control-plane with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>} {Key:node-role.kubernetes.io/control-plane Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
2022-09-24T12:16:59.2678206Z Sep 24 12:16:36.056: INFO: Number of nodes with available pods controlled by daemonset topology-serve-hostname: 2
2022-09-24T12:16:59.2679184Z Sep 24 12:16:36.056: INFO: Number of running nodes: 2, number of available pods: 2 in daemonset topology-serve-hostname
2022-09-24T12:16:59.2680092Z Sep 24 12:16:36.081: INFO: DaemonSet pods can't tolerate node ovn-control-plane with taints [{Key:node-role.kubernetes.io/master Value: Effect:NoSchedule TimeAdded:<nil>} {Key:node-role.kubernetes.io/control-plane Value: Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
2022-09-24T12:16:59.2680779Z Sep 24 12:16:36.161: INFO: Waiting for 2 endpoints to be tracked in EndpointSlices
2022-09-24T12:16:59.2681156Z [1mSTEP[0m: having hints set for each endpoint
2022-09-24T12:16:59.2681557Z [1mSTEP[0m: keeping requests in the same zone
2022-09-24T12:16:59.2681947Z [1mSTEP[0m: creating a client pod for probing the service from zone-1
2022-09-24T12:16:59.2682483Z Sep 24 12:16:41.182: INFO: The status of Pod curl-from-zone-1 is Pending, waiting for it to be Running (with Ready = true)
2022-09-24T12:16:59.2683269Z Sep 24 12:16:43.185: INFO: The status of Pod curl-from-zone-1 is Pending, waiting for it to be Running (with Ready = true)
2022-09-24T12:16:59.2683769Z Sep 24 12:16:45.191: INFO: The status of Pod curl-from-zone-1 is Running (Ready = true)
2022-09-24T12:16:59.2684305Z Sep 24 12:16:45.201: INFO: Ensuring that requests from curl-from-zone-1 pod on ovn-worker2 node stay in zone-1 zone
2022-09-24T12:16:59.2684675Z Sep 24 12:16:50.229: INFO: Pod client logs: Sat Sep 24 12:16:43 UTC 2022
2022-09-24T12:16:59.2685027Z Date: Sat Sep 24 12:16:44 UTC 2022 Try: 1
2022-09-24T12:16:59.2685340Z topology-serve-hostname-xcc4c
2022-09-24T12:16:59.2685597Z Date: Sat Sep 24 12:16:46 UTC 2022 Try: 2
2022-09-24T12:16:59.2685880Z topology-serve-hostname-xcc4c
2022-09-24T12:16:59.2686132Z Date: Sat Sep 24 12:16:47 UTC 2022 Try: 3
2022-09-24T12:16:59.2686507Z topology-serve-hostname-xcc4c
2022-09-24T12:16:59.2686750Z Date: Sat Sep 24 12:16:48 UTC 2022 Try: 4
2022-09-24T12:16:59.2687039Z topology-serve-hostname-xcc4c
2022-09-24T12:16:59.2687285Z Date: Sat Sep 24 12:16:49 UTC 2022 Try: 5
2022-09-24T12:16:59.2687560Z topology-serve-hostname-xcc4c
2022-09-24T12:16:59.2687870Z 
2022-09-24T12:16:59.2688118Z [1mSTEP[0m: creating a client pod for probing the service from zone-0
2022-09-24T12:16:59.2688656Z Sep 24 12:16:50.245: INFO: The status of Pod curl-from-zone-0 is Pending, waiting for it to be Running (with Ready = true)
2022-09-24T12:16:59.2689235Z Sep 24 12:16:52.302: INFO: The status of Pod curl-from-zone-0 is Pending, waiting for it to be Running (with Ready = true)
2022-09-24T12:16:59.2689713Z Sep 24 12:16:54.247: INFO: The status of Pod curl-from-zone-0 is Running (Ready = true)
2022-09-24T12:16:59.2690250Z Sep 24 12:16:54.249: INFO: Ensuring that requests from curl-from-zone-0 pod on ovn-worker node stay in zone-0 zone
2022-09-24T12:16:59.2690638Z Sep 24 12:16:59.255: INFO: Pod client logs: Sat Sep 24 12:16:52 UTC 2022
2022-09-24T12:16:59.2690910Z Date: Sat Sep 24 12:16:53 UTC 2022 Try: 1
2022-09-24T12:16:59.2691209Z topology-serve-hostname-zfgqq
2022-09-24T12:16:59.2691459Z Date: Sat Sep 24 12:16:55 UTC 2022 Try: 2
2022-09-24T12:16:59.2691740Z topology-serve-hostname-zfgqq
2022-09-24T12:16:59.2691981Z Date: Sat Sep 24 12:16:56 UTC 2022 Try: 3
2022-09-24T12:16:59.2692275Z topology-serve-hostname-zfgqq
2022-09-24T12:16:59.2692528Z Date: Sat Sep 24 12:16:57 UTC 2022 Try: 4
2022-09-24T12:16:59.2692799Z topology-serve-hostname-zfgqq
2022-09-24T12:16:59.2693034Z Date: Sat Sep 24 12:16:58 UTC 2022 Try: 5
2022-09-24T12:16:59.2693311Z topology-serve-hostname-zfgqq
2022-09-24T12:16:59.2693876Z 
2022-09-24T12:16:59.2694104Z [AfterEach] [sig-network] [Feature:Topology Hints]
2022-09-24T12:16:59.2714990Z   test/e2e/framework/framework.go:188
2022-09-24T12:16:59.2715523Z Sep 24 12:16:59.255: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
2022-09-24T12:16:59.2716229Z [1mSTEP[0m: Destroying namespace "topology-hints-5855" for this suite.
2022-09-24T12:16:59.2716434Z 
2022-09-24T12:16:59.2716441Z 
2022-09-24T12:16:59.2716659Z [32m• [SLOW TEST:33.455 seconds][0m
2022-09-24T12:16:59.2716965Z [sig-network] [Feature:Topology Hints]
2022-09-24T12:16:59.2717322Z [90mtest/e2e/network/common/framework.go:23[0m
2022-09-24T12:16:59.2717609Z   should distribute endpoints evenly
2022-09-24T12:16:59.2717981Z   [90mtest/e2e/network/topology_hints.go:55[0m
2022-09-24T12:16:59.2718299Z [90m------------------------------[0m
2022-09-24T12:16:59.2718830Z {"msg":"PASSED [sig-network] [Feature:Topology Hints] should distribute endpoints evenly",
```
Sufficient Unit tests have been added to test the LB filtering which is the main logic for this feature.

Directly tested on a KIND cluster as well.

**- Description for the changelog**
`Support Topology Aware Hints in OVNK`