### PR TITLE
retry: refactor stop channel/WaitGroup usage to reduce dependency on WatchFactory

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -283,8 +283,8 @@ func runOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 		// register ovnkube node specific prometheus metrics exported by the node
 		metrics.RegisterNodeMetrics()
 		start := time.Now()
-		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, stopChan, nodeEventRecorder)
-		if err := n.Start(ctx.Context, wg); err != nil {
+		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, stopChan, wg, nodeEventRecorder)
+		if err := n.Start(ctx.Context); err != nil {
 			return err
 		}
 		end := time.Since(start)

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -346,7 +346,7 @@ func (n *OvnNode) initGateway(subnets []*net.IPNet, nodeAnnotator kube.Annotator
 	}
 
 	initGwFunc := func() error {
-		return gw.Init(n.watchFactory)
+		return gw.Init(n.watchFactory, n.stopChan, n.wg)
 	}
 
 	readyGwFunc := func() (bool, error) {
@@ -440,7 +440,7 @@ func (n *OvnNode) initGatewayDPUHost(kubeNodeIP net.IP) error {
 		return fmt.Errorf("failed to add MAC bindings for service routing")
 	}
 
-	err = gw.Init(n.watchFactory)
+	err = gw.Init(n.watchFactory, n.stopChan, n.wg)
 	n.gateway = gw
 	return err
 }

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -237,13 +237,13 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			sharedGw, err := newSharedGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil, nodeAnnotator, k,
 				&fakeMgmtPortConfig, wf)
 			Expect(err).NotTo(HaveOccurred())
-			err = sharedGw.Init(wf)
+			err = sharedGw.Init(wf, stop, wg)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			sharedGw.Start(stop, wg)
+			sharedGw.Start()
 
 			// Verify the code moved eth0's IP address, MAC, and routes
 			// over to breth0
@@ -533,13 +533,13 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 				gatewayIntf, "", gwIPs, nodeAnnotator, k, &fakeMgmtPortConfig, wf)
 
 			Expect(err).NotTo(HaveOccurred())
-			err = sharedGw.Init(wf)
+			err = sharedGw.Init(wf, stop, wg)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			sharedGw.Start(stop, wg)
+			sharedGw.Start()
 			return nil
 		})
 
@@ -602,8 +602,10 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 		stop := make(chan struct{})
 		wf, err := factory.NewNodeWatchFactory(fakeClient, nodeName)
 		Expect(err).NotTo(HaveOccurred())
+		wg := &sync.WaitGroup{}
 		defer func() {
 			close(stop)
+			wg.Wait()
 			wf.Shutdown()
 		}()
 		err = wf.Start()
@@ -612,6 +614,8 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 		n := OvnNode{
 			watchFactory: wf,
 			name:         nodeName,
+			stopChan:     stop,
+			wg:           wg,
 		}
 
 		err = testNS.Do(func(ns.NetNS) error {
@@ -890,13 +894,13 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 			localGw, err := newLocalGateway(nodeName, ovntest.MustParseIPNets(nodeSubnet), gatewayNextHops, gatewayIntf, "", nil,
 				nodeAnnotator, &fakeMgmtPortConfig, k, wf)
 			Expect(err).NotTo(HaveOccurred())
-			err = localGw.Init(wf)
+			err = localGw.Init(wf, stop, wg)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = nodeAnnotator.Run()
 			Expect(err).NotTo(HaveOccurred())
 
-			localGw.Start(stop, wg)
+			localGw.Start()
 
 			// Verify the code moved eth0's IP address, MAC, and routes
 			// over to breth0

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -94,7 +95,7 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNClientset, fak
 	return err
 }
 
-func startNodePortWatcherWithRetry(n *nodePortWatcher, fakeClient *util.OVNClientset, fakeMgmtPortConfig *managementPortConfig, stopChan chan struct{}) (*retry.RetryFramework, error) {
+func startNodePortWatcherWithRetry(n *nodePortWatcher, fakeClient *util.OVNClientset, fakeMgmtPortConfig *managementPortConfig, stopChan chan struct{}, wg *sync.WaitGroup) (*retry.RetryFramework, error) {
 	if err := initLocalGatewayIPTables(); err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func startNodePortWatcherWithRetry(n *nodePortWatcher, fakeClient *util.OVNClien
 	ip, _, _ := net.ParseCIDR(localHostNetEp)
 	n.nodeIPManager.addAddr(ip)
 
-	nodePortWatcherRetry := n.newRetryFrameworkForTests(factory.ServiceForFakeNodePortWatcherType)
+	nodePortWatcherRetry := n.newRetryFrameworkForTests(factory.ServiceForFakeNodePortWatcherType, stopChan, wg)
 	if _, err := nodePortWatcherRetry.WatchResource(); err != nil {
 		return nil, fmt.Errorf("failed to start watching services with retry framework: %v", err)
 	}
@@ -253,6 +254,7 @@ var _ = Describe("Node Operations", func() {
 	})
 
 	AfterEach(func() {
+		fakeOvnNode.shutdown()
 		util.SetNetLinkOpMockInst(origNetlinkInst)
 	})
 
@@ -357,7 +359,6 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -434,7 +435,6 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				err = f4.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -514,7 +514,6 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				err = f4.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -610,7 +609,6 @@ var _ = Describe("Node Operations", func() {
 				Expect(err).NotTo(HaveOccurred())
 				flows := fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -705,7 +703,6 @@ var _ = Describe("Node Operations", func() {
 				f4 := iptV4.(*util.FakeIPTables)
 				err = f4.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -823,7 +820,6 @@ var _ = Describe("Node Operations", func() {
 				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
 				Expect(flows).To(Equal(expectedLBExternalIPFlows))
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -936,7 +932,6 @@ var _ = Describe("Node Operations", func() {
 				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
 				Expect(flows).To(Equal(expectedLBExternalIPFlows))
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -1062,7 +1057,6 @@ var _ = Describe("Node Operations", func() {
 				flows = fNPW.ofm.flowCache["External_namespace1_service1_1.1.1.1_8080"]
 				Expect(flows).To(Equal(expectedLBExternalIPFlows))
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -1159,7 +1153,6 @@ var _ = Describe("Node Operations", func() {
 				f6 := iptV6.(*util.FakeIPTables)
 				err = f6.MatchState(expectedTables6)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -1258,7 +1251,6 @@ var _ = Describe("Node Operations", func() {
 				f6 := iptV6.(*util.FakeIPTables)
 				err = f6.MatchState(expectedTables6)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -1345,7 +1337,6 @@ var _ = Describe("Node Operations", func() {
 				f6 := iptV6.(*util.FakeIPTables)
 				err = f6.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -1429,7 +1420,6 @@ var _ = Describe("Node Operations", func() {
 				f6 := iptV6.(*util.FakeIPTables)
 				err = f6.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -1547,7 +1537,6 @@ var _ = Describe("Node Operations", func() {
 				f4 = iptV4.(*util.FakeIPTables)
 				err = f4.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -1586,7 +1575,7 @@ var _ = Describe("Node Operations", func() {
 				By("starting node port watcher retry framework")
 				fNPW.watchFactory = fakeOvnNode.watcher
 				nodePortWatcherRetry, err = startNodePortWatcherWithRetry(
-					fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig, fakeOvnNode.stopChan)
+					fNPW, fakeOvnNode.fakeClient, &fakeMgmtPortConfig, fakeOvnNode.stopChan, fakeOvnNode.wg)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(nodePortWatcherRetry).NotTo(BeNil())
 
@@ -1664,7 +1653,6 @@ var _ = Describe("Node Operations", func() {
 				})
 
 				// TODO Make delete operation fail, check retry entry, run a successful delete
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -1916,7 +1904,6 @@ var _ = Describe("Node Operations", func() {
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -2061,7 +2048,6 @@ var _ = Describe("Node Operations", func() {
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -2208,7 +2194,6 @@ var _ = Describe("Node Operations", func() {
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -2354,7 +2339,6 @@ var _ = Describe("Node Operations", func() {
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -2500,7 +2484,6 @@ var _ = Describe("Node Operations", func() {
 				flows = fNPW.ofm.flowCache["NodePort_namespace1_service1_tcp_31111"]
 				Expect(flows).To(BeNil())
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})
@@ -2659,7 +2642,6 @@ var _ = Describe("Node Operations", func() {
 				err = f4.MatchState(expectedTables)
 				Expect(err).NotTo(HaveOccurred())
 
-				fakeOvnNode.shutdown()
 				return nil
 			}
 			err := app.Run([]string{app.Name})

--- a/go-controller/pkg/node/obj_retry_gateway.go
+++ b/go-controller/pkg/node/obj_retry_gateway.go
@@ -36,7 +36,7 @@ func (g *gateway) newRetryFrameworkNodeWithParameters(
 			syncFunc: syncFunc,
 		},
 	}
-	r := retry.NewRetryFramework(g.watchFactory, resourceHandler)
+	r := retry.NewRetryFramework(g.stopChan, g.wg, g.watchFactory, resourceHandler)
 
 	return r
 }

--- a/go-controller/pkg/node/obj_retry_node.go
+++ b/go-controller/pkg/node/obj_retry_node.go
@@ -44,7 +44,7 @@ func (n *OvnNode) newRetryFrameworkNodeWithParameters(
 		},
 	}
 
-	r := retry.NewRetryFramework(n.watchFactory.(*factory.WatchFactory), resourceHandler)
+	r := retry.NewRetryFramework(n.stopChan, n.wg, n.watchFactory.(*factory.WatchFactory), resourceHandler)
 
 	return r
 }

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -34,7 +34,6 @@ func NewFakeOVNNode(fexec *ovntest.FakeExec) *FakeOVNNode {
 	return &FakeOVNNode{
 		fakeExec: fexec,
 		recorder: record.NewFakeRecorder(1),
-		wg:       &sync.WaitGroup{},
 	}
 }
 
@@ -66,10 +65,11 @@ func (o *FakeOVNNode) init() {
 	var err error
 
 	o.stopChan = make(chan struct{})
+	o.wg = &sync.WaitGroup{}
 
 	o.watcher, err = factory.NewNodeWatchFactory(o.fakeClient, fakeNodeName)
 	Expect(err).NotTo(HaveOccurred())
 
-	o.node = NewNode(o.fakeClient.KubeClient, o.watcher, fakeNodeName, o.stopChan, o.recorder)
-	o.node.Start(context.TODO(), o.wg)
+	o.node = NewNode(o.fakeClient.KubeClient, o.watcher, fakeNodeName, o.stopChan, o.wg, o.recorder)
+	o.node.Start(context.TODO())
 }

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -280,6 +280,8 @@ func (oc *DefaultNetworkController) newRetryFrameworkWithParameters(
 		EventHandler:           eventHandler,
 	}
 	r := retry.NewRetryFramework(
+		oc.stopChan,
+		oc.wg,
 		oc.watchFactory,
 		resourceHandler,
 	)
@@ -292,7 +294,7 @@ func (oc *DefaultNetworkController) Start(ctx context.Context) error {
 		return err
 	}
 
-	return oc.Run(ctx, oc.wg)
+	return oc.Run(ctx)
 }
 
 // Stop gracefully stops the controller
@@ -379,7 +381,7 @@ func (oc *DefaultNetworkController) Init() error {
 }
 
 // Run starts the actual watching.
-func (oc *DefaultNetworkController) Run(ctx context.Context, wg *sync.WaitGroup) error {
+func (oc *DefaultNetworkController) Run(ctx context.Context) error {
 	oc.syncPeriodic()
 	klog.Infof("Starting all the Watchers...")
 	start := time.Now()
@@ -405,7 +407,7 @@ func (oc *DefaultNetworkController) Run(ctx context.Context, wg *sync.WaitGroup)
 	oc.svcFactory.Start(oc.stopChan)
 
 	// Services should be started after nodes to prevent LB churn
-	if err := oc.StartServiceController(wg, true); err != nil {
+	if err := oc.StartServiceController(oc.wg, true); err != nil {
 		return err
 	}
 
@@ -472,16 +474,16 @@ func (oc *DefaultNetworkController) Run(ctx context.Context, wg *sync.WaitGroup)
 			oc.watchFactory.EgressQoSInformer(),
 			oc.watchFactory.PodCoreInformer(),
 			oc.watchFactory.NodeCoreInformer())
-		wg.Add(1)
+		oc.wg.Add(1)
 		go func() {
-			defer wg.Done()
+			defer oc.wg.Done()
 			oc.runEgressQoSController(1, oc.stopChan)
 		}()
 	}
 
-	wg.Add(1)
+	oc.wg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer oc.wg.Done()
 		oc.egressSvcController.Run(1)
 	}()
 
@@ -497,9 +499,9 @@ func (oc *DefaultNetworkController) Run(ctx context.Context, wg *sync.WaitGroup)
 		if err != nil {
 			return err
 		}
-		wg.Add(1)
+		oc.wg.Add(1)
 		go func() {
-			defer wg.Done()
+			defer oc.wg.Done()
 			unidlingController.Run(oc.stopChan)
 		}()
 	}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1583,7 +1583,11 @@ func TestController_syncNodes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stopChan := make(chan struct{})
-			defer close(stopChan)
+			wg := &sync.WaitGroup{}
+			defer func() {
+				close(stopChan)
+				wg.Wait()
+			}()
 
 			testNode := v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1621,7 +1625,7 @@ func TestController_syncNodes(t *testing.T) {
 				nbClient,
 				sbClient,
 				record.NewFakeRecorder(0),
-				&sync.WaitGroup{})
+				wg)
 			controller.joinSwIPManager, err = lsm.NewJoinLogicalSwitchIPManager(nbClient, "", []string{})
 			if err != nil {
 				t.Fatalf("%s: Error creating joinSwIPManager: %v", tt.name, err)
@@ -1676,7 +1680,11 @@ func TestController_deleteStaleNodeChassis(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stopChan := make(chan struct{})
-			defer close(stopChan)
+			wg := &sync.WaitGroup{}
+			defer func() {
+				close(stopChan)
+				wg.Wait()
+			}()
 
 			kubeFakeClient := fake.NewSimpleClientset()
 			egressFirewallFakeClient := &egressfirewallfake.Clientset{}
@@ -1708,7 +1716,7 @@ func TestController_deleteStaleNodeChassis(t *testing.T) {
 				nbClient,
 				sbClient,
 				record.NewFakeRecorder(0),
-				&sync.WaitGroup{})
+				wg)
 			controller.joinSwIPManager, err = lsm.NewJoinLogicalSwitchIPManager(nbClient, "", []string{})
 			if err != nil {
 				t.Fatalf("%s: Error creating joinSwIPManager: %v", tt.name, err)


### PR DESCRIPTION
Instead of having the WatchFactory expose a WaitGroup (which is somewhat of an encapsulation violation), we can pass the top-level WaitGroup from ovnkube.go down to the retry code and use it there. We're already using that WaitGroup many places in the master and node code so we might as well push it down to retry code too. This keeps the factory code somewhat cleaner by not exposing its own internal WaitGroup.

All we really care about is that the goroutine that calls `periodicallyRetryResources()` exits when the OvnController or OvnNode is shut down, and adding it to the top-level WaitGroup accomplishes that.

As a bonus, consolidate FakeOvnNode shutdown code in the node tests into AfterEach().

@trozet @npinaeva @bpickard22 

Reverts part of #3226 