### PR TITLE
 refactor retry to close watchFactory

### DIFF
--- a/go-controller/pkg/ovn/obj_retry_master.go
+++ b/go-controller/pkg/ovn/obj_retry_master.go
@@ -59,7 +59,6 @@ func (oc *Controller) newRetryFrameworkMasterWithParameters(
 		},
 	}
 	r := retry.NewRetryFramework(
-		oc.stopChan,
 		oc.watchFactory,
 		resourceHandler,
 	)


### PR DESCRIPTION
leverage stop channel on watch factory when periodic retry stopchannel is called

Problem: Hybrid test was creating creating an ovn-controller for some tests.
The tests could not use the waitGroup in the test so the afterEach function
(cleanup function after each test) could execute while leaving controllers up.
In the tests, we were leveraging the code in ovn.go to run the controllers
and creating a watcher pod on them. This issue was just a symptom of the main
issue which was that we were using the incorrect stopChannel in the retry logic.

Solution: The stopChannel that we use in the watchFactory is private, so we
created a function that when called will close the watcher stopChannel,
closing the watcher. We then call this function in the select
(basically a switch statement in go but for channels) to close the watcher,
because when we stop watching an object, that means we no longer care about it
and should stop retrying it.

Signed-off-by: Ben Pickard <bpickard@redhat.com>
Closes: https://github.com/ovn-org/ovn-kubernetes/issues/3203
