### PR TITLE
ovn: consolidate event recording and add Node event support

### DIFF
--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -156,7 +156,6 @@ func (oc *DefaultNetworkController) addPodExternalGW(pod *kapi.Pod) error {
 	foundGws, err := getExGwPodIPs(pod)
 	if err != nil {
 		klog.Errorf("Error getting exgw IPs for pod: %s, error: %v", pod.Name, err)
-		oc.recordPodEvent("ErrorAddingLogicalPort", err, pod)
 		return nil
 	}
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -706,7 +706,6 @@ func (oc *DefaultNetworkController) addUpdateNodeEvent(node *kapi.Node, nSyncs *
 			oc.gatewaysFailed.Store(node.Name, true)
 			oc.hybridOverlayFailed.Store(node.Name, config.HybridOverlay.Enabled)
 			err = fmt.Errorf("nodeAdd: error adding node %q: %w", node.Name, err)
-			oc.recordNodeErrorEvent(node, err)
 			return err
 		}
 		oc.addNodeFailed.Delete(node.Name)
@@ -778,11 +777,7 @@ func (oc *DefaultNetworkController) addUpdateNodeEvent(node *kapi.Node, nSyncs *
 		}
 	}
 
-	err = kerrors.NewAggregate(errs)
-	if err != nil {
-		oc.recordNodeErrorEvent(node, err)
-	}
-	return err
+	return kerrors.NewAggregate(errs)
 }
 
 func (oc *DefaultNetworkController) deleteNodeEvent(node *kapi.Node) error {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1274,7 +1274,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					eventsCopy = append(eventsCopy, e)
 				}
 				return eventsCopy
-			}, 10).Should(gomega.ContainElement(gomega.ContainSubstring("Warning ErrorReconcilingNode error creating gateway for node node1")))
+			}, 10).Should(gomega.ContainElement(gomega.ContainSubstring("Warning ErrorUpdatingResource error creating gateway for node node1")))
 
 			connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 			defer cancel()

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -28,9 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
 )
 
@@ -97,17 +95,6 @@ func (oc *DefaultNetworkController) getPortInfo(pod *kapi.Pod) *lpInfo {
 		portInfo, _ = oc.logicalPortCache.get(pod, ovntypes.DefaultNetworkName)
 	}
 	return portInfo
-}
-
-func (oc *DefaultNetworkController) recordPodEvent(reason string, addErr error, pod *kapi.Pod) {
-	podRef, err := ref.GetReference(scheme.Scheme, pod)
-	if err != nil {
-		klog.Errorf("Couldn't get a reference to pod %s/%s to post an event: '%v'",
-			pod.Namespace, pod.Name, err)
-	} else {
-		klog.V(5).Infof("Posting a %s event for Pod %s/%s", kapi.EventTypeWarning, pod.Namespace, pod.Name)
-		oc.recorder.Eventf(podRef, kapi.EventTypeWarning, reason, addErr.Error())
-	}
 }
 
 func exGatewayAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {


### PR DESCRIPTION
Use the generic object retry event recorder instead of separate recorders for pod and node events.