### PR TITLE
Revert "fix hybridOverlay DRIP address allocation"

### DIFF
--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -9,7 +9,6 @@ import (
 
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	ipam "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/ipallocator/allocator"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -293,10 +292,8 @@ func (manager *LogicalSwitchManager) AllocateHybridOverlay(switchName string, hy
 		for _, ip := range hybridOverlayAnnotation {
 			allocateAddresses = append(allocateAddresses, &net.IPNet{IP: net.ParseIP(ip).To4(), Mask: net.CIDRMask(32, 32)})
 		}
-		// attempt to allocate the IP address that is annotated on the node. The only way there would be a collision is if the annotations of podIP or hybridOverlayDRIP
-		// where manually edited and we do not support that
 		err := manager.AllocateIPs(switchName, allocateAddresses)
-		if err != nil && err != ipallocator.ErrAllocated {
+		if err != nil {
 			return nil, err
 		}
 		return allocateAddresses, nil

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -62,21 +62,6 @@ func (oc *DefaultNetworkController) syncPods(pods []interface{}) error {
 			}
 		}
 	}
-
-	if config.HybridOverlay.Enabled {
-		// allocate all previously annoted hybridOverlay Distributed Router IP addresses. Allocation needs to happen here
-		// before a Pod Add event can be processed and be allocated a previously assigned hybridOverlay Distributed Router IP address.
-		// we do not support manually setting the hybrid overlay DRIP address
-		nodes, err := oc.watchFactory.GetNodes()
-		if err != nil {
-			return fmt.Errorf("failed to get nodes: %v", err)
-		}
-		for _, node := range nodes {
-			if err := oc.allocateHybridOverlayDRIP(node); err != nil {
-				return fmt.Errorf("cannot allocate hybridOverlay DRIP on node %s (%v)", node.Name, err)
-			}
-		}
-	}
 	// all pods present before ovn-kube startup have been processed
 	atomic.StoreUint32(&oc.allInitialPodsProcessed, 1)
 


### PR DESCRIPTION
This reverts commit dabaf9fb8e024d8a52fbb1dc470fdce596caf505.

Original PR never passed control plane tests.

