### PR TITLE
Control forwarding on OVNK managed interfaces

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -93,6 +93,7 @@ usage() {
     echo "                 [-ho |--hybrid-enabled] [-ii|--install-ingress] [-n4|--no-ipv4]"
     echo "                 [-i6 |--ipv6] [-wk|--num-workers <num>] [-ds|--disable-snat-multiple-gws]"
     echo "                 [-dp |--disable-pkt-mtu-check]"
+    echo "                 [-df |--disable-forwarding]"
     echo "                 [-nf |--netflow-targets <targets>] [sf|--sflow-targets <targets>]"
     echo "                 [-if |--ipfix-targets <targets>]  [-ifs|--ipfix-sampling <num>]"
     echo "                 [-ifm|--ipfix-cache-max-flows <num>] [-ifa|--ipfix-cache-active-timeout <num>]"
@@ -120,6 +121,7 @@ usage() {
     echo "-ho  | --hybrid-enabled             Enable hybrid overlay. DEFAULT: Disabled."
     echo "-ds  | --disable-snat-multiple-gws  Disable SNAT for multiple gws. DEFAULT: Disabled."
     echo "-dp  | --disable-pkt-mtu-check      Disable checking packet size greater than MTU. Default: Disabled"
+    echo "-df  | --disable-forwarding         Disable forwarding on OVNK managed interfaces. Default: Disabled"
     echo "-nf  | --netflow-targets            Comma delimited list of ip:port or :port (using node IP) netflow collectors. DEFAULT: Disabled."
     echo "-sf  | --sflow-targets              Comma delimited list of ip:port or :port (using node IP) sflow collectors. DEFAULT: Disabled."
     echo "-if  | --ipfix-targets              Comma delimited list of ip:port or :port (using node IP) ipfix collectors. DEFAULT: Disabled."
@@ -183,6 +185,8 @@ parse_args() {
             -ho | --hybrid-enabled )            OVN_HYBRID_OVERLAY_ENABLE=true
                                                 ;;
             -ds | --disable-snat-multiple-gws ) OVN_DISABLE_SNAT_MULTIPLE_GWS=true
+                                                ;;
+            -df | --disable-forwarding )        OVN_DISABLE_FORWARDING=true
                                                 ;;
             -dp | --disable-pkt-mtu-check )     OVN_DISABLE_PKT_MTU_CHECK=true
                                                 ;;
@@ -348,6 +352,7 @@ print_params() {
      echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
      echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
      echo "OVN_DISABLE_SNAT_MULTIPLE_GWS = $OVN_DISABLE_SNAT_MULTIPLE_GWS"
+     echo "OVN_DISABLE_FORWARDING = $OVN_DISABLE_FORWARDING"
      echo "OVN_DISABLE_PKT_MTU_CHECK = $OVN_DISABLE_PKT_MTU_CHECK"
      echo "OVN_NETFLOW_TARGETS = $OVN_NETFLOW_TARGETS"
      echo "OVN_SFLOW_TARGETS = $OVN_SFLOW_TARGETS"
@@ -482,6 +487,7 @@ set_default_params() {
   ENABLE_IPSEC=${ENABLE_IPSEC:-false}
   OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
   OVN_DISABLE_SNAT_MULTIPLE_GWS=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-false}
+  OVN_DISABLE_FORWARDING=${OVN_DISABLE_FORWARDING:=false}
   OVN_DISABLE_PKT_MTU_CHECK=${OVN_DISABLE_PKT_MTU_CHECK:-false}
   OVN_EMPTY_LB_EVENTS=${OVN_EMPTY_LB_EVENTS:-false}
   OVN_MULTICAST_ENABLE=${OVN_MULTICAST_ENABLE:-false}
@@ -762,6 +768,7 @@ create_ovn_kube_manifests() {
     --enable-ipsec="${ENABLE_IPSEC}" \
     --hybrid-enabled="${OVN_HYBRID_OVERLAY_ENABLE}" \
     --disable-snat-multiple-gws="${OVN_DISABLE_SNAT_MULTIPLE_GWS}" \
+    --disable-forwarding="${OVN_DISABLE_FORWARDING}" \
     --disable-pkt-mtu-check="${OVN_DISABLE_PKT_MTU_CHECK}" \
     --ovn-empty-lb-events="${OVN_EMPTY_LB_EVENTS}" \
     --multicast-enabled="${OVN_MULTICAST_ENABLE}" \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -56,6 +56,7 @@ OVN_LFLOW_CACHE_LIMIT=""
 OVN_LFLOW_CACHE_LIMIT_KB=""
 OVN_HYBRID_OVERLAY_ENABLE=""
 OVN_DISABLE_SNAT_MULTIPLE_GWS=""
+OVN_DISABLE_FORWARDING=""
 OVN_DISABLE_PKT_MTU_CHECK=""
 OVN_EMPTY_LB_EVENTS=""
 OVN_MULTICAST_ENABLE=""
@@ -204,6 +205,9 @@ while [ "$1" != "" ]; do
     ;;
   --disable-snat-multiple-gws)
     OVN_DISABLE_SNAT_MULTIPLE_GWS=$VALUE
+    ;;
+  --disable-forwarding)
+    OVN_DISABLE_FORWARDING=$VALUE
     ;;
   --disable-pkt-mtu-check)
     OVN_DISABLE_PKT_MTU_CHECK=$VALUE
@@ -364,6 +368,8 @@ ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR}
 echo "ovn_hybrid_overlay_net_cidr: ${ovn_hybrid_overlay_net_cidr}"
 ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS}
 echo "ovn_disable_snat_multiple_gws: ${ovn_disable_snat_multiple_gws}"
+ovn_disable_forwarding=${OVN_DISABLE_FORWARDING}
+echo "ovn_disable_forwarding: ${ovn_disable_forwarding}"
 ovn_disable_pkt_mtu_check=${OVN_DISABLE_PKT_MTU_CHECK}
 echo "ovn_disable_pkt_mtu_check: ${ovn_disable_pkt_mtu_check}"
 ovn_empty_lb_events=${OVN_EMPTY_LB_EVENTS}
@@ -440,6 +446,7 @@ ovn_image=${ovnkube_image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_disable_forwarding=${ovn_disable_forwarding} \
   ovn_disable_pkt_mtu_check=${ovn_disable_pkt_mtu_check} \
   ovn_v4_join_subnet=${ovn_v4_join_subnet} \
   ovn_v6_join_subnet=${ovn_v6_join_subnet} \
@@ -482,6 +489,7 @@ ovn_image=${image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_disable_forwarding=${ovn_disable_forwarding} \
   ovn_disable_pkt_mtu_check=${ovn_disable_pkt_mtu_check} \
   ovn_v4_join_subnet=${ovn_v4_join_subnet} \
   ovn_v6_join_subnet=${ovn_v6_join_subnet} \
@@ -512,6 +520,7 @@ ovn_image=${ovnkube_image} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
   ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
   ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_disable_forwarding=${ovn_disable_forwarding} \
   ovn_disable_pkt_mtu_check=${ovn_disable_pkt_mtu_check} \
   ovn_empty_lb_events=${ovn_empty_lb_events} \
   ovn_v4_join_subnet=${ovn_v4_join_subnet} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -82,6 +82,7 @@ fi
 # OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME - ovnkube node management port device plugin resource
 # OVN_ENCAP_IP - encap IP to be used for OVN traffic on the node. mandatory in case ovnkube-node-mode=="dpu"
 # OVN_HOST_NETWORK_NAMESPACE - namespace to classify host network traffic for applying network policies
+# OVN_DISABLE_FORWARDING - disable forwarding on OVNK controlled interfaces
 
 # The argument to the command is the operation to be performed
 # ovn-master ovn-controller ovn-node display display_env ovn_debug
@@ -195,6 +196,7 @@ ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE:-}
 ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR:-}
 ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-}
+ovn_disable_forwarding=${OVN_DISABLE_FORWARDING:-}
 ovn_disable_pkt_mtu_check=${OVN_DISABLE_PKT_MTU_CHECK:-}
 ovn_empty_lb_events=${OVN_EMPTY_LB_EVENTS:-}
 # OVN_V4_JOIN_SUBNET - v4 join subnet
@@ -917,6 +919,11 @@ ovn-master() {
       disable_snat_multiple_gws_flag="--disable-snat-multiple-gws"
   fi
 
+  disable_forwarding_flag=
+  if [[ ${ovn_disable_forwarding} == "true" ]]; then
+      disable_forwarding_flag="--disable-forwarding"
+  fi
+
   disable_pkt_mtu_check_flag=
   if [[ ${ovn_disable_pkt_mtu_check} == "true" ]]; then
       disable_pkt_mtu_check_flag="--disable-pkt-mtu-check"
@@ -1025,6 +1032,7 @@ ovn-master() {
     --logfile-maxage=${ovnkube_logfile_maxage} \
     ${hybrid_overlay_flags} \
     ${disable_snat_multiple_gws_flag} \
+    ${disable_forwarding_flag} \
     ${empty_lb_events_flag} \
     ${ovn_v4_join_subnet_opt} \
     ${ovn_v6_join_subnet_opt} \
@@ -1380,6 +1388,11 @@ ovn-node() {
       disable_snat_multiple_gws_flag="--disable-snat-multiple-gws"
   fi
 
+  disable_forwarding_flag=
+  if [[ ${ovn_disable_forwarding} == "true" ]]; then
+      disable_forwarding_flag="--disable-forwarding"
+  fi
+
   disable_pkt_mtu_check_flag=
   if [[ ${ovn_disable_pkt_mtu_check} == "true" ]]; then
       disable_pkt_mtu_check_flag="--disable-pkt-mtu-check"
@@ -1546,6 +1559,7 @@ ovn-node() {
     --logfile-maxage=${ovnkube_logfile_maxage} \
     ${hybrid_overlay_flags} \
     ${disable_snat_multiple_gws_flag} \
+    ${disable_forwarding_flag} \
     ${disable_pkt_mtu_check_flag} \
     --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
     --gateway-router-subnet=${ovn_gateway_router_subnet} \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -209,6 +209,8 @@ spec:
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
           value: "{{ ovn_disable_snat_multiple_gws }}"
+        - name: OVN_DISABLE_FORWARDING
+          value: "{{ ovn_disable_forwarding }}"
         - name: OVN_EMPTY_LB_EVENTS
           value: "{{ ovn_empty_lb_events }}"
         - name: OVN_V4_JOIN_SUBNET

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -159,6 +159,8 @@ spec:
           value: "{{ ovn_hybrid_overlay_net_cidr }}"
         - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
           value: "{{ ovn_disable_snat_multiple_gws }}"
+        - name: OVN_DISABLE_FORWARDING
+          value: "{{ ovn_disable_forwarding }}"
         - name: OVN_DISABLE_PKT_MTU_CHECK
           value: "{{ ovn_disable_pkt_mtu_check }}"
         - name: OVN_NETFLOW_TARGETS

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -85,7 +85,7 @@ configuration options when deploying. Use `./kind.sh -h` to see the latest optio
 usage: kind.sh [[[-cf |--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]
                  [-ho |--hybrid-enabled] [-ii|--install-ingress] [-n4|--no-ipv4]
                  [-i6 |--ipv6] [-wk|--num-workers <num>] [-ds|--disable-snat-multiple-gws]
-                 [-dp |--disable-pkt-mtu-check]
+                 [-dp |--disable-pkt-mtu-check] [-df|--disable-forwarding]
                  [-nf |--netflow-targets <targets>] [sf|--sflow-targets <targets>]
                  [-if |--ipfix-targets <targets>] [-ifs|--ipfix-sampling <num>]
                  [-ifm|--ipfix-cache-max-flows <num>] [-ifa|--ipfix-cache-active-timeout <num>]
@@ -107,6 +107,7 @@ usage: kind.sh [[[-cf |--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]
 -ho  | --hybrid-enabled             Enable hybrid overlay. DEFAULT: Disabled.
 -ds  | --disable-snat-multiple-gws  Disable SNAT for multiple gws. DEFAULT: Disabled.
 -dp  | --disable-pkt-mtu-check      Disable checking packet size greater than MTU. Default: Disabled
+-df  | --disable-forwarding         Disable forwarding on OVNK controlled interfaces. Default: Enabled
 -nf  | --netflow-targets            Comma delimited list of ip:port or :port (using node IP) netflow collectors. DEFAULT: Disabled.
 -sf  | --sflow-targets              Comma delimited list of ip:port or :port (using node IP) sflow collectors. DEFAULT: Disabled.
 -if  | --ipfix-targets              Comma delimited list of ip:port or :port (using node IP) ipfix collectors. DEFAULT: Disabled.

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -392,6 +392,8 @@ type GatewayConfig struct {
 	RouterSubnet string `gcfg:"router-subnet"`
 	// SingeNode indicates the cluster has only one node
 	SingleNode bool `gcfg:"single-node"`
+	// DisableForwarding (enabled by default) controls if forwarding is allowed on OVNK controlled interfaces
+	DisableForwarding bool `gcfg:"disable-forwarding"`
 }
 
 // OvnAuthConfig holds client authentication and location details for
@@ -1185,6 +1187,11 @@ var OVNGatewayFlags = []cli.Flag{
 		Name:        "disable-snat-multiple-gws",
 		Usage:       "Disable SNAT for egress traffic with multiple gateways.",
 		Destination: &cliConfig.Gateway.DisableSNATMultipleGWs,
+	},
+	&cli.BoolFlag{
+		Name:        "disable-forwarding",
+		Usage:       "Disable forwarding on OVNK controlled interfaces.",
+		Destination: &cliConfig.Gateway.DisableForwarding,
 	},
 	&cli.StringFlag{
 		Name:        "gateway-v4-join-subnet",

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -202,6 +202,7 @@ v4-join-subnet=100.65.0.0/16
 v6-join-subnet=fd90::/64
 router-subnet=10.50.0.0/16
 single-node=false
+disable-forwarding=true
 
 [hybridoverlay]
 enabled=true
@@ -305,6 +306,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OvnKubeNode.MgmtPortRepresentor).To(gomega.Equal(""))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal(""))
 			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
+			gomega.Expect(Gateway.DisableForwarding).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(1))
 			gomega.Expect(OVNKubernetesFeature.EgressIPNodeHealthCheckPort).To(gomega.Equal(0))
 			gomega.Expect(OVNKubernetesFeature.EnableMultiNetwork).To(gomega.BeFalse())
@@ -611,6 +613,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.V6JoinSubnet).To(gomega.Equal("fd90::/64"))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.50.0.0/16"))
 			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
+			gomega.Expect(Gateway.DisableForwarding).To(gomega.BeTrue())
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(3))
@@ -696,6 +699,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.V6JoinSubnet).To(gomega.Equal("fd99::/48"))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.55.0.0/16"))
 			gomega.Expect(Gateway.SingleNode).To(gomega.BeTrue())
+			gomega.Expect(Gateway.DisableForwarding).To(gomega.BeTrue())
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(5))
@@ -747,6 +751,7 @@ var _ = Describe("Config Operations", func() {
 			"-gateway-v6-join-subnet=fd99::/48",
 			"-gateway-router-subnet=10.55.0.0/16",
 			"-single-node",
+			"-disable-forwarding",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=11.132.0.0/14/23",
 			"-monitor-all=false",

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -20,6 +20,25 @@ import (
 // created from the bridge name and the node name
 func bridgedGatewayNodeSetup(nodeName, bridgeName, bridgeInterface, physicalNetworkName string,
 	syncBridgeMAC bool) (string, net.HardwareAddr, error) {
+	// enable forwarding on bridge interface always
+	createForwardingRule := func(family string) error {
+		stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.%s.conf.%s.forwarding=1", family, bridgeName))
+		if err != nil || stdout != fmt.Sprintf("net.%s.conf.%s.forwarding = 1", family, bridgeName) {
+			return fmt.Errorf("could not set the correct forwarding value for interface %s: stdout: %v, stderr: %v, err: %v",
+				bridgeName, stdout, stderr, err)
+		}
+		return nil
+	}
+	if config.IPv4Mode {
+		if err := createForwardingRule("ipv4"); err != nil {
+			return "", nil, fmt.Errorf("could not add IPv4 forwarding rule: %v", err)
+		}
+	}
+	if config.IPv6Mode {
+		if err := createForwardingRule("ipv6"); err != nil {
+			return "", nil, fmt.Errorf("could not add IPv6 forwarding rule: %v", err)
+		}
+	}
 	// A OVS bridge's mac address can change when ports are added to it.
 	// We cannot let that happen, so make the bridge mac address permanent.
 	macAddress, err := util.GetOVSPortMACAddress(bridgeInterface)

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -92,6 +92,18 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				})
 			},
 		})
+		if config.IPv4Mode {
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "sysctl -w net.ipv4.conf.breth0.forwarding=1",
+				Output: "net.ipv4.conf.breth0.forwarding = 1",
+			})
+		}
+		if config.IPv6Mode {
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "sysctl -w net.ipv6.conf.breth0.forwarding=1",
+				Output: "net.ipv6.conf.breth0.forwarding = 1",
+			})
+		}
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,
@@ -414,6 +426,18 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd: "ovs-vsctl --timeout=15 get interface p0 ofport",
 		})
+		if config.IPv4Mode {
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "sysctl -w net.ipv4.conf.brp0.forwarding=1",
+				Output: "net.ipv4.conf.brp0.forwarding = 1",
+			})
+		}
+		if config.IPv6Mode {
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "sysctl -w net.ipv6.conf.brp0.forwarding=1",
+				Output: "net.ipv6.conf.brp0.forwarding = 1",
+			})
+		}
 		// bridgedGatewayNodeSetup
 		// GetOVSPortMACAddress
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
@@ -778,6 +802,18 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 				})
 			},
 		})
+		if config.IPv4Mode {
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "sysctl -w net.ipv4.conf.breth0.forwarding=1",
+				Output: "net.ipv4.conf.breth0.forwarding = 1",
+			})
+		}
+		if config.IPv6Mode {
+			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+				Cmd:    "sysctl -w net.ipv6.conf.breth0.forwarding=1",
+				Output: "net.ipv6.conf.breth0.forwarding = 1",
+			})
+		}
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,

--- a/go-controller/pkg/node/gateway_iptables.go
+++ b/go-controller/pkg/node/gateway_iptables.go
@@ -352,6 +352,96 @@ func getExternalIPTRules(svcPort kapi.ServicePort, externalIP, dstIP string, svc
 	}
 }
 
+func getGatewayForwardRules(svcCIDR *net.IPNet) []iptRule {
+	protocol := getIPTablesProtocol(svcCIDR.IP.String())
+	masqueradeIP := types.V4OVNMasqueradeIP
+	if protocol == iptables.ProtocolIPv6 {
+		masqueradeIP = types.V6OVNMasqueradeIP
+	}
+	return []iptRule{
+		{
+			table: "filter",
+			chain: "FORWARD",
+			args: []string{
+				"-s", svcCIDR.String(),
+				"-j", "ACCEPT",
+			},
+			protocol: protocol,
+		},
+		{
+			table: "filter",
+			chain: "FORWARD",
+			args: []string{
+				"-d", svcCIDR.String(),
+				"-j", "ACCEPT",
+			},
+			protocol: protocol,
+		},
+		{
+			table: "filter",
+			chain: "FORWARD",
+			args: []string{
+				"-s", masqueradeIP,
+				"-j", "ACCEPT",
+			},
+			protocol: protocol,
+		},
+		{
+			table: "filter",
+			chain: "FORWARD",
+			args: []string{
+				"-d", masqueradeIP,
+				"-j", "ACCEPT",
+			},
+			protocol: protocol,
+		},
+	}
+}
+
+func getGatewayDropRules(ifName string) []iptRule {
+	var dropRules []iptRule
+	for _, protocol := range clusterIPTablesProtocols() {
+		dropRules = append(dropRules, []iptRule{
+			{
+				table: "filter",
+				chain: "FORWARD",
+				args: []string{
+					"-i", ifName,
+					"-j", "DROP",
+				},
+				protocol: protocol,
+			},
+			{
+				table: "filter",
+				chain: "FORWARD",
+				args: []string{
+					"-o", ifName,
+					"-j", "DROP",
+				},
+				protocol: protocol,
+			},
+		}...)
+	}
+	return dropRules
+}
+
+// initExternalBridgeForwardingRules sets up iptables rules for br-* interface svc traffic forwarding
+// -A FORWARD -s 10.96.0.0/16 -j ACCEPT
+// -A FORWARD -d 10.96.0.0/16 -j ACCEPT
+// -A FORWARD -s 169.254.169.1 -j ACCEPT
+// -A FORWARD -d 169.254.169.1 -j ACCEPT
+func initExternalBridgeServiceForwardingRules(cidr *net.IPNet) error {
+	return insertIptRules(getGatewayForwardRules(cidr))
+}
+
+// initExternalBridgeDropRules sets up iptables rules to block forwarding
+// in br-* interfaces (also for 2ndary bridge) - we block for v4 and v6 based on clusterStack
+// -A FORWARD -i breth1 -j DROP
+// -A FORWARD -o breth1 -j DROP
+func initExternalBridgeDropForwardingRules(ifName string) error {
+	return appendIptRules(getGatewayDropRules(ifName))
+}
+
 func getLocalGatewayNATRules(ifname string, cidr *net.IPNet) []iptRule {
 	// Allow packets to/from the gateway interface in case defaults deny
 	protocol := getIPTablesProtocol(cidr.IP.String())

--- a/go-controller/pkg/node/gateway_localnet.go
+++ b/go-controller/pkg/node/gateway_localnet.go
@@ -76,6 +76,11 @@ func newLocalGateway(nodeName string, hostSubnets []*net.IPNet, gwNextHops []net
 			if err != nil {
 				return err
 			}
+			if config.Gateway.DisableForwarding {
+				if err := initExternalBridgeDropForwardingRules(exGwBridge.bridgeName); err != nil {
+					return fmt.Errorf("failed to add forwarding block rules for bridge %s: err %v", exGwBridge.bridgeName, err)
+				}
+			}
 		}
 
 		gw.nodeIPManager = newAddressManager(nodeName, kube, cfg, watchFactory, gwBridge)

--- a/test/scripts/upgrade-ovn.sh
+++ b/test/scripts/upgrade-ovn.sh
@@ -126,6 +126,7 @@ create_ovn_kube_manifests() {
     --gateway-mode="${OVN_GATEWAY_MODE}" \
     --hybrid-enabled="${OVN_HYBRID_OVERLAY_ENABLE}" \
     --disable-snat-multiple-gws="${OVN_DISABLE_SNAT_MULTIPLE_GWS}" \
+    --disable-forwarding="${OVN_DISABLE_FORWARDING}" \
     --disable-pkt-mtu-check="${OVN_DISABLE_PKT_MTU_CHECK}" \
     --ovn-empty-lb-events="${OVN_EMPTY_LB_EVENTS}" \
     --multicast-enabled="${OVN_MULTICAST_ENABLE}" \
@@ -158,6 +159,7 @@ set_default_ovn_manifest_params() {
   OVN_GATEWAY_MODE=${OVN_GATEWAY_MODE:-shared}
   OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
   OVN_DISABLE_SNAT_MULTIPLE_GWS=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-false}
+  OVN_DISABLE_FORWARDING=${OVN_DISABLE_FORWARDING:-false}
   OVN_DISABLE_PKT_MTU_CHECK=${OVN_DISABLE_PKT_MTU_CHECK:-false}
   OVN_EMPTY_LB_EVENTS=${OVN_EMPTY_LB_EVENTS:-false}
   OVN_MULTICAST_ENABLE=${OVN_MULTICAST_ENABLE:-false}
@@ -206,6 +208,7 @@ print_ovn_manifest_params() {
      echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
      echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
      echo "OVN_DISABLE_SNAT_MULTIPLE_GWS = $OVN_DISABLE_SNAT_MULTIPLE_GWS"
+     echo "OVN_DISABLE_FORWARDING = $OVN_DISABLE_FORWARDING"
      echo "OVN_DISABLE_PKT_MTU_CHECK = $OVN_DISABLE_PKT_MTU_CHECK"
      echo "OVN_NETFLOW_TARGETS = $OVN_NETFLOW_TARGETS"
      echo "OVN_SFLOW_TARGETS = $OVN_SFLOW_TARGETS"


### PR DESCRIPTION
This PR does two things:

1) We add the following rules to our setup: 
```
	"-d 172.16.1.0/24 -j ACCEPT",
	"-s 172.16.1.0/24 -j ACCEPT",
	"-o breth0 -j DROP",
	"-i breth0 -j DROP",
```
(for primary and secondary bridges) if the DisableForwardingOnInterfaces=true

Problem: When packets are destined towards externalIPs/loadbalancerVIPs against unexposed ports, the packets follow this path: external->br-ex->host->br-ex->external and this causes a loop with the user's gw router. As per CNI plugin requirements, we shouldn't be interfering with this undefined traffic and sending it out if we don't know where to route this since its afterall service traffic. Just like we drop serviceCIDR traffic against unexposed ports, let's add drop rules for this kind of traffic coming from breth0 and getting routed back to breth0. Except the lgw service traffic flows nothing else should be using this path. We allow service CIDR traffic to be forwarded across all interfaces. NOTE: Same as https://github.com/ovn-org/ovn-kubernetes/pull/3346 but for externally exposed services.


Apart from the above problem, hosts are acting as routers between multiple interfaces which is undesired. (See @trozet 's comments below), this PR aims to fix that problem as well. Since we can't break backwards compatibility we also add a new knob to gatewayConfig which can be used to disable forwarding. It's an opt-in behaviour so users can stay on the default mode for backwards compatibility

2) We explicitly enable forwarding on mp0 interface irrespective of the OS settings since we own it.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

