### PR TITLE
Don't log in iterateRetryResources when there are no retry entries

### DIFF
--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -338,10 +338,13 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 // Deleted entries will be ignored, and all the updates will be reflected with key Lock.
 // Keys added after the snapshot was done won't be retried during this run.
 func (r *RetryFramework) iterateRetryResources() {
+	entriesKeys := r.retryEntries.GetKeys()
+	if len(entriesKeys) == 0 {
+		return
+	}
 	now := time.Now()
 	wg := &sync.WaitGroup{}
 
-	entriesKeys := r.retryEntries.GetKeys()
 	// Process the above list of objects that need retry by holding the lock for each one of them.
 	klog.V(5).Infof("Going to retry %v resource setup for %d objects: %s", r.ResourceHandler.ObjType, len(entriesKeys), entriesKeys)
 


### PR DESCRIPTION
Avoid unnecessary log messages like:

> I1103 16:08:37.699509   89653 obj_retry.go:197] Iterate retry objects requested (resource *v1.Pod)
> I1103 16:08:37.699523   89653 master.go:1299] Posting Warning event for Node node1: [cannot allocate hybrid overlay distributed router ip for nodes until all initial pods are processed, k8s.ovn.org/node-chassis-id annotation not found for node node1, macAddress annotation not found for node "node1" , failed to set up hybrid overlay logical switch port for node1: unable to setup Hybrid Subnet Logical Route Policy for node: node1, error: unable to find router port rtoj-GR_node1: object not found, k8s.ovn.org/l3-gateway-config annotation not found for node "node1"]
> I1103 16:09:07.688454   89653 obj_retry.go:346] Going to retry *v1.Namespace resource setup for 0 objects: []
> I1103 16:09:07.688589   89653 obj_retry.go:355] Waiting for all the *v1.Namespace retry setup to complete in iterateRetryResources
> I1103 16:09:07.688698   89653 obj_retry.go:357] Function iterateRetryResources for *v1.Namespace ended (in 349.566µs)
> I1103 16:09:37.688995   89653 obj_retry.go:346] Going to retry *v1.Namespace resource setup for 0 objects: []

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>
