### PR TITLE
 Refactor egress IP assignment so that all operations are done as a single libovsdb transaction

### DIFF
--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -356,12 +356,12 @@ func DeleteLogicalRouterPoliciesWithPredicate(nbClient libovsdbclient.Client, ro
 	return err
 }
 
-// CreateOrAddNextHopsToLogicalRouterPolicyWithPredicate looks up a logical
+// CreateOrAddNextHopsToLogicalRouterPolicyWithPredicateOps looks up a logical
 // router policy from the cache based on a given predicate. If it doesn't find
 // any, it creates the provided logical router policy. If it does, adds any
 // missing Nexthops to the existing logical router policy. The logical router
-// policy is added to the provided logical router.
-func CreateOrAddNextHopsToLogicalRouterPolicyWithPredicate(nbClient libovsdbclient.Client, routerName string, lrp *nbdb.LogicalRouterPolicy, p logicalRouterPolicyPredicate) error {
+// policy is added to the provided logical router. Returns the corresponding ops
+func CreateOrAddNextHopsToLogicalRouterPolicyWithPredicateOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrp *nbdb.LogicalRouterPolicy, p logicalRouterPolicyPredicate) ([]libovsdb.Operation, error) {
 	router := &nbdb.LogicalRouter{
 		Name: routerName,
 	}
@@ -385,8 +385,7 @@ func CreateOrAddNextHopsToLogicalRouterPolicyWithPredicate(nbClient libovsdbclie
 	}
 
 	m := newModelClient(nbClient)
-	_, err := m.CreateOrUpdate(opModels...)
-	return err
+	return m.CreateOrUpdateOps(ops, opModels...)
 }
 
 func deleteNextHopsFromLogicalRouterPolicyOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, lrps []*nbdb.LogicalRouterPolicy, nextHops ...string) ([]libovsdb.Operation, error) {
@@ -472,7 +471,7 @@ func DeleteNextHopFromLogicalRouterPoliciesWithPredicateOps(nbClient libovsdbcli
 		return nil, err
 	}
 
-	return deleteNextHopsFromLogicalRouterPolicyOps(nbClient, nil, routerName, lrps, nextHop)
+	return deleteNextHopsFromLogicalRouterPolicyOps(nbClient, ops, routerName, lrps, nextHop)
 }
 
 // DeleteNextHopFromLogicalRouterPoliciesWithPredicate looks up a logical router

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1139,7 +1139,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 			fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp, udp_dst=%d, "+
 				"actions=output:%s", defaultOpenFlowCookie, ovsLocalPort, config.Default.EncapPort, ofPortPhys))
 
-		physicalIP, err := util.MatchIPNetFamily(false, bridgeIPs)
+		physicalIP, err := util.MatchFirstIPNetFamily(false, bridgeIPs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine IPv4 physical IP of host: %v", err)
 		}
@@ -1195,7 +1195,7 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 			fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp6, udp_dst=%d, "+
 				"actions=output:%s", defaultOpenFlowCookie, ovsLocalPort, config.Default.EncapPort, ofPortPhys))
 
-		physicalIP, err := util.MatchIPNetFamily(true, bridgeIPs)
+		physicalIP, err := util.MatchFirstIPNetFamily(true, bridgeIPs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine IPv6 physical IP of host: %v", err)
 		}
@@ -1380,7 +1380,7 @@ func commonFlows(bridge *bridgeConfiguration) ([]string, error) {
 			defaultOpenFlowCookie, ofPortPhys, bridgeMacAddress, ofPortPatch, ofPortHost))
 
 	if config.IPv4Mode {
-		physicalIP, err := util.MatchIPNetFamily(false, bridgeIPs)
+		physicalIP, err := util.MatchFirstIPNetFamily(false, bridgeIPs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine IPv4 physical IP of host: %v", err)
 		}
@@ -1414,7 +1414,7 @@ func commonFlows(bridge *bridgeConfiguration) ([]string, error) {
 				"actions=ct(commit,zone=%d,nat, table=1)", defaultOpenFlowCookie, ofPortPhys, config.Default.ConntrackZone))
 	}
 	if config.IPv6Mode {
-		physicalIP, err := util.MatchIPNetFamily(true, bridgeIPs)
+		physicalIP, err := util.MatchFirstIPNetFamily(true, bridgeIPs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine IPv6 physical IP of host: %v", err)
 		}

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -344,7 +344,7 @@ func (bnc *BaseNetworkController) addRoutesGatewayIP(pod *kapi.Pod, network *nad
 		case ovntypes.Layer3Topology:
 			for _, podIfAddr := range podAnnotation.IPs {
 				isIPv6 := utilnet.IsIPv6CIDR(podIfAddr)
-				nodeSubnet, err := util.MatchIPNetFamily(isIPv6, nodeSubnets)
+				nodeSubnet, err := util.MatchFirstIPNetFamily(isIPv6, nodeSubnets)
 				if err != nil {
 					return err
 				}
@@ -386,7 +386,7 @@ func (bnc *BaseNetworkController) addRoutesGatewayIP(pod *kapi.Pod, network *nad
 
 	for _, podIfAddr := range podAnnotation.IPs {
 		isIPv6 := utilnet.IsIPv6CIDR(podIfAddr)
-		nodeSubnet, err := util.MatchIPNetFamily(isIPv6, nodeSubnets)
+		nodeSubnet, err := util.MatchFirstIPNetFamily(isIPv6, nodeSubnets)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -525,7 +525,6 @@ func (oc *DefaultNetworkController) addGWRoutesForPod(gateways []*gatewayInfo, p
 }
 
 // buildPodSNAT builds per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
-// if allSNATs flag is set, then all the SNATs (including against egressIPs if any) for that pod will be returned
 func buildPodSNAT(extIPs, podIPNets []*net.IPNet) ([]*nbdb.NAT, error) {
 	nats := make([]*nbdb.NAT, 0, len(extIPs)*len(podIPNets))
 	var nat *nbdb.NAT
@@ -568,21 +567,35 @@ func getExternalIPsGR(watchFactory *factory.WatchFactory, nodeName string) ([]*n
 }
 
 // deletePodSNAT removes per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
-// if allSNATs flag is set, then all the SNATs (including against egressIPs if any) for that pod will be deleted
 // used when disableSNATMultipleGWs=true
 func deletePodSNAT(nbClient libovsdbclient.Client, nodeName string, extIPs, podIPNets []*net.IPNet) error {
-	nats, err := buildPodSNAT(extIPs, podIPNets)
+	ops, err := deletePodSNATOps(nbClient, nil, nodeName, extIPs, podIPNets)
 	if err != nil {
 		return err
+	}
+
+	_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+	if err != nil {
+		return fmt.Errorf("failed to delete SNAT rule for pod on gateway router %s: %w", types.GWRouterPrefix+nodeName, err)
+	}
+	return nil
+}
+
+// deletePodSNATOps creates ovsdb operation that removes per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
+// used when disableSNATMultipleGWs=true
+func deletePodSNATOps(nbClient libovsdbclient.Client, ops []ovsdb.Operation, nodeName string, extIPs, podIPNets []*net.IPNet) ([]ovsdb.Operation, error) {
+	nats, err := buildPodSNAT(extIPs, podIPNets)
+	if err != nil {
+		return nil, err
 	}
 	logicalRouter := nbdb.LogicalRouter{
 		Name: types.GWRouterPrefix + nodeName,
 	}
-	err = libovsdbops.DeleteNATs(nbClient, &logicalRouter, nats...)
+	ops, err = libovsdbops.DeleteNATsOps(nbClient, ops, &logicalRouter, nats...)
 	if err != nil {
-		return fmt.Errorf("failed to delete SNAT rule for pod on gateway router %s: %v", logicalRouter.Name, err)
+		return nil, fmt.Errorf("failed create operation for deleting SNAT rule for pod on gateway router %s: %v", logicalRouter.Name, err)
 	}
-	return nil
+	return ops, nil
 }
 
 // addOrUpdatePodSNAT adds or updates per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides
@@ -601,17 +614,17 @@ func addOrUpdatePodSNAT(nbClient libovsdbclient.Client, nodeName string, extIPs,
 	return nil
 }
 
-// addOrUpdatePodSNATReturnOps returns the operation that adds or updates per pod SNAT rules towards the nodeIP that are
+// addOrUpdatePodSNATOps returns the operation that adds or updates per pod SNAT rules towards the nodeIP that are
 // applied to the GR where the pod resides
 // used when disableSNATMultipleGWs=true
-func (oc *DefaultNetworkController) addOrUpdatePodSNATReturnOps(nodeName string, extIPs, podIfAddrs []*net.IPNet, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
+func addOrUpdatePodSNATOps(nbClient libovsdbclient.Client, nodeName string, extIPs, podIfAddrs []*net.IPNet, ops []ovsdb.Operation) ([]ovsdb.Operation, error) {
 	gr := types.GWRouterPrefix + nodeName
 	router := &nbdb.LogicalRouter{Name: gr}
 	nats, err := buildPodSNAT(extIPs, podIfAddrs)
 	if err != nil {
 		return nil, err
 	}
-	if ops, err = libovsdbops.CreateOrUpdateNATsOps(oc.nbClient, ops, router, nats...); err != nil {
+	if ops, err = libovsdbops.CreateOrUpdateNATsOps(nbClient, ops, router, nats...); err != nil {
 		return nil, fmt.Errorf("failed to update SNAT for pods of router: %s, error: %v", gr, err)
 	}
 	return ops, nil

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -649,7 +649,7 @@ func (oc *DefaultNetworkController) addHybridRoutePolicyForPod(podIP net.IP, nod
 		if err != nil {
 			return fmt.Errorf("unable to find IP address for node: %s, %s port, err: %v", node, types.GWRouterToJoinSwitchPrefix, err)
 		}
-		grJoinIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6(podIP), grJoinIfAddrs)
+		grJoinIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(podIP), grJoinIfAddrs)
 		if err != nil {
 			return fmt.Errorf("failed to match gateway router join interface IPs: %v, err: %v", grJoinIfAddr, err)
 		}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -2365,7 +2365,7 @@ func (e *egressIPController) getGatewayRouterJoinIP(node string, wantsIPv6 bool)
 	if err != nil {
 		return nil, fmt.Errorf("attempt at finding node gateway router network information failed, err: %w", err)
 	}
-	if gatewayIP, err := util.MatchIPNetFamily(wantsIPv6, gatewayIPs); err != nil {
+	if gatewayIP, err := util.MatchFirstIPNetFamily(wantsIPv6, gatewayIPs); err != nil {
 		return nil, fmt.Errorf("could not find node %s gateway router: %v", node, err)
 	} else {
 		return gatewayIP.IP, nil

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -202,7 +202,7 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 	}
 
 	for _, entry := range clusterIPSubnet {
-		drLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(entry), drLRPIfAddrs)
+		drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(entry), drLRPIfAddrs)
 		if err != nil {
 			return fmt.Errorf("failed to add a static route in GR %s with distributed "+
 				"router as the nexthop: %v",

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -102,7 +102,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		} else {
 			hasIPv4 = true
 		}
-		nexthop, _ := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(subnet), defLRPIPs)
+		nexthop, _ := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(subnet), defLRPIPs)
 		grStaticRouteNamedUUID := fmt.Sprintf("static-subnet-route-%v-UUID", i)
 		grStaticRoutes = append(grStaticRoutes, grStaticRouteNamedUUID)
 		testData = append(testData, &nbdb.LogicalRouterStaticRoute{
@@ -114,7 +114,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 	}
 	if config.Gateway.Mode == config.GatewayModeShared {
 		for i, hostSubnet := range hostSubnets {
-			joinLRPIP, _ := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hostSubnet), joinLRPIPs)
+			joinLRPIP, _ := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(hostSubnet), joinLRPIPs)
 			ocrStaticRouteNamedUUID := fmt.Sprintf("subnet-static-route-ovn-cluster-router-%v-UUID", i)
 			expectedOVNClusterRouter.StaticRoutes = append(expectedOVNClusterRouter.StaticRoutes, ocrStaticRouteNamedUUID)
 			testData = append(testData, &nbdb.LogicalRouterStaticRoute{
@@ -200,7 +200,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		for i, subnet := range clusterIPSubnets {
 			natUUID := fmt.Sprintf("nat-%d-UUID", i)
 			natUUIDs = append(natUUIDs, natUUID)
-			physicalIP, _ := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(subnet), l3GatewayConfig.IPAddresses)
+			physicalIP, _ := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(subnet), l3GatewayConfig.IPAddresses)
 			testData = append(testData, &nbdb.NAT{
 				UUID:       natUUID,
 				ExternalIP: physicalIP.IP.String(),

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -238,7 +238,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 			if err != nil {
 				return err
 			}
-			gwLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), gwLRPIfAddrs)
+			gwLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), gwLRPIfAddrs)
 			if err != nil {
 				return err
 			}
@@ -289,7 +289,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 			if err != nil {
 				return err
 			}
-			drLRPIfAddr, err := util.MatchIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), drLRPIfAddrs)
+			drLRPIfAddr, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6CIDR(hybridCIDR), drLRPIfAddrs)
 			if err != nil {
 				return fmt.Errorf("failed to match cluster router join interface IPs: %v, err: %v", drLRPIfAddr, err)
 			}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -313,7 +313,7 @@ func (oc *DefaultNetworkController) syncGatewayLogicalNetwork(node *kapi.Node, l
 
 	for _, subnet := range hostSubnets {
 		hostIfAddr := util.GetNodeManagementIfAddr(subnet)
-		l3GatewayConfigIP, err := util.MatchIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
+		l3GatewayConfigIP, err := util.MatchFirstIPNetFamily(utilnet.IsIPv6(hostIfAddr.IP), l3GatewayConfig.IPAddresses)
 		if err != nil {
 			return err
 		}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -210,7 +210,7 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 		// namespace annotations to go through external egress router
 		if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
 			return err
-		} else if ops, err = oc.addOrUpdatePodSNATReturnOps(pod.Spec.NodeName, extIPs, podAnnotation.IPs, ops); err != nil {
+		} else if ops, err = addOrUpdatePodSNATOps(oc.nbClient, pod.Spec.NodeName, extIPs, podAnnotation.IPs, ops); err != nil {
 			return err
 		}
 	}

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -251,9 +251,9 @@ func MatchFirstIPFamily(isIPv6 bool, ips []net.IP) (net.IP, error) {
 	return nil, fmt.Errorf("no %s IP available", IPFamilyName(isIPv6))
 }
 
-// MatchIPNetFamily loops through the array of *net.IPNet and returns the
+// MatchFirstIPNetFamily loops through the array of ipnets and returns the
 // first entry in the list in the same IP Family, based on input flag isIPv6.
-func MatchIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) (*net.IPNet, error) {
+func MatchFirstIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) (*net.IPNet, error) {
 	for _, ipnet := range ipnets {
 		if utilnet.IsIPv6CIDR(ipnet) == isIPv6 {
 			return ipnet, nil

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -262,6 +262,18 @@ func MatchFirstIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) (*net.IPNet, error)
 	return nil, fmt.Errorf("no %s value available", IPFamilyName(isIPv6))
 }
 
+// MatchAllIPNetFamily loops through the array of *net.IPNet and returns a
+// slice of ipnets with the same IP Family, based on input flag isIPv6.
+func MatchAllIPNetFamily(isIPv6 bool, ipnets []*net.IPNet) []*net.IPNet {
+	var ret []*net.IPNet
+	for _, ipnet := range ipnets {
+		if utilnet.IsIPv6CIDR(ipnet) == isIPv6 {
+			ret = append(ret, ipnet)
+		}
+	}
+	return ret
+}
+
 // MatchIPStringFamily loops through the array of string and returns the
 // first entry in the list in the same IP Family, based on input flag isIPv6.
 func MatchIPStringFamily(isIPv6 bool, ipStrings []string) (string, error) {

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -281,7 +281,7 @@ func TestMatchIPFamily(t *testing.T) {
 	}
 }
 
-func TestMatchIPNetFamily(t *testing.T) {
+func TestMatchFirstIPNetFamily(t *testing.T) {
 	tests := []struct {
 		desc       string
 		inpIsIPv6  bool // true matches with IPv6 and false with IPv4
@@ -321,7 +321,7 @@ func TestMatchIPNetFamily(t *testing.T) {
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
-			res, err := MatchIPNetFamily(tc.inpIsIPv6, ovntest.MustParseIPNets(tc.inpSubnets...))
+			res, err := MatchFirstIPNetFamily(tc.inpIsIPv6, ovntest.MustParseIPNets(tc.inpSubnets...))
 			t.Log(res, err)
 			if tc.expected == "" {
 				assert.Error(t, err)

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -328,8 +328,8 @@ type primaryIfAddrAnnotation struct {
 
 // SetNodePrimaryIfAddr sets the IPv4 / IPv6 values of the node's primary network interface
 func SetNodePrimaryIfAddrs(nodeAnnotator kube.Annotator, ifAddrs []*net.IPNet) (err error) {
-	nodeIPNetv4, _ := MatchIPNetFamily(false, ifAddrs)
-	nodeIPNetv6, _ := MatchIPNetFamily(true, ifAddrs)
+	nodeIPNetv4, _ := MatchFirstIPNetFamily(false, ifAddrs)
+	nodeIPNetv6, _ := MatchFirstIPNetFamily(true, ifAddrs)
 
 	primaryIfAddrAnnotation := primaryIfAddrAnnotation{}
 	if nodeIPNetv4 != nil {


### PR DESCRIPTION
Refactor egress IP assignment so that all operations are done as a single libovsdb transaction.

Commit egress IP pod assignment as one transaction with the following ops:
 1. Add SNAT towards egress IP on egress gw router
 2. Add a router policy to forward pod traffic to the egress node
 3. Delete SNAT towards nodeIP(only if the egress node is the same as the pod host)

Commit egress IP pod assignment removal as one transaction with the following ops:
 1. Add SNAT towards nodeIP(only if the egress node is the same as the pod host)
 2. Remove router policy that forwards pod traffic to the egress node
 3. Remove SNAT towards egress IP from the egress node

NOTE: Unfortunately there is still a chance that the flow won't be configured when the packet arrives at the egress node but it is less likely to happen with the proposed change.

/cc @dceara 

Signed-off-by: Patryk Diak <pdiak@redhat.com>