### PR TITLE
Fix cluster exclusion for egress firewall in dualstack mode

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -345,7 +345,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						buildEgressFwAclName("namespace1", t.EgressFirewallStartPriority),
 						nbdb.ACLDirectionToLport,
 						t.EgressFirewallStartPriority,
-						"(ip6.dst == 2002::1234:abcd:ffff:c0a8:101/64) && (ip4.src == $a10481622940199974102 || ip6.src == $a10481620741176717680)",
+						"(ip6.dst == 2002::1234:abcd:ffff:c0a8:101/64) && ip6.src == $a10481620741176717680",
 						nbdb.ACLActionAllow,
 						t.OvnACLLoggingMeter,
 						"",
@@ -949,7 +949,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						buildEgressFwAclName("namespace1", t.EgressFirewallStartPriority),
 						nbdb.ACLDirectionToLport,
 						t.EgressFirewallStartPriority,
-						"(ip4.dst == 0.0.0.0/0) && ip4.src == $a10481622940199974102 && ip4.dst != "+clusterSubnetStr,
+						fmt.Sprintf("(ip4.dst == 0.0.0.0/0 && ip4.dst != %s) && ip4.src == $a10481622940199974102", clusterSubnetStr),
 						nbdb.ACLActionDrop,
 						t.OvnACLLoggingMeter,
 						"",
@@ -1058,7 +1058,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				ipv6Mode:       true,
 				destinations:   []matchTarget{{matchKindV4CIDR, "1.2.3.4/32", false}},
 				ports:          nil,
-				output:         "(ip4.dst == 1.2.3.4/32) && (ip4.src == $testv4 || ip6.src == $testv6)",
+				output:         "(ip4.dst == 1.2.3.4/32) && ip4.src == $testv4",
 			},
 			{
 				clusterSubnets: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
@@ -1088,7 +1088,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				ipv6Mode:       true,
 				destinations:   []matchTarget{{matchKindV6CIDR, "2001::/64", false}},
 				ports:          nil,
-				output:         "(ip6.dst == 2001::/64) && (ip4.src == $testv4 || ip6.src == $testv6)",
+				output:         "(ip6.dst == 2001::/64) && ip6.src == $testv6",
 			},
 			{
 				clusterSubnets: []string{"2002:0:0:1234::/64"},
@@ -1109,7 +1109,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				ipv6Mode:       false,
 				destinations:   []matchTarget{{matchKindV4CIDR, "1.2.3.4/32", true}},
 				ports:          nil,
-				output:         "(ip4.dst == 1.2.3.4/32) && ip4.src == $testv4 && ip4.dst != 10.128.0.0/14",
+				output:         "(ip4.dst == 1.2.3.4/32 && ip4.dst != 10.128.0.0/14) && ip4.src == $testv4",
 			},
 			{
 				clusterSubnets: []string{"2002:0:0:1234::/64"},
@@ -1119,7 +1119,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				ipv6Mode:       true,
 				destinations:   []matchTarget{{matchKindV6AddressSet, "destv6", true}},
 				ports:          nil,
-				output:         "(ip6.dst == $destv6) && ip6.src == $testv6 && ip6.dst != 2002:0:0:1234::/64",
+				output:         "(ip6.dst == $destv6) && ip6.src == $testv6",
 			},
 			{
 				clusterSubnets: []string{"10.128.0.0/14", "2002:0:0:1234::/64"},
@@ -1129,7 +1129,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 				ipv6Mode:       true,
 				destinations:   []matchTarget{{matchKindV4CIDR, "1.2.3.4/32", true}},
 				ports:          nil,
-				output:         "(ip4.dst == 1.2.3.4/32) && (ip4.src == $testv4 || ip6.src == $testv6) && ip4.dst != 10.128.0.0/14 && ip6.dst != 2002:0:0:1234::/64",
+				output:         "(ip4.dst == 1.2.3.4/32 && ip4.dst != 10.128.0.0/14) && ip4.src == $testv4",
 			},
 		}
 


### PR DESCRIPTION
Previous to this change, OVN was always evaluating our cluster exclusion ACL match expression to false if we had a match expression that directly compared IP V4 and IP V6 operands. 
Example:
```
(ip4.dst == 0.0.0.0/0) && (ip4.src == $a5154718082306775057 || ip6.src == $a5154715883283518635) && ip4.dst != 10.244.0.0/16 && ip6.dst != fd00:10:244::/48" 
```
Notice at the end of that expression, we have operand "ip6.dst" AND'd with everything previous to it, therefore we always compare to this operand even if the packet is IP V4. OVN doesnt like this and will always evaluate this expression to false for IP V4.

~~This code will need a refactor in the future to consider if an exclusion for IP V6 and/or IP V4 is needed.
For example, if the match expression only contains IP V4 operands, then theres no need for IP V6 cluster exclusion operators.~~ Added