### PR TITLE
Process delete handlers in reverse order of priority

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -80,9 +80,9 @@ const (
 	defaultNumEventQueues uint32 = 15
 
 	// default priorities for various handlers (also the highest priority)
-	defaultHandlerPriority uint32 = 0
+	defaultHandlerPriority int = 0
 	// lowest priority among various handlers (See GetHandlerPriority for more information)
-	minHandlerPriority uint32 = 4
+	minHandlerPriority int = 4
 )
 
 // types for dynamic handlers created when adding a network policy
@@ -423,7 +423,7 @@ type AddHandlerFuncType func(namespace string, sel labels.Selector, funcs cache.
 // By default handlers get the defaultHandlerPriority which is 0 (highest priority). Higher the number, lower the priority to get an event.
 // Example: EgressIPPodType will always get the pod event after PodType and PeerPodSelectorType will always get the event after PodType and EgressIPPodType
 // NOTE: If you are touching this function to add a new object type that uses shared objects, please make sure to update `minHandlerPriority` if needed
-func (wf *WatchFactory) GetHandlerPriority(objType reflect.Type) (priority uint32) {
+func (wf *WatchFactory) GetHandlerPriority(objType reflect.Type) (priority int) {
 	switch objType {
 	case EgressIPPodType:
 		return 1
@@ -513,7 +513,7 @@ func (wf *WatchFactory) GetResourceHandlerFunc(objType reflect.Type) (AddHandler
 	return nil, fmt.Errorf("cannot get ObjectMeta from type %v", objType)
 }
 
-func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+func (wf *WatchFactory) addHandler(objType reflect.Type, namespace string, sel labels.Selector, funcs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority int) (*Handler, error) {
 	inf, ok := wf.informers[objType]
 	if !ok {
 		klog.Fatalf("Tried to add handler of unknown object type %v", objType)
@@ -579,7 +579,7 @@ func (wf *WatchFactory) AddPodHandler(handlerFuncs cache.ResourceEventHandler, p
 }
 
 // AddFilteredPodHandler adds a handler function that will be executed when Pod objects that match the given filters change
-func (wf *WatchFactory) AddFilteredPodHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+func (wf *WatchFactory) AddFilteredPodHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority int) (*Handler, error) {
 	return wf.addHandler(PodType, namespace, sel, handlerFuncs, processExisting, priority)
 }
 
@@ -664,7 +664,7 @@ func (wf *WatchFactory) AddNamespaceHandler(handlerFuncs cache.ResourceEventHand
 }
 
 // AddFilteredNamespaceHandler adds a handler function that will be executed when Namespace objects that match the given filters change
-func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+func (wf *WatchFactory) AddFilteredNamespaceHandler(namespace string, sel labels.Selector, handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority int) (*Handler, error) {
 	return wf.addHandler(NamespaceType, namespace, sel, handlerFuncs, processExisting, priority)
 }
 
@@ -674,7 +674,7 @@ func (wf *WatchFactory) RemoveNamespaceHandler(handler *Handler) {
 }
 
 // AddNodeHandler adds a handler function that will be executed on Node object changes
-func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority uint32) (*Handler, error) {
+func (wf *WatchFactory) AddNodeHandler(handlerFuncs cache.ResourceEventHandler, processExisting func([]interface{}) error, priority int) (*Handler, error) {
 	return wf.addHandler(NodeType, "", nil, handlerFuncs, processExisting, priority)
 }
 

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -379,7 +379,7 @@ var _ = Describe("Watch Factory Operations", func() {
 	})
 
 	Context("when a processExisting is given", func() {
-		testExisting := func(objType reflect.Type, namespace string, sel labels.Selector, priority uint32) {
+		testExisting := func(objType reflect.Type, namespace string, sel labels.Selector, priority int) {
 			if objType == EndpointSliceType {
 				wf, err = NewNodeWatchFactory(ovnClientset, nodeName)
 			} else {
@@ -401,7 +401,7 @@ var _ = Describe("Watch Factory Operations", func() {
 			wf.removeHandler(objType, h)
 		}
 
-		testExistingFilteredHandler := func(objType reflect.Type, realObj reflect.Type, namespace string, sel labels.Selector, priority uint32) {
+		testExistingFilteredHandler := func(objType reflect.Type, realObj reflect.Type, namespace string, sel labels.Selector, priority int) {
 			if objType == EndpointSliceType {
 				wf, err = NewNodeWatchFactory(ovnClientset, nodeName)
 			} else {
@@ -1171,12 +1171,14 @@ var _ = Describe("Watch Factory Operations", func() {
 			namespace *v1.Namespace
 			added     int
 			updated   int
+			deleted   int
 		}
 		testNamespaces := make(map[string]*opTest)
 
 		for i := 0; i < 998; i++ {
 			name := fmt.Sprintf("mynamespace-%d", i)
 			namespace := newNamespace(name)
+			namespace.Status.Phase = ""
 			testNamespaces[name] = &opTest{namespace: namespace}
 			// Add all namespaces to the initial list
 			namespaces = append(namespaces, namespace)
@@ -1197,6 +1199,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				defer ot.mu.Unlock()
 				Expect(ot.added).To(Equal(0))
 				ot.added++
+				Expect(namespace.Status.Phase).To(BeEmpty())
 			},
 			UpdateFunc: func(old, new interface{}) {
 				defer GinkgoRecover()
@@ -1209,9 +1212,22 @@ var _ = Describe("Watch Factory Operations", func() {
 				Expect(ot.added).To(Equal(4), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(0))
 				ot.updated++
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceActive))
+			},
+			DeleteFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				newNamespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Verify that deletes were processed after the updates and adds
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(4), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(4), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.deleted).To(Equal(8))
+				ot.deleted = ot.deleted / 2
 				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
 			},
-			DeleteFunc: func(obj interface{}) {},
 		})
 
 		eipnsh, c2 := addPriorityHandler(wf, NamespaceType, EgressIPNamespaceType, cache.ResourceEventHandlerFuncs{
@@ -1224,6 +1240,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				defer ot.mu.Unlock()
 				Expect(ot.added).To(Equal(1), "add for EIP namespace %s processed before initial namespace add!", namespace.Name)
 				ot.added = ot.added * 10
+				Expect(namespace.Status.Phase).To(BeEmpty())
 			},
 			UpdateFunc: func(old, new interface{}) {
 				defer GinkgoRecover()
@@ -1236,9 +1253,22 @@ var _ = Describe("Watch Factory Operations", func() {
 				Expect(ot.added).To(Equal(4), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(1), "update for EIP namespace %s processed before initial namespace update!", newNamespace.Name)
 				ot.updated = ot.updated * 10
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceActive))
+			},
+			DeleteFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				newNamespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Verify that deletes were processed after the updates and adds
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(4), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(4), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.deleted).To(Equal(10))
+				ot.deleted = ot.deleted - 2
 				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
 			},
-			DeleteFunc: func(obj interface{}) {},
 		})
 		peernsh, c3 := addPriorityHandler(wf, NamespaceType, PeerNamespaceSelectorType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -1250,6 +1280,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				defer ot.mu.Unlock()
 				Expect(ot.added).To(Equal(10), "add for peer namespace %s processed before EIP namespace add!", namespace.Name)
 				ot.added = ot.added - 2
+				Expect(namespace.Status.Phase).To(BeEmpty())
 			},
 			UpdateFunc: func(old, new interface{}) {
 				defer GinkgoRecover()
@@ -1262,9 +1293,22 @@ var _ = Describe("Watch Factory Operations", func() {
 				Expect(ot.added).To(Equal(4), "update for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(10), "update for peer namespace %s processed before EIP namespace update!", newNamespace.Name)
 				ot.updated = ot.updated - 2
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceActive))
+			},
+			DeleteFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				newNamespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Verify that deletes were processed after the updates and adds
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(4), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(4), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.deleted).To(Equal(1))
+				ot.deleted = ot.deleted * 10
 				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
 			},
-			DeleteFunc: func(obj interface{}) {},
 		})
 		peerpodnsh, c4 := addPriorityHandler(wf, NamespaceType, PeerNamespaceAndPodSelectorType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -1276,6 +1320,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				defer ot.mu.Unlock()
 				Expect(ot.added).To(Equal(8), "add for peerPod namespace %s processed before peer namespace add!", namespace.Name)
 				ot.added = ot.added / 2
+				Expect(namespace.Status.Phase).To(BeEmpty())
 			},
 			UpdateFunc: func(old, new interface{}) {
 				defer GinkgoRecover()
@@ -1288,15 +1333,28 @@ var _ = Describe("Watch Factory Operations", func() {
 				Expect(ot.added).To(Equal(4), "update for peerPod namespace %s processed before peerPod namespace add!", newNamespace.Name)
 				Expect(ot.updated).To(Equal(8), "update for peerPod namespace %s processed before peer namespace update!", newNamespace.Name)
 				ot.updated = ot.updated / 2
+				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceActive))
+			},
+			DeleteFunc: func(obj interface{}) {
+				defer GinkgoRecover()
+				newNamespace := obj.(*v1.Namespace)
+				ot, ok := testNamespaces[newNamespace.Name]
+				Expect(ok).To(BeTrue())
+				// Verify that deletes were processed after the updates and adds
+				ot.mu.Lock()
+				defer ot.mu.Unlock()
+				Expect(ot.added).To(Equal(4), "delete for EIP namespace %s processed before add was processed in all handlers!", newNamespace.Name)
+				Expect(ot.updated).To(Equal(4), "delete for EIP namespace %s processed before update was processed in all handlers!", newNamespace.Name)
+				Expect(ot.deleted).To(Equal(0))
+				ot.deleted++
 				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
 			},
-			DeleteFunc: func(obj interface{}) {},
 		})
 		done := make(chan bool)
 		go func() {
 			// Send an update event for each namespace
 			for _, n := range namespaces {
-				n.Status.Phase = v1.NamespaceTerminating
+				n.Status.Phase = v1.NamespaceActive
 				namespaceWatch.Modify(n)
 			}
 			done <- true
@@ -1324,6 +1382,28 @@ var _ = Describe("Watch Factory Operations", func() {
 			ot.mu.Lock()
 			// ((((0 + 1) * 10) - 2) / 2) = 4
 			Expect(ot.updated).To(Equal(4), "missing update for namespace %s", ot.namespace.Name)
+			ot.mu.Unlock()
+		}
+
+		go func() {
+			// Send a delete event for each namespace
+			for _, n := range namespaces {
+				n.Status.Phase = v1.NamespaceTerminating
+				namespaceWatch.Delete(n)
+			}
+			done <- true
+		}()
+		<-done
+		// Deletes are async and may take a bit longer to finish
+		Eventually(c1.getDeleted, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c2.getDeleted, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c3.getDeleted, 10).Should(Equal(len(testNamespaces)))
+		Eventually(c4.getDeleted, 10).Should(Equal(len(testNamespaces)))
+
+		for _, ot := range testNamespaces {
+			ot.mu.Lock()
+			// ((((0 + 1) * 10) - 2) / 2) = 4
+			Expect(ot.deleted).To(Equal(4), "missing delete for namespace %s", ot.namespace.Name)
 			ot.mu.Unlock()
 		}
 

--- a/go-controller/pkg/factory/handler.go
+++ b/go-controller/pkg/factory/handler.go
@@ -39,7 +39,7 @@ type Handler struct {
 	// priority is used to track the handler's priority of being invoked.
 	// example: a handler with priority 0 will process the received event first
 	// before a handler with priority 1.
-	priority uint32
+	priority int
 }
 
 func (h *Handler) OnAdd(obj interface{}) {
@@ -88,7 +88,7 @@ type informer struct {
 	// before a handler with priority 1, 0 being the higest priority.
 	// NOTE: we can have multiple handlers with the same priority hence the value
 	// is a map of handlers keyed by its unique id.
-	handlers map[uint32]map[uint64]*Handler
+	handlers map[int]map[uint64]*Handler
 	events   []chan *event
 	lister   listerInterface
 	// initialAddFunc will be called to deliver the initial list of objects
@@ -103,8 +103,19 @@ func (i *informer) forEachQueuedHandler(f func(h *Handler)) {
 	i.RLock()
 	defer i.RUnlock()
 
-	for priority := 0; uint32(priority) <= minHandlerPriority; priority++ { // loop over priority higest to lowest
-		for _, handler := range i.handlers[uint32(priority)] {
+	for priority := 0; priority <= minHandlerPriority; priority++ { // loop over priority higest to lowest
+		for _, handler := range i.handlers[priority] {
+			f(handler)
+		}
+	}
+}
+
+func (i *informer) forEachQueuedHandlerReversed(f func(h *Handler)) {
+	i.RLock()
+	defer i.RUnlock()
+
+	for priority := minHandlerPriority; priority >= 0; priority-- { // loop over priority lowest to highest
+		for _, handler := range i.handlers[priority] {
 			f(handler)
 		}
 	}
@@ -120,14 +131,31 @@ func (i *informer) forEachHandler(obj interface{}, f func(h *Handler)) {
 		return
 	}
 
-	for priority := 0; uint32(priority) <= minHandlerPriority; priority++ { // loop over priority higest to lowest
-		for _, handler := range i.handlers[uint32(priority)] {
+	for priority := 0; priority <= minHandlerPriority; priority++ { // loop over priority higest to lowest
+		for _, handler := range i.handlers[priority] {
 			f(handler)
 		}
 	}
 }
 
-func (i *informer) addHandler(id uint64, priority uint32, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler, existingItems []interface{}) *Handler {
+func (i *informer) forEachHandlerReversed(obj interface{}, f func(h *Handler)) {
+	i.RLock()
+	defer i.RUnlock()
+
+	objType := reflect.TypeOf(obj)
+	if objType != i.oType {
+		klog.Errorf("Object type %v did not match expected %v", objType, i.oType)
+		return
+	}
+
+	for priority := minHandlerPriority; priority >= 0; priority-- { // loop over priority lowest to highest
+		for _, handler := range i.handlers[priority] {
+			f(handler)
+		}
+	}
+}
+
+func (i *informer) addHandler(id uint64, priority int, filterFunc func(obj interface{}) bool, funcs cache.ResourceEventHandler, existingItems []interface{}) *Handler {
 	handler := &Handler{
 		cache.FilteringResourceEventHandler{
 			FilterFunc: filterFunc,
@@ -334,7 +362,7 @@ func (i *informer) newFederatedQueuedHandler(numEventQueues uint32) cache.Resour
 			i.enqueueEvent(nil, realObj, entry.queue, func(e *event) {
 				metrics.MetricResourceUpdateCount.WithLabelValues(name, "delete").Inc()
 				start := time.Now()
-				i.forEachQueuedHandler(func(h *Handler) {
+				i.forEachQueuedHandlerReversed(func(h *Handler) {
 					h.OnDelete(e.obj)
 				})
 				metrics.MetricResourceDeleteLatency.Observe(time.Since(start).Seconds())
@@ -380,7 +408,7 @@ func (i *informer) newFederatedHandler() cache.ResourceEventHandlerFuncs {
 			}
 			metrics.MetricResourceUpdateCount.WithLabelValues(name, "delete").Inc()
 			start := time.Now()
-			i.forEachHandler(realObj, func(h *Handler) {
+			i.forEachHandlerReversed(realObj, func(h *Handler) {
 				h.OnDelete(realObj)
 			})
 			metrics.MetricResourceDeleteLatency.Observe(time.Since(start).Seconds())
@@ -443,7 +471,7 @@ func newBaseInformer(oType reflect.Type, sharedInformer cache.SharedIndexInforme
 		oType:    oType,
 		inf:      sharedInformer,
 		lister:   lister,
-		handlers: make(map[uint32]map[uint64]*Handler),
+		handlers: make(map[int]map[uint64]*Handler),
 		queueMap: make(map[ktypes.NamespacedName]*queueMapEntry),
 	}, nil
 }


### PR DESCRIPTION
If the priorities of the handlers represent interdependencies between them, it makes sense to process deletes in reverse order of adds to minimize potential problems were a high priority handler deltes something a lower priority handler depends on.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->