### PR TITLE
Correct the deletion of noHostSubnet nodes

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -801,7 +801,12 @@ func (oc *DefaultNetworkController) deleteNodeEvent(node *kapi.Node) error {
 		"various caches", node.Name)
 
 	if config.HybridOverlay.Enabled {
-		oc.releaseHybridOverlayNodeSubnet(node.Name)
+		if noHostSubnet := noHostSubnet(node); noHostSubnet {
+			// noHostSubnet nodes are different, only remove the switch and delete the hybrid overlay subnet
+			oc.lsManager.DeleteSwitch(node.Name)
+			oc.releaseHybridOverlayNodeSubnet(node.Name)
+			return nil
+		}
 		if _, ok := node.Annotations[hotypes.HybridOverlayDRMAC]; ok && !houtil.IsHybridOverlayNode(node) {
 			oc.deleteHybridOverlayPort(node)
 		}


### PR DESCRIPTION
Currently when deleting a noHostSubnet node the operation always fails because we are trying to delete ovn constructs that only get created for typical nodes.

Change the deletion of noHostSubnet nodes to only delete the logical switch and in the case of hybrid overlay the allocated subnet. 

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->