### PR TITLE
ovnkube-trace: Fail gracefully on failed ovn-detrace dependency check

### DIFF
--- a/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
+++ b/go-controller/cmd/ovnkube-trace/ovnkube-trace.go
@@ -1008,6 +1008,7 @@ func main() {
 	dstPort := flag.String("dst-port", "80", "dst-port: destination port")
 	tcp := flag.Bool("tcp", false, "use tcp transport protocol")
 	udp := flag.Bool("udp", false, "use udp transport protocol")
+	skipOvnDetrace := flag.Bool("skip-detrace", false, "skip ovn-detrace command")
 	loglevel := flag.String("loglevel", "0", "loglevel: klog level")
 	flag.Parse()
 
@@ -1122,6 +1123,9 @@ func main() {
 		klog.V(5).Infof("Running a trace to an IP address")
 		egressNodeName, egressBridgeName := runOvnTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, sbcmd, ovnNamespace, protocol, *dstPort)
 		appSrcDstOut := runOfprotoTraceToIP(coreclient, restconfig, srcPodInfo, parsedDstIP, ovnNamespace, protocol, *dstPort, egressNodeName, egressBridgeName)
+		if *skipOvnDetrace {
+			return
+		}
 		err = runOvnDetrace(coreclient, restconfig, "pod to external IP", srcPodInfo, parsedDstIP.String(), appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys, nbcmd)
 		if err != nil {
 			klog.Infof("Skipped ovn-detrace due to: %q", err)
@@ -1169,6 +1173,9 @@ func main() {
 	appDstSrcOut := runOfprotoTraceToPod(coreclient, restconfig, "destination pod to source pod", dstPodInfo, srcPodInfo, ovnNamespace, protocol, *dstPort)
 
 	// ovn-detrace commands below
+	if *skipOvnDetrace {
+		return
+	}
 	err = runOvnDetrace(coreclient, restconfig, "source pod to destination pod", srcPodInfo, dstPodInfo.PodName, appSrcDstOut, ovnNamespace, nbURI, sbURI, sslCertKeys, nbcmd)
 	if err != nil {
 		klog.Infof("Skipped ovn-detrace due to: %q", err)


### PR DESCRIPTION
Instead of exiting with an error, exit gracefully with an info message. Add a flag so that ovnkube-detrace can be skipped altogether.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
~~~
[akaris@linux go-controller (ovnkube-trace-2022-11-06)]$ ./_output/go/bin/ovnkube-trace -src-namespace openshift-network-diagnostics -dst-namespace openshift-network-diagnostics -src network-check-target-4dq2b -dst network-check-target-7fbh7 -tcp
I1106 14:32:16.248415 1761302 ovs.go:90] Maximum command line arguments set to: 191102
ovn-trace source pod to destination pod indicates success from network-check-target-4dq2b to network-check-target-7fbh7
ovn-trace destination pod to source pod indicates success from network-check-target-7fbh7 to network-check-target-4dq2b
ovs-appctl ofproto/trace source pod to destination pod indicates success from network-check-target-4dq2b to network-check-target-7fbh7
ovs-appctl ofproto/trace destination pod to source pod indicates success from network-check-target-7fbh7 to network-check-target-4dq2b
ovn-detrace source pod to destination pod indicates success from network-check-target-4dq2b to network-check-target-7fbh7
ovn-detrace destination pod to source pod indicates success from network-check-target-7fbh7 to network-check-target-4dq2b
~~~

~~~
[akaris@linux go-controller (ovnkube-trace-2022-11-06)]$ ./_output/go/bin/ovnkube-trace -src-namespace openshift-network-diagnostics -dst-namespace openshift-network-diagnostics -src network-check-target-4dq2b -dst network-check-target-7fbh7 -tcp -skip-detrace
I1106 14:33:21.222128 1761337 ovs.go:90] Maximum command line arguments set to: 191102
ovn-trace source pod to destination pod indicates success from network-check-target-4dq2b to network-check-target-7fbh7
ovn-trace destination pod to source pod indicates success from network-check-target-7fbh7 to network-check-target-4dq2b
ovs-appctl ofproto/trace source pod to destination pod indicates success from network-check-target-4dq2b to network-check-target-7fbh7
ovs-appctl ofproto/trace destination pod to source pod indicates success from network-check-target-7fbh7 to network-check-target-4dq2b
[akaris@linux go-controller (ovnkube-trace-2022-11-06)]$ 
~~~

~~~
[akaris@linux go-controller (ovnkube-trace-2022-11-06)]$ ./_output/go/bin/ovnkube-trace -src-namespace openshift-network-diagnostics -src network-check-target-4dq2b -dst-ip 8.8.8.8 -tcp
I1106 14:37:24.611297 1762780 ovs.go:90] Maximum command line arguments set to: 191102
ovn-trace from pod to IP indicates success from network-check-target-4dq2b to 8.8.8.8
ovs-appctl ofproto/trace pod to IP indicates success from network-check-target-4dq2b to 8.8.8.8
ovn-detrace pod to external IP indicates success from network-check-target-4dq2b to 8.8.8.8
~~~

~~~
[akaris@linux go-controller (ovnkube-trace-2022-11-06)]$ ./_output/go/bin/ovnkube-trace -src-namespace openshift-network-diagnostics -src network-check-target-4dq2b -dst-ip 8.8.8.8 -tcp -skip-detrace
I1106 14:40:01.248545 1762904 ovs.go:90] Maximum command line arguments set to: 191102
ovn-trace from pod to IP indicates success from network-check-target-4dq2b to 8.8.8.8
ovs-appctl ofproto/trace pod to IP indicates success from network-check-target-4dq2b to 8.8.8.8
~~~


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->