### PR TITLE
ovnkube-node: Existing management port check

### DIFF
--- a/go-controller/pkg/node/management-port-dpu.go
+++ b/go-controller/pkg/node/management-port-dpu.go
@@ -42,18 +42,27 @@ func (mp *managementPortRepresentor) Create(nodeAnnotator kube.Annotator, waiter
 	if config.OvnKubeNode.MgmtPortRepresentor != "" {
 		k8sMgmtIntfName += "_0"
 	}
+
+	klog.Infof("Lookup representor link and existing management port")
 	// Get management port representor netdevice
 	link, err := util.GetNetLinkOps().LinkByName(mp.repName)
 	if err != nil {
+		if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			return nil, fmt.Errorf("failed to lookup %s link: %v", mp.repName, err)
+		}
 		// It may fail in case this is not the first run after reboot and management port has already been renamed.
 		link, err = util.GetNetLinkOps().LinkByName(k8sMgmtIntfName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get link device for %s. %v", mp.repName, err)
 		}
+	} else if mp.repName != k8sMgmtIntfName {
+		if err := syncMgmtPortInterface(mp.hostSubnets, k8sMgmtIntfName, false); err != nil {
+			return nil, fmt.Errorf("failed to check existing management port: %v", err)
+		}
 	}
 
 	// configure management port: rename, set MTU and set link up and connect representor port to br-int
-	klog.Infof("Create representor management port: %s", link.Attrs().Name)
+	klog.Infof("Setup representor management port: %s", link.Attrs().Name)
 	setName := link.Attrs().Name != k8sMgmtIntfName
 	setMTU := link.Attrs().MTU != config.Default.MTU
 
@@ -64,10 +73,6 @@ func (mp *managementPortRepresentor) Create(nodeAnnotator kube.Annotator, waiter
 
 		if setName {
 			if err = util.GetNetLinkOps().LinkSetName(link, k8sMgmtIntfName); err != nil {
-				// NOTE(adrianc): rename may fail with "file exists" in case an interface is already named
-				// ovn-k8s-mp*, this may happen if mgmt-port-netdev changes during deployment. ATM we are
-				// not handling it.
-				// TODO: handle mgmt-port-netdev change.
 				return nil, fmt.Errorf("failed to set link name for device %s. %v", mp.repName, err)
 			}
 		}
@@ -83,11 +88,16 @@ func (mp *managementPortRepresentor) Create(nodeAnnotator kube.Annotator, waiter
 		return nil, fmt.Errorf("failed to set link up for device %s. %v", link.Attrs().Name, err)
 	}
 
-	// Plug management port representor to OVS.
-	stdout, stderr, err := util.RunOVSVsctl(
+	ovsArgs := []string{
 		"--", "--may-exist", "add-port", "br-int", k8sMgmtIntfName,
 		"--", "set", "interface", k8sMgmtIntfName,
-		"external-ids:iface-id="+types.K8sPrefix+mp.nodeName)
+		"external-ids:iface-id=" + types.K8sPrefix + mp.nodeName,
+	}
+	if mp.repName != k8sMgmtIntfName {
+		ovsArgs = append(ovsArgs, "external-ids:ovn-orig-mgmt-port-rep-name="+mp.repName)
+	}
+	// Plug management port representor to OVS.
+	stdout, stderr, err := util.RunOVSVsctl(ovsArgs...)
 	if err != nil {
 		klog.Errorf("Failed to add port %q to br-int, stdout: %q, stderr: %q, error: %v",
 			k8sMgmtIntfName, stdout, stderr, err)
@@ -165,20 +175,34 @@ func newManagementPortNetdev(hostSubnets []*net.IPNet) ManagementPort {
 }
 
 func (mp *managementPortNetdev) Create(nodeAnnotator kube.Annotator, waiter *startupWaiter) (*managementPortConfig, error) {
-	// get Netdev that is used for management port.
+	klog.Infof("Lookup netdevice link and existing management port")
+	// get netdev that is used for management port.
 	link, err := util.GetNetLinkOps().LinkByName(mp.netdevName)
 	if err != nil {
+		if !util.GetNetLinkOps().IsLinkNotFoundError(err) {
+			return nil, fmt.Errorf("failed to lookup %s link: %v", mp.netdevName, err)
+		}
 		// this may not the first time invoked on the node after reboot
 		// netdev may have already been renamed to ovn-k8s-mp0.
 		link, err = util.GetNetLinkOps().LinkByName(types.K8sMgmtIntfName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get link device for %s. %v", mp.netdevName, err)
 		}
+	} else if mp.netdevName != types.K8sMgmtIntfName {
+		if config.OvnKubeNode.Mode == types.NodeModeDPUHost {
+			// We do not expect OVS running here so just check if no old mgmt port netdevice exists and unconfigure it
+			err = unconfigureMgmtNetdevicePort(mp.hostSubnets, types.K8sMgmtIntfName)
+		} else {
+			err = syncMgmtPortInterface(mp.hostSubnets, types.K8sMgmtIntfName, false)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to sync management port: %v", err)
+		}
 	}
 
 	// configure management port: name, mac, MTU, iptables
 	// mac addr, derived from the first entry in host subnets using the .2 address as mac with a fixed prefix.
-	klog.Infof("Setup management port dpu host: %s", link.Attrs().Name)
+	klog.Infof("Setup netdevice management port: %s", link.Attrs().Name)
 	mgmtPortMac := util.IPAddrToHWAddr(util.GetNodeManagementIfAddr(mp.hostSubnets[0]).IP)
 	setMac := link.Attrs().HardwareAddr.String() != mgmtPortMac.String()
 	setName := link.Attrs().Name != types.K8sMgmtIntfName
@@ -200,10 +224,6 @@ func (mp *managementPortNetdev) Create(nodeAnnotator kube.Annotator, waiter *sta
 		if setName {
 			err := util.GetNetLinkOps().LinkSetName(link, types.K8sMgmtIntfName)
 			if err != nil {
-				// NOTE(adrianc): rename may fail with "file exists" in case an interface is already named
-				// ovn-k8s-mp0, this may happen if mgmt-port-netdev changes during deployment. ATM we are
-				// not handling it.
-				// TODO: handle mgmt-port-netdev change.
 				return nil, fmt.Errorf("failed to set management port name. %v", err)
 			}
 		}
@@ -213,6 +233,14 @@ func (mp *managementPortNetdev) Create(nodeAnnotator kube.Annotator, waiter *sta
 			if err != nil {
 				return nil, fmt.Errorf("failed to set management port MTU. %v", err)
 			}
+		}
+	}
+
+	if mp.netdevName != types.K8sMgmtIntfName && config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+		// Store original interface name for later use
+		if _, stderr, err := util.RunOVSVsctl("set", "Open_vSwitch", ".",
+			"external-ids:ovn-orig-mgmt-port-netdev-name="+mp.netdevName); err != nil {
+			return nil, fmt.Errorf("failed to store original mgmt port interface name: %s", stderr)
 		}
 	}
 

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -70,6 +70,12 @@ func newManagementPort(nodeName string, hostSubnets []*net.IPNet) ManagementPort
 }
 
 func (mp *managementPort) Create(nodeAnnotator kube.Annotator, waiter *startupWaiter) (*managementPortConfig, error) {
+	for _, mgmtPortName := range []string{types.K8sMgmtIntfName, types.K8sMgmtIntfName + "_0"} {
+		if err := syncMgmtPortInterface(mp.hostSubnets, mgmtPortName, true); err != nil {
+			return nil, fmt.Errorf("failed to sync management port: %v", err)
+		}
+	}
+
 	// Create a OVS internal interface.
 	legacyMgmtIntfName := util.GetLegacyK8sMgmtIntfName(mp.nodeName)
 	stdout, stderr, err := util.RunOVSVsctl(
@@ -140,6 +146,6 @@ func managementPortReady() (bool, error) {
 	if !strings.Contains(stdout, "actions=output:"+ofport) {
 		return false, nil
 	}
-	klog.Info("Management port %s is ready", k8sMgmtIntfName)
+	klog.Infof("Management port %s is ready", k8sMgmtIntfName)
 	return true, nil
 }

--- a/go-controller/pkg/node/management-port_dpu_test.go
+++ b/go-controller/pkg/node/management-port_dpu_test.go
@@ -17,9 +17,16 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func genOVSAddMgmtPortCmd(nodeName string) string {
-	return fmt.Sprintf("ovs-vsctl --timeout=15 -- --may-exist add-port br-int %s -- set interface %s external-ids:iface-id=%s",
-		types.K8sMgmtIntfName, types.K8sMgmtIntfName, types.K8sPrefix+nodeName)
+func genOVSAddMgmtPortCmd(nodeName, repName string) string {
+	return fmt.Sprintf("ovs-vsctl --timeout=15 -- --may-exist add-port br-int %s -- set interface %s external-ids:iface-id=%s"+
+		" external-ids:ovn-orig-mgmt-port-rep-name=%s",
+		types.K8sMgmtIntfName, types.K8sMgmtIntfName, types.K8sPrefix+nodeName, repName)
+}
+
+func mockOVSListInterfaceMgmtPortNotExistCmd(execMock *ovntest.FakeExec, mgmtPortName string) {
+	execMock.AddFakeCmdsNoOutputNoError([]string{
+		"ovs-vsctl --timeout=15 --no-headings --data bare --format csv --columns type,name find Interface name=" + mgmtPortName,
+	})
 }
 
 var _ = Describe("Mananagement port DPU tests", func() {
@@ -47,6 +54,17 @@ var _ = Describe("Mananagement port DPU tests", func() {
 	})
 
 	Context("Create Management port DPU", func() {
+		It("Fails if representor link lookup failed with error", func() {
+			mgmtPortDpu := managementPortRepresentor{
+				repName: "non-existent-netdev",
+			}
+			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(nil, fmt.Errorf("netlink mock error"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
+
+			_, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("Fails if representor and ovn-k8s-mp0 netdev is not found", func() {
 			mgmtPortDpu := managementPortRepresentor{
 				repName: "non-existent-netdev",
@@ -55,6 +73,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				nil, fmt.Errorf("failed to get interface"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
 			_, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
 			Expect(err).To(HaveOccurred())
@@ -69,8 +88,12 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+				nil, fmt.Errorf("link not found"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(fmt.Errorf("failed to set name"))
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
 
 			_, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
 			Expect(err).To(HaveOccurred())
@@ -92,12 +115,16 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+				nil, fmt.Errorf("link not found"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName),
+				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
 
 			mpcfg, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
@@ -123,11 +150,12 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				nil, fmt.Errorf("failed to get link device"))
-			netlinkOpsMock.On("LinkByName", "ovn-k8s-mp0").Return(
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				linkMock, nil)
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName),
+				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
 
 			mpcfg, err := mgmtPortDpu.Create(nodeAnnotatorMock, waiter)
@@ -139,6 +167,17 @@ var _ = Describe("Mananagement port DPU tests", func() {
 	})
 
 	Context("Create Management port DPU host", func() {
+		It("Fails if netdev link lookup failed", func() {
+			mgmtPortDpuHost := managementPortNetdev{
+				netdevName: "non-existent-netdev",
+			}
+			netlinkOpsMock.On("LinkByName", "non-existent-netdev").Return(nil, fmt.Errorf("netlink mock error"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(false)
+
+			_, err := mgmtPortDpuHost.Create(nil, waiter)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("Fails if netdev does not exist", func() {
 			mgmtPortDpuHost := managementPortNetdev{
 				netdevName: "non-existent-netdev",
@@ -147,6 +186,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 				nil, fmt.Errorf("failed to get interface"))
 			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				nil, fmt.Errorf("failed to get interface"))
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 
 			_, err := mgmtPortDpuHost.Create(nil, waiter)
 			Expect(err).To(HaveOccurred())
@@ -169,11 +209,16 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
 			netlinkOpsMock.On("LinkSetHardwareAddr", linkMock, expectedMgmtPortMac).Return(nil)
 			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil)
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
+			execMock.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevName,
+			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.
@@ -203,9 +248,13 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				nil, fmt.Errorf("failed to get link")).Once()
-			netlinkOpsMock.On("LinkByName", "ovn-k8s-mp0").Return(
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				linkMock, nil).Once()
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil).Once()
+			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
+			execMock.AddFakeCmdsNoOutputNoError([]string{
+				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevName,
+			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.

--- a/go-controller/pkg/util/mocks/NetLinkOps.go
+++ b/go-controller/pkg/util/mocks/NetLinkOps.go
@@ -87,6 +87,20 @@ func (_m *NetLinkOps) ConntrackDeleteFilter(table netlink.ConntrackTableType, fa
 	return r0, r1
 }
 
+// IsLinkNotFoundError provides a mock function with given fields: err
+func (_m *NetLinkOps) IsLinkNotFoundError(err error) bool {
+	ret := _m.Called(err)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(error) bool); ok {
+		r0 = rf(err)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // LinkByIndex provides a mock function with given fields: index
 func (_m *NetLinkOps) LinkByIndex(index int) (netlink.Link, error) {
 	ret := _m.Called(index)

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"reflect"
 	"time"
 
 	kapi "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ type NetLinkOps interface {
 	LinkSetHardwareAddr(link netlink.Link, hwaddr net.HardwareAddr) error
 	LinkSetMTU(link netlink.Link, mtu int) error
 	LinkSetTxQLen(link netlink.Link, qlen int) error
+	IsLinkNotFoundError(err error) bool
 	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
 	AddrDel(link netlink.Link, addr *netlink.Addr) error
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
@@ -106,6 +108,10 @@ func (defaultNetLinkOps) LinkSetMTU(link netlink.Link, mtu int) error {
 
 func (defaultNetLinkOps) LinkSetTxQLen(link netlink.Link, qlen int) error {
 	return netlink.LinkSetTxQLen(link, qlen)
+}
+
+func (defaultNetLinkOps) IsLinkNotFoundError(err error) bool {
+	return reflect.TypeOf(err) == reflect.TypeOf(netlink.LinkNotFoundError{})
 }
 
 func (defaultNetLinkOps) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {


### PR DESCRIPTION
When ovnkube-node configures management port interface it may fail if host already have it configured but it is different interface. To handle that do the following:
- verify that port exists on the integrational bridge and it represents provided management port netdevice or OVS internal port, if no netdevice were provided;
- verify that no interface exists with the name of the management port;

If any of the checks had failed then need to remove port from the bridge and if it wasn't OVS internal port - flush IP addresses, routes, tables and rename the interface.

Because ovnkube doesn't have unload sequence, port check done during new management port creation.

Signed-off-by: Dmytro Linkin <dlinkin@nvidia.com>