### PR TITLE
Add logging verbosity to configuring OVN logs

### DIFF
--- a/go-controller/pkg/libovsdbops/transact.go
+++ b/go-controller/pkg/libovsdbops/transact.go
@@ -38,7 +38,7 @@ func TransactAndCheck(c client.Client, ops []ovsdb.Operation) ([]ovsdb.Operation
 		return []ovsdb.OperationResult{{}}, nil
 	}
 
-	klog.Infof("Configuring OVN: %+v", ops)
+	klog.V(5).Infof("Configuring OVN: %+v", ops)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), types.OVSDBTimeout)
 	defer cancel()


### PR DESCRIPTION
When updating a large number of address_set, logs get flooded with "Configuring OVN" which cannot be reduced.
Also klog shows up in the profiling data as a source of CPU consumption of ovnkube-master.

We make it configurable and assign it a verbosity of 4 which is default on OpenShift.

Signed-off-by: François Rigault <frigo@amadeus.com>