### PR TITLE
[WIP] specify detailed host paths for ovnkube-node spec

### DIFF
--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -56,8 +56,33 @@ spec:
         volumeMounts:
         # Common mounts
         # for the iptables wrapper
-        - mountPath: /host
-          name: host-slash
+        # ubuntu iptables symlink
+        - name: host-etc-alts
+          mountPath: /host/etc/alternatives
+          readOnly: true
+        # centos iptables/nftables symlink & binary
+        - name: host-sbin
+          mountPath: /host/sbin
+          readOnly: true
+        # ubuntu iptables binary
+        - name: host-usr-sbin
+          mountPath: /host/usr/sbin
+          readOnly: true
+        # iptables modules
+        - mountPath: /host/usr/lib
+          name: host-usr-lib
+          readOnly: true
+        # arm lib
+        - name: host-lib
+          mountPath: /host/lib
+          readOnly: true
+        # x86_64 lib
+        - name: host-lib64
+          mountPath: /host/lib64
+          readOnly: true
+        # run
+        - name: host-run
+          mountPath: /host/run
           readOnly: true
         - mountPath: /var/run/dbus/
           name: host-var-run-dbus
@@ -346,12 +371,37 @@ spec:
       - name: host-etc-cni-netd
         hostPath:
           path: /etc/cni/net.d
-      - name: host-slash
-        hostPath:
-          path: /
       - name: host-netns
         hostPath:
           path: /var/run/netns
+      # ubuntu iptables symlink
+      - name: host-etc-alts
+        hostPath:
+          path: /etc/alternatives
+      # centos iptables/nftables symlink & binary
+      - name: host-sbin
+        hostPath:
+          path: /sbin
+      # ubuntu iptables binary
+      - name: host-usr-sbin
+        hostPath:
+          path: /usr/sbin
+      # iptables modules
+      - hostPath:
+          path: /usr/lib
+        name: host-usr-lib
+      # amd64 libc
+      - name: host-lib64
+        hostPath:
+          path: /lib64
+      # arm libc
+      - name: host-lib
+        hostPath:
+          path: /lib
+      # /run
+      - name: host-run
+        hostPath:
+          path: /run
       {%- if ovnkube_app_name=="ovnkube-node" %}
       # non DPU related volumes
       - name: host-var-log-ovs


### PR DESCRIPTION
mounting "/" from host to container has security concerns, this commit specifies required folders only from host to mount into ovnkube-node container.

- /etc/alternatives: ubuntu iptables symlink
- /lib: arm libs
- /lib64: x86_64 libs
- /sbin: centos iptables symlink and binaries
- /usr/sbin: ubuntu iptables binary

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->