### PR TITLE
kind: Fix ipsec in kind.sh and fix counter expression

### DIFF
--- a/dist/templates/ovn-ipsec.yaml.j2
+++ b/dist/templates/ovn-ipsec.yaml.j2
@@ -104,7 +104,7 @@ spec:
             counter=0
             until [ ! -z $(kubectl get csr/$(hostname) -o jsonpath='{.status.certificate}' 2>/dev/null) ]
             do
-              counter=$[counter+1]
+              counter=$((counter+1))
               sleep 1
               if [ $counter -gt 60 ];
               then
@@ -180,7 +180,7 @@ spec:
           counter=0
           until [ -f /etc/cni/net.d/10-ovn-kubernetes.conf ]
           do
-            counter=$[counter+1]
+            counter=$((counter+1))
             sleep 1
             if [ $counter -gt 300 ];
             then


### PR DESCRIPTION
* Add help text for ipsec option to kind.sh
* Fix OpenSSL version check
* Run certificate signer in foreground
* In ovn-ipsec.yaml.j2 make the counter increment the same as in downstream cluster-network-operator

Signed-off-by: Andreas Karis <ak.karis@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**

Check help text:
~~~
contrib/kind.sh -h
~~~

Launch kind with IPsec:
~~~
contrib/kind.sh --ipsec
~~~

You should see IPsec pods after deployment:
~~~
[root@ovnkubernetes ovn-kubernetes]# export KUBECONFIG=/root/ovn.conf 
[root@ovnkubernetes ovn-kubernetes]# oc get pods -A -o wide | grep ipsec
ovn-kubernetes       ovn-ipsec-97xml                             1/1     Running   0               5m10s   172.18.0.4   ovn-worker          <none>           <none>
ovn-kubernetes       ovn-ipsec-dcn69                             1/1     Running   0               5m10s   172.18.0.3   ovn-control-plane   <none>           <none>
ovn-kubernetes       ovn-ipsec-pq6jx                             1/1     Running   0               5m10s   172.18.0.2   ovn-worker2         <none>           <none>
~~~

Let me know if you encounter any issues with that so that I can fix them. 

There should be a working dependency check for openssl v3 and the script should fail early if openssl v3 cannot be found as either openssl or openssl3 binary

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->