### PR TITLE
Network policy: use shared pod selector address sets

### DIFF
--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -444,28 +444,22 @@ var _ = Describe("Watch Factory Operations", func() {
 			testExisting(PolicyType, "", nil, defaultHandlerPriority)
 		})
 
-		It("is called for each existing policy: PeerPodSelectorType", func() {
+		It("is called for each existing policy: AddressSetPodSelectorType", func() {
 			policies = append(policies, newPolicy("denyall", "default"))
 			pods = append(pods, newPod("pod1", "default"))
-			testExistingFilteredHandler(PodType, PeerPodSelectorType, "default", nil, 2)
+			testExistingFilteredHandler(PodType, AddressSetPodSelectorType, "default", nil, 2)
 		})
 
 		It("is called for each existing policy: LocalPodSelectorType", func() {
 			policies = append(policies, newPolicy("denyall", "default"))
 			pods = append(pods, newPod("pod1", "default"))
-			testExistingFilteredHandler(PodType, LocalPodSelectorType, "default", nil, 4)
+			testExistingFilteredHandler(PodType, LocalPodSelectorType, "default", nil, 3)
 		})
 
-		It("is called for each existing policy: PeerPodForNamespaceAndPodSelectorType", func() {
+		It("is called for each existing policy: AddressSetNamespaceAndPodSelectorType", func() {
 			policies = append(policies, newPolicy("denyall", "default"))
 			pods = append(pods, newPod("pod1", "default"))
-			testExistingFilteredHandler(PodType, PeerPodForNamespaceAndPodSelectorType, "default", nil, 3)
-		})
-
-		It("is called for each existing policy: PeerNamespaceAndPodSelectorType", func() {
-			policies = append(policies, newPolicy("denyall", "default"))
-			pods = append(pods, newPod("pod1", "default"))
-			testExistingFilteredHandler(NamespaceType, PeerNamespaceAndPodSelectorType, "default", nil, 3)
+			testExistingFilteredHandler(NamespaceType, AddressSetNamespaceAndPodSelectorType, "default", nil, 3)
 		})
 
 		It("is called for each existing policy: PeerNamespaceSelectorType", func() {
@@ -1310,7 +1304,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				Expect(newNamespace.Status.Phase).To(Equal(v1.NamespaceTerminating))
 			},
 		})
-		peerpodnsh, c4 := addPriorityHandler(wf, NamespaceType, PeerNamespaceAndPodSelectorType, cache.ResourceEventHandlerFuncs{
+		peerpodnsh, c4 := addPriorityHandler(wf, NamespaceType, AddressSetNamespaceAndPodSelectorType, cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				defer GinkgoRecover()
 				namespace := obj.(*v1.Namespace)

--- a/go-controller/pkg/libovsdbops/db_object_types.go
+++ b/go-controller/pkg/libovsdbops/db_object_types.go
@@ -9,11 +9,13 @@ const (
 	// owner types
 	EgressFirewallDNSOwnerType ownerType = "EgressFirewallDNS"
 	EgressQoSOwnerType         ownerType = "EgressQoS"
-	NetworkPolicyOwnerType     ownerType = "NetworkPolicy"
-	NamespaceOwnerType         ownerType = "Namespace"
-	HybridNodeRouteOwnerType   ownerType = "HybridNodeRoute"
-	EgressIPOwnerType          ownerType = "EgressIP"
-	EgressServiceOwnerType     ownerType = "EgressService"
+	// only used for cleanup now, as the stale owner of network policy address sets
+	NetworkPolicyOwnerType   ownerType = "NetworkPolicy"
+	PodSelectorOwnerType     ownerType = "PodSelector"
+	NamespaceOwnerType       ownerType = "Namespace"
+	HybridNodeRouteOwnerType ownerType = "HybridNodeRoute"
+	EgressIPOwnerType        ownerType = "EgressIP"
+	EgressServiceOwnerType   ownerType = "EgressService"
 
 	// owner extra IDs, make sure to define only 1 ExternalIDKey for every string value
 	PriorityKey           ExternalIDKey = "priority"
@@ -44,6 +46,13 @@ var AddressSetEgressQoS = newObjectIDsType(addressSet, EgressQoSOwnerType, []Ext
 	AddressSetIPFamilyKey,
 })
 
+var AddressSetPodSelector = newObjectIDsType(addressSet, PodSelectorOwnerType, []ExternalIDKey{
+	// pod selector string representation
+	ObjectNameKey,
+	AddressSetIPFamilyKey,
+})
+
+// deprecated, should only be used for sync
 var AddressSetNetworkPolicy = newObjectIDsType(addressSet, NetworkPolicyOwnerType, []ExternalIDKey{
 	// namespace_name
 	ObjectNameKey,

--- a/go-controller/pkg/metrics/master.go
+++ b/go-controller/pkg/metrics/master.go
@@ -221,16 +221,6 @@ var metricNetpolLocalPodEventLatency = prometheus.NewHistogramVec(prometheus.His
 		"event",
 	})
 
-var metricNetpolPeerPodEventLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: MetricOvnkubeNamespace,
-	Subsystem: MetricOvnkubeSubsystemMaster,
-	Name:      "network_policy_peer_pod_event_latency_seconds",
-	Help:      "The latency of peer pod events handling (add, delete)",
-	Buckets:   prometheus.ExponentialBuckets(.002, 2, 15)},
-	[]string{
-		"event",
-	})
-
 var metricNetpolPeerNamespaceEventLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
@@ -241,10 +231,20 @@ var metricNetpolPeerNamespaceEventLatency = prometheus.NewHistogramVec(prometheu
 		"event",
 	})
 
-var metricNetpolPeerNamespaceAndPodEventLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+var metricPodSelectorAddrSetPodEventLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: MetricOvnkubeNamespace,
 	Subsystem: MetricOvnkubeSubsystemMaster,
-	Name:      "network_policy_peer_namespace_and_pod_event_latency_seconds",
+	Name:      "pod_selector_address_set_pod_event_latency_seconds",
+	Help:      "The latency of peer pod events handling (add, delete)",
+	Buckets:   prometheus.ExponentialBuckets(.002, 2, 15)},
+	[]string{
+		"event",
+	})
+
+var metricPodSelectorAddrSetNamespaceEventLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: MetricOvnkubeNamespace,
+	Subsystem: MetricOvnkubeSubsystemMaster,
+	Name:      "pod_selector_address_set_namespace_event_latency_seconds",
 	Help:      "The latency of peer namespace events handling (add, delete)",
 	Buckets:   prometheus.ExponentialBuckets(.002, 2, 15)},
 	[]string{
@@ -419,9 +419,9 @@ func RegisterMasterFunctional() {
 		prometheus.MustRegister(metricEgressIPUnassignLatency)
 		prometheus.MustRegister(metricNetpolEventLatency)
 		prometheus.MustRegister(metricNetpolLocalPodEventLatency)
-		prometheus.MustRegister(metricNetpolPeerPodEventLatency)
 		prometheus.MustRegister(metricNetpolPeerNamespaceEventLatency)
-		prometheus.MustRegister(metricNetpolPeerNamespaceAndPodEventLatency)
+		prometheus.MustRegister(metricPodSelectorAddrSetPodEventLatency)
+		prometheus.MustRegister(metricPodSelectorAddrSetNamespaceEventLatency)
 		prometheus.MustRegister(metricPodEventLatency)
 	}
 	prometheus.MustRegister(metricEgressIPNodeUnreacheableCount)
@@ -539,16 +539,16 @@ func RecordNetpolLocalPodEvent(eventName string, duration time.Duration) {
 	metricNetpolLocalPodEventLatency.WithLabelValues(eventName).Observe(duration.Seconds())
 }
 
-func RecordNetpolPeerPodEvent(eventName string, duration time.Duration) {
-	metricNetpolPeerPodEventLatency.WithLabelValues(eventName).Observe(duration.Seconds())
-}
-
 func RecordNetpolPeerNamespaceEvent(eventName string, duration time.Duration) {
 	metricNetpolPeerNamespaceEventLatency.WithLabelValues(eventName).Observe(duration.Seconds())
 }
 
-func RecordNetpolPeerNamespaceAndPodEvent(eventName string, duration time.Duration) {
-	metricNetpolPeerNamespaceAndPodEventLatency.WithLabelValues(eventName).Observe(duration.Seconds())
+func RecordPodSelectorAddrSetPodEvent(eventName string, duration time.Duration) {
+	metricPodSelectorAddrSetPodEventLatency.WithLabelValues(eventName).Observe(duration.Seconds())
+}
+
+func RecordPodSelectorAddrSetNamespaceEvent(eventName string, duration time.Duration) {
+	metricPodSelectorAddrSetNamespaceEventLatency.WithLabelValues(eventName).Observe(duration.Seconds())
 }
 
 func RecordPodEvent(eventName string, duration time.Duration) {

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -275,18 +275,11 @@ func (asf *ovnAddressSetFactory) validateDbIDs(dbIDs *libovsdbops.DbObjectIDs) e
 	return fmt.Errorf("wrong set of keys is unset %v", unsetKeys)
 }
 
-// GetHashNamesForAS returns hashed address set names for given dbIDs, based on config.IPv<x>Mode
+// GetHashNamesForAS returns hashed address set names for given dbIDs for both ip families.
 // Can be used to cleanup e.g. address set references if the address set was deleted.
 func GetHashNamesForAS(dbIDs *libovsdbops.DbObjectIDs) (string, string) {
-	var ipv4AS string
-	var ipv6AS string
-	if config.IPv4Mode {
-		ipv4AS = buildAddressSet(dbIDs, ipv4InternalID).Name
-	}
-	if config.IPv6Mode {
-		ipv6AS = buildAddressSet(dbIDs, ipv6InternalID).Name
-	}
-	return ipv4AS, ipv6AS
+	return buildAddressSet(dbIDs, ipv4InternalID).Name,
+		buildAddressSet(dbIDs, ipv6InternalID).Name
 }
 
 // GetDbObjsForAS returns nbdb.AddressSet objects both for ipv4 and ipv6, regardless of current config.

--- a/go-controller/pkg/ovn/base_event_handler.go
+++ b/go-controller/pkg/ovn/base_event_handler.go
@@ -24,8 +24,7 @@ func hasResourceAnUpdateFunc(objType reflect.Type) bool {
 	switch objType {
 	case factory.PodType,
 		factory.NodeType,
-		factory.PeerPodSelectorType,
-		factory.PeerPodForNamespaceAndPodSelectorType,
+		factory.AddressSetPodSelectorType,
 		factory.EgressIPType,
 		factory.EgressIPNamespaceType,
 		factory.EgressIPPodType,
@@ -76,15 +75,14 @@ func (h *baseNetworkControllerEventHandler) areResourcesEqual(objType reflect.Ty
 
 	case factory.PodType,
 		factory.EgressIPPodType,
-		factory.PeerPodSelectorType,
-		factory.PeerPodForNamespaceAndPodSelectorType,
+		factory.AddressSetPodSelectorType,
 		factory.LocalPodSelectorType:
 		// For these types, there was no old vs new obj comparison in the original update code,
 		// so pretend they're always different so that the update code gets executed
 		return false, nil
 
 	case factory.PeerNamespaceSelectorType,
-		factory.PeerNamespaceAndPodSelectorType:
+		factory.AddressSetNamespaceAndPodSelectorType:
 		// For these types there is no update code, so pretend old and new
 		// objs are always equivalent and stop processing the update event.
 		return true, nil
@@ -153,13 +151,12 @@ func (h *baseNetworkControllerEventHandler) getResourceFromInformerCache(objType
 		obj, err = watchFactory.GetNode(name)
 
 	case factory.PodType,
-		factory.PeerPodSelectorType,
-		factory.PeerPodForNamespaceAndPodSelectorType,
+		factory.AddressSetPodSelectorType,
 		factory.LocalPodSelectorType,
 		factory.EgressIPPodType:
 		obj, err = watchFactory.GetPod(namespace, name)
 
-	case factory.PeerNamespaceAndPodSelectorType,
+	case factory.AddressSetNamespaceAndPodSelectorType,
 		factory.PeerNamespaceSelectorType,
 		factory.EgressIPNamespaceType,
 		factory.NamespaceType:
@@ -210,8 +207,7 @@ func needsUpdateDuringRetry(objType reflect.Type) bool {
 func (h *baseNetworkControllerEventHandler) isObjectInTerminalState(objType reflect.Type, obj interface{}) bool {
 	switch objType {
 	case factory.PodType,
-		factory.PeerPodSelectorType,
-		factory.PeerPodForNamespaceAndPodSelectorType,
+		factory.AddressSetPodSelectorType,
 		factory.LocalPodSelectorType,
 		factory.EgressIPPodType:
 		pod := obj.(*kapi.Pod)

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -103,8 +103,8 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			// namespace-owned address set for stale namespace, should be deleted
 			ns2 := getNamespaceAddrSetDbIDs("namespace2", DefaultNetworkControllerName)
 			fakeOvn.asf.NewAddressSet(ns2, []net.IP{net.ParseIP("1.1.1.2")})
-			// netpol-owned address set for existing netpol, should stay
-			netpol := getNetpolAddrSetDbIDs("namespace1", "netpol1", "egress", "0", controllerName)
+			// netpol peer address set for existing netpol, should stay
+			netpol := getPodSelectorAddrSetDbIDs("pasName", DefaultNetworkControllerName)
 			fakeOvn.asf.NewAddressSet(netpol, []net.IP{net.ParseIP("1.1.1.3")})
 			// egressQoS-owned address set, should stay
 			qos := getEgressQosAddrSetDbIDs("namespace", "0", controllerName)

--- a/go-controller/pkg/ovn/pod_selector_address_set.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set.go
@@ -1,0 +1,720 @@
+package ovn
+
+import (
+	"fmt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	kapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	kerrorsutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+)
+
+// PodSelectorAddressSet should always be accessed with oc.podSelectorAddressSets key lock
+type PodSelectorAddressSet struct {
+	// unique key that identifies given PodSelectorAddressSet
+	key string
+
+	// backRefs is a map of objects that use this address set.
+	// keys must be unique for all possible users, e.g. for NetworkPolicy use (np *networkPolicy) getKeyWithKind().
+	// Must only be changed with oc.podSelectorAddressSets Lock.
+	backRefs map[string]bool
+
+	// handler is either pod or namespace handler
+	handler *factory.Handler
+
+	podSelector       labels.Selector
+	namespaceSelector labels.Selector
+	// namespace is used when namespaceSelector is nil to set static namespace
+	namespace string
+	// if needsCleanup is true, try to cleanup before doing any other ops,
+	// is cleanup returns error, return error for the op
+	needsCleanup bool
+	addrSetDbIDs *libovsdbops.DbObjectIDs
+
+	// handlerResources holds the data that is used and updated by the handlers.
+	handlerResources *PodSelectorAddrSetHandlerInfo
+}
+
+// EnsurePodSelectorAddressSet returns address set for requested (podSelector, namespaceSelector, namespace).
+// If namespaceSelector is nil, namespace will be used with podSelector statically.
+// podSelector should not be nil, use metav1.LabelSelector{} to match all pods.
+// namespaceSelector can only be nil when namespace is set, use metav1.LabelSelector{} to match all namespaces.
+// podSelector = metav1.LabelSelector{} + static namespace may be replaced with namespace address set,
+// podSelector = metav1.LabelSelector{} + namespaceSelector may be replaced with a set of namespace address sets,
+// but both cases will work here too.
+//
+// backRef is the key that should be used for cleanup.
+// if err != nil, cleanup is required by calling DeletePodSelectorAddressSet or EnsurePodSelectorAddressSet again.
+// psAddrSetHashV4, psAddrSetHashV6 may be set to empty string if address set for that ipFamily wasn't created.
+func (oc *DefaultNetworkController) EnsurePodSelectorAddressSet(podSelector, namespaceSelector *metav1.LabelSelector,
+	namespace, backRef string) (addrSetKey, psAddrSetHashV4, psAddrSetHashV6 string, err error) {
+	if podSelector == nil {
+		err = fmt.Errorf("pod selector is nil")
+		return
+	}
+	if namespaceSelector == nil && namespace == "" {
+		err = fmt.Errorf("namespace selector is nil and namespace is empty")
+		return
+	}
+	if namespaceSelector != nil {
+		// namespace will be ignored in this case
+		namespace = ""
+	}
+	var nsSel, podSel labels.Selector
+	if namespaceSelector != nil {
+		nsSel, err = metav1.LabelSelectorAsSelector(namespaceSelector)
+		if err != nil {
+			err = fmt.Errorf("can't parse namespace selector %v: %w", namespaceSelector, err)
+			return
+		}
+	}
+
+	podSel, err = metav1.LabelSelectorAsSelector(podSelector)
+	if err != nil {
+		err = fmt.Errorf("can't parse pod selector %v: %w", podSelector, err)
+		return
+	}
+	addrSetKey = getPodSelectorKey(podSelector, namespaceSelector, namespace)
+	err = oc.podSelectorAddressSets.DoWithLock(addrSetKey, func(key string) error {
+		psAddrSet, found := oc.podSelectorAddressSets.Load(key)
+		if !found {
+			psAddrSet = &PodSelectorAddressSet{
+				key:               key,
+				backRefs:          map[string]bool{},
+				podSelector:       podSel,
+				namespaceSelector: nsSel,
+				namespace:         namespace,
+				addrSetDbIDs:      getPodSelectorAddrSetDbIDs(addrSetKey, oc.controllerName),
+			}
+			err = psAddrSet.init(oc)
+			// save object anyway for future use or cleanup
+			oc.podSelectorAddressSets.LoadOrStore(key, psAddrSet)
+			if err != nil {
+				psAddrSet.needsCleanup = true
+				return fmt.Errorf("failed to init pod selector address set %s: %v", addrSetKey, err)
+			}
+		}
+		if psAddrSet.needsCleanup {
+			cleanupErr := psAddrSet.destroy(oc)
+			if cleanupErr != nil {
+				return fmt.Errorf("failed to cleanup pod selector address set %s: %v", addrSetKey, err)
+			}
+			// psAddrSet.destroy will set psAddrSet.needsCleanup to false if no error was returned
+			// try to init again
+			err = psAddrSet.init(oc)
+			if err != nil {
+				psAddrSet.needsCleanup = true
+				return fmt.Errorf("failed to init pod selector address set %s after cleanup: %v", addrSetKey, err)
+			}
+		}
+		// psAddrSet is successfully inited, and doesn't need cleanup
+		psAddrSet.backRefs[backRef] = true
+		psAddrSetHashV4, psAddrSetHashV6, err = psAddrSet.handlerResources.GetASHashNames()
+		return err
+	})
+	if err != nil {
+		return
+	}
+	return
+}
+
+func (oc *DefaultNetworkController) DeletePodSelectorAddressSet(addrSetKey, backRef string) error {
+	return oc.podSelectorAddressSets.DoWithLock(addrSetKey, func(key string) error {
+		psAddrSet, found := oc.podSelectorAddressSets.Load(key)
+		if !found {
+			return nil
+		}
+		delete(psAddrSet.backRefs, backRef)
+		if len(psAddrSet.backRefs) == 0 {
+			err := psAddrSet.destroy(oc)
+			if err != nil {
+				// psAddrSet.destroy will set psAddrSet.needsCleanup to true in case of error,
+				// cleanup should be retried later
+				return fmt.Errorf("failed to destroy pod selector address set %s: %v", addrSetKey, err)
+			}
+			oc.podSelectorAddressSets.Delete(key)
+		}
+		return nil
+	})
+}
+
+func (psas *PodSelectorAddressSet) init(oc *DefaultNetworkController) error {
+	// create pod handler resources before starting the handlers
+	if psas.handlerResources == nil {
+		as, err := oc.addressSetFactory.NewAddressSet(psas.addrSetDbIDs, nil)
+		if err != nil {
+			return err
+		}
+		psas.handlerResources = &PodSelectorAddrSetHandlerInfo{
+			addressSet:        as,
+			key:               psas.key,
+			podSelector:       psas.podSelector,
+			namespaceSelector: psas.namespaceSelector,
+			namespace:         psas.namespace,
+		}
+	}
+
+	var err error
+	if psas.handler == nil {
+		if psas.namespace != "" {
+			// static namespace
+			if psas.podSelector.Empty() {
+				// nil selector means no filtering
+				err = oc.addPodSelectorHandler(psas, nil, psas.namespace)
+			} else {
+				// namespaced pod selector
+				err = oc.addPodSelectorHandler(psas, psas.podSelector, psas.namespace)
+			}
+		} else if psas.namespaceSelector.Empty() {
+			// any namespace
+			if psas.podSelector.Empty() {
+				// all cluster pods
+				err = oc.addPodSelectorHandler(psas, nil, "")
+			} else {
+				// global pod selector
+				err = oc.addPodSelectorHandler(psas, psas.podSelector, "")
+			}
+		} else {
+			// selected namespaces, use namespace handler
+			err = oc.addNamespacedPodSelectorHandler(psas)
+		}
+	}
+	if err == nil {
+		klog.Infof("Created shared address set for pod selector %s", psas.key)
+	}
+	return err
+}
+
+func (psas *PodSelectorAddressSet) destroy(oc *DefaultNetworkController) error {
+	klog.Infof("Deleting shared address set for pod selector %s", psas.key)
+	psas.needsCleanup = true
+	if psas.handlerResources != nil {
+		err := psas.handlerResources.destroy(oc)
+		if err != nil {
+			return fmt.Errorf("failed to delete handler resources: %w", err)
+		}
+	}
+	if psas.handler != nil {
+		oc.watchFactory.RemovePodHandler(psas.handler)
+		psas.handler = nil
+	}
+	psas.needsCleanup = false
+	return nil
+}
+
+// namespace = "" means all namespaces
+// podSelector = nil means all pods
+func (oc *DefaultNetworkController) addPodSelectorHandler(psAddrSet *PodSelectorAddressSet, podSelector labels.Selector, namespace string) error {
+	podHandlerResources := psAddrSet.handlerResources
+	syncFunc := func(objs []interface{}) error {
+		// ignore returned error, since any pod that wasn't properly handled will be retried individually.
+		_ = oc.handlePodAddUpdate(podHandlerResources, objs...)
+		return nil
+	}
+	retryFramework := oc.newRetryFrameworkWithParameters(
+		factory.AddressSetPodSelectorType,
+		syncFunc,
+		podHandlerResources)
+
+	podHandler, err := retryFramework.WatchResourceFiltered(namespace, podSelector)
+	if err != nil {
+		klog.Errorf("Failed WatchResource for addPodSelectorHandler: %v", err)
+		return err
+	}
+	psAddrSet.handler = podHandler
+	return nil
+}
+
+// addNamespacedPodSelectorHandler starts a watcher for AddressSetNamespaceAndPodSelectorType.
+// Add event for every existing namespace will be executed sequentially first, and an error will be
+// returned if something fails.
+func (oc *DefaultNetworkController) addNamespacedPodSelectorHandler(psAddrSet *PodSelectorAddressSet) error {
+	// start watching namespaces selected by the namespace selector nsSel;
+	// upon namespace add event, start watching pods in that namespace selected
+	// by the label selector podSel
+	retryFramework := oc.newRetryFrameworkWithParameters(
+		factory.AddressSetNamespaceAndPodSelectorType,
+		nil,
+		psAddrSet.handlerResources,
+	)
+	namespaceHandler, err := retryFramework.WatchResourceFiltered("", psAddrSet.namespaceSelector)
+	if err != nil {
+		klog.Errorf("Failed WatchResource for addNamespacedPodSelectorHandler: %v", err)
+		return err
+	}
+
+	psAddrSet.handler = namespaceHandler
+	return nil
+}
+
+type PodSelectorAddrSetHandlerInfo struct {
+	// PodSelectorAddrSetHandlerInfo is updated by PodSelectorAddressSet's handler, and it may be deleted by
+	// PodSelectorAddressSet.
+	// To make sure pod handlers won't try to update deleted resources, this lock is used together with deleted field.
+	sync.RWMutex
+	// this is a signal for local event handlers that they are/should be stopped.
+	// it will be set to true before any PodSelectorAddrSetHandlerInfo infrastructure is deleted,
+	// therefore every handler can either do its work and be sure all required resources are there,
+	// or this value will be set to true and handler can't proceed.
+	// Use PodSelectorAddrSetHandlerInfo.RLock to read this field and hold it for the whole event handling.
+	// PodSelectorAddrSetHandlerInfo.destroy
+	deleted bool
+
+	// resources updated by podHandler
+	addressSet addressset.AddressSet
+	// namespaced pod handlers, the only type of handler that can be dynamically deleted without deleting the whole
+	// PodSelectorAddressSet. When namespace is deleted, podHandler for that namespace should be deleted too.
+	// Can be used by multiple namespace handlers in parallel for different keys
+	// namespace(string): *factory.Handler
+	namespacedPodHandlers sync.Map
+
+	// read-only fields
+	// unique key that identifies given PodSelectorAddressSet
+	key               string
+	podSelector       labels.Selector
+	namespaceSelector labels.Selector
+	// namespace is used when namespaceSelector is nil to set static namespace
+	namespace string
+}
+
+// idempotent
+func (handlerInfo *PodSelectorAddrSetHandlerInfo) destroy(oc *DefaultNetworkController) error {
+	handlerInfo.Lock()
+	defer handlerInfo.Unlock()
+	// signal to local pod handlers to ignore new events
+	handlerInfo.deleted = true
+	handlerInfo.namespacedPodHandlers.Range(func(_, value interface{}) bool {
+		oc.watchFactory.RemovePodHandler(value.(*factory.Handler))
+		return true
+	})
+	handlerInfo.namespacedPodHandlers = sync.Map{}
+	if handlerInfo.addressSet != nil {
+		err := handlerInfo.addressSet.Destroy()
+		if err != nil {
+			return err
+		}
+		handlerInfo.addressSet = nil
+	}
+	return nil
+}
+
+func (handlerInfo *PodSelectorAddrSetHandlerInfo) GetASHashNames() (string, string, error) {
+	handlerInfo.RLock()
+	defer handlerInfo.RUnlock()
+	if handlerInfo.deleted {
+		return "", "", fmt.Errorf("addresss set is deleted")
+	}
+	v4Hash, v6Hash := handlerInfo.addressSet.GetASHashNames()
+	return v4Hash, v6Hash, nil
+}
+
+// addPods will get all currently assigned ips for given pods, and add them to the address set.
+// If pod ips change, this function should be called again.
+// must be called with PodSelectorAddrSetHandlerInfo read lock
+func (handlerInfo *PodSelectorAddrSetHandlerInfo) addPods(pods ...*v1.Pod) error {
+	if handlerInfo.addressSet == nil {
+		return fmt.Errorf("pod selector AddressSet %s is nil, cannot add pod(s)", handlerInfo.key)
+	}
+
+	podIPFactor := 1
+	if config.IPv4Mode && config.IPv6Mode {
+		podIPFactor = 2
+	}
+	ips := make([]net.IP, 0, len(pods)*podIPFactor)
+	for _, pod := range pods {
+		podIPs, err := util.GetPodIPsOfNetwork(pod, &util.DefaultNetInfo{})
+		if err != nil {
+			return err
+		}
+		ips = append(ips, podIPs...)
+	}
+	return handlerInfo.addressSet.AddIPs(ips)
+}
+
+// must be called with PodSelectorAddrSetHandlerInfo read lock
+func (handlerInfo *PodSelectorAddrSetHandlerInfo) deletePod(pod *v1.Pod) error {
+	ips, err := util.GetPodIPsOfNetwork(pod, &util.DefaultNetInfo{})
+	if err != nil {
+		// if pod ips can't be fetched on delete, we don't expect that information about ips will ever be updated,
+		// therefore just log the error and return.
+		klog.Infof("Failed to get pod IPs %s/%s to delete from pod selector address set: %w", pod.Namespace, pod.Name, err)
+		return nil
+	}
+	return handlerInfo.addressSet.DeleteIPs(ips)
+}
+
+// handlePodAddUpdate adds the IP address of a pod that has been
+// selected by PodSelectorAddressSet.
+func (oc *DefaultNetworkController) handlePodAddUpdate(podHandlerInfo *PodSelectorAddrSetHandlerInfo, objs ...interface{}) error {
+	if config.Metrics.EnableScaleMetrics {
+		start := time.Now()
+		defer func() {
+			duration := time.Since(start)
+			metrics.RecordPodSelectorAddrSetPodEvent("add", duration)
+		}()
+	}
+	podHandlerInfo.RLock()
+	defer podHandlerInfo.RUnlock()
+	if podHandlerInfo.deleted {
+		return nil
+	}
+	pods := make([]*kapi.Pod, 0, len(objs))
+	for _, obj := range objs {
+		pod := obj.(*kapi.Pod)
+		if pod.Spec.NodeName == "" {
+			// update event will be received for this pod later, no ips should be assigned yet
+			continue
+		}
+		pods = append(pods, pod)
+	}
+	// podHandlerInfo.addPods must be called with PodSelectorAddressSet RLock.
+	return podHandlerInfo.addPods(pods...)
+}
+
+// handlePodDelete removes the IP address of a pod that no longer
+// matches a selector
+func (oc *DefaultNetworkController) handlePodDelete(podHandlerInfo *PodSelectorAddrSetHandlerInfo, obj interface{}) error {
+	if config.Metrics.EnableScaleMetrics {
+		start := time.Now()
+		defer func() {
+			duration := time.Since(start)
+			metrics.RecordPodSelectorAddrSetPodEvent("delete", duration)
+		}()
+	}
+	podHandlerInfo.RLock()
+	defer podHandlerInfo.RUnlock()
+	if podHandlerInfo.deleted {
+		return nil
+	}
+	pod := obj.(*kapi.Pod)
+	if pod.Spec.NodeName == "" {
+		klog.Infof("Pod %s/%s not scheduled on any node, skipping it", pod.Namespace, pod.Name)
+		return nil
+	}
+	collidingPodName, err := oc.podSelectorPodNeedsDelete(pod, podHandlerInfo)
+	if err != nil {
+		return fmt.Errorf("failed to check if ip is reused for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	if collidingPodName != "" {
+		// the same ip is used by another pod in the same address set, leave ip
+		klog.Infof("Pod %s/%s won't be deleted from the address set %s, since another pod %s is using its ip",
+			pod.Namespace, pod.Name, podHandlerInfo.key, collidingPodName)
+		return nil
+	}
+	// podHandlerInfo.deletePod must be called with PodSelectorAddressSet RLock.
+	if err := podHandlerInfo.deletePod(pod); err != nil {
+		return err
+	}
+	return nil
+}
+
+// podSelectorPodNeedsDelete is designed to avoid problems with completed pods. Delete event for a completed pod may
+// come much later than an Update(completed) event, which will be handled as delete event. RetryFramework takes care of
+// that by using terminatedObjects cache, In case ovn-k get restarted, this information will be lost and the delete
+// event for completed pod may be handled twice. The only problem with that is if another pod is already re-using ip
+// of completed pod, then that ip should stay in the address set in case new pod is selected by the PodSelectorAddressSet.
+// returns collidingPod namespace+name if the ip shouldn't be removed, because it is reused.
+// Must be called with PodSelectorAddressSet.RLock.
+func (oc *DefaultNetworkController) podSelectorPodNeedsDelete(pod *kapi.Pod, podHandlerInfo *PodSelectorAddrSetHandlerInfo) (string, error) {
+	if !util.PodCompleted(pod) {
+		return "", nil
+	}
+	ips, err := util.GetPodIPsOfNetwork(pod, &util.DefaultNetInfo{})
+	if err != nil {
+		return "", fmt.Errorf("can't get pod IPs %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	// completed pod be deleted a long time ago, check if there is a new pod with that same ip
+	collidingPod, err := oc.findPodWithIPAddresses(ips)
+	if err != nil {
+		return "", fmt.Errorf("lookup for pods with the same IPs [%s] failed: %w", util.JoinIPs(ips, " "), err)
+	}
+	if collidingPod == nil {
+		return "", nil
+	}
+	collidingPodName := collidingPod.Namespace + "/" + collidingPod.Name
+
+	v4ips, v6ips := podHandlerInfo.addressSet.GetIPs()
+	addrSetIPs := sets.NewString(append(v4ips, v6ips...)...)
+	podInAddrSet := false
+	for _, podIP := range ips {
+		if addrSetIPs.Has(podIP.String()) {
+			podInAddrSet = true
+			break
+		}
+	}
+	if !podInAddrSet {
+		return "", nil
+	}
+	// we found a colliding pod and pod ip is still in the address set.
+	// If the IP is used by another Pod that is targeted by the same selector, don't remove the IP from the address set
+	if !podHandlerInfo.podSelector.Matches(labels.Set(collidingPod.Labels)) {
+		return "", nil
+	}
+
+	// pod selector matches, check namespace match
+	if podHandlerInfo.namespace != "" {
+		if collidingPod.Namespace == podHandlerInfo.namespace {
+			// namespace matches the static namespace, leave ip
+			return collidingPodName, nil
+		}
+	} else {
+		// namespace selector is present
+		if podHandlerInfo.namespaceSelector.Empty() {
+			// matches all namespaces, leave ip
+			return collidingPodName, nil
+		} else {
+			// get namespace to match labels
+			ns, err := oc.watchFactory.GetNamespace(collidingPod.Namespace)
+			if err != nil {
+				return "", fmt.Errorf("failed to get namespace %s for pod with the same ip: %w", collidingPod.Namespace, err)
+			}
+			// if colliding pod's namespace doesn't match labels, then we can safely delete pod
+			if !podHandlerInfo.namespaceSelector.Matches(labels.Set(ns.Labels)) {
+				return "", nil
+			} else {
+				return collidingPodName, nil
+			}
+		}
+	}
+	return "", nil
+}
+
+func (oc *DefaultNetworkController) handleNamespaceAddUpdate(podHandlerInfo *PodSelectorAddrSetHandlerInfo, obj interface{}) error {
+	if config.Metrics.EnableScaleMetrics {
+		start := time.Now()
+		defer func() {
+			duration := time.Since(start)
+			metrics.RecordPodSelectorAddrSetNamespaceEvent("add", duration)
+		}()
+	}
+	namespace := obj.(*kapi.Namespace)
+	podHandlerInfo.RLock()
+	locked := true
+	defer func() {
+		if locked {
+			podHandlerInfo.RUnlock()
+		}
+	}()
+	if podHandlerInfo.deleted {
+		return nil
+	}
+
+	// start watching pods in this namespace and selected by the label selector in extraParameters.podSelector
+	syncFunc := func(objs []interface{}) error {
+		// ignore returned error, since any pod that wasn't properly handled will be retried individually.
+		_ = oc.handlePodAddUpdate(podHandlerInfo, objs...)
+		return nil
+	}
+	retryFramework := oc.newRetryFrameworkWithParameters(
+		factory.AddressSetPodSelectorType,
+		syncFunc,
+		podHandlerInfo,
+	)
+	// syncFunc and factory.AddressSetPodSelectorType add event handler also take np.RLock,
+	// and will be called form the same thread. The same thread shouldn't take the same rlock twice.
+	// unlock
+	podHandlerInfo.RUnlock()
+	locked = false
+	podHandler, err := retryFramework.WatchResourceFiltered(namespace.Name, podHandlerInfo.podSelector)
+	if err != nil {
+		klog.Errorf("Failed WatchResource for AddressSetNamespaceAndPodSelectorType: %v", err)
+		return err
+	}
+	// lock PodSelectorAddressSet again to update namespacedPodHandlers
+	podHandlerInfo.RLock()
+	locked = true
+	if podHandlerInfo.deleted {
+		oc.watchFactory.RemovePodHandler(podHandler)
+		return nil
+	}
+	podHandlerInfo.namespacedPodHandlers.Store(namespace.Name, podHandler)
+	return nil
+}
+
+func (oc *DefaultNetworkController) handleNamespaceDel(podHandlerInfo *PodSelectorAddrSetHandlerInfo, obj interface{}) error {
+	if config.Metrics.EnableScaleMetrics {
+		start := time.Now()
+		defer func() {
+			duration := time.Since(start)
+			metrics.RecordPodSelectorAddrSetNamespaceEvent("delete", duration)
+		}()
+	}
+	podHandlerInfo.RLock()
+	defer podHandlerInfo.RUnlock()
+	if podHandlerInfo.deleted {
+		return nil
+	}
+
+	// when the namespace labels no longer apply
+	// stop pod handler,
+	// remove the namespaces pods from the address_set
+	var errs []error
+	namespace := obj.(*kapi.Namespace)
+
+	if handler, ok := podHandlerInfo.namespacedPodHandlers.Load(namespace.Name); ok {
+		oc.watchFactory.RemovePodHandler(handler.(*factory.Handler))
+		podHandlerInfo.namespacedPodHandlers.Delete(namespace.Name)
+	}
+
+	pods, err := oc.watchFactory.GetPods(namespace.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get namespace %s pods: %v", namespace.Namespace, err)
+	}
+	for _, pod := range pods {
+		// call functions from oc.handlePodDelete
+		// PodSelectorAddressSet.deletePod must be called with PodSelectorAddressSet RLock.
+		if err = podHandlerInfo.deletePod(pod); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return kerrorsutil.NewAggregate(errs)
+}
+
+func getPodSelectorAddrSetDbIDs(psasKey, controller string) *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetPodSelector, controller, map[libovsdbops.ExternalIDKey]string{
+		// pod selector address sets are cluster-scoped, only need name
+		libovsdbops.ObjectNameKey: psasKey,
+	})
+}
+
+// sortedLSRString is based on *LabelSelectorRequirement.String(),
+// but adds sorting for Values
+func sortedLSRString(lsr *metav1.LabelSelectorRequirement) string {
+	if lsr == nil {
+		return "nil"
+	}
+	lsrValues := make([]string, 0, len(lsr.Values))
+	lsrValues = append(lsrValues, lsr.Values...)
+	sort.Strings(lsrValues)
+	s := strings.Join([]string{`LSR{`,
+		`Key:` + fmt.Sprintf("%v", lsr.Key) + `,`,
+		`Operator:` + fmt.Sprintf("%v", lsr.Operator) + `,`,
+		`Values:` + fmt.Sprintf("%v", lsrValues) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+
+// shortLabelSelectorString is based on *LabelSelector.String(),
+// but makes sure to generate the same string for equivalent selectors (by additional sorting).
+// It also tries to reduce return string length, since this string will be put to the db ad ExternalID.
+func shortLabelSelectorString(sel *metav1.LabelSelector) string {
+	if sel == nil {
+		return "nil"
+	}
+	var repeatedStringForMatchExpressions, mapStringForMatchLabels string
+	if len(sel.MatchExpressions) > 0 {
+		repeatedStringForMatchExpressions = "ME:{"
+		matchExpressions := make([]string, 0, len(sel.MatchExpressions))
+		for _, f := range sel.MatchExpressions {
+			matchExpressions = append(matchExpressions, sortedLSRString(&f))
+		}
+		// sort match expressions to not depend on MatchExpressions order
+		sort.Strings(matchExpressions)
+		repeatedStringForMatchExpressions += strings.Join(matchExpressions, ",")
+		repeatedStringForMatchExpressions += "}"
+	} else {
+		repeatedStringForMatchExpressions = ""
+	}
+	keysForMatchLabels := make([]string, 0, len(sel.MatchLabels))
+	for k := range sel.MatchLabels {
+		keysForMatchLabels = append(keysForMatchLabels, k)
+	}
+	sort.Strings(keysForMatchLabels)
+	if len(keysForMatchLabels) > 0 {
+		mapStringForMatchLabels = "ML:{"
+		for _, k := range keysForMatchLabels {
+			mapStringForMatchLabels += fmt.Sprintf("%v: %v,", k, sel.MatchLabels[k])
+		}
+		mapStringForMatchLabels += "}"
+	} else {
+		mapStringForMatchLabels = ""
+	}
+	s := "LS{"
+	if mapStringForMatchLabels != "" {
+		s += mapStringForMatchLabels + ","
+	}
+	if repeatedStringForMatchExpressions != "" {
+		s += repeatedStringForMatchExpressions + ","
+	}
+	s += "}"
+	return s
+}
+
+func getPodSelectorKey(podSelector, namespaceSelector *metav1.LabelSelector, namespace string) string {
+	var namespaceKey string
+	if namespaceSelector == nil {
+		// namespace is static
+		namespaceKey = namespace
+	} else {
+		namespaceKey = shortLabelSelectorString(namespaceSelector)
+	}
+	return namespaceKey + "_" + shortLabelSelectorString(podSelector)
+}
+
+func (oc *DefaultNetworkController) cleanupPodSelectorAddressSets() error {
+	err := oc.deleteStaleNetpolPeerAddrSets()
+	if err != nil {
+		return fmt.Errorf("can't delete stale netpol address sets %w", err)
+	}
+
+	predicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetPodSelector, oc.controllerName, nil)
+	asPred := libovsdbops.GetPredicate[*nbdb.AddressSet](predicateIDs, nil)
+	return deleteAddrSetsWithoutACLRef(asPred, oc.nbClient)
+}
+
+// network policies will start using new shared address sets after the initial Add events handling.
+// On the next restart old address sets will be unreferenced and can be safely deleted.
+func (oc *DefaultNetworkController) deleteStaleNetpolPeerAddrSets() error {
+	predicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNetworkPolicy, oc.controllerName, nil)
+	asPred := libovsdbops.GetPredicate[*nbdb.AddressSet](predicateIDs, nil)
+	return deleteAddrSetsWithoutACLRef(asPred, oc.nbClient)
+}
+
+func deleteAddrSetsWithoutACLRef(predicate func(set *nbdb.AddressSet) bool,
+	nbClient libovsdbclient.Client) error {
+	addrSets, err := libovsdbops.FindAddressSetsWithPredicate(nbClient, predicate)
+	if err != nil {
+		return fmt.Errorf("failed to find address sets with predicate: %w", err)
+	}
+	ops := []ovsdb.Operation{}
+	for _, addrSet := range addrSets {
+		acls, err := libovsdbops.FindACLsWithPredicate(nbClient, func(item *nbdb.ACL) bool {
+			return strings.Contains(item.Match, addrSet.Name)
+		})
+		if err != nil {
+			return fmt.Errorf("cannot find ACLs referencing address set: %v", err)
+		}
+		if len(acls) == 0 {
+			// no references for stale address set, delete
+			ops, err = libovsdbops.DeleteAddressSetsOps(nbClient, ops, addrSet)
+			if err != nil {
+				return fmt.Errorf("failed to get delete address set ops: %w", err)
+			}
+		}
+	}
+	// update acls to not reference stale address sets
+	_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("faile to trasact db ops: %v", err)
+	}
+	return nil
+}

--- a/go-controller/pkg/ovn/pod_selector_address_set_test.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set_test.go
@@ -1,0 +1,541 @@
+package ovn
+
+import (
+	"context"
+	"fmt"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	"github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"net"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	knet "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getPolicyKeyWithKind(policy *knet.NetworkPolicy) string {
+	return fmt.Sprintf("%v/%v/%v", "NetworkPolicy", policy.Namespace, policy.Name)
+}
+
+var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
+	const (
+		namespaceName1 = "namespace1"
+		namespaceName2 = "namespace2"
+		netPolicyName1 = "networkpolicy1"
+		netPolicyName2 = "networkpolicy2"
+		nodeName       = "node1"
+		podLabelKey    = "podLabel"
+		ip1            = "10.128.1.1"
+		ip2            = "10.128.1.2"
+		ip3            = "10.128.1.3"
+		ip4            = "10.128.1.4"
+	)
+	var (
+		fakeOvn   *FakeOVN
+		initialDB libovsdbtest.TestSetup
+	)
+
+	ginkgo.BeforeEach(func() {
+		// Restore global default values before each testcase
+		config.PrepareTestConfig()
+		fakeOvn = NewFakeOVN()
+
+		initialDB = libovsdbtest.TestSetup{
+			NBData: []libovsdbtest.TestData{},
+		}
+	})
+
+	ginkgo.AfterEach(func() {
+		if fakeOvn.watcher != nil {
+			// fakeOVN was inited
+			fakeOvn.shutdown()
+		}
+	})
+
+	startOvn := func(dbSetup libovsdbtest.TestSetup, namespaces []v1.Namespace, networkPolicies []knet.NetworkPolicy,
+		pods []testPod, podLabels map[string]string) {
+		var podsList []v1.Pod
+		for _, testPod := range pods {
+			knetPod := newPod(testPod.namespace, testPod.podName, testPod.nodeName, testPod.podIP)
+			if len(podLabels) > 0 {
+				knetPod.Labels = podLabels
+			}
+			podsList = append(podsList, *knetPod)
+		}
+		fakeOvn.startWithDBSetup(dbSetup,
+			&v1.NamespaceList{
+				Items: namespaces,
+			},
+			&v1.PodList{
+				Items: podsList,
+			},
+			&knet.NetworkPolicyList{
+				Items: networkPolicies,
+			},
+		)
+		for _, testPod := range pods {
+			testPod.populateLogicalSwitchCache(fakeOvn, getLogicalSwitchUUID(fakeOvn.controller.nbClient, nodeName))
+		}
+		var err error
+		if namespaces != nil {
+			err = fakeOvn.controller.WatchNamespaces()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		if pods != nil {
+			err = fakeOvn.controller.WatchPods()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		err = fakeOvn.controller.WatchNetworkPolicy()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	ginkgo.It("validates selectors", func() {
+		// start ovn without any objects
+		startOvn(initialDB, nil, nil, nil, nil)
+		namespace := *newNamespace(namespaceName1)
+		networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace.Name,
+			"", "label1", true, true)
+		// create peer with invalid Operator
+		peer := knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "key",
+					Operator: "",
+					Values:   []string{"value"},
+				}},
+			},
+		}
+		// try to add invalid peer
+		peerASKey, _, _, err := fakeOvn.controller.EnsurePodSelectorAddressSet(
+			peer.PodSelector, peer.NamespaceSelector, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy))
+		// error should happen on handler add
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("is not a valid label selector operator"))
+		// address set will not be created
+		peerASIDs := getPodSelectorAddrSetDbIDs(peerASKey, DefaultNetworkControllerName)
+		fakeOvn.asf.EventuallyExpectNoAddressSet(peerASIDs)
+
+		// add nil pod selector
+		peerASKey, _, _, err = fakeOvn.controller.EnsurePodSelectorAddressSet(
+			nil, peer.NamespaceSelector, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy))
+		// error should happen on handler add
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("pod selector is nil"))
+		// address set will not be created
+		peerASIDs = getPodSelectorAddrSetDbIDs(peerASKey, DefaultNetworkControllerName)
+		fakeOvn.asf.EventuallyExpectNoAddressSet(peerASIDs)
+
+		// namespace selector is nil and namespace is empty
+		peerASKey, _, _, err = fakeOvn.controller.EnsurePodSelectorAddressSet(
+			peer.PodSelector, nil, "", getPolicyKeyWithKind(networkPolicy))
+		// error should happen on handler add
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("namespace selector is nil and namespace is empty"))
+		// address set will not be created
+		peerASIDs = getPodSelectorAddrSetDbIDs(peerASKey, DefaultNetworkControllerName)
+		fakeOvn.asf.EventuallyExpectNoAddressSet(peerASIDs)
+	})
+	ginkgo.It("creates one address set for multiple users with the same selector", func() {
+		namespace1 := *newNamespace(namespaceName1)
+		namespace2 := *newNamespace(namespaceName2)
+		networkPolicy1 := getMatchLabelsNetworkPolicy(netPolicyName1, namespace1.Name,
+			"", "label1", true, true)
+		networkPolicy2 := getMatchLabelsNetworkPolicy(netPolicyName2, namespace2.Name,
+			"", "label1", true, true)
+		startOvn(initialDB, []v1.Namespace{namespace1}, []knet.NetworkPolicy{*networkPolicy1, *networkPolicy2},
+			nil, nil)
+
+		fakeOvn.asf.ExpectEmptyAddressSet(namespaceName1)
+		peer := networkPolicy1.Spec.Ingress[0].From[0]
+		peerASKey := getPodSelectorKey(peer.PodSelector, peer.NamespaceSelector, namespace1.Name)
+		peerASIDs := getPodSelectorAddrSetDbIDs(peerASKey, DefaultNetworkControllerName)
+		fakeOvn.asf.EventuallyExpectEmptyAddressSetExist(peerASIDs)
+		// expect namespace and peer address sets only
+		fakeOvn.asf.ExpectNumberOfAddressSets(2)
+	})
+	table.DescribeTable("adds selected pod ips to the address set",
+		func(peer knet.NetworkPolicyPeer, staticNamespace string, addrSetIPs []string) {
+			namespace1 := *newNamespace(namespaceName1)
+			namespace2 := *newNamespace(namespaceName2)
+			ns1pod1 := newPod(namespace1.Name, "ns1pod1", nodeName, ip1)
+			ns1pod2 := newPod(namespace1.Name, "ns1pod2", nodeName, ip2)
+			ns2pod1 := newPod(namespace2.Name, "ns2pod1", nodeName, ip3)
+			ns2pod2 := newPod(namespace2.Name, "ns2pod2", nodeName, ip4)
+			podsList := []v1.Pod{}
+			for _, pod := range []*v1.Pod{ns1pod1, ns1pod2, ns2pod1, ns2pod2} {
+				pod.Labels = map[string]string{podLabelKey: pod.Name}
+				podsList = append(podsList, *pod)
+			}
+			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{},
+				&v1.NamespaceList{
+					Items: []v1.Namespace{namespace1, namespace2},
+				},
+				&v1.PodList{
+					Items: podsList,
+				},
+			)
+
+			peerASKey, _, _, err := fakeOvn.controller.EnsurePodSelectorAddressSet(
+				peer.PodSelector, peer.NamespaceSelector, staticNamespace, "backRef")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// address set should be created and pod ips added
+			peerASIDs := getPodSelectorAddrSetDbIDs(peerASKey, DefaultNetworkControllerName)
+			fakeOvn.asf.ExpectAddressSetWithIPs(peerASIDs, addrSetIPs)
+		},
+		table.Entry("all pods from a static namespace", knet.NetworkPolicyPeer{
+			PodSelector:       &metav1.LabelSelector{},
+			NamespaceSelector: nil,
+		}, namespaceName1, []string{ip1, ip2}),
+		table.Entry("selected pods from a static namespace", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{podLabelKey: "ns1pod1"},
+			},
+			NamespaceSelector: nil,
+		}, namespaceName1, []string{ip1}),
+		table.Entry("all pods from all namespaces", knet.NetworkPolicyPeer{
+			PodSelector:       &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{},
+		}, namespaceName1, []string{ip1, ip2, ip3, ip4}),
+		table.Entry("selected pods from all namespaces", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      podLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"ns1pod1", "ns2pod1"},
+					},
+				},
+			},
+			NamespaceSelector: &metav1.LabelSelector{},
+		}, namespaceName1, []string{ip1, ip3}),
+		table.Entry("all pods from selected namespaces", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": namespaceName2,
+				},
+			},
+		}, namespaceName1, []string{ip3, ip4}),
+		table.Entry("selected pods from selected namespaces", knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{podLabelKey: "ns2pod1"},
+			},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": namespaceName2,
+				},
+			},
+		}, namespaceName1, []string{ip3}),
+	)
+	ginkgo.It("is cleaned up with DeletePodSelectorAddressSet call", func() {
+		// start ovn without any objects
+		startOvn(initialDB, nil, nil, nil, nil)
+		namespace := *newNamespace(namespaceName1)
+		networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace.Name,
+			"", "label1", true, true)
+		peer := networkPolicy.Spec.Ingress[0].From[0]
+
+		// make asf return error on the next NewAddressSet call
+		fakeOvn.asf.ErrOnNextNewASCall()
+		peerASKey, _, _, err := fakeOvn.controller.EnsurePodSelectorAddressSet(
+			peer.PodSelector, peer.NamespaceSelector, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy))
+		// error should happen on address set add
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring(addressset.FakeASFError))
+		// address set should not be created
+		peerASIDs := getPodSelectorAddrSetDbIDs(peerASKey, DefaultNetworkControllerName)
+		fakeOvn.asf.EventuallyExpectNoAddressSet(peerASIDs)
+		// peerAddressSet should be present in the map with needsCleanup=true
+		asObj, loaded := fakeOvn.controller.podSelectorAddressSets.Load(peerASKey)
+		gomega.Expect(loaded).To(gomega.BeTrue())
+		gomega.Expect(asObj.needsCleanup).To(gomega.BeTrue())
+		// delete invalid peer, check all resources are cleaned up
+		err = fakeOvn.controller.DeletePodSelectorAddressSet(peerASKey, getPolicyKeyWithKind(networkPolicy))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// address set should still not exist
+		fakeOvn.asf.EventuallyExpectNoAddressSet(peerASIDs)
+		fakeOvn.asf.ExpectNumberOfAddressSets(0)
+		// peerAddressSet should be deleted from the map
+		_, loaded = fakeOvn.controller.podSelectorAddressSets.Load(peerASKey)
+		gomega.Expect(loaded).To(gomega.BeFalse())
+	})
+	ginkgo.It("is cleaned up with second GetPodSelectorAddressSet call", func() {
+		// start ovn without any objects
+		startOvn(initialDB, nil, nil, nil, nil)
+		namespace := *newNamespace(namespaceName1)
+		networkPolicy := getMatchLabelsNetworkPolicy(netPolicyName1, namespace.Name,
+			"", "label1", true, true)
+		peer := networkPolicy.Spec.Ingress[0].From[0]
+
+		// make asf return error on the next NewAddressSet call
+		fakeOvn.asf.ErrOnNextNewASCall()
+		peerASKey, _, _, err := fakeOvn.controller.EnsurePodSelectorAddressSet(
+			peer.PodSelector, peer.NamespaceSelector, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy))
+		// error should happen on address set add
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring(addressset.FakeASFError))
+		// address set should not be created
+		peerASIDs := getPodSelectorAddrSetDbIDs(peerASKey, DefaultNetworkControllerName)
+		fakeOvn.asf.EventuallyExpectNoAddressSet(peerASIDs)
+		// peerAddressSet should be present in the map with needsCleanup=true
+		asObj, loaded := fakeOvn.controller.podSelectorAddressSets.Load(peerASKey)
+		gomega.Expect(loaded).To(gomega.BeTrue())
+		gomega.Expect(asObj.needsCleanup).To(gomega.BeTrue())
+		// run add again, NewAddressSet should succeed this time
+		peerASKey, _, _, err = fakeOvn.controller.EnsurePodSelectorAddressSet(
+			peer.PodSelector, peer.NamespaceSelector, networkPolicy.Namespace, getPolicyKeyWithKind(networkPolicy))
+		// address set should be created
+		fakeOvn.asf.ExpectEmptyAddressSet(peerASIDs)
+		fakeOvn.asf.ExpectNumberOfAddressSets(1)
+		// peerAddressSet should be present in the map with needsCleanup=false
+		asObj, loaded = fakeOvn.controller.podSelectorAddressSets.Load(peerASKey)
+		gomega.Expect(loaded).To(gomega.BeTrue())
+		gomega.Expect(asObj.needsCleanup).To(gomega.BeFalse())
+	})
+	ginkgo.It("on cleanup deletes unreferenced and leaves referenced address sets", func() {
+		namespaceName := "namespace1"
+		policyName := "networkpolicy1"
+		staleNetpolIDs := getStaleNetpolAddrSetDbIDs(namespaceName, policyName, "ingress", "0", DefaultNetworkControllerName)
+		staleNetpolAS, _ := addressset.GetDbObjsForAS(staleNetpolIDs, []net.IP{net.ParseIP("1.1.1.1")})
+		staleNetpolAS.UUID = staleNetpolAS.Name + "-UUID"
+		unusedPodSelIDs := getPodSelectorAddrSetDbIDs("pasName", DefaultNetworkControllerName)
+		unusedPodSelAS, _ := addressset.GetDbObjsForAS(unusedPodSelIDs, []net.IP{net.ParseIP("1.1.1.2")})
+		unusedPodSelAS.UUID = unusedPodSelAS.Name + "-UUID"
+		refNetpolIDs := getStaleNetpolAddrSetDbIDs(namespaceName, policyName, "egress", "0", DefaultNetworkControllerName)
+		refNetpolAS, _ := addressset.GetDbObjsForAS(refNetpolIDs, []net.IP{net.ParseIP("1.1.1.3")})
+		refNetpolAS.UUID = refNetpolAS.Name + "-UUID"
+		netpolACL := libovsdbops.BuildACL(
+			"netpolACL",
+			nbdb.ACLDirectionFromLport,
+			types.EgressFirewallStartPriority,
+			fmt.Sprintf("ip4.src == {$%s} && outport == @a13757631697825269621", refNetpolAS.Name),
+			nbdb.ACLActionAllowRelated,
+			types.OvnACLLoggingMeter,
+			"",
+			false,
+			nil,
+			map[string]string{
+				"apply-after-lb": "true",
+			},
+		)
+		netpolACL.UUID = "netpolACL-UUID"
+		refPodSelIDs := getPodSelectorAddrSetDbIDs("pasName2", DefaultNetworkControllerName)
+		refPodSelAS, _ := addressset.GetDbObjsForAS(refPodSelIDs, []net.IP{net.ParseIP("1.1.1.4")})
+		refPodSelAS.UUID = refPodSelAS.Name + "-UUID"
+		podSelACL := libovsdbops.BuildACL(
+			"podSelACL",
+			nbdb.ACLDirectionFromLport,
+			types.EgressFirewallStartPriority,
+			fmt.Sprintf("ip4.src == {$%s} && outport == @a13757631697825269621", refPodSelAS.Name),
+			nbdb.ACLActionAllowRelated,
+			types.OvnACLLoggingMeter,
+			"",
+			false,
+			nil,
+			map[string]string{
+				"apply-after-lb": "true",
+			},
+		)
+		podSelACL.UUID = "podSelACL-UUID"
+
+		initialDb := []libovsdbtest.TestData{
+			staleNetpolAS,
+			unusedPodSelAS,
+			refNetpolAS,
+			netpolACL,
+			refPodSelAS,
+			podSelACL,
+		}
+		dbSetup := libovsdbtest.TestSetup{NBData: initialDb}
+		fakeOvn.startWithDBSetup(dbSetup)
+
+		err := fakeOvn.controller.cleanupPodSelectorAddressSets()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		finalDB := []libovsdbtest.TestData{
+			refNetpolAS,
+			netpolACL,
+			refPodSelAS,
+			podSelACL,
+		}
+		gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalDB))
+	})
+	ginkgo.It("reconciles a completed and deleted pod whose IP has been assigned to a running pod", func() {
+		namespace1 := *newNamespace(namespaceName1)
+		nodeName := "node1"
+		podIP := "10.128.1.3"
+		peer := knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{},
+		}
+
+		fakeOvn.startWithDBSetup(initialDB,
+			&v1.NamespaceList{
+				Items: []v1.Namespace{
+					namespace1,
+				},
+			},
+		)
+
+		_, _, _, err := fakeOvn.controller.EnsurePodSelectorAddressSet(
+			peer.PodSelector, peer.NamespaceSelector, namespace1.Name, "backRef")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Start a pod
+		completedPod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespace1.Name).
+			Create(
+				context.TODO(),
+				newPod(namespace1.Name, "completed-pod", nodeName, podIP),
+				metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// pod should be added to the address set
+		eventuallyExpectAddressSetsWithIP(fakeOvn, peer, namespace1.Name, podIP)
+
+		// Spawn a pod with an IP address that collides with a completed pod (we don't watch pods in this test,
+		// therefore the same ip is allowed)
+		_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespace1.Name).
+			Create(
+				context.TODO(),
+				newPod(namespace1.Name, "running-pod", nodeName, podIP),
+				metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Mark the pod as Completed, so delete event will be generated
+		completedPod.Status.Phase = v1.PodSucceeded
+		completedPod, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(completedPod.Namespace).
+			Update(context.TODO(), completedPod, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// make sure the delete event is handled and address set is not changed
+		time.Sleep(100 * time.Millisecond)
+		// Running pod policy should not be affected by pod deletions
+		eventuallyExpectAddressSetsWithIP(fakeOvn, peer, namespace1.Name, podIP)
+	})
+	ginkgo.It("reconciles a completed pod whose IP has been assigned to a running pod with non-matching namespace selector", func() {
+		namespace1 := *newNamespace(namespaceName1)
+		namespace2 := *newNamespace(namespaceName2)
+		nodeName := "node1"
+		podIP := "10.128.1.3"
+		peer := knet.NetworkPolicyPeer{
+			PodSelector: &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": namespaceName1,
+				},
+			},
+		}
+
+		fakeOvn.startWithDBSetup(initialDB,
+			&v1.NamespaceList{
+				Items: []v1.Namespace{
+					namespace1,
+					namespace2,
+				},
+			},
+		)
+
+		_, _, _, err := fakeOvn.controller.EnsurePodSelectorAddressSet(
+			peer.PodSelector, peer.NamespaceSelector, namespace1.Name, "backRef")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Start a pod
+		completedPod, err := fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespace1.Name).
+			Create(
+				context.TODO(),
+				newPod(namespace1.Name, "completed-pod", nodeName, podIP),
+				metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// pod should be added to the address set
+		eventuallyExpectAddressSetsWithIP(fakeOvn, peer, namespace1.Name, podIP)
+
+		// Spawn a pod with an IP address that collides with a completed pod (we don't watch pods in this test,
+		// therefore the same ip is allowed). This pod has another namespace that is not matched by the address set
+		_, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(namespace2.Name).
+			Create(
+				context.TODO(),
+				newPod(namespace2.Name, "running-pod", nodeName, podIP),
+				metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Mark the pod as Completed, so delete event will be generated
+		completedPod.Status.Phase = v1.PodSucceeded
+		completedPod, err = fakeOvn.fakeClient.KubeClient.CoreV1().Pods(completedPod.Namespace).
+			Update(context.TODO(), completedPod, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// IP should be deleted from the address set on delete event, since the new pod with the same ip
+		// should not be present in given address set
+		eventuallyExpectEmptyAddressSetsExist(fakeOvn, peer, namespace1.Name)
+	})
+})
+
+var _ = ginkgo.Describe("shortLabelSelectorString function", func() {
+	ginkgo.It("handles LabelSelectorRequirement.Values order", func() {
+		ls1 := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      "key",
+				Operator: "",
+				Values:   []string{"v1", "v2", "v3"},
+			}},
+		}
+		ls2 := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      "key",
+				Operator: "",
+				Values:   []string{"v3", "v2", "v1"},
+			}},
+		}
+		gomega.Expect(shortLabelSelectorString(ls1)).To(gomega.Equal(shortLabelSelectorString(ls2)))
+	})
+	ginkgo.It("handles MatchExpressions order", func() {
+		ls1 := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "key1",
+					Operator: "",
+					Values:   []string{"v1", "v2", "v3"},
+				},
+				{
+					Key:      "key2",
+					Operator: "",
+					Values:   []string{"v1", "v2", "v3"},
+				},
+				{
+					Key:      "key3",
+					Operator: "",
+					Values:   []string{"v1", "v2", "v3"},
+				},
+			},
+		}
+		ls2 := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "key2",
+					Operator: "",
+					Values:   []string{"v1", "v2", "v3"},
+				},
+				{
+					Key:      "key1",
+					Operator: "",
+					Values:   []string{"v1", "v2", "v3"},
+				},
+				{
+					Key:      "key3",
+					Operator: "",
+					Values:   []string{"v1", "v2", "v3"},
+				},
+			},
+		}
+		gomega.Expect(shortLabelSelectorString(ls1)).To(gomega.Equal(shortLabelSelectorString(ls2)))
+	})
+	ginkgo.It("handles MatchLabels order", func() {
+		ls1 := &metav1.LabelSelector{
+			MatchLabels: map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"},
+		}
+		ls2 := &metav1.LabelSelector{
+			MatchLabels: map[string]string{"k2": "v2", "k1": "v1", "k3": "v3"},
+		}
+		gomega.Expect(shortLabelSelectorString(ls1)).To(gomega.Equal(shortLabelSelectorString(ls2)))
+	})
+})

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -20,7 +20,6 @@ import (
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	kerrorsutil "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -142,12 +141,9 @@ type networkPolicy struct {
 	// 3. Delete network policy - disable local events, and Update namespace loglevel event,
 	// send deletion signal to already running event handlers, delete resources
 	//
-	// 5 types of local events (those use the same networkPolicy object there were created for):
+	// 2 types of local events (those use the same networkPolicy object there were created for):
 	// 1. localPod events - update portGroup, defaultDenyPortGroups and localPods
-	// 2. peerNamespaceAndPod events - update namespacedPodHandlers
-	// 3. peerNamespace events - add/delete gressPolicy address set, update ACLs for portGroup
-	// 4. peerPod events - update gressPolicy address set
-	// 5. peerSvc events - update gressPolicy address set
+	// 2. peerNamespace events - add/delete gressPolicy address set, update ACLs for portGroup
 	//
 	// Delete network policy conflict with all other handlers, therefore we need to make sure it only runs
 	// when no other handlers are executing, and that no other handlers will try to work with networkPolicy after
@@ -173,16 +169,14 @@ type networkPolicy struct {
 	egressPolicies  []*gressPolicy
 	isIngress       bool
 	isEgress        bool
-	// handlers that don't require synchronization, since they are updated sequentially during network policy creation.
-	// local and peer pod handlers
-	podHandlerList []*factory.Handler
+
+	// network policy owns only 1 local pod handler
+	localPodHandler *factory.Handler
 	// peer namespace handlers
 	nsHandlerList []*factory.Handler
-	// peer namespaced pod handlers, the only type of handler that can be dynamically deleted without deleting the whole
-	// networkPolicy. When namespace is deleted, podHandler for that namespace should be deleted too.
-	// Can be used by multiple PeerNamespace handlers in parallel for different keys
-	// namespace(string): *factory.Handler
-	namespacedPodHandlers sync.Map
+	// peerAddressSets stores PodSelectorAddressSet keys for peers that this network policy was successfully added to.
+	// Required for cleanup.
+	peerAddressSets []string
 
 	// localPods is a map of pods affected by this policy.
 	// It is used to update defaultDeny port group port counters, when deleting network policy.
@@ -205,16 +199,14 @@ type networkPolicy struct {
 func NewNetworkPolicy(policy *knet.NetworkPolicy) *networkPolicy {
 	policyTypeIngress, policyTypeEgress := getPolicyType(policy)
 	np := &networkPolicy{
-		name:                  policy.Name,
-		namespace:             policy.Namespace,
-		ingressPolicies:       make([]*gressPolicy, 0),
-		egressPolicies:        make([]*gressPolicy, 0),
-		isIngress:             policyTypeIngress,
-		isEgress:              policyTypeEgress,
-		podHandlerList:        make([]*factory.Handler, 0),
-		nsHandlerList:         make([]*factory.Handler, 0),
-		namespacedPodHandlers: sync.Map{},
-		localPods:             sync.Map{},
+		name:            policy.Name,
+		namespace:       policy.Namespace,
+		ingressPolicies: make([]*gressPolicy, 0),
+		egressPolicies:  make([]*gressPolicy, 0),
+		isIngress:       policyTypeIngress,
+		isEgress:        policyTypeEgress,
+		nsHandlerList:   make([]*factory.Handler, 0),
+		localPods:       sync.Map{},
 	}
 	return np
 }
@@ -285,49 +277,73 @@ func (oc *DefaultNetworkController) updateStaleDefaultDenyACLNames(npType knet.P
 }
 
 func (oc *DefaultNetworkController) syncNetworkPolicies(networkPolicies []interface{}) error {
-	expectedAddressSets := make(map[string]bool)
+	// find network policies that don't exist in k8s anymore, but still present in the dbs, and cleanup.
+	// Peer address sets and network policy's port groups (together with acls) will be cleaned up.
+	// Delete port groups with acls first, since address sets may be referenced in these acls, and
+	// cause SyntaxError in ovn-controller, if address sets deleted first, but acls still reference them.
+	expectedPolicies := make(map[string]map[string]bool)
 	for _, npInterface := range networkPolicies {
 		policy, ok := npInterface.(*knet.NetworkPolicy)
 		if !ok {
 			return fmt.Errorf("spurious object in syncNetworkPolicies: %v", npInterface)
 		}
-		expectedAddressSets[buildAddrSetName(policy.Namespace, policy.Name)] = true
+
+		if nsMap, ok := expectedPolicies[policy.Namespace]; ok {
+			nsMap[policy.Name] = true
+		} else {
+			expectedPolicies[policy.Namespace] = map[string]bool{
+				policy.Name: true,
+			}
+		}
 	}
 
-	stalePGs := []string{}
-	err := oc.addressSetFactory.ProcessEachAddressSet(oc.controllerName, libovsdbops.AddressSetNetworkPolicy,
-		func(dbIDs *libovsdbops.DbObjectIDs) error {
-			asName := dbIDs.GetObjectID(libovsdbops.ObjectNameKey)
-			if !expectedAddressSets[asName] {
-				// policy doesn't exist on k8s. Delete the port group.
-				// port group name is build same as address set name, which is <namespace>_<name>
-				portGroupName := asName
-				hashedLocalPortGroup := hashedPortGroup(portGroupName)
-				stalePGs = append(stalePGs, hashedLocalPortGroup)
-				// delete the address sets for this old policy from OVN
-				if err := oc.addressSetFactory.DestroyAddressSet(dbIDs); err != nil {
-					klog.Errorf(err.Error())
-					return err
+	// cleanup port groups based on acl search
+	p := func(item *nbdb.ACL) bool {
+		return item.ExternalIDs[policyACLExtIdKey] != "" || item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] != ""
+	}
+	netpolACLs, err := libovsdbops.FindACLsWithPredicate(oc.nbClient, p)
+	if err != nil {
+		return fmt.Errorf("cannot find NetworkPolicy ACLs: %v", err)
+	}
+	stalePGs := sets.Set[string]{}
+	if len(netpolACLs) > 0 {
+		for _, netpolACL := range netpolACLs {
+			if netpolACL.ExternalIDs[policyACLExtIdKey] != "" {
+				// policy-owned acl
+				namespace := netpolACL.ExternalIDs[namespaceACLExtIdKey]
+				policyName := netpolACL.ExternalIDs[policyACLExtIdKey]
+				if !expectedPolicies[namespace][policyName] {
+					// policy doesn't exist on k8s, cleanup
+					portGroupName, _ := getNetworkPolicyPGName(namespace, policyName)
+					stalePGs.Insert(portGroupName)
+				}
+			} else if netpolACL.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] != "" {
+				// default deny acl
+				// parse the namespace.Name from the ACL name (if ACL name is 63 chars, then it will fully be namespace.Name)
+				namespace := strings.Split(*netpolACL.Name, "_")[0]
+				if _, ok := expectedPolicies[namespace]; !ok {
+					// no policies in that namespace are found, delete default deny port group
+					stalePGs.Insert(defaultDenyPortGroupName(namespace, ingressDefaultDenySuffix))
+					stalePGs.Insert(defaultDenyPortGroupName(namespace, egressDefaultDenySuffix))
 				}
 			}
-			return nil
-		})
-	if err != nil {
-		return fmt.Errorf("error in syncing network policies: %v", err)
-	}
 
+		}
+	}
 	if len(stalePGs) > 0 {
-		err = libovsdbops.DeletePortGroups(oc.nbClient, stalePGs...)
+		sets.List[string](stalePGs)
+		err = libovsdbops.DeletePortGroups(oc.nbClient, sets.List[string](stalePGs)...)
 		if err != nil {
 			return fmt.Errorf("error removing stale port groups %v: %v", stalePGs, err)
 		}
+		klog.Infof("Network policy sync cleaned up %d stale port groups", len(stalePGs))
 	}
 
 	// Update existing egress network policies to use the updated ACLs
 	// Note that the default multicast egress acls were created with the correct direction, but
 	// we'd still need to update its apply-after-lb=true option, so that the ACL priorities can apply properly;
 	// If acl's option["apply-after-lb"] is already set to true, then its direction should be also correct.
-	p := func(item *nbdb.ACL) bool {
+	p = func(item *nbdb.ACL) bool {
 		return (item.ExternalIDs[policyTypeACLExtIdKey] == string(knet.PolicyTypeEgress) ||
 			item.ExternalIDs[defaultDenyPolicyTypeACLExtIdKey] == string(knet.PolicyTypeEgress)) &&
 			item.Options["apply-after-lb"] != "true"
@@ -963,18 +979,8 @@ func (oc *DefaultNetworkController) addLocalPodHandler(policy *knet.NetworkPolic
 		return err
 	}
 
-	np.podHandlerList = append(np.podHandlerList, podHandler)
+	np.localPodHandler = podHandler
 	return nil
-}
-
-// we only need to create an address set if there is a podSelector or namespaceSelector
-func hasAnyLabelSelector(peers []knet.NetworkPolicyPeer) bool {
-	for _, peer := range peers {
-		if peer.PodSelector != nil || peer.NamespaceSelector != nil {
-			return true
-		}
-	}
-	return false
 }
 
 func getNetworkPolicyPGName(namespace, name string) (pgName, readablePGName string) {
@@ -985,7 +991,6 @@ func getNetworkPolicyPGName(namespace, name string) (pgName, readablePGName stri
 type policyHandler struct {
 	gress             *gressPolicy
 	namespaceSelector *metav1.LabelSelector
-	podSelector       *metav1.LabelSelector
 }
 
 // createNetworkPolicy creates a network policy, should be retriable.
@@ -1008,7 +1013,7 @@ func (oc *DefaultNetworkController) createNetworkPolicy(policy *knet.NetworkPoli
 
 	npKey := getPolicyKey(policy)
 	var np *networkPolicy
-	var policyHandlers []policyHandler
+	var policyHandlers []*policyHandler
 
 	err := oc.networkPolicies.DoWithLock(npKey, func(npKey string) error {
 		oldNP, found := oc.networkPolicies.Load(npKey)
@@ -1047,7 +1052,7 @@ func (oc *DefaultNetworkController) createNetworkPolicy(policy *knet.NetworkPoli
 		// policy type. A pod is isolated as long as as it is selected by any
 		// namespace policy. Since we don't process all namespace policies on a
 		// given policy update that might change the isolation status of a selected
-		// pod, we have create the allow ACLs derived from the policy rules in case
+		// pod, we have created the allow ACLs derived from the policy rules in case
 		// the selected pods become isolated in the future even if that is not their
 		// current status.
 
@@ -1065,23 +1070,15 @@ func (oc *DefaultNetworkController) createNetworkPolicy(policy *knet.NetworkPoli
 			for _, portJSON := range ingressJSON.Ports {
 				ingress.addPortPolicy(&portJSON)
 			}
-			if hasAnyLabelSelector(ingressJSON.From) {
-				klog.V(5).Infof("Network policy %s with ingress rule %s has a selector", npKey, ingress.policyName)
-				if err = ingress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
+
+			for _, fromJSON := range ingressJSON.From {
+				handler, err := oc.setupGressPolicy(np, ingress, fromJSON)
+				if err != nil {
 					return err
 				}
-			}
-			for _, fromJSON := range ingressJSON.From {
-				// Add IPBlock to ingress network policy
-				if fromJSON.IPBlock != nil {
-					ingress.addIPBlock(fromJSON.IPBlock)
+				if handler != nil {
+					policyHandlers = append(policyHandlers, handler)
 				}
-
-				policyHandlers = append(policyHandlers, policyHandler{
-					gress:             ingress,
-					namespaceSelector: fromJSON.NamespaceSelector,
-					podSelector:       fromJSON.PodSelector,
-				})
 			}
 		}
 
@@ -1100,25 +1097,17 @@ func (oc *DefaultNetworkController) createNetworkPolicy(policy *knet.NetworkPoli
 				egress.addPortPolicy(&portJSON)
 			}
 
-			if hasAnyLabelSelector(egressJSON.To) {
-				klog.V(5).Infof("Network policy %s with egress rule %s has a selector", npKey, egress.policyName)
-				if err = egress.ensurePeerAddressSet(oc.addressSetFactory); err != nil {
+			for _, toJSON := range egressJSON.To {
+				handler, err := oc.setupGressPolicy(np, egress, toJSON)
+				if err != nil {
 					return err
 				}
-			}
-			for _, toJSON := range egressJSON.To {
-				// Add IPBlock to egress network policy
-				if toJSON.IPBlock != nil {
-					egress.addIPBlock(toJSON.IPBlock)
+				if handler != nil {
+					policyHandlers = append(policyHandlers, handler)
 				}
-
-				policyHandlers = append(policyHandlers, policyHandler{
-					gress:             egress,
-					namespaceSelector: toJSON.NamespaceSelector,
-					podSelector:       toJSON.PodSelector,
-				})
 			}
 		}
+		klog.Infof("Policy %s added to peer address sets %v", npKey, np.peerAddressSets)
 
 		// 3. Add policy to default deny port group
 		// Pods are not added to default deny port groups yet, this is just a preparation step
@@ -1166,26 +1155,9 @@ func (oc *DefaultNetworkController) createNetworkPolicy(policy *knet.NetworkPoli
 
 		// 6. Start peer handlers to update all allow rules first
 		for _, handler := range policyHandlers {
-			if handler.namespaceSelector != nil && handler.podSelector != nil {
-				// For each rule that contains both peer namespace selector and
-				// peer pod selector, we create a watcher for each matching namespace
-				// that populates the addressSet
-				nsSel, _ := metav1.LabelSelectorAsSelector(handler.namespaceSelector)
-				if nsSel.Empty() {
-					// namespace is not limited by a selector, just use pod selector with empty namespace
-					err = oc.addPeerPodHandler(handler.podSelector, handler.gress, np, "")
-				} else {
-					err = oc.addPeerNamespaceAndPodHandler(handler.namespaceSelector, handler.podSelector, handler.gress, np)
-				}
-			} else if handler.namespaceSelector != nil {
-				// For each peer namespace selector, we create a watcher that
-				// populates ingress.peerAddressSets
-				err = oc.addPeerNamespaceHandler(handler.namespaceSelector, handler.gress, np)
-			} else if handler.podSelector != nil {
-				// For each peer pod selector, we create a watcher that
-				// populates the addressSet
-				err = oc.addPeerPodHandler(handler.podSelector, handler.gress, np, np.namespace)
-			}
+			// For each peer namespace selector, we create a watcher that
+			// populates ingress.peerAddressSets
+			err = oc.addPeerNamespaceHandler(handler.namespaceSelector, handler.gress, np)
 			if err != nil {
 				return fmt.Errorf("failed to start peer handler: %v", err)
 			}
@@ -1200,6 +1172,58 @@ func (oc *DefaultNetworkController) createNetworkPolicy(policy *knet.NetworkPoli
 		return nil
 	})
 	return np, err
+}
+
+func (oc *DefaultNetworkController) setupGressPolicy(np *networkPolicy, gp *gressPolicy,
+	peer knet.NetworkPolicyPeer) (*policyHandler, error) {
+	// Add IPBlock to ingress network policy
+	if peer.IPBlock != nil {
+		gp.addIPBlock(peer.IPBlock)
+		return nil, nil
+	}
+	if peer.PodSelector == nil && peer.NamespaceSelector == nil {
+		// undefined behaviour
+		klog.Errorf("setupGressPolicy failed: all fields unset")
+		return nil, nil
+	}
+
+	podSelector := peer.PodSelector
+	if podSelector == nil {
+		// nil pod selector is equivalent to empty pod selector, which selects all
+		podSelector = &metav1.LabelSelector{}
+	}
+	podSel, _ := metav1.LabelSelectorAsSelector(podSelector)
+	nsSel, _ := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+
+	if podSel.Empty() && (peer.NamespaceSelector == nil || !nsSel.Empty()) {
+		// namespace-based filtering
+		if peer.NamespaceSelector == nil {
+			// nil namespace selector means same namespace
+			_, err := gp.addNamespaceAddressSet(np.namespace, oc.addressSetFactory)
+			if err != nil {
+				return nil, fmt.Errorf("failed to add namespace address set for gress policy: %w", err)
+			}
+		} else if !nsSel.Empty() {
+			// namespace selector, use namespace address sets
+			handler := &policyHandler{
+				gress:             gp,
+				namespaceSelector: peer.NamespaceSelector,
+			}
+			return handler, nil
+		}
+	} else {
+		// use podSelector address set
+		// np.namespace will be used when fromJSON.NamespaceSelector = nil
+		asKey, ipv4as, ipv6as, err := oc.EnsurePodSelectorAddressSet(
+			podSelector, peer.NamespaceSelector, np.namespace, np.getKeyWithKind())
+		// even if GetPodSelectorAddressSet failed, add key for future cleanup or retry.
+		np.peerAddressSets = append(np.peerAddressSets, asKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to ensure pod selector address set %s: %v", asKey, err)
+		}
+		gp.addPeerAddressSets(ipv4as, ipv6as)
+	}
+	return nil, nil
 }
 
 // addNetworkPolicy creates and applies OVN ACLs to pod logical switch
@@ -1353,7 +1377,8 @@ func (oc *DefaultNetworkController) deleteNetworkPolicy(policy *knet.NetworkPoli
 // No need to log network policy key here, because caller of cleanupNetworkPolicy should prepend error message with
 // that information.
 func (oc *DefaultNetworkController) cleanupNetworkPolicy(np *networkPolicy) error {
-	klog.Infof("Cleanup network policy %s", np.getKey())
+	npKey := np.getKey()
+	klog.Infof("Cleaning up network policy %s", npKey)
 	np.Lock()
 	defer np.Unlock()
 
@@ -1363,6 +1388,16 @@ func (oc *DefaultNetworkController) cleanupNetworkPolicy(np *networkPolicy) erro
 	// stop handlers, retriable
 	oc.shutdownHandlers(np)
 	var err error
+
+	// delete from peer address set
+	for i, asKey := range np.peerAddressSets {
+		if err := oc.DeletePodSelectorAddressSet(asKey, np.getKeyWithKind()); err != nil {
+			// remove deleted address sets from the list
+			np.peerAddressSets = np.peerAddressSets[i:]
+			return fmt.Errorf("failed to delete network policy from peer address set %s: %v", asKey, err)
+		}
+	}
+	np.peerAddressSets = nil
 
 	// Delete the port group, idempotent
 	ops, err := libovsdbops.DeletePortGroupsOps(oc.nbClient, nil, np.portGroupName)
@@ -1389,282 +1424,15 @@ func (oc *DefaultNetworkController) cleanupNetworkPolicy(np *networkPolicy) erro
 		return fmt.Errorf("unable to delete policy from default deny port groups: %v", err)
 	}
 
-	// Delete ingress/egress address sets, idempotent
-	for i, policy := range np.ingressPolicies {
-		err = policy.destroy()
-		if err != nil {
-			// remove deleted policies from the list
-			np.ingressPolicies = np.ingressPolicies[i:]
-			return fmt.Errorf("failed to delete network policy ingress address sets: %v", err)
-		}
-	}
-	np.ingressPolicies = make([]*gressPolicy, 0)
-	for i, policy := range np.egressPolicies {
-		err = policy.destroy()
-		if err != nil {
-			// remove deleted policies from the list
-			np.egressPolicies = np.egressPolicies[i:]
-			return fmt.Errorf("failed to delete network policy egress address sets: %v", err)
-		}
-	}
-	np.egressPolicies = make([]*gressPolicy, 0)
-
 	// finally, delete netpol from existing networkPolicies
 	// this is the signal that cleanup was successful
-	oc.networkPolicies.Delete(np.getKey())
-	return nil
-}
-
-// handlePeerPodSelectorAddUpdate adds the IP address of a pod that has been
-// selected as a peer by a NetworkPolicy's ingress/egress section to that
-// ingress/egress address set
-func (oc *DefaultNetworkController) handlePeerPodSelectorAddUpdate(np *networkPolicy, gp *gressPolicy, objs ...interface{}) error {
-	if config.Metrics.EnableScaleMetrics {
-		start := time.Now()
-		defer func() {
-			duration := time.Since(start)
-			metrics.RecordNetpolPeerPodEvent("add", duration)
-		}()
-	}
-	np.RLock()
-	defer np.RUnlock()
-	if np.deleted {
-		return nil
-	}
-	pods := make([]*kapi.Pod, 0, len(objs))
-	for _, obj := range objs {
-		pod := obj.(*kapi.Pod)
-		if pod.Spec.NodeName == "" {
-			// update event will be received for this pod later, no ips should be assigned yet
-			continue
-		}
-		pods = append(pods, pod)
-	}
-	// gressPolicy.addPeerPods must be called with networkPolicy RLock.
-	return gp.addPeerPods(pods...)
-}
-
-// handlePeerPodSelectorDelete removes the IP address of a pod that no longer
-// matches a NetworkPolicy ingress/egress section's selectors from that
-// ingress/egress address set
-func (oc *DefaultNetworkController) handlePeerPodSelectorDelete(np *networkPolicy, gp *gressPolicy, podSelector labels.Selector, obj interface{}) error {
-	if config.Metrics.EnableScaleMetrics {
-		start := time.Now()
-		defer func() {
-			duration := time.Since(start)
-			metrics.RecordNetpolPeerPodEvent("delete", duration)
-		}()
-	}
-	np.RLock()
-	defer np.RUnlock()
-	if np.deleted {
-		return nil
-	}
-	pod := obj.(*kapi.Pod)
-	if pod.Spec.NodeName == "" {
-		klog.Infof("Pod %s/%s not scheduled on any node, skipping it", pod.Namespace, pod.Name)
-		return nil
-	}
-
-	if util.PodCompleted(pod) {
-		ips, err := util.GetPodIPsOfNetwork(pod, &util.DefaultNetInfo{})
-		if err != nil {
-			return fmt.Errorf("can't get pod IPs %s/%s: %w", pod.Namespace, pod.Name, err)
-		}
-
-		collidingPod, err := oc.findPodWithIPAddresses(ips)
-		if err != nil {
-			return fmt.Errorf("lookup for pods with the same IPs [%s] failed: %w", util.JoinIPs(ips, " "), err)
-		}
-
-		if collidingPod != nil {
-
-			// If the IP is used by another Pod that is targeted by the same network policy, don't remove the IP from the Address_Set
-			if podSelector.Matches(labels.Set(collidingPod.Labels)) {
-				klog.Infof("Not deleting Pod %s/%s IPs [%s] as they are used by %s/%s", pod.Namespace, pod.Name,
-					util.JoinIPs(ips, " "), collidingPod.Namespace, collidingPod.Name)
-				return nil
-			}
-		}
-	}
-
-	// gressPolicy.deletePeerPod must be called with networkPolicy RLock.
-	if err := gp.deletePeerPod(pod); err != nil {
-		return err
-	}
+	oc.networkPolicies.Delete(npKey)
 	return nil
 }
 
 type NetworkPolicyExtraParameters struct {
-	np          *networkPolicy
-	gp          *gressPolicy
-	podSelector labels.Selector
-}
-
-// addPeerPodHandler starts a watcher for PeerPodSelectorType.
-// Sync function and Add event for every existing namespace will be executed sequentially first, and an error will be
-// returned if something fails.
-// PeerPodSelectorType uses handlePeerPodSelectorAddUpdate on Add and Update,
-// and handlePeerPodSelectorDelete on Delete.
-func (oc *DefaultNetworkController) addPeerPodHandler(podSelector *metav1.LabelSelector,
-	gp *gressPolicy, np *networkPolicy, namespace string) error {
-
-	// NetworkPolicy is validated by the apiserver; this can't fail.
-	sel, _ := metav1.LabelSelectorAsSelector(podSelector)
-
-	// start watching pods in the same namespace as the network policy and selected by the
-	// label selector
-	syncFunc := func(objs []interface{}) error {
-		// ignore returned error, since any pod that wasn't properly handled will be retried individually.
-		_ = oc.handlePeerPodSelectorAddUpdate(np, gp, objs...)
-		return nil
-	}
-	retryPeerPods := oc.newRetryFrameworkWithParameters(
-		factory.PeerPodSelectorType,
-		syncFunc,
-		&NetworkPolicyExtraParameters{
-			np:          np,
-			gp:          gp,
-			podSelector: sel,
-		})
-
-	podHandler, err := retryPeerPods.WatchResourceFiltered(namespace, sel)
-	if err != nil {
-		klog.Errorf("Failed WatchResource for addPeerPodHandler: %v", err)
-		return err
-	}
-
-	np.podHandlerList = append(np.podHandlerList, podHandler)
-	return nil
-}
-
-func (oc *DefaultNetworkController) handlePeerNamespaceAndPodAdd(np *networkPolicy, gp *gressPolicy,
-	podSelector labels.Selector, obj interface{}) error {
-	if config.Metrics.EnableScaleMetrics {
-		start := time.Now()
-		defer func() {
-			duration := time.Since(start)
-			metrics.RecordNetpolPeerNamespaceAndPodEvent("add", duration)
-		}()
-	}
-	namespace := obj.(*kapi.Namespace)
-	np.RLock()
-	locked := true
-	defer func() {
-		if locked {
-			np.RUnlock()
-		}
-	}()
-	if np.deleted {
-		return nil
-	}
-
-	// start watching pods in this namespace and selected by the label selector in extraParameters.podSelector
-	syncFunc := func(objs []interface{}) error {
-		// ignore returned error, since any pod that wasn't properly handled will be retried individually.
-		_ = oc.handlePeerPodSelectorAddUpdate(np, gp, objs...)
-		return nil
-	}
-	retryPeerPods := oc.newRetryFrameworkWithParameters(
-		factory.PeerPodForNamespaceAndPodSelectorType,
-		syncFunc,
-		&NetworkPolicyExtraParameters{
-			gp:          gp,
-			np:          np,
-			podSelector: podSelector,
-		},
-	)
-	// syncFunc and factory.PeerPodForNamespaceAndPodSelectorType add event handler also take np.RLock,
-	// and will be called form the same thread. The same thread shouldn't take the same rlock twice.
-	// unlock
-	np.RUnlock()
-	locked = false
-	podHandler, err := retryPeerPods.WatchResourceFiltered(namespace.Name, podSelector)
-	if err != nil {
-		klog.Errorf("Failed WatchResource for PeerNamespaceAndPodSelectorType: %v", err)
-		return err
-	}
-	// lock networkPolicy again to update namespacedPodHandlers
-	np.RLock()
-	locked = true
-	if np.deleted {
-		oc.watchFactory.RemovePodHandler(podHandler)
-		return nil
-	}
-	np.namespacedPodHandlers.Store(namespace.Name, podHandler)
-	return nil
-}
-
-func (oc *DefaultNetworkController) handlePeerNamespaceAndPodDel(np *networkPolicy, gp *gressPolicy, obj interface{}) error {
-	if config.Metrics.EnableScaleMetrics {
-		start := time.Now()
-		defer func() {
-			duration := time.Since(start)
-			metrics.RecordNetpolPeerNamespaceAndPodEvent("delete", duration)
-		}()
-	}
-	np.RLock()
-	defer np.RUnlock()
-	if np.deleted {
-		return nil
-	}
-
-	// when the namespace labels no longer apply
-	// stop pod handler,
-	// remove the namespaces pods from the address_set
-	var errs []error
-	namespace := obj.(*kapi.Namespace)
-
-	if handler, ok := np.namespacedPodHandlers.Load(namespace.Name); ok {
-		oc.watchFactory.RemovePodHandler(handler.(*factory.Handler))
-		np.namespacedPodHandlers.Delete(namespace.Name)
-	}
-
-	pods, err := oc.watchFactory.GetPods(namespace.Name)
-	if err != nil {
-		return fmt.Errorf("failed to get namespace %s pods: %v", namespace.Namespace, err)
-	}
-	for _, pod := range pods {
-		// call functions from handlePeerPodSelectorDelete
-		// gressPolicy.deletePeerPod must be called with networkPolicy RLock.
-		if err = gp.deletePeerPod(pod); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return kerrorsutil.NewAggregate(errs)
-}
-
-// addPeerNamespaceAndPodHandler starts a watcher for PeerNamespaceAndPodSelectorType.
-// Add event for every existing namespace will be executed sequentially first, and an error will be
-// returned if something fails.
-// PeerNamespaceAndPodSelectorType uses handlePeerNamespaceAndPodAdd on Add,
-// and handlePeerNamespaceAndPodDel on Delete.
-func (oc *DefaultNetworkController) addPeerNamespaceAndPodHandler(namespaceSelector *metav1.LabelSelector,
-	podSelector *metav1.LabelSelector, gp *gressPolicy, np *networkPolicy) error {
-	// NetworkPolicy is validated by the apiserver; this can't fail.
-	nsSel, _ := metav1.LabelSelectorAsSelector(namespaceSelector)
-	podSel, _ := metav1.LabelSelectorAsSelector(podSelector)
-
-	// start watching namespaces selected by the namespace selector nsSel;
-	// upon namespace add event, start watching pods in that namespace selected
-	// by the label selector podSel
-	retryPeerNamespaces := oc.newRetryFrameworkWithParameters(
-		factory.PeerNamespaceAndPodSelectorType,
-		nil,
-		&NetworkPolicyExtraParameters{
-			gp:          gp,
-			np:          np,
-			podSelector: podSel}, // will be used in the addFunc to create a pod handler
-	)
-
-	namespaceHandler, err := retryPeerNamespaces.WatchResourceFiltered("", nsSel)
-	if err != nil {
-		klog.Errorf("Failed WatchResource for addPeerNamespaceAndPodHandler: %v", err)
-		return err
-	}
-
-	np.nsHandlerList = append(np.nsHandlerList, namespaceHandler)
-	return nil
+	np *networkPolicy
+	gp *gressPolicy
 }
 
 func (oc *DefaultNetworkController) handlePeerNamespaceSelectorAdd(np *networkPolicy, gp *gressPolicy, objs ...interface{}) error {
@@ -1804,19 +1572,14 @@ func (oc *DefaultNetworkController) addPeerNamespaceHandler(
 }
 
 func (oc *DefaultNetworkController) shutdownHandlers(np *networkPolicy) {
-	for _, handler := range np.podHandlerList {
-		oc.watchFactory.RemovePodHandler(handler)
+	if np.localPodHandler != nil {
+		oc.watchFactory.RemovePodHandler(np.localPodHandler)
+		np.localPodHandler = nil
 	}
-	np.podHandlerList = make([]*factory.Handler, 0)
 	for _, handler := range np.nsHandlerList {
 		oc.watchFactory.RemoveNamespaceHandler(handler)
 	}
 	np.nsHandlerList = make([]*factory.Handler, 0)
-	np.namespacedPodHandlers.Range(func(_, value interface{}) bool {
-		oc.watchFactory.RemovePodHandler(value.(*factory.Handler))
-		return true
-	})
-	np.namespacedPodHandlers = sync.Map{}
 }
 
 // The following 2 functions should return the same key for network policy based on k8s on internal networkPolicy object
@@ -1826,6 +1589,10 @@ func getPolicyKey(policy *knet.NetworkPolicy) string {
 
 func (np *networkPolicy) getKey() string {
 	return fmt.Sprintf("%v/%v", np.namespace, np.name)
+}
+
+func (np *networkPolicy) getKeyWithKind() string {
+	return fmt.Sprintf("%v/%v/%v", "NetworkPolicy", np.namespace, np.name)
 }
 
 // PortGroupHasPorts returns true if a port group contains all given ports
@@ -1839,4 +1606,15 @@ func PortGroupHasPorts(nbClient libovsdbclient.Client, pgName string, portUUIDs 
 	}
 
 	return sets.NewString(pg.Ports...).HasAll(portUUIDs...)
+}
+
+// getStaleNetpolAddrSetDbIDs returns the ids for address sets that were owned by network policy before we
+// switched to shared address sets with PodSelectorAddressSet. Should only be used for sync and testing.
+func getStaleNetpolAddrSetDbIDs(policyNamespace, policyName, policyType, idx, controller string) *libovsdbops.DbObjectIDs {
+	return libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetNetworkPolicy, controller, map[libovsdbops.ExternalIDKey]string{
+		libovsdbops.ObjectNameKey: policyNamespace + "_" + policyName,
+		// direction and idx uniquely identify address set (= gress policy rule)
+		libovsdbops.PolicyDirectionKey: strings.ToLower(policyType),
+		libovsdbops.GressIdxKey:        idx,
+	})
 }

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -1186,6 +1186,7 @@ func (oc *DefaultNetworkController) setupGressPolicy(np *networkPolicy, gp *gres
 		klog.Errorf("setupGressPolicy failed: all fields unset")
 		return nil, nil
 	}
+	gp.hasPeerSelector = true
 
 	podSelector := peer.PodSelector
 	if podSelector == nil {


### PR DESCRIPTION
 Add PodSelectorAddressSet object, that should be used to manage network
policy peers with pod selector (network policy object is only
responsible for local pods and peer namespace-only handlers).

This should improve performance, since every peer selector will have only
1 address set to update (and 1 handler), instead of 1 address set per 
NetworkPolicy[In/E]gressRule, and 1 handler per every pod selector.


Update syncNetworkPolicies to cleanup policies based on acls, and not
address sets, since address sets are not created for policies without
peers with selectors, and it doesn't cleanup default deny port groups.
New sync is based on acls, it will only skip empty policies without
any gress rules. This should be fixed later with proper ownership
indexing for port groups.
Note: default deny port groups not being deleted for non-existing namespace was recently noticed by RH customer during migration (case 03389949)
