### PR TITLE
Ensure routes are not duplicated

### DIFF
--- a/go-controller/pkg/config/utils.go
+++ b/go-controller/pkg/config/utils.go
@@ -226,3 +226,21 @@ func (cs *configSubnets) checkIPFamilies() (usingIPv4, usingIPv6 bool, err error
 
 	return false, false, fmt.Errorf("illegal network configuration: %s", netConfig)
 }
+
+func ContainsJoinIP(ip net.IP) bool {
+	var joinSubnetsConfig []string
+	if IPv4Mode {
+		joinSubnetsConfig = append(joinSubnetsConfig, Gateway.V4JoinSubnet)
+	}
+	if IPv6Mode {
+		joinSubnetsConfig = append(joinSubnetsConfig, Gateway.V6JoinSubnet)
+	}
+
+	for _, subnet := range joinSubnetsConfig {
+		_, joinSubnet, _ := net.ParseCIDR(subnet)
+		if joinSubnet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -700,6 +700,7 @@ func DeleteLogicalRouterStaticRoutes(nbClient libovsdbclient.Client, routerName 
 
 	opModels := make([]operationModel, 0, len(lrsrs)+1)
 	for _, lrsr := range lrsrs {
+		lrsr := lrsr
 		router.StaticRoutes = append(router.StaticRoutes, lrsr.UUID)
 		opModel := operationModel{
 			Model:       lrsr,

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -264,18 +264,23 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 
 			// Static route to steer packets from external to nodePort service backed by pods on hybrid overlay node.
 			// This route is to used for triggering above route policy
-			clutsterRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
+			clusterRouterStaticRoutes := nbdb.LogicalRouterStaticRoute{
 				IPPrefix: hybridCIDR.String(),
 				Nexthop:  drIP.String(),
 				ExternalIDs: map[string]string{
 					"name": ovntypes.HybridSubnetPrefix + nodeName,
 				},
 			}
-			if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, &clutsterRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
-				return item.IPPrefix == clutsterRouterStaticRoutes.IPPrefix && item.Nexthop == clutsterRouterStaticRoutes.Nexthop &&
-					item.ExternalIDs["name"] == clutsterRouterStaticRoutes.ExternalIDs["name"]
-			}); err != nil {
-				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", clutsterRouterStaticRoutes.IPPrefix, clutsterRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
+			if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
+				ovntypes.OVNClusterRouter, &clusterRouterStaticRoutes,
+				func(item *nbdb.LogicalRouterStaticRoute) bool {
+					return item.IPPrefix == clusterRouterStaticRoutes.IPPrefix &&
+						item.ExternalIDs["name"] == clusterRouterStaticRoutes.ExternalIDs["name"] &&
+						libovsdbops.PolicyEqualPredicate(clusterRouterStaticRoutes.Policy, item.Policy)
+				}, &clusterRouterStaticRoutes.Nexthop); err != nil {
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v",
+					clusterRouterStaticRoutes.IPPrefix, clusterRouterStaticRoutes.Nexthop,
+					ovntypes.GWRouterPrefix+nodeName, err)
 			}
 			klog.Infof("Created hybrid overlay logical route static route at cluster router for node %s", nodeName)
 
@@ -295,11 +300,16 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 					"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
 				},
 			}
-			if err := libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.GWRouterPrefix+nodeName, &nodeGWRouterStaticRoutes, func(item *nbdb.LogicalRouterStaticRoute) bool {
-				return item.IPPrefix == nodeGWRouterStaticRoutes.IPPrefix && item.Nexthop == nodeGWRouterStaticRoutes.Nexthop &&
-					item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"]
-			}); err != nil {
-				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v", nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop, ovntypes.GWRouterPrefix+nodeName, err)
+			if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
+				ovntypes.GWRouterPrefix+nodeName, &nodeGWRouterStaticRoutes,
+				func(item *nbdb.LogicalRouterStaticRoute) bool {
+					return item.IPPrefix == nodeGWRouterStaticRoutes.IPPrefix &&
+						item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"] &&
+						libovsdbops.PolicyEqualPredicate(nodeGWRouterStaticRoutes.Policy, item.Policy)
+				}, &nodeGWRouterStaticRoutes.Nexthop); err != nil {
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v",
+					nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop,
+					ovntypes.GWRouterPrefix+nodeName, err)
 			}
 			klog.Infof("Created hybrid overlay logical route static route at gateway router for node %s", nodeName)
 		}


### PR DESCRIPTION
There can be a case where multiple routes exist on ovn_cluster_router matching on the same IP prefix. For example:

            10.130.0.0/23                100.64.0.4 src-ip ecmp
            10.130.0.0/23                100.64.0.6 src-ip ecmp
            10.130.0.0/23                100.64.0.9 src-ip ecmp

In this case stale routes exist for old join subnet nexthops matching on
the same host subnet. OVN allows for these extra routes to be added and
considers them ecmp.

This commit modifies our behavior to ensure only a single route exists.
If more than one route for a predicate are found, the additional routes
are removed and then the leftover route is updated with the correct
fields.

A route is considered unique when it has the same prefix and policy type
(dst-ip vs src-ip) on the same router. The only case in OVNK where we
will allow more than one identical route is for ECMP routes with
multiple external gateways. In this case it is intended for a single
prefix to have multiple nexthops. Note, egressgw code uses its own
method to generate the ops for creating the routes.

Signed-off-by: Tim Rozet <trozet@redhat.com>

