### PR TITLE
egress ip: ovnkube-node for DPU can skip gRPC server

### DIFF
--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -674,6 +674,9 @@ func (n *OvnNode) startEgressIPHealthCheckingServer(wg *sync.WaitGroup, mgmtPort
 		if err := ip.SettleAddresses(mgmtPortConfig.ifName, 10); err != nil {
 			return fmt.Errorf("failed start health checking server due to unsettled IPv6: %w", err)
 		}
+	} else if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		klog.Info("Skipping Egress IP health checking server for node in DPU mode: no mgmt ip")
+		return nil
 	} else {
 		return fmt.Errorf("unable to start health checking server: no mgmt ip")
 	}


### PR DESCRIPTION
egress ip: ovnkube-node for DPU can skip gRPC server

ovnkube-node running in DPU mode may have no management ip.
In such cases, Egress IP shoud be able to handle it gracefully
by not attempting to start listening for gRPC connections.

Also see discussion in:    https://github.com/ovn-org/ovn-kubernetes/pull/3251

Reported-at: https://issues.redhat.com/browse/OCPBUGS-4098


