### PR TITLE
node/cni: initialize OVS exec runner early to prevent races

### DIFF
--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -42,9 +42,7 @@ func ResetRunner() {
 
 func ovsExec(args ...string) (string, error) {
 	if runner == nil {
-		if err := SetExec(kexec.New()); err != nil {
-			return "", err
-		}
+		return "", fmt.Errorf("OVS exec runner not initialized")
 	}
 
 	args = append([]string{"--timeout=30"}, args...)
@@ -124,9 +122,7 @@ func ovsClear(table, record string, columns ...string) error {
 
 func ofctlExec(args ...string) (string, error) {
 	if runner == nil {
-		if err := SetExec(kexec.New()); err != nil {
-			return "", err
-		}
+		return "", fmt.Errorf("OVS exec runner not initialized")
 	}
 
 	args = append([]string{"--timeout=10", "--no-stats", "--strict"}, args...)


### PR DESCRIPTION
The pkg/cni OVS exec operations don't lock the runner variable, partly for performance reasons (since multiple podRequests could be in-flight at the same time). This causes a race where one pod operation found 'runner == nil', calls SetExec() which sets 'runner = r', but before the first operation can find the OVS binaries a second pod operation finds 'runner = [something]' and proceeds to call os/exec functions with an empty path.

```
W1212 22:57:22.431136    5515 helper_linux.go:588] Failed to delete pod "openshift-kube-scheduler/revision-pruner-7-ip-10-0-181-91.us-west-2.compute.internal" OVS port 14b76a3e6667536: failed to run 'ovs-vsctl --timeout=30 del-port br-int 14b76a3e6667536': exec: no command
  ""
  ""
```

This sometimes happens on ovnkube-node startup when kubelet already has pods on the node and a bunch of pod requests are queued up waiting.

Make sure we initialize the CNI OVS runner early in ovnkube-node startup to prevent races. Again we don't want to lock the runner as that will create lock contention and slow things down in high churn scenarios.

@trozet 