### PR TITLE
Egress Services: Fix nodeSelector parsing

### DIFF
--- a/go-controller/pkg/ovn/controller/egress_services/egress_services_service.go
+++ b/go-controller/pkg/ovn/controller/egress_services/egress_services_service.go
@@ -176,7 +176,7 @@ func (c *Controller) syncService(key string) error {
 		return c.clearServiceResources(key, state)
 	}
 
-	conf, err := util.ParseEgressSVCAnnotation(svc)
+	conf, err := util.ParseEgressSVCAnnotation(svc.Annotations)
 	if err != nil && !util.IsAnnotationNotSetError(err) {
 		return err
 	}
@@ -213,7 +213,11 @@ func (c *Controller) syncService(key string) error {
 		nodeSelector.MatchExpressions = append(nodeSelector.MatchExpressions, matchEpsNodes)
 	}
 
-	selector, _ := metav1.LabelSelectorAsSelector(nodeSelector)
+	selector, err := metav1.LabelSelectorAsSelector(nodeSelector)
+	if err != nil {
+		return err
+	}
+
 	totalEps := len(v4Endpoints) + len(v6Endpoints)
 
 	// We don't want to select a node for a service without endpoints to not "waste" an

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -919,836 +919,836 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
+	})
 
-		ginkgo.Context("on endpointslices changes", func() {
-			ginkgo.It("should create/update/delete logical router policies", func() {
-				app.Action = func(ctx *cli.Context) error {
-					namespaceT := *newNamespace("testns")
-					node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
+	ginkgo.Context("on endpointslices changes", func() {
+		ginkgo.It("should create/update/delete logical router policies", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespaceT := *newNamespace("testns")
+				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
 
-					clusterRouter := &nbdb.LogicalRouter{
-						Name: types.OVNClusterRouter,
-						UUID: types.OVNClusterRouter + "-UUID",
-					}
-
-					dbSetup := libovsdbtest.TestSetup{
-						NBData: []libovsdbtest.TestData{
-							clusterRouter,
-						},
-					}
-
-					ginkgo.By("creating a service with v4 endpoints that will be allocated on the node")
-					svc1 := svcFor("testns", "svc1", map[string]string{
-						util.EgressSVCAnnotation: "{}",
-					})
-
-					v4EpSlice := &discovery.EndpointSlice{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-ipv4-epslice",
-							Namespace: "testns",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-							ResourceVersion: "1",
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{"10.128.1.5"},
-							},
-							{
-								Addresses: []string{"10.128.1.6"},
-							},
-						},
-					}
-
-					v6EpSlice := &discovery.EndpointSlice{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-ipv6-epslice",
-							Namespace: "testns",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-							ResourceVersion: "1",
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{"fe00:10:128:1::5"},
-							},
-							{
-								Addresses: []string{"fe00:10:128:1::6"},
-							},
-						},
-					}
-
-					fakeOVN.startWithDBSetup(dbSetup,
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
-								namespaceT,
-							},
-						},
-						&v1.NodeList{
-							Items: []v1.Node{
-								*node1,
-							},
-						},
-						&v1.ServiceList{
-							Items: []v1.Service{
-								svc1,
-							},
-						},
-						&discovery.EndpointSliceList{
-							Items: []discovery.EndpointSlice{
-								*v4EpSlice,
-							},
-						},
-					)
-
-					fakeOVN.InitAndRunEgressSVCController()
-
-					v4lrp1 := lrpForEgressSvcEndpoint("v4lrp1-UUID", "testns/svc1", "10.128.1.5", "10.128.1.2")
-					v4lrp2 := lrpForEgressSvcEndpoint("v4lrp2-UUID", "testns/svc1", "10.128.1.6", "10.128.1.2")
-					clusterRouter.Policies = []string{"v4lrp1-UUID", "v4lrp2-UUID"}
-					expectedDatabaseState := []libovsdbtest.TestData{
-						clusterRouter,
-						v4lrp1,
-						v4lrp2,
-					}
-
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					ginkgo.By("creating the v6 endpoints corresponding lrps will be added")
-					v6EpSlice, err := fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Create(context.TODO(), v6EpSlice, metav1.CreateOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					v6lrp1 := lrpForEgressSvcEndpoint("v6lrp1-UUID", "testns/svc1", "fe00:10:128:1::5", "fe00:10:128:1::2")
-					v6lrp2 := lrpForEgressSvcEndpoint("v6lrp2-UUID", "testns/svc1", "fe00:10:128:1::6", "fe00:10:128:1::2")
-
-					clusterRouter.Policies = []string{"v4lrp1-UUID", "v4lrp2-UUID", "v6lrp1-UUID", "v6lrp2-UUID"}
-					expectedDatabaseState = []libovsdbtest.TestData{
-						clusterRouter,
-						v4lrp1,
-						v4lrp2,
-						v6lrp1,
-						v6lrp2,
-					}
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					ginkgo.By("updating the v4 and v6 endpoints the lrps will be updated accordingly")
-					v4EpSlice.Endpoints = append(v4EpSlice.Endpoints, discovery.Endpoint{Addresses: []string{"10.128.1.7"}})
-					v4EpSlice.ResourceVersion = "2"
-					v4EpSlice, err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v4EpSlice, metav1.UpdateOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					v6EpSlice.Endpoints = []discovery.Endpoint{{Addresses: []string{"fe00:10:128:1::5"}}}
-					v6EpSlice.ResourceVersion = "2"
-					v6EpSlice, err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v6EpSlice, metav1.UpdateOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					v4lrp3 := lrpForEgressSvcEndpoint("v4lrp3-UUID", "testns/svc1", "10.128.1.7", "10.128.1.2")
-					clusterRouter.Policies = []string{"v4lrp1-UUID", "v4lrp2-UUID", "v4lrp3-UUID", "v6lrp1-UUID"}
-					expectedDatabaseState = []libovsdbtest.TestData{
-						clusterRouter,
-						v4lrp1,
-						v4lrp2,
-						v4lrp3,
-						v6lrp1,
-					}
-
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					ginkgo.By("deleting the v4 endpoints the corresponding lrps will be deleted")
-					err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Delete(context.TODO(), v4EpSlice.Name, metav1.DeleteOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-					clusterRouter.Policies = []string{"v6lrp1-UUID"}
-					expectedDatabaseState = []libovsdbtest.TestData{
-						clusterRouter,
-						v6lrp1,
-					}
-
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					ginkgo.By("deleting the v6 endpoints the corresponding lrps will be deleted")
-					err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Delete(context.TODO(), v6EpSlice.Name, metav1.DeleteOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-					clusterRouter.Policies = []string{}
-					expectedDatabaseState = []libovsdbtest.TestData{
-						clusterRouter,
-					}
-
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					return nil
+				clusterRouter := &nbdb.LogicalRouter{
+					Name: types.OVNClusterRouter,
+					UUID: types.OVNClusterRouter + "-UUID",
 				}
-				err := app.Run([]string{app.Name})
+
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						clusterRouter,
+					},
+				}
+
+				ginkgo.By("creating a service with v4 endpoints that will be allocated on the node")
+				svc1 := svcFor("testns", "svc1", map[string]string{
+					util.EgressSVCAnnotation: "{}",
+				})
+
+				v4EpSlice := &discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1-ipv4-epslice",
+						Namespace: "testns",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc1",
+						},
+						ResourceVersion: "1",
+					},
+					AddressType: discovery.AddressTypeIPv4,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.128.1.5"},
+						},
+						{
+							Addresses: []string{"10.128.1.6"},
+						},
+					},
+				}
+
+				v6EpSlice := &discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1-ipv6-epslice",
+						Namespace: "testns",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc1",
+						},
+						ResourceVersion: "1",
+					},
+					AddressType: discovery.AddressTypeIPv6,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"fe00:10:128:1::5"},
+						},
+						{
+							Addresses: []string{"fe00:10:128:1::6"},
+						},
+					},
+				}
+
+				fakeOVN.startWithDBSetup(dbSetup,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							*node1,
+						},
+					},
+					&v1.ServiceList{
+						Items: []v1.Service{
+							svc1,
+						},
+					},
+					&discovery.EndpointSliceList{
+						Items: []discovery.EndpointSlice{
+							*v4EpSlice,
+						},
+					},
+				)
+
+				fakeOVN.InitAndRunEgressSVCController()
+
+				v4lrp1 := lrpForEgressSvcEndpoint("v4lrp1-UUID", "testns/svc1", "10.128.1.5", "10.128.1.2")
+				v4lrp2 := lrpForEgressSvcEndpoint("v4lrp2-UUID", "testns/svc1", "10.128.1.6", "10.128.1.2")
+				clusterRouter.Policies = []string{"v4lrp1-UUID", "v4lrp2-UUID"}
+				expectedDatabaseState := []libovsdbtest.TestData{
+					clusterRouter,
+					v4lrp1,
+					v4lrp2,
+				}
+
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("creating the v6 endpoints corresponding lrps will be added")
+				v6EpSlice, err := fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Create(context.TODO(), v6EpSlice, metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			})
 
-			ginkgo.It("should create/update/delete logical router policies for ETP=Local Service", func() {
-				app.Action = func(ctx *cli.Context) error {
-					namespaceT := *newNamespace("testns")
-					node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
-					node1.Labels["square"] = "pants"
-					node2 := nodeFor(node2Name, node2IPv4, node2IPv6, node2IPv4Subnet, node2IPv6Subnet)
+				v6lrp1 := lrpForEgressSvcEndpoint("v6lrp1-UUID", "testns/svc1", "fe00:10:128:1::5", "fe00:10:128:1::2")
+				v6lrp2 := lrpForEgressSvcEndpoint("v6lrp2-UUID", "testns/svc1", "fe00:10:128:1::6", "fe00:10:128:1::2")
 
-					clusterRouter := &nbdb.LogicalRouter{
-						Name: types.OVNClusterRouter,
-						UUID: types.OVNClusterRouter + "-UUID",
-					}
+				clusterRouter.Policies = []string{"v4lrp1-UUID", "v4lrp2-UUID", "v6lrp1-UUID", "v6lrp2-UUID"}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+					v4lrp1,
+					v4lrp2,
+					v6lrp1,
+					v6lrp2,
+				}
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
-					dbSetup := libovsdbtest.TestSetup{
-						NBData: []libovsdbtest.TestData{
-							clusterRouter,
-						},
-					}
+				ginkgo.By("updating the v4 and v6 endpoints the lrps will be updated accordingly")
+				v4EpSlice.Endpoints = append(v4EpSlice.Endpoints, discovery.Endpoint{Addresses: []string{"10.128.1.7"}})
+				v4EpSlice.ResourceVersion = "2"
+				v4EpSlice, err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v4EpSlice, metav1.UpdateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-					ginkgo.By("creating a service with a selector matching a node without local eps lrps should not be created")
-					svc1 := svcFor("testns", "svc1", map[string]string{
-						util.EgressSVCAnnotation: "{\"nodeSelector\":{\"matchLabels\":{\"square\": \"pants\"}}}",
-					})
-					svc1.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+				v6EpSlice.Endpoints = []discovery.Endpoint{{Addresses: []string{"fe00:10:128:1::5"}}}
+				v6EpSlice.ResourceVersion = "2"
+				v6EpSlice, err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v6EpSlice, metav1.UpdateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-					v4EpSlice := &discovery.EndpointSlice{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-epslice",
-							Namespace: "testns",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-							ResourceVersion: "1",
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{"10.128.2.5"},
-								NodeName:  &node2.Name,
-							},
-						},
-					}
+				v4lrp3 := lrpForEgressSvcEndpoint("v4lrp3-UUID", "testns/svc1", "10.128.1.7", "10.128.1.2")
+				clusterRouter.Policies = []string{"v4lrp1-UUID", "v4lrp2-UUID", "v4lrp3-UUID", "v6lrp1-UUID"}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+					v4lrp1,
+					v4lrp2,
+					v4lrp3,
+					v6lrp1,
+				}
 
-					fakeOVN.startWithDBSetup(dbSetup,
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
-								namespaceT,
-							},
-						},
-						&v1.NodeList{
-							Items: []v1.Node{
-								*node1,
-							},
-						},
-						&v1.ServiceList{
-							Items: []v1.Service{
-								svc1,
-							},
-						},
-						&discovery.EndpointSliceList{
-							Items: []discovery.EndpointSlice{
-								*v4EpSlice,
-							},
-						},
-					)
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
-					fakeOVN.InitAndRunEgressSVCController()
+				ginkgo.By("deleting the v4 endpoints the corresponding lrps will be deleted")
+				err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Delete(context.TODO(), v4EpSlice.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				clusterRouter.Policies = []string{"v6lrp1-UUID"}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+					v6lrp1,
+				}
 
-					expectedDatabaseState := []libovsdbtest.TestData{
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("deleting the v6 endpoints the corresponding lrps will be deleted")
+				err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Delete(context.TODO(), v6EpSlice.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				clusterRouter.Policies = []string{}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+				}
+
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should create/update/delete logical router policies for ETP=Local Service", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespaceT := *newNamespace("testns")
+				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
+				node1.Labels["square"] = "pants"
+				node2 := nodeFor(node2Name, node2IPv4, node2IPv6, node2IPv4Subnet, node2IPv6Subnet)
+
+				clusterRouter := &nbdb.LogicalRouter{
+					Name: types.OVNClusterRouter,
+					UUID: types.OVNClusterRouter + "-UUID",
+				}
+
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
 						clusterRouter,
-					}
+					},
+				}
 
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-					gomega.Consistently(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				ginkgo.By("creating a service with a selector matching a node without local eps lrps should not be created")
+				svc1 := svcFor("testns", "svc1", map[string]string{
+					util.EgressSVCAnnotation: "{\"nodeSelector\":{\"matchLabels\":{\"square\": \"pants\"}}}",
+				})
+				svc1.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 
-					ginkgo.By("updating the endpointslice to have an endpoint on node1 corresponding lrps will be created")
-					v4EpSlice.Endpoints = append(v4EpSlice.Endpoints, discovery.Endpoint{
-						Addresses: []string{"10.128.1.5"},
-						NodeName:  &node1.Name,
-					})
-					v4EpSlice, err := fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v4EpSlice, metav1.UpdateOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					v4lrp1 := lrpForEgressSvcEndpoint("v4lrp1-UUID", "testns/svc1", "10.128.1.5", "10.128.1.2")
-					v4lrp2 := lrpForEgressSvcEndpoint("v4lrp2-UUID", "testns/svc1", "10.128.2.5", "10.128.1.2")
-
-					clusterRouter.Policies = []string{"v4lrp1-UUID", "v4lrp2-UUID"}
-					expectedDatabaseState = []libovsdbtest.TestData{
-						clusterRouter,
-						v4lrp1,
-						v4lrp2,
-					}
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					ginkgo.By("removing node1's local ep should delete both lrps")
-					v4EpSlice.Endpoints = append(v4EpSlice.Endpoints, discovery.Endpoint{Addresses: []string{"10.128.1.7"}})
-					v4EpSlice.ResourceVersion = "2"
-					v4EpSlice, err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v4EpSlice, metav1.UpdateOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					v4EpSlice.Endpoints = []discovery.Endpoint{
+				v4EpSlice := &discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1-epslice",
+						Namespace: "testns",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc1",
+						},
+						ResourceVersion: "1",
+					},
+					AddressType: discovery.AddressTypeIPv4,
+					Endpoints: []discovery.Endpoint{
 						{
 							Addresses: []string{"10.128.2.5"},
 							NodeName:  &node2.Name,
 						},
-					}
-					v4EpSlice.ResourceVersion = "3"
-					v4EpSlice, err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v4EpSlice, metav1.UpdateOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					clusterRouter.Policies = []string{}
-					expectedDatabaseState = []libovsdbtest.TestData{
-						clusterRouter,
-					}
-
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					return nil
+					},
 				}
-				err := app.Run([]string{app.Name})
+
+				fakeOVN.startWithDBSetup(dbSetup,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							*node1,
+						},
+					},
+					&v1.ServiceList{
+						Items: []v1.Service{
+							svc1,
+						},
+					},
+					&discovery.EndpointSliceList{
+						Items: []discovery.EndpointSlice{
+							*v4EpSlice,
+						},
+					},
+				)
+
+				fakeOVN.InitAndRunEgressSVCController()
+
+				expectedDatabaseState := []libovsdbtest.TestData{
+					clusterRouter,
+				}
+
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				gomega.Consistently(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("updating the endpointslice to have an endpoint on node1 corresponding lrps will be created")
+				v4EpSlice.Endpoints = append(v4EpSlice.Endpoints, discovery.Endpoint{
+					Addresses: []string{"10.128.1.5"},
+					NodeName:  &node1.Name,
+				})
+				v4EpSlice, err := fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v4EpSlice, metav1.UpdateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			})
+
+				v4lrp1 := lrpForEgressSvcEndpoint("v4lrp1-UUID", "testns/svc1", "10.128.1.5", "10.128.1.2")
+				v4lrp2 := lrpForEgressSvcEndpoint("v4lrp2-UUID", "testns/svc1", "10.128.2.5", "10.128.1.2")
+
+				clusterRouter.Policies = []string{"v4lrp1-UUID", "v4lrp2-UUID"}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+					v4lrp1,
+					v4lrp2,
+				}
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("removing node1's local ep should delete both lrps")
+				v4EpSlice.Endpoints = append(v4EpSlice.Endpoints, discovery.Endpoint{Addresses: []string{"10.128.1.7"}})
+				v4EpSlice.ResourceVersion = "2"
+				v4EpSlice, err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v4EpSlice, metav1.UpdateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				v4EpSlice.Endpoints = []discovery.Endpoint{
+					{
+						Addresses: []string{"10.128.2.5"},
+						NodeName:  &node2.Name,
+					},
+				}
+				v4EpSlice.ResourceVersion = "3"
+				v4EpSlice, err = fakeOVN.fakeClient.KubeClient.DiscoveryV1().EndpointSlices("testns").Update(context.TODO(), v4EpSlice, metav1.UpdateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				clusterRouter.Policies = []string{}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+				}
+
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
-
-		ginkgo.Context("on nodes changes", func() {
-			ginkgo.It("should create/update/delete logical router policies, labels and annotations", func() {
-				app.Action = func(ctx *cli.Context) error {
-					namespaceT := *newNamespace("testns")
-					node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
-					node1.Labels = map[string]string{"home": "pineapple"}
-					node2 := nodeFor(node2Name, node2IPv4, node2IPv6, node2IPv4Subnet, node2IPv6Subnet)
-					node2.Labels = map[string]string{"home": "rock"}
-
-					clusterRouter := &nbdb.LogicalRouter{
-						Name: types.OVNClusterRouter,
-						UUID: types.OVNClusterRouter + "-UUID",
-					}
-
-					dbSetup := libovsdbtest.TestSetup{
-						NBData: []libovsdbtest.TestData{
-							clusterRouter,
-						},
-					}
-
-					ginkgo.By("creating two services with different selectors")
-					svc1 := svcFor("testns", "svc1", map[string]string{
-						util.EgressSVCAnnotation: "{\"nodeSelector\":{\"matchLabels\":{\"home\": \"pineapple\"}}}",
-					})
-					svc2 := svcFor("testns", "svc2", map[string]string{
-						util.EgressSVCAnnotation: "{\"nodeSelector\":{\"matchLabels\":{\"home\": \"moai\"}}}",
-					})
-
-					svc1V4EpSlice := discovery.EndpointSlice{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-ipv4-epslice",
-							Namespace: "testns",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{"10.128.1.5"},
-							},
-						},
-					}
-
-					svc1V6EpSlice := discovery.EndpointSlice{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-ipv6-epslice",
-							Namespace: "testns",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{"fe00:10:128:1::5"},
-							},
-						},
-					}
-
-					svc2V4EpSlice := discovery.EndpointSlice{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc2-ipv4-epslice",
-							Namespace: "testns",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc2",
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{"10.128.2.5"},
-							},
-						},
-					}
-
-					svc2V6EpSlice := discovery.EndpointSlice{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc2-ipv6-epslice",
-							Namespace: "testns",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc2",
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{"fe00:10:128:2::5"},
-							},
-						},
-					}
-
-					fakeOVN.startWithDBSetup(dbSetup,
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
-								namespaceT,
-							},
-						},
-						&v1.NodeList{
-							Items: []v1.Node{
-								*node1,
-								*node2,
-							},
-						},
-						&v1.ServiceList{
-							Items: []v1.Service{
-								svc1,
-								svc2,
-							},
-						},
-						&discovery.EndpointSliceList{
-							Items: []discovery.EndpointSlice{
-								svc1V4EpSlice,
-								svc1V6EpSlice,
-								svc2V4EpSlice,
-								svc2V6EpSlice,
-							},
-						},
-					)
-
-					fakeOVN.InitAndRunEgressSVCController()
-					gomega.Eventually(func() error {
-						svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						val := svc.Annotations[util.EgressSVCHostAnnotation]
-						if val != node1Name {
-							return fmt.Errorf("expected svc1's host annotation value %s to be node1", val)
-						}
-
-						node1ExpectedLabels := map[string]string{
-							"home": "pineapple",
-							fmt.Sprintf("%s/testns-svc1", util.EgressSVCLabelPrefix): "",
-						}
-
-						node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
-							return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
-						}
-
-						return nil
-					}).ShouldNot(gomega.HaveOccurred())
-					gomega.Eventually(func() error {
-						svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc2.Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						val, ok := svc.Annotations[util.EgressSVCHostAnnotation]
-						if ok {
-							return fmt.Errorf("expected svc2's egress host annotation to be empty, got: %s", val)
-						}
-
-						node2ExpectedLabels := map[string]string{
-							"home": "rock",
-						}
-
-						node2, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node2Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						if !reflect.DeepEqual(node2.Labels, node2ExpectedLabels) {
-							return fmt.Errorf("expected node2's labels %v to be equal %v", node2.Labels, node2ExpectedLabels)
-						}
-
-						return nil
-					}).ShouldNot(gomega.HaveOccurred())
-
-					svc1v4lrp1 := lrpForEgressSvcEndpoint("svc1v4lrp1-UUID", "testns/svc1", "10.128.1.5", "10.128.1.2")
-					svc1v6lrp1 := lrpForEgressSvcEndpoint("svc1v6lrp1-UUID", "testns/svc1", "fe00:10:128:1::5", "fe00:10:128:1::2")
-					clusterRouter.Policies = []string{"svc1v4lrp1-UUID", "svc1v6lrp1-UUID"}
-					expectedDatabaseState := []libovsdbtest.TestData{
-						clusterRouter,
-						svc1v4lrp1,
-						svc1v6lrp1,
-					}
-
-					for _, lrp := range getDefaultNoReroutePolicies(*node1, *node2) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					ginkgo.By("updating the first node's to be not ready the resources of first service will be deleted")
-					node1.Status.Conditions = []v1.NodeCondition{
-						{
-							Type:   v1.NodeReady,
-							Status: v1.ConditionFalse,
-						},
-					}
-					node1.ResourceVersion = "2"
-					node1, err := fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node1, metav1.UpdateOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					ginkgo.By("updating the second node's labels to match the second service will allocate it")
-					node2.Labels["home"] = "moai"
-					node2.ResourceVersion = "2"
-					node2, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					gomega.Eventually(func() error {
-						svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						val, ok := svc.Annotations[util.EgressSVCHostAnnotation]
-						if ok {
-							return fmt.Errorf("expected svc1's egress host annotation to be empty, got: %s", val)
-						}
-
-						node1ExpectedLabels := map[string]string{
-							"home": "pineapple",
-						}
-
-						node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
-							return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
-						}
-
-						return nil
-					}).ShouldNot(gomega.HaveOccurred())
-
-					gomega.Eventually(func() error {
-						svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc2.Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						val := svc.Annotations[util.EgressSVCHostAnnotation]
-						if val != node2Name {
-							return fmt.Errorf("expected svc2's host annotation value %s to be node2", val)
-						}
-
-						node2ExpectedLabels := map[string]string{
-							"home": "moai",
-							fmt.Sprintf("%s/testns-svc2", util.EgressSVCLabelPrefix): "",
-						}
-
-						node2, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node2Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						if !reflect.DeepEqual(node2.Labels, node2ExpectedLabels) {
-							return fmt.Errorf("expected node2's labels %v to be equal %v", node2.Labels, node2ExpectedLabels)
-						}
-
-						return nil
-					}).ShouldNot(gomega.HaveOccurred())
-
-					svc2v4lrp1 := lrpForEgressSvcEndpoint("svc2v4lrp1-UUID", "testns/svc2", "10.128.2.5", "10.128.2.2")
-					svc2v6lrp1 := lrpForEgressSvcEndpoint("svc2v6lrp1-UUID", "testns/svc2", "fe00:10:128:2::5", "fe00:10:128:2::2")
-					clusterRouter.Policies = []string{"svc2v4lrp1-UUID", "svc2v6lrp1-UUID"}
-					expectedDatabaseState = []libovsdbtest.TestData{
-						clusterRouter,
-						svc2v4lrp1,
-						svc2v6lrp1,
-					}
-					for _, lrp := range getDefaultNoReroutePolicies(*node1, *node2) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					ginkgo.By("deleting the second node the second service's resources will be deleted")
-					err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node2.Name, metav1.DeleteOptions{})
-					gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-					clusterRouter.Policies = []string{}
-					expectedDatabaseState = []libovsdbtest.TestData{
-						clusterRouter,
-					}
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					return nil
-				}
-				err := app.Run([]string{app.Name})
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			})
-
-			ginkgo.It("should update logical router policies, labels and annotations on reachability failure", func() {
-				app.Action = func(ctx *cli.Context) error {
-					namespaceT := *newNamespace("testns")
-					node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
-
-					clusterRouter := &nbdb.LogicalRouter{
-						Name: types.OVNClusterRouter,
-						UUID: types.OVNClusterRouter + "-UUID",
-					}
-
-					dbSetup := libovsdbtest.TestSetup{
-						NBData: []libovsdbtest.TestData{
-							clusterRouter,
-						},
-					}
-
-					ginkgo.By("creating a service selecting the node")
-					svc1 := svcFor("testns", "svc1", map[string]string{
-						util.EgressSVCAnnotation: "{\"nodeSelector\":{\"matchLabels\":{\"kubernetes.io/hostname\": \"node1\"}}}",
-					})
-
-					svc1V4EpSlice := discovery.EndpointSlice{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-ipv4-epslice",
-							Namespace: "testns",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						AddressType: discovery.AddressTypeIPv4,
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{"10.128.1.5"},
-							},
-						},
-					}
-
-					svc1V6EpSlice := discovery.EndpointSlice{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "svc1-ipv6-epslice",
-							Namespace: "testns",
-							Labels: map[string]string{
-								discovery.LabelServiceName: "svc1",
-							},
-						},
-						AddressType: discovery.AddressTypeIPv6,
-						Endpoints: []discovery.Endpoint{
-							{
-								Addresses: []string{"fe00:10:128:1::5"},
-							},
-						},
-					}
-
-					fakeOVN.startWithDBSetup(dbSetup,
-						&v1.NamespaceList{
-							Items: []v1.Namespace{
-								namespaceT,
-							},
-						},
-						&v1.NodeList{
-							Items: []v1.Node{
-								*node1,
-							},
-						},
-						&v1.ServiceList{
-							Items: []v1.Service{
-								svc1,
-							},
-						},
-						&discovery.EndpointSliceList{
-							Items: []discovery.EndpointSlice{
-								svc1V4EpSlice,
-								svc1V6EpSlice,
-							},
-						},
-					)
-
-					ginkgo.By("modifying the controller's IsReachable func to return false on the first call and true for the second")
-					count := 0
-					fakeOVN.controller.egressSvcController.IsReachable = func(nodeName string, _ []net.IP, _ healthcheck.EgressIPHealthClient) bool {
-						count++
-						return count == 2
-					}
-					fakeOVN.InitAndRunEgressSVCController()
-					gomega.Eventually(func() error {
-						svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						val := svc.Annotations[util.EgressSVCHostAnnotation]
-						if val != node1Name {
-							return fmt.Errorf("expected svc1's host annotation value %s to be node1", val)
-						}
-
-						node1ExpectedLabels := map[string]string{
-							"kubernetes.io/hostname":                                 "node1",
-							fmt.Sprintf("%s/testns-svc1", util.EgressSVCLabelPrefix): "",
-						}
-
-						node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
-							return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
-						}
-
-						return nil
-					}).ShouldNot(gomega.HaveOccurred())
-
-					svc1v4lrp1 := lrpForEgressSvcEndpoint("svc1v4lrp1-UUID", "testns/svc1", "10.128.1.5", "10.128.1.2")
-					svc1v6lrp1 := lrpForEgressSvcEndpoint("svc1v6lrp1-UUID", "testns/svc1", "fe00:10:128:1::5", "fe00:10:128:1::2")
-					clusterRouter.Policies = []string{"svc1v4lrp1-UUID", "svc1v6lrp1-UUID"}
-					expectedDatabaseState := []libovsdbtest.TestData{
-						clusterRouter,
-						svc1v4lrp1,
-						svc1v6lrp1,
-					}
-
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					ginkgo.By("calling the reachability check which will return that the node is unreachable it will be drained")
-					fakeOVN.controller.egressSvcController.CheckNodesReachabilityIterate()
-					gomega.Eventually(func() error {
-						svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						val, ok := svc.Annotations[util.EgressSVCHostAnnotation]
-						if ok {
-							return fmt.Errorf("expected svc1's egress host annotation to be empty, got: %s", val)
-						}
-
-						node1ExpectedLabels := map[string]string{
-							"kubernetes.io/hostname": "node1",
-						}
-
-						node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
-							return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
-						}
-
-						return nil
-					}).ShouldNot(gomega.HaveOccurred())
-					clusterRouter.Policies = []string{}
-					expectedDatabaseState = []libovsdbtest.TestData{clusterRouter}
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-
-					ginkgo.By("calling the reachability check which will return that the node is reachable the service will be reallocated")
-					fakeOVN.controller.egressSvcController.CheckNodesReachabilityIterate()
-					gomega.Eventually(func() error {
-						svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						val := svc.Annotations[util.EgressSVCHostAnnotation]
-						if val != node1Name {
-							return fmt.Errorf("expected svc1's host annotation value %s to be node1", val)
-						}
-
-						node1ExpectedLabels := map[string]string{
-							"kubernetes.io/hostname":                                 "node1",
-							fmt.Sprintf("%s/testns-svc1", util.EgressSVCLabelPrefix): "",
-						}
-
-						node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-
-						if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
-							return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
-						}
-
-						return nil
-					}).ShouldNot(gomega.HaveOccurred())
-
-					clusterRouter.Policies = []string{"svc1v4lrp1-UUID", "svc1v6lrp1-UUID"}
-					expectedDatabaseState = []libovsdbtest.TestData{
-						clusterRouter,
-						svc1v4lrp1,
-						svc1v6lrp1,
-					}
-
-					for _, lrp := range getDefaultNoReroutePolicies(*node1) {
-						expectedDatabaseState = append(expectedDatabaseState, lrp)
-						clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
-					}
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
-					return nil
-				}
-				err := app.Run([]string{app.Name})
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			})
-		})
-
 	})
+
+	ginkgo.Context("on nodes changes", func() {
+		ginkgo.It("should create/update/delete logical router policies, labels and annotations", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespaceT := *newNamespace("testns")
+				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
+				node1.Labels = map[string]string{"home": "pineapple"}
+				node2 := nodeFor(node2Name, node2IPv4, node2IPv6, node2IPv4Subnet, node2IPv6Subnet)
+				node2.Labels = map[string]string{"home": "rock"}
+
+				clusterRouter := &nbdb.LogicalRouter{
+					Name: types.OVNClusterRouter,
+					UUID: types.OVNClusterRouter + "-UUID",
+				}
+
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						clusterRouter,
+					},
+				}
+
+				ginkgo.By("creating two services with different selectors")
+				svc1 := svcFor("testns", "svc1", map[string]string{
+					util.EgressSVCAnnotation: "{\"nodeSelector\":{\"matchLabels\":{\"home\": \"pineapple\"}}}",
+				})
+				svc2 := svcFor("testns", "svc2", map[string]string{
+					util.EgressSVCAnnotation: "{\"nodeSelector\":{\"matchLabels\":{\"home\": \"moai\"}}}",
+				})
+
+				svc1V4EpSlice := discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1-ipv4-epslice",
+						Namespace: "testns",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc1",
+						},
+					},
+					AddressType: discovery.AddressTypeIPv4,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.128.1.5"},
+						},
+					},
+				}
+
+				svc1V6EpSlice := discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1-ipv6-epslice",
+						Namespace: "testns",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc1",
+						},
+					},
+					AddressType: discovery.AddressTypeIPv6,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"fe00:10:128:1::5"},
+						},
+					},
+				}
+
+				svc2V4EpSlice := discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc2-ipv4-epslice",
+						Namespace: "testns",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc2",
+						},
+					},
+					AddressType: discovery.AddressTypeIPv4,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.128.2.5"},
+						},
+					},
+				}
+
+				svc2V6EpSlice := discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc2-ipv6-epslice",
+						Namespace: "testns",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc2",
+						},
+					},
+					AddressType: discovery.AddressTypeIPv6,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"fe00:10:128:2::5"},
+						},
+					},
+				}
+
+				fakeOVN.startWithDBSetup(dbSetup,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							*node1,
+							*node2,
+						},
+					},
+					&v1.ServiceList{
+						Items: []v1.Service{
+							svc1,
+							svc2,
+						},
+					},
+					&discovery.EndpointSliceList{
+						Items: []discovery.EndpointSlice{
+							svc1V4EpSlice,
+							svc1V6EpSlice,
+							svc2V4EpSlice,
+							svc2V6EpSlice,
+						},
+					},
+				)
+
+				fakeOVN.InitAndRunEgressSVCController()
+				gomega.Eventually(func() error {
+					svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					val := svc.Annotations[util.EgressSVCHostAnnotation]
+					if val != node1Name {
+						return fmt.Errorf("expected svc1's host annotation value %s to be node1", val)
+					}
+
+					node1ExpectedLabels := map[string]string{
+						"home": "pineapple",
+						fmt.Sprintf("%s/testns-svc1", util.EgressSVCLabelPrefix): "",
+					}
+
+					node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
+						return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
+					}
+
+					return nil
+				}).ShouldNot(gomega.HaveOccurred())
+				gomega.Eventually(func() error {
+					svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc2.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					val, ok := svc.Annotations[util.EgressSVCHostAnnotation]
+					if ok {
+						return fmt.Errorf("expected svc2's egress host annotation to be empty, got: %s", val)
+					}
+
+					node2ExpectedLabels := map[string]string{
+						"home": "rock",
+					}
+
+					node2, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node2Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					if !reflect.DeepEqual(node2.Labels, node2ExpectedLabels) {
+						return fmt.Errorf("expected node2's labels %v to be equal %v", node2.Labels, node2ExpectedLabels)
+					}
+
+					return nil
+				}).ShouldNot(gomega.HaveOccurred())
+
+				svc1v4lrp1 := lrpForEgressSvcEndpoint("svc1v4lrp1-UUID", "testns/svc1", "10.128.1.5", "10.128.1.2")
+				svc1v6lrp1 := lrpForEgressSvcEndpoint("svc1v6lrp1-UUID", "testns/svc1", "fe00:10:128:1::5", "fe00:10:128:1::2")
+				clusterRouter.Policies = []string{"svc1v4lrp1-UUID", "svc1v6lrp1-UUID"}
+				expectedDatabaseState := []libovsdbtest.TestData{
+					clusterRouter,
+					svc1v4lrp1,
+					svc1v6lrp1,
+				}
+
+				for _, lrp := range getDefaultNoReroutePolicies(*node1, *node2) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("updating the first node's to be not ready the resources of first service will be deleted")
+				node1.Status.Conditions = []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionFalse,
+					},
+				}
+				node1.ResourceVersion = "2"
+				node1, err := fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node1, metav1.UpdateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				ginkgo.By("updating the second node's labels to match the second service will allocate it")
+				node2.Labels["home"] = "moai"
+				node2.ResourceVersion = "2"
+				node2, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), node2, metav1.UpdateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Eventually(func() error {
+					svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					val, ok := svc.Annotations[util.EgressSVCHostAnnotation]
+					if ok {
+						return fmt.Errorf("expected svc1's egress host annotation to be empty, got: %s", val)
+					}
+
+					node1ExpectedLabels := map[string]string{
+						"home": "pineapple",
+					}
+
+					node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
+						return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
+					}
+
+					return nil
+				}).ShouldNot(gomega.HaveOccurred())
+
+				gomega.Eventually(func() error {
+					svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc2.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					val := svc.Annotations[util.EgressSVCHostAnnotation]
+					if val != node2Name {
+						return fmt.Errorf("expected svc2's host annotation value %s to be node2", val)
+					}
+
+					node2ExpectedLabels := map[string]string{
+						"home": "moai",
+						fmt.Sprintf("%s/testns-svc2", util.EgressSVCLabelPrefix): "",
+					}
+
+					node2, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node2Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					if !reflect.DeepEqual(node2.Labels, node2ExpectedLabels) {
+						return fmt.Errorf("expected node2's labels %v to be equal %v", node2.Labels, node2ExpectedLabels)
+					}
+
+					return nil
+				}).ShouldNot(gomega.HaveOccurred())
+
+				svc2v4lrp1 := lrpForEgressSvcEndpoint("svc2v4lrp1-UUID", "testns/svc2", "10.128.2.5", "10.128.2.2")
+				svc2v6lrp1 := lrpForEgressSvcEndpoint("svc2v6lrp1-UUID", "testns/svc2", "fe00:10:128:2::5", "fe00:10:128:2::2")
+				clusterRouter.Policies = []string{"svc2v4lrp1-UUID", "svc2v6lrp1-UUID"}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+					svc2v4lrp1,
+					svc2v6lrp1,
+				}
+				for _, lrp := range getDefaultNoReroutePolicies(*node1, *node2) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("deleting the second node the second service's resources will be deleted")
+				err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node2.Name, metav1.DeleteOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				clusterRouter.Policies = []string{}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+				}
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should update logical router policies, labels and annotations on reachability failure", func() {
+			app.Action = func(ctx *cli.Context) error {
+				namespaceT := *newNamespace("testns")
+				node1 := nodeFor(node1Name, node1IPv4, node1IPv6, node1IPv4Subnet, node1IPv6Subnet)
+
+				clusterRouter := &nbdb.LogicalRouter{
+					Name: types.OVNClusterRouter,
+					UUID: types.OVNClusterRouter + "-UUID",
+				}
+
+				dbSetup := libovsdbtest.TestSetup{
+					NBData: []libovsdbtest.TestData{
+						clusterRouter,
+					},
+				}
+
+				ginkgo.By("creating a service selecting the node")
+				svc1 := svcFor("testns", "svc1", map[string]string{
+					util.EgressSVCAnnotation: "{\"nodeSelector\":{\"matchLabels\":{\"kubernetes.io/hostname\": \"node1\"}}}",
+				})
+
+				svc1V4EpSlice := discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1-ipv4-epslice",
+						Namespace: "testns",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc1",
+						},
+					},
+					AddressType: discovery.AddressTypeIPv4,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"10.128.1.5"},
+						},
+					},
+				}
+
+				svc1V6EpSlice := discovery.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1-ipv6-epslice",
+						Namespace: "testns",
+						Labels: map[string]string{
+							discovery.LabelServiceName: "svc1",
+						},
+					},
+					AddressType: discovery.AddressTypeIPv6,
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{"fe00:10:128:1::5"},
+						},
+					},
+				}
+
+				fakeOVN.startWithDBSetup(dbSetup,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{
+							*node1,
+						},
+					},
+					&v1.ServiceList{
+						Items: []v1.Service{
+							svc1,
+						},
+					},
+					&discovery.EndpointSliceList{
+						Items: []discovery.EndpointSlice{
+							svc1V4EpSlice,
+							svc1V6EpSlice,
+						},
+					},
+				)
+
+				ginkgo.By("modifying the controller's IsReachable func to return false on the first call and true for the second")
+				count := 0
+				fakeOVN.controller.egressSvcController.IsReachable = func(nodeName string, _ []net.IP, _ healthcheck.EgressIPHealthClient) bool {
+					count++
+					return count == 2
+				}
+				fakeOVN.InitAndRunEgressSVCController()
+				gomega.Eventually(func() error {
+					svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					val := svc.Annotations[util.EgressSVCHostAnnotation]
+					if val != node1Name {
+						return fmt.Errorf("expected svc1's host annotation value %s to be node1", val)
+					}
+
+					node1ExpectedLabels := map[string]string{
+						"kubernetes.io/hostname":                                 "node1",
+						fmt.Sprintf("%s/testns-svc1", util.EgressSVCLabelPrefix): "",
+					}
+
+					node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
+						return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
+					}
+
+					return nil
+				}).ShouldNot(gomega.HaveOccurred())
+
+				svc1v4lrp1 := lrpForEgressSvcEndpoint("svc1v4lrp1-UUID", "testns/svc1", "10.128.1.5", "10.128.1.2")
+				svc1v6lrp1 := lrpForEgressSvcEndpoint("svc1v6lrp1-UUID", "testns/svc1", "fe00:10:128:1::5", "fe00:10:128:1::2")
+				clusterRouter.Policies = []string{"svc1v4lrp1-UUID", "svc1v6lrp1-UUID"}
+				expectedDatabaseState := []libovsdbtest.TestData{
+					clusterRouter,
+					svc1v4lrp1,
+					svc1v6lrp1,
+				}
+
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("calling the reachability check which will return that the node is unreachable it will be drained")
+				fakeOVN.controller.egressSvcController.CheckNodesReachabilityIterate()
+				gomega.Eventually(func() error {
+					svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					val, ok := svc.Annotations[util.EgressSVCHostAnnotation]
+					if ok {
+						return fmt.Errorf("expected svc1's egress host annotation to be empty, got: %s", val)
+					}
+
+					node1ExpectedLabels := map[string]string{
+						"kubernetes.io/hostname": "node1",
+					}
+
+					node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
+						return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
+					}
+
+					return nil
+				}).ShouldNot(gomega.HaveOccurred())
+				clusterRouter.Policies = []string{}
+				expectedDatabaseState = []libovsdbtest.TestData{clusterRouter}
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+				ginkgo.By("calling the reachability check which will return that the node is reachable the service will be reallocated")
+				fakeOVN.controller.egressSvcController.CheckNodesReachabilityIterate()
+				gomega.Eventually(func() error {
+					svc, err := fakeOVN.fakeClient.KubeClient.CoreV1().Services("testns").Get(context.TODO(), svc1.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					val := svc.Annotations[util.EgressSVCHostAnnotation]
+					if val != node1Name {
+						return fmt.Errorf("expected svc1's host annotation value %s to be node1", val)
+					}
+
+					node1ExpectedLabels := map[string]string{
+						"kubernetes.io/hostname":                                 "node1",
+						fmt.Sprintf("%s/testns-svc1", util.EgressSVCLabelPrefix): "",
+					}
+
+					node1, err = fakeOVN.fakeClient.KubeClient.CoreV1().Nodes().Get(context.TODO(), node1Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					if !reflect.DeepEqual(node1.Labels, node1ExpectedLabels) {
+						return fmt.Errorf("expected node1's labels %v to be equal %v", node1.Labels, node1ExpectedLabels)
+					}
+
+					return nil
+				}).ShouldNot(gomega.HaveOccurred())
+
+				clusterRouter.Policies = []string{"svc1v4lrp1-UUID", "svc1v6lrp1-UUID"}
+				expectedDatabaseState = []libovsdbtest.TestData{
+					clusterRouter,
+					svc1v4lrp1,
+					svc1v6lrp1,
+				}
+
+				for _, lrp := range getDefaultNoReroutePolicies(*node1) {
+					expectedDatabaseState = append(expectedDatabaseState, lrp)
+					clusterRouter.Policies = append(clusterRouter.Policies, lrp.UUID)
+				}
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+	})
+
 })
 
 func (o *FakeOVN) InitAndRunEgressSVCController() {

--- a/go-controller/pkg/util/service_annotations_test.go
+++ b/go-controller/pkg/util/service_annotations_test.go
@@ -1,0 +1,275 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseEgressSVCAnnotation(t *testing.T) {
+	tests := []struct {
+		desc        string
+		annotations map[string]string
+		errMatch    error
+	}{
+		{
+			desc: "valid empty annotation should work",
+			annotations: map[string]string{
+				"k8s.ovn.org/egress-service": "{}",
+			},
+		},
+		{
+			desc: "valid annotation with matchLabels in nodeSelector should work",
+			annotations: map[string]string{
+				"k8s.ovn.org/egress-service": "{\"nodeSelector\":{\"matchLabels\":{\"happy\": \"true\"}}}",
+			},
+		},
+		{
+			desc: "valid annotation with matchLabels in nodeSelector should work",
+			annotations: map[string]string{
+				"k8s.ovn.org/egress-service": "{\"nodeSelector\":{\"matchExpressions\":[{\"key\": \"happy\",\"operator\": \"In\",\"values\":[\"true\"]}]}}",
+			},
+		},
+		{
+			desc:        "missing annotation should fail",
+			annotations: nil,
+			errMatch:    fmt.Errorf("k8s.ovn.org/egress-service annotation not found"),
+		},
+		{
+			desc: "invalid annotation should fail",
+			annotations: map[string]string{
+				"k8s.ovn.org/egress-service": "{&&}",
+			},
+			errMatch: fmt.Errorf("failed to unmarshal egress svc config"),
+		},
+		{
+			desc: "invalid matchLabels should fail",
+			annotations: map[string]string{
+				"k8s.ovn.org/egress-service": "{\"nodeSelector\":{\"matchLabels\":{\"$hould\": \"F@il\"}}}",
+			},
+			errMatch: fmt.Errorf("failed to parse the nodeSelector"),
+		},
+		{
+			desc: "invalid matchExpressions should fail",
+			annotations: map[string]string{
+				"k8s.ovn.org/egress-service": "{\"nodeSelector\":{\"matchExpressions\":[{\"key\": \"sad\",\"operator\": \"rainy\",\"values\":[\"true\"]}]}}",
+			},
+			errMatch: fmt.Errorf("failed to parse the nodeSelector"),
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			res, e := ParseEgressSVCAnnotation(tc.annotations)
+			t.Log(res)
+			if tc.errMatch != nil {
+				assert.Contains(t, e.Error(), tc.errMatch.Error())
+			} else {
+				assert.Nil(t, e)
+				assert.NotNil(t, res)
+			}
+		})
+	}
+}
+
+func TestHasEgressServiceAnnotation(t *testing.T) {
+	tests := []struct {
+		desc     string
+		svc      *kapi.Service
+		expected bool
+	}{
+		{
+			desc: "a service with the annotation should be considered an egress service",
+			svc: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/egress-service": "{}",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "a service without the proper annotation should not be considered an egress service",
+			svc: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"unrelated": "value",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			desc:     "a service without annotations should not be considered an egress service",
+			svc:      &kapi.Service{},
+			expected: false,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			res := HasEgressSVCAnnotation(tc.svc)
+			t.Log(res)
+			assert.Equal(t, res, tc.expected)
+		})
+	}
+}
+
+func TestHasEgressSVCHostAnnotation(t *testing.T) {
+	tests := []struct {
+		desc     string
+		svc      *kapi.Service
+		expected bool
+	}{
+		{
+			desc: "a service with the annotation should be considered as one that has a host",
+			svc: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/egress-service-host": "dummy",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "a service without the proper annotation should not be considered as having a host",
+			svc: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"unrelated": "value",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			desc:     "a service without annotations should not be considered as having a host",
+			svc:      &kapi.Service{},
+			expected: false,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			res := HasEgressSVCHostAnnotation(tc.svc)
+			t.Log(res)
+			assert.Equal(t, res, tc.expected)
+		})
+	}
+}
+
+func TestGetEgressSVCHost(t *testing.T) {
+	tests := []struct {
+		desc     string
+		svc      *kapi.Service
+		expected string
+		errMatch error
+	}{
+		{
+			desc: "a service with the annotation should be considered as one that has a host",
+			svc: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/egress-service-host": "dummy",
+					},
+				},
+			},
+			expected: "dummy",
+		},
+		{
+			desc: "a service without the proper annotation should not return a host",
+			svc: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"unrelated": "value",
+					},
+				},
+			},
+			errMatch: fmt.Errorf("annotation not found for service"),
+		},
+		{
+			desc:     "a service without annotations should not return a host",
+			svc:      &kapi.Service{},
+			errMatch: fmt.Errorf("annotation not found for service"),
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			res, e := GetEgressSVCHost(tc.svc)
+			t.Log(res)
+			if tc.errMatch != nil {
+				assert.Contains(t, e.Error(), tc.errMatch.Error())
+			} else {
+				assert.Nil(t, e)
+				assert.NotNil(t, res)
+			}
+		})
+	}
+}
+
+func TestEgressSVCHostChanged(t *testing.T) {
+	tests := []struct {
+		desc     string
+		svc1     *kapi.Service
+		svc2     *kapi.Service
+		expected bool
+	}{
+		{
+			desc: "same host should be false",
+			svc1: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/egress-service-host": "dummy",
+					},
+				},
+			},
+			svc2: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/egress-service-host": "dummy",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			desc: "different host should be true",
+			svc1: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/egress-service-host": "dummy",
+					},
+				},
+			},
+			svc2: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/egress-service-host": "dummy2",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "host and empty should be considered a change",
+			svc1: &kapi.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.ovn.org/egress-service-host": "dummy",
+					},
+				},
+			},
+			svc2:     &kapi.Service{},
+			expected: true,
+		},
+	}
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
+			res := EgressSVCHostChanged(tc.svc1, tc.svc2)
+			t.Log(res)
+			assert.Equal(t, res, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
**- What this PR does and why is it needed**
The egress service nodeSelector parsing did
not take into account wrong values that cause
errors (such as "name part must consist of alphanumeric characters"),
and the controller did not handle them gracefully given a bad input.

This PR adds some sort of validation to the
annotation given and some tests to verify the correct behavior.

**- Special notes for reviewers**
The first commit is pretty much cosmetic (the long diff is misleading :slightly_smiling_face:)