### PR TITLE
egress IP: fix log when gRPC connection fails

### DIFF
--- a/go-controller/pkg/ovn/healthcheck/egressip_healthcheck.go
+++ b/go-controller/pkg/ovn/healthcheck/egressip_healthcheck.go
@@ -159,9 +159,9 @@ func (ehc *egressIPHealthClient) Connect(dialCtx context.Context, mgmtIPs []net.
 		if err == nil && conn != nil {
 			break
 		}
+		klog.Warningf("Could not connect to %s (%s): %v", ehc.nodeName, nodeAddr, err)
 	}
 	if conn == nil {
-		klog.Warningf("Could not connect to %s (%s): %v", ehc.nodeName, nodeAddr, err)
 		return false
 	}
 


### PR DESCRIPTION
Connecting logic iterates through all the management addresses that egress IP can use to reach its egress nodes. The log, however, was only providing the last one it tried.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-2004
Signed-off-by: Flavio Fernandes <flaviof@redhat.com>
