### PR TITLE
vendor: bump libovsdb to 8f21d188c3a50d0ce378bd66ec68215967aaad77

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift/api v0.0.0-20221004161420-ef2c62cf20d0
 	github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e
-	github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a
+	github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -633,8 +633,8 @@ github.com/openshift/api v0.0.0-20221004161420-ef2c62cf20d0/go.mod h1:JRz+ZvTqu9
 github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e h1:ab+BJg7h50pi2/rbMkDSXfYx8w80HLmr7NBs8H1hEvU=
 github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e/go.mod h1:e+TTiBDGWB3O3p3iAzl054x3cZDWhrZ5+jxJRCdEFkA=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a h1:fcKT5QPXQfNURcy4QddDFnI8f2GTNVlJrQMwJ+pZbI8=
-github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a/go.mod h1:S/+Hux9//oB7yLaPsUKnXTzZc6S1C4a9HP0UifXfKz0=
+github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5 h1:Cw0JXIHSGp8etz5/P7zNQ0tCMmTljBGBr8Rn2P1PuzQ=
+github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5/go.mod h1:S/+Hux9//oB7yLaPsUKnXTzZc6S1C4a9HP0UifXfKz0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/client/client.go
@@ -778,7 +778,10 @@ func (o *ovsdbClient) transact(ctx context.Context, dbName string, operation ...
 	if o.rpcClient == nil {
 		return nil, ErrNotConnected
 	}
-	o.logger.V(4).Info("transacting operations", "database", dbName, "operations", fmt.Sprintf("%+v", operation))
+	dbgLogger := o.logger.WithValues("database", dbName).V(4)
+	if dbgLogger.Enabled() {
+		dbgLogger.Info("transacting operations", "operations", fmt.Sprintf("%+v", operation))
+	}
 	err := o.rpcClient.CallWithContext(ctx, "transact", args, &reply)
 	if err != nil {
 		if err == rpc2.ErrShutdown {

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
@@ -5,6 +5,8 @@ package serverdb
 
 import "github.com/ovn-org/libovsdb/model"
 
+const DatabaseTable = "Database"
+
 type (
 	DatabaseModel = string
 )

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -272,7 +272,7 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20220901025242-999ca1972a3a
+# github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5
 ## explicit; go 1.18
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client


### PR DESCRIPTION
Pulls in the following commits, for which we really just care about the client logging one for performance.

64a1543b16 client: don't construct transaction log string when it's not needed
https://github.com/ovn-org/libovsdb/pull/342

14b9f5b67b Make table name a const above generated model
https://github.com/ovn-org/libovsdb/pull/337