### PR TITLE
spike, cni: use tap devices if kubevirt

### DIFF
--- a/go-controller/pkg/kubevirt/kubevirt.go
+++ b/go-controller/pkg/kubevirt/kubevirt.go
@@ -1,0 +1,17 @@
+package kubevirt
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func OwnsPod(ctx context.Context, kclient kubernetes.Interface, namespace, name string) (bool, error) {
+	pod, err := kclient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	_, ok := pod.Labels["kubevirt.io/vm"]
+	return ok, nil
+}


### PR DESCRIPTION
Problems:
- VMs has to route over the node they are running but if we live migrate with primary interface router then this is not going to happend
  - A solution would be to do a flow that answer that ARP with the mac of the LRP for the chassis the vm is runnig on or do some kind of proxy arp 