### PR TITLE
node: mock conntrack delete operations for service and EgressIP testcases

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -41,13 +41,13 @@ func TestNewEgressDNS(t *testing.T) {
 			desc:   "fails to read the /etc/resolv.conf file",
 			errExp: true,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}, 0, 1},
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{nil, fmt.Errorf("mock error")}, 0, 1},
 			},
 		},
 		{
 			desc: "positive tests case",
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{&dns.ClientConfig{}, nil}, 0, 1},
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{}, nil}, 0, 1},
 			},
 		},
 	}
@@ -112,12 +112,12 @@ func TestAdd(t *testing.T) {
 			errExp:   true,
 			syncTime: 5 * time.Minute,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{&dns.ClientConfig{
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
 					Servers: []string{"1.1.1.1"},
 					Port:    "1234"}, nil}, 0, 1},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{nil, fmt.Errorf("mock error")}, 0, 1},
+				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{}, []interface{}{nil, fmt.Errorf("mock error")}, 0, 1},
 			},
 		},
 		{
@@ -129,19 +129,19 @@ func TestAdd(t *testing.T) {
 			configIPv6: false,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{&dns.ClientConfig{
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
 					Servers: []string{"1.1.1.1"},
 					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{test1DNSName}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
 
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil}, 0, 1},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
-				{"SetIPs", []string{"[]net.IP"}, []interface{}{nil}, 0, 1},
+				{"SetIPs", []string{"[]net.IP"}, []interface{}{}, []interface{}{nil}, 0, 1},
 			},
 		},
 
@@ -155,21 +155,21 @@ func TestAdd(t *testing.T) {
 			configIPv6:               true,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{&dns.ClientConfig{
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
 					Servers: []string{"1.1.1.1"},
 					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{test1DNSName}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{test1DNSName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv6, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv6, "300")}}, 500 * time.Second, nil}, 0, 1},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
-				{"SetIPs", []string{"[]net.IP"}, []interface{}{nil}, 0, 1},
+				{"SetIPs", []string{"[]net.IP"}, []interface{}{}, []interface{}{nil}, 0, 1},
 			},
 		},
 		{
@@ -182,25 +182,25 @@ func TestAdd(t *testing.T) {
 			configIPv6:               false,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{&dns.ClientConfig{
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
 					Servers: []string{"1.1.1.1"},
 					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{test1DNSName}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
 
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
 				// return a very low ttl so that the update based on ttl timeout occurs
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "4")}}, 1 * time.Second, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{test1DNSName}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "4")}}, 1 * time.Second, nil}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
 
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4Update, "300")}}, 1 * time.Second, nil}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4Update, "300")}}, 1 * time.Second, nil}, 0, 1},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
-				{"SetIPs", []string{"[]net.IP"}, []interface{}{nil}, 0, 1},
-				{"SetIPs", []string{"[]net.IP"}, []interface{}{nil}, 0, 1},
+				{"SetIPs", []string{"[]net.IP"}, []interface{}{}, []interface{}{nil}, 0, 1},
+				{"SetIPs", []string{"[]net.IP"}, []interface{}{}, []interface{}{nil}, 0, 1},
 			},
 		},
 	}
@@ -326,22 +326,22 @@ func TestDelete(t *testing.T) {
 			configIPv6:               true,
 
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{&dns.ClientConfig{
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{
 					Servers: []string{"1.1.1.1"},
 					Port:    "1234"}, nil}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{test1DNSName}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{test1DNSName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv6, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{test1DNSName}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv4, "300")}}, 500 * time.Second, nil}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{Answer: []dns.RR{generateRR(test1DNSName, test1IPv6, "300")}}, 500 * time.Second, nil}, 0, 1},
 			},
 			addressSetFactoryOpsHelper: []ovntest.TestifyMockHelper{
-				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{mockAddressSetOps, nil}, 0, 1},
+				{"NewAddressSet", []string{"string", "[]net.IP"}, []interface{}{}, []interface{}{mockAddressSetOps, nil}, 0, 1},
 			},
 			addressSetOpsHelper: []ovntest.TestifyMockHelper{
-				{"SetIPs", []string{"[]net.IP"}, []interface{}{nil}, 0, 1},
-				{"Destroy", []string{}, []interface{}{nil}, 0, 1},
+				{"SetIPs", []string{"[]net.IP"}, []interface{}{}, []interface{}{nil}, 0, 1},
+				{"Destroy", []string{}, []interface{}{}, []interface{}{nil}, 0, 1},
 			},
 		},
 	}

--- a/go-controller/pkg/testing/testifymockhelper.go
+++ b/go-controller/pkg/testing/testifymockhelper.go
@@ -15,6 +15,9 @@ type TestifyMockHelper struct {
 	// OnCallMethodArgType - argument types of the method that will be called.
 	// Refer the `Arguments` field at https://godoc.org/github.com/stretchr/testify/mock#Call
 	OnCallMethodArgType []string
+	// OnCallMethodArgs - argument values we expect to be passed to the method.
+	// Refer the `Arguments` field at https://godoc.org/github.com/stretchr/testify/mock#Call
+	OnCallMethodArgs []interface{}
 	// RetArgList - arguments returned by mock method when called.
 	// Refer the `ReturnArguments` field at https://godoc.org/github.com/stretchr/testify/mock#Call
 	RetArgList []interface{}
@@ -41,12 +44,16 @@ func ProcessMockFn(mockObj *mock.Mock, mArgs TestifyMockHelper) {
 		panic("mock object missing")
 	}
 	call := mockObj.On(mArgs.OnCallMethodName)
-	for _, arg := range mArgs.OnCallMethodArgType {
-		call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
-	}
-	// append the repetitive arg types of `string` at the end
-	for i := 0; i < mArgs.OnCallMethodsArgsStrTypeAppendCount; i++ {
-		call.Arguments = append(call.Arguments, mock.AnythingOfType("string"))
+	if len(mArgs.OnCallMethodArgs) > 0 {
+		call.Arguments = mArgs.OnCallMethodArgs
+	} else {
+		for _, arg := range mArgs.OnCallMethodArgType {
+			call.Arguments = append(call.Arguments, mock.AnythingOfType(arg))
+		}
+		// append the repetitive arg types of `string` at the end
+		for i := 0; i < mArgs.OnCallMethodsArgsStrTypeAppendCount; i++ {
+			call.Arguments = append(call.Arguments, mock.AnythingOfType("string"))
+		}
 	}
 	for _, ret := range mArgs.RetArgList {
 		call.ReturnArguments = append(call.ReturnArguments, ret)

--- a/go-controller/pkg/util/dns_test.go
+++ b/go-controller/pkg/util/dns_test.go
@@ -27,14 +27,14 @@ func TestNewDNS(t *testing.T) {
 			desc:   "fails to read config file ",
 			errExp: true,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{nil, fmt.Errorf("mock error")}, 0, 1},
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{nil, fmt.Errorf("mock error")}, 0, 1},
 			},
 		},
 		{
 			desc:   "positive test case",
 			errExp: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"ClientConfigFromFile", []string{"string"}, []interface{}{&dns.ClientConfig{}, nil}, 0, 1},
+				{"ClientConfigFromFile", []string{"string"}, []interface{}{}, []interface{}{&dns.ClientConfig{}, nil}, 0, 1},
 			},
 		},
 	}
@@ -79,9 +79,9 @@ func TestGetIPsAndMinTTL(t *testing.T) {
 			ipv4Mode: true,
 			ipv6Mode: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{"www.test.com"}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{nil, 0 * time.Second, fmt.Errorf("mock error")}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{"www.test.com"}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{nil, 0 * time.Second, fmt.Errorf("mock error")}, 0, 1},
 			},
 		},
 		{
@@ -90,9 +90,9 @@ func TestGetIPsAndMinTTL(t *testing.T) {
 			ipv4Mode: true,
 			ipv6Mode: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Fqdn", []string{"string"}, []interface{}{"www.test.com"}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: 2}}, 0 * time.Second, nil}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{"www.test.com"}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: 2}}, 0 * time.Second, nil}, 0, 1},
 			},
 		},
 	}
@@ -155,9 +155,9 @@ func TestUpdate(t *testing.T) {
 			},
 			},
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{nil, 0 * time.Second, fmt.Errorf("mock error")}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{nil, 0 * time.Second, fmt.Errorf("mock error")}, 0, 1},
 			},
 			errExp: true,
 		},
@@ -168,9 +168,9 @@ func TestUpdate(t *testing.T) {
 			},
 			},
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: newIP}}}, 0 * time.Second, nil}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: newIP}}}, 0 * time.Second, nil}, 0, 1},
 			},
 			errExp:    false,
 			changeExp: false,
@@ -182,9 +182,9 @@ func TestUpdate(t *testing.T) {
 			},
 			},
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: newIP}}}, 0 * time.Second, nil}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: newIP}}}, 0 * time.Second, nil}, 0, 1},
 			},
 			errExp:    false,
 			changeExp: true,
@@ -240,18 +240,18 @@ func TestAdd(t *testing.T) {
 			desc:   "Add fails",
 			errExp: true,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{}}, 0 * time.Second, nil}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{}}, 0 * time.Second, nil}, 0, 1},
 			},
 		},
 		{
 			desc:   "Add succeeds ",
 			errExp: false,
 			dnsOpsMockHelper: []ovntest.TestifyMockHelper{
-				{"Fqdn", []string{"string"}, []interface{}{dnsName}, 0, 1},
-				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{&dns.Msg{}}, 0, 1},
-				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: addedIP}}}, 0 * time.Second, nil}, 0, 1},
+				{"Fqdn", []string{"string"}, []interface{}{}, []interface{}{dnsName}, 0, 1},
+				{"SetQuestion", []string{"*dns.Msg", "string", "uint16"}, []interface{}{}, []interface{}{&dns.Msg{}}, 0, 1},
+				{"Exchange", []string{"*dns.Client", "*dns.Msg", "string"}, []interface{}{}, []interface{}{&dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}, Answer: []dns.RR{&dns.A{A: addedIP}}}, 0 * time.Second, nil}, 0, 1},
 			},
 		},
 	}


### PR DESCRIPTION
If real conntrack operations are performed against the CI host we may get operation errors because we're not running a real node in the testcases and we fake out all the iptables stuff too. We shouldn't mix real operations in the CI host's netns with fake operations in the testscases because then we cannot control the test parameters.

Second, don't start the node IP handler's netlink watch or sync host IPs in testcases because it scrapes the CI host's IP addresses which service deletion uses when clearing conntrack, which the testcases know nothing about. Just stick with the fake node IP that the testcases already add.

```
[91m[1m• Failure [0.114 seconds][0m
Node Operations
[90m/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/gateway_localnet_linux_test.go:161[0m
  on delete
  [90m/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/gateway_localnet_linux_test.go:1211[0m
    [91m[1mdeletes iptables rules with ExternalIP [It][0m
    [90m/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/gateway_localnet_linux_test.go:1212[0m

    [91mUnexpected error:
        <*errors.errorString | 0xc000de8cb0>: {
            s: "DeleteService failed for nodePortWatcher: failed to delete conntrack entry for service namespace1/service1: failed to delete conntrack entry for service namespace1/service1 with svcVIP 1.1.1.1, svcPort 8032, protocol TCP: operation not permitted",
        }
        DeleteService failed for nodePortWatcher: failed to delete conntrack entry for service namespace1/service1: failed to delete conntrack entry for service namespace1/service1 with svcVIP 1.1.1.1, svcPort 8032, protocol TCP: operation not permitted
    occurred[0m

    /go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/gateway_localnet_linux_test.go:1243
[90m------------------------------[0m
[0mNode Operations[0m [90mon delete[0m 
  [1mdeletes iptables rules for NodePort[0m
  [37m/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/node/gateway_localnet_linux_test.go:1295[0m
```