### PR TITLE
[rfe] keep dns stale entries in address_set

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_dns_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns_test.go
@@ -269,7 +269,7 @@ func TestAdd(t *testing.T) {
 				for stay, timeout := true, time.After(15*time.Second); stay; {
 					_, dnsResolves, _ := res.getDNSEntry(tc.dnsName)
 					if dnsResolves != nil {
-						if len(dnsResolves) == 1 && dnsResolves[0].String() == test1IPv4Update {
+						if len(dnsResolves) == 2 /* && dnsResolves[0].String() == test1IPv4Update */ {
 							break
 						}
 					}
@@ -439,7 +439,14 @@ func (e *EgressDNS) getDNSEntry(dnsName string) (map[string]struct{}, []net.IP, 
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	if dnsEntry, exists := e.dnsEntries[dnsName]; exists {
-		return dnsEntry.namespaces, dnsEntry.dnsResolves, dnsEntry.dnsAddressSet
+		if dnsEntry.dnsResolves == nil {
+			return dnsEntry.namespaces, nil, dnsEntry.dnsAddressSet
+		}
+		ips := make([]net.IP, 0, len(dnsEntry.dnsResolves))
+		for _, val := range dnsEntry.dnsResolves {
+			ips = append(ips, val.ip)
+		}
+		return dnsEntry.namespaces, ips, dnsEntry.dnsAddressSet
 	}
 
 	return nil, nil, nil

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -13,7 +13,6 @@ import (
 	egressfirewallapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
@@ -2056,17 +2055,3 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 		}
 	})
 })
-
-//helper functions to help test egressfirewallDNS
-
-// Create an EgressDNS object without the Sync function
-// To make it easier to mock EgressFirewall functionality create an egressFirewall
-// without the go routine of the sync function
-
-// GetDNSEntryForTest Gets a dnsEntry from a EgressDNS object for testing
-func (e *EgressDNS) GetDNSEntryForTest(dnsName string) (map[string]struct{}, []net.IP, addressset.AddressSet, error) {
-	if e.dnsEntries[dnsName] == nil {
-		return nil, nil, nil, fmt.Errorf("there is no dnsEntry for dnsName: %s", dnsName)
-	}
-	return e.dnsEntries[dnsName].namespaces, e.dnsEntries[dnsName].dnsResolves, e.dnsEntries[dnsName].dnsAddressSet, nil
-}


### PR DESCRIPTION
For records containing multiple IPs, DNS server may answer a frequently changing subset of IPs from a fixed, larger pool of IPs. This causes flows to "flap" as IPs are moving in and out of address_set after each DNS answer, causing flows to be continuously added and removed.

To avoid that, if an entry has been seen returned by the DNS server we keep it in the address_set even though the DNS server does not answer it anymore.  This looses up the EgressFirewall rule, as some previous IPs will keep being matched for a little while.

This partially addresses https://issues.redhat.com/browse/RFE-1355

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

Address the continuous changes of flows when putting a DNS entry like this one:
```
$ dig foo.webhook.office.com

; <<>> DiG 9.16.1-Ubuntu <<>> foo.webhook.office.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 48861
;; flags: qr rd ra; QUERY: 1, ANSWER: 8, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;foo.webhook.office.com.		IN	A

;; ANSWER SECTION:
foo.webhook.office.com.	294	IN	CNAME	outlook.office365.com.
outlook.office365.com.	213	IN	CNAME	outlook.ha.office365.com.
outlook.ha.office365.com. 42	IN	CNAME	outlook.ms-acdc.office.com.
outlook.ms-acdc.office.com. 2	IN	CNAME	CDG-efz.ms-acdc.office.com.
CDG-efz.ms-acdc.office.com. 8	IN	A	40.101.137.98
CDG-efz.ms-acdc.office.com. 8	IN	A	40.99.217.66
CDG-efz.ms-acdc.office.com. 8	IN	A	52.98.151.226
CDG-efz.ms-acdc.office.com. 8	IN	A	40.99.217.130

;; Query time: 40 msec
;; SERVER: 127.0.0.53#53(127.0.0.53)
;; WHEN: lun. déc. 26 00:45:10 CET 2022
;; MSG SIZE  rcvd: 224

```
the 4 IPs there keep changing, and everytime they change we see flows being added and removed on the chassis.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
it's more a RFE, or a request for feedback... Thanks!


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
```
apiVersion: v1
kind: Namespace
metadata:
  name: abc
---
apiVersion: k8s.ovn.org/v1
kind: EgressFirewall
metadata:
  name: default
  namespace: abc
spec:
  egress:
  - to:
      dnsName: "foo.webhook.office.com"
    type: Allow
  - to:
      cidrSelector: "0.0.0.0/0"
    type: Deny
---
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: myclient
  name: myclient
  namespace: abc
spec:
  containers:
  - command:
    - sh
    - "-c"
    - sleep 60
    image: alpine
    name: myclient
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: Always
```

without the change, we see the address_set changing every few seconds, and flows being added and removed.
with the change we see the address_set occasionally growing


**- Description for the changelog**
keep state DNS entries in the address_set