### PR TITLE
Fix Network Policy Service Hairpin Traffic

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -88,7 +88,6 @@ const (
 )
 
 // types for dynamic handlers created when adding a network policy
-type peerService struct{}
 type peerNamespaceAndPodSelector struct{}
 type peerPodForNamespaceAndPodSelector struct{} // created during the add function of peerNamespaceAndPodSelectorType
 type peerNamespaceSelector struct{}
@@ -122,7 +121,6 @@ var (
 	EgressNodeType                        reflect.Type = reflect.TypeOf(&egressNode{})
 	CloudPrivateIPConfigType              reflect.Type = reflect.TypeOf(&ocpcloudnetworkapi.CloudPrivateIPConfig{})
 	EgressQoSType                         reflect.Type = reflect.TypeOf(&egressqosapi.EgressQoS{})
-	PeerServiceType                       reflect.Type = reflect.TypeOf(&peerService{})
 	PeerNamespaceAndPodSelectorType       reflect.Type = reflect.TypeOf(&peerNamespaceAndPodSelector{})
 	PeerPodForNamespaceAndPodSelectorType reflect.Type = reflect.TypeOf(&peerPodForNamespaceAndPodSelector{})
 	PeerNamespaceSelectorType             reflect.Type = reflect.TypeOf(&peerNamespaceSelector{})
@@ -478,7 +476,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 			return wf.AddNodeHandler(funcs, processExisting, priority)
 		}, nil
 
-	case PeerServiceType, ServiceForGatewayType, ServiceForFakeNodePortWatcherType:
+	case ServiceForGatewayType, ServiceForFakeNodePortWatcherType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
 			return wf.AddFilteredServiceHandler(namespace, funcs, processExisting)

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -614,9 +614,10 @@ func nodeSwitchRouterLoadBalancerName(nodeName string, serviceNamespace string, 
 
 func servicesOptions() map[string]string {
 	return map[string]string{
-		"event":     "false",
-		"reject":    "true",
-		"skip_snat": "false",
+		"event":           "false",
+		"reject":          "true",
+		"skip_snat":       "false",
+		"hairpin_snat_ip": "169.254.169.5 fd69::5",
 	}
 }
 

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -8,18 +8,15 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/gateway"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
-	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -137,34 +134,6 @@ func (gp *gressPolicy) ensurePeerAddressSet(factory addressset.AddressSetFactory
 		gp.peerV6AddressSets.Store("$"+ipv6HashedAS, true)
 	}
 	return nil
-}
-
-// must be called with network policy read lock
-func (gp *gressPolicy) addPeerSvcVip(nbClient client.Client, service *v1.Service) error {
-	if gp.peerAddressSet == nil {
-		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
-			service.ObjectMeta.Name, gp.policyName)
-	}
-
-	klog.V(5).Infof("Service %s is applied to same namespace as network Policy, finding Service VIPs", service.Name)
-	ips := getSvcVips(nbClient, service)
-
-	klog.V(5).Infof("Adding SVC clusterIP to gressPolicy's Address Set: %v", ips)
-	return gp.peerAddressSet.AddIPs(ips)
-}
-
-// must be called with network policy read lock
-func (gp *gressPolicy) deletePeerSvcVip(nbClient client.Client, service *v1.Service) error {
-	if gp.peerAddressSet == nil {
-		return fmt.Errorf("peer AddressSet is nil, cannot add peer Service: %s for gressPolicy: %s",
-			service.ObjectMeta.Name, gp.policyName)
-	}
-
-	klog.V(5).Infof("Service %s is applied to same namespace as network Policy, finding cluster IPs", service.Name)
-	ips := getSvcVips(nbClient, service)
-
-	klog.Infof("Deleting service %s, possible VIPs: %v from gressPolicy's %s Address Set", service.Name, ips, gp.policyName)
-	return gp.peerAddressSet.DeleteIPs(ips)
 }
 
 // addPeerPods will get all currently assigned ips for given pods, and add them to the address set.
@@ -468,73 +437,4 @@ func (gp *gressPolicy) destroy() error {
 		gp.peerAddressSet = nil
 	}
 	return nil
-}
-
-// SVC can be of types 1. clusterIP, 2. NodePort, 3. LoadBalancer,
-// or 4.ExternalIP
-// TODO adjust for upstream patch when it lands:
-// https://bugzilla.redhat.com/show_bug.cgi?id=1908540
-func getSvcVips(nbClient client.Client, service *v1.Service) []net.IP {
-	ips := make([]net.IP, 0)
-
-	if util.ServiceTypeHasNodePort(service) {
-		gatewayRouters, err := gateway.GetOvnGateways(nbClient)
-		if err != nil {
-			klog.Errorf("Cannot get gateways: %s", err)
-		}
-		for _, gatewayRouter := range gatewayRouters {
-			// VIPs would be the physical IPS of the GRs(IPs of the node) in this case
-			physicalIPs, err := gateway.GetGatewayPhysicalIPs(nbClient, gatewayRouter)
-			if err != nil {
-				klog.Errorf("Unable to get gateway router %s physical ip, error: %v", gatewayRouter, err)
-				continue
-			}
-
-			for _, physicalIP := range physicalIPs {
-				ip := net.ParseIP(physicalIP)
-				if ip == nil {
-					klog.Errorf("Failed to parse physical IP %q", physicalIP)
-					continue
-				}
-				ips = append(ips, ip)
-			}
-		}
-	}
-	if util.ServiceTypeHasClusterIP(service) {
-		ipStrs := util.GetClusterIPs(service)
-		for _, ipStr := range ipStrs {
-			ip := net.ParseIP(ipStr)
-			if ip == nil {
-				klog.Errorf("Failed to parse cluster IP %q", ipStr)
-				continue
-			}
-			ips = append(ips, ip)
-		}
-
-		for _, ing := range service.Status.LoadBalancer.Ingress {
-			if ing.IP != "" {
-				klog.V(5).Infof("Adding ingress IPs: %s from Service: %s to VIP set", ing.IP, service.Name)
-				ips = append(ips, utilnet.ParseIPSloppy(ing.IP))
-			}
-		}
-
-		if len(service.Spec.ExternalIPs) > 0 {
-			for _, extIP := range service.Spec.ExternalIPs {
-				ip := utilnet.ParseIPSloppy(extIP)
-				if ip == nil {
-					klog.Errorf("Failed to parse external IP %q", extIP)
-					continue
-				}
-				klog.V(5).Infof("Adding external IP: %s, from Service: %s to VIP set",
-					ip, service.Name)
-				ips = append(ips, ip)
-			}
-		}
-	}
-	if len(ips) == 0 {
-		klog.V(5).Infof("Service has no VIPs")
-		return nil
-	}
-
-	return ips
 }

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -229,11 +229,17 @@ func (gp *gressPolicy) constructMatchString(v4AddressSets, v6AddressSets []strin
 	if len(v4AddressSets) > 0 {
 		v4AddressSetStr := strings.Join(v4AddressSets, ", ")
 		v4MatchStr = fmt.Sprintf("%s.%s == {%s}", "ip4", direction, v4AddressSetStr)
+		if gp.policyType == knet.PolicyTypeIngress {
+			v4MatchStr = fmt.Sprintf("(%s || (%s.src == %s && %s.dst == {%s}))", v4MatchStr, "ip4", types.V4OVNServiceHairpinMasqueradeIP, "ip4", v4AddressSetStr)
+		}
 		matchStr = v4MatchStr
 	}
 	if len(v6AddressSets) > 0 {
 		v6AddressSetStr := strings.Join(v6AddressSets, ", ")
 		v6MatchStr = fmt.Sprintf("%s.%s == {%s}", "ip6", direction, v6AddressSetStr)
+		if gp.policyType == knet.PolicyTypeIngress {
+			v6MatchStr = fmt.Sprintf("(%s || (%s.src == %s && %s.dst == {%s}))", v6MatchStr, "ip6", types.V6OVNServiceHairpinMasqueradeIP, "ip6", v6AddressSetStr)
+		}
 		matchStr = v6MatchStr
 	}
 	if len(v4AddressSets) > 0 && len(v6AddressSets) > 0 {

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	"k8s.io/klog/v2"
@@ -252,9 +253,10 @@ func buildLB(lb *LB) *nbdb.LoadBalancer {
 	}
 
 	options := map[string]string{
-		"reject":    reject,
-		"event":     event,
-		"skip_snat": skipSNAT,
+		"reject":          reject,
+		"event":           event,
+		"skip_snat":       skipSNAT,
+		"hairpin_snat_ip": fmt.Sprintf("%s %s", types.V4OVNServiceHairpinMasqueradeIP, types.V6OVNServiceHairpinMasqueradeIP),
 	}
 
 	// Session affinity

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -81,16 +81,18 @@ const (
 	V4NodeLocalNATSubnetNextHop    = "169.254.0.1"
 	V4NodeLocalDistributedGWPortIP = "169.254.0.2"
 
-	V4MasqueradeSubnet         = "169.254.169.0/29"
-	V6MasqueradeSubnet         = "fd69::/125"
-	V4HostMasqueradeIP         = "169.254.169.2"
-	V6HostMasqueradeIP         = "fd69::2"
-	V4OVNMasqueradeIP          = "169.254.169.1"
-	V6OVNMasqueradeIP          = "fd69::1"
-	V4HostETPLocalMasqueradeIP = "169.254.169.3"
-	V6HostETPLocalMasqueradeIP = "fd69::3"
-	V4DummyNextHopMasqueradeIP = "169.254.169.4"
-	V6DummyNextHopMasqueradeIP = "fd69::4"
+	V4MasqueradeSubnet              = "169.254.169.0/29"
+	V6MasqueradeSubnet              = "fd69::/125"
+	V4HostMasqueradeIP              = "169.254.169.2"
+	V6HostMasqueradeIP              = "fd69::2"
+	V4OVNMasqueradeIP               = "169.254.169.1"
+	V6OVNMasqueradeIP               = "fd69::1"
+	V4HostETPLocalMasqueradeIP      = "169.254.169.3"
+	V6HostETPLocalMasqueradeIP      = "fd69::3"
+	V4DummyNextHopMasqueradeIP      = "169.254.169.4"
+	V6DummyNextHopMasqueradeIP      = "fd69::4"
+	V4OVNServiceHairpinMasqueradeIP = "169.254.169.5"
+	V6OVNServiceHairpinMasqueradeIP = "fd69::5"
 
 	// OpenFlow and Networking constants
 	RouteAdvertisementICMPType    = 134

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -1469,7 +1469,7 @@ spec:
 		ginkgo.By("3. Create two pods, and matching service, matching both egress firewall and egress IP")
 		createGenericPodWithLabel(f, pod1Name, pod1Node.name, f.Namespace.Name, command, podEgressLabel)
 		createGenericPodWithLabel(f, pod2Name, pod2Node.name, f.Namespace.Name, command, podEgressLabel)
-		serviceIP, err := createServiceForPodsWithLabel(f, f.Namespace.Name, servicePort, podHTTPPort, "ClusterIP", podEgressLabel)
+		serviceIP, err := createServiceForPodsWithLabel(f, f.Namespace.Name, servicePort, podHTTPPort, 0, "ClusterIP", podEgressLabel)
 		framework.ExpectNoError(err, "Step 3. Create two pods, and matching service, matching both egress firewall and egress IP, failed creating service, err: %v", err)
 
 		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Currently NP's with service hairpin traffic is broken***. This PR revives the work done in https://github.com/ovn-org/ovn-kubernetes/pull/2332. We add a new masqueradeIP that will be passed as the explicit hairpin_snat_ip into OVN LBs. Based on that masqeuradeIP we update all ingressACLs to be `ip.src == srcAS || ip.src == masqueradeIP && ip.dst == srcAS`. See commit4 for more details. By doing this we can remove the dependency for network policies to watch for services and we can get rid of `peerServiceType`.

*** When I say broken, I mean more broken than it was, since we allow/deny in a random manner in OVNK for hairpin traffic. Example: Let's consider nsA with podA and podB and podC. We have a svc backed by all these pods.
case1: 1) We have a default-deny on nsA, 2) we create an allow-from-namespaceA -> hairpin traffic from podA towards svc backed by podA won't be allowed while podA towards svc backed by podB or podC will be allowed. Expected: Allow traffic from podA as well.
case2: 1) We have a default-deny on nsA, 2) we create an allow-from-podC policy -> hairpin traffic from podA towards svc backed by podA is suddenly allowed since we add the svcIP to the allowed list in the address-set for podC selector. Expected: Only allow traffic from podC.

Besides that, we know that different CNI plugins implement this differently: https://github.com/kubernetes/kubernetes/issues/95879#issuecomment-717914687 and there is no "right or wrong way" of doing this.

**- Special notes for reviewers**
Hairpin traffic will no longer have SVC VIP in its reply packets, instead it will the new hairpin_snat_masquerade_ip.
```
   10.244.2.3.58434 > 10.96.1.35.80: Flags [S], cksum 0x18a8 (incorrect -> 0xd5d3), seq 1069836489, win 65280, options [mss 1360,sackOK,TS val 3992903670 ecr 0,nop,wscale 7
], length 0                                                                                                                                                                  
11:37:22.548438 0a:58:0a:f4:02:01 > 0a:58:0a:f4:02:03, ethertype IPv4 (0x0800), length 74: (tos 0x0, ttl 64, id 44654, offset 0, flags [DF], proto TCP (6), length 60)       
    169.254.169.5.58434 > 10.244.2.3.8080: Flags [S], cksum 0x6f12 (correct), seq 1069836489, win 65280, options [mss 1360,sackOK,TS val 3992903670 ecr 0,nop,wscale 7], leng
th 0                                                                                                                                                                         
11:37:22.548473 0a:58:0a:f4:02:03 > 0a:58:0a:f4:02:01, ethertype IPv4 (0x0800), length 74: (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 60)           
    10.244.2.3.8080 > 169.254.169.5.58434: Flags [S.], cksum 0x6029 (incorrect -> 0xd33a), seq 498848086, ack 1069836490, win 64704, options [mss 1360,sackOK,TS val 42672252
43 ecr 3992903670,nop,wscale 7], length 0                                                                                                                                    
11:37:22.548845 0a:58:0a:f4:02:01 > 0a:58:0a:f4:02:03, ethertype IPv4 (0x0800), length 74: (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 60)           
    10.96.1.35.80 > 10.244.2.3.58434: Flags [S.], cksum 0x39fc (correct), seq 498848086, ack 1069836490, win 64704, options [mss 1360,sackOK,TS val 4267225243 ecr 3992903670
,nop,wscale 7], length 0
11:37:22.548876 0a:58:0a:f4:02:03 > 0a:58:0a:f4:02:01, ethertype IPv4 (0x0800), length 66: (tos 0x0, ttl 64, id 44655, offset 0, flags [DF], proto TCP (6), length 52)
    10.244.2.3.58434 > 10.96.1.35.80: Flags [.], cksum 0x18a0 (incorrect -> 0x6325), ack 1, win 510, options [nop,nop,TS val 3992903672 ecr 4267225243], length 0
```


**- How to verify it**
Tested on KIND, ACL matches have been updated in unit tests. Network Policy tests for service hairpin do exist, See https://github.com/kubernetes/kubernetes/blob/1294f557b90b5221e19d4fe3bffb06c09cd8ea81/test/e2e/network/netpol/network_policy.go#L42. https://github.com/kubernetes/kubernetes/blob/master/test/e2e/network/netpol/network_legacy.go seems to have some client-server interactions. If any new netpol e2e's need to be added lmk and I can add them.

e2e for service traffic hairpin as done in https://github.com/ovn-org/ovn-kubernetes/pull/2332/commits/7495df57a1e03d8cf26cf69f5331f9dcb687211f has been refactored and added into commit3.


**- Description for the changelog**
`Support network policies with service hairpin traffic correctly`