### PR TITLE
pods: deleteLogicalPort should not fail when ls is gone

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	ovstypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
@@ -1159,7 +1160,6 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				pod, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(podTest.namespace).Get(context.TODO(), podTest.podName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				// Deleting port that no longer exists should be okay!
 				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port that no longer exists should be okay")
 
 				err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, *metav1.NewDeleteOptions(0))
@@ -1167,6 +1167,12 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 
 				// check the retry cache has no entry
 				checkRetryObjectEventually(key, false, fakeOvn.controller.retryPods)
+
+				// Remove Logical Switch created on behalf of node and make sure deleteLogicalPort will not fail
+				err = libovsdbops.DeleteLogicalSwitch(fakeOvn.controller.nbClient, pod.Spec.NodeName)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port from switch that no longer exists should be okay")
+
 				return nil
 			}
 


### PR DESCRIPTION
While testing the  removal of a node that has completed pods stuck on finalizers, I ran
into this codepath. It fails removal of logical port (which had already been removed) because
it logical switch is already removed as well.

This PR fixes that, in addition to including a test that exercises the logic mentioned here. 

Closes https://github.com/ovn-org/ovn-kubernetes/issues/3168
Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
