### PR TITLE
Bug 2080060: Make sure VXLAN interface is up when setting up VXLAN tunnel

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -201,6 +201,11 @@ func addEnsureHybridOverlayBridgeMocks(nlMock *mocks.NetLinkOps) {
 			Index: 555,
 		},
 	}
+	mockVxlan := &fakeLink{
+		attrs: &netlink.LinkAttrs{
+			Index: 556,
+		},
+	}
 	mockMp0 := &fakeLink{
 		attrs: &netlink.LinkAttrs{
 			Index:        777,
@@ -228,6 +233,16 @@ func addEnsureHybridOverlayBridgeMocks(nlMock *mocks.NetLinkOps) {
 			OnCallMethodName: "LinkByName",
 			OnCallMethodArgs: []interface{}{"ovn-k8s-mp0"},
 			RetArgList:       []interface{}{mockMp0, nil},
+		},
+		{
+			OnCallMethodName: "LinkByName",
+			OnCallMethodArgs: []interface{}{fmt.Sprintf(OVSVXLANDeviceTemplate, config.HybridOverlay.VXLANPort)},
+			RetArgList:       []interface{}{mockVxlan, nil},
+		},
+		{
+			OnCallMethodName: "LinkSetUp",
+			OnCallMethodArgs: []interface{}{mockVxlan},
+			RetArgList:       []interface{}{nil},
 		},
 		{
 			OnCallMethodName: "RouteAdd",


### PR DESCRIPTION
When running ovs-configure, if network manager is restarted more than once, it will bring down the VXLAN interface for hybrid overlay. Let's bring the interface up systematically when setting up the VXLAN tunnel.

Fixes #2080060

Signed-off-by: Riccardo Ravaioli <rravaiol@redhat.com>

