### PR TITLE
Dockerfile.fedora: bump OVN to 22.09.0-22

### DIFF
--- a/dist/images/Dockerfile.fedora
+++ b/dist/images/Dockerfile.fedora
@@ -15,7 +15,7 @@ USER root
 
 ENV PYTHONDONTWRITEBYTECODE yes
 
-ARG ovnver=ovn-22.09.0-4.fc36
+ARG ovnver=ovn-22.09.0-22.fc36
 # Automatically populated when using docker buildx
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Mainly for the session affinity timeout feature.

@tssurya @numansiddique @trozet 