### PR TITLE
Fully remove dependency on default gateway for services

### DIFF
--- a/go-controller/pkg/ovn/gateway/gateway.go
+++ b/go-controller/pkg/ovn/gateway/gateway.go
@@ -61,8 +61,9 @@ func GetGatewayPhysicalIPs(nbClient libovsdbclient.Client, gatewayRouter string)
 	return nil, fmt.Errorf("no physical IPs found for gateway %s", gatewayRouter)
 }
 
-// CreateDummyGWMacBinding creates a mac binding for a fake next hop when a node has no default gateway
-func CreateDummyGWMacBinding(sbClient libovsdbclient.Client, nodeName string) error {
+// CreateDummyGWMacBindings creates mac bindings (ipv4 and ipv6) for a fake next hops
+// used by host->service traffic
+func CreateDummyGWMacBindings(sbClient libovsdbclient.Client, nodeName string) error {
 	for _, nextHop := range node.DummyNextHopIPs() {
 		dummyNextHopMAC := util.IPAddrToHWAddr(nextHop)
 		nodeGWRouter := util.GetGatewayRouterFromNode(nodeName)

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -264,10 +264,30 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 	externalRouterPort := types.GWRouterToExtSwitchPrefix + gatewayRouter
 
 	nextHops := l3GatewayConfig.NextHops
-	if len(l3GatewayConfig.NextHops) == 0 {
-		nextHops = node.DummyNextHopIPs()
-		if err := gateway.CreateDummyGWMacBinding(oc.sbClient, nodeName); err != nil {
-			return err
+
+	if err := gateway.CreateDummyGWMacBindings(oc.sbClient, nodeName); err != nil {
+		return err
+	}
+
+	for _, nextHop := range node.DummyNextHopIPs() {
+		// Add return service route for OVN back to host
+		prefix := types.V4MasqueradeSubnet
+		if utilnet.IsIPv6(nextHop) {
+			prefix = types.V6MasqueradeSubnet
+		}
+		lrsr := nbdb.LogicalRouterStaticRoute{
+			IPPrefix:   prefix,
+			Nexthop:    nextHop.String(),
+			OutputPort: &externalRouterPort,
+		}
+		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
+			return item.OutputPort != nil && *item.OutputPort == *lrsr.OutputPort && item.IPPrefix == lrsr.IPPrefix &&
+				libovsdbops.PolicyEqualPredicate(item.Policy, lrsr.Policy)
+		}
+		err = libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient, gatewayRouter, &lrsr, p,
+			&lrsr.Nexthop)
+		if err != nil {
+			return fmt.Errorf("error creating service static route %+v in GR %s: %v", lrsr, gatewayRouter, err)
 		}
 	}
 

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -33,9 +33,9 @@ func init() {
 	format.MaxLength = 0
 }
 
-func generateGatewayInitExpectedSB(testData []libovsdbtest.TestData, nodeName string, hasIPv4, hasIPv6 bool) []libovsdbtest.TestData {
+func generateGatewayInitExpectedSB(testData []libovsdbtest.TestData, nodeName string) []libovsdbtest.TestData {
 	gr := types.GWRouterPrefix + nodeName
-	if hasIPv4 {
+	if config.IPv4Mode {
 		testData = append(testData, &sbdb.MACBinding{
 			UUID:        "MAC-binding-UUID",
 			Datapath:    gr + "-UUID",
@@ -44,7 +44,7 @@ func generateGatewayInitExpectedSB(testData []libovsdbtest.TestData, nodeName st
 			MAC:         util.IPAddrToHWAddr(net.ParseIP(types.V4DummyNextHopMasqueradeIP)).String(),
 		})
 	}
-	if hasIPv6 {
+	if config.IPv6Mode {
 		testData = append(testData, &sbdb.MACBinding{
 			UUID:        "MAC-binding-2-UUID",
 			Datapath:    gr + "-UUID",
@@ -138,17 +138,30 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 		}
 	}
 
-	nexthops := l3GatewayConfig.NextHops
-	if len(nexthops) == 0 {
-		if hasIPv4 {
-			nexthops = append(nexthops, net.ParseIP(types.V4DummyNextHopMasqueradeIP))
-		}
-		if hasIPv6 {
-			nexthops = append(nexthops, net.ParseIP(types.V6DummyNextHopMasqueradeIP))
-		}
+	if hasIPv4 {
+		staticServiceRouteNamedUUID := "static-service-route-v4-UUID"
+		grStaticRoutes = append(grStaticRoutes, staticServiceRouteNamedUUID)
+
+		testData = append(testData, &nbdb.LogicalRouterStaticRoute{
+			UUID:       staticServiceRouteNamedUUID,
+			IPPrefix:   types.V4MasqueradeSubnet,
+			Nexthop:    types.V4DummyNextHopMasqueradeIP,
+			OutputPort: &externalRouterPort,
+		})
+	}
+	if hasIPv6 {
+		staticServiceRouteNamedUUID := "static-service-route-v6-UUID"
+		grStaticRoutes = append(grStaticRoutes, staticServiceRouteNamedUUID)
+
+		testData = append(testData, &nbdb.LogicalRouterStaticRoute{
+			UUID:       staticServiceRouteNamedUUID,
+			IPPrefix:   types.V6MasqueradeSubnet,
+			Nexthop:    types.V6DummyNextHopMasqueradeIP,
+			OutputPort: &externalRouterPort,
+		})
 	}
 
-	for i, nexthop := range nexthops {
+	for i, nexthop := range l3GatewayConfig.NextHops {
 		var allIPs string
 		if utilnet.IsIPv6(nexthop) {
 			allIPs = "::/0"
@@ -355,6 +368,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				UUID: types.ClusterLBGroupName + "-UUID",
 				Name: types.ClusterLBGroupName,
 			}
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					// tests migration from local to shared
@@ -366,6 +384,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedOVNClusterRouter,
 					expectedNodeSwitch,
 					expectedClusterLBGroup,
+				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
 				},
 			})
 
@@ -401,6 +422,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
 				"1400")
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+			testData = []libovsdb.TestData{datapath}
+			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName)
+			gomega.Eventually(fakeOvn.sbClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 		})
 
 		ginkgo.It("creates an IPv4 gateway in OVN without next hops", func() {
@@ -477,7 +502,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			testData = []libovsdb.TestData{datapath}
-			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName, true, false)
+			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName)
 			gomega.Eventually(fakeOvn.sbClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 		})
 
@@ -495,6 +520,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				UUID: types.ClusterLBGroupName + "-UUID",
 				Name: types.ClusterLBGroupName,
 			}
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -504,6 +534,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedOVNClusterRouter,
 					expectedNodeSwitch,
 					expectedClusterLBGroup,
+				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
 				},
 			})
 
@@ -551,6 +584,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
 				"1400")
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+			testData = []libovsdb.TestData{datapath}
+			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName)
+			gomega.Eventually(fakeOvn.sbClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 		})
 
 		ginkgo.It("creates an IPv6 gateway in OVN", func() {
@@ -566,6 +603,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				UUID: types.ClusterLBGroupName + "-UUID",
 				Name: types.ClusterLBGroupName,
 			}
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -576,13 +618,17 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedNodeSwitch,
 					expectedClusterLBGroup,
 				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
+				},
 			})
 
+			config.IPv4Mode = false
+			config.IPv6Mode = true
 			clusterIPSubnets := ovntest.MustParseIPNets("fd01::/48")
 			hostSubnets := ovntest.MustParseIPNets("fd01:0:0:2::/64")
 			joinLRPIPs := ovntest.MustParseIPNets("fd98::3/64")
 			defLRPIPs := ovntest.MustParseIPNets("fd98::1/64")
-			nodeName := "test-node"
 			l3GatewayConfig := &util.L3GatewayConfig{
 				Mode:           config.GatewayModeLocal,
 				ChassisID:      "SYSTEM-ID",
@@ -610,6 +656,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
 				"1400")
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+			testData = []libovsdb.TestData{datapath}
+			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName)
+			gomega.Eventually(fakeOvn.sbClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 		})
 
 		ginkgo.It("creates an IPv6 gateway in OVN without next hops", func() {
@@ -680,7 +730,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 			testData = []libovsdb.TestData{datapath}
-			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName, false, true)
+			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName)
 			gomega.Eventually(fakeOvn.sbClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 		})
 
@@ -697,6 +747,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				UUID: types.ClusterLBGroupName + "-UUID",
 				Name: types.ClusterLBGroupName,
 			}
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -707,8 +762,13 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedNodeSwitch,
 					expectedClusterLBGroup,
 				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
+				},
 			})
 
+			config.IPv4Mode = true
+			config.IPv6Mode = true
 			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14", "fd01::/48")
 			hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23", "fd01:0:0:2::/64")
 			joinLRPIPs := ovntest.MustParseIPNets("100.64.0.3/16", "fd98::3/64")
@@ -741,6 +801,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
 				"1400")
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+			testData = []libovsdb.TestData{datapath}
+			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName)
+			gomega.Eventually(fakeOvn.sbClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 		})
 
 		ginkgo.It("removes leftover SNAT entries during init", func() {
@@ -756,6 +820,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				UUID: types.ClusterLBGroupName + "-UUID",
 				Name: types.ClusterLBGroupName,
 			}
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -765,6 +834,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedOVNClusterRouter,
 					expectedNodeSwitch,
 					expectedClusterLBGroup,
+				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
 				},
 			})
 
@@ -801,6 +873,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
 				"1400")
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+			testData = []libovsdb.TestData{datapath}
+			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName)
+			gomega.Eventually(fakeOvn.sbClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 		})
 
 		ginkgo.It("ensures only a single static route per node for ovn_cluster_router", func() {
@@ -847,6 +923,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				UUID: types.ClusterLBGroupName + "-UUID",
 				Name: types.ClusterLBGroupName,
 			}
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -860,6 +941,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedOVNClusterRouter,
 					expectedNodeSwitch,
 					expectedClusterLBGroup,
+				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
 				},
 			})
 			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")
@@ -937,6 +1021,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				Name: types.ClusterLBGroupName,
 				UUID: types.ClusterLBGroupName + "-UUID",
 			}
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					// tests migration from shared to local
@@ -950,8 +1039,13 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedNodeSwitch,
 					expectedClusterLBGroup,
 				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
+				},
 			})
 
+			config.IPv4Mode = true
+			config.IPv6Mode = true
 			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14", "fd01::/48")
 			hostSubnets := ovntest.MustParseIPNets("10.130.0.0/23", "fd01:0:0:2::/64")
 			joinLRPIPs := ovntest.MustParseIPNets("100.64.0.3/16", "fd98::3/64")
@@ -985,6 +1079,10 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				nodeName, clusterIPSubnets, hostSubnets, l3GatewayConfig, joinLRPIPs, defLRPIPs, skipSnat, mgmtPortIP,
 				"1400")
 			gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+
+			testData = []libovsdb.TestData{datapath}
+			expectedSBDatabaseState := generateGatewayInitExpectedSB(testData, nodeName)
+			gomega.Eventually(fakeOvn.sbClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 		})
 
 		ginkgo.It("ensures a leftover route on ovn_cluster_router to join subnet is removed", func() {
@@ -1010,6 +1108,11 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 				UUID: types.ClusterLBGroupName + "-UUID",
 				Name: types.ClusterLBGroupName,
 			}
+			gr := types.GWRouterPrefix + nodeName
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
 					&nbdb.LogicalSwitch{
@@ -1020,6 +1123,9 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 					expectedOVNClusterRouter,
 					expectedNodeSwitch,
 					expectedClusterLBGroup,
+				},
+				SBData: []libovsdbtest.TestData{
+					datapath,
 				},
 			})
 			clusterIPSubnets := ovntest.MustParseIPNets("10.128.0.0/14")

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -355,6 +355,11 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				UUID:        types.OVNClusterRouter + "-UUID",
 				ExternalIDs: map[string]string{"logical-router": expectedOVNClusterRouter.UUID, "name": types.OVNClusterRouter},
 			}
+			gr := types.GWRouterPrefix + node1.Name
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
@@ -368,6 +373,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				},
 				SBData: []libovsdbtest.TestData{
 					clusterRouterDatapath,
+					datapath,
 				},
 			}
 			var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
@@ -438,7 +444,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedDatabaseStateWithHybridNode := append([]libovsdbtest.TestData{hybridSubnetStaticRoute1, hybridSubnetLRP2, hybridSubnetLRP1, hybridLogicalSwitchPort, hybridLogicalRouterStaticRoute}, expectedDatabaseState...)
 
 			expectedMACBinding := &sbdb.MACBinding{
-				UUID:        "MAC-binding-UUID",
+				UUID:        "MAC-binding-HO-UUID",
 				Datapath:    clusterRouterDatapath.UUID,
 				IP:          nodeHOIP,
 				LogicalPort: "rtos-node1",
@@ -446,10 +452,12 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			expectedSBDatabaseState := []libovsdbtest.TestData{
+				datapath,
 				expectedMACBinding,
 				clusterRouterDatapath,
 			}
 
+			expectedSBDatabaseState = generateGatewayInitExpectedSB(expectedSBDatabaseState, node1.Name)
 			gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseStateWithHybridNode))
 			gomega.Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 
@@ -624,6 +632,11 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				UUID:        types.OVNClusterRouter + "-UUID",
 				ExternalIDs: map[string]string{"logical-router": expectedOVNClusterRouter.UUID, "name": types.OVNClusterRouter},
 			}
+			gr := types.GWRouterPrefix + node1.Name
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 
 			expectedDatabaseState := []libovsdbtest.TestData{ovnClusterRouterLRP}
 			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
@@ -658,7 +671,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedDatabaseStateWithHybridNode := append([]libovsdbtest.TestData{hybridSubnetStaticRoute1, hybridSubnetLRP2, hybridSubnetLRP1, hybridLogicalSwitchPort, hybridLogicalRouterStaticRoute}, expectedDatabaseState...)
 
 			expectedMACBinding := &sbdb.MACBinding{
-				UUID:        "MAC-binding-UUID",
+				UUID:        "MAC-binding-HO-UUID",
 				Datapath:    clusterRouterDatapath.UUID,
 				IP:          nodeHOIP,
 				LogicalPort: "rtos-node1",
@@ -666,6 +679,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			expectedSBDatabaseState := []libovsdbtest.TestData{
+				datapath,
 				clusterRouterDatapath,
 				expectedMACBinding,
 			}
@@ -702,6 +716,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}, 2).Should(gomega.HaveKeyWithValue(hotypes.HybridOverlayDRMAC, nodeHOMAC))
 
 			gomega.Consistently(libovsdbOvnNBClient, 2).Should(libovsdbtest.HaveData(expectedDatabaseStateWithHybridNode))
+			expectedSBDatabaseState = generateGatewayInitExpectedSB(expectedSBDatabaseState, node1.Name)
 			gomega.Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 
 			return nil
@@ -820,6 +835,11 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				UUID:        types.OVNClusterRouter + "-UUID",
 				ExternalIDs: map[string]string{"logical-router": expectedOVNClusterRouter.UUID, "name": types.OVNClusterRouter},
 			}
+			gr := types.GWRouterPrefix + node1.Name
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
@@ -833,6 +853,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				},
 				SBData: []libovsdbtest.TestData{
 					clusterRouterDatapath,
+					datapath,
 				},
 			}
 			var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
@@ -895,7 +916,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedDatabaseStateWithHybridNode := append([]libovsdbtest.TestData{hybridSubnetStaticRoute1, hybridSubnetLRP2, hybridSubnetLRP1, hybridLogicalSwitchPort, hybridLogicalRouterStaticRoute}, expectedDatabaseState...)
 
 			expectedMACBinding := &sbdb.MACBinding{
-				UUID:        "MAC-binding-UUID",
+				UUID:        "MAC-binding-HO-UUID",
 				Datapath:    clusterRouterDatapath.UUID,
 				IP:          nodeHOIP,
 				LogicalPort: "rtos-node1",
@@ -903,10 +924,12 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			expectedSBDatabaseState := []libovsdbtest.TestData{
+				datapath,
 				expectedMACBinding,
 				clusterRouterDatapath,
 			}
 
+			expectedSBDatabaseState = generateGatewayInitExpectedSB(expectedSBDatabaseState, node1.Name)
 			gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseStateWithHybridNode))
 			gomega.Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 
@@ -1081,6 +1104,11 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				UUID:        types.OVNClusterRouter + "-UUID",
 				ExternalIDs: map[string]string{"logical-router": expectedOVNClusterRouter.UUID, "name": types.OVNClusterRouter},
 			}
+			gr := types.GWRouterPrefix + node1.Name
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 
 			dbSetup := libovsdbtest.TestSetup{
 				NBData: []libovsdbtest.TestData{
@@ -1094,6 +1122,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 				},
 				SBData: []libovsdbtest.TestData{
 					clusterRouterDatapath,
+					datapath,
 				},
 			}
 			var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
@@ -1157,7 +1186,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			expectedDatabaseStateWithHybridNode := append([]libovsdbtest.TestData{hybridSubnetStaticRoute1, hybridSubnetLRP2, hybridSubnetLRP1, hybridLogicalSwitchPort, hybridLogicalRouterStaticRoute}, expectedDatabaseState...)
 
 			expectedMACBinding := &sbdb.MACBinding{
-				UUID:        "MAC-binding-UUID",
+				UUID:        "MAC-binding-HO-UUID",
 				Datapath:    clusterRouterDatapath.UUID,
 				IP:          nodeHOIP,
 				LogicalPort: "rtos-node1",
@@ -1165,10 +1194,12 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			}
 
 			expectedSBDatabaseState := []libovsdbtest.TestData{
+				datapath,
 				expectedMACBinding,
 				clusterRouterDatapath,
 			}
 
+			expectedSBDatabaseState = generateGatewayInitExpectedSB(expectedSBDatabaseState, node1.Name)
 			gomega.Eventually(libovsdbOvnNBClient).Should(libovsdbtest.HaveData(expectedDatabaseStateWithHybridNode))
 			gomega.Eventually(libovsdbOvnSBClient).Should(libovsdbtest.HaveData(expectedSBDatabaseState))
 

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	lsm "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/logical_switch_manager"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
@@ -219,7 +220,11 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			expectedNodeSwitch := node1.logicalSwitch(expectedClusterLBGroup.UUID)
 			expectedClusterRouterPortGroup := newRouterPortGroup()
 			expectedClusterPortGroup := newClusterPortGroup()
-
+			gr := ovntypes.GWRouterPrefix + node1.Name
+			datapath := &sbdb.DatapathBinding{
+				UUID:        gr + "-UUID",
+				ExternalIDs: map[string]string{"logical-router": gr + "-UUID", "name": gr},
+			}
 			fakeOvn.startWithDBSetup(
 				libovsdbtest.TestSetup{
 					NBData: []libovsdbtest.TestData{
@@ -229,6 +234,9 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 						expectedClusterRouterPortGroup,
 						expectedClusterPortGroup,
 						expectedClusterLBGroup,
+					},
+					SBData: []libovsdbtest.TestData{
+						datapath,
 					},
 				},
 				&v1.NamespaceList{


### PR DESCRIPTION
There remained a dependency for return service traffic from OVN->Host where OVN would need to think it was routing towards the default gw. Once this traffic made it into the shared gw bridge, it would be hijacked and redirected back to the Host. This only applied to clusters where a default gateway exists. In a cluster with no default gateway, the default route for OVN pointed to a fake gw (169.254.169.4) with a static MAC binding for this address.

However, in a cluster where there is a default gateway, but we are unable to ARP and create a MAC binding, return service traffic will fail to be routed. This commit changes the behavior so that:

1. Dummy GW MAC bindings are always created
2. Always add a route destined to the dummy masquerade subnet via dummy GW. Like "169.254.169.0/29 via 169.254.169.4"

This removes depending on an external default gateway for routing return service traffic from OVN.

Signed-off-by: Tim Rozet <trozet@redhat.com>

