### PR TITLE
Move check_pkt_larger to gateway router ports

### DIFF
--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -268,38 +268,45 @@ func gatewayInitInternal(nodeName, gwIntf, egressGatewayIntf string, gwNextHops 
 		return nil, nil, err
 	}
 
-	if !config.Gateway.DisablePacketMTUCheck {
+	// Set annotation that determines if options:gateway_mtu shall be set for this node.
+	enableGatewayMTU := true
+	if config.Gateway.DisablePacketMTUCheck {
+		klog.Warningf("Config option disable-pkt-mtu-check is set to true. " +
+			"options:gateway_mtu will be disabled on gateway routers. " +
+			"IP fragmentation or large TCP/UDP payloads may not be forwarded correctly.")
+		enableGatewayMTU = false
+	} else {
 		chkPktLengthSupported, err := util.DetectCheckPktLengthSupport(gatewayBridge.bridgeName)
 		if err != nil {
 			return nil, nil, err
 		}
-
-		ovsHardwareOffloadEnabled, err := util.IsOvsHwOffloadEnabled()
-		if err != nil {
-			return nil, nil, err
-		}
-
-		reason := ""
 		if !chkPktLengthSupported {
-			reason += "OVS on this node does not support check packet length action in kernel datapath. "
+			klog.Warningf("OVS does not support check_packet_length action. " +
+				"options:gateway_mtu will be disabled on gateway routers. " +
+				"IP fragmentation or large TCP/UDP payloads may not be forwarded correctly.")
+			enableGatewayMTU = false
+		} else {
+			/* This is a work around. In order to have the most optimal performance, the packet MTU check should be
+			 * disabled when OVS HW Offload is enabled on the node. The reason is that OVS HW Offload does not support
+			 * packet MTU checks properly without the offload support for sFlow.
+			 * The patches for sFlow in OvS: https://patchwork.ozlabs.org/project/openvswitch/list/?series=290804
+			 * As of writing these offload support patches for sFlow are in review.
+			 * TODO: This workaround should be removed once the offload support for sFlow patches are merged upstream OvS.
+			 */
+			ovsHardwareOffloadEnabled, err := util.IsOvsHwOffloadEnabled()
+			if err != nil {
+				return nil, nil, err
+			}
+			if ovsHardwareOffloadEnabled {
+				klog.Warningf("OVS hardware offloading is enabled. " +
+					"options:gateway_mtu will be disabled on gateway routers for performance reasons. " +
+					"IP fragmentation or large TCP/UDP payloads may not be forwarded correctly.")
+				enableGatewayMTU = false
+			}
 		}
-		/* This is a work around. In order to have the most optimal performance, the packet MTU check should be
-		 * disabled when OVS HW Offload is enabled on the node. The reason is that OVS HW Offload does not support
-		 * packet MTU checks properly without the offload support for sFlow.
-		 * The patches for sFlow in OvS: https://patchwork.ozlabs.org/project/openvswitch/list/?series=290804
-		 * As of writing these offload support patches for sFlow are in review.
-		 * TODO: This workaround should be removed once the offload support for sFlow patches are merged upstream OvS.
-		 */
-		if ovsHardwareOffloadEnabled {
-			reason += "OVS Hardware Offload, enabled on this node, does not support check packet length action offloading. "
-		}
-
-		if !chkPktLengthSupported || ovsHardwareOffloadEnabled {
-			klog.Warningf("Disable Packet MTU Check will be forced true. %sThis will cause incoming packets "+
-				"destined to OVN and larger than pod MTU: %d to the node, being dropped "+
-				"without sending fragmentation needed", reason, config.Default.MTU)
-			config.Gateway.DisablePacketMTUCheck = true
-		}
+	}
+	if err := util.SetGatewayMTUSupport(nodeAnnotator, enableGatewayMTU); err != nil {
+		return nil, nil, err
 	}
 
 	if config.Default.EnableUDPAggregation {
@@ -345,11 +352,6 @@ func gatewayReady(patchPort string) (bool, error) {
 
 func (g *gateway) GetGatewayBridgeIface() string {
 	return g.openflowManager.defaultBridge.bridgeName
-}
-
-// getMaxFrameLength returns the maximum frame size (ignoring VLAN header) that a gateway can handle
-func getMaxFrameLength() int {
-	return config.Default.MTU + 14
 }
 
 type bridgeConfiguration struct {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -234,6 +234,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			defer GinkgoRecover()
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
+			Expect(err).NotTo(HaveOccurred())
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator, k,
 				&fakeMgmtPortConfig, wf)
 			Expect(err).NotTo(HaveOccurred())
@@ -265,6 +266,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Expect(l.Attrs().HardwareAddr.String()).To(Equal(eth0MAC))
 			return nil
 		})
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(fexec.CalledMatchesExpected, 5).Should(BeTrue(), fexec.ErrorDesc)
 
@@ -527,6 +529,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			defer GinkgoRecover()
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
+			Expect(err).NotTo(HaveOccurred())
 			// provide host IP as GR IP
 			gwIPs := []*net.IPNet{ovntest.MustParseIPNet(hostCIDR)}
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops,
@@ -542,6 +545,7 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 			sharedGw.Start(stop, wg)
 			return nil
 		})
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(fexec.CalledMatchesExpected, 5).Should(BeTrue(), fexec.ErrorDesc)
 
@@ -625,6 +629,7 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 			link, err := netlink.LinkByName(uplinkName)
 			Expect(err).NotTo(HaveOccurred())
 			routes, err := netlink.RouteList(link, netlink.FAMILY_ALL)
+			Expect(err).NotTo(HaveOccurred())
 			for _, expRoute := range expectedRoutes {
 				found := false
 				for _, route := range routes {
@@ -638,6 +643,7 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 			}
 			return nil
 		})
+		Expect(err).NotTo(HaveOccurred())
 		return nil
 	}
 
@@ -887,6 +893,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 			defer GinkgoRecover()
 
 			gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
+			Expect(err).NotTo(HaveOccurred())
 			localGw, err := newLocalGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil,
 				nodeAnnotator, &fakeMgmtPortConfig, k, wf)
 			Expect(err).NotTo(HaveOccurred())
@@ -918,6 +925,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 			Expect(l.Attrs().HardwareAddr.String()).To(Equal(eth0MAC))
 			return nil
 		})
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(fexec.CalledMatchesExpected, 5).Should(BeTrue(), fexec.ErrorDesc)
 

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -1038,17 +1038,17 @@ var _ = Describe("Node Operations", func() {
 					},
 				}
 				expectedNodePortFlows := []string{
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=check_pkt_larger(1414)->reg0[0],resubmit(,11)",
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, tcp, tp_src=31111, actions=output:eth0",
 				}
 				expectedLBIngressFlows := []string{
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
-					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, tcp, nw_dst=5.5.5.5, tp_dst=8080, actions=check_pkt_larger(1414)->reg0[0],resubmit(,11)",
+					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, tcp, nw_dst=5.5.5.5, tp_dst=8080, actions=output:patch-breth0_ov",
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=patch-breth0_ov, tcp, nw_src=5.5.5.5, tp_src=8080, actions=output:eth0",
 				}
 				expectedLBExternalIPFlows := []string{
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
-					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, tcp, nw_dst=1.1.1.1, tp_dst=8080, actions=check_pkt_larger(1414)->reg0[0],resubmit(,11)",
+					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, tcp, nw_dst=1.1.1.1, tp_dst=8080, actions=output:patch-breth0_ov",
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=patch-breth0_ov, tcp, nw_src=1.1.1.1, tp_src=8080, actions=output:eth0",
 				}
 
@@ -2009,7 +2009,7 @@ var _ = Describe("Node Operations", func() {
 				}
 				expectedFlows := []string{
 					// default
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=check_pkt_larger(1414)->reg0[0],resubmit(,11)",
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, tcp, tp_src=31111, actions=output:eth0",
 				}
 
@@ -2302,7 +2302,7 @@ var _ = Describe("Node Operations", func() {
 				}
 				expectedFlows := []string{
 					// default
-					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=check_pkt_larger(1414)->reg0[0],resubmit(,11)",
+					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=eth0, tcp, tp_dst=31111, actions=output:patch-breth0_ov",
 					"cookie=0x453ae29bcbbc08bd, priority=110, in_port=patch-breth0_ov, tcp, tp_src=31111, actions=output:eth0",
 				}
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -114,18 +114,9 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 	var err error
 	var errors []error
 
-	// 14 bytes of overhead for ethernet header (does not include VLAN)
-	maxPktLength := getMaxFrameLength()
 	isServiceTypeETPLocal := util.ServiceExternalTrafficPolicyLocal(service)
 
-	var actions string
-	if config.Gateway.DisablePacketMTUCheck {
-		actions = fmt.Sprintf("output:%s", npw.ofportPatch)
-	} else {
-		// check packet length larger than MTU + eth header - vlan overhead
-		// send to table 11 to check if it needs to go to kernel for ICMP needs frag
-		actions = fmt.Sprintf("check_pkt_larger(%d)->reg0[0],resubmit(,11)", maxPktLength)
-	}
+	actions := fmt.Sprintf("output:%s", npw.ofportPatch)
 
 	// cookie is only used for debugging purpose. so it is not fatal error if cookie is failed to be generated.
 	for _, svcPort := range service.Spec.Ports {
@@ -235,7 +226,7 @@ func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, h
 // `add` parameter indicates if the flows should exist or be removed from the cache
 // `hasLocalHostNetworkEp` indicates if at least one host networked endpoint exists for this service which is local to this node.
 // `protocol` is TCP/UDP/SCTP as set in the svc.Port
-// `actions`: based on config.Gateway.DisablePacketMTUCheck, this will either be "send to patchport" or "send to table11 for checking if it needs to go to kernel for ICMP needs frag"
+// `actions`: "send to patchport"
 // `externalIPOrLBIngressIP` is either externalIP.IP or LB.status.ingress.IP
 // `ipType` is either "External" or "Ingress"
 func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, svcPort *kapi.ServicePort, add bool, hasLocalHostNetworkEp bool, protocol string, actions string, externalIPOrLBIngressIP string, ipType string) error {
@@ -1045,8 +1036,6 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 	bridgeIPs := bridge.ips
 
 	var dftFlows []string
-	// 14 bytes of overhead for ethernet header (does not include VLAN)
-	maxPktLength := getMaxFrameLength()
 
 	if config.IPv4Mode {
 		// table0, Geneve packets coming from external. Skip conntrack and go directly to host
@@ -1188,14 +1177,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 				protoPrefix, masqIP, HostMasqCTZone))
 	}
 
-	var actions string
-	if config.Gateway.DisablePacketMTUCheck {
-		actions = fmt.Sprintf("output:%s", ofPortPatch)
-	} else {
-		// check packet length larger than MTU + eth header - vlan overhead
-		// send to table 11 to check if it needs to go to kernel for ICMP needs frag
-		actions = fmt.Sprintf("check_pkt_larger(%d)->reg0[0],resubmit(,11)", maxPktLength)
-	}
+	actions := fmt.Sprintf("output:%s", ofPortPatch)
 
 	if config.IPv4Mode {
 		// table 1, established and related connections in zone 64000 with ct_mark ctMarkOVN go to OVN
@@ -1298,7 +1280,6 @@ func commonFlows(bridge *bridgeConfiguration) []string {
 	ofPortHost := bridge.ofPortHost
 
 	var dftFlows []string
-	maxPktLength := getMaxFrameLength()
 
 	// table 0, we check to see if this dest mac is the shared mac, if so flood to both ports
 	dftFlows = append(dftFlows,
@@ -1348,19 +1329,10 @@ func commonFlows(bridge *bridgeConfiguration) []string {
 				"actions=ct(zone=%d, table=1)", defaultOpenFlowCookie, ofPortPhys, config.Default.ConntrackZone))
 	}
 
-	var actions string
-	if config.Gateway.DisablePacketMTUCheck {
-		actions = fmt.Sprintf("output:%s", ofPortPatch)
-	} else {
-		// check packet length larger than MTU + eth header - vlan overhead
-		// send to table 11 to check if it needs to go to kernel for ICMP needs frag
-		actions = fmt.Sprintf("check_pkt_larger(%d)->reg0[0],resubmit(,11)", maxPktLength)
-	}
+	actions := fmt.Sprintf("output:%s", ofPortPatch)
 
 	if config.Gateway.DisableSNATMultipleGWs {
 		// table 1, traffic to pod subnet go directly to OVN
-		// check packet length larger than MTU + eth header - vlan overhead
-		// send to table 11 to check if it needs to go to kernel for ICMP needs frag/packet too big
 		for _, clusterEntry := range config.Default.ClusterSubnets {
 			cidr := clusterEntry.CIDR
 			var ipPrefix string
@@ -1403,17 +1375,6 @@ func commonFlows(bridge *bridgeConfiguration) []string {
 				defaultOpenFlowCookie, ofPortPhys, ofPortPatch, ofPortHost))
 	}
 
-	// New dispatch table 11
-	// packets larger than known acceptable MTU need to go to kernel to create ICMP frag needed
-	if !config.Gateway.DisablePacketMTUCheck {
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=10, table=11, reg0=0x1, "+
-				"actions=output:%s", defaultOpenFlowCookie, ofPortHost))
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=1, table=11, "+
-				"actions=output:%s", defaultOpenFlowCookie, ofPortPatch))
-
-	}
 	// table 1, all other connections do normal processing
 	dftFlows = append(dftFlows,
 		fmt.Sprintf("cookie=%s, priority=0, table=1, actions=output:NORMAL", defaultOpenFlowCookie))

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -805,7 +805,8 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		mgmtSync := failed || macAddressChanged(oldNode, newNode) || nodeSubnetChanged(oldNode, newNode)
 		_, failed = h.oc.gatewaysFailed.Load(newNode.Name)
 		gwSync := (failed || gatewayChanged(oldNode, newNode) ||
-			nodeSubnetChanged(oldNode, newNode) || hostAddressesChanged(oldNode, newNode))
+			nodeSubnetChanged(oldNode, newNode) || hostAddressesChanged(oldNode, newNode) ||
+			nodeGatewayMTUSupportChanged(oldNode, newNode))
 		_, hoSync := h.oc.hybridOverlayFailed.Load(newNode.Name)
 
 		return h.oc.addUpdateNodeEvent(newNode, &nodeSyncs{nodeSync, clusterRtrSync, mgmtSync, gwSync, hoSync})

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -418,7 +418,10 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			skipSnat := false
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config, []*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
+				node1.NodeMgmtPortIP, "1400")
 
 			hybridSubnetStaticRoute1, hybridLogicalRouterStaticRoute, hybridSubnetLRP1, hybridSubnetLRP2, hybridLogicalSwitchPort := setupHybridOverlayOVNObjects(node1, hoSubnet, nodeHOIP, nodeHOMAC)
 
@@ -637,7 +640,10 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			skipSnat := false
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config, []*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
+				node1.NodeMgmtPortIP, "1400")
 
 			hybridSubnetStaticRoute1, hybridLogicalRouterStaticRoute, hybridSubnetLRP1, hybridSubnetLRP2, hybridLogicalSwitchPort := setupHybridOverlayOVNObjects(node1, hoSubnet, nodeHOIP, nodeHOMAC)
 
@@ -873,7 +879,10 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			skipSnat := false
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config, []*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
+				node1.NodeMgmtPortIP, "1400")
 
 			hybridSubnetStaticRoute1, hybridLogicalRouterStaticRoute, hybridSubnetLRP1, hybridSubnetLRP2, hybridLogicalSwitchPort := setupHybridOverlayOVNObjects(node1, winNodeSubnet, nodeHOIP, nodeHOMAC)
 
@@ -1133,7 +1142,10 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			skipSnat := false
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config, []*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
+				node1.NodeMgmtPortIP, "1400")
 
 			hybridSubnetStaticRoute1, hybridLogicalRouterStaticRoute, hybridSubnetLRP1, hybridSubnetLRP2, hybridLogicalSwitchPort := setupHybridOverlayOVNObjects(node1, hoSubnet, nodeHOIP, nodeHOMAC)
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -329,7 +329,11 @@ func (oc *DefaultNetworkController) syncGatewayLogicalNetwork(node *kapi.Node, l
 	}
 
 	drLRPIPs, _ := oc.joinSwIPManager.EnsureJoinLRPIPs(types.OVNClusterRouter)
-	err = oc.gatewayInit(node.Name, clusterSubnets, hostSubnets, l3GatewayConfig, oc.SCTPSupport, gwLRPIPs, drLRPIPs)
+
+	enableGatewayMTU := util.ParseNodeGatewayMTUSupport(node)
+
+	err = oc.gatewayInit(node.Name, clusterSubnets, hostSubnets, l3GatewayConfig, oc.SCTPSupport, gwLRPIPs, drLRPIPs,
+		enableGatewayMTU)
 	if err != nil {
 		return fmt.Errorf("failed to init shared interface gateway: %v", err)
 	}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1061,7 +1061,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			}
 
 			skipSnat := false
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig, []*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
+				skipSnat, node1.NodeMgmtPortIP, "1400")
 			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			return nil
@@ -1116,7 +1119,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			}
 
 			skipSnat := false
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig, []*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
+				skipSnat, node1.NodeMgmtPortIP, "1400")
 			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			return nil
@@ -1173,7 +1179,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			skipSnat := config.Gateway.DisableSNATMultipleGWs
 			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
 
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig, []*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3GatewayConfig,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
+				skipSnat, node1.NodeMgmtPortIP, "1400")
 
 			// add stale SNATs from pods to nodes on wrong node
 			staleNats := []*nbdb.NAT{
@@ -1245,7 +1254,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			skipSnat := false
 			l3Config := node1.gatewayConfig(config.GatewayModeShared, uint(vlanID))
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config, []*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
+				skipSnat, node1.NodeMgmtPortIP, "1400")
 			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			ginkgo.By("modifying the node and triggering an update")
@@ -1307,7 +1319,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 
 			skipSnat := false
 			l3Config := node1.gatewayConfig(config.GatewayModeLocal, uint(vlanID))
-			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config, []*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{subnet}, l3Config,
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)},
+				skipSnat, node1.NodeMgmtPortIP, "1400")
 			gomega.Eventually(clusterController.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 			ginkgo.By("Bringing down NBDB")
 			// inject transient problem, nbdb is down

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -261,7 +261,8 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			skipSnat := false
 			expectedDatabaseState = generateGatewayInitExpectedNB(expectedDatabaseState, expectedOVNClusterRouter,
 				expectedNodeSwitch, node1.Name, clusterSubnets, []*net.IPNet{nodeSubnet}, l3Config,
-				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat, node1.NodeMgmtPortIP)
+				[]*net.IPNet{classBIPAddress(node1.LrpIP)}, []*net.IPNet{classBIPAddress(node1.DrLrpIP)}, skipSnat,
+				node1.NodeMgmtPortIP, "1400")
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			// check the namespace again and ensure the address set

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	ref "k8s.io/client-go/tools/reference"
 	"net"
 	"reflect"
 	"sync"
 	"time"
+
+	ref "k8s.io/client-go/tools/reference"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
@@ -400,6 +401,11 @@ func nodeChassisChanged(oldNode, node *kapi.Node) bool {
 	oldChassis, _ := util.ParseNodeChassisIDAnnotation(oldNode)
 	newChassis, _ := util.ParseNodeChassisIDAnnotation(node)
 	return oldChassis != newChassis
+}
+
+// nodeGatewayMTUSupportChanged returns true if annotation "k8s.ovn.org/gateway-mtu-support" on the node was updated.
+func nodeGatewayMTUSupportChanged(oldNode, node *kapi.Node) bool {
+	return util.ParseNodeGatewayMTUSupport(oldNode) != util.ParseNodeGatewayMTUSupport(node)
 }
 
 // noHostSubnet() compares the no-hostsubnet-nodes flag with node labels to see if the node is managing its

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -45,6 +45,9 @@ const (
 	// ovnNodeL3GatewayConfig is the constant string representing the l3 gateway annotation key
 	ovnNodeL3GatewayConfig = "k8s.ovn.org/l3-gateway-config"
 
+	// ovnNodeGatewayMtuSupport determines if option:gateway_mtu shall be set for GR router ports.
+	ovnNodeGatewayMtuSupport = "k8s.ovn.org/gateway-mtu-support"
+
 	// OvnDefaultNetworkGateway captures L3 gateway config for default OVN network interface
 	ovnDefaultNetworkGateway = "default"
 
@@ -247,6 +250,22 @@ func SetL3GatewayConfig(nodeAnnotator kube.Annotator, cfg *L3GatewayConfig) erro
 		}
 	}
 	return nil
+}
+
+// SetGatewayMTUSupport sets annotation "k8s.ovn.org/gateway-mtu-support" to "false" or removes the annotation from
+// this node.
+func SetGatewayMTUSupport(nodeAnnotator kube.Annotator, set bool) error {
+	if set {
+		nodeAnnotator.Delete(ovnNodeGatewayMtuSupport)
+		return nil
+	}
+	return nodeAnnotator.Set(ovnNodeGatewayMtuSupport, "false")
+}
+
+// ParseNodeGatewayMTUSupport parses annotation "k8s.ovn.org/gateway-mtu-support". The default behavior should be true,
+// therefore only an explicit string of "false" will make this function return false.
+func ParseNodeGatewayMTUSupport(node *kapi.Node) bool {
+	return node.Annotations[ovnNodeGatewayMtuSupport] != "false"
 }
 
 // ParseNodeL3GatewayAnnotation returns the parsed l3-gateway-config annotation

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +19,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/pointer"
 
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -27,6 +29,14 @@ import (
 var _ = ginkgo.Describe("Services", func() {
 	const (
 		serviceName = "testservice"
+
+		echoServerPodNameTemplate = "echo-server-pod-%d"
+		echoClientPodName         = "echo-client-pod"
+		echoServiceNameTemplate   = "echo-service-%d"
+		echoServerPodPortMin      = 9800
+		echoServerPodPortMax      = 9899
+		echoServicePortMin        = 31200
+		echoServicePortMax        = 31299
 	)
 
 	f := wrappedTestFramework("services")
@@ -94,6 +104,253 @@ var _ = ginkgo.Describe("Services", func() {
 		})
 		framework.ExpectNoError(err)
 	})
+
+	// The below series of tests queries nodePort services with hostNetwork:true and hostNetwork:false pods as endpoints,
+	// for both HTTP and UDP and different ingress and egress payload sizes.
+	// Steps:
+	// * Set up a hostNetwork:true|false pod (agnhost echo server) on node z
+	// * Set up a nodePort service on node y
+	// * Set up a hostNetwork:true client pod on node x
+	// * Query from node x to the service on node y that targets the pod on node z
+	for _, hostNetwork := range []bool{true, false} {
+		hostNetwork := hostNetwork
+		ginkgo.When(fmt.Sprintf("a nodePort service targeting a pod with hostNetwork:%t is created", hostNetwork), func() {
+			var serverPod *v1.Pod
+			var serverPodNodeName string
+			var serverPodPort int
+			var serverPodName string
+
+			var svc v1.Service
+			var serviceNode v1.Node
+			var serviceNodeInternalIPs []string
+			var servicePort int
+
+			var clientPod *v1.Pod
+			var clientPodNodeName string
+
+			var echoPayloads = map[string]string{
+				"small": fmt.Sprintf("%010d", 1),
+				"large": fmt.Sprintf("%01420d", 1),
+			}
+			var echoMtuRegex = regexp.MustCompile(`cache expires.*mtu.*`)
+
+			ginkgo.BeforeEach(func() {
+				ginkgo.By("Selecting 3 schedulable nodes")
+				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
+
+				ginkgo.By("Selecting nodes for pods and service")
+				serverPodNodeName = nodes.Items[0].Name
+				serviceNode = nodes.Items[1]
+				clientPodNodeName = nodes.Items[2].Name
+
+				ginkgo.By("Getting all InternalIP addresses of the service node")
+				serviceNodeInternalIPs = e2enode.GetAddresses(&serviceNode, v1.NodeInternalIP)
+				gomega.Expect(len(serviceNodeInternalIPs)).To(gomega.BeNumerically(">", 0))
+
+				ginkgo.By("Creating hostNetwork:true client pod")
+				clientPod = e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
+				clientPod.Spec.NodeName = clientPodNodeName
+				clientPod.Spec.HostNetwork = true
+				for k := range clientPod.Spec.Containers {
+					if clientPod.Spec.Containers[k].Name == "agnhost-container" {
+						clientPod.Spec.Containers[k].Command = []string{
+							"sleep",
+							"infinity",
+						}
+						clientPod.Spec.Containers[k].SecurityContext.Privileged = pointer.Bool(true)
+					}
+				}
+				f.PodClient().CreateSync(clientPod)
+
+				ginkgo.By(fmt.Sprintf("Creating the server pod with hostNetwork:%t", hostNetwork))
+				// Create the server pod.
+				// Wait for 1 minute and if the pod does not come up, select a different port and try again.
+				// Wait for a max of 5 minutes.
+				gomega.Eventually(func() error {
+					serverPodPort = rand.Intn(echoServerPodPortMax-echoServerPodPortMin) + echoServerPodPortMin
+					serverPodName = fmt.Sprintf(echoServerPodNameTemplate, serverPodPort)
+					framework.Logf("Creating server pod listening on TCP and UDP port %d", serverPodPort)
+					serverPod = e2epod.NewAgnhostPod(f.Namespace.Name, serverPodName, nil, nil, nil, "netexec",
+						"--http-port",
+						fmt.Sprintf("%d", serverPodPort),
+						"--udp-port",
+						fmt.Sprintf("%d", serverPodPort))
+					serverPod.ObjectMeta.Labels = map[string]string{
+						"app": serverPodName,
+					}
+					serverPod.Spec.HostNetwork = hostNetwork
+					serverPod.Spec.NodeName = serverPodNodeName
+					f.PodClient().Create(serverPod)
+
+					err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, serverPod.Name, f.Namespace.Name, 1*time.Minute)
+					if err != nil {
+						f.PodClient().Delete(context.TODO(), serverPod.Name, metav1.DeleteOptions{})
+						return err
+					}
+					serverPod, err = f.PodClient().Get(context.TODO(), serverPod.Name, metav1.GetOptions{})
+					return err
+				}, 5*time.Minute, 1*time.Second).Should(gomega.Succeed())
+
+				ginkgo.By("Creating the nodePort service")
+				// Create the service.
+				// If the servicePorts are already in use, creating the service should fail and we should choose another
+				// random port.
+				gomega.Eventually(func() error {
+					servicePort = rand.Intn(echoServicePortMax-echoServicePortMin) + echoServicePortMin
+					framework.Logf("Creating the nodePort service listening on TCP and UDP port %d and targeting pod port %d",
+						servicePort, serverPodPort)
+					svc = v1.Service{
+						ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf(echoServiceNameTemplate, servicePort)},
+						Spec: v1.ServiceSpec{
+							Ports: []v1.ServicePort{
+								{
+									Name:     "tcp-port",
+									NodePort: int32(servicePort),
+									Port:     int32(serverPodPort),
+									Protocol: v1.ProtocolTCP,
+								},
+								{
+									Name:     "udp-port",
+									NodePort: int32(servicePort),
+									Port:     int32(serverPodPort),
+									Protocol: v1.ProtocolUDP,
+								},
+							},
+							Selector: map[string]string{"app": serverPodName},
+							Type:     v1.ServiceTypeNodePort},
+					}
+					_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), &svc, metav1.CreateOptions{})
+					return err
+				}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
+			})
+
+			// Run queries against the service both with a small (10 bytes + overhead for echo service) and
+			// a large (1420 bytes + overhead for echo service) payload.
+			// The payload is transmitted to and echoed from the echo service for both HTTP and UDP tests.
+			ginkgo.When("tests are run towards the agnhost echo service", func() {
+				ginkgo.It("queries to the nodePort service shall work for TCP", func() {
+					for _, size := range []string{"small", "large"} {
+						for _, serviceNodeIP := range serviceNodeInternalIPs {
+							ginkgo.By(fmt.Sprintf("Sending TCP %s payload to service IP %s "+
+								"and expecting to receive the same payload", size, serviceNodeIP))
+							cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s:%d/echo?msg=%s",
+								serviceNodeIP,
+								servicePort,
+								echoPayloads[size],
+							)
+							framework.Logf("Testing TCP %s with command %q", size, cmd)
+							stdout, err := framework.RunHostCmdWithRetries(
+								clientPod.Namespace,
+								clientPod.Name,
+								cmd,
+								framework.Poll,
+								60*time.Second)
+							framework.ExpectNoError(err, fmt.Sprintf("Testing TCP with %s payload failed", size))
+							gomega.Expect(stdout).To(gomega.Equal(echoPayloads[size]), fmt.Sprintf("Testing TCP with %s payload failed", size))
+						}
+					}
+				})
+
+				// We have 2 possible scenarios - hostNetwork endpoints and non-hostNetwork endpoints.
+				// We will only see fragmentation for large (> 1400 Bytes) packets and non-hostNetwork endpoints.
+				//
+				// hostNetwork endpoints:
+				// Packet from ovn-worker2 to GR_ovn-worker where it will hit LB:
+				// # ovn-nbctl lr-lb-list GR_ovn-worker | grep udp | grep 31206
+				// 083a13aa-13e0-45bb-8a1a-175ce7e9fe81    Service_services    udp        172.18.0.3:31206      10.244.2.3:9894
+				// With routes:
+				// # ovn-nbctl lr-route-list GR_ovn-worker  | grep dst-ip
+				//            10.244.0.0/16                100.64.0.1 dst-ip
+				//                0.0.0.0/0                172.18.0.1 dst-ip rtoe-GR_ovn-worker
+				// This means that the packet will enter port rtoe-GR_ovn-worker, be load-balanced and
+				// exit port rtoe-GR_ovn-worker right away.
+				// In OVN, we must apply the gateway_mtu setting to the rtoj port:
+				// # ovn-nbctl find Logical_Router_Port name=rtoj-GR_ovn-control-plane | grep options
+				// options             : {gateway_mtu="1400"}
+				// As a consequence, we shall never see fragmentation for hostNetwork:true pods.
+				//
+				// non-hostNetwork endpoints:
+				// # ovn-nbctl lr-lb-list GR_ovn-worker | grep udp | grep 31206
+				// 083a13aa-13e0-45bb-8a1a-175ce7e9fe81    Service_services    udp        172.18.0.3:31206      10.244.2.3:9894
+				// # ovn-nbctl lr-route-list GR_ovn-worker  | grep dst-ip
+				//            10.244.0.0/16                100.64.0.1 dst-ip
+				//                0.0.0.0/0                172.18.0.1 dst-ip rtoe-GR_ovn-worker
+				// This time, the packet will leave the rtoj port and it will be fragmented.
+				ginkgo.It("queries to the nodePort service shall work for UDP", func() {
+					for _, size := range []string{"small", "large"} {
+						for _, serviceNodeIP := range serviceNodeInternalIPs {
+							if size == "large" && !hostNetwork {
+								// Flushing the IP route cache will remove any routes in the cache
+								// that are a result of receiving a "need to frag" packet.
+								ginkgo.By("Flushing the ip route cache")
+								_, err := framework.RunHostCmdWithRetries(
+									clientPod.Namespace,
+									clientPod.Name,
+									"ip route flush cache",
+									framework.Poll,
+									60*time.Second)
+								framework.ExpectNoError(err, "Flushing the ip route cache failed")
+
+								// List the current IP route cache for informative purposes.
+								cmd := fmt.Sprintf("ip route get %s", serviceNodeIP)
+								stdout, err := framework.RunHostCmd(
+									clientPod.Namespace,
+									clientPod.Name,
+									cmd)
+								framework.ExpectNoError(err, "Listing IP route cache")
+								framework.Logf("%s: %s", cmd, stdout)
+							}
+
+							// We expect the following to fail at least once for large payloads and non-hostNetwork
+							// endpoints: the first request will fail as we have to receive a "need to frag" ICMP
+							// message, subsequent requests then should succeed.
+							gomega.Eventually(func() error {
+								ginkgo.By(fmt.Sprintf("Sending UDP %s payload to service IP %s "+
+									"and expecting to receive the same payload", size, serviceNodeIP))
+								// Send payload via UDP.
+								cmd := fmt.Sprintf("echo 'echo %s' | nc -w2 -u %s %d",
+									echoPayloads[size],
+									serviceNodeIP,
+									servicePort,
+								)
+								framework.Logf("Testing UDP %s with command %q", size, cmd)
+								stdout, err := framework.RunHostCmd(
+									clientPod.Namespace,
+									clientPod.Name,
+									cmd)
+								if err != nil {
+									return err
+								}
+								// Compare received payload vs sent payload.
+								if stdout != echoPayloads[size] {
+									return fmt.Errorf("stdout does not match payloads[%s], %s != %s", size, stdout, echoPayloads[size])
+								}
+
+								if size == "large" && !hostNetwork {
+									ginkgo.By("Making sure that the ip route cache contains an MTU route")
+									// Get IP route cache and make sure that it contains an MTU route.
+									cmd = fmt.Sprintf("ip route get %s", serviceNodeIP)
+									stdout, err = framework.RunHostCmd(
+										clientPod.Namespace,
+										clientPod.Name,
+										cmd)
+									if err != nil {
+										return fmt.Errorf("could not list IP route cache, err: %q", err)
+									}
+									if !echoMtuRegex.Match([]byte(stdout)) {
+										return fmt.Errorf("cannot find MTU cache entry in route: %s", stdout)
+									}
+								}
+								return nil
+							}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
+						}
+					}
+				})
+			})
+		})
+	}
 
 	// This test checks a special case: we add another IP address on the node *and* manually set that
 	// IP address in to endpoints. It is used for some special apiserver hacks by remote cluster people.


### PR DESCRIPTION
A series of patches around 947e8d450ebaa8ce4ab81cb480a419618f1508c7
in the ovn-org/ovn repository now enable check_pkt_larger for gateway
router ports. Take advantage of this new feature to solve https://issues.redhat.com/browse/OCPBUGS-2827

Also see: http://patchwork.ozlabs.org/project/ovn/cover/cover.1627405420.git.lorenzo.bianconi@redhat.com/

Reported-at: https://issues.redhat.com/browse/OCPBUGS-2827
Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->