### PR TITLE
Prioritize the order of adding events across handlers for shared resources

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -78,6 +78,9 @@ const (
 
 	// namespace, node, and pod handlers
 	defaultNumEventQueues uint32 = 15
+
+	// default priorities for various handlers
+	defaultHandlerPriority uint32 = 0
 )
 
 // types for dynamic handlers created when adding a network policy
@@ -394,7 +397,31 @@ func getObjectMeta(objType reflect.Type, obj interface{}) (*metav1.ObjectMeta, e
 
 type AddHandlerFuncType func(namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error)
 
+func (wf *WatchFactory) GetHandlerPriority(objType reflect.Type) (priority uint32) {
+	switch objType {
+	case EgressIPPodType:
+		return 1
+	case PeerPodSelectorType:
+		return 2
+	case PeerPodForNamespaceAndPodSelectorType:
+		return 3
+	case LocalPodSelectorType:
+		return 4
+	case EgressIPNamespaceType:
+		return 1
+	case PeerNamespaceSelectorType:
+		return 2
+	case PeerNamespaceAndPodSelectorType:
+		return 3
+	case EgressNodeType:
+		return 1
+	default:
+		return defaultHandlerPriority
+	}
+}
+
 func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandlerFuncType, error) {
+	priority := wf.GetHandlerPriority(objType)
 	switch objType {
 	case NamespaceType:
 		return func(namespace string, sel labels.Selector,
@@ -411,7 +438,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 	case NodeType, EgressNodeType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-			return wf.AddNodeHandler(funcs, processExisting)
+			return wf.AddNodeHandler(funcs, processExisting, priority)
 		}, nil
 
 	case PeerServiceType:
@@ -420,22 +447,16 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 			return wf.AddFilteredServiceHandler(namespace, funcs, processExisting)
 		}, nil
 
-	case PeerPodSelectorType, LocalPodSelectorType, PodType, EgressIPPodType:
+	case PeerPodSelectorType, LocalPodSelectorType, PodType, EgressIPPodType, PeerPodForNamespaceAndPodSelectorType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-			return wf.AddFilteredPodHandler(namespace, sel, funcs, processExisting)
+			return wf.AddFilteredPodHandler(namespace, sel, funcs, processExisting, priority)
 		}, nil
 
 	case PeerNamespaceAndPodSelectorType, PeerNamespaceSelectorType, EgressIPNamespaceType:
 		return func(namespace string, sel labels.Selector,
 			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-			return wf.AddFilteredNamespaceHandler(namespace, sel, funcs, processExisting)
-		}, nil
-
-	case PeerPodForNamespaceAndPodSelectorType:
-		return func(namespace string, sel labels.Selector,
-			funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-			return wf.AddFilteredPodHandler(namespace, sel, funcs, processExisting)
+			return wf.AddFilteredNamespaceHandler(namespace, sel, funcs, processExisting, priority)
 		}, nil
 
 	case EgressFirewallType:
@@ -459,7 +480,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 	return nil, fmt.Errorf("cannot get ObjectMeta from type %v", objType)
 }
 
-func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
+func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
 	inf, ok := wf.informers[objType]
 	if !ok {
 		klog.Fatalf("Tried to add handler of unknown object type %v", objType)
@@ -510,7 +531,7 @@ func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel l
 	}
 
 	handlerID := atomic.AddUint64(&wf.handlerCounter, 1)
-	handler := inf.addHandler(handlerID, filterFunc, funcs, items)
+	handler := inf.addHandler(handlerID, priority, filterFunc, funcs, items)
 	klog.V(5).Infof("Added %v event handler %d", objType, handler.id)
 	return handler, nil
 }
@@ -521,12 +542,12 @@ func (wf *WatchFactory) removeHandler(objType reflect.Type, handler *Handler) {
 
 // AddPodHandler adds a handler function that will be executed on Pod object changes
 func (wf *WatchFactory) AddPodHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(PodType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(PodType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // AddFilteredPodHandler adds a handler function that will be executed when Pod objects that match the given filters change
-func (wf *WatchFactory) AddFilteredPodHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(PodType, namespace, sel, handlerFuncs, processExisting)
+func (wf *WatchFactory) AddFilteredPodHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+	return wf.addHandler(PodType, namespace, sel, handlerFuncs, processExisting, priority)
 }
 
 // RemovePodHandler removes a Pod object event handler function
@@ -536,12 +557,12 @@ func (wf *WatchFactory) RemovePodHandler(handler *Handler) {
 
 // AddServiceHandler adds a handler function that will be executed on Service object changes
 func (wf *WatchFactory) AddServiceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(ServiceType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(ServiceType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // AddFilteredServiceHandler adds a handler function that will be executed on all Service object changes for a specific namespace
 func (wf *WatchFactory) AddFilteredServiceHandler(namespace string, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(ServiceType, namespace, nil, handlerFuncs, processExisting)
+	return wf.addHandler(ServiceType, namespace, nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveServiceHandler removes a Service object event handler function
@@ -551,7 +572,7 @@ func (wf *WatchFactory) RemoveServiceHandler(handler *Handler) {
 
 // AddEndpointSliceHandler adds a handler function that will be executed on EndpointSlice object changes
 func (wf *WatchFactory) AddEndpointSliceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(EndpointSliceType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(EndpointSliceType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveEndpointSliceHandler removes a EndpointSlice object event handler function
@@ -561,7 +582,7 @@ func (wf *WatchFactory) RemoveEndpointSliceHandler(handler *Handler) {
 
 // AddPolicyHandler adds a handler function that will be executed on NetworkPolicy object changes
 func (wf *WatchFactory) AddPolicyHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(PolicyType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(PolicyType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemovePolicyHandler removes a NetworkPolicy object event handler function
@@ -571,7 +592,7 @@ func (wf *WatchFactory) RemovePolicyHandler(handler *Handler) {
 
 // AddEgressFirewallHandler adds a handler function that will be executed on EgressFirewall object changes
 func (wf *WatchFactory) AddEgressFirewallHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(EgressFirewallType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(EgressFirewallType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveEgressFirewallHandler removes an EgressFirewall object event handler function
@@ -586,7 +607,7 @@ func (wf *WatchFactory) RemoveEgressQoSHandler(handler *Handler) {
 
 // AddEgressIPHandler adds a handler function that will be executed on EgressIP object changes
 func (wf *WatchFactory) AddEgressIPHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(EgressIPType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(EgressIPType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveEgressIPHandler removes an EgressIP object event handler function
@@ -596,7 +617,7 @@ func (wf *WatchFactory) RemoveEgressIPHandler(handler *Handler) {
 
 // AddCloudPrivateIPConfigHandler adds a handler function that will be executed on CloudPrivateIPConfig object changes
 func (wf *WatchFactory) AddCloudPrivateIPConfigHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(CloudPrivateIPConfigType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(CloudPrivateIPConfigType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveCloudPrivateIPConfigHandler removes an CloudPrivateIPConfig object event handler function
@@ -606,12 +627,12 @@ func (wf *WatchFactory) RemoveCloudPrivateIPConfigHandler(handler *Handler) {
 
 // AddNamespaceHandler adds a handler function that will be executed on Namespace object changes
 func (wf *WatchFactory) AddNamespaceHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(NamespaceType, "", nil, handlerFuncs, processExisting)
+	return wf.addHandler(NamespaceType, "", nil, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // AddFilteredNamespaceHandler adds a handler function that will be executed when Namespace objects that match the given filters change
-func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(NamespaceType, namespace, sel, handlerFuncs, processExisting)
+func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+	return wf.addHandler(NamespaceType, namespace, sel, handlerFuncs, processExisting, priority)
 }
 
 // RemoveNamespaceHandler removes a Namespace object event handler function
@@ -620,13 +641,13 @@ func (wf *WatchFactory) RemoveNamespaceHandler(handler *Handler) {
 }
 
 // AddNodeHandler adds a handler function that will be executed on Node object changes
-func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(NodeType, "", nil, handlerFuncs, processExisting)
+func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+	return wf.addHandler(NodeType, "", nil, handlerFuncs, processExisting, priority)
 }
 
 // AddFilteredNodeHandler dds a handler function that will be executed when Node objects that match the given label selector
 func (wf *WatchFactory) AddFilteredNodeHandler(sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error) (*Handler, error) {
-	return wf.addHandler(NodeType, "", sel, handlerFuncs, processExisting)
+	return wf.addHandler(NodeType, "", sel, handlerFuncs, processExisting, defaultHandlerPriority)
 }
 
 // RemoveNodeHandler removes a Node object event handler function


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
When handlers share the informer for the same type of objects - example egressIP feature also watches for Pods and creates a handler to receive events for any pod-related activities - it is better to prioritize the order in which a specific event for a pod will be processed. Pod creation should happen first, so addLogicalPort should go first before egressIP Pod handler. Similarly for network policies and other controllers.

Today OVNK already handles the events serially, the only problem is we don't control which handler gets the event first, so this PR adds a priority system for the handlers where by we say all critical handlers get priority 0 - this is the highest priority and it applies to pods/namespaces/nodes and all the CRD objects. Then we start handing out priority to rest of the handlers, example egressIP pod handler will have priority 1 which means it will always get the event _after_ the main pod handler has got it. Same for egressIP namespace handler which will always get the event _after_ the main namespace handler has got it.

**- Special notes for reviewers**
See if the priorities assigned make sense?
Few unit tests have been added to check if expected priority is passed into and I manually checked logs in KIND to test if this change takes effect. I am open to ideas on adding more tests - we should have some on making sure events land on handlers in the order we want them to...ideas?


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
`Pass events to handlers for shared informers based on priority`