### PR TITLE
Don't delete equivalent ACLs by predicate

### DIFF
--- a/go-controller/pkg/libovsdbops/portgroup.go
+++ b/go-controller/pkg/libovsdbops/portgroup.go
@@ -196,6 +196,19 @@ func DeleteACLsFromPortGroupOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 	return m.DeleteOps(ops, opModel)
 }
 
+func DeleteACLsFromPortGroups(nbClient libovsdbclient.Client, names []string, acls ...*nbdb.ACL) error {
+	var err error
+	var ops []libovsdb.Operation
+	for _, pgName := range names {
+		ops, err = DeleteACLsFromPortGroupOps(nbClient, ops, pgName, acls...)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
+}
+
 // DeletePortGroupsOps deletes the provided port groups and returns the
 // corresponding ops
 func DeletePortGroupsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, names ...string) ([]libovsdb.Operation, error) {

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -411,7 +411,7 @@ func (oc *DefaultNetworkController) deleteEgressFirewallRules(externalID string)
 	// delete egress firewall acls off any logical switch which has it,
 	// then manually remove the egressFirewall ACLs instead of relying on ovsdb garbage collection to do so
 	pSwitch := func(item *nbdb.LogicalSwitch) bool { return true }
-	err = libovsdbops.DeleteACLs(oc.nbClient, nil, pSwitch, egressFirewallACLs...)
+	err = libovsdbops.RemoveACLsFromLogicalSwitchesWithPredicate(oc.nbClient, pSwitch, egressFirewallACLs...)
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -189,8 +189,16 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 				// check severity was reset from default to nil
 				keepACL.Severity = nil
 
+				// purgeACL ACL will be deleted when test server starts deleting dereferenced ACLs
+				// for now we need to update its fields, since it is present in the db
+				purgeACL.Direction = nbdb.ACLDirectionToLport
+				newName2 := buildEgressFwAclName("none", t.EgressFirewallStartPriority)
+				purgeACL.Name = &newName2
+				purgeACL.Severity = nil
+
 				expectedDatabaseState := []libovsdb.TestData{
 					otherACL,
+					purgeACL,
 					keepACL,
 					finalNodeSwitch,
 					finalJoinSwitch,
@@ -597,6 +605,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 				nodeSwitch1.ACLs = []string{}
 				nodeSwitch2.ACLs = []string{}
 				expectedDatabaseState = []libovsdb.TestData{
+					// this ACL will be deleted when test server starts deleting dereferenced ACLs
+					ipv4ACL,
 					nodeSwitch1,
 					nodeSwitch2,
 					clusterRouter,
@@ -842,6 +852,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for local gateway mode", 
 				nodeSwitch1.ACLs = []string{}
 				nodeSwitch2.ACLs = []string{}
 				expectedDatabaseState = []libovsdb.TestData{
+					// this ACL will be deleted when test server starts deleting dereferenced ACLs
+					ipv4ACL,
 					nodeSwitch1,
 					nodeSwitch2,
 					clusterRouter,
@@ -1242,8 +1254,16 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 				keepACL.Name = &newName
 				keepACL.Meter = &meter
 
+				// purgeACL ACL will be deleted when test server starts deleting dereferenced ACLs
+				// for now we need to update its fields, since it is present in the db
+				purgeACL.Direction = nbdb.ACLDirectionToLport
+				newName2 := buildEgressFwAclName("none", t.EgressFirewallStartPriority)
+				purgeACL.Name = &newName2
+				purgeACL.Meter = &meter
+
 				expectedDatabaseState := []libovsdb.TestData{
 					otherACL,
+					purgeACL,
 					keepACL,
 					finalNodeSwitch,
 					finalJoinSwitch,
@@ -1621,7 +1641,9 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations for shared gateway mode",
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// join switch should return to orignal state, egfw was deleted
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(fakeOVN.dbSetup.NBData))
+				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(append(fakeOVN.dbSetup.NBData,
+					// this ACL will be deleted when test server starts deleting dereferenced ACLs
+					ipv4ACL)))
 
 				return nil
 			}

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -259,7 +259,7 @@ func (oc *DefaultNetworkController) updateStaleDefaultDenyACLNames(npType knet.P
 			// this should never be the case but delete everything except 1st ACL
 			ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
 			egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
-			err := libovsdbops.DeleteACLs(oc.nbClient, []string{ingressPGName, egressPGName}, nil, aclList[1:]...)
+			err := libovsdbops.DeleteACLsFromPortGroups(oc.nbClient, []string{ingressPGName, egressPGName}, aclList[1:]...)
 			if err != nil {
 				return err
 			}
@@ -383,7 +383,7 @@ func (oc *DefaultNetworkController) syncNetworkPolicies(networkPolicies []interf
 			pgName = strings.TrimPrefix(gressACL.Match, "outport == @")
 		}
 		pgName = strings.TrimSuffix(pgName, " && "+staleArpAllowPolicyMatch)
-		ops, err = libovsdbops.DeleteACLsOps(oc.nbClient, ops, []string{pgName}, nil, gressACL)
+		ops, err = libovsdbops.DeleteACLsFromPortGroupOps(oc.nbClient, ops, pgName, gressACL)
 		if err != nil {
 			return fmt.Errorf("failed getting delete acl ops: %v", err)
 		}
@@ -546,25 +546,14 @@ func (oc *DefaultNetworkController) createDefaultDenyPGAndACLs(namespace, policy
 // deleteDefaultDenyPGAndACLs deletes the default port groups and acls for a namespace
 // must be called with defaultDenyPortGroups lock
 func (oc *DefaultNetworkController) deleteDefaultDenyPGAndACLs(namespace, policy string) error {
-	var aclsToBeDeleted []*nbdb.ACL
-
 	ingressPGName := defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix)
-	ingressDenyACL, ingressAllowACL := buildDenyACLs(namespace, ingressPGName, nil, lportIngress)
-	aclsToBeDeleted = append(aclsToBeDeleted, ingressDenyACL, ingressAllowACL)
 	egressPGName := defaultDenyPortGroupName(namespace, egressDefaultDenySuffix)
-	egressDenyACL, egressAllowACL := buildDenyACLs(namespace, egressPGName, nil, lportEgressAfterLB)
-	aclsToBeDeleted = append(aclsToBeDeleted, egressDenyACL, egressAllowACL)
 
 	ops, err := libovsdbops.DeletePortGroupsOps(oc.nbClient, nil, ingressPGName, egressPGName)
 	if err != nil {
 		return err
 	}
-	// Manually remove the default ACLs instead of relying on ovsdb garbage collection to do so
-	// don't delete ACL references because port group is completely deleted in the same tnx
-	ops, err = libovsdbops.DeleteACLsOps(oc.nbClient, ops, nil, nil, aclsToBeDeleted...)
-	if err != nil {
-		return err
-	}
+	// No need to delete ACLs, since they will be garbage collected with deleted port groups
 	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
 	if err != nil {
 		return fmt.Errorf("failed to transact deleteDefaultDenyPGAndACLs: %v", err)


### PR DESCRIPTION
 since it will fail if equivalent ACL is not deleted from port group/switch. e.g. on netpol sync, users (somehow) ended up with equivalent default deny ACLs with different names, one of them will be updated and one will be sent to DeleteACLsOps. DeleteACLsOps will find both ACLs because of predicate search, and will try to delete both of them, but only one of them is de-referenced from the port group in the beginning, so it will return delete error like `cannot delete ACL row 7b55ba0c-150f-4a63-9601-cfde25f29408 because of 1 remaining reference(s)`

Only delete ACLs when owner port group/switch is not deleted, only allow deletion for ACLs with UUID to make sure it is properly dereferenced. 
Update netpol tests to include not-garbage-collected ACLs for deleted port groups.

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>