### PR TITLE
Define NetworkControllerSpecificInterface

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -2,17 +2,28 @@ package ovn
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"time"
 
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 )
+
+// BaseSecondaryNetworkController structure holds per-network fields and network specific
+// configuration for secondary network controller
+type BaseSecondaryNetworkController struct {
+	BaseNetworkController
+}
 
 func (bsnc *BaseSecondaryNetworkController) getPortInfoForSecondaryNetwork(pod *kapi.Pod) map[string]*lpInfo {
 	if !util.PodWantsNetwork(pod) {
@@ -102,7 +113,7 @@ func (bsnc *BaseSecondaryNetworkController) ensurePodForSecondaryNetwork(pod *ka
 	}
 
 	// If a node does not have an assigned hostsubnet don't wait for the logical switch to appear
-	switchName, err := bsnc.getExpectedSwitchName(pod)
+	switchName, err := bsnc.GetExpectedSwitchName(pod)
 	if err != nil {
 		return err
 	}
@@ -265,4 +276,53 @@ func (bsnc *BaseSecondaryNetworkController) syncPodsForSecondaryNetwork(pods []i
 		}
 	}
 	return bsnc.deleteStaleLogicalSwitchPorts(expectedLogicalPorts)
+}
+
+func (bsnc *BaseSecondaryNetworkController) GetLogicalPortName(pod *kapi.Pod, nadName string) string {
+	return util.GetSecondaryNetworkLogicalPortName(pod.Namespace, pod.Name, nadName)
+}
+
+func (bsnc *BaseSecondaryNetworkController) AddConfigDurationRecord(kind, namespace, name string) (
+	[]ovsdb.Operation, func(), time.Time, error) {
+	// TBD: no op for secondary network for now
+	return []ovsdb.Operation{}, func() {}, time.Time{}, nil
+}
+
+func (bsnc *BaseSecondaryNetworkController) AddRoutesGatewayIP(pod *kapi.Pod, network *nadapi.NetworkSelectionElement,
+	podAnnotation *util.PodAnnotation, nodeSubnets []*net.IPNet) error {
+	topoType := bsnc.TopologyType()
+	if topoType != ovntypes.Layer3Topology {
+		return fmt.Errorf("topology type %s not supported", topoType)
+	}
+	// secondary layer3 network, see if its network-attachment's annotation has default-route key.
+	// If present, then we need to add default route for it
+	podAnnotation.Gateways = append(podAnnotation.Gateways, network.GatewayRequest...)
+	for _, podIfAddr := range podAnnotation.IPs {
+		isIPv6 := utilnet.IsIPv6CIDR(podIfAddr)
+		nodeSubnet, err := util.MatchIPNetFamily(isIPv6, nodeSubnets)
+		if err != nil {
+			return err
+		}
+		gatewayIPnet := util.GetNodeGatewayIfAddr(nodeSubnet)
+		layer3NetConfInfo := bsnc.NetConfInfo.(*util.Layer3NetConfInfo)
+		for _, clusterSubnet := range layer3NetConfInfo.ClusterSubnets {
+			if isIPv6 == utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
+				podAnnotation.Routes = append(podAnnotation.Routes, util.PodRoute{
+					Dest:    clusterSubnet.CIDR,
+					NextHop: gatewayIPnet.IP,
+				})
+			}
+		}
+	}
+	return nil
+}
+
+func (bsnc *BaseSecondaryNetworkController) GetExpectedSwitchName(pod *kapi.Pod) (string, error) {
+	topoType := bsnc.TopologyType()
+	switch topoType {
+	case ovntypes.Layer3Topology:
+		return bsnc.GetNetworkScopedName(pod.Spec.NodeName), nil
+	default:
+		return "", fmt.Errorf("topology type %s not supported", topoType)
+	}
 }

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	ocpcloudnetworkapi "github.com/openshift/api/cloudnetwork/v1"
+	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewall "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
@@ -490,6 +491,15 @@ func (oc *DefaultNetworkController) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (oc *DefaultNetworkController) GetLogicalPortName(pod *kapi.Pod, nadName string) string {
+	return util.GetLogicalPortName(pod.Namespace, pod.Name)
+}
+
+func (bnc *DefaultNetworkController) AddConfigDurationRecord(kind, namespace, name string) (
+	[]ovsdb.Operation, func(), time.Time, error) {
+	return metrics.GetConfigDurationRecorder().AddOVN(bnc.nbClient, kind, namespace, name)
 }
 
 type defaultNetworkControllerEventHandler struct {

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/ovn-org/libovsdb/ovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
@@ -13,9 +14,11 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+
 	kapi "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 )
 
 func (oc *DefaultNetworkController) syncPods(pods []interface{}) error {
@@ -245,4 +248,72 @@ func (oc *DefaultNetworkController) addLogicalPort(pod *kapi.Pod) (err error) {
 		metrics.RecordPodCreated(pod, oc.NetInfo)
 	}
 	return nil
+}
+
+func (oc *DefaultNetworkController) AddRoutesGatewayIP(pod *kapi.Pod, network *nadapi.NetworkSelectionElement,
+	podAnnotation *util.PodAnnotation, nodeSubnets []*net.IPNet) error {
+	// if there are other network attachments for the pod, then check if those network-attachment's
+	// annotation has default-route key. If present, then we need to skip adding default route for
+	// OVN interface
+	networks, err := util.GetK8sPodAllNetworks(pod)
+	if err != nil {
+		return fmt.Errorf("error while getting network attachment definition for [%s/%s]: %v",
+			pod.Namespace, pod.Name, err)
+	}
+	otherDefaultRouteV4 := false
+	otherDefaultRouteV6 := false
+	for _, network := range networks {
+		for _, gatewayRequest := range network.GatewayRequest {
+			if utilnet.IsIPv6(gatewayRequest) {
+				otherDefaultRouteV6 = true
+			} else {
+				otherDefaultRouteV4 = true
+			}
+		}
+	}
+
+	for _, podIfAddr := range podAnnotation.IPs {
+		isIPv6 := utilnet.IsIPv6CIDR(podIfAddr)
+		nodeSubnet, err := util.MatchIPNetFamily(isIPv6, nodeSubnets)
+		if err != nil {
+			return err
+		}
+
+		gatewayIPnet := util.GetNodeGatewayIfAddr(nodeSubnet)
+
+		otherDefaultRoute := otherDefaultRouteV4
+		if isIPv6 {
+			otherDefaultRoute = otherDefaultRouteV6
+		}
+		var gatewayIP net.IP
+		if otherDefaultRoute {
+			for _, clusterSubnet := range config.Default.ClusterSubnets {
+				if isIPv6 == utilnet.IsIPv6CIDR(clusterSubnet.CIDR) {
+					podAnnotation.Routes = append(podAnnotation.Routes, util.PodRoute{
+						Dest:    clusterSubnet.CIDR,
+						NextHop: gatewayIPnet.IP,
+					})
+				}
+			}
+			for _, serviceSubnet := range config.Kubernetes.ServiceCIDRs {
+				if isIPv6 == utilnet.IsIPv6CIDR(serviceSubnet) {
+					podAnnotation.Routes = append(podAnnotation.Routes, util.PodRoute{
+						Dest:    serviceSubnet,
+						NextHop: gatewayIPnet.IP,
+					})
+				}
+			}
+		} else {
+			gatewayIP = gatewayIPnet.IP
+		}
+
+		if gatewayIP != nil {
+			podAnnotation.Gateways = append(podAnnotation.Gateways, gatewayIP)
+		}
+	}
+	return nil
+}
+
+func (oc *DefaultNetworkController) GetExpectedSwitchName(pod *kapi.Pod) (string, error) {
+	return pod.Spec.NodeName, nil
 }


### PR DESCRIPTION
for functions that have different implementations based on the embedding type (these are the functions that had 2 separate branches with "if bnc.IsSecondary()" condition).
Move BaseSecondaryNetworkController definition to
base_network_controller_secondary.go

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>