### PR TITLE
Fix unit tests not shutting down watch factory

### DIFF
--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1621,6 +1621,7 @@ func TestController_syncNodes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: Error creating master watch factory: %v", tt.name, err)
 			}
+			defer f.Shutdown()
 
 			dbSetup := libovsdbtest.TestSetup{
 				SBData: tt.initialSBDB,
@@ -1712,6 +1713,7 @@ func TestController_deleteStaleNodeChassis(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: Error creating master watch factory: %v", tt.name, err)
 			}
+			defer f.Shutdown()
 
 			dbSetup := libovsdbtest.TestSetup{
 				SBData: tt.initialSBDB,


### PR DESCRIPTION
Data race seen at: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_ovn-kubernetes/1449/pull-ci-openshift-ovn-kubernetes-master-unit/1603150200489119744/artifacts/test/build-log.txt

Signed-off-by: Tim Rozet <trozet@redhat.com>

