### PR TITLE
Silence error logs for IPv6

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -705,7 +705,8 @@ func (n *OvnNode) checkAndDeleteStaleConntrackEntriesForNamespace(newNs *kapi.Na
 	for _, gwIP := range gatewayIPs {
 		go func(gwIP string) {
 			defer wg.Done()
-			if len(gwIP) > 0 {
+			if len(gwIP) > 0 && !utilnet.IsIPv6String(gwIP) {
+				// TODO: Add support for IPv6 external gateways
 				if hwAddr, err := util.GetMACAddressFromARP(net.ParseIP(gwIP)); err != nil {
 					klog.Errorf("Failed to lookup hardware address for gatewayIP %s: %v", gwIP, err)
 				} else if len(hwAddr) > 0 {


### PR DESCRIPTION
GetMACAddressFromArp does not support IPv6 addresses as IPv6 does not have ARP.
Silenced the logs by checking if ip that is passed in is v6 and added TODO to add support 
for IPv6 external gateways.
Also adds a warning if an attempt to find the mac address is done with an IPv6 gatewayIP

Signed-off-by: Ben Pickard <bpickard@redhat.com>
