### PR TITLE
Fix address set cleanup: only delete address sets owned by given object.

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -135,6 +135,8 @@ func (asf *ovnAddressSetFactory) EnsureAddressSet(name string) (AddressSet, erro
 	return &ovnAddressSets{nbClient: asf.nbClient, name: name, ipv4: v4set, ipv6: v6set}, nil
 }
 
+// forEachAddressSet executes a do function on each address set found to have ExternalIDs["name"].
+// do function should take parameters: hashed addr set name, real name
 func forEachAddressSet(nbClient libovsdbclient.Client, do func(string, string) error) error {
 	p := func(addrSet *nbdb.AddressSet) bool {
 		_, exists := addrSet.ExternalIDs["name"]

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -24,7 +24,7 @@ const (
 	ipv6AddressSetSuffix = "_v6"
 )
 
-type AddressSetIterFunc func(hashedName, namespace, suffix string) error
+type AddressSetIterFunc func(hashedName, name string) error
 type AddressSetDoFunc func(as AddressSet) error
 
 // AddressSetFactory is an interface for managing address set objects
@@ -135,7 +135,7 @@ func (asf *ovnAddressSetFactory) EnsureAddressSet(name string) (AddressSet, erro
 	return &ovnAddressSets{nbClient: asf.nbClient, name: name, ipv4: v4set, ipv6: v6set}, nil
 }
 
-func forEachAddressSet(nbClient libovsdbclient.Client, do func(string) error) error {
+func forEachAddressSet(nbClient libovsdbclient.Client, do func(string, string) error) error {
 	p := func(addrSet *nbdb.AddressSet) bool {
 		_, exists := addrSet.ExternalIDs["name"]
 		return exists
@@ -147,7 +147,7 @@ func forEachAddressSet(nbClient libovsdbclient.Client, do func(string) error) er
 
 	var errors []error
 	for _, addrSet := range addrSetList {
-		if err := do(addrSet.ExternalIDs["name"]); err != nil {
+		if err := do(addrSet.Name, addrSet.ExternalIDs["name"]); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -159,12 +159,10 @@ func forEachAddressSet(nbClient libovsdbclient.Client, do func(string) error) er
 	return nil
 }
 
-// ProcessEachAddressSet will pass the unhashed address set name, namespace name
-// and the first suffix in the name to the 'iteratorFn' for every address_set in
-// OVN. (Unhashed address set names are of the form namespaceName[.suffix1.suffix2. .suffixN])
+// ProcessEachAddressSet will pass the hashed and unhashed address set name to iteratorFn for every address set.
 func (asf *ovnAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIterFunc) error {
 	processedAddressSets := sets.String{}
-	return forEachAddressSet(asf.nbClient, func(name string) error {
+	return forEachAddressSet(asf.nbClient, func(hashedName, name string) error {
 		// Remove the suffix from the address set name and normalize
 		addrSetName := truncateSuffixFromAddressSet(name)
 		if processedAddressSets.Has(addrSetName) {
@@ -174,13 +172,7 @@ func (asf *ovnAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIter
 			return nil
 		}
 		processedAddressSets.Insert(addrSetName)
-		names := strings.Split(addrSetName, ".")
-		addrSetNamespace := names[0]
-		nameSuffix := ""
-		if len(names) >= 2 {
-			nameSuffix = names[1]
-		}
-		return iteratorFn(addrSetName, addrSetNamespace, nameSuffix)
+		return iteratorFn(hashedName, addrSetName)
 	})
 }
 

--- a/go-controller/pkg/ovn/address_set/address_set_cleanup.go
+++ b/go-controller/pkg/ovn/address_set/address_set_cleanup.go
@@ -16,7 +16,7 @@ func NonDualStackAddressSetCleanup(nbClient libovsdbclient.Client) error {
 	const old = 0
 	const new = 1
 	addressSets := map[string][2]bool{}
-	err := forEachAddressSet(nbClient, func(name string) error {
+	err := forEachAddressSet(nbClient, func(hashedName, name string) error {
 		shortName := truncateSuffixFromAddressSet(name)
 		spec, found := addressSets[shortName]
 		if !found {

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -70,16 +70,16 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 					NBData: []libovsdbtest.TestData{
 						&nbdb.AddressSet{
 							Name:        "1",
-							ExternalIDs: map[string]string{"name": "ns1.foo.bar"},
+							ExternalIDs: map[string]string{"name": "foo.bar"},
 						},
 						&nbdb.AddressSet{
 							Name:        "2",
-							ExternalIDs: map[string]string{"name": "ns2.test.test2"},
+							ExternalIDs: map[string]string{"name": "test.test2"},
 						},
 
 						&nbdb.AddressSet{
 							Name:        "3",
-							ExternalIDs: map[string]string{"name": "ns3"},
+							ExternalIDs: map[string]string{"name": "test3"},
 						},
 					},
 				}
@@ -91,17 +91,17 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 
 				_, err = config.InitConfig(ctx, nil, nil)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				namespaces := map[string]bool{
-					"ns1.foo.bar":    true,
-					"ns2.test.test2": true,
-					"ns3":            true,
+				expectedAddressSets := map[string]bool{
+					"foo.bar":    true,
+					"test.test2": true,
+					"test3":      true,
 				}
 				err = asFactory.ProcessEachAddressSet(func(hashedName, addrSetName string) error {
-					gomega.Expect(namespaces[addrSetName]).To(gomega.BeTrue())
-					delete(namespaces, addrSetName)
+					gomega.Expect(expectedAddressSets[addrSetName]).To(gomega.BeTrue())
+					delete(expectedAddressSets, addrSetName)
 					return nil
 				})
-				gomega.Expect(len(namespaces)).To(gomega.Equal(0))
+				gomega.Expect(len(expectedAddressSets)).To(gomega.Equal(0))
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				return nil
 			}

--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -3,14 +3,12 @@ package addressset
 import (
 	"k8s.io/klog/v2"
 	"net"
-	"strings"
 	"sync"
 	"sync/atomic"
 
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	utilnet "k8s.io/utils/net"
 
 	"github.com/onsi/gomega"
@@ -73,21 +71,17 @@ func (f *FakeAddressSetFactory) EnsureAddressSet(name string) (AddressSet, error
 
 func (f *FakeAddressSetFactory) ProcessEachAddressSet(iteratorFn AddressSetIterFunc) error {
 	f.Lock()
-	defer f.Unlock()
-	asNames := sets.String{}
+	asNames := map[string]string{}
 	for _, set := range f.sets {
 		asName := truncateSuffixFromAddressSet(set.getName())
-		if asNames.Has(asName) {
+		if _, ok := asNames[asName]; ok {
 			continue
 		}
-		asNames.Insert(asName)
-		parts := strings.Split(asName, ".")
-		addrSetNamespace := parts[0]
-		nameSuffix := ""
-		if len(parts) >= 2 {
-			nameSuffix = parts[1]
-		}
-		if err := iteratorFn(asName, addrSetNamespace, nameSuffix); err != nil {
+		asNames[asName] = set.hashName
+	}
+	f.Unlock()
+	for asName, hashName := range asNames {
+		if err := iteratorFn(hashName, asName); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -275,14 +275,14 @@ func (oc *DefaultNetworkController) deleteEgressFirewall(egressFirewallObj *egre
 			break
 		}
 	}
+	// delete acls first, then dns address set that is referenced in these acls
+	if err := oc.deleteEgressFirewallRules(egressFirewallObj.Namespace); err != nil {
+		return err
+	}
 	if deleteDNS {
 		if err := oc.egressFirewallDNS.Delete(egressFirewallObj.Namespace); err != nil {
 			return err
 		}
-	}
-
-	if err := oc.deleteEgressFirewallRules(egressFirewallObj.Namespace); err != nil {
-		return err
 	}
 	oc.egressFirewalls.Delete(egressFirewallObj.Namespace)
 	return nil

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
@@ -67,11 +70,38 @@ func (oc *DefaultNetworkController) syncNamespaces(namespaces []interface{}) err
 		expectedNs[ns.Name] = true
 	}
 
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, nameSuffix string) error {
-		if nameSuffix == "" && !expectedNs[namespaceName] {
-			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
-				klog.Errorf(err.Error())
-				return err
+	err := oc.addressSetFactory.ProcessEachAddressSet(func(hashedName, addrSetName string) error {
+		// filter out address sets owned by HybridRoutePolicy and EgressQoS by prefix, and
+		// owned by network policy by dot in the name (namespace can't have dots in its name).
+		// the only left address sets may be owned by egress firewall dns or namespace
+		if !strings.HasPrefix(addrSetName, types.HybridRoutePolicyPrefix) &&
+			!strings.HasPrefix(addrSetName, types.EgressQoSRulePrefix) &&
+			!strings.Contains(addrSetName, ".") {
+			// make sure address set is not owned by egress firewall dns
+			// find ACLs referencing given address set (by hashName)
+			aclPred := func(acl *nbdb.ACL) bool {
+				return strings.Contains(acl.Match, "$"+hashedName)
+			}
+			acls, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, aclPred)
+			if err != nil {
+				return fmt.Errorf("failed to find referencing acls for address set %s: %v", addrSetName, err)
+			}
+			if len(acls) > 0 {
+				// if given address set is owned by egress firewall, all ACLs will be owned by the same object
+				acl := acls[0]
+				// check if egress firewall dns is the owner
+				// the only address set that may be referenced in egress firewall destination is dns address set
+				if acl.ExternalIDs[egressFirewallACLExtIdKey] != "" && strings.Contains(acl.Match, ".dst == $"+hashedName) {
+					// address set is owned by egress firewall, skip
+					return nil
+				}
+			}
+			// address set is owned by namespace, namespace name = address set name
+			if !expectedNs[addrSetName] {
+				if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
+					klog.Errorf(err.Error())
+					return err
+				}
 			}
 		}
 		return nil

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -2,6 +2,7 @@ package ovn
 
 import (
 	"context"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"net"
 	"sync"
 
@@ -88,6 +89,44 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 	})
 
 	ginkgo.Context("on startup", func() {
+		ginkgo.It("only cleans up address sets owned by namespace", func() {
+			namespace1 := newNamespace(namespaceName)
+			// namespace-owned address set for existing namespace, should stay
+			fakeOvn.asf.NewAddressSet(namespaceName, []net.IP{net.ParseIP("1.1.1.1")})
+			// namespace-owned address set for stale namespace, should be deleted
+			fakeOvn.asf.NewAddressSet("namespace2", []net.IP{net.ParseIP("1.1.1.2")})
+			// netpol-owned address set for existing netpol, should stay
+			fakeOvn.asf.NewAddressSet("namespace1.netpol1.egress.0", []net.IP{net.ParseIP("1.1.1.3")})
+			// egressQoS-owned address set, should stay
+			fakeOvn.asf.NewAddressSet(ovntypes.EgressQoSRulePrefix+"namespace", []net.IP{net.ParseIP("1.1.1.4")})
+			// hybridNode-owned address set, should stay
+			fakeOvn.asf.NewAddressSet(ovntypes.HybridRoutePolicyPrefix+"node", []net.IP{net.ParseIP("1.1.1.5")})
+			// egress firewall-owned address set, should stay
+			// needs exiting ACL to distinguish from namespace-owned
+			dnsAS, err := fakeOvn.asf.NewAddressSet("dnsname", []net.IP{net.ParseIP("1.1.1.6")})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			dnsHashName, _ := dnsAS.GetASHashNames()
+			egressFirewallACL := BuildACL(
+				"aclName",
+				1,
+				"ip4.dst == $"+dnsHashName,
+				nbdb.ACLActionAllow,
+				nil,
+				lportIngress,
+				map[string]string{egressFirewallACLExtIdKey: "egressfirewall1"},
+			)
+
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{NBData: []libovsdbtest.TestData{egressFirewallACL}})
+			err = fakeOvn.controller.syncNamespaces([]interface{}{namespace1})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			fakeOvn.asf.ExpectAddressSetWithIPs(namespaceName, []string{"1.1.1.1"})
+			fakeOvn.asf.EventuallyExpectNoAddressSet("namespace2")
+			fakeOvn.asf.ExpectAddressSetWithIPs("namespace1.netpol1.egress.0", []string{"1.1.1.3"})
+			fakeOvn.asf.ExpectAddressSetWithIPs(ovntypes.EgressQoSRulePrefix+"namespace", []string{"1.1.1.4"})
+			fakeOvn.asf.ExpectAddressSetWithIPs(ovntypes.HybridRoutePolicyPrefix+"node", []string{"1.1.1.5"})
+			fakeOvn.asf.ExpectAddressSetWithIPs("dnsname", []string{"1.1.1.6"})
+		})
 
 		ginkgo.It("reconciles an existing namespace with pods", func() {
 			namespaceT := *newNamespace(namespaceName)

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -2,7 +2,6 @@ package ovn
 
 import (
 	"context"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"net"
 	"sync"
 
@@ -11,6 +10,7 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -102,7 +102,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			// hybridNode-owned address set, should stay
 			fakeOvn.asf.NewAddressSet(ovntypes.HybridRoutePolicyPrefix+"node", []net.IP{net.ParseIP("1.1.1.5")})
 			// egress firewall-owned address set, should stay
-			// needs exiting ACL to distinguish from namespace-owned
+			// needs existing ACL to distinguish from namespace-owned
 			dnsAS, err := fakeOvn.asf.NewAddressSet("dnsname", []net.IP{net.ParseIP("1.1.1.6")})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			dnsHashName, _ := dnsAS.GetASHashNames()

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -3,6 +3,7 @@ package ovn
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -300,16 +301,28 @@ func (oc *DefaultNetworkController) syncNetworkPolicies(networkPolicies []interf
 	}
 
 	stalePGs := []string{}
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(addrSetName, namespaceName, policyName string) error {
-		if policyName != "" && !expectedPolicies[namespaceName][policyName] {
-			// policy doesn't exist on k8s. Delete the port group
-			portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
-			hashedLocalPortGroup := hashedPortGroup(portGroupName)
-			stalePGs = append(stalePGs, hashedLocalPortGroup)
-			// delete the address sets for this old policy from OVN
-			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
-				klog.Errorf(err.Error())
-				return err
+	err := oc.addressSetFactory.ProcessEachAddressSet(func(hashedName, addrSetName string) error {
+		// netpol name has format fmt.Sprintf("%s.%s.%s.%d", gp.policyNamespace, gp.policyName, direction, gp.idx)
+		s := strings.Split(addrSetName, ".")
+		sLen := len(s)
+		// priority should be a number
+		_, numErr := strconv.Atoi(s[sLen-1])
+		if sLen >= 4 && (s[sLen-2] == "ingress" || s[sLen-2] == "egress") && numErr == nil {
+			// address set is owned by network policy
+			// namespace doesn't have dots
+			namespaceName := s[0]
+			// policyName may have dots, join in that case
+			policyName := strings.Join(s[1:sLen-2], ".")
+			if !expectedPolicies[namespaceName][policyName] {
+				// policy doesn't exist on k8s. Delete the port group
+				portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
+				hashedLocalPortGroup := hashedPortGroup(portGroupName)
+				stalePGs = append(stalePGs, hashedLocalPortGroup)
+				// delete the address sets for this old policy from OVN
+				if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
+					klog.Errorf(err.Error())
+					return err
+				}
 			}
 		}
 		return nil

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -301,28 +301,30 @@ func (oc *DefaultNetworkController) syncNetworkPolicies(networkPolicies []interf
 	}
 
 	stalePGs := []string{}
-	err := oc.addressSetFactory.ProcessEachAddressSet(func(hashedName, addrSetName string) error {
+	err := oc.addressSetFactory.ProcessEachAddressSet(func(_, addrSetName string) error {
 		// netpol name has format fmt.Sprintf("%s.%s.%s.%d", gp.policyNamespace, gp.policyName, direction, gp.idx)
 		s := strings.Split(addrSetName, ".")
 		sLen := len(s)
 		// priority should be a number
 		_, numErr := strconv.Atoi(s[sLen-1])
-		if sLen >= 4 && (s[sLen-2] == "ingress" || s[sLen-2] == "egress") && numErr == nil {
-			// address set is owned by network policy
-			// namespace doesn't have dots
-			namespaceName := s[0]
-			// policyName may have dots, join in that case
-			policyName := strings.Join(s[1:sLen-2], ".")
-			if !expectedPolicies[namespaceName][policyName] {
-				// policy doesn't exist on k8s. Delete the port group
-				portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
-				hashedLocalPortGroup := hashedPortGroup(portGroupName)
-				stalePGs = append(stalePGs, hashedLocalPortGroup)
-				// delete the address sets for this old policy from OVN
-				if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
-					klog.Errorf(err.Error())
-					return err
-				}
+		if sLen < 4 || (s[sLen-2] != "ingress" && s[sLen-2] != "egress") || numErr != nil {
+			// address set name is not formatted by network policy
+			return nil
+		}
+
+		// address set is owned by network policy
+		// namespace doesn't have dots
+		namespaceName := s[0]
+		// policyName may have dots, join in that case
+		policyName := strings.Join(s[1:sLen-2], ".")
+		if !expectedPolicies[namespaceName][policyName] {
+			// policy doesn't exist on k8s. Delete the port group
+			portGroupName := fmt.Sprintf("%s_%s", namespaceName, policyName)
+			hashedLocalPortGroup := hashedPortGroup(portGroupName)
+			stalePGs = append(stalePGs, hashedLocalPortGroup)
+			// delete the address sets for this old policy from OVN
+			if err := oc.addressSetFactory.DestroyAddressSetInBackingStore(addrSetName); err != nil {
+				return err
 			}
 		}
 		return nil


### PR DESCRIPTION
Fix FakeAddressSetFactory.ProcessEachAddressSet locking to allow calling other FakeAddressSetFactory in iteratorFn.

Address set may be owned by one of 5 object types: namespace, network policy, egress firewall dns, egress qos, and hybrid node. Only namespace and network policy are trying to delete stale address sets on initial sync.
Previously namespace considered address sets that don't have dots in its name to be owned by namespace and network policy considered everything with the dot to be owned by network policy. This logic was based on network policy address set naming: it has a format of `fmt.Sprintf("%s.%s.%s.%d", policyNamespace, policyName, direction, gp.idx)`. Besides the fact that this logic ignores 3 other owners of address sets, it also ignores the fact that network policy name may have dots in it. Parsing address set name using dots logic was also integrated into `ovnAddressSetFactory`.

This fix updates namespace and network policy sync logic to make sure it only changes objects owned by the corresponding object type. `ovnAddressSetFactory` doesn't have any parsing logic now, it was delegated to the `AddressSetIterFunc`.

Last commit is to address another syntax Error https://issues.redhat.com/browse/OCPBUGS-4448

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>
