### PR TITLE
[poc] multi-homing, layer2: Add dhcp, attach to primary network and support kubevirt live migration

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -700,7 +700,8 @@ create_ovn_kube_manifests() {
     --egress-qos-enable=true \
     --v4-join-subnet="${JOIN_SUBNET_IPV4}" \
     --v6-join-subnet="${JOIN_SUBNET_IPV6}" \
-    --ex-gw-network-interface="${OVN_EX_GW_NETWORK_INTERFACE}"
+    --ex-gw-network-interface="${OVN_EX_GW_NETWORK_INTERFACE}" \
+    --multi-network-enable=true
   popd
 }
 

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -146,7 +146,7 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, podLister corev1listers.PodL
 		return nil, err
 	}
 	podInterfaceInfo, err := PodAnnotation2PodInfo(annotations, podNADAnnotation, useOVSExternalIDs, pr.PodUID, vfNetdevName,
-		pr.nadName, pr.netName, pr.CNIConf.MTU)
+		pr.nadName, pr.netName, pr.CNIConf.MTU, pr.CNIConf.DHCP)
 	if err != nil {
 		return nil, err
 	}

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -157,6 +157,12 @@ func setupNetwork(link netlink.Link, ifInfo *PodInterfaceInfo) error {
 		}
 	}
 
+	// don't configure pod's network if DHCP, ovn-k will just answer to a
+	// DHCP request who ever is asking of it on the LSP (pod or VM).
+	if ifInfo.DHCP {
+		return nil
+	}
+
 	// set the IP address
 	for _, ip := range ifInfo.IPs {
 		addr := &netlink.Addr{IPNet: ip}

--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -360,8 +360,13 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 
 	ifaceID := util.GetIfaceId(namespace, podName)
 	if ifInfo.NetName != types.DefaultNetworkName {
-		ifaceID = util.GetSecondaryNetworkIfaceId(namespace, podName, ifInfo.NADName)
+		pod, err := getPod(podLister, kclient, namespace, podName)
+		if err != nil {
+			return err
+		}
+		ifaceID = util.GetSecondaryNetworkIfaceId(pod, ifInfo.NADName)
 	}
+	// TODO: Do we dump son VM uuid instead ?
 	initialPodUID := ifInfo.PodUID
 
 	ipStrs := make([]string, len(ifInfo.IPs))

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -49,6 +49,7 @@ type PodInterfaceInfo struct {
 	PodUID               string `json:"pod-uid"`
 	VfNetdevName         string `json:"vf-netdev-name"`
 	EnableUDPAggregation bool   `json:"enable-udp-aggregation"`
+	DHCP                 bool   `json:"dhcp"`
 
 	// network name, for default network, it is "default", otherwise it is net-attach-def's netconf spec name
 	NetName string `json:"netName"`

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -18,7 +18,11 @@ type NetConf struct {
 	MTU int `json:"mtu,omitempty"`
 	// comma-seperated subnet cidr
 	// for secondary layer3 network, eg. 10.128.0.0/14/23
+	// for layer2 network, eg. 10.1.130.0/24
 	Subnets string `json:"subnets,omitempty"`
+	// list of IPs, expressed with prefix length, to be excluded from being allocated for Pod
+	// valid for localnet or layer 2 network topology
+	ExcludeCIDRs []string `json:"excludeCIDRs,omitempty"`
 
 	// PciAddrs in case of using sriov
 	DeviceID string `json:"deviceID,omitempty"`

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"github.com/containernetworking/cni/pkg/types"
 	"net"
+
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 // NetConf is CNI NetConf with DeviceID
@@ -23,6 +24,9 @@ type NetConf struct {
 	// list of IPs, expressed with prefix length, to be excluded from being allocated for Pod
 	// valid for localnet or layer 2 network topology
 	ExcludeCIDRs []string `json:"excludeCIDRs,omitempty"`
+	// DHCP if true the address from Subnet will be deliver
+	// using DHCP
+	DHCP bool `json:"dhcp,omitempty"`
 
 	// PciAddrs in case of using sriov
 	DeviceID string `json:"deviceID,omitempty"`

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -27,6 +27,9 @@ type NetConf struct {
 	// DHCP if true the address from Subnet will be deliver
 	// using DHCP
 	DHCP bool `json:"dhcp,omitempty"`
+	// Expose if true the interface address will be
+	// exposed to kubernetes
+	Expose bool `json:"expose,omitempty"`
 
 	// PciAddrs in case of using sriov
 	DeviceID string `json:"deviceID,omitempty"`

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -104,7 +104,7 @@ func GetPodAnnotations(ctx context.Context, podLister corev1listers.PodLister, k
 
 // PodAnnotation2PodInfo creates PodInterfaceInfo from Pod annotations and additional attributes
 func PodAnnotation2PodInfo(podAnnotation map[string]string, podNADAnnotation *util.PodAnnotation, checkExtIDs bool, podUID,
-	vfNetdevname, nadName string, netName string, mtu int) (*PodInterfaceInfo, error) {
+	vfNetdevname, nadName string, netName string, mtu int, dhcp bool) (*PodInterfaceInfo, error) {
 	var err error
 	// get pod's annotation of the given NAD if it is not available
 	if podNADAnnotation == nil {
@@ -135,6 +135,7 @@ func PodAnnotation2PodInfo(podAnnotation map[string]string, podNADAnnotation *ut
 		NetName:              netName,
 		NADName:              nadName,
 		EnableUDPAggregation: config.Default.EnableUDPAggregation,
+		DHCP:                 dhcp,
 	}
 	return podInterfaceInfo, nil
 }

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1685,7 +1685,7 @@ func completeHybridOverlayConfig(allSubnets *configSubnets) error {
 	}
 
 	var err error
-	HybridOverlay.ClusterSubnets, err = ParseClusterSubnetEntries(HybridOverlay.RawClusterSubnets)
+	HybridOverlay.ClusterSubnets, err = ParseClusterSubnetEntries(HybridOverlay.RawClusterSubnets, true)
 	if err != nil {
 		return fmt.Errorf("hybrid overlay cluster subnet invalid: %v", err)
 	}
@@ -1720,7 +1720,7 @@ func buildDefaultConfig(cli, file *config) error {
 // into their final form.
 func completeDefaultConfig(allSubnets *configSubnets) error {
 	var err error
-	Default.ClusterSubnets, err = ParseClusterSubnetEntries(Default.RawClusterSubnets)
+	Default.ClusterSubnets, err = ParseClusterSubnetEntries(Default.RawClusterSubnets, true)
 	if err != nil {
 		return fmt.Errorf("cluster subnet invalid: %v", err)
 	}

--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -37,7 +37,8 @@ type CIDRNetworkEntry struct {
 // ParseClusterSubnetEntries returns the parsed set of CIDRNetworkEntries passed by the user on the command line
 // These entries define the clusters network space by specifying a set of CIDR and netmasks the SDN can allocate
 // addresses from.
-func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, error) {
+// For layer2 CIDRs, not to check subnet length
+func ParseClusterSubnetEntries(clusterSubnetCmd string, checkHostSubnetLength bool) ([]CIDRNetworkEntry, error) {
 	var parsedClusterList []CIDRNetworkEntry
 	clusterEntriesList := strings.Split(clusterSubnetCmd, ",")
 
@@ -77,7 +78,7 @@ func ParseClusterSubnetEntries(clusterSubnetCmd string) ([]CIDRNetworkEntry, err
 			}
 		}
 
-		if parsedClusterEntry.HostSubnetLength <= entryMaskLength {
+		if checkHostSubnetLength && parsedClusterEntry.HostSubnetLength <= entryMaskLength {
 			return nil, fmt.Errorf("cannot use a host subnet length mask shorter than or equal to the cluster subnet mask. "+
 				"host subnet length: %d, cluster subnet length: %d", parsedClusterEntry.HostSubnetLength, entryMaskLength)
 		}

--- a/go-controller/pkg/config/utils_test.go
+++ b/go-controller/pkg/config/utils_test.go
@@ -111,7 +111,7 @@ func TestParseClusterSubnetEntries(t *testing.T) {
 
 	for _, tc := range tests {
 
-		parsedList, err := ParseClusterSubnetEntries(tc.cmdLineArg)
+		parsedList, err := ParseClusterSubnetEntries(tc.cmdLineArg, true)
 		if err != nil && !tc.expectedErr {
 			t.Errorf("Test case \"%s\" expected no errors, got %v", tc.name, err)
 		}

--- a/go-controller/pkg/kubevirt/migration.go
+++ b/go-controller/pkg/kubevirt/migration.go
@@ -1,0 +1,41 @@
+package kubevirt
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+const (
+	VMLabelKey = "kubevirt.io/vm"
+)
+
+func PodIsLiveMigrationLeftOver(client clientset.Interface, pod *corev1.Pod) (bool, error) {
+	vmName, ok := OwnsPodAsVirtualMachine(pod)
+	if !ok {
+		return false, nil
+	}
+	matchVMLabel := labels.Set{VMLabelKey: vmName}
+	vmPods, err := client.CoreV1().Pods(pod.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: matchVMLabel.String()})
+	if err != nil {
+		return false, err
+	}
+
+	// Is there is a another virt-launcher pod for this VM but with newer
+	// creation time then this pod is a leftover
+	for _, vmPod := range vmPods.Items {
+		if vmPod.CreationTimestamp.After(pod.CreationTimestamp.Time) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func OwnsPodAsVirtualMachine(pod *corev1.Pod) (string, bool) {
+	vmName, ok := pod.Labels[VMLabelKey]
+	return vmName, ok
+}

--- a/go-controller/pkg/libovsdbops/dhcp.go
+++ b/go-controller/pkg/libovsdbops/dhcp.go
@@ -1,0 +1,40 @@
+package libovsdbops
+
+import (
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+)
+
+func CreateOrUpdateDhcpv4OptionsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lsp *nbdb.LogicalSwitchPort, dhcpOptions *nbdb.DHCPOptions) ([]libovsdb.Operation, error) {
+	opModels := []operationModel{}
+	opModel := operationModel{
+		Model:          dhcpOptions,
+		ModelPredicate: func(item *nbdb.DHCPOptions) bool { return item.Cidr == dhcpOptions.Cidr },
+		OnModelUpdates: onModelUpdatesAllNonDefault(),
+		DoAfter:        func() { lsp.Dhcpv4Options = &dhcpOptions.UUID },
+		ErrNotFound:    false,
+		BulkOp:         false,
+	}
+	opModels = append(opModels, opModel)
+	opModel = operationModel{
+		Model:          lsp,
+		ModelPredicate: func(item *nbdb.LogicalSwitchPort) bool { return item.Name == lsp.Name },
+		OnModelUpdates: onModelUpdatesAllNonDefault(),
+		ErrNotFound:    true,
+		BulkOp:         false,
+	}
+	opModels = append(opModels, opModel)
+
+	m := newModelClient(nbClient)
+	return m.CreateOrUpdateOps(ops, opModels...)
+}
+
+func CreateOrUpdateDhcpv4Options(nbClient libovsdbclient.Client, lsp *nbdb.LogicalSwitchPort, dhcpOptions *nbdb.DHCPOptions) error {
+	ops, err := CreateOrUpdateDhcpv4OptionsOps(nbClient, nil, lsp, dhcpOptions)
+	if err != nil {
+		return err
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
+}

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -60,6 +60,8 @@ func getUUID(model model.Model) string {
 		return t.UUID
 	case *nbdb.QoS:
 		return t.UUID
+	case *nbdb.DHCPOptions:
+		return t.UUID
 	default:
 		panic(fmt.Sprintf("getUUID: unknown model %T", t))
 	}
@@ -112,6 +114,8 @@ func setUUID(model model.Model, uuid string) {
 	case *sbdb.SBGlobal:
 		t.UUID = uuid
 	case *nbdb.QoS:
+		t.UUID = uuid
+	case *nbdb.DHCPOptions:
 		t.UUID = uuid
 	default:
 		panic(fmt.Sprintf("setUUID: unknown model %T", t))
@@ -226,6 +230,10 @@ func copyIndexes(model model.Model) model.Model {
 		return &nbdb.QoS{
 			UUID: t.UUID,
 		}
+	case *nbdb.DHCPOptions:
+		return &nbdb.DHCPOptions{
+			UUID: t.UUID,
+		}
 	default:
 		panic(fmt.Sprintf("copyIndexes: unknown model %T", t))
 	}
@@ -277,6 +285,8 @@ func getListFromModel(model model.Model) interface{} {
 		return &[]*sbdb.MACBinding{}
 	case *nbdb.QoS:
 		return &[]nbdb.QoS{}
+	case *nbdb.DHCPOptions:
+		return &[]nbdb.DHCPOptions{}
 	default:
 		panic(fmt.Sprintf("getModelList: unknown model %T", t))
 	}
@@ -395,9 +405,11 @@ func buildFailOnDuplicateOps(c client.Client, m model.Model) ([]ovsdb.Operation,
 func getAllUpdatableFields(model model.Model) []interface{} {
 	switch t := model.(type) {
 	case *nbdb.LogicalSwitchPort:
-		return []interface{}{&t.Addresses, &t.Type, &t.TagRequest, &t.Options, &t.PortSecurity}
+		return []interface{}{&t.Addresses, &t.Type, &t.TagRequest, &t.Options, &t.PortSecurity, &t.Dhcpv4Options}
 	case *nbdb.PortGroup:
 		return []interface{}{&t.ACLs, &t.Ports, &t.ExternalIDs}
+	case *nbdb.DHCPOptions:
+		return []interface{}{&t.Cidr, &t.Options, &t.ExternalIDs}
 	default:
 		panic(fmt.Sprintf("getAllUpdatableFields: unknown model %T", t))
 	}

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -64,6 +64,40 @@ func CreateOrUpdateLogicalSwitch(nbClient libovsdbclient.Client, sw *nbdb.Logica
 	return err
 }
 
+// UpdateLogicalSwitchSetExternalIDs sets external IDs on the provided logical
+// switch adding any missing, removing the ones set to an empty value and
+// updating existing
+func UpdateLogicalSwitchSetExternalIDs(nbClient libovsdbclient.Client, logicalSwitch *nbdb.LogicalSwitch) error {
+	externalIds := logicalSwitch.ExternalIDs
+	logicalSwitch, err := GetLogicalSwitch(nbClient, logicalSwitch)
+	if err != nil {
+		return err
+	}
+
+	if logicalSwitch.ExternalIDs == nil {
+		logicalSwitch.ExternalIDs = map[string]string{}
+	}
+
+	for k, v := range externalIds {
+		if v == "" {
+			delete(logicalSwitch.ExternalIDs, k)
+		} else {
+			logicalSwitch.ExternalIDs[k] = v
+		}
+	}
+
+	opModel := operationModel{
+		Model:          logicalSwitch,
+		OnModelUpdates: []interface{}{&logicalSwitch.ExternalIDs},
+		ErrNotFound:    true,
+		BulkOp:         false,
+	}
+
+	m := newModelClient(nbClient)
+	_, err = m.CreateOrUpdate(opModel)
+	return err
+}
+
 type logicalSwitchPredicate func(*nbdb.LogicalSwitch) bool
 
 // DeleteLogicalSwitchesWithPredicateOps returns the operations to delete the logical switches matching the provided predicate

--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -77,8 +77,11 @@ func (cm *networkControllerManager) NewNetworkController(nInfo util.NetInfo,
 	netConfInfo util.NetConfInfo) (NetworkController, error) {
 	cnci := cm.newCommonNetworkControllerInfo()
 	topotype := netConfInfo.TopologyType()
-	if topotype == ovntypes.Layer3Topology {
+	switch topotype {
+	case ovntypes.Layer3Topology:
 		return ovn.NewSecondaryLayer3NetworkController(cnci, nInfo, netConfInfo), nil
+	case ovntypes.Layer2Topology:
+		return ovn.NewSecondaryLayer2NetworkController(cnci, nInfo, netConfInfo), nil
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topotype)
 }
@@ -90,6 +93,8 @@ func (cm *networkControllerManager) newDummyNetworkController(topoType, netName 
 	switch topoType {
 	case ovntypes.Layer3Topology:
 		return ovn.NewSecondaryLayer3NetworkController(cnci, netInfo, &util.Layer3NetConfInfo{}), nil
+	case ovntypes.Layer2Topology:
+		return ovn.NewSecondaryLayer2NetworkController(cnci, netInfo, &util.Layer2NetConfInfo{}), nil
 	}
 	return nil, fmt.Errorf("topology type %s not supported", topoType)
 }

--- a/go-controller/pkg/node/node_dpu.go
+++ b/go-controller/pkg/node/node_dpu.go
@@ -53,7 +53,7 @@ func (n *OvnNode) watchPodsDPU(isOvnUpEnabled bool) error {
 					return
 				}
 				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, nil, isOvnUpEnabled, string(pod.UID),
-					"", nadName, netName, config.Default.MTU)
+					"", nadName, netName, config.Default.MTU, false /*DHCP*/)
 				if err != nil {
 					retryPods.Store(pod.UID, true)
 					return
@@ -90,7 +90,7 @@ func (n *OvnNode) watchPodsDPU(isOvnUpEnabled bool) error {
 					return
 				}
 				podInterfaceInfo, err := cni.PodAnnotation2PodInfo(pod.Annotations, nil, isOvnUpEnabled, string(pod.UID),
-					"", nadName, netName, config.Default.MTU)
+					"", nadName, netName, config.Default.MTU, false /*DHCP*/)
 				if err != nil {
 					return
 				}

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -132,7 +132,7 @@ func (bnc *BaseNetworkController) GetLogicalPortName(pod *kapi.Pod, nadName stri
 	if !bnc.IsSecondary() {
 		return util.GetLogicalPortName(pod.Namespace, pod.Name)
 	} else {
-		return util.GetSecondaryNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
+		return util.GetSecondaryNetworkLogicalPortName(pod, nadName)
 	}
 }
 

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -493,11 +493,48 @@ func (bnc *BaseNetworkController) updateL3TopologyVersion() error {
 	return nil
 }
 
-// determineOVNTopoVersionFromOVN determines what OVN Topology version is being used
+func (bnc *BaseNetworkController) updateL2TopologyVersion() error {
+	var switchName string
+
+	currentTopologyVersion := strconv.Itoa(types.OvnCurrentTopologyVersion)
+	topoType := bnc.TopologyType()
+	switch topoType {
+	case types.Layer2Topology:
+		switchName = bnc.GetNetworkScopedName(types.OVNLayer2Switch)
+	default:
+		return fmt.Errorf("topology type %s is not supported", topoType)
+	}
+	logicalSwitch := nbdb.LogicalSwitch{
+		Name:        switchName,
+		ExternalIDs: map[string]string{"k8s-ovn-topo-version": currentTopologyVersion},
+	}
+	err := libovsdbops.UpdateLogicalSwitchSetExternalIDs(bnc.nbClient, &logicalSwitch)
+	if err != nil {
+		return fmt.Errorf("failed to generate set topology version, err: %v", err)
+	}
+	klog.Infof("Updated Logical_Switch %s topology version to %s", switchName, currentTopologyVersion)
+	return nil
+}
+
+// determineOVNTopoVersionFromOVN determines what OVN Topology version is being used.
 // If "k8s-ovn-topo-version" key in external_ids column does not exist, it is prior to OVN topology versioning
 // and therefore set version number to OvnCurrentTopologyVersion
 func (bnc *BaseNetworkController) determineOVNTopoVersionFromOVN() (int, error) {
-	clusterRouterName := bnc.GetNetworkScopedName(types.OVNClusterRouter)
+	if !bnc.IsSecondary() {
+		return bnc.getOVNTopoVersionFromLogicalRouter(types.OVNClusterRouter)
+	}
+	topoType := bnc.TopologyType()
+	switch topoType {
+	case types.Layer3Topology:
+		return bnc.getOVNTopoVersionFromLogicalRouter(bnc.GetNetworkScopedName(types.OVNClusterRouter))
+	case types.Layer2Topology:
+		return bnc.getOVNTopoVersionFromLogicalSwitch(bnc.GetNetworkScopedName(types.OVNLayer2Switch))
+	default:
+		return 0, fmt.Errorf("topology type %s not supported", topoType)
+	}
+}
+
+func (bnc *BaseNetworkController) getOVNTopoVersionFromLogicalRouter(clusterRouterName string) (int, error) {
 	logicalRouter := &nbdb.LogicalRouter{Name: clusterRouterName}
 	logicalRouter, err := libovsdbops.GetLogicalRouter(bnc.nbClient, logicalRouter)
 	if err != nil && err != libovsdbclient.ErrNotFound {
@@ -514,7 +551,25 @@ func (bnc *BaseNetworkController) determineOVNTopoVersionFromOVN() (int, error) 
 	}
 	ver, err := strconv.Atoi(v)
 	if err != nil {
-		return 0, fmt.Errorf("invalid OVN topology version string for the cluster, err: %v", err)
+		return 0, fmt.Errorf("invalid OVN topology version string for network %s, err: %v", bnc.GetNetworkName(), err)
+	}
+	return ver, nil
+}
+
+func (bnc *BaseNetworkController) getOVNTopoVersionFromLogicalSwitch(switchName string) (int, error) {
+	logicalSwitch := &nbdb.LogicalSwitch{Name: switchName}
+	logicalSwitch, err := libovsdbops.GetLogicalSwitch(bnc.nbClient, logicalSwitch)
+	if err != nil && err != libovsdbclient.ErrNotFound {
+		return 0, fmt.Errorf("error getting switch %s: %v", switchName, err)
+	}
+	if err == libovsdbclient.ErrNotFound {
+		// no switch exists, DB is empty, nothing to upgrade
+		return math.MaxInt32, nil
+	}
+	v := logicalSwitch.ExternalIDs["k8s-ovn-topo-version"]
+	ver, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid OVN topology version string for network %s, err: %v", bnc.GetNetworkName(), err)
 	}
 	return ver, nil
 }

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -94,6 +94,8 @@ func (bnc *BaseNetworkController) deleteStaleLogicalSwitchPorts(expectedLogicalP
 			}
 			switchNames = append(switchNames, switchName)
 		}
+	} else if topoType == ovntypes.Layer2Topology {
+		switchNames = []string{bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch)}
 	} else {
 		return fmt.Errorf("topology type %s not supported", topoType)
 	}
@@ -331,31 +333,35 @@ func (bnc *BaseNetworkController) waitForNodeLogicalSwitchInCache(switchName str
 func (bnc *BaseNetworkController) addRoutesGatewayIP(pod *kapi.Pod, network *nadapi.NetworkSelectionElement,
 	podAnnotation *util.PodAnnotation, nodeSubnets []*net.IPNet) error {
 	if bnc.IsSecondary() {
-		topoType := bnc.TopologyType()
-		if topoType != ovntypes.Layer3Topology {
-			return fmt.Errorf("topology type %s not supported", topoType)
-		}
-		// secondary layer3 network, see if its network-attachment's annotation has default-route key.
+		// for secondary network, see if its network-attachment's annotation has default-route key.
 		// If present, then we need to add default route for it
 		podAnnotation.Gateways = append(podAnnotation.Gateways, network.GatewayRequest...)
-		for _, podIfAddr := range podAnnotation.IPs {
-			isIPv6 := utilnet.IsIPv6CIDR(podIfAddr)
-			nodeSubnet, err := util.MatchIPNetFamily(isIPv6, nodeSubnets)
-			if err != nil {
-				return err
-			}
-			gatewayIPnet := util.GetNodeGatewayIfAddr(nodeSubnet)
-			layer3NetConfInfo := bnc.NetConfInfo.(*util.Layer3NetConfInfo)
-			for _, clusterSubnet := range layer3NetConfInfo.ClusterSubnets {
-				if isIPv6 == utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
-					podAnnotation.Routes = append(podAnnotation.Routes, util.PodRoute{
-						Dest:    clusterSubnet.CIDR,
-						NextHop: gatewayIPnet.IP,
-					})
+		topoType := bnc.TopologyType()
+		switch topoType {
+		case ovntypes.Layer2Topology:
+			// no route needed for directly connected subnets
+			return nil
+		case ovntypes.Layer3Topology:
+			for _, podIfAddr := range podAnnotation.IPs {
+				isIPv6 := utilnet.IsIPv6CIDR(podIfAddr)
+				nodeSubnet, err := util.MatchIPNetFamily(isIPv6, nodeSubnets)
+				if err != nil {
+					return err
+				}
+				gatewayIPnet := util.GetNodeGatewayIfAddr(nodeSubnet)
+				layer3NetConfInfo := bnc.NetConfInfo.(*util.Layer3NetConfInfo)
+				for _, clusterSubnet := range layer3NetConfInfo.ClusterSubnets {
+					if isIPv6 == utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
+						podAnnotation.Routes = append(podAnnotation.Routes, util.PodRoute{
+							Dest:    clusterSubnet.CIDR,
+							NextHop: gatewayIPnet.IP,
+						})
+					}
 				}
 			}
+			return nil
 		}
-		return nil
+		return fmt.Errorf("topology type %s not supported", topoType)
 	}
 
 	// if there are other network attachments for the pod, then check if those network-attachment's
@@ -438,6 +444,8 @@ func (bnc *BaseNetworkController) getExpectedSwitchName(pod *kapi.Pod) (string, 
 		switch topoType {
 		case ovntypes.Layer3Topology:
 			switchName = bnc.GetNetworkScopedName(pod.Spec.NodeName)
+		case ovntypes.Layer2Topology:
+			switchName = bnc.GetNetworkScopedName(ovntypes.OVNLayer2Switch)
 		default:
 			return "", fmt.Errorf("topology type %s not supported", topoType)
 		}

--- a/go-controller/pkg/ovn/dhcp/dhcp.go
+++ b/go-controller/pkg/ovn/dhcp/dhcp.go
@@ -1,0 +1,38 @@
+package dhcp
+
+import (
+	"context"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+func ComposeOptionsWithKubeDNS(k8scli clientset.Interface, cidr string, router string) (*nbdb.DHCPOptions, error) {
+	dnsServer, err := kubeDNSNameServer(k8scli)
+	if err != nil {
+		return nil, err
+	}
+
+	dhcpOptions := nbdb.DHCPOptions{
+		Cidr: cidr,
+		Options: map[string]string{
+			"lease_time": "3500", /*TODO: Configure it*/
+			"router":     router,
+			"dns_server": dnsServer,
+			"server_id":  router,
+			"server_mac": "c0:ff:ee:00:00:01", /*TODO: Generate it*/
+		},
+	}
+
+	return &dhcpOptions, nil
+}
+
+func kubeDNSNameServer(cli clientset.Interface) (string, error) {
+	svc, err := cli.CoreV1().Services("kube-system").Get(context.Background(), "kube-dns", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return svc.Spec.ClusterIP, nil
+}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -998,7 +998,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		gomega.Expect(oc).NotTo(gomega.BeNil())
 		oc.defaultCOPPUUID, err = EnsureDefaultCOPP(nbClient)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		subnets, err := config.ParseClusterSubnetEntries(clusterCIDR)
+		subnets, err := config.ParseClusterSubnetEntries(clusterCIDR, true)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = oc.masterSubnetAllocator.InitRanges(subnets)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -185,7 +185,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			config.Gateway.Mode = config.GatewayModeShared
 			config.Gateway.NodeportEnable = true
 			var err error
-			config.Default.ClusterSubnets, err = config.ParseClusterSubnetEntries(clusterCIDR)
+			config.Default.ClusterSubnets, err = config.ParseClusterSubnetEntries(clusterCIDR, true)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			node1 := tNode{

--- a/go-controller/pkg/ovn/port_cache.go
+++ b/go-controller/pkg/ovn/port_cache.go
@@ -47,7 +47,7 @@ func (c *portCache) get(pod *kapi.Pod, nadName string) (*lpInfo, error) {
 	if nadName == types.DefaultNetworkName {
 		logicalPort = util.GetLogicalPortName(pod.Namespace, pod.Name)
 	} else {
-		logicalPort = util.GetSecondaryNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
+		logicalPort = util.GetSecondaryNetworkLogicalPortName(pod, nadName)
 	}
 	c.RLock()
 	defer c.RUnlock()
@@ -82,7 +82,7 @@ func (c *portCache) add(pod *kapi.Pod, logicalSwitch, nadName, uuid string, mac 
 	if nadName == types.DefaultNetworkName {
 		logicalPort = util.GetLogicalPortName(pod.Namespace, pod.Name)
 	} else {
-		logicalPort = util.GetSecondaryNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
+		logicalPort = util.GetSecondaryNetworkLogicalPortName(pod, nadName)
 	}
 	c.Lock()
 	defer c.Unlock()
@@ -112,7 +112,7 @@ func (c *portCache) remove(pod *kapi.Pod, nadName string) {
 	if nadName == types.DefaultNetworkName {
 		logicalPort = util.GetLogicalPortName(pod.Namespace, pod.Name)
 	} else {
-		logicalPort = util.GetSecondaryNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
+		logicalPort = util.GetSecondaryNetworkLogicalPortName(pod, nadName)
 	}
 
 	c.Lock()

--- a/go-controller/pkg/ovn/secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_layer2_network_controller.go
@@ -1,0 +1,300 @@
+package ovn
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+)
+
+type secondaryLayer2NetworkControllerEventHandler struct {
+	baseHandler  baseNetworkControllerEventHandler
+	watchFactory *factory.WatchFactory
+	objType      reflect.Type
+	oc           *SecondaryLayer2NetworkController
+	syncFunc     func([]interface{}) error
+}
+
+// AreResourcesEqual returns true if, given two objects of a known resource type, the update logic for this resource
+// type considers them equal and therefore no update is needed. It returns false when the two objects are not considered
+// equal and an update needs be executed. This is regardless of how the update is carried out (whether with a dedicated update
+// function or with a delete on the old obj followed by an add on the new obj).
+func (h *secondaryLayer2NetworkControllerEventHandler) AreResourcesEqual(obj1, obj2 interface{}) (bool, error) {
+	return h.baseHandler.areResourcesEqual(h.objType, obj1, obj2)
+}
+
+// GetInternalCacheEntry returns the internal cache entry for this object, given an object and its type.
+// This is now used only for pods, which will get their the logical port cache entry.
+func (h *secondaryLayer2NetworkControllerEventHandler) GetInternalCacheEntry(obj interface{}) interface{} {
+	return h.oc.GetInternalCacheEntryForSecondaryNetwork(h.objType, obj)
+}
+
+// GetResourceFromInformerCache returns the latest state of the object, given an object key and its type.
+// from the informers cache.
+func (h *secondaryLayer2NetworkControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
+	return h.baseHandler.getResourceFromInformerCache(h.objType, h.watchFactory, key)
+}
+
+// RecordAddEvent records the add event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordAddEvent(obj interface{}) {
+}
+
+// RecordUpdateEvent records the udpate event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordUpdateEvent(obj interface{}) {
+}
+
+// RecordDeleteEvent records the delete event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordDeleteEvent(obj interface{}) {
+}
+
+// RecordSuccessEvent records the success event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordSuccessEvent(obj interface{}) {
+}
+
+// RecordErrorEvent records the error event on this given object.
+func (h *secondaryLayer2NetworkControllerEventHandler) RecordErrorEvent(obj interface{}, reason string, err error) {
+}
+
+// IsResourceScheduled returns true if the given object has been scheduled.
+// Only applied to pods for now. Returns true for all other types.
+func (h *secondaryLayer2NetworkControllerEventHandler) IsResourceScheduled(obj interface{}) bool {
+	return h.baseHandler.isResourceScheduled(h.objType, obj)
+}
+
+// AddResource adds the specified object to the cluster according to its type and returns the error,
+// if any, yielded during object creation.
+// Given an object to add and a boolean specifying if the function was executed from iterateRetryResources
+func (h *secondaryLayer2NetworkControllerEventHandler) AddResource(obj interface{}, fromRetryLoop bool) error {
+	return h.oc.AddSecondaryNetworkResourceCommon(h.objType, obj)
+}
+
+// UpdateResource updates the specified object in the cluster to its version in newObj according to its
+// type and returns the error, if any, yielded during the object update.
+// Given an old and a new object; The inRetryCache boolean argument is to indicate if the given resource
+// is in the retryCache or not.
+func (h *secondaryLayer2NetworkControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
+	return h.oc.UpdateSecondaryNetworkResourceCommon(h.objType, oldObj, newObj, inRetryCache)
+}
+
+// DeleteResource deletes the object from the cluster according to the delete logic of its resource type.
+// Given an object and optionally a cachedObj; cachedObj is the internal cache entry for this object,
+// used for now for pods and network policies.
+func (h *secondaryLayer2NetworkControllerEventHandler) DeleteResource(obj, cachedObj interface{}) error {
+	return h.oc.DeleteSecondaryNetworkResourceCommon(h.objType, obj, cachedObj)
+}
+
+func (h *secondaryLayer2NetworkControllerEventHandler) SyncFunc(objs []interface{}) error {
+	var syncFunc func([]interface{}) error
+
+	if h.syncFunc != nil {
+		// syncFunc was provided explicitly
+		syncFunc = h.syncFunc
+	} else {
+		switch h.objType {
+		case factory.PodType:
+			syncFunc = h.oc.syncPodsForSecondaryNetwork
+
+		default:
+			return fmt.Errorf("no sync function for object type %s", h.objType)
+		}
+	}
+	if syncFunc == nil {
+		return nil
+	}
+	return syncFunc(objs)
+}
+
+// IsObjectInTerminalState returns true if the given object is a in terminal state.
+// This is used now for pods that are either in a PodSucceeded or in a PodFailed state.
+func (h *secondaryLayer2NetworkControllerEventHandler) IsObjectInTerminalState(obj interface{}) bool {
+	return h.baseHandler.isObjectInTerminalState(h.objType, obj)
+}
+
+// SecondaryLayer2NetworkController is created for logical network infrastructure and policy
+// for a secondary layer2 network
+type SecondaryLayer2NetworkController struct {
+	BaseSecondaryNetworkController
+
+	// waitGroup per-Controller
+	wg *sync.WaitGroup
+}
+
+// NewSecondaryLayer2NetworkController create a new OVN controller for the given secondary layer2 nad
+func NewSecondaryLayer2NetworkController(cnci *CommonNetworkControllerInfo, netInfo util.NetInfo,
+	netconfInfo util.NetConfInfo) *SecondaryLayer2NetworkController {
+	stopChan := make(chan struct{})
+
+	oc := &SecondaryLayer2NetworkController{
+		BaseSecondaryNetworkController: BaseSecondaryNetworkController{
+			BaseNetworkController: BaseNetworkController{
+				CommonNetworkControllerInfo: *cnci,
+				NetConfInfo:                 netconfInfo,
+				NetInfo:                     netInfo,
+				lsManager:                   lsm.NewL2SwitchManager(),
+				logicalPortCache:            newPortCache(stopChan),
+				namespaces:                  make(map[string]*namespaceInfo),
+				namespacesMutex:             sync.Mutex{},
+				addressSetFactory:           addressset.NewOvnAddressSetFactory(cnci.nbClient),
+				stopChan:                    stopChan,
+			},
+		},
+		wg: &sync.WaitGroup{},
+	}
+
+	// disable multicast support for secondary networks
+	oc.multicastSupport = false
+
+	oc.initRetryFramework()
+	return oc
+}
+
+func (oc *SecondaryLayer2NetworkController) initRetryFramework() {
+	oc.retryPods = oc.newRetryFramework(factory.PodType)
+}
+
+// newRetryFramework builds and returns a retry framework for the input resource type;
+func (oc *SecondaryLayer2NetworkController) newRetryFramework(
+	objectType reflect.Type) *retry.RetryFramework {
+	eventHandler := &secondaryLayer2NetworkControllerEventHandler{
+		baseHandler:  baseNetworkControllerEventHandler{},
+		objType:      objectType,
+		watchFactory: oc.watchFactory,
+		oc:           oc,
+		syncFunc:     nil,
+	}
+	resourceHandler := &retry.ResourceHandler{
+		HasUpdateFunc:          hasResourceAnUpdateFunc(objectType),
+		NeedsUpdateDuringRetry: needsUpdateDuringRetry(objectType),
+		ObjType:                objectType,
+		EventHandler:           eventHandler,
+	}
+	return retry.NewRetryFramework(
+		oc.stopChan,
+		oc.wg,
+		oc.watchFactory,
+		resourceHandler,
+	)
+}
+
+// Start starts the secondary layer2 controller, handles all events and creates all needed logical entities
+func (oc *SecondaryLayer2NetworkController) Start(ctx context.Context) error {
+	klog.Infof("Start secondary %s network controller of network %s", oc.TopologyType(), oc.GetNetworkName())
+	if err := oc.Init(); err != nil {
+		return err
+	}
+
+	return oc.Run()
+}
+
+// Stop gracefully stops the controller, and delete all logical entities for this network if requested
+func (oc *SecondaryLayer2NetworkController) Stop() {
+	klog.Infof("Stop secondary %s network controller of network %s", oc.TopologyType(), oc.GetNetworkName())
+	close(oc.stopChan)
+	oc.wg.Wait()
+
+	if oc.podHandler != nil {
+		oc.watchFactory.RemovePodHandler(oc.podHandler)
+	}
+}
+
+// Cleanup cleans up logical entities for the given network, called from net-attach-def routine
+// could be called from a dummy Controller (only has CommonNetworkControllerInfo set)
+func (oc *SecondaryLayer2NetworkController) Cleanup(netName string) error {
+	klog.Infof("Delete OVN logical entities for %s network controller of network %s", types.Layer3Topology, netName)
+
+	// delete layer 2 logical switches
+	ops, err := libovsdbops.DeleteLogicalSwitchesWithPredicateOps(oc.nbClient, nil,
+		func(item *nbdb.LogicalSwitch) bool {
+			return item.ExternalIDs[types.NetworkExternalID] == netName
+		})
+	if err != nil {
+		return fmt.Errorf("failed to get ops for deleting switches of network %s", netName)
+	}
+
+	_, err = libovsdbops.TransactAndCheck(oc.nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("failed to deleting switches of network %s", netName)
+	}
+
+	return nil
+}
+
+func (oc *SecondaryLayer2NetworkController) Run() error {
+	klog.Infof("Starting all the Watchers for network %s ...", oc.GetNetworkName())
+	start := time.Now()
+
+	if err := oc.WatchPods(); err != nil {
+		return err
+	}
+
+	klog.Infof("Completing all the Watchers for network %s took %v", oc.GetNetworkName(), time.Since(start))
+
+	// controller is fully running and resource handlers have synced, update Topology version in OVN
+	if err := oc.updateL2TopologyVersion(); err != nil {
+		return fmt.Errorf("failed to update topology version for network %s: %v", oc.GetNetworkName(), err)
+	}
+
+	return nil
+}
+
+func (oc *SecondaryLayer2NetworkController) Init() error {
+	switchName := oc.GetNetworkScopedName(types.OVNLayer2Switch)
+	logicalSwitch := nbdb.LogicalSwitch{
+		Name:        switchName,
+		ExternalIDs: map[string]string{},
+	}
+	if oc.IsSecondary() {
+		logicalSwitch.ExternalIDs[types.NetworkExternalID] = oc.GetNetworkName()
+		logicalSwitch.ExternalIDs[types.TopologyExternalID] = oc.TopologyType()
+	}
+
+	layer2NetConfInfo := oc.NetConfInfo.(*util.Layer2NetConfInfo)
+
+	hostSubnets := make([]*net.IPNet, 0, len(layer2NetConfInfo.ClusterSubnets))
+	for _, subnet := range layer2NetConfInfo.ClusterSubnets {
+		hostSubnet := subnet.CIDR
+		hostSubnets = append(hostSubnets, hostSubnet)
+		if utilnet.IsIPv6CIDR(hostSubnet) {
+			logicalSwitch.OtherConfig = map[string]string{"ipv6_prefix": hostSubnet.IP.String()}
+		} else {
+			logicalSwitch.OtherConfig = map[string]string{"subnet": hostSubnet.String()}
+		}
+	}
+
+	err := libovsdbops.CreateOrUpdateLogicalSwitch(oc.nbClient, &logicalSwitch, &logicalSwitch.OtherConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create logical switch %+v: %v", logicalSwitch, err)
+	}
+
+	err = oc.lsManager.AddSwitch(switchName, logicalSwitch.UUID, hostSubnets)
+	if err != nil {
+		return err
+	}
+
+	for _, excludeIP := range layer2NetConfInfo.ExcludeIPs {
+		var ipMask net.IPMask
+		if excludeIP.To4() != nil {
+			ipMask = net.CIDRMask(32, 32)
+		} else {
+			ipMask = net.CIDRMask(128, 128)
+		}
+
+		_ = oc.lsManager.AllocateIPs(switchName, []*net.IPNet{{IP: excludeIP, Mask: ipMask}})
+	}
+
+	return nil
+}

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -46,6 +46,9 @@ const (
 
 	NodeLocalSwitch = "node_local_switch"
 
+	// types.OVNLayer2Switch is the name of layer2 topology switch
+	OVNLayer2Switch = "ovn_layer2_switch"
+
 	// ACL Priorities
 
 	// Default routed multicast allow acl rule priority
@@ -166,4 +169,5 @@ const (
 
 	// different secondary network topology type defined in CNI netconf
 	Layer3Topology = "layer3"
+	Layer2Topology = "layer2"
 )

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -112,6 +112,7 @@ type NetConfInfo interface {
 	TopologyType() string
 	MTU() int
 	IsDHCP() bool
+	IsExpose() bool
 }
 
 // DefaultNetConfInfo is structure which holds specific default network information
@@ -139,6 +140,10 @@ func (defaultNetConfInfo *DefaultNetConfInfo) MTU() int {
 }
 
 func (*DefaultNetConfInfo) IsDHCP() bool {
+	return false
+}
+
+func (*DefaultNetConfInfo) IsExpose() bool {
 	return false
 }
 
@@ -224,12 +229,17 @@ func (layer3NetConfInfo *Layer3NetConfInfo) IsDHCP() bool {
 	return false
 }
 
+func (layer3NetConfInfo *Layer3NetConfInfo) IsExpose() bool {
+	return false
+}
+
 // Layer2NetConfInfo is structure which holds specific secondary layer2 network information
 type Layer2NetConfInfo struct {
 	subnets      string
 	mtu          int
 	excludeCIDRs []string
 	DHCP         bool
+	expose       bool
 
 	ClusterSubnets []config.CIDRNetworkEntry
 	ExcludeIPs     []net.IP
@@ -279,6 +289,7 @@ func newLayer2NetConfInfo(netconf *ovncnitypes.NetConf) (*Layer2NetConfInfo, err
 		excludeCIDRs:   netconf.ExcludeCIDRs,
 		ClusterSubnets: clusterSubnets,
 		DHCP:           netconf.DHCP,
+		expose:         netconf.Expose,
 		ExcludeIPs:     excludeIPs,
 	}, nil
 }
@@ -324,6 +335,10 @@ func (layer2NetConfInfo *Layer2NetConfInfo) MTU() int {
 }
 func (layer2NetConfInfo *Layer2NetConfInfo) IsDHCP() bool {
 	return layer2NetConfInfo.DHCP
+}
+
+func (layer2NetConfInfo *Layer2NetConfInfo) IsExpose() bool {
+	return layer2NetConfInfo.expose
 }
 
 // GetNADName returns key of NetAttachDefInfo.NetAttachDefs map, also used as Pod annotation key


### PR DESCRIPTION
**- What this PR does and why is it needed**
This is a draft PR to implement features needed for hypershift hosted workers:
- seamless kubevirt live migration
  - stable IPs
  - stable connections
- east/west and north/south communication
- access to services

To accomplish that on top of https://github.com/ovn-org/ovn-kubernetes/pull/3350 the following features has being added
- Don't configure ip address at pod but activate DHCP options so VMs are configured with it
- Connect secondary network the default network topology so services and north/south works fine.
- Specific to kubevirt, when a pod is a leftover from live migration:
  - On pod delete keep the LSP
  - On pod update don't change requested-chassis.

Tasks: 
- [ ] Cleanup
    - [ ] Delete port a ovn_cluster_router
    - [ ] Delete routes and policies at ovn_cluster_router
    - [ ] Delete routes and snat at gw routers
    - [ ] DHCP options
- [x] Configure pod LSP with DHCP Options and don't configer address at veth
- [ ] Live migration
  - [x] Address follow logical switch port and VM
  - [x] Connectivity 
  - [ ] Investigate [net.netfilter.nf](http://net.netfilter.nf/)_conntrack_tcp_loose = 1 for snat + live migration
  - [ ] Investigate multi requested-chassis feature for live migration
- [x] east/west communication
- [x] Add north/south communication
- [ ] Services
  - [ ] After dynamic address is present add an annotation to the pod like the ones from multus for the specified network
  - [ ] Change ovn-kubernetes controller to understand `k8s.v1.cni.cncf.io/service-network` so it get the IP from pod's annotation for this network, it wil then create proper endpoints.
- [ ] Isolation/network policies/vlans

Docs:
- [ovn + dhcp](https://blog.oddbit.com/post/2019-12-19-ovn-and-dhcp/)
- [Live migration](https://www.youtube.com/watch?v=ijZTMXAg-eI)
- [How to create an Open Virtual Network distributed gateway router](https://developers.redhat.com/blog/2018/11/08/how-to-create-an-open-virtual-network-distributed-gateway-router)
- http://www.openvswitch.org/support/boston2017/1150-ovn-gateways-ipv6.pdf
- [localnet](https://weiti.org/ovn/2018/01/03/ovn-l2-breakout-options.html)
- Load Balancer https://www.cnblogs.com/yaodd/p/7477848.html
- ovn-kuberntes lb:   -  https://github.com/ovn-org/ovn-kubernetes/blob/90d77b70b04530763ed2e8e91bf7a268a25caf42/go-controller/pkg/ovn/loadbalancer/loadbalancer.go#L42

**- How to verify it**
This is verify with the umbrella project https://github.com/qinqon/ovn-kubevirt

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->