### PR TITLE
Support LB Session Affinity TimeOut

### DIFF
--- a/go-controller/pkg/libovsdbops/loadbalancer.go
+++ b/go-controller/pkg/libovsdbops/loadbalancer.go
@@ -47,14 +47,13 @@ func getNonZeroLoadBalancerMutableFields(lb *nbdb.LoadBalancer) []interface{} {
 }
 
 // BuildLoadBalancer builds a load balancer
-func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, selectionFields []nbdb.LoadBalancerSelectionFields, vips, options, externalIds map[string]string) *nbdb.LoadBalancer {
+func BuildLoadBalancer(name string, protocol nbdb.LoadBalancerProtocol, vips, options, externalIds map[string]string) *nbdb.LoadBalancer {
 	return &nbdb.LoadBalancer{
-		Name:            name,
-		Protocol:        &protocol,
-		SelectionFields: selectionFields,
-		Vips:            vips,
-		Options:         options,
-		ExternalIDs:     externalIds,
+		Name:        name,
+		Protocol:    &protocol,
+		Vips:        vips,
+		Options:     options,
+		ExternalIDs: externalIds,
 	}
 }
 

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -260,20 +260,16 @@ func buildLB(lb *LB) *nbdb.LoadBalancer {
 	}
 
 	// Session affinity
-	// If enabled, then bucket flows by 3-tuple (proto, srcip, dstip)
+	// If enabled, then bucket flows by 3-tuple (proto, srcip, dstip) for the specific timeout value
 	// otherwise, use default ovn value
-	selectionFields := []nbdb.LoadBalancerSelectionFields{}
-	if lb.Opts.Affinity {
-		selectionFields = []string{
-			nbdb.LoadBalancerSelectionFieldsIPSrc,
-			nbdb.LoadBalancerSelectionFieldsIPDst,
-		}
+	if lb.Opts.AffinityTimeOut > 0 {
+		options["affinity_timeout"] = fmt.Sprintf("%d", lb.Opts.AffinityTimeOut)
 	}
 
 	// vipMap
 	vips := buildVipMap(lb.Rules)
 
-	return libovsdbops.BuildLoadBalancer(lb.Name, strings.ToLower(lb.Protocol), selectionFields, vips, options, lb.ExternalIDs)
+	return libovsdbops.BuildLoadBalancer(lb.Name, strings.ToLower(lb.Protocol), vips, options, lb.ExternalIDs)
 }
 
 // buildVipMap returns a viups map from a set of rules

--- a/go-controller/pkg/ovn/loadbalancer/types.go
+++ b/go-controller/pkg/ovn/loadbalancer/types.go
@@ -22,8 +22,8 @@ type LBOpts struct {
 	// if true, then enable unidling. Otherwise, generate reject
 	Unidling bool
 
-	// If true, then enable per-client-IP affinity.
-	Affinity bool
+	// If greater than 0, then enable per-client-IP affinity.
+	AffinityTimeOut int32
 
 	// If true, then disable SNAT entirely
 	SkipSNAT bool

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -26,9 +26,6 @@ kube-proxy
 should set TCP CLOSE_WAIT timeout
 \[Feature:ProxyTerminatingEndpoints\]
 
-# not implemented - OVN doesn't support time
-should have session affinity timeout work
-
 # NOT IMPLEMENTED; SEE DISCUSSION IN https://github.com/ovn-org/ovn-kubernetes/pull/1225
 named port.+\[Feature:NetworkPolicy\]
 


### PR DESCRIPTION



**- What this PR does and why is it needed**

Implements Load Balancer Session Affinity TimeOut. Most of the work is in OVN. This PR just sets the needed option on the load balancer to get it to work correctly. We also remove the older method of using selectionFields in OVN.


**- Special notes for reviewers**
Based on KIND testing:
```
Name:              hello-world-2
Namespace:         surya
Labels:            <none>
Annotations:       service.kubernetes.io/topology-aware-hints: auto
Selector:          run=load-balancer-example-2
Type:              ClusterIP
IP Family Policy:  SingleStack
IP Families:       IPv4
IP:                10.96.169.9
IPs:               10.96.169.9
Port:              <unset>  80/TCP
TargetPort:        8080/TCP
Endpoints:         10.244.0.3:8080,10.244.1.3:8080,10.244.1.4:8080 + 2 more...
Session Affinity:  ClientIP
Events:            <none>
```
translates to:
```
_uuid               : 3dc8659e-12a7-44b9-bb42-aeeba8081433
external_ids        : {"k8s.ovn.org/kind"=Service, "k8s.ovn.org/owner"="surya/hello-world-2"}
health_check        : []
ip_port_mappings    : {}
name                : "Service_surya/hello-world-2_TCP_cluster"
options             : {affinity_timeout="10800", event="false", reject="true", skip_snat="false"}
protocol            : tcp
selection_fields    : [ip_dst, ip_src]
vips                : {"10.96.169.9:80"="10.244.0.3:8080,10.244.1.3:8080,10.244.1.4:8080,10.244.2.6:8080,10.244.2.7:8080"}
```
We can see the affinity_timeout getting set correctly ^ default value since nothing is provided.

Next specifically set the session affinity timeout to a specified value:
```
$ oc get svc -n surya hello-world-2 -oyaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    service.kubernetes.io/topology-aware-hints: auto
  creationTimestamp: "2022-11-09T17:54:37Z"
  name: hello-world-2
  namespace: surya
  resourceVersion: "18768"
  uid: e4169597-f6bf-45c9-af0b-b7b2c9b03e63
spec:
  clusterIP: 10.96.132.9
  clusterIPs:
  - 10.96.132.9
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - port: 80
    protocol: TCP
    targetPort: 8080
  selector:
    run: load-balancer-example-2
  sessionAffinity: ClientIP
  sessionAffinityConfig:
    clientIP:
      timeoutSeconds: 300
  type: ClusterIP
status:
  loadBalancer: {}
```
translates to:
```
_uuid               : ee763d69-d695-4b4f-9e05-f82eb874f01b
external_ids        : {"k8s.ovn.org/kind"=Service, "k8s.ovn.org/owner"="surya/hello-world-2"}
health_check        : []
ip_port_mappings    : {}
name                : "Service_surya/hello-world-2_TCP_cluster"
options             : {affinity_timeout="300", event="false", reject="true", skip_snat="false"}
protocol            : tcp
selection_fields    : [ip_dst, ip_src]
vips                : {"10.96.132.9:80"="10.244.0.3:8080,10.244.1.3:8080,10.244.1.4:8080,10.244.2.6:8080,10.244.2.7:8080"}
```
For the second case, started a curl and it picked one endpoint where pkts started arriving around:
```
17:58:37.281071 IP 169.254.169.2.51996 > hello-world-2-7f4f9dd6b9-mhdzt.http-alt: Flags [S], seq 2586196738, win 65280, options [mss 1360,sackOK,TS val 891685377 ecr 0,nop,wscale 7], length 0                                                                                                                                                           
17:58:37.281155 ARP, Request who-has 10.244.1.1 tell hello-world-2-7f4f9dd6b9-mhdzt, length 28                                                                               17:58:37.281500 ARP, Reply 10.244.1.1 is-at 0a:58:0a:f4:01:01 (oui Unknown), length 28                                                                                       
17:58:37.281510 IP hello-world-2-7f4f9dd6b9-mhdzt.http-alt > 169.254.169.2.51996: Flags [S.], seq 221941955, ack 2586196739, win 64704, options [mss 1360,sackOK,TS val 1307631493 ecr 891685377,nop,wscale 7], length 0                                                                                                                                  
17:58:37.282474 IP hello-world-2-7f4f9dd6b9-mhdzt.51959 > kube-dns.kube-system.svc.cluster.local.domain: 58286+ PTR? 2.169.254.169.in-addr.arpa. (44)                        17:58:37.285724 IP 100.64.0.3.51996 > hello-world-2-7f4f9dd6b9-mhdzt.http-alt: Flags [P.], seq 2586196739:2586196815, ack 221941956, win 510, options [nop,nop,TS val 8916853
82 ecr 1307631493], length 76: HTTP: HEAD / HTTP/1.1                                                                                                                         17:58:37.285777 IP hello-world-2-7f4f9dd6b9-mhdzt.http-alt > 100.64.0.3.51996: Flags [R], seq 221941956, win 0, length 0                                                     
17:58:37.292226 IP hello-world-2-7f4f9dd6b9-mhdzt.50612 > kube-dns.kube-system.svc.cluster.local.domain: 65383+ PTR? 1.1.244.10.in-addr.arpa. (41)                           17:58:37.338198 IP hello-world-2-7f4f9dd6b9-mhdzt.55005 > kube-dns.kube-system.svc.cluster.local.domain: 1979+ PTR? 10.0.96.10.in-addr.arpa. (41)                            
17:58:37.338878 IP kube-dns.kube-system.svc.cluster.local.domain > hello-world-2-7f4f9dd6b9-mhdzt.55005: 1979*- 1/0/0 PTR kube-dns.kube-system.svc.cluster.local. (116)      17:58:37.339112 IP hello-world-2-7f4f9dd6b9-mhdzt.49948 > kube-dns.kube-system.svc.cluster.local.domain: 14259+ PTR? 3.0.64.100.in-addr.arpa. (41)                           
17:58:37.339805 IP kube-dns.kube-system.svc.cluster.local.domain > hello-world-2-7f4f9dd6b9-mhdzt.49948: 14259 NXDomain*- 0/1/0 (131)                                        17:58:37.345766 IP 169.254.169.2.52020 > hello-world-2-7f4f9dd6b9-mhdzt.http-alt: Flags [S], seq 1671399059, win 65280, options [mss 1360,sackOK,TS val 891685444 ecr 0,nop,w
scale 7], length 0                                                                                                                                                           17:58:37.345794 IP hello-world-2-7f4f9dd6b9-mhdzt.http-alt > 169.254.169.2.52020: Flags [S.], seq 1997620607, ack 1671399060, win 64704, options [mss 1360,sackOK,TS val 1307
631558 ecr 891685444,nop,wscale 7], length 0                                                                                                                                 17:58:37.345872 IP 100.64.0.3.52020 > hello-world-2-7f4f9dd6b9-mhdzt.http-alt: Flags [.], ack 1997620608, win 510, options [nop,nop,TS val 891685444 ecr 1307631558], length 
0                                                                                          
```

**- How to verify it**
Conformance tests from k8 are running in CI lane.


**- Description for the changelog**
`Implement Session Affinity timeout`