### PR TITLE
egressip: fix test data race accessing podAssignment cache

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2047,6 +2047,19 @@ type podAssignmentState struct {
 	standbyEgressIPNames sets.String
 }
 
+// Clone deep-copies and returns the copied podAssignmentState
+func (pas *podAssignmentState) Clone() *podAssignmentState {
+	clone := &podAssignmentState{
+		egressIPName:         pas.egressIPName,
+		standbyEgressIPNames: pas.standbyEgressIPNames.Clone(),
+	}
+	clone.egressStatuses = make(map[egressipv1.EgressIPStatusItem]string, len(pas.egressStatuses))
+	for k, v := range pas.egressStatuses {
+		clone.egressStatuses[k] = v
+	}
+	return clone
+}
+
 type allocator struct {
 	*sync.Mutex
 	// A cache used for egress IP assignments containing data for all cluster nodes


### PR DESCRIPTION
The tests were copying the podAssignment cache under the cache's lock, but unfortunately it was just a shallow-copy of element of that cache. Maps within structs are copied by reference, not by value (eg deep-copy), so neither the 'egressStatuses' nor the 'standbyEgressIPNames' members of each podAssignmentState element were deep-copied.

This led to data races in the tests like:

```
2022-10-27T13:00:36.6560710Z WARNING: DATA RACE
2022-10-27T13:00:36.6560988Z Write at 0x00c01c6480c0 by goroutine 1527:
2022-10-27T13:00:36.6561275Z   runtime.mapdelete_faststr()
2022-10-27T13:00:36.6561762Z       /opt/hostedtoolcache/go/1.18.4/x64/src/runtime/map_faststr.go:301 +0x0
2022-10-27T13:00:36.6562144Z   k8s.io/apimachinery/pkg/util/sets.String.Delete()
2022-10-27T13:00:36.6563012Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/sets/string.go:59 +0x1557
2022-10-27T13:00:36.6563831Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).addPodEgressIPAssignments()
2022-10-27T13:00:36.6564613Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:1108 +0x14bc
2022-10-27T13:00:36.6565295Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).addPodEgressIPAssignmentsWithLock()
2022-10-27T13:00:36.6566049Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:1053 +0x14c
2022-10-27T13:00:36.6566705Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).addNamespaceEgressIPAssignments()
2022-10-27T13:00:36.6567461Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:1043 +0x2ae
2022-10-27T13:00:36.6568085Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).addEgressIPAssignments()
2022-10-27T13:00:36.6568808Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:1020 +0x1e5
2022-10-27T13:00:36.6569415Z   github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*Controller).reconcileEgressIP()
2022-10-27T13:00:36.6570142Z       /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/egressip.go:214 +0x1eb3
```

because sets.String objects are actually maps underneath. We need to clone them (and the 'egressStatuses' map) before tests can use them.

@tssurya 