### PR TITLE
Update egress node assignability on every egress node update

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -832,9 +832,9 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		if !oldHadEgressLabel && !newHasEgressLabel {
 			return nil
 		}
+		h.oc.setNodeEgressAssignable(newNode.Name, newHasEgressLabel)
 		if oldHadEgressLabel && !newHasEgressLabel {
 			klog.Infof("Node: %s has been un-labeled, deleting it from egress assignment", newNode.Name)
-			h.oc.setNodeEgressAssignable(oldNode.Name, false)
 			return h.oc.deleteEgressNode(oldNode.Name)
 		}
 		isOldReady := h.oc.isEgressNodeReady(oldNode)
@@ -843,7 +843,6 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		h.oc.setNodeEgressReady(newNode.Name, isNewReady)
 		if !oldHadEgressLabel && newHasEgressLabel {
 			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
-			h.oc.setNodeEgressAssignable(newNode.Name, true)
 			if isNewReady && isNewReachable {
 				h.oc.setNodeEgressReachable(newNode.Name, isNewReachable)
 				if err := h.oc.addEgressNode(newNode.Name); err != nil {


### PR DESCRIPTION
`setNodeEgressAssignable` sets an egress node as assignable when it exists in the allocator cache, otherwise it does nothing.
 Currently the egress node update handler only calls `setNodeEgressAssignable` when it detects that the `nodeEgressLabel` was added/removed.
In cloud environment a node is added to the allocator cache after it gets annotatated with `cloud.network.openshift.io/egress-ipconfig` by CNCC.

In a scenario where a node is labeled for egress IP assignment before it is annotated by CNCC, it never gets set as assignable(`isEgressAssignable`). 
To address that call `setNodeEgressAssignable` on every node update.

It was found in https://issues.redhat.com/browse/OCPBUGS-4969.

Signed-off-by: Patryk Diak <pdiak@redhat.com>