### PR TITLE
pods: deleteLogicalPort should not fail when node is gone

### DIFF
--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
+	logicalswitchmanager "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/pkg/errors"
@@ -305,11 +306,15 @@ func (oc *DefaultNetworkController) deleteLogicalPort(pod *kapi.Pod, portInfo *l
 	// Releasing IPs needs to happen last so that we can deterministically know that if delete failed that
 	// the IP of the pod needs to be released. Otherwise we could have a completed pod failed to be removed
 	// and we dont know if the IP was released or not, and subsequently could accidentally release the IP
-	// while it is now on another pod
+	// while it is now on another pod. Releasing IPs may fail at this point if cache knows nothing about it,
+	// which is okay since node may have been deleted.
 	klog.Infof("Attempting to release IPs for pod: %s/%s, ips: %s", pod.Namespace, pod.Name,
 		util.JoinIPNetIPs(podIfAddrs, " "))
 	if err := oc.lsManager.ReleaseIPs(switchName, podIfAddrs); err != nil {
-		return fmt.Errorf("cannot release IPs for pod %s: %w", podDesc, err)
+		if !errors.Is(err, logicalswitchmanager.SwitchNotFound) {
+			return fmt.Errorf("cannot release IPs for pod %s on node %s: %w", podDesc, switchName, err)
+		}
+		klog.Warningf("Ignoring release IPs failure for pod %s on node %s: %w", podDesc, switchName, err)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -1205,6 +1205,10 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port from switch that no longer exists should be okay")
 
+				// Delete cache from lsManager and make sure deleteLogicalPort will not fail
+				fakeOvn.controller.lsManager.DeleteSwitch(pod.Spec.NodeName)
+				gomega.Expect(fakeOvn.controller.deleteLogicalPort(pod, nil)).To(gomega.Succeed(), "Deleting port from node that no longer exists should be okay")
+
 				return nil
 			}
 


### PR DESCRIPTION
deleteLogicalPort should not fail when node is already deleted from lsManager's cache.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-3739
