### PR TITLE
Handle cases where a pod may exist but the node does not

### DIFF
--- a/go-controller/pkg/ovn/obj_retry_master.go
+++ b/go-controller/pkg/ovn/obj_retry_master.go
@@ -814,7 +814,7 @@ func (h *masterEventHandler) SyncFunc(objs []interface{}) error {
 	return syncFunc(objs)
 }
 
-// Given an object and its type, IsObjectInTerminalState returns true if the object is a in terminal state.
+// IsObjectInTerminalState returns true if the object is in a terminal state.
 // This is used now for pods that are either in a PodSucceeded or in a PodFailed state.
 func (h *masterEventHandler) IsObjectInTerminalState(obj interface{}) bool {
 	switch h.objType {

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -1820,5 +1820,60 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+
+		ginkgo.It("reconciles a terminating pod with no node", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				namespaceT := *newNamespace("namespace1")
+				t := newTPod(
+					"node1",
+					"10.128.1.0/24",
+					"10.128.1.2",
+					"10.128.1.1",
+					"myPod",
+					"10.128.1.3",
+					"0a:58:0a:80:01:03",
+					namespaceT.Name,
+				)
+
+				p := newPod(t.namespace, t.podName, t.nodeName, t.podIP)
+				now := metav1.Now()
+				p.SetDeletionTimestamp(&now)
+
+				fakeOvn.startWithDBSetup(initialDB,
+					&v1.NamespaceList{
+						Items: []v1.Namespace{
+							namespaceT,
+						},
+					},
+					&v1.PodList{
+						Items: []v1.Pod{
+							*p,
+						},
+					},
+				)
+				// pod exists, networks annotations don't
+				pod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(t.namespace).Get(context.TODO(), t.podName, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, ok := pod.Annotations[util.OvnPodAnnotationName]
+				gomega.Expect(ok).To(gomega.BeFalse())
+
+				err = fakeOvn.controller.WatchNamespaces()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				err = fakeOvn.controller.WatchPods()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// port should not be in cache, because it should never have been added
+				logicalPort := util.GetLogicalPortName(t.namespace, t.podName)
+				_, err = fakeOvn.controller.logicalPortCache.get(logicalPort)
+				gomega.Expect(err).NotTo(gomega.BeNil())
+				myPod1Key, err := retry.GetResourceKey(pod)
+				retry.CheckRetryObjectEventually(myPod1Key, true, fakeOvn.controller.retryPods)
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 })

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -265,6 +265,11 @@ func PodScheduled(pod *kapi.Pod) bool {
 	return pod.Spec.NodeName != ""
 }
 
+// PodTerminating checks if the pod has been deleted via API but still in the process of terminating
+func PodTerminating(pod *kapi.Pod) bool {
+	return pod.DeletionTimestamp != nil
+}
+
 // EventRecorder returns an EventRecorder type that can be
 // used to post Events to different object's lifecycles.
 func EventRecorder(kubeClient kubernetes.Interface) record.EventRecorder {


### PR DESCRIPTION
Fixes a scenario where a pod exists but the node does not and upon ovnk master reboot our sync would fail. During sync we should attempt to preallocate all existing pod IPs, which include terminating pods with finalizers.

Signed-off-by: Tim Rozet <trozet@redhat.com>

