### PR TITLE
kind.sh: Add IPsec option to kind deployments

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -28,9 +28,11 @@ RUN INSTALL_PKGS=" \
 	libpcap hostname kubernetes-client util-linux \
         ovn ovn-central ovn-host python3-openvswitch tcpdump openvswitch-test python3-pyOpenSSL \
 	iptables iproute iputils strace socat koji \
+        libreswan openvswitch-ipsec \
         " && \
 	dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
 	dnf clean all && rm -rf /var/cache/dnf/*
+RUN ln -s /usr/bin/python3 /usr/libexec/platform-python
 
 RUN mkdir -p /var/run/openvswitch
 

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -100,6 +100,9 @@ while [ "$1" != "" ]; do
   --gateway-options)
     OVN_GATEWAY_OPTS=$VALUE
     ;;
+  --enable-ipsec)
+    ENABLE_IPSEC=$VALUE
+    ;;
   --ovn-monitor-all)
     OVN_MONITOR_ALL=$VALUE
     ;;
@@ -292,6 +295,9 @@ echo "ovn_gateway_mode: ${ovn_gateway_mode}"
 
 ovn_gateway_opts=${OVN_GATEWAY_OPTS}
 echo "ovn_gateway_opts: ${ovn_gateway_opts}"
+
+enable_ipsec=${ENABLE_IPSEC:-false}
+echo "enable_ipsec: ${enable_ipsec}"
 
 ovn_db_replicas=${OVN_DB_REPLICAS:-3}
 echo "ovn_db_replicas: ${ovn_db_replicas}"
@@ -499,6 +505,7 @@ ovn_image=${image} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_nb_port=${ovn_nb_port} \
   ovn_sb_port=${ovn_sb_port} \
+  enable_ipsec=${enable_ipsec} \
   j2 ../templates/ovnkube-db.yaml.j2 -o ${output_dir}/ovnkube-db.yaml
 
 ovn_image=${image} \
@@ -517,12 +524,18 @@ ovn_image=${image} \
   ovn_sb_port=${ovn_sb_port} \
   ovn_nb_raft_port=${ovn_nb_raft_port} \
   ovn_sb_raft_port=${ovn_sb_raft_port} \
+  enable_ipsec=${enable_ipsec} \
   j2 ../templates/ovnkube-db-raft.yaml.j2 -o ${output_dir}/ovnkube-db-raft.yaml
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \
   ovn_unprivileged_mode=${ovn_unprivileged_mode} \
   j2 ../templates/ovs-node.yaml.j2 -o ${output_dir}/ovs-node.yaml
+
+if ${enable_ipsec}; then
+  ovn_image=${image} \
+    j2 ../templates/ovn-ipsec.yaml.j2 -o ${output_dir}/ovn-ipsec.yaml
+fi
 
 # ovn-setup.yaml
 net_cidr=${OVN_NET_CIDR:-"10.128.0.0/14/23"}

--- a/dist/images/ovndb-raft-functions.sh
+++ b/dist/images/ovndb-raft-functions.sh
@@ -370,6 +370,9 @@ ovsdb-raft() {
       set_election_timer ${db} ${election_timer}
       if [[ ${db} == "nb" ]]; then
         set_northd_probe_interval
+        [[ "true" == "${ENABLE_IPSEC}" ]] && {
+          ovn-nbctl set nb_global . ipsec=true
+        }
       fi
       # set the connection and disable inactivity probe, this deletes the old connection if any
       # this will unblock pod-1 and pod-2 waiters

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -726,6 +726,10 @@ nb-ovsdb() {
     ovn-nbctl set-ssl ${ovn_nb_pk} ${ovn_nb_cert} ${ovn_ca_cert}
     echo "=============== nb-ovsdb ========== reconfigured for SSL"
   }
+ [[ "true" == "${ENABLE_IPSEC}" ]] && {
+    ovn-nbctl set nb_global . ipsec=true
+    echo "=============== nb-ovsdb ========== reconfigured for ipsec"
+  }
   ovn-nbctl --inactivity-probe=0 set-connection p${transport}:${ovn_nb_port}:$(bracketify ${ovn_db_host})
   if memory_trim_on_compaction_supported "nbdb"
   then

--- a/dist/templates/ovn-ipsec.yaml.j2
+++ b/dist/templates/ovn-ipsec.yaml.j2
@@ -1,0 +1,274 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovn-ipsec
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn ipsec networking components for all nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovn-ipsec
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: ovn-ipsec
+        component: network
+        type: infra
+        openshift.io/component: network
+        kubernetes.io/os: "linux"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: network.operator.openshift.io/dpu-host
+                operator: DoesNotExist
+      serviceAccountName: ovn
+      hostNetwork: true
+      dnsPolicy: Default
+      priorityClassName: "system-node-critical"
+      initContainers:
+      - name: ovn-keys
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -exuo pipefail
+
+          # Every time we restart this container, we will create a new key pair if
+          # we are close to key expiration or if we do not already have a signed key pair.
+          #
+          # Each node has a key pair which is used by OVS to encrypt/decrypt/authenticate traffic
+          # between each node. The CA cert is used as the root of trust for all certs so we need
+          # the CA to sign our certificate signing requests with the CA private key. In this way,
+          # we can validate that any signed certificates that we receive from other nodes are
+          # authentic.
+          echo "Configuring IPsec keys"
+
+          # If the certificate does not exist or it will expire in the next 6 months
+          # (15770000 seconds), we will generate a new one.
+          if [ ! -e /etc/openvswitch/keys/ipsec-cert.pem ] || [ ! openssl x509 -noout -dates -checkend 15770000 ];
+          then
+            # We use the system-id as the CN for our certificate signing request. This
+            # is a requirement by OVN.
+            cn=$(ovs-vsctl --retry -t 60 get Open_vSwitch . external-ids:system-id | tr -d "\"")
+
+            mkdir -p /etc/openvswitch/keys
+
+            # Generate an SSL private key and use the key to create a certitificate signing request
+            umask 077 && openssl genrsa -out /etc/openvswitch/keys/ipsec-privkey.pem 2048
+            openssl req -new -text \
+                        -extensions v3_req \
+                        -addext "subjectAltName = DNS:${cn}" \
+                        -subj "/C=US/O=ovnkubernetes/OU=kind/CN=${cn}" \
+                        -key /etc/openvswitch/keys/ipsec-privkey.pem \
+                        -out /etc/openvswitch/keys/ipsec-req.pem
+
+            csr_64=$(cat /etc/openvswitch/keys/ipsec-req.pem | base64 | tr -d "\n")
+
+            # The signer controller does not allow re-signing a key. We will
+            # delete the old key to be sure it is not there
+            kubectl delete --ignore-not-found=true csr/$(hostname)
+
+            # Request that our generated certificate signing request is
+            # signed by the "network.openshift.io/signer" signer that is
+            # implemented by the CNO signer controller. This will sign the
+            # certificate signing request using the signer-ca which has been
+            # set up by the OperatorPKI. In this way, we have a signed certificate
+            # and our private key has remained private on this host.
+            cat <<EOF | kubectl apply -f -
+            apiVersion: certificates.k8s.io/v1
+            kind: CertificateSigningRequest
+            metadata:
+              name: $(hostname)
+            spec:
+              request: ${csr_64}
+              signerName: network.openshift.io/signer
+              usages:
+              - ipsec tunnel
+          EOF
+
+            # Wait until the certificate signing request has been signed.
+            counter=0
+            until [ ! -z $(kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' 2>/dev/null) ]
+            do
+              counter=$[counter+1]
+              sleep 1
+              if [ $counter -gt 60 ];
+              then
+                      echo "Unable to sign certificate after $counter seconds"
+                      exit 1
+              fi
+            done
+
+            # Decode the signed certificate.
+            kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' | base64 -d | openssl x509 -outform pem -text -out /etc/openvswitch/keys/ipsec-cert.pem
+
+            kubectl delete csr/$(hostname)
+
+            # Get the CA certificate so we can authenticate peer nodes.
+            cat /signer-ca/ca-bundle.crt | openssl x509 -outform pem -text > /etc/openvswitch/keys/ipsec-cacert.pem
+          fi
+
+          # Configure OVS with the relevant keys for this node. This is required by ovs-monitor-ipsec.
+          #
+          # Updating the certificates does not need to be an atomic operation as
+          # the will get read and loaded into NSS by the ovs-monitor-ipsec process
+          # which has not started yet.
+          ovs-vsctl --retry -t 60 set Open_vSwitch . other_config:certificate=/etc/openvswitch/keys/ipsec-cert.pem \
+                                                     other_config:private_key=/etc/openvswitch/keys/ipsec-privkey.pem \
+                                                     other_config:ca_cert=/etc/openvswitch/keys/ipsec-cacert.pem
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-ovs
+        - mountPath: /signer-ca
+          name: signer-ca
+        - mountPath: /etc/openvswitch
+          name: etc-openvswitch
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+      containers:
+      # ovs-monitor-ipsec and libreswan daemons
+      - name: ovn-ipsec
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -exuo pipefail
+
+          function cleanup()
+          {
+            # In order to maintain traffic flows during container restart, we
+            # need to ensure that xfrm state and policies are not flushed.
+
+            # Don't allow ovs monitor to cleanup persistent state
+            kill $(cat /var/run/openvswitch/ovs-monitor-ipsec.pid 2>/dev/null) 2>/dev/null || true
+            # Don't allow pluto to clear xfrm state and policies on exit
+            kill -9 $(cat /var/run/pluto/pluto.pid 2>/devnull) 2>/dev/null || true
+
+            /usr/sbin/ipsec --stopnflog
+            exit 0
+          }
+          trap cleanup SIGTERM
+
+          # Don't start IPsec until ovnkube-node has finished setting up the node
+          counter=0
+          until [ -f /etc/cni/net.d/10-ovn-kubernetes.conf ]
+          do
+            counter=$[counter+1]
+            sleep 1
+            if [ $counter -gt 300 ];
+            then
+                    echo "ovnkube-node pod has not started after $counter seconds"
+                    exit 1
+            fi
+          done
+          echo "ovnkube-node has configured node."
+
+          # After a restart of this container (or on initial startup), we flush xfrm state and policy
+          # before we start pluto and ovs-monitor-ipsec in order to start in a known good state. This
+          # will result in a small interruption in traffic until pluto and ovs-monitor-ipsec start again.
+          ip x s flush
+          ip x p flush
+
+          # Workaround for https://github.com/libreswan/libreswan/issues/373
+          ulimit -n 1024
+
+          /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
+          # Check kernel modules
+          /usr/libexec/ipsec/_stackmanager start
+          # Check nss database status
+          /usr/sbin/ipsec --checknss
+          # Start the pluto IKE daemon
+          /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --logfile /var/log/openvswitch/libreswan.log
+
+          # Start ovs-monitor-ipsec which will monitor for changes in the ovs
+          # tunnelling configuration (for example addition of a node) and configures
+          # libreswan appropriately.
+          # We are running this in the foreground so that the container will be restarted when ovs-monitor-ipsec fails.
+          # Upstream hack --ipsec-d for https://bugzilla.redhat.com/show_bug.cgi?id=1975039#c11
+          /usr/libexec/platform-python /usr/share/openvswitch/scripts/ovs-monitor-ipsec \
+            --pidfile=/var/run/openvswitch/ovs-monitor-ipsec.pid --ike-daemon=libreswan --no-restart-ike-daemon \
+            --log-file --monitor unix:/var/run/openvswitch/db.sock \
+            --ipsec-d /var/lib/ipsec/nss
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        # To check that network setup is complete
+        - mountPath: /etc/cni/net.d
+          name: host-cni-netd
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /etc/openvswitch
+          name: etc-openvswitch
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              ipsec status
+          initialDelaySeconds: 15
+          periodSeconds: 60
+      nodeSelector:
+        beta.kubernetes.io/os: "linux"
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+          type: DirectoryOrCreate
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+          type: DirectoryOrCreate
+      - name: signer-ca
+        configMap:
+          name: signer-ca
+      - name: etc-openvswitch
+        hostPath:
+          path: /var/lib/openvswitch/etc
+          type: DirectoryOrCreate
+      - name: host-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      tolerations:
+      - operator: "Exists"

--- a/dist/templates/ovn-setup.yaml.j2
+++ b/dist/templates/ovn-setup.yaml.j2
@@ -91,6 +91,16 @@ rules:
   resources:
   - customresourcedefinitions
   verbs: ["list", "get", "watch"]
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
 
 
 ---

--- a/dist/templates/ovnkube-db-raft.yaml.j2
+++ b/dist/templates/ovnkube-db-raft.yaml.j2
@@ -161,6 +161,8 @@ spec:
               fieldPath: status.hostIP
         - name: OVN_SSL_ENABLE
           value: "{{ ovn_ssl_en }}"
+        - name: ENABLE_IPSEC
+          value: "{{ enable_ipsec }}"
         - name: OVN_NB_RAFT_ELECTION_TIMER
           value: "{{ ovn_nb_raft_election_timer }}"
         - name: OVN_NB_PORT

--- a/dist/templates/ovnkube-db.yaml.j2
+++ b/dist/templates/ovnkube-db.yaml.j2
@@ -124,6 +124,8 @@ spec:
           value: "{{ ovn_ssl_en }}"
         - name: OVN_NB_PORT
           value: "{{ ovn_nb_port }}"
+        - name: ENABLE_IPSEC
+          value: "{{ enable_ipsec }}"
         readinessProbe:
           exec:
             command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
Deploy with:
~~~
contrib/kind.sh -ha --ipsec
~~~

Or without the -ha parameter

Once deployed, check the pods:
~~~
[root@ovnkubernetes ovn-kubernetes]# oc get pods -n ovn-kubernetes | grep ipsec
ovn-ipsec-btm5l                   1/1     Running   0          16m
ovn-ipsec-n252g                   1/1     Running   0          16m
ovn-ipsec-wkxks                   1/1     Running   0          16m
~~~

And run a tcpdump inside one of the docker containers:
~~~
# nsenter -n -t <pid of kubelet>
[root@ovnkubernetes ovn-kubernetes]# tcpdump -nne -i eth0 esp
(...)
~~~

While pinging from one pod on the cluster to another:
~~~
[root@ovnkubernetes ~]# oc get pods -o wide
NAME                                   READY   STATUS    RESTARTS   AGE    IP           NODE          NOMINATED NODE   READINESS GATES
netshoot-deployment-7bb976f978-kwzn7   1/1     Running   0          73s    10.244.2.3   ovn-worker2   <none>           <none>
netshoot-deployment-7bb976f978-llmlw   1/1     Running   0          103s   10.244.1.3   ovn-worker    <none>           <none>
[root@ovnkubernetes ~]# oc rsh netshoot-deployment-7bb976f978-kwzn7
~ # ping 10.244.1.3
PING 10.244.1.3 (10.244.1.3) 56(84) bytes of data.
64 bytes from 10.244.1.3: icmp_seq=1 ttl=63 time=10.3 ms
^C
--- 10.244.1.3 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 10.293/10.293/10.293/0.000 ms
~~~

The packet capture should show ESP traffic:
~~~
dropped privs to tcpdump
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
16:40:43.809889 02:42:ac:12:00:03 > 02:42:ac:12:00:04, ethertype IPv4 (0x0800), length 190: 172.18.0.3 > 172.18.0.4: ESP(spi=0x3661f9f5,seq=0x1), length 156
16:40:43.813405 02:42:ac:12:00:04 > 02:42:ac:12:00:03, ethertype IPv4 (0x0800), length 190: 172.18.0.4 > 172.18.0.3: ESP(spi=0x4ec1699d,seq=0x1), length 156
^C
2 packets captured
2 packets received by filter
0 packets dropped by kernel
~~~

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->