### PR TITLE
LinkRoutesAddOrUpdateSourceOrMTU/LinkRoutesApply: update route GW if it was changed 

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -247,7 +247,7 @@ func configureSvcRouteViaInterface(iface string, gwIPs []net.IP) error {
 			mtu = config.Default.RoutableMTU
 		}
 
-		err = util.LinkRoutesAddOrUpdateSourceOrMTU(link, gwIP[0], []*net.IPNet{subnet}, mtu, nil)
+		err = util.LinkRoutesApply(link, gwIP[0], []*net.IPNet{subnet}, mtu, nil)
 		if err != nil {
 			return fmt.Errorf("unable to add/update route for service via %s for gwIP %s, error: %v", iface, gwIP[0].String(), err)
 		}

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1763,7 +1763,7 @@ func addMasqueradeRoute(netIfaceName, nodeName string, watchFactory factory.Node
 		}
 		if masqIPNet != nil {
 			klog.Infof("Setting OVN Masquerade route with source: %s", nodeIP)
-			err = util.LinkRoutesAddOrUpdateSourceOrMTU(netIfaceLink, nil, []*net.IPNet{masqIPNet},
+			err = util.LinkRoutesApply(netIfaceLink, nil, []*net.IPNet{masqIPNet},
 				mtu, nodeIP)
 			if err != nil {
 				return fmt.Errorf("unable to add OVN masquerade route to host, error: %v", err)

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -187,7 +187,7 @@ func setupManagementPortIPFamilyConfig(mpcfg *managementPortConfig, cfg *managem
 			return warnings, err
 		}
 
-		err = util.LinkRoutesAddOrUpdateSourceOrMTU(mpcfg.link, cfg.gwIP, []*net.IPNet{subnet}, config.Default.RoutableMTU, nil)
+		err = util.LinkRoutesApply(mpcfg.link, cfg.gwIP, []*net.IPNet{subnet}, config.Default.RoutableMTU, nil)
 		if err != nil {
 			return warnings, err
 		}

--- a/go-controller/pkg/node/node.go
+++ b/go-controller/pkg/node/node.go
@@ -541,7 +541,7 @@ func (n *OvnNode) Start(ctx context.Context, wg *sync.WaitGroup) error {
 					} else {
 						gwIP = mgmtPortConfig.ipv6.gwIP
 					}
-					err := util.LinkRoutesAddOrUpdateSourceOrMTU(link, gwIP, []*net.IPNet{subnet}, config.Default.RoutableMTU, nil)
+					err := util.LinkRoutesApply(link, gwIP, []*net.IPNet{subnet}, config.Default.RoutableMTU, nil)
 					if err != nil {
 						return fmt.Errorf("unable to add legacy route for services via mp0, error: %v", err)
 					}

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -302,7 +302,7 @@ func LinkRoutesAdd(link netlink.Link, gwIP net.IP, subnets []*net.IPNet, mtu int
 	return nil
 }
 
-func LinkRoutesAddOrUpdateSourceOrMTU(link netlink.Link, gwIP net.IP, subnets []*net.IPNet, mtu int, src net.IP) error {
+func LinkRoutesApply(link netlink.Link, gwIP net.IP, subnets []*net.IPNet, mtu int, src net.IP) error {
 	for _, subnet := range subnets {
 		route, err := LinkRouteGetFilteredRoute(filterRouteByDst(link, subnet))
 		if err != nil {

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -636,7 +636,7 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
 				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
 					{
-						Gw:  ovntest.MustParseIP("192.168.0.1"),
+						Gw:  nil,
 						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
 						MTU: 1400,
 						Src: ovntest.MustParseIP("192.168.0.10"),
@@ -649,9 +649,32 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 			},
 		},
 		{
-			desc:         "Route exists, has the same (mtu and source) and is not updated",
+			desc:         "Route exists, has different gw and is updated",
 			inputLink:    mockLink,
-			inputGwIP:    nil,
+			inputGwIP:    ovntest.MustParseIP("192.168.0.1"),
+			inputSubnets: ovntest.MustParseIPNets("10.18.20.0/24"),
+			inputMTU:     1400,
+			inputSrc:     ovntest.MustParseIP("192.168.0.8"),
+			errExp:       false,
+			onRetArgsNetLinkLibOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "RouteListFiltered", OnCallMethodArgType: []string{"int", "*netlink.Route", "uint64"}, RetArgList: []interface{}{[]netlink.Route{
+					{
+						Gw:  ovntest.MustParseIP("192.168.0.2"),
+						Dst: ovntest.MustParseIPNet("10.18.20.0/24"),
+						MTU: 1400,
+						Src: ovntest.MustParseIP("192.168.0.8"),
+					},
+				}, nil}},
+				{OnCallMethodName: "RouteReplace", OnCallMethodArgType: []string{"*netlink.Route"}, RetArgList: []interface{}{nil}},
+			},
+			onRetArgsLinkIfaceOpers: []ovntest.TestifyMockHelper{
+				{OnCallMethodName: "Attrs", OnCallMethodArgType: []string{}, RetArgList: []interface{}{&netlink.LinkAttrs{Name: "testIfaceName", Index: 1}}},
+			},
+		},
+		{
+			desc:         "Route exists, has the same (mtu, source and gw) and is not updated",
+			inputLink:    mockLink,
+			inputGwIP:    ovntest.MustParseIP("192.168.0.1"),
 			inputSubnets: ovntest.MustParseIPNets("10.18.20.0/24"),
 			inputMTU:     1400,
 			inputSrc:     ovntest.MustParseIP("192.168.0.10"),

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -671,7 +671,7 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 			},
 		},
 		{
-			desc: "LinkRoutesAddOrUpdateSrcOrMTU() returns NO error when subnets input list is empty",
+			desc: "LinkRoutesApply() returns NO error when subnets input list is empty",
 		},
 	}
 	for i, tc := range tests {
@@ -680,7 +680,7 @@ func TestLinkRoutesAddOrUpdateMTU(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
 			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
 
-			err := LinkRoutesAddOrUpdateSourceOrMTU(tc.inputLink, tc.inputGwIP, tc.inputSubnets, tc.inputMTU, tc.inputSrc)
+			err := LinkRoutesApply(tc.inputLink, tc.inputGwIP, tc.inputSubnets, tc.inputMTU, tc.inputSrc)
 			t.Log(err)
 			if tc.errExp {
 				assert.Error(t, err)


### PR DESCRIPTION
Previously, when `LinkRoutesAddOrUpdateSourceOrMTU` found a route with a gateway different from `gwIP` parameter it never updated it.
In the proposed change we update the route if any of the parameters(`gwIP`,`mtu`,`src`) changed.

/cc @tssurya @jcaamano 