### PR TITLE
egressip node update: set the node as reachable only when it is beingadded as an egressip node

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2103,6 +2103,8 @@ type egressIPController struct {
 	watchFactory *factory.WatchFactory
 	// EgressIP Node reachability total timeout configuration
 	egressIPTotalTimeout int
+	// reachability check interval
+	reachabilityCheckInterval time.Duration
 	// EgressIP Node reachability gRPC port (0 means it should use dial instead)
 	egressIPNodeHealthCheckPort int
 }
@@ -2411,7 +2413,7 @@ func (e *egressIPController) deleteEgressIPStatusSetup(name string, status egres
 // is important because egress IP is based upon routing traffic to these nodes,
 // and if they aren't reachable we shouldn't be using them for egress IP.
 func (oc *DefaultNetworkController) checkEgressNodesReachability() {
-	timer := time.NewTicker(5 * time.Second)
+	timer := time.NewTicker(oc.eIPC.reachabilityCheckInterval)
 	defer timer.Stop()
 	for {
 		select {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -7438,6 +7438,112 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
+		ginkgo.It("egress node update should not mark the node as reachable if there was no label/readiness change", func() {
+			// When an egress node becomes reachable during a node update event and there is no changes to node labels/readiness
+			// unassigned egress IP should be eventually added by the periodic reachability check.
+			// Test steps:
+			//  - disable periodic check from running in background, so it can be called directly from the test
+			//  - assign egress IP to an available node
+			//  - make the node unreachable and verify that the egress IP was unassigned
+			//  - make the node reachable and update a node
+			//  - verify that the egress IP was assigned by calling the periodic reachability check
+			app.Action = func(ctx *cli.Context) error {
+				egressIP := "192.168.126.101"
+				nodeIPv4 := "192.168.126.51/24"
+				node := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", nodeIPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\"]}", v4NodeSubnet),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				eIP1 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				fakeOvn.startWithDBSetup(
+					libovsdbtest.TestSetup{
+						NBData: []libovsdbtest.TestData{
+							&nbdb.LogicalRouter{
+								Name: ovntypes.OVNClusterRouter,
+								UUID: ovntypes.OVNClusterRouter + "-UUID",
+							},
+							&nbdb.LogicalRouter{
+								Name: ovntypes.GWRouterPrefix + node.Name,
+								UUID: ovntypes.GWRouterPrefix + node.Name + "-UUID",
+							},
+							&nbdb.LogicalRouterPort{
+								UUID:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node.Name + "-UUID",
+								Name:     ovntypes.GWRouterToJoinSwitchPrefix + ovntypes.GWRouterPrefix + node.Name,
+								Networks: []string{nodeLogicalRouterIfAddrV4},
+							},
+							&nbdb.LogicalSwitchPort{
+								UUID: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name + "UUID",
+								Name: types.EXTSwitchToGWRouterPrefix + types.GWRouterPrefix + node.Name,
+								Type: "router",
+								Options: map[string]string{
+									"router-port": types.GWRouterToExtSwitchPrefix + "GR_" + node.Name,
+								},
+							},
+						},
+					},
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP1},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node},
+					},
+				)
+
+				// Virtually disable background reachability check by using a huge interval
+				fakeOvn.controller.eIPC.reachabilityCheckInterval = time.Hour
+
+				err := fakeOvn.controller.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+				egressIPs, _ := getEgressIPStatus(eIP1.Name)
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				hcClient := fakeOvn.controller.eIPC.allocator.cache[node.Name].healthClient.(*fakeEgressIPHealthClient)
+				hcClient.FakeProbeFailure = true
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeOvn.controller)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(0))
+
+				hcClient.FakeProbeFailure = false
+				node.Annotations["test"] = "dummy"
+				_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(hcClient.IsConnected()).Should(gomega.Equal(true))
+				// the node should not be marked as reachable in the update handler as it is not getting added
+				gomega.Consistently(func() bool { return fakeOvn.controller.eIPC.allocator.cache[node.Name].isReachable }).Should(gomega.Equal(false))
+
+				// egress IP should get assigned on the next checkEgressNodesReachabilityIterate call
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeOvn.controller)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
 	})
 
 	ginkgo.Context("Dual-stack assignment", func() {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	egressFirewallDNSDefaultDuration time.Duration = 30 * time.Minute
+	egressFirewallDNSDefaultDuration  = 30 * time.Minute
+	egressIPReachabilityCheckInterval = 5 * time.Second
 )
 
 // ACL logging severity levels


### PR DESCRIPTION
There are three places where ovnkube marks an egress node as reachable:
 - node add event handler
 - node update even handler
 - periodic connectivity checker

In a scenario where the egressip node becomes reachable at the same time as the node object is updated the node is set as reachable but because there was no label/readiness change it is never added as an egressip node: https://github.com/ovn-org/ovn-kubernetes/blob/17ab3c3de635c33489a64b58c68b2c4b0935dfb7/go-controller/pkg/ovn/obj_retry_master.go#L614-L632 The periodic check will then ignore the node because it considers it as already reachable: 
https://github.com/ovn-org/ovn-kubernetes/blob/17ab3c3de635c33489a64b58c68b2c4b0935dfb7/go-controller/pkg/ovn/egressip.go#L2432-L2438
To address the issue only set the node as reachable if it is actually getting added as an egressip node.

Signed-off-by: Patryk Diak <pdiak@redhat.com>

**Reproducer in kind:**
1. Make one node egressip assignable and create an egress IP.
2. Enter the node and make it unreachable:
  `iptables -A INPUT -p tcp --destination-port 9107 -j  DROP`
3. Make sure that the egress IP is not assigned to any node:
  ```
  NAME         EGRESSIPS     ASSIGNED NODE   ASSIGNED EGRESSIPS
  egressip-1   172.18.0.33
  ```
5. Watch ovnkube-master logs in one window and straight after  `Could not connect to <node> (<ip>:9107): context deadline exceeded` is observed run the following command on the node to make it reachable and cause a node object update:
   `iptables -D INPUT -p tcp --destination-port 9107 -j DROP && ip a a 172.15.0.100/16 dev eth0`
   > NOTE: This is time sensitive and the update has to happen before the next periodic reachability check
7. Verify if the existing egress IP got assigned to the node
 
