### PR TITLE
Add single-node gateway config option

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -380,6 +380,8 @@ type GatewayConfig struct {
 	// RouterSubnet is the subnet to be used for the GR external port. auto-detected if not given.
 	// Must match the the kube node IP address. Currently valid for DPU only.
 	RouterSubnet string `gcfg:"router-subnet"`
+	// SingeNode indicates the cluster has only one node
+	SingleNode bool `gcfg:"single-node"`
 }
 
 // OvnAuthConfig holds client authentication and location details for
@@ -1169,6 +1171,12 @@ var OVNGatewayFlags = []cli.Flag{
 			"Currently valid for DPUs only",
 		Destination: &cliConfig.Gateway.RouterSubnet,
 		Value:       Gateway.RouterSubnet,
+	},
+	&cli.BoolFlag{
+		Name: "single-node",
+		Usage: "Enable single node optimizations. " +
+			"Single node indicates a one node cluster and allows to simplify ovn-kubernetes gateway logic",
+		Destination: &cliConfig.Gateway.SingleNode,
 	},
 	// Deprecated CLI options
 	&cli.BoolFlag{

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -200,6 +200,7 @@ nodeport=false
 v4-join-subnet=100.65.0.0/16
 v6-join-subnet=fd90::/64
 router-subnet=10.50.0.0/16
+single-node=false
 
 [hybridoverlay]
 enabled=true
@@ -299,6 +300,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal(""))
 			gomega.Expect(OvnKubeNode.MgmtPortRepresentor).To(gomega.Equal(""))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal(""))
+			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(1))
 			gomega.Expect(OVNKubernetesFeature.EgressIPNodeHealthCheckPort).To(gomega.Equal(0))
 
@@ -602,6 +604,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.V4JoinSubnet).To(gomega.Equal("100.65.0.0/16"))
 			gomega.Expect(Gateway.V6JoinSubnet).To(gomega.Equal("fd90::/64"))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.50.0.0/16"))
+			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(3))
@@ -684,6 +687,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.V4JoinSubnet).To(gomega.Equal("100.63.0.0/16"))
 			gomega.Expect(Gateway.V6JoinSubnet).To(gomega.Equal("fd99::/48"))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.55.0.0/16"))
+			gomega.Expect(Gateway.SingleNode).To(gomega.BeTrue())
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(5))
@@ -733,6 +737,7 @@ var _ = Describe("Config Operations", func() {
 			"-gateway-v4-join-subnet=100.63.0.0/16",
 			"-gateway-v6-join-subnet=fd99::/48",
 			"-gateway-router-subnet=10.55.0.0/16",
+			"-single-node",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=11.132.0.0/14/23",
 			"-monitor-all=false",

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -843,12 +843,16 @@ func (n *OvnNode) validateVTEPInterfaceMTU() error {
 
 	// calc required MTU
 	var requiredMTU int
-	if config.IPv4Mode && !config.IPv6Mode {
-		// we run in single-stack IPv4 only
-		requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv4
+	if config.Gateway.SingleNode {
+		requiredMTU = config.Default.MTU
 	} else {
-		// we run in single-stack IPv6 or dual-stack mode
-		requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv6
+		if config.IPv4Mode && !config.IPv6Mode {
+			// we run in single-stack IPv4 only
+			requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv4
+		} else {
+			// we run in single-stack IPv6 or dual-stack mode
+			requiredMTU = config.Default.MTU + types.GeneveHeaderLengthIPv6
+		}
 	}
 
 	if mtu < requiredMTU {

--- a/go-controller/pkg/node/node_test.go
+++ b/go-controller/pkg/node/node_test.go
@@ -43,6 +43,8 @@ var _ = Describe("Node", func() {
 			mtuTooSmallForIPv4AndIPv6      = configDefaultMTU + types.GeneveHeaderLengthIPv4 - 1
 			mtuOkForIPv4ButTooSmallForIPv6 = configDefaultMTU + types.GeneveHeaderLengthIPv4
 			mtuOkForIPv4AndIPv6            = configDefaultMTU + types.GeneveHeaderLengthIPv6
+			mtuTooSmallForSingleNode       = configDefaultMTU - 1
+			mtuOkForSingleNode             = configDefaultMTU
 		)
 
 		BeforeEach(func() {
@@ -160,6 +162,38 @@ var _ = Describe("Node", func() {
 				It("should untaint the node", func() {
 					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
 						MTU:  mtuOkForIPv4AndIPv6,
+						Name: linkName,
+					})
+
+					err := ovnNode.validateVTEPInterfaceMTU()
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+		})
+
+		Context("with a single-node cluster", func() {
+			BeforeEach(func() {
+				config.Gateway.SingleNode = true
+			})
+
+			Context("with the node having a too small MTU", func() {
+
+				It("should taint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU:  mtuTooSmallForSingleNode,
+						Name: linkName,
+					})
+
+					err := ovnNode.validateVTEPInterfaceMTU()
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("with the node having a big enough MTU", func() {
+
+				It("should untaint the node", func() {
+					netlinkLinkMock.On("Attrs").Return(&netlink.LinkAttrs{
+						MTU:  mtuOkForSingleNode,
 						Name: linkName,
 					})
 


### PR DESCRIPTION
Single node indicates a one node cluster and allows to
simplify ovn-kubernetes feature logic to reduce overall
cpu and memory footprints which are required in small
form factor deployment.
    
This change enable future work to have optimized logic
for single node ovnk deployment.