### PR TITLE
Process completed deleted resources conditionally

### DIFF
--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -78,8 +78,9 @@ type RetryFramework struct {
 	stopChan <-chan struct{}
 	doneWg   *sync.WaitGroup
 
-	watchFactory    *factory.WatchFactory
-	ResourceHandler *ResourceHandler
+	watchFactory      *factory.WatchFactory
+	ResourceHandler   *ResourceHandler
+	terminatedObjects sync.Map
 }
 
 // NewRetryFramework returns a new RetryFramework instance, essential for the whole retry logic.
@@ -92,12 +93,13 @@ func NewRetryFramework(
 	watchFactory *factory.WatchFactory,
 	resourceHandler *ResourceHandler) *RetryFramework {
 	return &RetryFramework{
-		retryEntries:    syncmap.NewSyncMap[*retryObjEntry](),
-		retryChan:       make(chan struct{}, 1),
-		watchFactory:    watchFactory,
-		stopChan:        stopChan,
-		doneWg:          doneWg,
-		ResourceHandler: resourceHandler,
+		retryEntries:      syncmap.NewSyncMap[*retryObjEntry](),
+		retryChan:         make(chan struct{}, 1),
+		watchFactory:      watchFactory,
+		stopChan:          stopChan,
+		doneWg:            doneWg,
+		ResourceHandler:   resourceHandler,
+		terminatedObjects: sync.Map{},
 	}
 }
 
@@ -400,10 +402,17 @@ var (
 // free its resources. (for now, this applies to completed pods)
 // processObjectInTerminalState doesn't unlock key
 func (r *RetryFramework) processObjectInTerminalState(obj interface{}, lockedKey string, event resourceEvent) {
+	_, loaded := r.terminatedObjects.LoadOrStore(lockedKey, true)
+	if loaded {
+		// object was already terminated
+		klog.Infof("Detected object %s of type %s in terminal state (e.g. completed) will be " +
+			"ignored as it has already been processed")
+		return
+	}
+
 	// The object is in a terminal state: delete it from the cluster, delete its retry entry and return.
 	klog.Infof("Detected object %s of type %s in terminal state (e.g. completed)"+
 		" during %s event: will remove it", lockedKey, r.ResourceHandler.ObjType, event)
-
 	internalCacheEntry := r.ResourceHandler.GetInternalCacheEntry(obj)
 	retryEntry := r.InitRetryObjWithDelete(obj, lockedKey, internalCacheEntry, true) // set up the retry obj for deletion
 	if err := r.ResourceHandler.DeleteResource(obj, internalCacheEntry); err != nil {
@@ -646,9 +655,16 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 				// If object is in terminal state, we would have already deleted it during update.
 				// No reason to attempt to delete it here again.
 				if r.ResourceHandler.IsObjectInTerminalState(obj) {
-					klog.Infof("Ignoring delete event for resource in terminal state %s %s",
-						r.ResourceHandler.ObjType, key)
-					return
+					// If object is in terminal state, check if we have already processed it in a previous update.
+					// We cannot blindly handle multiple delete operations for the same pod currently. There can be races
+					// where other pod handlers are removing IP addresses from address sets when they shouldn't be, etc.
+					// See: https://github.com/ovn-org/ovn-kubernetes/pull/3318#issuecomment-1349804450
+					if _, loaded := r.terminatedObjects.LoadAndDelete(key); loaded {
+						// object was already terminated
+						klog.Infof("Ignoring delete event for resource in terminal state %s %s",
+							r.ResourceHandler.ObjType, key)
+						return
+					}
 				}
 				r.DoWithLock(key, func(key string) {
 					internalCacheEntry := r.ResourceHandler.GetInternalCacheEntry(obj)


### PR DESCRIPTION
For completed resources (pods) we were not processing them if completed
because they should have been handled already during update. However we
may miss an update event where the pod was completed, and only get a
delete event with the pod completed. In this case we were ignoring
deleting the pod and the IP and port would not be cleaned up.

Ideally we would want the delete to be idempotent no matter how many
times it is called. This is true for the deleteLogicalPort path, but not
true for other pod types (peer address set, local pod, egress ip pod
type, etc). Therefore it is currently unsafe to attempt to delete more
than one time. This should be resolved once we have level driven
controllers, but for now we can at least try to do something in the pod
delete event if we know we have never attempted to delete this pod
before.

Signed-off-by: Tim Rozet <trozet@redhat.com>

Reported-at: https://issues.redhat.com/browse/OCPBUGS-4825

For history on why this was added in the first place:
https://github.com/ovn-org/ovn-kubernetes/pull/2957/commits/7bcc8da30344a87a3eb4e1ab3f73861ff848a4b4