### PR TITLE
fixes to windows testing

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -5,14 +5,10 @@ import (
 	"net"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -33,45 +29,101 @@ import (
 )
 
 const (
-	testOVSMAC     string = "11:22:33:44:55:66"
-	testMgmtMAC    string = "06:05:04:03:02:01"
-	testDRMAC      string = "00:00:00:7a:af:04"
-	testNodeSubnet string = "1.2.3.0/24"
-	testNodeIP     string = "1.2.3.3"
+	testMgmtMAC string = "06:05:04:03:02:01"
+
+	thisNodeSubnet string = "1.2.3.0/24"
+	thisNodeDRIP   string = "1.2.3.3"
+	thisNodeDRMAC  string = "22:33:44:55:66:77"
 )
 
+// returns if the two flowCaches are the same
+func compareFlowCache(returnedFlowCache, expectedFlowCache map[string]*flowCacheEntry) error {
+	if len(returnedFlowCache) != len(expectedFlowCache) {
+		return fmt.Errorf("the number of expected flow cache entries (%d) does not equal the number returned (%d)", len(expectedFlowCache), len(returnedFlowCache))
+	}
+
+	for key, entry := range returnedFlowCache {
+		expectedEntry, ok := expectedFlowCache[key]
+		if !ok {
+			return fmt.Errorf("unexpected entry %s in nodes flowCache", entry.flows)
+		}
+		if err := compareFlowCacheEntry(entry, expectedEntry); err != nil {
+			return fmt.Errorf("returned flowCacheEntry[%s] does not equal expectedCacheEntry[%s]: %v", key, key, err)
+		}
+	}
+	return nil
+
+}
+
+// compares two entries in the flow cache
+func compareFlowCacheEntry(returnedEntry, expectedEntry *flowCacheEntry) error {
+	if returnedEntry.learnedFlow != expectedEntry.learnedFlow {
+		return fmt.Errorf("the number of flows in the flow cache entry is unexpected")
+	}
+	if returnedEntry.ignoreLearn != expectedEntry.ignoreLearn {
+		return fmt.Errorf("the flowCacheEntry ignoreLearn field is not expected")
+	}
+	if len(returnedEntry.flows) != len(expectedEntry.flows) {
+		return fmt.Errorf("the number of flows is not equal to the number of flows expected")
+	}
+
+	for key, returnedEntryFlow := range returnedEntry.flows {
+		if returnedEntryFlow != expectedEntry.flows[key] {
+			return fmt.Errorf("returnedflowCacheEntry[%d] = %s does not equal expectedFlowCacheEntry[%d] = %s", key, returnedEntryFlow, key, expectedEntry.flows[key])
+		}
+
+	}
+
+	return nil
+}
+
+func generateInitialFlowCacheEntry(mgmtInterfaceAddr string) *flowCacheEntry {
+	mgmtPortLink, err := netlink.LinkByName(types.K8sMgmtIntfName)
+	Expect(err).NotTo(HaveOccurred())
+	mgmtPortMAC := mgmtPortLink.Attrs().HardwareAddr
+	_, ipNet, err := net.ParseCIDR(thisNodeSubnet)
+	Expect(err).NotTo(HaveOccurred())
+	gwIfAddr := util.GetNodeGatewayIfAddr(ipNet)
+	gwPortMAC := util.IPAddrToHWAddr(gwIfAddr.IP)
+	thisNodeDRMACRaw := strings.Replace(thisNodeDRMAC, ":", "", -1)
+	return &flowCacheEntry{
+		flows: []string{
+			"table=0,priority=0,actions=drop",
+			"table=1,priority=0,actions=drop",
+			"table=2,priority=0,actions=drop",
+			"table=10,priority=0,actions=drop",
+			"table=20,priority=0,actions=drop",
+			"table=0,priority=100,in_port=ext,arp_op=1,arp,arp_tpa=" + thisNodeDRIP + ",actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:" + thisNodeDRMAC + ",load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0x" + thisNodeDRMACRaw + "->NXM_NX_ARP_SHA[],load:0x" + getIPAsHexString(net.ParseIP(thisNodeDRIP)) + "->NXM_OF_ARP_SPA[],IN_PORT,resubmit(,1)",
+			"table=0,priority=100,in_port=ext-vxlan,ip,nw_dst=" + thisNodeSubnet + ",dl_dst=" + thisNodeDRMAC + ",actions=goto_table:10",
+			"table=0,priority=10,arp,in_port=ext-vxlan,arp_op=1,arp_tpa=" + thisNodeSubnet + ",actions=resubmit(,2)",
+			"table=2,priority=100,arp,in_port=ext-vxlan,arp_op=1,arp_tpa=" + thisNodeSubnet + ",actions=move:tun_src->tun_dst,load:4097->NXM_NX_TUN_ID[0..31],move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:" + thisNodeDRMAC + ",load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0x" + thisNodeDRMACRaw + "->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT",
+			"table=10,priority=100,ip,nw_dst=" + mgmtInterfaceAddr + ",actions=mod_dl_src:" + thisNodeDRMAC + ",mod_dl_dst:" + mgmtPortMAC.String() + ",output:ext",
+			"table=10,priority=100,ip,nw_dst=" + thisNodeDRIP + ",actions=mod_nw_dst:100.64.0.3,mod_dl_src:" + thisNodeDRMAC + ",mod_dl_dst:" + gwPortMAC.String() + ",output:ext",
+		},
+	}
+
+}
+
 // returns a fake node IP and DR MAC
-func addNodeSetupCmds(fexec *ovntest.FakeExec, nodeName string) (string, string) {
+func addNodeSetupCmds(fexec *ovntest.FakeExec, nodeName string) {
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovn-nbctl --timeout=15 get logical_switch mynode other-config:subnet",
-		Output: testNodeSubnet,
-	})
-	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface ovn-k8s-mp0 mac_in_use",
-		Output: testMgmtMAC,
+		Output: thisNodeSubnet,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovs-vsctl --timeout=15 --may-exist add-br br-ext -- set Bridge br-ext fail_mode=secure -- set Interface br-ext mtu_request=1400",
 	})
 	fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 		Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface br-ext mac_in_use",
-		Output: testOVSMAC,
+		Output: thisNodeDRMAC,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-vsctl --timeout=15 set bridge br-ext other-config:hwaddr=" + testOVSMAC,
+		"ovs-vsctl --timeout=15 set bridge br-ext other-config:hwaddr=" + thisNodeDRMAC,
 		"ovs-vsctl --timeout=15 --may-exist add-port br-int int -- --may-exist add-port br-ext ext -- set Interface int type=patch options:peer=ext external-ids:iface-id=int-" + nodeName + " -- set Interface ext type=patch options:peer=int",
-		"ovs-ofctl add-flow br-ext table=0,priority=0,actions=drop",
 	})
-	testDRMACRaw := strings.Replace(testDRMAC, ":", "", -1)
-	testNodeIPRaw := getIPAsHexString(ovntest.MustParseIP(testNodeIP))
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovs-ofctl add-flow br-ext table=0,priority=100,in_port=ext,arp,arp_tpa=" + testNodeIP + ",actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:" + testDRMAC + ",load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],load:0x" + testDRMACRaw + "->NXM_NX_ARP_SHA[],load:0x" + testNodeIPRaw + "->NXM_OF_ARP_SPA[],IN_PORT",
 		`ovs-vsctl --timeout=15 --may-exist add-port br-ext ext-vxlan -- set interface ext-vxlan type=vxlan options:remote_ip="flow" options:key="flow" options:dst_port=4789`,
-		"ovs-ofctl add-flow br-ext table=0,priority=100,in_port=ext-vxlan,ip,nw_dst=" + testNodeSubnet + ",dl_dst=" + testDRMAC + ",actions=goto_table:10",
-		"ovs-ofctl add-flow br-ext table=0,priority=100,arp,in_port=ext-vxlan,arp_tpa=" + testNodeSubnet + ",actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:" + testDRMAC + ",load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0x" + testDRMACRaw + "->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT",
-		"ovs-ofctl add-flow br-ext table=10,priority=0,actions=drop",
 	})
-	return testNodeIP, testDRMAC
 }
 
 func createNode(name, os, ip string, annotations map[string]string) *v1.Node {
@@ -172,15 +224,16 @@ func createNodeAnnotationsForSubnet(subnet string) map[string]string {
 
 var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 	var (
-		app      *cli.App
-		fexec    *ovntest.FakeExec
-		netns    ns.NetNS
-		stopChan chan struct{}
-		wg       *sync.WaitGroup
+		app        *cli.App
+		fexec      *ovntest.FakeExec
+		netns      ns.NetNS
+		stopChan   chan struct{}
+		wg         *sync.WaitGroup
+		mgmtIfAddr *net.IPNet
 	)
 	const (
 		thisNode   string = "mynode"
-		thisSubnet string = "1.2.3.0/24"
+		thisNodeIP string = "10.0.0.1"
 	)
 
 	BeforeEach(func() {
@@ -208,9 +261,9 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			// Set up management interface with its address
 			link := ovntest.AddLink(types.K8sMgmtIntfName)
-			_, thisNet, err := net.ParseCIDR(thisSubnet)
+			_, thisNet, err := net.ParseCIDR(thisNodeSubnet)
 			Expect(err).NotTo(HaveOccurred())
-			mgmtIfAddr := util.GetNodeManagementIfAddr(thisNet)
+			mgmtIfAddr = util.GetNodeManagementIfAddr(thisNet)
 			err = netlink.AddrAdd(link, &netlink.Addr{IPNet: mgmtIfAddr})
 			Expect(err).NotTo(HaveOccurred())
 			return nil
@@ -232,15 +285,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
 				Items: []v1.Node{
-					*createNode(node1Name, "linux", "10.0.0.1", nil),
+					*createNode(node1Name, "linux", thisNodeIP, nil),
 				},
-			})
-
-			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Assume fresh OVS bridge
-				Output: "",
 			})
 
 			_, err := config.InitConfig(ctx, fexec, nil)
@@ -263,9 +309,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				defer wg.Done()
 				n.nodeEventHandler.Run(1, stopChan)
 			}()
-
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			// don't add any commands the setup will fail because the master has not set the correct annotations
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
 		}
 		appRun(app, netns)
@@ -276,7 +321,7 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			const (
 				node1Name   string = "node1"
 				node1Subnet string = "1.2.4.0/24"
-				node1IP     string = "10.0.0.2"
+				node1IP     string = "10.11.12.1"
 			)
 
 			annotations := createNodeAnnotationsForSubnet(node1Subnet)
@@ -286,13 +331,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				},
 			})
 
-			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Assume fresh OVS bridge
-				Output: "",
-			})
-
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
@@ -313,8 +351,8 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				n.nodeEventHandler.Run(1, stopChan)
 			}()
 
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			// similarly to above no ovs commands will be issued to exec because the hybrid overlay setup will fail
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
 		}
 		appRun(app, netns)
@@ -322,26 +360,17 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 	ovntest.OnSupportedPlatformsIt("sets up local node hybrid overlay bridge", func() {
 		app.Action = func(ctx *cli.Context) error {
-			const (
-				thisDrMAC string = "22:33:44:55:66:77"
-			)
 
-			annotations := createNodeAnnotationsForSubnet(thisSubnet)
-			annotations[hotypes.HybridOverlayDRMAC] = thisDrMAC
+			annotations := createNodeAnnotationsForSubnet(thisNodeSubnet)
+			annotations[hotypes.HybridOverlayDRMAC] = thisNodeDRMAC
 			annotations["k8s.ovn.org/node-gateway-router-lrp-ifaddr"] = "{\"ipv4\":\"100.64.0.3/16\"}"
-			annotations[hotypes.HybridOverlayDRIP] = "1.2.3.3"
-			node := createNode(thisNode, "linux", "10.0.0.1", annotations)
+			annotations[hotypes.HybridOverlayDRIP] = thisNodeDRIP
+			node := createNode(thisNode, "linux", thisNodeIP, annotations)
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
 				Items: []v1.Node{*node},
 			})
 
-			// Node setup from initial node sync
 			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Assume fresh OVS bridge
-				Output: "",
-			})
 			config.HybridOverlay.RawClusterSubnets = "10.0.0.1/16/23"
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -359,9 +388,28 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			err = n.controller.EnsureHybridOverlayBridge(node)
 			Expect(err).NotTo(HaveOccurred())
 
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			validateNetlinkState(thisSubnet, "1.2.3.3")
+			linuxNode, okay := n.controller.(*NodeController)
+			Expect(okay).To(BeTrue())
+			Expect(linuxNode.initialized).To(BeTrue())
+
+			// ovs commands generated by the initial sync
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-ofctl dump-flows --no-stats br-ext table=20",
+				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
+			})
+
+			//  perform the requested cacheSync
+			linuxNode.syncFlows()
+
+			// the flow cache will be sync'ed to ovs from the above bundled command but there is not a good way using fexec to
+			// get that data so I am comapring the flowcache to what it should be
+			initialFlowCache := map[string]*flowCacheEntry{
+				"0x0": generateInitialFlowCacheEntry(mgmtIfAddr.IP.String()),
+			}
+			Expect(compareFlowCache(linuxNode.flowCache, initialFlowCache)).NotTo(HaveOccurred())
+
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			validateNetlinkState(thisNodeSubnet, thisNodeDRIP)
 			return nil
 		}
 		appRun(app, netns)
@@ -369,17 +417,16 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 	ovntest.OnSupportedPlatformsIt("sets up local linux pod", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
-				thisDrMAC string = "22:33:44:55:66:77"
-				pod1IP    string = "1.2.3.5"
-				pod1CIDR  string = pod1IP + "/24"
-				pod1MAC   string = "aa:bb:cc:dd:ee:ff"
+				pod1IP   string = "1.2.3.5"
+				pod1CIDR string = pod1IP + "/24"
+				pod1MAC  string = "aa:bb:cc:dd:ee:ff"
 			)
 
-			annotations := createNodeAnnotationsForSubnet(thisSubnet)
-			annotations[hotypes.HybridOverlayDRMAC] = thisDrMAC
+			annotations := createNodeAnnotationsForSubnet(thisNodeSubnet)
+			annotations[hotypes.HybridOverlayDRMAC] = thisNodeDRMAC
 			annotations["k8s.ovn.org/node-gateway-router-lrp-ifaddr"] = "{\"ipv4\":\"100.64.0.3/16\"}"
-			annotations[hotypes.HybridOverlayDRIP] = "1.2.3.3"
-			node := createNode(thisNode, "linux", "10.0.0.1", annotations)
+			annotations[hotypes.HybridOverlayDRIP] = thisNodeDRIP
+			node := createNode(thisNode, "linux", thisNodeIP, annotations)
 			testPod := createPod("test", "pod1", thisNode, pod1CIDR, pod1MAC)
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
 				Items: []v1.Node{*node},
@@ -387,11 +434,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			// Node setup from initial node sync
 			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Assume fresh OVS bridge
-				Output: "",
-			})
 			config.HybridOverlay.RawClusterSubnets = "10.0.0.1/16/23"
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -409,12 +451,41 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 
 			err = n.controller.EnsureHybridOverlayBridge(node)
 			Expect(err).NotTo(HaveOccurred())
+			linuxNode, okay := n.controller.(*NodeController)
+			Expect(okay).To(BeTrue())
+			Expect(linuxNode.initialized).To(BeTrue())
+			// ovs commands generated by the initial sync
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-ofctl dump-flows --no-stats br-ext table=20",
+				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
+			})
 
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			validateNetlinkState(thisSubnet, "1.2.3.3")
+			// perform the requested cacheSync
+			linuxNode.syncFlows()
+			initialFlowCache := map[string]*flowCacheEntry{
+				"0x0": generateInitialFlowCacheEntry(mgmtIfAddr.IP.String()),
+			}
+			Expect(compareFlowCache(linuxNode.flowCache, initialFlowCache)).NotTo(HaveOccurred())
+
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			validateNetlinkState(thisNodeSubnet, thisNodeDRIP)
 			err = n.controller.AddPod(testPod)
 			Expect(err).NotTo(HaveOccurred())
+			// ovs commands generated by second cacheSync
+			fexec.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-ofctl dump-flows --no-stats br-ext table=20",
+				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
+			})
+
+			// perform the requested cacheSync
+			linuxNode.syncFlows()
+			// make sure that the flow that sends traffic to the windows pod is present
+			initialFlowCache[podIPToCookie(net.ParseIP(pod1IP))] = &flowCacheEntry{
+				flows:       []string{"table=10,cookie=0x" + podIPToCookie(net.ParseIP(pod1IP)) + ",priority=100,ip,nw_dst=" + pod1IP + ",actions=set_field:" + thisNodeDRMAC + "->eth_src,set_field:" + pod1MAC + "->eth_dst,output:ext"},
+				ignoreLearn: true,
+			}
+			Expect(compareFlowCache(linuxNode.flowCache, initialFlowCache)).NotTo(HaveOccurred())
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
 		}
 		appRun(app, netns)
@@ -424,30 +495,25 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 		app.Action = func(ctx *cli.Context) error {
 			const (
 				node1Name   string = "node1"
-				node1IP     string = "10.0.0.2"
-				node1DrMAC  string = "22:33:44:55:66:77"
-				node1Subnet string = "5.6.7.0/24"
+				node1Subnet string = "10.11.12.0/24"
+				node1DRMAC  string = "00:00:00:7f:af:03"
+				node1IP     string = "10.11.12.1"
 			)
 
+			annotations := createNodeAnnotationsForSubnet(thisNodeSubnet)
+			annotations[hotypes.HybridOverlayDRMAC] = thisNodeDRMAC
+			annotations["k8s.ovn.org/node-gateway-router-lrp-ifaddr"] = "{\"ipv4\":\"100.64.0.3/16\"}"
+			annotations[hotypes.HybridOverlayDRIP] = thisNodeDRIP
+			node := createNode(thisNode, "linux", thisNodeIP, annotations)
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
 				Items: []v1.Node{
-					*createNode(node1Name, "windows", node1IP, map[string]string{
-						hotypes.HybridOverlayNodeSubnet: node1Subnet,
-						hotypes.HybridOverlayDRMAC:      node1DrMAC,
-					}),
+					*node,
 				},
 			})
 
-			node1DrMACRaw := strings.Replace(node1DrMAC, ":", "", -1)
-
+			// Node setup from initial node sync
 			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-ofctl dump-flows br-ext table=0",
-				// Adds flows for existing node1
-				"ovs-ofctl add-flow br-ext cookie=0xca12f31b,table=0,priority=100,arp,in_port=ext,arp_tpa=" + node1Subnet + ",actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:" + node1DrMAC + ",load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0x" + node1DrMACRaw + "->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT",
-				"ovs-ofctl add-flow br-ext cookie=0xca12f31b,table=0,priority=100,ip,nw_dst=5.6.7.0/24,actions=load:4097->NXM_NX_TUN_ID[0..31],set_field:10.0.0.2->tun_dst,set_field:22:33:44:55:66:77->eth_dst,output:ext-vxlan",
-			})
-
+			config.HybridOverlay.RawClusterSubnets = "10.0.0.1/16/23"
 			_, err := config.InitConfig(ctx, fexec, nil)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -462,199 +528,49 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.nodeEventHandler.Run(1, stopChan)
-			}()
+			err = n.controller.EnsureHybridOverlayBridge(node)
+			Expect(err).NotTo(HaveOccurred())
+			linuxNode, okay := n.controller.(*NodeController)
+			Expect(okay).To(BeTrue())
 
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
-		appRun(app, netns)
-	})
-
-	ovntest.OnSupportedPlatformsIt("removes stale node flows on initial sync", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				node1Name string = "node1"
-				node1IP   string = "10.0.0.2"
-			)
-
-			fakeClient := fake.NewSimpleClientset(&v1.NodeList{
-				Items: []v1.Node{*createNode(node1Name, "linux", node1IP, nil)},
-			})
-
-			addNodeSetupCmds(fexec, thisNode)
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=0",
-				// Return output for a stale node
-				Output: ` cookie=0x0, duration=137014.498s, table=0, n_packets=20, n_bytes=2605, priority=100,ip,in_port="ext-vxlan",dl_dst=00:00:00:4d:d9:c1,nw_dst=10.128.1.0/24 actions=resubmit(,10)
- cookie=0x1f40e27c, duration=61107.432s, table=0, n_packets=0, n_bytes=0, priority=100,arp,in_port=ext,arp_tpa=10.132.0.0/24 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:00:00:00:33:65:d0,load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0x3365d0->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT
- cookie=0x1f40e27c, duration=61107.417s, table=0, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.132.0.0/24 actions=load:0x1001->NXM_NX_TUN_ID[0..31],load:0xac110003->NXM_NX_TUN_IPV4_DST[],mod_dl_dst:00:00:00:33:65:d0,output:"ext-vxlan"
- cookie=0x0, duration=61107.658s, table=0, n_packets=50, n_bytes=3576, priority=0 actions=drop`,
-			})
+			Expect(linuxNode.initialized).To(BeTrue())
+			// ovs commands generated by the initial sync
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				// Deletes flows for stale node in OVS
-				"ovs-ofctl del-flows br-ext cookie=0x1f40e27c/0xffffffff",
-			})
-
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
-
-			n, err := NewNode(
-				&kube.Kube{KClient: fakeClient},
-				thisNode,
-				f.Core().V1().Nodes().Informer(),
-				f.Core().V1().Pods().Informer(),
-				informer.NewTestEventHandler,
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.nodeEventHandler.Run(1, stopChan)
-			}()
-
-			//FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
-		appRun(app, netns)
-	})
-
-	ovntest.OnSupportedPlatformsIt("removes stale pod flows on initial sync", func() {
-		app.Action = func(ctx *cli.Context) error {
-			fakeClient := fake.NewSimpleClientset()
-
-			addNodeSetupCmds(fexec, thisNode)
-
-			// Put one live pod and one stale pod into the OVS bridge flows
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=10",
-				Output: ` cookie=0xaabbccdd, duration=29398.539s, table=10, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=1.2.3.4 actions=mod_dl_src:ab:cd:ef:ab:cd:ef,mod_dl_dst:ef:cd:ab:ef:cd:ab,output:ext
- cookie=0x0, duration=29398.687s, table=10, n_packets=0, n_bytes=0, priority=0 actions=drop`,
-			})
-			fexec.AddFakeCmdsNoOutputNoError([]string{
-				// Deletes flows for pod in OVS that is not in Kube
-				"ovs-ofctl del-flows br-ext cookie=0xaabbccdd/0xffffffff",
-				// provide cover for up to 3 runs of flows thread
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
 				"ovs-ofctl dump-flows --no-stats br-ext table=20",
 				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
-
-			n, err := NewNode(
-				&kube.Kube{KClient: fakeClient},
-				thisNode,
-				f.Core().V1().Nodes().Informer(),
-				f.Core().V1().Pods().Informer(),
-				informer.NewTestEventHandler,
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.Run(stopChan)
-			}()
-
-			// Wait for the controller to start
-			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.IsReady() == true, nil })
-			Expect(err).NotTo(HaveOccurred())
-
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
-			return nil
-		}
-		appRun(app, netns)
-	})
-
-	ovntest.OnSupportedPlatformsIt("sets up local pod flows", func() {
-		app.Action = func(ctx *cli.Context) error {
-			const (
-				pod1IP   string = "1.2.3.5"
-				pod1CIDR string = pod1IP + "/24"
-				pod1MAC  string = "aa:bb:cc:dd:ee:ff"
-			)
-
-			ns := &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					UID:  k8stypes.UID("test"),
-					Name: "test",
-					Annotations: map[string]string{
-						hotypes.HybridOverlayDRMAC: "00:11:22:33:44:55:66",
-					},
-				},
-				Spec:   v1.NamespaceSpec{},
-				Status: v1.NamespaceStatus{},
+			// perform the requested cacheSync
+			linuxNode.syncFlows()
+			initialFlowCache := map[string]*flowCacheEntry{
+				"0x0": generateInitialFlowCacheEntry(mgmtIfAddr.IP.String()),
 			}
-			fakeClient := fake.NewSimpleClientset([]runtime.Object{
-				ns,
-				createPod("test", "pod1", thisNode, pod1CIDR, pod1MAC),
-			}...)
+			Expect(compareFlowCache(linuxNode.flowCache, initialFlowCache)).NotTo(HaveOccurred())
 
-			_, hybMAC := addNodeSetupCmds(fexec, thisNode)
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			validateNetlinkState(thisNodeSubnet, thisNodeDRIP)
 
-			// Put one live pod and one stale pod into the OVS bridge flows
-			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovs-ofctl dump-flows br-ext table=10",
-				Output: ` cookie=0x7fdcde17, duration=29398.539s, table=10, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=` + pod1CIDR + ` actions=mod_dl_src:` + hybMAC + `,mod_dl_dst:` + pod1MAC + `,output:ext
- cookie=0x0, duration=29398.687s, table=10, n_packets=0, n_bytes=0, priority=0 actions=drop`,
-			})
+			windowsAnnotation := createNodeAnnotationsForSubnet(node1Subnet)
+			windowsAnnotation[hotypes.HybridOverlayDRMAC] = node1DRMAC
+			n.controller.AddNode(createNode(node1Name, "windows", node1IP, windowsAnnotation))
+
 			fexec.AddFakeCmdsNoOutputNoError([]string{
-				// provide cover for up to 3 runs of flows thread
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
-				"ovs-ofctl dump-flows --no-stats br-ext table=20",
-				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
 				"ovs-ofctl dump-flows --no-stats br-ext table=20",
 				"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
 			})
 
-			_, err := config.InitConfig(ctx, fexec, nil)
-			Expect(err).NotTo(HaveOccurred())
-			f := informers.NewSharedInformerFactory(fakeClient, informer.DefaultResyncInterval)
+			linuxNode.syncFlows()
+			node1Cookie := nameToCookie(node1Name)
+			initialFlowCache[node1Cookie] = &flowCacheEntry{
+				flows: []string{
+					"cookie=0x" + node1Cookie + ",table=0,priority=100,arp,in_port=ext,arp_tpa=" + node1Subnet + ",actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:" + node1DRMAC + ",load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0x" + strings.ReplaceAll(node1DRMAC, ":", "") + "->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT",
+					"cookie=0x" + node1Cookie + ",table=0,priority=100,ip,nw_dst=" + node1Subnet + ",actions=load:4097->NXM_NX_TUN_ID[0..31],set_field:" + node1IP + "->tun_dst,set_field:" + node1DRMAC + "->eth_dst,output:ext-vxlan",
+					"cookie=0x" + node1Cookie + ",table=0,priority=101,ip,nw_dst=" + node1Subnet + ",nw_src=100.64.0.3,actions=load:4097->NXM_NX_TUN_ID[0..31],set_field:" + thisNodeDRIP + "->nw_src,set_field:" + node1IP + "->tun_dst,set_field:" + node1DRMAC + "->eth_dst,output:ext-vxlan",
+				},
+			}
+			Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
+			Expect(compareFlowCache(linuxNode.flowCache, initialFlowCache)).NotTo(HaveOccurred())
 
-			n, err := NewNode(
-				&kube.Kube{KClient: fakeClient},
-				thisNode,
-				f.Core().V1().Nodes().Informer(),
-				f.Core().V1().Pods().Informer(),
-				informer.NewTestEventHandler,
-			)
-			Expect(err).NotTo(HaveOccurred())
-			// FIXME: DT Why are these needed?
-			// n.drIP = net.ParseIP(hybIP)
-			// n.drMAC, err = net.ParseMAC(hybMAC)
-			// Expect(err).NotTo(HaveOccurred())
-
-			f.Start(stopChan)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				n.Run(stopChan)
-			}()
-
-			// Wait for the controller to start
-			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) { return n.IsReady() == true, nil })
-			Expect(err).NotTo(HaveOccurred())
-
-			// FIXME
-			// Eventually(fexec.CalledMatchesExpected, 2).Should(BeTrue(), fexec.ErrorDesc)
 			return nil
 		}
 		appRun(app, netns)


### PR DESCRIPTION
general fixes to the windows node_linux.go testing to make the testing more meaningful. The tests are not ideal because there is no interface into fakeCmd to get the bundled ovs commands but we can compare the cache to what we believe it should be.

I also removed tests that where no longer meaningful

test "removes stale node flows on initial sync" and "removes stale pod flows on initial sync" are no longer needed because we sync to the flowCache on every sync and that stale nodes/pods will be taken care of then.

test "sets up local pod flows" is a duplicate of "sets up local linux pod" so I removed the former

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->