### PR TITLE
Fixes incorrect GR hairpin flows

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -954,6 +954,11 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 				continue
 			}
 
+			// not needed for special masquerade IP
+			if ip.Equal(net.ParseIP(types.V4HostMasqueradeIP)) {
+				continue
+			}
+
 			dftFlows = append(dftFlows,
 				fmt.Sprintf("cookie=%s, priority=500, in_port=%s, ip, ip_dst=%s, ip_src=%s,"+
 					"actions=ct(commit,zone=%d,table=4)",
@@ -1002,6 +1007,11 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 			}
 			// not needed for the physical IP
 			if ip.Equal(physicalIP.IP) {
+				continue
+			}
+
+			// not needed for special masquerade IP
+			if ip.Equal(net.ParseIP(types.V6HostMasqueradeIP)) {
 				continue
 			}
 


### PR DESCRIPTION
Now that the special masquerade IPs are assigned to the interface, they default flows that end up DNAT'ing return traffic from the GR->host from masquerade ip -> host ip were being overridden with secondary ip flows for extra ips. This fixes it by skipping special ips when evaluting the extra ips on a node.

Signed-off-by: Tim Rozet <trozet@redhat.com>

