### PR TITLE
Add support for creating stateless OVN ACLs for K8s Network Policies

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -78,6 +78,7 @@ OVN_EX_GW_NETWORK_INTERFACE=""
 OVNKUBE_NODE_MGMT_PORT_NETDEV=""
 OVNKUBE_CONFIG_DURATION_ENABLE=
 OVNKUBE_METRICS_SCALE_ENABLE=
+OVN_STATELESS_NETPOL_ENABLE="false"
 # IN_UPGRADE is true only if called by upgrade-ovn.sh during the upgrade test,
 # it will render only the parts in ovn-setup.yaml related to RBAC permissions.
 IN_UPGRADE=
@@ -276,6 +277,9 @@ while [ "$1" != "" ]; do
   --in-upgrade)
     IN_UPGRADE=true
     ;;
+  --stateless-netpol-enable)
+    OVN_STATELESS_NETPOL_ENABLE=$VALUE
+    ;;
 
   *)
     echo "WARNING: unknown parameter \"$PARAM\""
@@ -420,6 +424,8 @@ ovnkube_config_duration_enable=${OVNKUBE_CONFIG_DURATION_ENABLE}
 echo "ovnkube_config_duration_enable: ${ovnkube_config_duration_enable}"
 ovnkube_metrics_scale_enable=${OVNKUBE_METRICS_SCALE_ENABLE}
 echo "ovnkube_metrics_scale_enable: ${ovnkube_metrics_scale_enable}"
+ovn_stateless_netpol_enable=${OVN_STATELESS_NETPOL_ENABLE}
+echo "ovn_stateless_netpol_enable: ${ovn_stateless_netpol_enable}"
 
 ovn_image=${ovnkube_image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -520,6 +526,7 @@ ovn_image=${ovnkube_image} \
   ovn_master_count=${ovn_master_count} \
   ovn_gateway_mode=${ovn_gateway_mode} \
   ovn_ex_gw_networking_interface=${ovn_ex_gw_networking_interface} \
+  ovn_stateless_netpol_enable=${ovn_netpol_acl_enable} \
   j2 ../templates/ovnkube-master.yaml.j2 -o ${output_dir}/ovnkube-master.yaml
 
 ovn_image=${image} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -230,6 +230,9 @@ ovn_ipfix_targets=${OVN_IPFIX_TARGETS:-}
 ovn_ipfix_sampling=${OVN_IPFIX_SAMPLING:-} \
 ovn_ipfix_cache_max_flows=${OVN_IPFIX_CACHE_MAX_FLOWS:-} \
 ovn_ipfix_cache_active_timeout=${OVN_IPFIX_CACHE_ACTIVE_TIMEOUT:-} \
+#OVN_STATELESS_NETPOL_ENABLE - enable stateless network policy for ovn-kubernetes
+ovn_stateless_netpol_enable=${OVN_STATELESS_NETPOL_ENABLE:-false}
+
 
 # OVNKUBE_NODE_MODE - is the mode which ovnkube node operates
 ovnkube_node_mode=${OVNKUBE_NODE_MODE:-"full"}
@@ -1003,6 +1006,12 @@ ovn-master() {
     ovnkube_metrics_scale_enable_flag="--metrics-enable-scale"
   fi
   echo "ovnkube_metrics_scale_enable_flag: ${ovnkube_metrics_scale_enable_flag}"
+  
+  ovn_stateless_netpol_enable_flag=
+  if [[ ${ovn_stateless_netpol_enable} == "true" ]]; then
+          ovn_stateless_netpol_enable_flag="--enable-stateless-netpol"
+  fi
+  echo "ovn_stateless_netpol_enable_flag: ${ovn_stateless_netpol_enable_flag}"
 
   echo "=============== ovn-master ========== MASTER ONLY"
   /usr/bin/ovnkube \
@@ -1032,6 +1041,7 @@ ovn-master() {
     ${ovnkube_config_duration_enable_flag} \
     ${ovnkube_metrics_scale_enable_flag} \
     ${multi_network_enabled_flag} \
+    ${ovn_stateless_netpol_enable_flag} \
     --metrics-bind-address ${ovnkube_master_metrics_bind_address} \
     --host-network-namespace ${ovn_host_network_namespace} &
 

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -223,6 +223,8 @@ spec:
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_ACL_LOGGING_RATE_LIMIT
           value: "{{ ovn_acl_logging_rate_limit }}"
+        - name: OVN_STATELESS_NETPOL_ENABLE
+          value: "{{ ovn_stateless_netpol_enable }}"
         - name: OVN_HOST_NETWORK_NAMESPACE
           valueFrom:
             configMapKeyRef:

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -347,6 +347,7 @@ type OVNKubernetesFeatureConfig struct {
 	EnableEgressQoS                 bool `gcfg:"enable-egress-qos"`
 	EgressIPNodeHealthCheckPort     int  `gcfg:"egressip-node-healthcheck-port"`
 	EnableMultiNetwork              bool `gcfg:"enable-multi-network"`
+	EnableStatelessNetPol           bool `gcfg:"enable-stateless-netpol"`
 }
 
 // GatewayMode holds the node gateway mode
@@ -911,6 +912,12 @@ var OVNK8sFeatureFlags = []cli.Flag{
 		Usage:       "Configure to use multiple NetworkAttachmentDefinition CRD feature with ovn-kubernetes.",
 		Destination: &cliConfig.OVNKubernetesFeature.EnableMultiNetwork,
 		Value:       OVNKubernetesFeature.EnableMultiNetwork,
+	},
+	&cli.BoolFlag{
+		Name:        "enable-stateless-netpol",
+		Usage:       "Configure to use stateless network policy feature with ovn-kubernetes.",
+		Destination: &cliConfig.OVNKubernetesFeature.EnableStatelessNetPol,
+		Value:       OVNKubernetesFeature.EnableStatelessNetPol,
 	},
 }
 

--- a/go-controller/pkg/ovn/gress_policy_test.go
+++ b/go-controller/pkg/ovn/gress_policy_test.go
@@ -109,7 +109,7 @@ func TestGetMatchFromIPBlock(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		gressPolicy := newGressPolicy(knet.PolicyTypeIngress, 5, "testing", "test", DefaultNetworkControllerName)
+		gressPolicy := newGressPolicy(knet.PolicyTypeIngress, 5, "testing", "test", DefaultNetworkControllerName, false)
 		for _, ipBlock := range tc.ipBlocks {
 			gressPolicy.addIPBlock(ipBlock)
 		}


### PR DESCRIPTION
All K8s Network Policies are implemented as OVN ACLs and they are stateful by default. With stateful ACLs, the reply packets for an outbound connection are automatically matched and those packets are let in since the connection was started from within the Pod. There is no need to author additional network policy to match the reply packets.

This means that the Kernel needs to track connection state and match the incoming packets with that state to ascertain whether they are ‘reply’ packets or ‘new’ packets. This can be used to overwhelm the DPU by creating millions of connections and making the kernel track the state for each one of them and forcing the incoming packets to match those states thereby overwhelming the DPU CPU.

To mitigate this, the K8s Network Policies can be created as stateless OVN ACLs by annotating the K8s Network Policy with

ovnStatelessACLAnnotationName = "k8s.ovn.org/acl-stateless"

However, this means that we need to add additional network policy in the opposite direction otherwise connections will not complete.

Co-authored-by: Girish Moodalbail gmoodalbail@nvidia.com
Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>

