### PR TITLE
Serve NodePort services on secondary IP addresses

### DIFF
--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -611,7 +611,9 @@ func getGatewayIPTRules(service *kapi.Service, localEndpoints []string, svcHasLo
 				if svcTypeIsETPLocal && !svcHasLocalHostNetEndPnt {
 					// case1 (see function description for details)
 					// A DNAT rule to masqueradeIP is added that takes priority over DNAT to clusterIP.
-					rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					if config.Gateway.Mode == config.GatewayModeLocal {
+						rules = append(rules, getNodePortIPTRules(svcPort, clusterIP, svcPort.NodePort, svcHasLocalHostNetEndPnt, svcTypeIsETPLocal)...)
+					}
 					// add a skip SNAT rule to OVN-KUBE-SNAT-MGMTPORT to preserve sourceIP for etp=local traffic.
 					rules = append(rules, getNodePortETPLocalIPTRules(svcPort, clusterIP)...)
 				}

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -1155,7 +1155,6 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-ETP": []string{
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Status.LoadBalancer.Ingress[0].IP, service.Spec.Ports[0].Port, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 							fmt.Sprintf("-p %s -d %s --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, externalIP, service.Spec.Ports[0].Port, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
 						},
 						"OVN-KUBE-ITP":        []string{},
 						"OVN-KUBE-EGRESS-SVC": []string{"-m mark --mark 0x3f0 -m comment --comment Do not SNAT to SVC VIP -j RETURN"},
@@ -2116,9 +2115,7 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-SNAT-MGMTPORT": []string{
 							fmt.Sprintf("-p TCP --dport %v -j RETURN", service.Spec.Ports[0].NodePort),
 						},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
-						},
+						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-ITP":        []string{},
 						"OVN-KUBE-EGRESS-SVC": []string{"-m mark --mark 0x3f0 -m comment --comment Do not SNAT to SVC VIP -j RETURN"},
 					},
@@ -2405,10 +2402,8 @@ var _ = Describe("Node Operations", func() {
 						"OVN-KUBE-SNAT-MGMTPORT": []string{
 							fmt.Sprintf("-p TCP --dport %v -j RETURN", service.Spec.Ports[0].NodePort),
 						},
-						"OVN-KUBE-ITP": []string{},
-						"OVN-KUBE-ETP": []string{
-							fmt.Sprintf("-p %s -m addrtype --dst-type LOCAL --dport %v -j DNAT --to-destination %s:%v", service.Spec.Ports[0].Protocol, service.Spec.Ports[0].NodePort, types.V4HostETPLocalMasqueradeIP, service.Spec.Ports[0].NodePort),
-						},
+						"OVN-KUBE-ITP":        []string{},
+						"OVN-KUBE-ETP":        []string{},
 						"OVN-KUBE-EGRESS-SVC": []string{"-m mark --mark 0x3f0 -m comment --comment Do not SNAT to SVC VIP -j RETURN"},
 					},
 					"filter": {},

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -74,7 +74,7 @@ func (c *lbConfig) makeNodeRouterTargetIPs(node *nodeInfo, epIPs []string, hostM
 
 	// any targets local to the node need to have a special
 	// harpin IP added, but only for the router LB
-	targetIPs, updated := util.UpdateIPsSlice(targetIPs, node.nodeIPsStr(), []string{hostMasqueradeIP})
+	targetIPs, updated := util.UpdateIPsSlice(targetIPs, node.l3gatewayAddressesStr(), []string{hostMasqueradeIP})
 
 	// We either only removed stuff from the original slice, or updated some IPs.
 	if len(targetIPs) != len(epIPs) || updated {
@@ -108,8 +108,8 @@ var protos = []v1.Protocol{
 // - services with InternalTrafficPolicy=Local
 //
 // Template LBs will be created for
-// - services with NodePort set but *without* ExternalTrafficPolicy=Local or
-//   affinity timeout set.
+//   - services with NodePort set but *without* ExternalTrafficPolicy=Local or
+//     affinity timeout set.
 func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice, useLBGroup, useTemplates bool) (perNodeConfigs, templateConfigs, clusterConfigs []lbConfig) {
 	needsAffinityTimeout := hasSessionAffinityTimeOut(service)
 
@@ -573,7 +573,7 @@ func buildPerNodeLBs(service *v1.Service, configs []lbConfig, nodes []nodeInfo) 
 				vips := make([]string, 0, len(config.vips))
 				for _, vip := range config.vips {
 					if vip == placeholderNodeIPs {
-						vips = append(vips, node.nodeIPsStr()...)
+						vips = append(vips, node.hostAddressesStr()...)
 					} else {
 						vips = append(vips, vip)
 					}

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -750,16 +750,18 @@ func Test_buildClusterLBs(t *testing.T) {
 
 	defaultNodes := []nodeInfo{
 		{
-			name:              "node-a",
-			nodeIPs:           []net.IP{net.ParseIP("10.0.0.1")},
-			gatewayRouterName: "gr-node-a",
-			switchName:        "switch-node-a",
+			name:               "node-a",
+			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.1")},
+			hostAddresses:      []net.IP{net.ParseIP("10.0.0.1")},
+			gatewayRouterName:  "gr-node-a",
+			switchName:         "switch-node-a",
 		},
 		{
-			name:              "node-b",
-			nodeIPs:           []net.IP{net.ParseIP("10.0.0.2")},
-			gatewayRouterName: "gr-node-b",
-			switchName:        "switch-node-b",
+			name:               "node-b",
+			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.2")},
+			hostAddresses:      []net.IP{net.ParseIP("10.0.0.2")},
+			gatewayRouterName:  "gr-node-b",
+			switchName:         "switch-node-b",
 		},
 	}
 
@@ -978,18 +980,20 @@ func Test_buildPerNodeLBs(t *testing.T) {
 
 	defaultNodes := []nodeInfo{
 		{
-			name:              "node-a",
-			nodeIPs:           []net.IP{net.ParseIP("10.0.0.1")},
-			gatewayRouterName: "gr-node-a",
-			switchName:        "switch-node-a",
-			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
+			name:               "node-a",
+			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.1")},
+			hostAddresses:      []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.111")},
+			gatewayRouterName:  "gr-node-a",
+			switchName:         "switch-node-a",
+			podSubnets:         []net.IPNet{{IP: net.ParseIP("10.128.0.0"), Mask: net.CIDRMask(24, 32)}},
 		},
 		{
-			name:              "node-b",
-			nodeIPs:           []net.IP{net.ParseIP("10.0.0.2")},
-			gatewayRouterName: "gr-node-b",
-			switchName:        "switch-node-b",
-			podSubnets:        []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
+			name:               "node-b",
+			l3gatewayAddresses: []net.IP{net.ParseIP("10.0.0.2")},
+			hostAddresses:      []net.IP{net.ParseIP("10.0.0.2")},
+			gatewayRouterName:  "gr-node-b",
+			switchName:         "switch-node-b",
+			podSubnets:         []net.IPNet{{IP: net.ParseIP("10.128.1.0"), Mask: net.CIDRMask(24, 32)}},
 		},
 	}
 
@@ -1079,6 +1083,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  Addr{IP: "10.0.0.1", Port: 80},
 							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}},
 						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
 					},
 					Opts: defaultOpts,
 				},
@@ -1107,6 +1115,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 					Rules: []LBRule{
 						{
 							Source:  Addr{IP: "10.0.0.1", Port: 80},
+							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 80},
 							Targets: []Addr{{IP: "10.128.0.2", Port: 8080}},
 						},
 					},
@@ -1166,6 +1178,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  Addr{IP: "10.0.0.1", Port: 80},
 							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}},
 						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 					Opts: defaultOpts,
 				},
@@ -1181,6 +1197,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 						},
 						{
 							Source:  Addr{IP: "10.0.0.1", Port: 80},
+							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 80},
 							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
 						},
 					},
@@ -1220,6 +1240,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  Addr{IP: "10.0.0.1", Port: 80},
 							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}},
 						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 					Opts: defaultOpts,
 				},
@@ -1235,6 +1259,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 						},
 						{
 							Source:  Addr{IP: "10.0.0.1", Port: 80},
+							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 80},
 							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
 						},
 					},
@@ -1315,6 +1343,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  Addr{IP: "10.0.0.1", Port: 80},
 							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}},
 						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 80},
+							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 				},
 				{
@@ -1333,6 +1365,14 @@ func Test_buildPerNodeLBs(t *testing.T) {
 						},
 						{
 							Source:  Addr{IP: "10.0.0.1", Port: 80},
+							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "169.254.169.3", Port: 80},
+							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 80},
 							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
 						},
 					},
@@ -1733,6 +1773,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  Addr{IP: "10.0.0.1", Port: 34345},
 							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
 						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 34345},
+							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 				},
 				{
@@ -1751,6 +1795,14 @@ func Test_buildPerNodeLBs(t *testing.T) {
 						},
 						{
 							Source:  Addr{IP: "10.0.0.1", Port: 34345},
+							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "169.254.169.3", Port: 34345},
+							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 34345},
 							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
 						},
 					},
@@ -1820,6 +1872,10 @@ func Test_buildPerNodeLBs(t *testing.T) {
 							Source:  Addr{IP: "10.0.0.1", Port: 34345},
 							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}}, // special skip_snat=true LB for ETP=local; used in SGW mode
 						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 34345},
+							Targets: []Addr{{IP: "169.254.169.2", Port: 8080}},
+						},
 					},
 				},
 				{
@@ -1838,6 +1894,14 @@ func Test_buildPerNodeLBs(t *testing.T) {
 						},
 						{
 							Source:  Addr{IP: "10.0.0.1", Port: 34345},
+							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "169.254.169.3", Port: 34345},
+							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}},
+						},
+						{
+							Source:  Addr{IP: "10.0.0.111", Port: 34345},
 							Targets: []Addr{{IP: "10.0.0.1", Port: 8080}}, // don't filter out eps for nodePorts on switches when ETP=local
 						},
 					},

--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -34,8 +35,10 @@ type nodeTracker struct {
 type nodeInfo struct {
 	// the node's Name
 	name string
-	// The list of physical IPs the node has, as reported by the gatewayconf annotation
-	nodeIPs []net.IP
+	// The list of physical IPs reported by the gatewayconf annotation
+	l3gatewayAddresses []net.IP
+	// The list of physical IPs the node has, as reported by the host-address annotation
+	hostAddresses []net.IP
 	// The pod network subnet(s)
 	podSubnets []net.IPNet
 	// the name of the node's GatewayRouter, or "" of non-existent
@@ -46,10 +49,18 @@ type nodeInfo struct {
 	chassisID string
 }
 
-func (ni *nodeInfo) nodeIPsStr() []string {
-	out := make([]string, 0, len(ni.nodeIPs))
-	for _, nodeIP := range ni.nodeIPs {
-		out = append(out, nodeIP.String())
+func (ni *nodeInfo) hostAddressesStr() []string {
+	out := make([]string, 0, len(ni.hostAddresses))
+	for _, ip := range ni.hostAddresses {
+		out = append(out, ip.String())
+	}
+	return out
+}
+
+func (ni *nodeInfo) l3gatewayAddressesStr() []string {
+	out := make([]string, 0, len(ni.l3gatewayAddresses))
+	for _, ip := range ni.l3gatewayAddresses {
+		out = append(out, ip.String())
 	}
 	return out
 }
@@ -58,7 +69,7 @@ func (ni *nodeInfo) nodeIPsStr() []string {
 // includes node IPs, still as a mask-1 net
 func (ni *nodeInfo) nodeSubnets() []net.IPNet {
 	out := append([]net.IPNet{}, ni.podSubnets...)
-	for _, ip := range ni.nodeIPs {
+	for _, ip := range ni.hostAddresses {
 		if ipv4 := ip.To4(); ipv4 != nil {
 			out = append(out, net.IPNet{
 				IP:   ip,
@@ -102,11 +113,16 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) (*nodeTracker, erro
 				return
 			}
 
-			// updateNode needs to be called only when hostSubnet annotation has changed or
-			// if L3Gateway annotation's ip addresses have changed or the name of the node (very rare)
-			// has changed. No need to trigger update for any other field change.
-			if util.NodeSubnetAnnotationChanged(oldObj, newObj) || util.NodeL3GatewayAnnotationChanged(oldObj, newObj) ||
-				util.NodeChassisIDAnnotationChanged(oldObj, newObj) || oldObj.Name != newObj.Name {
+			// updateNode needs to be called in the following cases:
+			// - hostSubnet annotation has changed
+			// - L3Gateway annotation's ip addresses have changed
+			// - the name of the node (very rare) has changed
+			// - the `host-addresses` annotation changed
+			// . No need to trigger update for any other field change.
+			if util.NodeSubnetAnnotationChanged(oldObj, newObj) ||
+				util.NodeL3GatewayAnnotationChanged(oldObj, newObj) ||
+				oldObj.Name != newObj.Name ||
+				util.NodeHostAddressesAnnotationChanged(oldObj, newObj) {
 				nt.updateNode(newObj)
 			}
 		},
@@ -136,14 +152,15 @@ func newNodeTracker(nodeInformer coreinformers.NodeInformer) (*nodeTracker, erro
 
 // updateNodeInfo updates the node info cache, and syncs all services
 // if it changed.
-func (nt *nodeTracker) updateNodeInfo(nodeName, switchName, routerName, chassisID string, nodeIPs []net.IP, podSubnets []*net.IPNet) {
+func (nt *nodeTracker) updateNodeInfo(nodeName, switchName, routerName, chassisID string, l3gatewayAddresses, hostAddresses []net.IP, podSubnets []*net.IPNet) {
 	ni := nodeInfo{
-		name:              nodeName,
-		nodeIPs:           nodeIPs,
-		podSubnets:        make([]net.IPNet, 0, len(podSubnets)),
-		gatewayRouterName: routerName,
-		switchName:        switchName,
-		chassisID:         chassisID,
+		name:               nodeName,
+		l3gatewayAddresses: l3gatewayAddresses,
+		hostAddresses:      hostAddresses,
+		podSubnets:         make([]net.IPNet, 0, len(podSubnets)),
+		gatewayRouterName:  routerName,
+		switchName:         switchName,
+		chassisID:          chassisID,
 	}
 	for i := range podSubnets {
 		ni.podSubnets = append(ni.podSubnets, *podSubnets[i]) // de-pointer
@@ -199,7 +216,7 @@ func (nt *nodeTracker) updateNode(node *v1.Node) {
 
 	switchName := node.Name
 	grName := ""
-	ips := []net.IP{}
+	l3gatewayAddresses := []net.IP{}
 	chassisID := ""
 
 	// if the node has a gateway config, it will soon have a gateway router
@@ -211,10 +228,22 @@ func (nt *nodeTracker) updateNode(node *v1.Node) {
 		grName = util.GetGatewayRouterFromNode(node.Name)
 		if gwConf.NodePortEnable {
 			for _, ip := range gwConf.IPAddresses {
-				ips = append(ips, ip.IP)
+				l3gatewayAddresses = append(l3gatewayAddresses, ip.IP)
 			}
 		}
 		chassisID = gwConf.ChassisID
+	}
+
+	hostAddresses, err := util.ParseNodeHostAddresses(node)
+	if err != nil {
+		klog.Warningf("Failed to get node host addresses for [%s]: %s", node.Name, err.Error())
+		hostAddresses = sets.New[string]()
+	}
+
+	hostAddressesIPs := make([]net.IP, 0, len(hostAddresses))
+	for _, ipStr := range hostAddresses.UnsortedList() {
+		ip := net.ParseIP(ipStr)
+		hostAddressesIPs = append(hostAddressesIPs, ip)
 	}
 
 	nt.updateNodeInfo(
@@ -222,7 +251,8 @@ func (nt *nodeTracker) updateNode(node *v1.Node) {
 		switchName,
 		grName,
 		chassisID,
-		ips,
+		l3gatewayAddresses,
+		hostAddressesIPs,
 		hsn,
 	)
 }

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -459,12 +459,12 @@ func (c *Controller) syncNodeInfos(nodeInfos []nodeInfo) {
 		// Services are currently supported only on the node's first IP.
 		// Extract that one and populate the node's IP template value.
 		if globalconfig.IPv4Mode {
-			if ipv4, err := util.MatchFirstIPFamily(false, node.nodeIPs); err == nil {
+			if ipv4, err := util.MatchFirstIPFamily(false, node.l3gatewayAddresses); err == nil {
 				c.nodeIPv4Template.Value[node.chassisID] = ipv4.String()
 			}
 		}
 		if globalconfig.IPv6Mode {
-			if ipv6, err := util.MatchFirstIPFamily(true, node.nodeIPs); err == nil {
+			if ipv6, err := util.MatchFirstIPFamily(true, node.l3gatewayAddresses); err == nil {
 				c.nodeIPv6Template.Value[node.chassisID] = ipv6.String()
 			}
 		}

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -635,7 +635,7 @@ func nodeIPTemplate(node *nodeInfo) *nbdb.ChassisTemplateVar {
 		UUID:    node.chassisID,
 		Chassis: node.chassisID,
 		Variables: map[string]string{
-			makeLBNodeIPTemplateName(v1.IPv4Protocol): node.nodeIPs[0].String(),
+			makeLBNodeIPTemplateName(v1.IPv4Protocol): node.hostAddresses[0].String(),
 		},
 	}
 }
@@ -679,11 +679,12 @@ func endpoint(ip string, port int32) string {
 
 func nodeConfig(nodeName string, nodeIP string) *nodeInfo {
 	return &nodeInfo{
-		name:              nodeName,
-		nodeIPs:           []net.IP{net.ParseIP(nodeIP)},
-		gatewayRouterName: nodeGWRouterName(nodeName),
-		switchName:        nodeSwitchName(nodeName),
-		chassisID:         nodeName,
+		name:               nodeName,
+		l3gatewayAddresses: []net.IP{net.ParseIP(nodeIP)},
+		hostAddresses:      []net.IP{net.ParseIP(nodeIP)},
+		gatewayRouterName:  nodeGWRouterName(nodeName),
+		switchName:         nodeSwitchName(nodeName),
+		chassisID:          nodeName,
 	}
 }
 

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -538,6 +539,10 @@ func GetNodeEgressLabel() string {
 
 func SetNodeHostAddresses(nodeAnnotator kube.Annotator, addresses sets.Set[string]) error {
 	return nodeAnnotator.Set(ovnNodeHostAddresses, addresses.UnsortedList())
+}
+
+func NodeHostAddressesAnnotationChanged(oldNode, newNode *v1.Node) bool {
+	return oldNode.Annotations[ovnNodeHostAddresses] != newNode.Annotations[ovnNodeHostAddresses]
 }
 
 // ParseNodeHostAddresses returns the parsed host addresses living on a node

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1836,7 +1836,8 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 								break
 							}
 						}
-						framework.ExpectEqual(valid, true, "Validation failed for node", node, responses, nodePort)
+						framework.ExpectEqual(valid, true,
+							fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Actual Responses=%v", node.Name, nodesHostnames, responses))
 					}
 				}
 			}
@@ -1988,7 +1989,8 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 										break
 									}
 								}
-								framework.ExpectEqual(valid, true, "Validation failed for node", nodeName, responses, port)
+								framework.ExpectEqual(valid, true,
+									fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Actual Responses=%v", nodeName, nodesHostnames, responses))
 							}
 						}
 					}
@@ -2058,7 +2060,8 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 							}
 
 						}
-						framework.ExpectEqual(valid, true, "Validation failed for node", node.Name, responses, nodePort)
+						framework.ExpectEqual(valid, true,
+							fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Actual Responses=%v", node.Name, expectedResponses, responses))
 					}
 				}
 			}
@@ -2118,7 +2121,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 							protocol,
 							externalPort))
 					valid = pokeExternalIpService(clientContainerName, protocol, externalAddress, externalPort, maxTries, nodesHostnames)
-					framework.ExpectEqual(valid, true, "Validation failed for external address", externalAddress)
+					framework.ExpectEqual(valid, true, "Validation failed for external address: %s", externalAddress)
 				}
 			}
 
@@ -2143,7 +2146,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 							protocol,
 							externalPort))
 					valid = pokeExternalIpService(clientContainerName, protocol, externalAddress, externalPort, maxTries, nodesHostnames)
-					framework.ExpectEqual(valid, true, "Validation failed for external address", externalAddress)
+					framework.ExpectEqual(valid, true, "Validation failed for external address: %s", externalAddress)
 				}
 			}
 		})
@@ -2259,7 +2262,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 							break
 						}
 					}
-					framework.ExpectEqual(valid, true, "Validation failed for external address", externalAddress)
+					framework.ExpectEqual(valid, true, "Validation failed for external address: %s", externalAddress)
 				}
 			}
 		})
@@ -2397,7 +2400,8 @@ var _ = ginkgo.Describe("e2e ingress to host-networked pods traffic validation",
 							}
 
 						}
-						framework.ExpectEqual(valid, true, "Validation failed for node", node.Name, responses, nodePort)
+						framework.ExpectEqual(valid, true,
+							fmt.Sprintf("Validation failed for node %s. Expected Responses=%v, Actual Responses=%v", node.Name, expectedResponses, responses))
 					}
 				}
 			}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -2151,7 +2151,8 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 			}
 		})
 	})
-	ginkgo.Context("Validating ExternalIP ingress traffic to manually added node IPs", func() {
+
+	ginkgo.Context("Validating ingress traffic to manually added node IPs", func() {
 		ginkgo.BeforeEach(func() {
 			endPoints = make([]*v1.Pod, 0)
 			nodesHostnames = sets.NewString()
@@ -2191,14 +2192,18 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 			// addresses.
 			createClusterExternalContainer(clientContainerName, agnhostImage, []string{"--network", "kind", "-P"}, []string{"netexec", "--http-port=80"})
 
+			// If `kindexgw` exists, connect client container to it
+			runCommand(containerRuntime, "network", "connect", "kindexgw", clientContainerName)
+
 			ginkgo.By("Adding ip addresses to each node")
 			// add new secondary IP from node subnet to all nodes, if the cluster is v6 add an ipv6 address
 			var newIP string
+			newNodeAddresses = make([]string, 0)
 			for i, node := range nodes.Items {
 				if utilnet.IsIPv6String(e2enode.GetAddresses(&node, v1.NodeInternalIP)[0]) {
 					newIP = "fc00:f853:ccd:e794::" + strconv.Itoa(i)
 				} else {
-					newIP = "172.18.1." + strconv.Itoa(i)
+					newIP = "172.18.1." + strconv.Itoa(i+1)
 				}
 				// manually add the a secondary IP to each node
 				_, err := runCommand(containerRuntime, "exec", node.Name, "ip", "addr", "add", newIP, "dev", "breth0")
@@ -2221,6 +2226,7 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 				}
 			}
 		})
+
 		// This test validates ingress traffic to externalservices after a new node Ip is added.
 		// It creates a service on both udp and tcp and assigns the new node IPs as
 		// external Addresses. Then, creates a backend pod on each node.
@@ -2263,6 +2269,62 @@ var _ = ginkgo.Describe("e2e ingress traffic validation", func() {
 						}
 					}
 					framework.ExpectEqual(valid, true, "Validation failed for external address: %s", externalAddress)
+				}
+			}
+		})
+
+		// This test verifies a NodePort service is reachable on manually added IP addresses.
+		ginkgo.It("for NodePort services", func() {
+			isIPv6Cluster := IsIPv6Cluster(f.ClientSet)
+			serviceName := "nodeportservice"
+
+			ginkgo.By("Creating NodePort service")
+			svcSpec := nodePortServiceSpecFrom(serviceName, v1.IPFamilyPolicyPreferDualStack, endpointHTTPPort, endpointUDPPort, clusterHTTPPort, clusterUDPPort, endpointsSelector, v1.ServiceExternalTrafficPolicyTypeLocal)
+			svcSpec, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.Background(), svcSpec, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for the endpoints to pop up")
+			err = framework.WaitForServiceEndpointsNum(f.ClientSet, f.Namespace.Name, serviceName, len(endPoints), time.Second, wait.ForeverTestTimeout)
+			framework.ExpectNoError(err, "failed to validate endpoints for service %s in namespace: %s", serviceName, f.Namespace.Name)
+
+			tcpNodePort, udpNodePort := nodePortsFromService(svcSpec)
+
+			toCheckNodesAddresses := sets.NewString()
+			for _, node := range nodes.Items {
+
+				addrAnnotation, ok := node.Annotations["k8s.ovn.org/host-addresses"]
+				gomega.Expect(ok).To(gomega.BeTrue())
+
+				var addrs []string
+				err := json.Unmarshal([]byte(addrAnnotation), &addrs)
+				framework.ExpectNoError(err, "failed to parse node[%s] host-address annotation[%s]", node.Name, addrAnnotation)
+
+				toCheckNodesAddresses.Insert(addrs...)
+			}
+
+			// Ensure newly added IP address are in the host-addresses annotation
+			for _, newAddress := range newNodeAddresses {
+				if !toCheckNodesAddresses.Has(newAddress) {
+					toCheckNodesAddresses.Insert(newAddress)
+				}
+			}
+
+			for _, protocol := range []string{"http", "udp"} {
+				toCurlPort := int32(tcpNodePort)
+				if protocol == "udp" {
+					toCurlPort = int32(udpNodePort)
+				}
+
+				for _, address := range toCheckNodesAddresses.List() {
+					if !isIPv6Cluster && utilnet.IsIPv6String(address) {
+						continue
+					}
+					ginkgo.By("Hitting the service on " + address + " via " + protocol)
+					gomega.Eventually(func() bool {
+						epHostname := pokeEndpoint("", clientContainerName, protocol, address, toCurlPort, "hostname")
+						// Expect to receive a valid hostname
+						return nodesHostnames.Has(epHostname)
+					}, "20s", "1s").Should(gomega.BeTrue())
 				}
 			}
 		})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -308,6 +308,7 @@ func pokeEndpoint(namespace, clientContainer, protocol, targetHost string, targe
 	if err != nil {
 		framework.Logf("FAILED Command was %s", curlCommand)
 		framework.Logf("FAILED Response was %v", res)
+		return ""
 	}
 	framework.ExpectNoError(err)
 


### PR DESCRIPTION
This PR makes NodePort services reachable on every IP address of a node.
They cannot be set only during `ovnkube-node` startup because other addresses can arrive later. The typical scenario is when a virtual IP address moves from a dead node the another.

PR adds End2End tests to the `control-plane` suite to cover the main scenario.

