### PR TITLE
Expose resource max retry failed metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,3 +54,4 @@ This list is to help notify if there are additions, changes or removals to metri
 - Add `ovnkube_master_network_programming_duration_seconds` and `ovnkube_master_network_programming_ovn_duration_seconds` (https://github.com/ovn-org/ovn-kubernetes/pull/2878)
 - Remove `ovnkube_master_skipped_nbctl_daemon_total` (https://github.com/ovn-org/ovn-kubernetes/pull/2707)
 - Add `ovnkube_master_egress_routing_via_host` (https://github.com/ovn-org/ovn-kubernetes/pull/2833)
+- Add `ovnkube_resource_retry_failures_total` (https://github.com/ovn-org/ovn-kubernetes/pull/3314)

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -382,6 +382,7 @@ func RegisterMasterFunctional() {
 	prometheus.MustRegister(metricEgressFirewallRuleCount)
 	prometheus.MustRegister(metricEgressFirewallCount)
 	prometheus.MustRegister(metricEgressRoutingViaHost)
+	prometheus.MustRegister(MetricResourceRetryFailuresCount)
 }
 
 // RunTimestamp adds a goroutine that registers and updates timestamp metrics.

--- a/go-controller/pkg/metrics/metrics.go
+++ b/go-controller/pkg/metrics/metrics.go
@@ -71,6 +71,15 @@ type stopwatchStatistics struct {
 	longTermAvg    string
 }
 
+// MetricResourceRetryFailuresCount is the number of times retrying to reconcile a Kubernetes
+// resource reached the maximum retry limit and will not be retried. This metric doesn't
+// need Subsystem string since it is applicable for both master and node.
+var MetricResourceRetryFailuresCount = prometheus.NewCounter(prometheus.CounterOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Name:      "resource_retry_failures_total",
+	Help:      "The total number of times processing a Kubernetes resource reached the maximum retry limit and was no longer processed",
+})
+
 // OVN/OVS components, namely ovn-northd, ovn-controller, and ovs-vswitchd provide various
 // metrics through the 'coverage/show' command. The following data structure holds all the
 // metrics we are interested in that output for a given component. We generalize capturing

--- a/go-controller/pkg/metrics/node.go
+++ b/go-controller/pkg/metrics/node.go
@@ -61,5 +61,6 @@ func RegisterNodeMetrics() {
 			func() float64 { return 1 },
 		))
 		registerWorkqueueMetrics(MetricOvnkubeNamespace, MetricOvnkubeSubsystemNode)
+		prometheus.MustRegister(MetricResourceRetryFailuresCount)
 	})
 }

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
 )
 
@@ -231,6 +232,7 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 			klog.Warningf("Dropping retry entry for %s %s: exceeded number of failed attempts",
 				r.ResourceHandler.ObjType, objKey)
 			r.DeleteRetryObj(key)
+			metrics.MetricResourceRetryFailuresCount.Inc()
 			return
 		}
 		forceRetry := false


### PR DESCRIPTION
The resource event handling has 15 max retries upon failures. once it reaches the limit, it won't be tried agin and logged with an warning message.
Now this exposes it as resource_max_retry_failed prometheus counter metric for both master and node when retries failed.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>