### PR TITLE
[poc]  kubevirt: Add hypershift requirements to primary interface

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -724,7 +724,7 @@ build_ovn_image() {
     echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
     OVN_REPO=https://github.com/qinqon/ovn 
     OVN_BRANCH=arp-proxy-additional-features
-    OVN_COMMIT=d1f985c68ffc1e83b5acc116c3111340ef7616bc
+    OVN_COMMIT=8b5383730c21155453ebc3a605e942ea7e2270e5
     OVN_DOCKERFILE=Dockerfile.fedora.dev
     $OCI_BIN build --build-arg OVN_REPO=${OVN_REPO} --build-arg OVN_BRANCH=${OVN_BRANCH} --build-arg=OVN_COMMIT=${OVN_COMMIT} -t "${OVN_IMAGE}" -f  ${OVN_DOCKERFILE} .
 

--- a/dist/images/Dockerfile.fedora.dev
+++ b/dist/images/Dockerfile.fedora.dev
@@ -28,7 +28,9 @@ RUN INSTALL_PKGS=" \
     python3-openvswitch python3-pyOpenSSL \
     autoconf automake libtool g++ gcc fedora-packager rpmdevtools \
     unbound unbound-devel groff python3-sphinx graphviz openssl openssl-devel \
-    checkpolicy libcap-ng-devel selinux-policy-devel" && \
+    checkpolicy libcap-ng-devel selinux-policy-devel \
+    libbpf-devel libxdp-devel numactl-devel" && \
+
     dnf install --best --refresh -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     dnf clean all && rm -rf /var/cache/dnf/*
 
@@ -50,8 +52,10 @@ RUN git log -n 1
 # Clone OVN Source Code.
 ARG OVN_REPO=https://github.com/ovn-org/ovn.git
 ARG OVN_BRANCH=main
+ARG OVN_COMMIT=HEAD
 WORKDIR /root
-RUN git clone $OVN_REPO --single-branch --branch=$OVN_BRANCH
+RUN git clone $OVN_REPO --single-branch --branch=$OVN_BRANCH && \
+    cd ovn && git reset --hard $OVN_COMMIT
 
 # Build OVN rpms.
 WORKDIR /root/ovn/

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -18,6 +18,7 @@ ifeq ($(ARCH),arm64)
         DOCKERFILE_ARCH=.arm64
 endif
 OVS_BRANCH ?= master
+OVN_REPO ?= https://github.com/ovn-org/ovn
 OVN_BRANCH ?= main
 OCI_BIN ?= docker
 
@@ -42,6 +43,7 @@ fedora: bld
 fedora-dev: bld
 	${OCI_BIN} build \
 		     --build-arg OVS_BRANCH=$(OVS_BRANCH) \
+		     --build-arg OVN_REPO=$(OVN_REPO) \
 		     --build-arg OVN_BRANCH=$(OVN_BRANCH) \
 		     -t ovn-kube-f-dev -f Dockerfile.fedora.dev .
 	# ${OCI_BIN} login -u ovnkube docker.io/ovnkube

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -92,6 +92,9 @@ while [ "$1" != "" ]; do
   --image)
     OVN_IMAGE=$VALUE
     ;;
+  --ovnkube-image)
+    OVNKUBE_IMAGE=$VALUE
+    ;;
   --image-pull-policy)
     OVN_IMAGE_PULL_POLICY=$VALUE
     ;;
@@ -291,6 +294,9 @@ echo "output_dir: $output_dir"
 image=${OVN_IMAGE:-"docker.io/ovnkube/ovn-daemonset:latest"}
 echo "image: ${image}"
 
+ovnkube_image=${OVNKUBE_IMAGE:-${image}}
+echo "ovnkube_image: ${ovnkube_image}"
+
 image_pull_policy=${OVN_IMAGE_PULL_POLICY:-"IfNotPresent"}
 echo "imagePullPolicy: ${image_pull_policy}"
 
@@ -406,7 +412,7 @@ echo "ovnkube_node_mgmt_port_netdev: ${ovnkube_node_mgmt_port_netdev}"
 ovnkube_config_duration_enable=${OVNKUBE_CONFIG_DURATION_ENABLE}
 echo "ovnkube_config_duration_enable: ${ovnkube_config_duration_enable}"
 
-ovn_image=${image} \
+ovn_image=${ovnkube_image} \
   ovn_image_pull_policy=${image_pull_policy} \
   ovn_unprivileged_mode=${ovn_unprivileged_mode} \
   ovn_gateway_mode=${ovn_gateway_mode} \
@@ -478,7 +484,7 @@ ovn_image=${image} \
   ovnkube_app_name=ovnkube-node-dpu-host \
   j2 ../templates/ovnkube-node.yaml.j2 -o ${output_dir}/ovnkube-node-dpu-host.yaml
 
-ovn_image=${image} \
+ovn_image=${ovnkube_image} \
   ovn_image_pull_policy=${image_pull_policy} \
   ovnkube_master_loglevel=${master_loglevel} \
   ovn_loglevel_northd=${ovn_loglevel_northd} \

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -134,6 +134,7 @@ usage: kind.sh [[[-cf |--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]
 -cl  | --ovn-loglevel-controller    Log config for ovn-controller DEFAULT: '-vconsole:info'.
 -ep  | --experimental-provider      Use an experimental OCI provider such as podman, instead of docker. DEFAULT: Disabled.
 -eb  | --egress-gw-separate-bridge  The external gateway traffic uses a separate bridge.
+-lr  |--local-kind-registry         Will start and connect a kind local registry to push/retrieve images
 --delete                      	    Delete current cluster
 ```
 

--- a/go-controller/pkg/cni/helper_linux_test.go
+++ b/go-controller/pkg/cni/helper_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
+	kapi "k8s.io/api/core/v1"
 )
 
 func TestRenameLink(t *testing.T) {
@@ -323,7 +324,7 @@ func TestSetupNetwork(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockLink.Mock, tc.linkMockHelper)
 			ovntest.ProcessMockFnList(&mockCNIPlugin.Mock, tc.cniPluginMockHelper)
 
-			err := setupNetwork(tc.inpLink, tc.inpPodIfaceInfo)
+			err := setupNetwork(tc.inpLink, tc.inpPodIfaceInfo, &kapi.Pod{})
 			t.Log(err)
 			if tc.errMatch != nil {
 				assert.Contains(t, err.Error(), tc.errMatch.Error())
@@ -402,7 +403,7 @@ func TestSetupInterface(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockCNIPlugin.Mock, tc.cniPluginMockHelper)
 			ovntest.ProcessMockFnList(&mockNS.Mock, tc.nsMockHelper)
 
-			hostIface, contIface, err := setupInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo)
+			hostIface, contIface, err := setupInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo, nil)
 			t.Log(hostIface, contIface, err)
 			if tc.errExp {
 				assert.NotNil(t, err)
@@ -1064,7 +1065,7 @@ func TestSetupSriovInterface(t *testing.T) {
 			ovntest.ProcessMockFnList(&mockLink.Mock, tc.linkMockHelper)
 			netNsDoError = nil
 
-			hostIface, contIface, err := setupSriovInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo, tc.inpPCIAddrs)
+			hostIface, contIface, err := setupSriovInterface(tc.inpNetNS, tc.inpContID, tc.inpIfaceName, tc.inpPodIfaceInfo, tc.inpPCIAddrs, &kapi.Pod{})
 			t.Log(hostIface, contIface, err)
 			if err == nil {
 				err = netNsDoError

--- a/go-controller/pkg/dhcp/dhcp.go
+++ b/go-controller/pkg/dhcp/dhcp.go
@@ -1,0 +1,47 @@
+package dhcp
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+func ComposeOptionsWithKubeDNS(k8scli clientset.Interface, hostname string, cidr string, router string) (*nbdb.DHCPOptions, error) {
+	dnsServer, err := kubeDNSNameServer(k8scli)
+	if err != nil {
+		return nil, err
+	}
+
+	dhcpOptions := nbdb.DHCPOptions{
+		Cidr: cidr,
+		Options: map[string]string{
+			"lease_time": "3500", /*TODO: Configure it*/
+			"router":     router,
+			"dns_server": dnsServer,
+			"server_id":  router,
+			"server_mac": "c0:ff:ee:00:00:01", /*TODO: Generate it*/
+			"hostname":   fmt.Sprintf("%q", hostname),
+		},
+	}
+
+	return &dhcpOptions, nil
+}
+
+func kubeDNSNameServer(cli clientset.Interface) (string, error) {
+	svc, err := cli.CoreV1().Services("kube-system").Get(context.Background(), "kube-dns", metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return "", err
+		}
+		svc, err = cli.CoreV1().Services("openshift-dns").Get(context.Background(), "dns-default", metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+	}
+	return svc.Spec.ClusterIP, nil
+}

--- a/go-controller/pkg/kubevirt/kubevirt.go
+++ b/go-controller/pkg/kubevirt/kubevirt.go
@@ -16,6 +16,7 @@ const (
 	NodeNameLabel                                = "kubevirt.io/nodeName"
 	IPPoolNameAnnotation                         = "kubevirt.io/ipPoolName"
 	AllowPodBridgeNetworkLiveMigrationAnnotation = "kubevirt.io/allow-pod-bridge-network-live-migration"
+	MigrationTargetStartTimestampAnnotation      = "kubevirt.io/migration-target-start-timestamp"
 )
 
 type IPConfig struct {

--- a/go-controller/pkg/kubevirt/kubevirt.go
+++ b/go-controller/pkg/kubevirt/kubevirt.go
@@ -1,0 +1,90 @@
+package kubevirt
+
+import (
+	"context"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+const (
+	VMLabel                                      = "kubevirt.io/vm"
+	NodeNameLabel                                = "kubevirt.io/nodeName"
+	IPPoolNameAnnotation                         = "kubevirt.io/ipPoolName"
+	AllowPodBridgeNetworkLiveMigrationAnnotation = "kubevirt.io/allow-pod-bridge-network-live-migration"
+)
+
+type IPConfig struct {
+	PoolName   string
+	Annotation string
+}
+
+func AllowPodBridgeNetworkLiveMigration(pod *kapi.Pod) bool {
+	_, ok := pod.Annotations[AllowPodBridgeNetworkLiveMigrationAnnotation]
+	return ok
+}
+
+// PodIsLiveMigrationLeftOver return true if there is a another virt-launcher
+// pod for this VM but with newer creation time then this pod is a leftover
+func PodIsLiveMigrationLeftOver(client clientset.Interface, pod *kapi.Pod) (bool, error) {
+	vmPods, err := FindPodsByVMLabel(client, pod)
+	if err != nil {
+		return false, err
+	}
+
+	for _, vmPod := range vmPods {
+		if vmPod.CreationTimestamp.After(pod.CreationTimestamp.Time) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// PodOnLiveMigration return true if there are multiple pods referening
+// the VM from the pod arg, meaning that the vm is on live migration
+func PodOnLiveMigration(client clientset.Interface, pod *kapi.Pod) (bool, error) {
+	vmPods, err := FindPodsByVMLabel(client, pod)
+	if err != nil {
+		return false, err
+	}
+	return len(vmPods) > 1, nil
+}
+
+func FindPodsByVMLabel(client clientset.Interface, pod *kapi.Pod) ([]kapi.Pod, error) {
+	vmName, ok := pod.Labels[VMLabel]
+	if !ok {
+		return []kapi.Pod{}, nil
+	}
+	matchVMLabel := labels.Set{VMLabel: vmName}
+	vmPods, err := client.CoreV1().Pods(pod.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: matchVMLabel.String()})
+	if err != nil {
+		return []kapi.Pod{}, err
+	}
+	return vmPods.Items, nil
+}
+
+func FindIPConfigByVMLabel(client clientset.Interface, pod *kapi.Pod) (IPConfig, error) {
+	vmPods, err := FindPodsByVMLabel(client, pod)
+	if err != nil {
+		return IPConfig{}, err
+	}
+	ipConfig := IPConfig{
+		PoolName: pod.Spec.NodeName,
+	}
+	for _, vmPod := range vmPods {
+		ipPoolName, ok := vmPod.Annotations[IPPoolNameAnnotation]
+		if ok {
+			ipConfig.PoolName = ipPoolName
+		}
+		ipAnnotation, ok := vmPod.Annotations[util.OvnPodAnnotationName]
+		if ok {
+			ipConfig.Annotation = ipAnnotation
+		}
+	}
+	return ipConfig, nil
+}

--- a/go-controller/pkg/libovsdbops/dhcp.go
+++ b/go-controller/pkg/libovsdbops/dhcp.go
@@ -1,0 +1,55 @@
+package libovsdbops
+
+import (
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+)
+
+type dhcpOptionsPredicate func(*nbdb.DHCPOptions) bool
+
+func CreateOrUpdateDhcpv4OptionsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, lsp *nbdb.LogicalSwitchPort, dhcpOptions *nbdb.DHCPOptions) ([]libovsdb.Operation, error) {
+	opModels := []operationModel{}
+	opModel := operationModel{
+		Model:          dhcpOptions,
+		ModelPredicate: func(item *nbdb.DHCPOptions) bool { return item.Cidr == dhcpOptions.Cidr },
+		OnModelUpdates: onModelUpdatesAllNonDefault(),
+		DoAfter:        func() { lsp.Dhcpv4Options = &dhcpOptions.UUID },
+		ErrNotFound:    false,
+		BulkOp:         false,
+	}
+	opModels = append(opModels, opModel)
+	opModel = operationModel{
+		Model:          lsp,
+		ModelPredicate: func(item *nbdb.LogicalSwitchPort) bool { return item.Name == lsp.Name },
+		OnModelUpdates: onModelUpdatesAllNonDefault(),
+		ErrNotFound:    true,
+		BulkOp:         false,
+	}
+	opModels = append(opModels, opModel)
+
+	m := newModelClient(nbClient)
+	return m.CreateOrUpdateOps(ops, opModels...)
+}
+
+func CreateOrUpdateDhcpv4Options(nbClient libovsdbclient.Client, lsp *nbdb.LogicalSwitchPort, dhcpOptions *nbdb.DHCPOptions) error {
+	ops, err := CreateOrUpdateDhcpv4OptionsOps(nbClient, nil, lsp, dhcpOptions)
+	if err != nil {
+		return err
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
+}
+
+func DeleteDHCPOptionsWithPredicate(nbClient libovsdbclient.Client, p dhcpOptionsPredicate) error {
+	opModel := operationModel{
+		Model:          &nbdb.DHCPOptions{},
+		ModelPredicate: p,
+		ErrNotFound:    false,
+		BulkOp:         true,
+	}
+
+	m := newModelClient(nbClient)
+	return m.Delete(opModel)
+
+}

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -62,6 +62,8 @@ func getUUID(model model.Model) string {
 		return t.UUID
 	case *nbdb.QoS:
 		return t.UUID
+	case *nbdb.DHCPOptions:
+		return t.UUID
 	default:
 		panic(fmt.Sprintf("getUUID: unknown model %T", t))
 	}
@@ -116,6 +118,8 @@ func setUUID(model model.Model, uuid string) {
 	case *sbdb.SBGlobal:
 		t.UUID = uuid
 	case *nbdb.QoS:
+		t.UUID = uuid
+	case *nbdb.DHCPOptions:
 		t.UUID = uuid
 	default:
 		panic(fmt.Sprintf("setUUID: unknown model %T", t))
@@ -234,6 +238,10 @@ func copyIndexes(model model.Model) model.Model {
 		return &nbdb.QoS{
 			UUID: t.UUID,
 		}
+	case *nbdb.DHCPOptions:
+		return &nbdb.DHCPOptions{
+			UUID: t.UUID,
+		}
 	default:
 		panic(fmt.Sprintf("copyIndexes: unknown model %T", t))
 	}
@@ -287,6 +295,8 @@ func getListFromModel(model model.Model) interface{} {
 		return &[]*sbdb.MACBinding{}
 	case *nbdb.QoS:
 		return &[]nbdb.QoS{}
+	case *nbdb.DHCPOptions:
+		return &[]nbdb.DHCPOptions{}
 	default:
 		panic(fmt.Sprintf("getModelList: unknown model %T", t))
 	}
@@ -408,6 +418,8 @@ func getAllUpdatableFields(model model.Model) []interface{} {
 		return []interface{}{&t.Addresses, &t.Type, &t.TagRequest, &t.Options, &t.PortSecurity}
 	case *nbdb.PortGroup:
 		return []interface{}{&t.ACLs, &t.Ports, &t.ExternalIDs}
+	case *nbdb.DHCPOptions:
+		return []interface{}{&t.Cidr, &t.Options, &t.ExternalIDs}
 	default:
 		panic(fmt.Sprintf("getAllUpdatableFields: unknown model %T", t))
 	}

--- a/go-controller/pkg/node/base_node_network_controller_dpu.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu.go
@@ -165,7 +165,7 @@ func (bnnc *BaseNodeNetworkController) addRepPort(pod *kapi.Pod, vfRepName strin
 		return fmt.Errorf("failed to get dpu annotation. %v", err)
 	}
 
-	err = cni.ConfigureOVS(context.TODO(), pod.Namespace, pod.Name, vfRepName, ifInfo, dpuCD.SandboxId, getter)
+	err = cni.ConfigureOVS(context.TODO(), pod, vfRepName, ifInfo, dpuCD.SandboxId, getter)
 	if err != nil {
 		// Note(adrianc): we are lenient with cleanup in this method as pod is going to be retried anyway.
 		_ = bnnc.delRepPort(vfRepName)

--- a/go-controller/pkg/ovn/kubevirt.go
+++ b/go-controller/pkg/ovn/kubevirt.go
@@ -1,0 +1,178 @@
+package ovn
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/dhcp"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kubevirt"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	kapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (oc *DefaultNetworkController) addDHCPOptions(pod *kapi.Pod, lsp *nbdb.LogicalSwitchPort) error {
+	ipPoolName, err := oc.getIPPoolName(pod)
+	if err != nil {
+		return err
+	}
+	var switchSubnets []*net.IPNet
+	if switchSubnets = oc.lsManager.GetSwitchSubnets(ipPoolName); switchSubnets == nil {
+		return fmt.Errorf("cannot retrieve subnet for assigning gateway routes switch: %s", ipPoolName)
+	}
+	// Fake router to delegate on proxy arp mechanism
+	router := arpProxyAddress
+	cidr := switchSubnets[0].String()
+	hostname := pod.Labels[kubevirt.VMLabel]
+	dhcpOptions, err := dhcp.ComposeOptionsWithKubeDNS(oc.client, hostname, cidr, router)
+	if err != nil {
+		return fmt.Errorf("failed composing DHCP options: %v", err)
+	}
+	dhcpOptions.ExternalIDs = map[string]string{
+		"namespace":      pod.Namespace,
+		kubevirt.VMLabel: pod.Labels[kubevirt.VMLabel],
+	}
+	err = libovsdbops.CreateOrUpdateDhcpv4Options(oc.nbClient, lsp, dhcpOptions)
+	if err != nil {
+		return fmt.Errorf("failed adding ovn operations to add DHCP v4 options: %v", err)
+	}
+	return nil
+}
+
+func matchesKubevirtPod(pod *kapi.Pod, externalIDs map[string]string) bool {
+	return len(externalIDs) > 1 && externalIDs["namespace"] == pod.Namespace && externalIDs[kubevirt.VMLabel] == pod.Labels[kubevirt.VMLabel]
+}
+
+func (oc *DefaultNetworkController) deleteDHCPOptions(pod *kapi.Pod) error {
+	predicate := func(item *nbdb.DHCPOptions) bool {
+		return matchesKubevirtPod(pod, item.ExternalIDs)
+	}
+	return libovsdbops.DeleteDHCPOptionsWithPredicate(oc.nbClient, predicate)
+}
+
+func (oc *DefaultNetworkController) deletePodEnrouting(pod *kapi.Pod) error {
+	routePredicate := func(item *nbdb.LogicalRouterStaticRoute) bool {
+		return matchesKubevirtPod(pod, item.ExternalIDs)
+	}
+	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, types.OVNClusterRouter, routePredicate); err != nil {
+		return err
+	}
+	policyPredicate := func(item *nbdb.LogicalRouterPolicy) bool {
+		return matchesKubevirtPod(pod, item.ExternalIDs)
+	}
+	if err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, types.OVNClusterRouter, policyPredicate); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (oc *DefaultNetworkController) enroutePodAddressesToNode(pod *kapi.Pod) error {
+	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, "default")
+	if err != nil {
+		return err
+	}
+
+	nodeGwAddress, err := oc.lrpAddress(types.GWRouterToJoinSwitchPrefix + types.GWRouterPrefix + pod.Spec.NodeName)
+	if err != nil {
+		return err
+	}
+	for _, podIP := range podAnnotation.IPs {
+		podAddress := podIP.IP.String()
+		// Add a reroute policy to route VM n/s traffic to the node where the VM
+		// is running
+		egressPolicy := nbdb.LogicalRouterPolicy{
+			Match:    fmt.Sprintf("ip4.src == %s", podAddress),
+			Action:   nbdb.LogicalRouterPolicyActionReroute,
+			Nexthops: []string{nodeGwAddress},
+			Priority: 1,
+			ExternalIDs: map[string]string{
+				"namespace":      pod.Namespace,
+				kubevirt.VMLabel: pod.Labels[kubevirt.VMLabel],
+			},
+		}
+		if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(oc.nbClient, types.OVNClusterRouter, &egressPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
+			return item.Priority == egressPolicy.Priority && item.Match == egressPolicy.Match && item.Action == egressPolicy.Action
+		}); err != nil {
+			return err
+		}
+
+		// Add a policy to force send an ARP to discover VMs MAC and send
+		// directly to it since there is no more routers in the middle
+		outputPort := types.RouterToSwitchPrefix + pod.Spec.NodeName
+		ingressRoute := nbdb.LogicalRouterStaticRoute{
+			IPPrefix:   podAddress,
+			Nexthop:    podAddress,
+			Policy:     &nbdb.LogicalRouterStaticRoutePolicyDstIP,
+			OutputPort: &outputPort,
+			ExternalIDs: map[string]string{
+				"namespace":      pod.Namespace,
+				kubevirt.VMLabel: pod.Labels[kubevirt.VMLabel],
+			},
+		}
+		if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, types.OVNClusterRouter, &ingressRoute, func(item *nbdb.LogicalRouterStaticRoute) bool {
+			matches := item.IPPrefix == ingressRoute.IPPrefix && item.Nexthop == ingressRoute.Nexthop && item.Policy != nil && *item.Policy == *ingressRoute.Policy
+			return matches
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (oc *DefaultNetworkController) enrouteVirtualMachine(pod *kapi.Pod) error {
+	targetNode := pod.Labels[kubevirt.NodeNameLabel]
+	// There is no live migration or live migration has finished
+	if targetNode == "" || targetNode == pod.Spec.NodeName {
+		if err := oc.enroutePodAddressesToNode(pod); err != nil {
+			return fmt.Errorf("failed enroutePodAddressesToNode for  %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
+	}
+	return nil
+}
+
+func (oc *DefaultNetworkController) lrpAddress(lrpName string) (string, error) {
+	lrp := &nbdb.LogicalRouterPort{
+		Name: lrpName,
+	}
+
+	lrp, err := libovsdbops.GetLogicalRouterPort(oc.nbClient, lrp)
+	if err != nil {
+		return "", err
+	}
+	lrpIP, _, err := net.ParseCIDR(lrp.Networks[0])
+	if err != nil {
+		return "", err
+	}
+	address := lrpIP.String()
+	if address == "" {
+		return "", fmt.Errorf("missing logical router port address")
+	}
+	return address, nil
+}
+
+func (bnc *BaseNetworkController) syncKubevirtPodIPConfig(pod *kapi.Pod) error {
+	vmIPConfig, err := kubevirt.FindIPConfigByVMLabel(bnc.client, pod)
+	if err != nil {
+		return err
+	}
+	pod.Annotations[kubevirt.IPPoolNameAnnotation] = vmIPConfig.PoolName
+	if vmIPConfig.Annotation != "" {
+		pod.Annotations[util.OvnPodAnnotationName] = vmIPConfig.Annotation
+	}
+	if _, err := bnc.client.CoreV1().Pods(pod.Namespace).Update(context.Background(), pod, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (bnc *BaseNetworkController) getIPPoolName(pod *kapi.Pod) (string, error) {
+	ipPoolName, ok := pod.Annotations[kubevirt.IPPoolNameAnnotation]
+	if !ok {
+		return bnc.getExpectedSwitchName(pod)
+	}
+	return ipPoolName, nil
+}

--- a/go-controller/pkg/ovn/kubevirt.go
+++ b/go-controller/pkg/ovn/kubevirt.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 func (oc *DefaultNetworkController) addDHCPOptions(pod *kapi.Pod, lsp *nbdb.LogicalSwitchPort) error {
@@ -125,8 +126,10 @@ func (oc *DefaultNetworkController) enroutePodAddressesToNode(pod *kapi.Pod) err
 
 func (oc *DefaultNetworkController) enrouteVirtualMachine(pod *kapi.Pod) error {
 	targetNode := pod.Labels[kubevirt.NodeNameLabel]
-	// There is no live migration or live migration has finished
-	if targetNode == "" || targetNode == pod.Spec.NodeName {
+	targetStartTimestamp := pod.Annotations[kubevirt.MigrationTargetStartTimestampAnnotation]
+	klog.Infof("deleteme, enrouteVirtualMachine: %s", targetStartTimestamp)
+	// No live migration or target node was reached || qemu is already ready
+	if targetNode == pod.Spec.NodeName || targetStartTimestamp != "" {
 		if err := oc.enroutePodAddressesToNode(pod); err != nil {
 			return fmt.Errorf("failed enroutePodAddressesToNode for  %s/%s: %w", pod.Namespace, pod.Name, err)
 		}

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -309,6 +309,7 @@ func addNodeLogicalFlows(testData []libovsdbtest.TestData, expectedOVNClusterRou
 		UUID: types.SwitchToRouterPrefix + node.Name + "-UUID",
 		Type: "router",
 		Options: map[string]string{
+			"arp_proxy":   "0a:58:a9:fe:01:01 169.254.1.1",
 			"router-port": types.RouterToSwitchPrefix + node.Name,
 		},
 		Addresses: []string{"router"},


### PR DESCRIPTION
**- What this PR does and why is it needed**
This is a draft PR to implement features needed for hypershift hosted workers:
- seamless kubevirt live migration
  - stable IPs
  - stable connections
- east/west and north/south communication
- access to services

# TODO
- [x] Don't set ip config at veth if kubevirt
- [x] Configure DHCP options at LSP
- [x] Use proxy_arp option from router LSP https://github.com/ovn-org/ovn/commit/8087cbc74628e785250f8c09e43f5e0e361e453e
  - https://github.com/ovn-org/ovn/pull/176
- [x] Add /32 routes ovn_cluster_router
- [x] Use route instead of policy for inbound traffic to specify the port.
- [ ] Sometimes new connections are not possible after live migration looks like endpoint slices are not correctly updated
  - https://github.com/kubernetes/kubernetes/pull/115907
  - backport: https://github.com/kubernetes/kubernetes/pull/116084
- [ ] Investigate `net.netfilter.nf_conntrack_tcp_loose=1` for snat + live migration
- [ ] Check that forcing the mac to the VM ends at ovn-k
- [x] Cleanup
  - [x] policy
  - [x] routes
  - [x] dhcp-options
- [x] Test services
- [x] Test connectivity + live migration
  - with proxy arp + LRP shared mac address we have < 1 second disruption
- [ ] Test postcopy migraiton
  - Ther is a 10s downtime, point to point route is correctly updated when annotation appears but traffic is not working.
  - Ednpoint slice for the new virt-launcher are not ready and not serving until src virt-launcher is not Completed
  - Traffic goes back between route change and virt-launcher src completed, but not at route change.
  - When annotation appears the src virt-launcher is not able to manage traffic
  - Maybe traffic is still going to the src virt-launcher when it already does not accept it.
  - Adding unpaused condition to target virt-launcher decreased 3-4 seconds the downtime
- [ ] Test network policies 
- [ ] Test hypershift
- [ ] Use kubevirt PRs:
  - https://github.com/kubevirt/kubevirt/pull/9144
  - https://github.com/kubevirt/kubevirt/pull/9193
  - https://github.com/kubevirt/kubevirt/pull/9290
  - https://github.com/kubevirt/kubevirt/pull/9330
- [ ] Use hypershift PRs:
  - https://github.com/openshift/hypershift/pull/2244
- [x] Investigate multi requested-chassis feature for live migration
  - It only works when LSP is not moved, meaning it only work with distributed switch.
- [ ] Reverse on to new ovnkube-master controllers, cluster-manager and network-controller-manager

# openshift issues
## "kube-dns" not found`
problem getting dns server `addLogicalPort failed for cluster1/virt-launcher-worker1-chdqx: failed composing DHCP options: services "kube-dns" not found`

For the poc we just fallback to openshift one, but we shoiuld "mimic" what kubevirt dhcp server is doing and read for virt-launcher pod resolv.conf, this can be done by the CNI annotating the pod then ovnkube-master will use those to generate DHCP options.

## node-valid-hostname.service
```
Failed Units: 1
  node-valid-hostname.service
```

## cannot migrate VMI: PVC test1-k7m4b-rhcos is not shared
```
You are using a client virtctl version that is different from the KubeVirt version running in the cluster
Client Version: v0.58.0
Server Version: v0.59.0-rc.1-19-ga5e3a1b9b
Error migrating VirtualMachine Internal error occurred: admission webhook "migration-create-validator.kubevirt.io" denied the request: Cannot migrate VMI, Reason: DisksNotLiveMigratable, Message: cannot migrate VMI: PVC test1-k7m4b-rhcos is not shared, live migration requires that all PVCs must be shared (using ReadWriteMany access mode)
```

We have to use the patch from other hypershift pocs to change the mode


We have to pass "hostname" same as kubevirt DHCP server and set it with the vm name labels from virt-launcher pod.

Using "hostname" at DHCP options is causing problem with DHCP and the VM end up without IP address

hostname option has to be quoted

# Cannot connect after live-migration

Looks like the endpoint is referencing the old virt-launcher pod wich has the same ip address, removing old virt-launchers fix
the issue
```yaml
apiVersion: v1
kind: Endpoints
metadata:
  annotations:
    endpoints.kubernetes.io/last-change-trigger-time: "2023-02-16T14:24:00Z"
  creationTimestamp: "2023-02-16T14:17:08Z"
  name: ssh-test1-2ghnh
  namespace: clusters-test1
  resourceVersion: "220258"
  uid: c7d4a953-f876-40b9-bfa7-a1ce5d3e43d0
subsets:
- addresses:
  - ip: 10.129.2.25
    nodeName: worker-1
    targetRef:
      kind: Pod
      name: virt-launcher-test1-2ghnh-tkhsb
      namespace: clusters-test1
      uid: d779f8a5-ba16-4146-bb4d-0b489ffee47b
  notReadyAddresses:
  - ip: 10.129.2.25
    nodeName: worker-2
    targetRef:
      kind: Pod
      name: virt-launcher-test1-2ghnh-t2x28
      namespace: clusters-test1
      uid: 650dfac8-00af-4f3f-8c14-c40cc3feb778
  ports:
  - port: 22
    protocol: TCP
```

Sometime the notReadyAddress is not there, looks like ovn-k Recocnile bug that appears when both pods has the same IP

# Nice to have
- [ ] Investigate solutions for VM restart

# Capk demo
https://asciinema.org/a/hEqzoFveibsuHKynQxZ3RxCHZ

**- How to verify it**
This is verify with the umbrella project https://github.com/qinqon/ovn-kubevirt

Docs:
- [ovn + dhcp](https://blog.oddbit.com/post/2019-12-19-ovn-and-dhcp/)
- [Live migration](https://www.youtube.com/watch?v=ijZTMXAg-eI)
- [How to create an Open Virtual Network distributed gateway router](https://developers.redhat.com/blog/2018/11/08/how-to-create-an-open-virtual-network-distributed-gateway-router)
- http://www.openvswitch.org/support/boston2017/1150-ovn-gateways-ipv6.pdf
- [localnet](https://weiti.org/ovn/2018/01/03/ovn-l2-breakout-options.html)
- Load Balancer https://www.cnblogs.com/yaodd/p/7477848.html
- ovn-kuberntes lb:   -  https://github.com/ovn-org/ovn-kubernetes/blob/90d77b70b04530763ed2e8e91bf7a268a25caf42/go-controller/pkg/ovn/loadbalancer/loadbalancer.go#L42
