### PR TITLE
fix hybrid overlay allocation on the master

### DIFF
--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -9,6 +9,7 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	ipam "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator/allocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -292,8 +293,10 @@ func (manager *LogicalSwitchManager) AllocateHybridOverlay(switchName string, hy
 		for _, ip := range hybridOverlayAnnotation {
 			allocateAddresses = append(allocateAddresses, &net.IPNet{IP: net.ParseIP(ip).To4(), Mask: net.CIDRMask(32, 32)})
 		}
+		// attempt to allocate the IP address that is annotated on the node. The only way there would be a collision is if the annotations of podIP or hybridOverlayDRIP
+		// where manually edited and we do not support that
 		err := manager.AllocateIPs(switchName, allocateAddresses)
-		if err != nil {
+		if err != nil && err != ipallocator.ErrAllocated {
 			return nil, err
 		}
 		return allocateAddresses, nil

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -62,6 +62,21 @@ func (oc *DefaultNetworkController) syncPods(pods []interface{}) error {
 			}
 		}
 	}
+
+	if config.HybridOverlay.Enabled {
+		// allocate all previously annoted hybridOverlay Distributed Router IP addresses. Allocation needs to happen here
+		// before a Pod Add event can be processed and be allocated a previously assigned hybridOverlay Distributed Router IP address.
+		// we do not support manually setting the hybrid overlay DRIP address
+		nodes, err := oc.watchFactory.GetNodes()
+		if err != nil {
+			return fmt.Errorf("failed to get nodes: %v", err)
+		}
+		for _, node := range nodes {
+			if err := oc.allocateHybridOverlayDRIP(node); err != nil {
+				return fmt.Errorf("cannot allocate hybridOverlay DRIP on node %s (%v)", node.Name, err)
+			}
+		}
+	}
 	// all pods present before ovn-kube startup have been processed
 	atomic.StoreUint32(&oc.allInitialPodsProcessed, 1)
 


### PR DESCRIPTION
currently there is a race condition when allocating the hybridOverlayDRIP on master startup. 

There is a period of time between when `syncPods()` is finished and the addNode event is retried where a valid addPod event can be processed and allocated an address previously assigned as the nodes hybrid overlay distributed router IP. 

In order to fix this we can allocate the ip address in the nodes `k8s.io/api/core/v1/distributed-router-gateway-ip` annotation during `syncPods()` this will ensure that no future event will allocate the already assigned ip address 

furthermore we can ignore the already allocated error from the ipallocator for the hybridOverlay because we do not support setting the annotations manually and that *should* be the only way there would be a collision. 
 
Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->