### PR TITLE
Support Egress IP on OVN-IC

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1269,6 +1269,17 @@ ovn-cluster-manager() {
   echo "=============== ovn-cluster-manager (wait for ready_to_start_node) ========== MASTER ONLY"
   wait_for_event ready_to_start_node
 
+  egressip_enabled_flag=
+  if [[ ${ovn_egressip_enable} == "true" ]]; then
+      egressip_enabled_flag="--enable-egress-ip"
+  fi
+
+  egressip_healthcheck_port_flag=
+  if [[ -n "${ovn_egress_ip_healthcheck_port}" ]]; then
+      egressip_healthcheck_port_flag="--egressip-node-healthcheck-port=${ovn_egress_ip_healthcheck_port}"
+  fi
+  echo "egressip_flags: ${egressip_enabled_flag}, ${egressip_healthcheck_port_flag}"
+
   hybrid_overlay_flags=
   if [[ ${ovn_hybrid_overlay_enable} == "true" ]]; then
     hybrid_overlay_flags="--enable-hybrid-overlay"
@@ -1329,6 +1340,8 @@ ovn-cluster-manager() {
     --logfile /var/log/ovn-kubernetes/ovnkube-cluster-manager.log \
     ${ovnkube_metrics_tls_opts} \
     ${multicast_enabled_flag} \
+    ${egressip_enabled_flag} \
+    ${egressip_healthcheck_port_flag} \
     ${multi_network_enabled_flag} \
     --metrics-bind-address ${ovnkube_cluster_manager_metrics_bind_address} \
     --host-network-namespace ${ovn_host_network_namespace} &

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1,0 +1,1505 @@
+package clustermanager
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	ocpcloudnetworkapi "github.com/openshift/api/cloudnetwork/v1"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
+	objretry "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+)
+
+const (
+	egressIPReachabilityCheckInterval = 5 * time.Second
+)
+
+type egressIPHealthcheckClientAllocator struct{}
+
+func (hccAlloc *egressIPHealthcheckClientAllocator) allocate(nodeName string) healthcheck.EgressIPHealthClient {
+	return healthcheck.NewEgressIPHealthClient(nodeName)
+}
+
+func isReachableViaGRPC(mgmtIPs []net.IP, healthClient healthcheck.EgressIPHealthClient, healthCheckPort, totalTimeout int) bool {
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Duration(totalTimeout)*time.Second)
+	defer dialCancel()
+
+	if !healthClient.IsConnected() {
+		// gRPC session is not up. Attempt to connect and if that suceeds, we will declare node as reacheable.
+		return healthClient.Connect(dialCtx, mgmtIPs, healthCheckPort)
+	}
+
+	// gRPC session is already established. Send a probe, which will succeed, or close the session.
+	return healthClient.Probe(dialCtx)
+}
+
+type egressIPDialer interface {
+	dial(ip net.IP, timeout time.Duration) bool
+}
+
+type egressIPDial struct{}
+
+var dialer egressIPDialer = &egressIPDial{}
+
+type healthcheckClientAllocator interface {
+	allocate(nodeName string) healthcheck.EgressIPHealthClient
+}
+
+// Blantant copy from: https://github.com/openshift/sdn/blob/master/pkg/network/common/egressip.go#L499-L505
+// Ping a node and return whether or not we think it is online. We do this by trying to
+// open a TCP connection to the "discard" service (port 9); if the node is offline, the
+// attempt will either time out with no response, or else return "no route to host" (and
+// we will return false). If the node is online then we presumably will get a "connection
+// refused" error; but the code below assumes that anything other than timeout or "no
+// route" indicates that the node is online.
+func (e *egressIPDial) dial(ip net.IP, timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip.String(), "9"), timeout)
+	if conn != nil {
+		conn.Close()
+	}
+	if opErr, ok := err.(*net.OpError); ok {
+		if opErr.Timeout() {
+			return false
+		}
+		if sysErr, ok := opErr.Err.(*os.SyscallError); ok && sysErr.Err == syscall.EHOSTUNREACH {
+			return false
+		}
+	}
+	return true
+}
+
+var hccAllocator healthcheckClientAllocator = &egressIPHealthcheckClientAllocator{}
+
+// egressNode is a cache helper used for egress IP assignment, representing an egress node
+type egressNode struct {
+	egressIPConfig     *util.ParsedNodeEgressIPConfiguration
+	mgmtIPs            []net.IP
+	allocations        map[string]string
+	healthClient       healthcheck.EgressIPHealthClient
+	isReady            bool
+	isReachable        bool
+	isEgressAssignable bool
+	name               string
+}
+
+func (e *egressNode) getAllocationCountForEgressIP(name string) (count int) {
+	for _, egressIPName := range e.allocations {
+		if egressIPName == name {
+			count++
+		}
+	}
+	return
+}
+
+// isAnyClusterNodeIP verifies that the IP is not any node IP.
+func (eIPC *egressIPClusterController) isAnyClusterNodeIP(ip net.IP) *egressNode {
+	for _, eNode := range eIPC.allocator.cache {
+		if ip.Equal(eNode.egressIPConfig.V6.IP) || ip.Equal(eNode.egressIPConfig.V4.IP) {
+			return eNode
+		}
+	}
+	return nil
+}
+
+type EgressIPPatchStatus struct {
+	Op    string                    `json:"op"`
+	Path  string                    `json:"path"`
+	Value egressipv1.EgressIPStatus `json:"value"`
+}
+
+// patchReplaceEgressIPStatus performs a replace patch operation of the egress
+// IP status by replacing the status with the provided value. This allows us to
+// update only the status field, without overwriting any other. This is
+// important because processing egress IPs can take a while (when running on a
+// public cloud and in the worst case), hence we don't want to perform a full
+// object update which risks resetting the EgressIP object's fields to the state
+// they had when we started processing the change.
+func (eIPC *egressIPClusterController) patchReplaceEgressIPStatus(name string, statusItems []egressipv1.EgressIPStatusItem) error {
+	klog.Infof("Patching status on EgressIP %s: %v", name, statusItems)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		t := []EgressIPPatchStatus{
+			{
+				Op:   "replace",
+				Path: "/status",
+				Value: egressipv1.EgressIPStatus{
+					Items: statusItems,
+				},
+			},
+		}
+		op, err := json.Marshal(&t)
+		if err != nil {
+			return fmt.Errorf("error serializing status patch operation: %+v, err: %v", statusItems, err)
+		}
+		return eIPC.kube.PatchEgressIP(name, op)
+	})
+}
+
+func (eIPC *egressIPClusterController) getAllocationTotalCount() float64 {
+	count := 0
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	for _, eNode := range eIPC.allocator.cache {
+		count += len(eNode.allocations)
+	}
+	return float64(count)
+}
+
+type allocator struct {
+	*sync.Mutex
+	// A cache used for egress IP assignments containing data for all cluster nodes
+	// used for egress IP assignments
+	cache map[string]*egressNode
+}
+
+type cloudPrivateIPConfigOp struct {
+	toAdd    string
+	toDelete string
+}
+
+// ipStringToCloudPrivateIPConfigName converts the net.IP string representation
+// to a CloudPrivateIPConfig compatible name.
+
+// The string representation of the IPv6 address fc00:f853:ccd:e793::54 will be
+// represented as: fc00.f853.0ccd.e793.0000.0000.0000.0054
+
+// We thus need to fully expand the IP string and replace every fifth
+// character's colon with a dot.
+func ipStringToCloudPrivateIPConfigName(ipString string) (name string) {
+	ip := net.ParseIP(ipString)
+	if ip.To4() != nil {
+		return ipString
+	}
+	dst := make([]byte, hex.EncodedLen(len(ip)))
+	hex.Encode(dst, ip)
+	for i := 0; i < len(dst); i += 4 {
+		if len(dst)-i == 4 {
+			name += string(dst[i : i+4])
+		} else {
+			name += string(dst[i:i+4]) + "."
+		}
+	}
+	return
+}
+
+func (eIPC *egressIPClusterController) executeCloudPrivateIPConfigOps(egressIPName string, ops map[string]*cloudPrivateIPConfigOp) error {
+	for egressIP, op := range ops {
+		cloudPrivateIPConfigName := ipStringToCloudPrivateIPConfigName(egressIP)
+		cloudPrivateIPConfig, err := eIPC.watchFactory.GetCloudPrivateIPConfig(cloudPrivateIPConfigName)
+		// toAdd and toDelete is non-empty, this indicates an UPDATE for which
+		// the object **must** exist, if not: that's an error.
+		if op.toAdd != "" && op.toDelete != "" {
+			if err != nil {
+				return fmt.Errorf("cloud update request failed for CloudPrivateIPConfig: %s, could not get item, err: %v", cloudPrivateIPConfigName, err)
+			}
+			// Do not update if object is being deleted
+			if !cloudPrivateIPConfig.GetDeletionTimestamp().IsZero() {
+				return fmt.Errorf("cloud update request failed, CloudPrivateIPConfig: %s is being deleted", cloudPrivateIPConfigName)
+			}
+			cloudPrivateIPConfig.Spec.Node = op.toAdd
+			if _, err := eIPC.kube.UpdateCloudPrivateIPConfig(cloudPrivateIPConfig); err != nil {
+				eIPRef := v1.ObjectReference{
+					Kind: "EgressIP",
+					Name: egressIPName,
+				}
+				eIPC.recorder.Eventf(&eIPRef, v1.EventTypeWarning, "CloudUpdateFailed", "egress IP: %s for object EgressIP: %s could not be updated, err: %v", egressIP, egressIPName, err)
+				return fmt.Errorf("cloud update request failed for CloudPrivateIPConfig: %s, err: %v", cloudPrivateIPConfigName, err)
+			}
+			// toAdd is non-empty, this indicates an ADD
+			// if the object already exists for the specified node that's a no-op
+			// if the object already exists and the request is for a different node, that's an error
+		} else if op.toAdd != "" {
+			if err == nil {
+				if op.toAdd == cloudPrivateIPConfig.Spec.Node {
+					klog.Infof("CloudPrivateIPConfig: %s already assigned to node: %s", cloudPrivateIPConfigName, cloudPrivateIPConfig.Spec.Node)
+					continue
+				}
+				return fmt.Errorf("cloud create request failed for CloudPrivateIPConfig: %s, err: item exists", cloudPrivateIPConfigName)
+			}
+			cloudPrivateIPConfig := ocpcloudnetworkapi.CloudPrivateIPConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cloudPrivateIPConfigName,
+					Annotations: map[string]string{
+						util.OVNEgressIPOwnerRefLabel: egressIPName,
+					},
+				},
+				Spec: ocpcloudnetworkapi.CloudPrivateIPConfigSpec{
+					Node: op.toAdd,
+				},
+			}
+			if _, err := eIPC.kube.CreateCloudPrivateIPConfig(&cloudPrivateIPConfig); err != nil {
+				eIPRef := v1.ObjectReference{
+					Kind: "EgressIP",
+					Name: egressIPName,
+				}
+				eIPC.recorder.Eventf(&eIPRef, v1.EventTypeWarning, "CloudAssignmentFailed", "egress IP: %s for object EgressIP: %s could not be created, err: %v", egressIP, egressIPName, err)
+				return fmt.Errorf("cloud add request failed for CloudPrivateIPConfig: %s, err: %v", cloudPrivateIPConfigName, err)
+			}
+			// toDelete is non-empty, this indicates a DELETE - if the object does not exist, log an Info message and continue with the next op.
+			// The reason for why we are not throwing an error here is that desired state (deleted) == isState (object not found).
+			// If for whatever reason we have a pending toDelete op for a deleted object, then this op should simply be silently ignored.
+			// Any other error, return an error to trigger a retry.
+		} else if op.toDelete != "" {
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					klog.Infof("Cloud deletion request failed for CloudPrivateIPConfig: %s, item already deleted, err: %v", cloudPrivateIPConfigName, err)
+					continue
+				} else {
+					return fmt.Errorf("cloud deletion request failed for CloudPrivateIPConfig: %s, could not get item, err: %v", cloudPrivateIPConfigName, err)
+				}
+			}
+			if err := eIPC.kube.DeleteCloudPrivateIPConfig(cloudPrivateIPConfigName); err != nil {
+				eIPRef := v1.ObjectReference{
+					Kind: "EgressIP",
+					Name: egressIPName,
+				}
+				eIPC.recorder.Eventf(&eIPRef, v1.EventTypeWarning, "CloudDeletionFailed", "egress IP: %s for object EgressIP: %s could not be deleted, err: %v", egressIP, egressIPName, err)
+				return fmt.Errorf("cloud deletion request failed for CloudPrivateIPConfig: %s, err: %v", cloudPrivateIPConfigName, err)
+			}
+		}
+	}
+	return nil
+}
+
+// executeCloudPrivateIPConfigChange computes a diff between what needs to be
+// assigned/removed and executes the object modification afterwards.
+// Specifically: if one egress IP is moved from nodeA to nodeB, we actually care
+// about an update on the CloudPrivateIPConfig object represented by that egress
+// IP, cloudPrivateIPConfigOp is a helper used to determine that sort of
+// operations from toAssign/toRemove
+func (eIPC *egressIPClusterController) executeCloudPrivateIPConfigChange(egressIPName string, toAssign, toRemove []egressipv1.EgressIPStatusItem) error {
+	eIPC.pendingCloudPrivateIPConfigsMutex.Lock()
+	defer eIPC.pendingCloudPrivateIPConfigsMutex.Unlock()
+	ops := make(map[string]*cloudPrivateIPConfigOp, len(toAssign)+len(toRemove))
+	for _, assignment := range toAssign {
+		ops[assignment.EgressIP] = &cloudPrivateIPConfigOp{
+			toAdd: assignment.Node,
+		}
+	}
+	for _, removal := range toRemove {
+		if op, exists := ops[removal.EgressIP]; exists {
+			op.toDelete = removal.Node
+		} else {
+			ops[removal.EgressIP] = &cloudPrivateIPConfigOp{
+				toDelete: removal.Node,
+			}
+		}
+	}
+	// Merge ops into the existing pendingCloudPrivateIPConfigsOps.
+	// This allows us to:
+	// a) execute only the new ops
+	// b) keep track of any pending changes
+	if len(ops) > 0 {
+		if _, ok := eIPC.pendingCloudPrivateIPConfigsOps[egressIPName]; !ok {
+			// Set all operations for the EgressIP object if none are in the cache currently.
+			eIPC.pendingCloudPrivateIPConfigsOps[egressIPName] = ops
+		} else {
+			for cloudPrivateIP, op := range ops {
+				if _, ok := eIPC.pendingCloudPrivateIPConfigsOps[egressIPName][cloudPrivateIP]; !ok {
+					// If this specific EgressIP object's CloudPrivateIPConfig address currently has no
+					// op, simply set it.
+					eIPC.pendingCloudPrivateIPConfigsOps[egressIPName][cloudPrivateIP] = op
+				} else {
+					// If an existing operation for this CloudPrivateIP exists, then the following logic should
+					// apply:
+					// If toDelete is currently set: keep the current toDelete. Theoretically, the oldest toDelete
+					// is the good one. If toDelete if currently not set, overwrite it with the new value.
+					// If toAdd is currently set: overwrite with the new toAdd. Theoretically, the newest toAdd is
+					// the good one.
+					// Therefore, only replace toAdd over a previously existing op and only replace toDelete if
+					// it's unset.
+					if op.toAdd != "" {
+						eIPC.pendingCloudPrivateIPConfigsOps[egressIPName][cloudPrivateIP].toAdd = op.toAdd
+					}
+					if eIPC.pendingCloudPrivateIPConfigsOps[egressIPName][cloudPrivateIP].toDelete == "" {
+						eIPC.pendingCloudPrivateIPConfigsOps[egressIPName][cloudPrivateIP].toDelete = op.toDelete
+					}
+				}
+			}
+		}
+	}
+	return eIPC.executeCloudPrivateIPConfigOps(egressIPName, ops)
+}
+
+type egressIPClusterController struct {
+	recorder record.EventRecorder
+	stopChan chan struct{}
+	wg       *sync.WaitGroup
+	kube     *kube.KubeOVN
+	// egressIPAssignmentMutex is used to ensure a safe updates between
+	// concurrent go-routines which could be modifying the egress IP status
+	// assignment simultaneously. Currently WatchEgressNodes and WatchEgressIP
+	// run two separate go-routines which do this.
+	egressIPAssignmentMutex *sync.Mutex
+	// pendingCloudPrivateIPConfigsMutex is used to ensure synchronized access
+	// to pendingCloudPrivateIPConfigsOps which is accessed by the egress IP and
+	// cloudPrivateIPConfig go-routines
+	pendingCloudPrivateIPConfigsMutex *sync.Mutex
+	// pendingCloudPrivateIPConfigsOps is a cache of pending
+	// CloudPrivateIPConfig changes that we are waiting on an answer for. Items
+	// in this map are only ever removed once the op is fully finished and we've
+	// been notified of this. That means:
+	// - On add operations we only delete once we've seen that the
+	// CloudPrivateIPConfig is fully added.
+	// - On delete: when it's fully deleted.
+	// - On update: once we finish processing the add - which comes after the
+	// delete.
+	pendingCloudPrivateIPConfigsOps map[string]map[string]*cloudPrivateIPConfigOp
+	// allocator is a cache of egress IP centric data needed to when both route
+	// health-checking and tracking allocations made
+	allocator allocator
+	// watchFactory watching k8s objects
+	watchFactory *factory.WatchFactory
+	// EgressIP Node reachability total timeout configuration
+	egressIPTotalTimeout int
+	// reachability check interval
+	reachabilityCheckInterval time.Duration
+	// EgressIP Node reachability gRPC port (0 means it should use dial instead)
+	egressIPNodeHealthCheckPort int
+	// retry framework for Egress nodes
+	retryEgressNodes *objretry.RetryFramework
+	// retry framework for egress IP
+	retryEgressIPs *objretry.RetryFramework
+	// retry framework for Cloud private IP config
+	retryCloudPrivateIPConfig *objretry.RetryFramework
+	// egressNodes events factory handler
+	egressNodeHandler *factory.Handler
+	// egressIP events factory handler
+	egressIPHandler *factory.Handler
+	// cloudPrivateIPConfig events factory handler
+	cloudPrivateIPConfigHandler *factory.Handler
+}
+
+func newEgressIPController(ovnClient *util.OVNClusterManagerClientset, wf *factory.WatchFactory, recorder record.EventRecorder) *egressIPClusterController {
+	kube := &kube.KubeOVN{
+		Kube:               kube.Kube{KClient: ovnClient.KubeClient},
+		EIPClient:          ovnClient.EgressIPClient,
+		CloudNetworkClient: ovnClient.CloudNetworkClient,
+	}
+	wg := &sync.WaitGroup{}
+	eIPC := &egressIPClusterController{
+		kube:                              kube,
+		wg:                                wg,
+		egressIPAssignmentMutex:           &sync.Mutex{},
+		pendingCloudPrivateIPConfigsMutex: &sync.Mutex{},
+		pendingCloudPrivateIPConfigsOps:   make(map[string]map[string]*cloudPrivateIPConfigOp),
+		allocator:                         allocator{&sync.Mutex{}, make(map[string]*egressNode)},
+		watchFactory:                      wf,
+		recorder:                          recorder,
+		egressIPTotalTimeout:              config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout,
+		reachabilityCheckInterval:         egressIPReachabilityCheckInterval,
+		egressIPNodeHealthCheckPort:       config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort,
+	}
+	eIPC.initRetryFramework()
+	return eIPC
+}
+
+func (eIPC *egressIPClusterController) initRetryFramework() {
+	eIPC.retryEgressNodes = eIPC.newRetryFramework(factory.EgressNodeType)
+	eIPC.retryEgressIPs = eIPC.newRetryFramework(factory.EgressIPType)
+	if util.PlatformTypeIsEgressIPCloudProvider() {
+		eIPC.retryCloudPrivateIPConfig = eIPC.newRetryFramework(factory.CloudPrivateIPConfigType)
+	}
+}
+
+func (eIPC *egressIPClusterController) newRetryFramework(objectType reflect.Type) *objretry.RetryFramework {
+	eventHandler := &egressIPClusterControllerEventHandler{
+		objType:  objectType,
+		eIPC:     eIPC,
+		syncFunc: nil,
+	}
+	resourceHandler := &objretry.ResourceHandler{
+		HasUpdateFunc:          true, // all egressIP types have update func
+		NeedsUpdateDuringRetry: true, // true for all egressIP types
+		ObjType:                objectType,
+		EventHandler:           eventHandler,
+	}
+	return objretry.NewRetryFramework(eIPC.stopChan, eIPC.wg, eIPC.watchFactory, resourceHandler)
+}
+
+func (eIPC *egressIPClusterController) Start() error {
+	var err error
+	// In cluster manager, we only need to watch for egressNodes, egressIPs
+	// and cloudPrivateIPConfig
+	if eIPC.egressNodeHandler, err = eIPC.WatchEgressNodes(); err != nil {
+		return fmt.Errorf("unable to watch egress nodes %w", err)
+	}
+	if eIPC.egressIPHandler, err = eIPC.WatchEgressIP(); err != nil {
+		return err
+	}
+	if util.PlatformTypeIsEgressIPCloudProvider() {
+		if eIPC.cloudPrivateIPConfigHandler, err = eIPC.WatchCloudPrivateIPConfig(); err != nil {
+			return err
+		}
+	}
+	if config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout == 0 {
+		klog.V(2).Infof("EgressIP node reachability check disabled")
+	} else if config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort != 0 {
+		klog.Infof("EgressIP node reachability enabled and using gRPC port %d",
+			config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort)
+	}
+	return nil
+}
+
+// WatchEgressNodes starts the watching of egress assignable nodes and calls
+// back the appropriate handler logic.
+func (eIPC *egressIPClusterController) WatchEgressNodes() (*factory.Handler, error) {
+	return eIPC.retryEgressNodes.WatchResource()
+}
+
+// WatchCloudPrivateIPConfig starts the watching of cloudprivateipconfigs
+// resource and calls back the appropriate handler logic.
+func (eIPC *egressIPClusterController) WatchCloudPrivateIPConfig() (*factory.Handler, error) {
+	return eIPC.retryCloudPrivateIPConfig.WatchResource()
+}
+
+// WatchEgressIP starts the watching of egressip resource and calls back the
+// appropriate handler logic. It also initiates the other dedicated resource
+// handlers for egress IP setup: namespaces, pods.
+func (eIPC *egressIPClusterController) WatchEgressIP() (*factory.Handler, error) {
+	return eIPC.retryEgressIPs.WatchResource()
+}
+
+func (eIPC *egressIPClusterController) Stop() {
+	close(eIPC.stopChan)
+	eIPC.wg.Wait()
+	if eIPC.egressNodeHandler != nil {
+		eIPC.watchFactory.RemoveNodeHandler(eIPC.egressNodeHandler)
+	}
+	if eIPC.egressIPHandler != nil {
+		eIPC.watchFactory.RemoveEgressIPHandler(eIPC.egressIPHandler)
+	}
+	if eIPC.cloudPrivateIPConfigHandler != nil {
+		eIPC.watchFactory.RemoveCloudPrivateIPConfigHandler(eIPC.cloudPrivateIPConfigHandler)
+	}
+}
+
+type egressIPNodeStatus struct {
+	Node string
+	Name string
+}
+
+// getSortedEgressData returns a sorted slice of all egressNodes based on the
+// amount of allocations found in the cache
+func (eIPC *egressIPClusterController) getSortedEgressData() ([]*egressNode, map[string]egressIPNodeStatus) {
+	assignableNodes := []*egressNode{}
+	allAllocations := make(map[string]egressIPNodeStatus)
+	for _, eNode := range eIPC.allocator.cache {
+		if eNode.isEgressAssignable && eNode.isReady && eNode.isReachable {
+			assignableNodes = append(assignableNodes, eNode)
+		}
+		for ip, eipName := range eNode.allocations {
+			allAllocations[ip] = egressIPNodeStatus{Node: eNode.name, Name: eipName}
+		}
+	}
+	sort.Slice(assignableNodes, func(i, j int) bool {
+		return len(assignableNodes[i].allocations) < len(assignableNodes[j].allocations)
+	})
+	return assignableNodes, allAllocations
+}
+
+func (eIPC *egressIPClusterController) initEgressNodeReachability(nodes []interface{}) error {
+	go eIPC.checkEgressNodesReachability()
+	return nil
+}
+
+func (eIPC *egressIPClusterController) setNodeEgressAssignable(nodeName string, isAssignable bool) {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	if eNode, exists := eIPC.allocator.cache[nodeName]; exists {
+		eNode.isEgressAssignable = isAssignable
+		// if the node is not assignable/ready/reachable anymore we need to
+		// empty all of it's allocations from our cache since we'll clear all
+		// assignments from this node later on, because of this.
+		if !isAssignable {
+			eNode.allocations = make(map[string]string)
+		}
+	}
+}
+
+func (eIPC *egressIPClusterController) isEgressNodeReady(egressNode *v1.Node) bool {
+	for _, condition := range egressNode.Status.Conditions {
+		if condition.Type == v1.NodeReady {
+			return condition.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func isReachableLegacy(node string, mgmtIPs []net.IP, totalTimeout int) bool {
+	var retryTimeOut, initialRetryTimeOut time.Duration
+
+	numMgmtIPs := len(mgmtIPs)
+	if numMgmtIPs == 0 {
+		return false
+	}
+
+	switch totalTimeout {
+	// Check if we need to do node reachability check
+	case 0:
+		return true
+	case 1:
+		// Using time duration for initial retry with 700/numIPs msec and retry of 100/numIPs msec
+		// to ensure total wait time will be in range with the configured value including a sleep of 100msec between attempts.
+		initialRetryTimeOut = time.Duration(700/numMgmtIPs) * time.Millisecond
+		retryTimeOut = time.Duration(100/numMgmtIPs) * time.Millisecond
+	default:
+		// Using time duration for initial retry with 900/numIPs msec
+		// to ensure total wait time will be in range with the configured value including a sleep of 100msec between attempts.
+		initialRetryTimeOut = time.Duration(900/numMgmtIPs) * time.Millisecond
+		retryTimeOut = initialRetryTimeOut
+	}
+
+	timeout := initialRetryTimeOut
+	endTime := time.Now().Add(time.Second * time.Duration(totalTimeout))
+	for time.Now().Before(endTime) {
+		for _, ip := range mgmtIPs {
+			if dialer.dial(ip, timeout) {
+				return true
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+		timeout = retryTimeOut
+	}
+	klog.Errorf("Failed reachability check for %s", node)
+	return false
+}
+
+// checkEgressNodesReachability continuously checks if all nodes used for egress
+// IP assignment are reachable, and updates the nodes following the result. This
+// is important because egress IP is based upon routing traffic to these nodes,
+// and if they aren't reachable we shouldn't be using them for egress IP.
+func (eIPC *egressIPClusterController) checkEgressNodesReachability() {
+	timer := time.NewTicker(eIPC.reachabilityCheckInterval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			checkEgressNodesReachabilityIterate(eIPC)
+		case <-eIPC.stopChan:
+			klog.V(5).Infof("Stop channel got triggered: will stop checkEgressNodesReachability")
+			return
+		}
+	}
+}
+
+func checkEgressNodesReachabilityIterate(eIPC *egressIPClusterController) {
+	reAddOrDelete := map[string]bool{}
+	eIPC.allocator.Lock()
+	for _, eNode := range eIPC.allocator.cache {
+		if eNode.isEgressAssignable && eNode.isReady {
+			wasReachable := eNode.isReachable
+			isReachable := eIPC.isReachable(eNode.name, eNode.mgmtIPs, eNode.healthClient)
+			if wasReachable && !isReachable {
+				reAddOrDelete[eNode.name] = true
+			} else if !wasReachable && isReachable {
+				reAddOrDelete[eNode.name] = false
+			}
+			eNode.isReachable = isReachable
+		} else {
+			// End connection (if there is one). This is important because
+			// it accounts for cases where node is not labelled with
+			// egress-assignable, so connection is no longer needed. Calling
+			// this on a already disconnected node is expected to be cheap.
+			eNode.healthClient.Disconnect()
+		}
+	}
+	eIPC.allocator.Unlock()
+	for nodeName, shouldDelete := range reAddOrDelete {
+		if shouldDelete {
+			metrics.RecordEgressIPUnreachableNode()
+			klog.Warningf("Node: %s is detected as unreachable, deleting it from egress assignment", nodeName)
+			if err := eIPC.deleteEgressNode(nodeName); err != nil {
+				klog.Errorf("Node: %s is detected as unreachable, but could not re-assign egress IPs, err: %v", nodeName, err)
+			}
+		} else {
+			klog.Infof("Node: %s is detected as reachable and ready again, adding it to egress assignment", nodeName)
+			if err := eIPC.addEgressNode(nodeName); err != nil {
+				klog.Errorf("Node: %s is detected as reachable and ready again, but could not re-assign egress IPs, err: %v", nodeName, err)
+			}
+		}
+	}
+}
+
+func (eIPC *egressIPClusterController) isReachable(nodeName string, mgmtIPs []net.IP, healthClient healthcheck.EgressIPHealthClient) bool {
+	// Check if we need to do node reachability check
+	if eIPC.egressIPTotalTimeout == 0 {
+		return true
+	}
+
+	if eIPC.egressIPNodeHealthCheckPort == 0 {
+		return isReachableLegacy(nodeName, mgmtIPs, eIPC.egressIPTotalTimeout)
+	}
+	return isReachableViaGRPC(mgmtIPs, healthClient, eIPC.egressIPNodeHealthCheckPort, eIPC.egressIPTotalTimeout)
+}
+
+func (eIPC *egressIPClusterController) isEgressNodeReachable(egressNode *v1.Node) bool {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	if eNode, exists := eIPC.allocator.cache[egressNode.Name]; exists {
+		return eNode.isReachable || eIPC.isReachable(eNode.name, eNode.mgmtIPs, eNode.healthClient)
+	}
+	return false
+}
+
+func (eIPC *egressIPClusterController) setNodeEgressReady(nodeName string, isReady bool) {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	if eNode, exists := eIPC.allocator.cache[nodeName]; exists {
+		eNode.isReady = isReady
+		// see setNodeEgressAssignable
+		if !isReady {
+			eNode.allocations = make(map[string]string)
+		}
+	}
+}
+
+func (eIPC *egressIPClusterController) setNodeEgressReachable(nodeName string, isReachable bool) {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	if eNode, exists := eIPC.allocator.cache[nodeName]; exists {
+		eNode.isReachable = isReachable
+		// see setNodeEgressAssignable
+		if !isReachable {
+			eNode.allocations = make(map[string]string)
+		}
+	}
+}
+
+func (eIPC *egressIPClusterController) addEgressNode(nodeName string) error {
+	var errors []error
+	klog.V(5).Infof("Egress node: %s about to be initialized", nodeName)
+
+	// If a node has been labelled for egress IP we need to check if there are any
+	// egress IPs which are missing an assignment. If there are, we need to send a
+	// synthetic update since reconcileEgressIP will then try to assign those IPs to
+	// this node (if possible)
+	egressIPs, err := eIPC.kube.GetEgressIPs()
+	if err != nil {
+		return fmt.Errorf("unable to list EgressIPs, err: %v", err)
+	}
+	for _, egressIP := range egressIPs.Items {
+		if len(egressIP.Spec.EgressIPs) != len(egressIP.Status.Items) {
+			// Send a "synthetic update" on all egress IPs which are not fully
+			// assigned, the reconciliation loop for WatchEgressIP will try to
+			// assign stuff to this new node. The workqueue's delta FIFO
+			// implementation will not trigger a watch event for updates on
+			// objects which have no semantic difference, hence: call the
+			// reconciliation function directly.
+			if err := eIPC.reconcileEgressIP(nil, &egressIP); err != nil {
+				errors = append(errors, fmt.Errorf("synthetic update for EgressIP: %s failed, err: %v", egressIP.Name, err))
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return utilerrors.NewAggregate(errors)
+	}
+	return nil
+}
+
+// deleteNodeForEgress remove the default allow logical router policies for the
+// node and removes the node from the allocator cache.
+func (eIPC *egressIPClusterController) deleteNodeForEgress(node *v1.Node) {
+	eIPC.allocator.Lock()
+	if eNode, exists := eIPC.allocator.cache[node.Name]; exists {
+		eNode.healthClient.Disconnect()
+	}
+	delete(eIPC.allocator.cache, node.Name)
+	eIPC.allocator.Unlock()
+}
+
+func (eIPC *egressIPClusterController) deleteEgressNode(nodeName string) error {
+	var errorAggregate []error
+	klog.V(5).Infof("Egress node: %s about to be removed", nodeName)
+	// Since the node has been labelled as "not usable" for egress IP
+	// assignments we need to find all egress IPs which have an assignment to
+	// it, and move them elsewhere.
+	egressIPs, err := eIPC.kube.GetEgressIPs()
+	if err != nil {
+		return fmt.Errorf("unable to list EgressIPs, err: %v", err)
+	}
+	for _, egressIP := range egressIPs.Items {
+		for _, status := range egressIP.Status.Items {
+			if status.Node == nodeName {
+				// Send a "synthetic update" on all egress IPs which have an
+				// assignment to this node. The reconciliation loop for
+				// WatchEgressIP will see that the current assignment status to
+				// this node is invalid and try to re-assign elsewhere. The
+				// workqueue's delta FIFO implementation will not trigger a
+				// watch event for updates on objects which have no semantic
+				// difference, hence: call the reconciliation function directly.
+				if err := eIPC.reconcileEgressIP(nil, &egressIP); err != nil {
+					errorAggregate = append(errorAggregate, fmt.Errorf("re-assignment for EgressIP: %s failed, unable to update object, err: %v", egressIP.Name, err))
+				}
+				break
+			}
+		}
+	}
+	if len(errorAggregate) > 0 {
+		return utilerrors.NewAggregate(errorAggregate)
+	}
+	return nil
+}
+
+func (eIPC *egressIPClusterController) initEgressIPAllocator(node *v1.Node) (err error) {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	if _, exists := eIPC.allocator.cache[node.Name]; !exists {
+		var parsedEgressIPConfig *util.ParsedNodeEgressIPConfiguration
+		if util.PlatformTypeIsEgressIPCloudProvider() {
+			parsedEgressIPConfig, err = util.ParseCloudEgressIPConfig(node)
+			if err != nil {
+				return fmt.Errorf("unable to use cloud node for egress assignment, err: %v", err)
+			}
+		} else {
+			parsedEgressIPConfig, err = util.ParseNodePrimaryIfAddr(node)
+			if err != nil {
+				return fmt.Errorf("unable to use node for egress assignment, err: %v", err)
+			}
+		}
+		nodeSubnets, err := util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName)
+		if err != nil {
+			return fmt.Errorf("failed to parse node %s subnets annotation %v", node.Name, err)
+		}
+		mgmtIPs := make([]net.IP, len(nodeSubnets))
+		for i, subnet := range nodeSubnets {
+			mgmtIPs[i] = util.GetNodeManagementIfAddr(subnet).IP
+		}
+		eIPC.allocator.cache[node.Name] = &egressNode{
+			name:           node.Name,
+			egressIPConfig: parsedEgressIPConfig,
+			mgmtIPs:        mgmtIPs,
+			allocations:    make(map[string]string),
+			healthClient:   hccAllocator.allocate(node.Name),
+		}
+	}
+	return nil
+}
+
+// deleteAllocatorEgressIPAssignments deletes the allocation as to keep the
+// cache state correct, also see addAllocatorEgressIPAssignments
+func (eIPC *egressIPClusterController) deleteAllocatorEgressIPAssignments(statusAssignments []egressipv1.EgressIPStatusItem) {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	for _, status := range statusAssignments {
+		if eNode, exists := eIPC.allocator.cache[status.Node]; exists {
+			delete(eNode.allocations, status.EgressIP)
+		}
+	}
+}
+
+// deleteAllocatorEgressIPAssignmentIfExists deletes egressIP config from node allocations map
+// if the entry is available and returns assigned node name, otherwise returns empty string.
+func (eIPC *egressIPClusterController) deleteAllocatorEgressIPAssignmentIfExists(name, egressIP string) string {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	for nodeName, eNode := range eIPC.allocator.cache {
+		if egressIPName, exists := eNode.allocations[egressIP]; exists && egressIPName == name {
+			delete(eNode.allocations, egressIP)
+			return nodeName
+		}
+	}
+	return ""
+}
+
+// addAllocatorEgressIPAssignments adds the allocation to the cache, so that
+// they are tracked during the life-cycle of ovnkube-master
+func (eIPC *egressIPClusterController) addAllocatorEgressIPAssignments(name string, statusAssignments []egressipv1.EgressIPStatusItem) {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	for _, status := range statusAssignments {
+		if eNode, exists := eIPC.allocator.cache[status.Node]; exists {
+			eNode.allocations[status.EgressIP] = name
+		}
+	}
+}
+
+func (eIPC *egressIPClusterController) reconcileEgressIP(old, new *egressipv1.EgressIP) (err error) {
+	// Lock the assignment, this is needed because this function can end up
+	// being called from WatchEgressNodes and WatchEgressIP, i.e: two different
+	// go-routines and we need to make sure the assignment is safe.
+	eIPC.egressIPAssignmentMutex.Lock()
+	defer eIPC.egressIPAssignmentMutex.Unlock()
+
+	name := ""
+
+	// Initialize a status which will be used to compare against
+	// new.spec.egressIPs and decide on what from the status should get deleted
+	// or kept.
+	status := []egressipv1.EgressIPStatusItem{}
+
+	// Initialize an empty objects as to avoid SIGSEGV. The code should play
+	// nicely with empty objects though.
+	newEIP := &egressipv1.EgressIP{}
+
+	// Initialize a sets.String which holds egress IPs that were not fully assigned
+	// but are allocated and they are meant to be removed.
+	staleEgressIPs := sets.NewString()
+	if old != nil {
+		name = old.Name
+		status = old.Status.Items
+		staleEgressIPs.Insert(old.Spec.EgressIPs...)
+	}
+	if new != nil {
+		newEIP = new
+		name = newEIP.Name
+		status = newEIP.Status.Items
+		if staleEgressIPs.Len() > 0 {
+			for _, egressIP := range newEIP.Spec.EgressIPs {
+				if staleEgressIPs.Has(egressIP) {
+					staleEgressIPs.Delete(egressIP)
+				}
+			}
+		}
+	}
+
+	// Validate the spec and use only the valid egress IPs when performing any
+	// successive operations, theoretically: the user could specify invalid IP
+	// addresses, which would break us.
+	validSpecIPs, err := eIPC.validateEgressIPSpec(name, newEIP.Spec.EgressIPs)
+	if err != nil {
+		return fmt.Errorf("invalid EgressIP spec, err: %v", err)
+	}
+
+	// Validate the status, on restart it could be the case that what might have
+	// been assigned when ovnkube-master last ran is not a valid assignment
+	// anymore (specifically if ovnkube-master has been crashing for a while).
+	// Any invalid status at this point in time needs to be removed and assigned
+	// to a valid node.
+	validStatus, invalidStatus := eIPC.validateEgressIPStatus(name, status)
+	for status := range validStatus {
+		// If the spec has changed and an egress IP has been removed by the
+		// user: we need to un-assign that egress IP
+		if !validSpecIPs.Has(status.EgressIP) {
+			invalidStatus[status] = ""
+			delete(validStatus, status)
+		}
+	}
+
+	invalidStatusLen := len(invalidStatus)
+	if invalidStatusLen > 0 {
+		metrics.RecordEgressIPRebalance(invalidStatusLen)
+	}
+
+	// Add only the diff between what is requested and valid and that which
+	// isn't already assigned.
+	ipsToAssign := validSpecIPs
+	ipsToRemove := sets.New[string]()
+	statusToAdd := make([]egressipv1.EgressIPStatusItem, 0, len(ipsToAssign))
+	statusToKeep := make([]egressipv1.EgressIPStatusItem, 0, len(validStatus))
+	for status := range validStatus {
+		statusToKeep = append(statusToKeep, status)
+		ipsToAssign.Delete(status.EgressIP)
+	}
+	statusToRemove := make([]egressipv1.EgressIPStatusItem, 0, invalidStatusLen)
+	for status := range invalidStatus {
+		statusToRemove = append(statusToRemove, status)
+		ipsToRemove.Insert(status.EgressIP)
+	}
+	if ipsToRemove.Len() > 0 {
+		// The following is added as to ensure that we only add after having
+		// successfully removed egress IPs. This case is not very important on
+		// bare-metal (since we execute the add after the remove below, and
+		// hence have full control of the execution - barring its success), but
+		// on a cloud: we patch all validStatsuses below, we wait for the status
+		// on the CloudPrivateIPConfig(s) we create to be set before executing
+		// anything in the OVN DB (Note that the status will be set by this
+		// controller in cluster-manager and asynchronously the ovnkube-master
+		// will read the CRD change and do the necessary plumbing (ADD/UPDATE/DELETE)
+		// in the OVN DB).
+		// So, we need to make sure that we delete and
+		// then add, mainly because if EIP1 is added to nodeX and then EIP2 is
+		// removed from nodeX, we might remove the setup made for EIP1. The
+		// add/delete ordering of events is not guaranteed on the cloud where we
+		// depend on other controllers to execute the work for us however. By
+		// comparing the spec to the status and applying the following truth
+		// table we can ensure that order of events.
+
+		// case ID    |    Egress IP to add    |    Egress IP to remove    |    ipsToAssign
+		// 1          |    e1                  |    e1                     |    e1
+		// 2          |    e2                  |    e1                     |    -
+		// 3          |    e2                  |    -                      |    e2
+		// 4          |    -                   |    e1                     |    -
+
+		// Case 1 handles updates. Case 2 and 3 makes sure we don't add until we
+		// successfully delete. Case 4 just shows an example of what would
+		// happen if we don't have anything to add
+		ipsToAssign = ipsToAssign.Intersection(ipsToRemove)
+	}
+
+	if !util.PlatformTypeIsEgressIPCloudProvider() {
+		if len(statusToRemove) > 0 {
+			// Delete the statusToRemove from the allocator cache. If we don't
+			// do this we will occupy assignment positions for the ipsToAssign,
+			// even though statusToRemove will be removed afterwards
+			eIPC.deleteAllocatorEgressIPAssignments(statusToRemove)
+		}
+		if len(ipsToAssign) > 0 {
+			statusToAdd = eIPC.assignEgressIPs(name, ipsToAssign.UnsortedList())
+			statusToKeep = append(statusToKeep, statusToAdd...)
+		}
+		// Add all assignments which are to be kept to the allocator cache,
+		// allowing us to track all assignments which have been performed and
+		// avoid incorrect future assignments due to a de-synchronized cache.
+		eIPC.addAllocatorEgressIPAssignments(name, statusToKeep)
+		// Update the object only on an ADD/UPDATE. If we are processing a
+		// DELETE, new will be nil and we should not update the object.
+		if len(statusToAdd) > 0 || (len(statusToRemove) > 0 && new != nil) {
+			if err := eIPC.patchReplaceEgressIPStatus(name, statusToKeep); err != nil {
+				return err
+			}
+		}
+	} else {
+		// Even when running on a public cloud, we must make sure that we unwire EgressIP
+		// configuration from OVN *before* we instruct the CloudNetworkConfigController
+		// to remove the CloudPrivateIPConfig object from the cloud.
+		// CloudPrivateIPConfig objects can be in the "Deleting" state for a long time,
+		// waiting for the underlying cloud to finish its action and to report success of the
+		// unattach operation. Some clouds such as Azure will remove the IP address nearly
+		// immediately, but then they will take a long time (seconds to minutes) to actually report
+		// success of the removal operation.
+		if len(statusToRemove) > 0 {
+			// Delete all assignments that are to be removed from the allocator
+			// cache. If we don't do this we will occupy assignment positions for
+			// the ipsToAdd, even though statusToRemove will be removed afterwards
+			eIPC.deleteAllocatorEgressIPAssignments(statusToRemove)
+			// Before updating the cloud private IP object, we need to remove the OVN configuration
+			// for these invalid statuses so that traffic is not blackholed to non-existing setup in the
+			// cloud. Thus we patch the egressIP status with the valid set of statuses which will
+			// trigger an event for the ovnkube-master to take action upon.
+			// Note that once we figure out the statusToAdd parts below we will trigger an
+			// update to cloudPrivateIP object which will trigger another patch for the eIP object.
+			if err := eIPC.patchReplaceEgressIPStatus(name, statusToKeep); err != nil {
+				return err
+			}
+		}
+		// When egress IP is not fully assigned to a node, then statusToRemove may not
+		// have those entries, hence retrieve it from staleEgressIPs for removing
+		// the item from cloudprivateipconfig.
+		for _, toRemove := range statusToRemove {
+			if !staleEgressIPs.Has(toRemove.EgressIP) {
+				continue
+			}
+			staleEgressIPs.Delete(toRemove.EgressIP)
+		}
+		for staleEgressIP := range staleEgressIPs {
+			if nodeName := eIPC.deleteAllocatorEgressIPAssignmentIfExists(name, staleEgressIP); nodeName != "" {
+				statusToRemove = append(statusToRemove,
+					egressipv1.EgressIPStatusItem{EgressIP: staleEgressIP, Node: nodeName})
+			}
+		}
+		// If running on a public cloud we should not program OVN just yet for assignment
+		// operations. We need confirmation from the cloud-network-config-controller that
+		// it can assign the IPs. reconcileCloudPrivateIPConfig will take care of
+		// processing the answer from the requests we make here, and update OVN
+		// accordingly when we know what the outcome is.
+		if len(ipsToAssign) > 0 {
+			statusToAdd = eIPC.assignEgressIPs(name, ipsToAssign.UnsortedList())
+			statusToKeep = append(statusToKeep, statusToAdd...)
+		}
+		// Same as above: Add all assignments which are to be kept to the
+		// allocator cache, allowing us to track all assignments which have been
+		// performed and avoid incorrect future assignments due to a
+		// de-synchronized cache.
+		eIPC.addAllocatorEgressIPAssignments(name, statusToKeep)
+
+		// Execute CloudPrivateIPConfig changes for assignments which need to be
+		// added/removed, assignments which don't change do not require any
+		// further setup.
+		if err := eIPC.executeCloudPrivateIPConfigChange(name, statusToAdd, statusToRemove); err != nil {
+			return err
+		}
+	}
+
+	// Record the egress IP allocator count
+	metrics.RecordEgressIPCount(eIPC.getAllocationTotalCount())
+	return nil
+}
+
+// assignEgressIPs is the main assignment algorithm for egress IPs to nodes.
+// Specifically we have a couple of hard constraints: a) the subnet of the node
+// must be able to host the egress IP b) the egress IP cannot be a node IP c)
+// the IP cannot already be assigned and reference by another EgressIP object d)
+// no two egress IPs for the same EgressIP object can be assigned to the same
+// node e) (for public clouds) the amount of egress IPs assigned to one node
+// must respect its assignment capacity. Moreover there is a soft constraint:
+// the assignments need to be balanced across all cluster nodes, so that no node
+// becomes a bottleneck. The balancing is achieved by sorting the nodes in
+// ascending order following their existing amount of allocations, and trying to
+// assign the egress IP to the node with the lowest amount of allocations every
+// time, this does not guarantee complete balance, but mostly complete.
+func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []string) []egressipv1.EgressIPStatusItem {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	assignments := []egressipv1.EgressIPStatusItem{}
+	assignableNodes, existingAllocations := eIPC.getSortedEgressData()
+	if len(assignableNodes) == 0 {
+		eIPRef := v1.ObjectReference{
+			Kind: "EgressIP",
+			Name: name,
+		}
+		eIPC.recorder.Eventf(&eIPRef, v1.EventTypeWarning, "NoMatchingNodeFound", "no assignable nodes for EgressIP: %s, please tag at least one node with label: %s", name, util.GetNodeEgressLabel())
+		klog.Errorf("No assignable nodes found for EgressIP: %s and requested IPs: %v", name, egressIPs)
+		return assignments
+	}
+	klog.V(5).Infof("Current assignments are: %+v", existingAllocations)
+	for _, egressIP := range egressIPs {
+		klog.V(5).Infof("Will attempt assignment for egress IP: %s", egressIP)
+		eIP := net.ParseIP(egressIP)
+		if status, exists := existingAllocations[eIP.String()]; exists {
+			// On public clouds we will re-process assignments for the same IP
+			// multiple times due to the nature of syncing each individual
+			// CloudPrivateIPConfig one at a time. This means that we are
+			// expected to end up in this situation multiple times per sync. Ex:
+			// Say we an EgressIP is created with IP1, IP2, IP3. We begin by
+			// assigning them all the first round. Next we get the
+			// CloudPrivateIPConfig confirming the addition of IP1, leading us
+			// to re-assign IP2, IP3, but since we've already assigned them
+			// we'll end up here. This is not an error. What would be an error
+			// is if the user created EIP1 with IP1 and a second EIP2 with IP1
+			if name == status.Name {
+				// IP is already assigned for this EgressIP object
+				assignments = append(assignments, egressipv1.EgressIPStatusItem{
+					Node:     status.Node,
+					EgressIP: eIP.String(),
+				})
+				continue
+			} else {
+				klog.Errorf("IP: %q for EgressIP: %s is already allocated for EgressIP: %s on %s", egressIP, name, status.Name, status.Node)
+				return assignments
+			}
+		}
+		if node := eIPC.isAnyClusterNodeIP(eIP); node != nil {
+			eIPRef := v1.ObjectReference{
+				Kind: "EgressIP",
+				Name: name,
+			}
+			eIPC.recorder.Eventf(
+				&eIPRef,
+				v1.EventTypeWarning,
+				"UnsupportedRequest",
+				"Egress IP: %v for object EgressIP: %s is the IP address of node: %s, this is unsupported", eIP, name, node.name,
+			)
+			klog.Errorf("Egress IP: %v is the IP address of node: %s", eIP, node.name)
+			return assignments
+		}
+		for _, eNode := range assignableNodes {
+			klog.V(5).Infof("Attempting assignment on egress node: %+v", eNode)
+			if eNode.getAllocationCountForEgressIP(name) > 0 {
+				klog.V(5).Infof("Node: %s is already in use by another egress IP for this EgressIP: %s, trying another node", eNode.name, name)
+				continue
+			}
+			if eNode.egressIPConfig.Capacity.IP < util.UnlimitedNodeCapacity {
+				if eNode.egressIPConfig.Capacity.IP-len(eNode.allocations) <= 0 {
+					klog.V(5).Infof("Additional allocation on Node: %s exhausts it's IP capacity, trying another node", eNode.name)
+					continue
+				}
+			}
+			if eNode.egressIPConfig.Capacity.IPv4 < util.UnlimitedNodeCapacity && utilnet.IsIPv4(eIP) {
+				if eNode.egressIPConfig.Capacity.IPv4-getIPFamilyAllocationCount(eNode.allocations, false) <= 0 {
+					klog.V(5).Infof("Additional allocation on Node: %s exhausts it's IPv4 capacity, trying another node", eNode.name)
+					continue
+				}
+			}
+			if eNode.egressIPConfig.Capacity.IPv6 < util.UnlimitedNodeCapacity && utilnet.IsIPv6(eIP) {
+				if eNode.egressIPConfig.Capacity.IPv6-getIPFamilyAllocationCount(eNode.allocations, true) <= 0 {
+					klog.V(5).Infof("Additional allocation on Node: %s exhausts it's IPv6 capacity, trying another node", eNode.name)
+					continue
+				}
+			}
+			if (eNode.egressIPConfig.V6.Net != nil && eNode.egressIPConfig.V6.Net.Contains(eIP)) ||
+				(eNode.egressIPConfig.V4.Net != nil && eNode.egressIPConfig.V4.Net.Contains(eIP)) {
+				assignments = append(assignments, egressipv1.EgressIPStatusItem{
+					Node:     eNode.name,
+					EgressIP: eIP.String(),
+				})
+				klog.Infof("Successful assignment of egress IP: %s on node: %+v", egressIP, eNode)
+				eNode.allocations[eIP.String()] = name
+				break
+			}
+		}
+	}
+	if len(assignments) == 0 {
+		eIPRef := v1.ObjectReference{
+			Kind: "EgressIP",
+			Name: name,
+		}
+		eIPC.recorder.Eventf(&eIPRef, v1.EventTypeWarning, "NoMatchingNodeFound", "No matching nodes found, which can host any of the egress IPs: %v for object EgressIP: %s", egressIPs, name)
+		klog.Errorf("No matching host found for EgressIP: %s", name)
+		return assignments
+	}
+	if len(assignments) < len(egressIPs) {
+		eIPRef := v1.ObjectReference{
+			Kind: "EgressIP",
+			Name: name,
+		}
+		eIPC.recorder.Eventf(&eIPRef, v1.EventTypeWarning, "UnassignedRequest", "Not all egress IPs for EgressIP: %s could be assigned, please tag more nodes", name)
+	}
+	return assignments
+}
+
+func getIPFamilyAllocationCount(allocations map[string]string, isIPv6 bool) (count int) {
+	for allocation := range allocations {
+		if utilnet.IsIPv4String(allocation) && !isIPv6 {
+			count++
+		}
+		if utilnet.IsIPv6String(allocation) && isIPv6 {
+			count++
+		}
+	}
+	return
+}
+
+func (eIPC *egressIPClusterController) validateEgressIPSpec(name string, egressIPs []string) (sets.Set[string], error) {
+	validatedEgressIPs := sets.New[string]()
+	for _, egressIP := range egressIPs {
+		ip := net.ParseIP(egressIP)
+		if ip == nil {
+			eIPRef := v1.ObjectReference{
+				Kind: "EgressIP",
+				Name: name,
+			}
+			eIPC.recorder.Eventf(&eIPRef, v1.EventTypeWarning, "InvalidEgressIP", "egress IP: %s for object EgressIP: %s is not a valid IP address", egressIP, name)
+			return nil, fmt.Errorf("unable to parse provided EgressIP: %s, invalid", egressIP)
+		}
+		validatedEgressIPs.Insert(ip.String())
+	}
+	return validatedEgressIPs, nil
+}
+
+// validateEgressIPStatus validates if the statuses are valid given what the
+// cache knows about all egress nodes. WatchEgressNodes is initialized before
+// any other egress IP handler, so the cache should be warm and correct once we
+// start going this.
+func (eIPC *egressIPClusterController) validateEgressIPStatus(name string, items []egressipv1.EgressIPStatusItem) (map[egressipv1.EgressIPStatusItem]string, map[egressipv1.EgressIPStatusItem]string) {
+	eIPC.allocator.Lock()
+	defer eIPC.allocator.Unlock()
+	valid, invalid := make(map[egressipv1.EgressIPStatusItem]string), make(map[egressipv1.EgressIPStatusItem]string)
+	for _, eIPStatus := range items {
+		validAssignment := true
+		eNode, exists := eIPC.allocator.cache[eIPStatus.Node]
+		if !exists {
+			klog.Errorf("Allocator error: EgressIP: %s claims to have an allocation on a node which is unassignable for egress IP: %s", name, eIPStatus.Node)
+			validAssignment = false
+		} else {
+			if eNode.getAllocationCountForEgressIP(name) > 1 {
+				klog.Errorf("Allocator error: EgressIP: %s claims multiple egress IPs on same node: %s, will attempt rebalancing", name, eIPStatus.Node)
+				validAssignment = false
+			}
+			if !eNode.isEgressAssignable {
+				klog.Errorf("Allocator error: EgressIP: %s assigned to node: %s which does not have egress label, will attempt rebalancing", name, eIPStatus.Node)
+				validAssignment = false
+			}
+			if !eNode.isReachable {
+				klog.Errorf("Allocator error: EgressIP: %s assigned to node: %s which is not reachable, will attempt rebalancing", name, eIPStatus.Node)
+				validAssignment = false
+			}
+			if !eNode.isReady {
+				klog.Errorf("Allocator error: EgressIP: %s assigned to node: %s which is not ready, will attempt rebalancing", name, eIPStatus.Node)
+				validAssignment = false
+			}
+			ip := net.ParseIP(eIPStatus.EgressIP)
+			if ip == nil {
+				klog.Errorf("Allocator error: EgressIP allocation contains unparsable IP address: %s", eIPStatus.EgressIP)
+				validAssignment = false
+			}
+			if node := eIPC.isAnyClusterNodeIP(ip); node != nil {
+				klog.Errorf("Allocator error: EgressIP allocation: %s is the IP of node: %s ", ip.String(), node.name)
+				validAssignment = false
+			}
+			if utilnet.IsIPv6(ip) && eNode.egressIPConfig.V6.Net != nil {
+				if !eNode.egressIPConfig.V6.Net.Contains(ip) {
+					klog.Errorf("Allocator error: EgressIP allocation: %s on subnet: %s which cannot host it", ip.String(), eNode.egressIPConfig.V4.Net.String())
+					validAssignment = false
+				}
+			} else if !utilnet.IsIPv6(ip) && eNode.egressIPConfig.V4.Net != nil {
+				if !eNode.egressIPConfig.V4.Net.Contains(ip) {
+					klog.Errorf("Allocator error: EgressIP allocation: %s on subnet: %s which cannot host it", ip.String(), eNode.egressIPConfig.V4.Net.String())
+					validAssignment = false
+				}
+			} else {
+				klog.Errorf("Allocator error: EgressIP allocation on node: %s which does not support its IP protocol version", eIPStatus.Node)
+				validAssignment = false
+			}
+		}
+		if validAssignment {
+			valid[eIPStatus] = ""
+		} else {
+			invalid[eIPStatus] = ""
+		}
+	}
+	return valid, invalid
+}
+
+func (eIPC *egressIPClusterController) reconcileCloudPrivateIPConfig(old, new *ocpcloudnetworkapi.CloudPrivateIPConfig) error {
+	oldCloudPrivateIPConfig, newCloudPrivateIPConfig := &ocpcloudnetworkapi.CloudPrivateIPConfig{}, &ocpcloudnetworkapi.CloudPrivateIPConfig{}
+	shouldDelete, shouldAdd := false, false
+	nodeToDelete := ""
+
+	if old != nil {
+		oldCloudPrivateIPConfig = old
+		// We need to handle three types of deletes, A) object UPDATE where the
+		// old egress IP <-> node assignment has been removed. This is indicated
+		// by the old object having a .status.node set and the new object having
+		// .status.node empty and the condition on the new being successful. B)
+		// object UPDATE where egress IP <-> node assignment has been updated.
+		// This is indicated by .status.node being different on old and new
+		// objects. C) object DELETE, for which new is nil
+		shouldDelete = oldCloudPrivateIPConfig.Status.Node != "" || new == nil
+		// On DELETE we need to delete the .spec.node for the old object
+		nodeToDelete = oldCloudPrivateIPConfig.Spec.Node
+	}
+	if new != nil {
+		newCloudPrivateIPConfig = new
+		// We should only proceed to setting things up for objects where the new
+		// object has the same .spec.node and .status.node, and assignment
+		// condition being true. This is how the cloud-network-config-controller
+		// indicates a successful cloud assignment.
+		shouldAdd = newCloudPrivateIPConfig.Status.Node == newCloudPrivateIPConfig.Spec.Node &&
+			ocpcloudnetworkapi.CloudPrivateIPConfigConditionType(newCloudPrivateIPConfig.Status.Conditions[0].Type) == ocpcloudnetworkapi.Assigned &&
+			v1.ConditionStatus(newCloudPrivateIPConfig.Status.Conditions[0].Status) == v1.ConditionTrue
+		// See above explanation for the delete
+		shouldDelete = shouldDelete &&
+			(newCloudPrivateIPConfig.Status.Node == "" || newCloudPrivateIPConfig.Status.Node != oldCloudPrivateIPConfig.Status.Node) &&
+			ocpcloudnetworkapi.CloudPrivateIPConfigConditionType(newCloudPrivateIPConfig.Status.Conditions[0].Type) == ocpcloudnetworkapi.Assigned &&
+			v1.ConditionStatus(newCloudPrivateIPConfig.Status.Conditions[0].Status) == v1.ConditionTrue
+		// On UPDATE we need to delete the old .status.node
+		if shouldDelete {
+			nodeToDelete = oldCloudPrivateIPConfig.Status.Node
+		}
+	}
+
+	// As opposed to reconcileEgressIP, here we are only interested in changes
+	// made to the status (since we are the only ones performing the change made
+	// to the spec). So don't process the object if there is no change made to
+	// the status.
+	if reflect.DeepEqual(oldCloudPrivateIPConfig.Status, newCloudPrivateIPConfig.Status) {
+		return nil
+	}
+
+	if shouldDelete {
+		// Get the EgressIP owner reference
+		egressIPName, exists := oldCloudPrivateIPConfig.Annotations[util.OVNEgressIPOwnerRefLabel]
+		if !exists {
+			// If a CloudPrivateIPConfig object does not have an egress IP owner reference annotation upon deletion,
+			// there is no way that the object will get one after deletion. Hence, simply log a warning message here
+			// for informative purposes instead of throwing the same error and retrying time and time again.
+			klog.Warningf("CloudPrivateIPConfig object %q was missing the egress IP owner reference annotation "+
+				"upon deletion", oldCloudPrivateIPConfig.Name)
+			return nil
+		}
+		// Check if the egress IP has been deleted or not, if we are processing
+		// a CloudPrivateIPConfig delete because the EgressIP has been deleted
+		// then we need to remove the setup made for it, but not update the
+		// object.
+		egressIP, err := eIPC.kube.GetEgressIP(egressIPName)
+		isDeleted := apierrors.IsNotFound(err)
+		if err != nil && !isDeleted {
+			return err
+		}
+		egressIPString := cloudPrivateIPConfigNameToIPString(oldCloudPrivateIPConfig.Name)
+		statusItem := egressipv1.EgressIPStatusItem{
+			Node:     nodeToDelete,
+			EgressIP: egressIPString,
+		}
+		// If we are not processing a delete, update the EgressIP object's
+		// status assignments
+		if !isDeleted {
+			// Deleting a status here means updating the object with the statuses we
+			// want to keep
+			updatedStatus := []egressipv1.EgressIPStatusItem{}
+			for _, status := range egressIP.Status.Items {
+				if !reflect.DeepEqual(status, statusItem) {
+					updatedStatus = append(updatedStatus, status)
+				}
+			}
+			if err := eIPC.patchReplaceEgressIPStatus(egressIP.Name, updatedStatus); err != nil {
+				return err
+			}
+		}
+		resyncEgressIPs, err := eIPC.removePendingOpsAndGetResyncs(egressIPName, egressIPString)
+		if err != nil {
+			return err
+		}
+		for _, resyncEgressIP := range resyncEgressIPs {
+			if err := eIPC.reconcileEgressIP(nil, &resyncEgressIP); err != nil {
+				return fmt.Errorf("synthetic update for EgressIP: %s failed, err: %v", egressIP.Name, err)
+			}
+		}
+	}
+	if shouldAdd {
+		// Get the EgressIP owner reference
+		egressIPName, exists := newCloudPrivateIPConfig.Annotations[util.OVNEgressIPOwnerRefLabel]
+		if !exists {
+			// If a CloudPrivateIPConfig object does not have an egress IP owner reference annotation upon creation
+			// then we should simply log this as a warning. We should get an update action later down the road where we
+			// then take care of the rest. Hence, do not throw an error here to avoid rescheduling. Even though not
+			// officially supported, think of someone creating a CloudPrivateIPConfig object manually which will never
+			// get the annotation.
+			klog.Warningf("CloudPrivateIPConfig object %q is missing the egress IP owner reference annotation. Skipping",
+				oldCloudPrivateIPConfig.Name)
+			return nil
+		}
+		egressIP, err := eIPC.kube.GetEgressIP(egressIPName)
+		if err != nil {
+			return err
+		}
+		egressIPString := cloudPrivateIPConfigNameToIPString(newCloudPrivateIPConfig.Name)
+		statusItem := egressipv1.EgressIPStatusItem{
+			Node:     newCloudPrivateIPConfig.Status.Node,
+			EgressIP: egressIPString,
+		}
+		// Guard against performing the same assignment twice, which might
+		// happen when multiple updates come in on the same object.
+		hasStatus := false
+		for _, status := range egressIP.Status.Items {
+			if reflect.DeepEqual(status, statusItem) {
+				hasStatus = true
+				break
+			}
+		}
+		if !hasStatus {
+			statusToKeep := append(egressIP.Status.Items, statusItem)
+			if err := eIPC.patchReplaceEgressIPStatus(egressIP.Name, statusToKeep); err != nil {
+				return err
+			}
+		}
+
+		eIPC.pendingCloudPrivateIPConfigsMutex.Lock()
+		defer eIPC.pendingCloudPrivateIPConfigsMutex.Unlock()
+		// Remove the finished add / update operation from the pending cache. We
+		// never process add and deletes in the same sync, and for updates:
+		// deletes are always performed before adds, hence we should only ever
+		// fully delete the item from the pending cache once the add has
+		// finished.
+		ops, pending := eIPC.pendingCloudPrivateIPConfigsOps[egressIPName]
+		if !pending {
+			// Do not return an error here, it will lead to spurious error
+			// messages on restart because we will process a bunch of adds for
+			// all existing objects, for which no CR was issued.
+			klog.V(5).Infof("No pending operation found for EgressIP: %s while processing created CloudPrivateIPConfig", egressIPName)
+			return nil
+		}
+		op, exists := ops[egressIPString]
+		if !exists {
+			klog.V(5).Infof("Pending operations found for EgressIP: %s, but not for the created CloudPrivateIPConfig: %s", egressIPName, egressIPString)
+			return nil
+		}
+		// Process finalized add / updates, hence: (op.toAdd != "" &&
+		// op.toDelete != "") || (op.toAdd != "" && op.toDelete == ""), which is
+		// equivalent the below.
+		if op.toAdd != "" {
+			delete(ops, egressIPString)
+		}
+		if len(ops) == 0 {
+			delete(eIPC.pendingCloudPrivateIPConfigsOps, egressIPName)
+		}
+	}
+	return nil
+}
+
+// cloudPrivateIPConfigNameToIPString converts the resource name to the string
+// representation of net.IP. Given a limitation in the Kubernetes API server
+// (see: https://github.com/kubernetes/kubernetes/pull/100950)
+// CloudPrivateIPConfig.metadata.name cannot represent an IPv6 address. To
+// work-around this limitation it was decided that the network plugin creating
+// the CR will fully expand the IPv6 address and replace all colons with dots,
+// ex:
+
+// The CloudPrivateIPConfig name fc00.f853.0ccd.e793.0000.0000.0000.0054 will be
+// represented as address: fc00:f853:ccd:e793::54
+
+// We thus need to replace every fifth character's dot with a colon.
+func cloudPrivateIPConfigNameToIPString(name string) string {
+	// Handle IPv4, which will work fine.
+	if ip := net.ParseIP(name); ip != nil {
+		return name
+	}
+	// Handle IPv6, for which we want to convert the fully expanded "special
+	// name" to go's default IP representation
+	name = strings.ReplaceAll(name, ".", ":")
+	return net.ParseIP(name).String()
+}
+
+// removePendingOps removes the existing pending CloudPrivateIPConfig operations
+// from the cache and returns the EgressIP object which can be re-synced given
+// the new assignment possibilities.
+func (eIPC *egressIPClusterController) removePendingOpsAndGetResyncs(egressIPName, egressIP string) ([]egressipv1.EgressIP, error) {
+	eIPC.pendingCloudPrivateIPConfigsMutex.Lock()
+	defer eIPC.pendingCloudPrivateIPConfigsMutex.Unlock()
+	ops, pending := eIPC.pendingCloudPrivateIPConfigsOps[egressIPName]
+	if !pending {
+		return nil, fmt.Errorf("no pending operation found for EgressIP: %s", egressIPName)
+	}
+	op, exists := ops[egressIP]
+	if !exists {
+		return nil, fmt.Errorf("pending operations found for EgressIP: %s, but not for the finalized IP: %s", egressIPName, egressIP)
+	}
+	// Make sure we are dealing with a delete operation, since for update
+	// operations will still need to process the add afterwards.
+	if op.toAdd == "" && op.toDelete != "" {
+		delete(ops, egressIP)
+	}
+	if len(ops) == 0 {
+		delete(eIPC.pendingCloudPrivateIPConfigsOps, egressIPName)
+	}
+
+	// Some EgressIP objects might not have all of their spec.egressIPs
+	// assigned because there was no room to assign them. Hence, every time
+	// we process a final deletion for a CloudPrivateIPConfig: have a look
+	// at what other EgressIP objects have something un-assigned, and force
+	// a reconciliation on them by sending a synthetic update.
+	egressIPs, err := eIPC.kube.GetEgressIPs()
+	if err != nil {
+		return nil, fmt.Errorf("unable to list EgressIPs, err: %v", err)
+	}
+	resyncs := make([]egressipv1.EgressIP, 0, len(egressIPs.Items))
+	for _, egressIP := range egressIPs.Items {
+		// Do not process the egress IP object which owns the
+		// CloudPrivateIPConfig for which we are currently processing the
+		// deletion for.
+		if egressIP.Name == egressIPName {
+			continue
+		}
+		unassigned := len(egressIP.Spec.EgressIPs) - len(egressIP.Status.Items)
+		ops, pending := eIPC.pendingCloudPrivateIPConfigsOps[egressIP.Name]
+		// If the EgressIP was never added to the pending cache to begin
+		// with, but has un-assigned egress IPs, try it.
+		if !pending && unassigned > 0 {
+			resyncs = append(resyncs, egressIP)
+			continue
+		}
+		// If the EgressIP has pending operations, have a look at if the
+		// unassigned operations superseed the pending ones. It could be
+		// that it could only execute a couple of assignments at one point.
+		if pending && unassigned > len(ops) {
+			resyncs = append(resyncs, egressIP)
+		}
+	}
+	return resyncs, nil
+}

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -1,0 +1,2349 @@
+package clustermanager
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/urfave/cli/v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilnet "k8s.io/utils/net"
+)
+
+type fakeEgressIPDialer struct{}
+
+func (f fakeEgressIPDialer) dial(ip net.IP, timeout time.Duration) bool {
+	return true
+}
+
+type fakeEgressIPHealthClient struct {
+	Connected        bool
+	ProbeCount       int
+	FakeProbeFailure bool
+}
+
+func (fehc *fakeEgressIPHealthClient) IsConnected() bool {
+	return fehc.Connected
+}
+
+func (fehc *fakeEgressIPHealthClient) Connect(dialCtx context.Context, mgmtIPs []net.IP, healthCheckPort int) bool {
+	if fehc.FakeProbeFailure {
+		return false
+	}
+	fehc.Connected = true
+	return true
+}
+
+func (fehc *fakeEgressIPHealthClient) Disconnect() {
+	fehc.Connected = false
+	fehc.ProbeCount = 0
+}
+
+func (fehc *fakeEgressIPHealthClient) Probe(dialCtx context.Context) bool {
+	if fehc.Connected && !fehc.FakeProbeFailure {
+		fehc.ProbeCount++
+		return true
+	}
+	return false
+}
+
+type fakeEgressIPHealthClientAllocator struct{}
+
+func (f *fakeEgressIPHealthClientAllocator) allocate(nodeName string) healthcheck.EgressIPHealthClient {
+	return &fakeEgressIPHealthClient{}
+}
+
+func newNamespaceMeta(namespace string, additionalLabels map[string]string) metav1.ObjectMeta {
+	labels := map[string]string{
+		"name": namespace,
+	}
+	for k, v := range additionalLabels {
+		labels[k] = v
+	}
+	return metav1.ObjectMeta{
+		UID:         k8stypes.UID(namespace),
+		Name:        namespace,
+		Labels:      labels,
+		Annotations: map[string]string{},
+	}
+}
+
+func newNamespace(namespace string) *v1.Namespace {
+	return &v1.Namespace{
+		ObjectMeta: newNamespaceMeta(namespace, nil),
+		Spec:       v1.NamespaceSpec{},
+		Status:     v1.NamespaceStatus{},
+	}
+}
+
+var egressPodLabel = map[string]string{"egress": "needed"}
+
+func newEgressIPMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		UID:  k8stypes.UID(name),
+		Name: name,
+		Labels: map[string]string{
+			"name": name,
+		},
+	}
+}
+
+func setupNode(nodeName string, ipNets []string, mockAllocationIPs map[string]string) egressNode {
+	var v4IP, v6IP net.IP
+	var v4Subnet, v6Subnet *net.IPNet
+	for _, ipNet := range ipNets {
+		ip, net, _ := net.ParseCIDR(ipNet)
+		if utilnet.IsIPv6CIDR(net) {
+			v6Subnet = net
+			v6IP = ip
+		} else {
+			v4Subnet = net
+			v4IP = ip
+		}
+	}
+
+	mockAllcations := map[string]string{}
+	for mockAllocationIP, egressIPName := range mockAllocationIPs {
+		mockAllcations[net.ParseIP(mockAllocationIP).String()] = egressIPName
+	}
+
+	node := egressNode{
+		egressIPConfig: &util.ParsedNodeEgressIPConfiguration{
+			V4: util.ParsedIFAddr{
+				IP:  v4IP,
+				Net: v4Subnet,
+			},
+			V6: util.ParsedIFAddr{
+				IP:  v6IP,
+				Net: v6Subnet,
+			},
+			Capacity: util.Capacity{
+				IP:   util.UnlimitedNodeCapacity,
+				IPv4: util.UnlimitedNodeCapacity,
+				IPv6: util.UnlimitedNodeCapacity,
+			},
+		},
+		allocations:        mockAllcations,
+		healthClient:       hccAllocator.allocate(nodeName), // using fakeEgressIPHealthClientAllocator
+		name:               nodeName,
+		isReady:            true,
+		isReachable:        true,
+		isEgressAssignable: true,
+	}
+	return node
+}
+
+var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
+	var (
+		app                   *cli.App
+		fakeClusterManagerOVN *FakeClusterManager
+	)
+
+	const (
+		node1Name     = "node1"
+		node2Name     = "node2"
+		egressIPName  = "egressip"
+		egressIPName2 = "egressip-2"
+		namespace     = "egressip-namespace"
+		v4NodeSubnet  = "10.128.0.0/24"
+		v6NodeSubnet  = "ae70::66/64"
+	)
+
+	dialer = fakeEgressIPDialer{}
+	hccAllocator = &fakeEgressIPHealthClientAllocator{}
+
+	getEgressIPAllocatorSizeSafely := func() int {
+		fakeClusterManagerOVN.eIPC.allocator.Lock()
+		defer fakeClusterManagerOVN.eIPC.allocator.Unlock()
+		return len(fakeClusterManagerOVN.eIPC.allocator.cache)
+	}
+
+	getEgressIPStatusLen := func(egressIPName string) func() int {
+		return func() int {
+			tmp, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			return len(tmp.Status.Items)
+		}
+	}
+
+	getEgressIPStatus := func(egressIPName string) ([]string, []string) {
+		tmp, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), egressIPName, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		var egressIPs, nodes []string
+		for _, status := range tmp.Status.Items {
+			egressIPs = append(egressIPs, status.EgressIP)
+			nodes = append(nodes, status.Node)
+		}
+		return egressIPs, nodes
+	}
+
+	getEgressIPReassignmentCount := func() int {
+		reAssignmentCount := 0
+		egressIPs, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().List(context.TODO(), metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, egressIP := range egressIPs.Items {
+			if len(egressIP.Spec.EgressIPs) != len(egressIP.Status.Items) {
+				reAssignmentCount++
+			}
+		}
+		return reAssignmentCount
+	}
+
+	isEgressAssignableNode := func(nodeName string) func() bool {
+		return func() bool {
+			fakeClusterManagerOVN.eIPC.allocator.Lock()
+			defer fakeClusterManagerOVN.eIPC.allocator.Unlock()
+			if item, exists := fakeClusterManagerOVN.eIPC.allocator.cache[nodeName]; exists {
+				return item.isEgressAssignable
+			}
+			return false
+		}
+	}
+
+	nodeSwitch := func() string {
+		_, nodes := getEgressIPStatus(egressIPName)
+		if len(nodes) != 1 {
+			return ""
+		}
+		return nodes[0]
+	}
+
+	ginkgo.BeforeEach(func() {
+		// Restore global default values before each testcase
+		gomega.Expect(config.PrepareTestConfig()).To(gomega.Succeed())
+		config.OVNKubernetesFeature.EnableEgressIP = true
+		config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort = 1234
+
+		app = cli.NewApp()
+		app.Name = "test"
+		app.Flags = config.Flags
+		fakeClusterManagerOVN = NewFakeClusterManagerOVN()
+	})
+
+	ginkgo.AfterEach(func() {
+		fakeClusterManagerOVN.shutdown()
+	})
+
+	ginkgo.Context("On node ADD/UPDATE/DELETE", func() {
+		ginkgo.It("should re-assign EgressIPs and perform proper egressIP allocation changes", func() {
+			app.Action = func(ctx *cli.Context) error {
+				egressIP := "192.168.126.101"
+				node1IPv4 := "192.168.126.202/24"
+				node2IPv4 := "192.168.126.51/24"
+				egressNamespace := newNamespace(namespace)
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: egressPodLabel,
+						},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": egressNamespace.Name,
+							},
+						},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1, node2},
+					},
+				)
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
+				gomega.Eventually(isEgressAssignableNode(node1.Name)).Should(gomega.BeTrue())
+				gomega.Eventually(isEgressAssignableNode(node2.Name)).Should(gomega.BeFalse())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				node1.Labels = map[string]string{}
+				node2.Labels = map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				}
+
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node1, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				gomega.Eventually(nodeSwitch).Should(gomega.Equal(node2.Name))
+				egressIPs, _ = getEgressIPStatus(egressIPName)
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				return nil
+			}
+
+			err := app.Run([]string{
+				app.Name,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should re-assign EgressIPs and perform proper egressIP allocation changes during node deletion", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP := "192.168.126.101"
+				node1IPv4 := "192.168.126.202/24"
+				node2IPv4 := "192.168.126.51/24"
+
+				egressNamespace := newNamespace(namespace)
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: egressPodLabel,
+						},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": egressNamespace.Name,
+							},
+						},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1, node2},
+					},
+				)
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
+				gomega.Eventually(isEgressAssignableNode(node1.Name)).Should(gomega.BeTrue())
+				gomega.Eventually(isEgressAssignableNode(node2.Name)).Should(gomega.BeFalse())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				node2.Labels = map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				}
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1Name, metav1.DeleteOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				gomega.Eventually(nodeSwitch).Should(gomega.Equal(node2.Name))
+				egressIPs, _ = getEgressIPStatus(egressIPName)
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+	})
+
+	ginkgo.Context("WatchEgressNodes", func() {
+
+		ginkgo.It("should populated egress node data as they are tagged `egress assignable` with variants of IPv4/IPv6", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				node1IPv4 := "192.168.128.202/24"
+				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
+				node2IPv4 := "192.168.126.51/24"
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\", \"%s\"]}", v4NodeSubnet, v6NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				fakeClusterManagerOVN.start(
+					&v1.NodeList{
+						Items: []v1.Node{},
+					},
+				)
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(0))
+
+				node1.Labels = map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				}
+
+				_, ip1V4Sub, err := net.ParseCIDR(node1IPv4)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, ip1V6Sub, err := net.ParseCIDR(node1IPv6)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, ip2V4Sub, err := net.ParseCIDR(node2IPv4)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node1, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(1))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node1.Name].egressIPConfig.V4.Net).To(gomega.Equal(ip1V4Sub))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node1.Name].egressIPConfig.V6.Net).To(gomega.Equal(ip1V6Sub))
+
+				node2.Labels = map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				}
+
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node2, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node2.Name].egressIPConfig.V4.Net).To(gomega.Equal(ip2V4Sub))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node1.Name].egressIPConfig.V4.Net).To(gomega.Equal(ip1V4Sub))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node1.Name].egressIPConfig.V6.Net).To(gomega.Equal(ip1V6Sub))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("using retry to create egress node with forced error followed by an update", func() {
+			app.Action = func(ctx *cli.Context) error {
+				nodeIPv4 := "192.168.126.51/24"
+				nodeIPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
+				node := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node",
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", nodeIPv4, nodeIPv6),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\", \"%s\"]}", v4NodeSubnet, v6NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				fakeClusterManagerOVN.start(
+					&v1.NodeList{
+						Items: []v1.Node{},
+					},
+				)
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(0))
+
+				_, ipV4Sub, err := net.ParseCIDR(nodeIPv4)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, ipV6Sub, err := net.ParseCIDR(nodeIPv6)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				node.Labels = map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				}
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				node.Labels = map[string]string{}
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(1))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node.Name].egressIPConfig.V4.Net).To(gomega.Equal(ipV4Sub))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node.Name].egressIPConfig.V6.Net).To(gomega.Equal(ipV6Sub))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("ensure only one egressIP is assinged to the given node while rest of the IPs go into pending state", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				config.Gateway.DisableSNATMultipleGWs = true
+
+				egressIP1 := "192.168.126.25"
+				egressIP2 := "192.168.126.30"
+				egressIP3 := "192.168.126.35"
+				node1IPv4 := "192.168.126.12/24"
+				node2IPv4 := "192.168.126.13/24"
+
+				egressNamespace := newNamespace(namespace)
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+							"k8s.ovn.org/l3-gateway-config":   `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:49", "ip-address":"192.168.126.12/24", "next-hop":"192.168.126.1"}}`,
+							"k8s.ovn.org/node-chassis-id":     "79fdcfc4-6fe6-4cd3-8242-c0f85a4668ec",
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node2IPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+							"k8s.ovn.org/l3-gateway-config":   `{"default":{"mode":"local","mac-address":"7e:57:f8:f0:3c:50", "ip-address":"192.168.126.13/24", "next-hop":"192.168.126.1"}}`,
+							"k8s.ovn.org/node-chassis-id":     "79fdcfc4-6fe6-4cd3-8242-c0f85a4668ec",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				eIP1 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1, egressIP2},
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: egressPodLabel,
+						},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": egressNamespace.Name,
+							},
+						},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				eIP2 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName2),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP3},
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: egressPodLabel,
+						},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": egressNamespace.Name,
+							},
+						},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP1, eIP2},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1, node2},
+					},
+				)
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// Ensure first egressIP object is assigned, since only node1 is an egressNode, only 1IP will be assigned, other will be pending
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(1))
+				recordedEvent := <-fakeClusterManagerOVN.fakeRecorder.Events
+				gomega.Expect(recordedEvent).To(gomega.ContainSubstring("Not all egress IPs for EgressIP: %s could be assigned, please tag more nodes", eIP1.Name))
+				egressIPs1, nodes1 := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes1[0]).To(gomega.Equal(node1.Name))
+				possibleAssignments := sets.NewString(egressIP1, egressIP2)
+				gomega.Expect(possibleAssignments.Has(egressIPs1[0])).To(gomega.BeTrue())
+
+				// Ensure second egressIP object is also assigned to node1, but no OVN config will be done for this
+				gomega.Eventually(getEgressIPStatusLen(egressIPName2)).Should(gomega.Equal(1))
+				egressIPs2, nodes2 := getEgressIPStatus(egressIPName2)
+				gomega.Expect(nodes2[0]).To(gomega.Equal(node1.Name))
+				gomega.Expect(egressIPs2[0]).To(gomega.Equal(egressIP3))
+
+				// Make second node egressIP assignable
+				node2.Labels = map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				}
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				// ensure secondIP from first object gets assigned to node2
+				gomega.Eventually(isEgressAssignableNode(node2.Name)).Should(gomega.BeTrue())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				egressIPs1, nodes1 = getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes1[1]).To(gomega.Equal(node2.Name))
+				gomega.Expect(possibleAssignments.Has(egressIPs1[1])).To(gomega.BeTrue())
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should skip populating egress node data for nodes that have incorrect IP address", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.OVNKubernetesFeature.EnableInterconnect = true // no impact on global eIPC functions
+				nodeIPv4 := "192.168.126.510/24"
+				nodeIPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
+				node := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", nodeIPv4, nodeIPv6),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\", \"%s\"]}", v4NodeSubnet, v6NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				fakeClusterManagerOVN.start(
+					&v1.NodeList{
+						Items: []v1.Node{node},
+					},
+				)
+
+				allocatorItems := func() int {
+					return len(fakeClusterManagerOVN.eIPC.allocator.cache)
+				}
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(allocatorItems).Should(gomega.Equal(0))
+
+				node.Labels = map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				}
+
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(allocatorItems).Should(gomega.Equal(0))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should probe nodes using grpc", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.OVNKubernetesFeature.EnableInterconnect = false // no impact on global eIPC functions
+				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
+				node2IPv4 := "192.168.126.51/24"
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", "", node1IPv6),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v6NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				fakeClusterManagerOVN.start()
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(0))
+
+				_, ip1V6Sub, err := net.ParseCIDR(node1IPv6)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, ip2V4Sub, err := net.ParseCIDR(node2IPv4)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node1, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(1))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node1.Name].egressIPConfig.V6.Net).To(gomega.Equal(ip1V6Sub))
+
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node2, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
+				gomega.Eventually(isEgressAssignableNode(node1.Name)).Should(gomega.BeTrue())
+				gomega.Eventually(isEgressAssignableNode(node2.Name)).Should(gomega.BeTrue())
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
+
+				cachedEgressNode1 := fakeClusterManagerOVN.eIPC.allocator.cache[node1.Name]
+				cachedEgressNode2 := fakeClusterManagerOVN.eIPC.allocator.cache[node2.Name]
+				gomega.Expect(cachedEgressNode1.egressIPConfig.V6.Net).To(gomega.Equal(ip1V6Sub))
+				gomega.Expect(cachedEgressNode2.egressIPConfig.V4.Net).To(gomega.Equal(ip2V4Sub))
+
+				// Explicitly call check reachibility so we need not to wait for slow periodic timer
+				checkEgressNodesReachabilityIterate(fakeClusterManagerOVN.eIPC)
+				gomega.Expect(cachedEgressNode1.isReachable).To(gomega.BeTrue())
+				gomega.Expect(cachedEgressNode2.isReachable).To(gomega.BeTrue())
+
+				// The test cases below will manipulate the fakeEgressIPHealthClient used for mocking
+				// a gRPC session dedicated to monitoring each of the 2 nodes created. It does that
+				// by setting the probe fail boolean which in turn causes the mocked probe call to
+				// pretend that the periodic monitor succeeded or not.
+				tests := []struct {
+					desc            string
+					node1FailProbes bool
+					node2FailProbes bool
+					// This function is an optional and generic function for the test case
+					// to allow any special pre-conditioning needed before invoking of
+					// checkEgressNodesReachabilityIterate in the test.
+					tcPrepareFunc func(hcc1, hcc2 *fakeEgressIPHealthClient)
+				}{
+					{
+						desc:            "disconnect nodes",
+						node1FailProbes: true,
+						node2FailProbes: true,
+						tcPrepareFunc: func(hcc1, hcc2 *fakeEgressIPHealthClient) {
+							hcc1.Disconnect()
+							hcc2.Disconnect()
+						},
+					},
+					{
+						desc:            "connect node1",
+						node2FailProbes: true,
+					},
+					{
+						desc: "node1 connected, connect node2",
+					},
+					{
+						desc:            "node1 and node2 connected, bump only node2 counters",
+						node1FailProbes: true,
+					},
+					{
+						desc:            "node2 connected, disconnect node1",
+						node1FailProbes: true,
+						node2FailProbes: true,
+						tcPrepareFunc: func(hcc1, hcc2 *fakeEgressIPHealthClient) {
+							hcc1.Disconnect()
+						},
+					},
+					{
+						desc:            "connect node1, disconnect node2",
+						node2FailProbes: true,
+						tcPrepareFunc: func(hcc1, hcc2 *fakeEgressIPHealthClient) {
+							hcc2.Disconnect()
+						},
+					},
+					{
+						desc: "node1 and node2 connected and both counters bump",
+						tcPrepareFunc: func(hcc1, hcc2 *fakeEgressIPHealthClient) {
+							// Perform an additional iteration, to make probe counters to bump on second call
+							checkEgressNodesReachabilityIterate(fakeClusterManagerOVN.eIPC)
+						},
+					},
+				}
+
+				// hcc1 and hcc2 are the mocked gRPC client to node1 and node2, respectively.
+				// They are what we use to manipulate whether probes to the node should fail or
+				// not, as well as a mechanism for explicitly disconnecting as part of the test.
+				hcc1 := cachedEgressNode1.healthClient.(*fakeEgressIPHealthClient)
+				hcc2 := cachedEgressNode2.healthClient.(*fakeEgressIPHealthClient)
+
+				// ttIterCheck is the common function used by each test case. It will check whether
+				// a client changed its connection state and if the number of probes to the node
+				// changed as expected.
+				ttIterCheck := func(hcc *fakeEgressIPHealthClient, prevNodeIsConnected bool, prevProbes int, failProbes bool, desc string) {
+					currNodeIsConnected := hcc.IsConnected()
+					gomega.Expect(currNodeIsConnected || failProbes).To(gomega.BeTrue(), desc)
+
+					if !prevNodeIsConnected && !currNodeIsConnected {
+						// Not connected (before and after): no probes should be successful
+						gomega.Expect(hcc.ProbeCount).To(gomega.Equal(prevProbes), desc)
+					} else if prevNodeIsConnected && currNodeIsConnected {
+						if failProbes {
+							// Still connected, but no probes should be successful
+							gomega.Expect(prevProbes).To(gomega.Equal(hcc.ProbeCount), desc)
+						} else {
+							// Still connected and probe counters should be going up
+							gomega.Expect(prevProbes < hcc.ProbeCount).To(gomega.BeTrue(), desc)
+						}
+					}
+				}
+
+				for _, tt := range tests {
+					hcc1.FakeProbeFailure = tt.node1FailProbes
+					hcc2.FakeProbeFailure = tt.node2FailProbes
+
+					prevNode1IsConnected := hcc1.IsConnected()
+					prevNode2IsConnected := hcc2.IsConnected()
+					prevNode1Probes := hcc1.ProbeCount
+					prevNode2Probes := hcc2.ProbeCount
+
+					if tt.tcPrepareFunc != nil {
+						tt.tcPrepareFunc(hcc1, hcc2)
+					}
+
+					// Perform connect or probing, depending on the state of the connections
+					checkEgressNodesReachabilityIterate(fakeClusterManagerOVN.eIPC)
+
+					ttIterCheck(hcc1, prevNode1IsConnected, prevNode1Probes, tt.node1FailProbes, tt.desc)
+					ttIterCheck(hcc2, prevNode2IsConnected, prevNode2Probes, tt.node2FailProbes, tt.desc)
+				}
+
+				gomega.Expect(hcc1.IsConnected()).To(gomega.BeTrue())
+				gomega.Expect(hcc2.IsConnected()).To(gomega.BeTrue())
+
+				// Lastly, remove egress assignable from node 2 and make sure it disconnects
+				node2.Labels = map[string]string{}
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(isEgressAssignableNode(node1.Name)).Should(gomega.BeTrue())
+				gomega.Eventually(isEgressAssignableNode(node2.Name)).Should(gomega.BeFalse())
+
+				// Explicitly call check reachibility so we need not to wait for slow periodic timer
+				checkEgressNodesReachabilityIterate(fakeClusterManagerOVN.eIPC)
+
+				gomega.Expect(hcc1.IsConnected()).To(gomega.BeTrue())
+				gomega.Expect(hcc2.IsConnected()).To(gomega.BeFalse())
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("WatchEgressNodes running with WatchEgressIP", func() {
+		ginkgo.It("should result in error and event if specified egress IP is a cluster node IP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP := "192.168.126.51"
+				node1IPv4 := "192.168.128.202/24"
+				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
+				node2IPv4 := "192.168.126.51/24"
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\", \"%s\"]}", v4NodeSubnet, v6NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1, node2},
+					})
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(0))
+				gomega.Eventually(fakeClusterManagerOVN.fakeRecorder.Events).Should(gomega.HaveLen(3))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should remove stale EgressIP setup when node label is removed while ovnkube-master is not running and assign to newly labelled node", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP1 := "192.168.126.25"
+				node1IPv4 := "192.168.126.51/24"
+
+				egressNamespace := newNamespace(namespace)
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", node1IPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1},
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: egressPodLabel,
+						},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": egressNamespace.Name,
+							},
+						},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								Node:     node1.Name,
+								EgressIP: egressIP1,
+							},
+						},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1, node2},
+					},
+				)
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should only get assigned EgressIPs which matches their subnet when the node is tagged", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP := "192.168.126.101"
+				node1IPv4 := "192.168.128.202/24"
+				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
+				node2IPv4 := "192.168.126.51/24"
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1, node2},
+					})
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, ip1V4Sub, err := net.ParseCIDR(node1IPv4)
+				_, ip1V6Sub, err := net.ParseCIDR(node1IPv6)
+				_, ip2V4Sub, err := net.ParseCIDR(node2IPv4)
+
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
+				gomega.Eventually(isEgressAssignableNode(node1.Name)).Should(gomega.BeFalse())
+				gomega.Eventually(isEgressAssignableNode(node2.Name)).Should(gomega.BeFalse())
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node1.Name].egressIPConfig.V4.Net).To(gomega.Equal(ip1V4Sub))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node1.Name].egressIPConfig.V6.Net).To(gomega.Equal(ip1V6Sub))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache[node2.Name].egressIPConfig.V4.Net).To(gomega.Equal(ip2V4Sub))
+				gomega.Eventually(eIP.Status.Items).Should(gomega.HaveLen(0))
+
+				node1.Labels = map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				}
+
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node1, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(0))
+				gomega.Eventually(isEgressAssignableNode(node1.Name)).Should(gomega.BeTrue())
+
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(1))
+
+				node2.Labels = map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				}
+
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node2, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.Name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				gomega.Eventually(getEgressIPReassignmentCount).Should(gomega.Equal(0))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should re-balance EgressIPs when their node is removed", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.OVNKubernetesFeature.EnableInterconnect = true // no impact on global eIPC functions
+				egressIP := "192.168.126.101"
+				node1IPv4 := "192.168.126.12/24"
+				node1IPv6 := "0:0:0:0:0:feff:c0a8:8e0c/64"
+				node2IPv4 := "192.168.126.51/24"
+
+				node1 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node1IPv4, node1IPv6),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\", \"%s\"]}", v4NodeSubnet, v6NodeSubnet),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				node2 := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node2Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\", \"ipv6\": \"%s\"}", node2IPv4, ""),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":\"%s\"}", v4NodeSubnet),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node1},
+					})
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(1))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Create(context.TODO(), &node2, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes = getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node1.Name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(2))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
+
+				err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), node1.Name, *metav1.NewDeleteOptions(0))
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPAllocatorSizeSafely).Should(gomega.Equal(1))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).ToNot(gomega.HaveKey(node1.Name))
+				gomega.Expect(fakeClusterManagerOVN.eIPC.allocator.cache).To(gomega.HaveKey(node2.Name))
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+
+				getNewNode := func() string {
+					_, nodes = getEgressIPStatus(egressIPName)
+					if len(nodes) > 0 {
+						return nodes[0]
+					}
+					return ""
+				}
+
+				gomega.Eventually(getNewNode).Should(gomega.Equal(node2.Name))
+				egressIPs, _ = getEgressIPStatus(egressIPName)
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("egress node update should not mark the node as reachable if there was no label/readiness change", func() {
+			// When an egress node becomes reachable during a node update event and there is no changes to node labels/readiness
+			// unassigned egress IP should be eventually added by the periodic reachability check.
+			// Test steps:
+			//  - disable periodic check from running in background, so it can be called directly from the test
+			//  - assign egress IP to an available node
+			//  - make the node unreachable and verify that the egress IP was unassigned
+			//  - make the node reachable and update a node
+			//  - verify that the egress IP was assigned by calling the periodic reachability check
+			app.Action = func(ctx *cli.Context) error {
+				config.OVNKubernetesFeature.EnableInterconnect = true // no impact on global eIPC functions
+				egressIP := "192.168.126.101"
+				nodeIPv4 := "192.168.126.51/24"
+				node := v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: node1Name,
+						Annotations: map[string]string{
+							"k8s.ovn.org/node-primary-ifaddr": fmt.Sprintf("{\"ipv4\": \"%s\"}", nodeIPv4),
+							"k8s.ovn.org/node-subnets":        fmt.Sprintf("{\"default\":[\"%s\"]}", v4NodeSubnet),
+						},
+						Labels: map[string]string{
+							"k8s.ovn.org/egress-assignable": "",
+						},
+					},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:   v1.NodeReady,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				}
+				eIP1 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP1},
+					},
+					&v1.NodeList{
+						Items: []v1.Node{node},
+					},
+				)
+
+				// Virtually disable background reachability check by using a huge interval
+				fakeClusterManagerOVN.eIPC.reachabilityCheckInterval = time.Hour
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressNodes()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+				egressIPs, _ := getEgressIPStatus(eIP1.Name)
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				hcClient := fakeClusterManagerOVN.eIPC.allocator.cache[node.Name].healthClient.(*fakeEgressIPHealthClient)
+				hcClient.FakeProbeFailure = true
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeClusterManagerOVN.eIPC)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(0))
+
+				hcClient.FakeProbeFailure = false
+				node.Annotations["test"] = "dummy"
+				_, err = fakeClusterManagerOVN.fakeClient.KubeClient.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(hcClient.IsConnected()).Should(gomega.Equal(true))
+				// the node should not be marked as reachable in the update handler as it is not getting added
+				gomega.Consistently(func() bool { return fakeClusterManagerOVN.eIPC.allocator.cache[node.Name].isReachable }).Should(gomega.Equal(false))
+
+				// egress IP should get assigned on the next checkEgressNodesReachabilityIterate call
+				// explicitly call check reachability, periodic checker is not active
+				checkEgressNodesReachabilityIterate(fakeClusterManagerOVN.eIPC)
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("IPv6 assignment", func() {
+
+		ginkgo.It("should be able to allocate non-conflicting IP on node with lowest amount of allocations", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIP := "0:0:0:0:0:feff:c0a8:8e0f"
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
+				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(node2.name))
+				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP).String()))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should be able to allocate several EgressIPs and avoid the same node", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIP1 := "0:0:0:0:0:feff:c0a8:8e0d"
+				egressIP2 := "0:0:0:0:0:feff:c0a8:8e0f"
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1, egressIP2},
+					},
+				}
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(2))
+				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(node2.name))
+				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP1).String()))
+				gomega.Expect(assignedStatuses[1].Node).To(gomega.Equal(node1.name))
+				gomega.Expect(assignedStatuses[1].EgressIP).To(gomega.Equal(net.ParseIP(egressIP2).String()))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should be able to allocate several EgressIPs and avoid the same node and leave one un-assigned without error", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIP1 := "0:0:0:0:0:feff:c0a8:8e0d"
+				egressIP2 := "0:0:0:0:0:feff:c0a8:8e0e"
+				egressIP3 := "0:0:0:0:0:feff:c0a8:8e0f"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1, egressIP2, egressIP3},
+					},
+				}
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(2))
+				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(node2.name))
+				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP1).String()))
+				gomega.Expect(assignedStatuses[1].Node).To(gomega.Equal(node1.name))
+				gomega.Expect(assignedStatuses[1].EgressIP).To(gomega.Equal(net.ParseIP(egressIP2).String()))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should return the already allocated IP with the same node if it is allocated again", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIP := "0:0:0:0:0:feff:c0a8:8e32"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{egressIP: egressIPName, "0:0:0:0:0:feff:c0a8:8e1e": "bogus1"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus2"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				egressIPs := []string{egressIP}
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: egressIPs,
+					},
+				}
+
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
+				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(node1Name))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should not be able to allocate node IP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIP := "0:0:0:0:0:feff:c0a8:8e0c"
+
+				node1 := setupNode(node1Name, []string{egressIP + "/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should not be able to allocate conflicting compressed IP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIP := "::feff:c0a8:8e32"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				egressIPs := []string{egressIP}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: egressIPs,
+					},
+				}
+
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should not be able to allocate IPv4 IP on nodes which can only host IPv6", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIP := "192.168.126.16"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIPs := []string{egressIP}
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: eIPs,
+					},
+				}
+
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should be able to allocate non-conflicting compressed uppercase IP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIP := "::FEFF:C0A8:8D32"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
+				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(node2.name))
+				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP).String()))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should not be able to allocate conflicting compressed uppercase IP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIP := "::FEFF:C0A8:8E32"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+				egressIPs := []string{egressIP}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: egressIPs,
+					},
+				}
+
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should not be able to allocate invalid IP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIPs := []string{"0:0:0:0:0:feff:c0a8:8e32:5"}
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: egressIPs,
+					},
+				}
+
+				assignedStatuses, err := fakeClusterManagerOVN.eIPC.validateEgressIPSpec(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).To(gomega.Equal(fmt.Sprintf("unable to parse provided EgressIP: %s, invalid", egressIPs[0])))
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(0))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("Dual-stack assignment", func() {
+
+		ginkgo.It("should be able to allocate non-conflicting IPv4 on node which can host it, even if it happens to be the node with more assignments", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+				egressIP := "192.168.126.99"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus1"})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus1", "192.168.126.102": "bogus2"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				assignedStatuses := fakeClusterManagerOVN.eIPC.assignEgressIPs(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(assignedStatuses).To(gomega.HaveLen(1))
+				gomega.Expect(assignedStatuses[0].Node).To(gomega.Equal(node2.name))
+				gomega.Expect(assignedStatuses[0].EgressIP).To(gomega.Equal(net.ParseIP(egressIP).String()))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+	})
+
+	ginkgo.Context("IPv4 assignment", func() {
+
+		ginkgo.It("Should not be able to assign egress IP defined in CIDR notation", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				fakeClusterManagerOVN.start()
+
+				egressIPs := []string{"192.168.126.99/32"}
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{"192.168.126.102": "bogus1", "192.168.126.111": "bogus2"})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: egressIPs,
+					},
+				}
+
+				validatedIPs, err := fakeClusterManagerOVN.eIPC.validateEgressIPSpec(eIP.Name, eIP.Spec.EgressIPs)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).To(gomega.Equal(fmt.Sprintf("unable to parse provided EgressIP: %s, invalid", egressIPs[0])))
+				gomega.Expect(validatedIPs).To(gomega.HaveLen(0))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+	})
+
+	ginkgo.Context("WatchEgressIP", func() {
+
+		ginkgo.It("should update status correctly for single-stack IPv4", func() {
+			app.Action = func(ctx *cli.Context) error {
+				fakeClusterManagerOVN.start()
+
+				egressIP := "192.168.126.10"
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{"192.168.126.102": "bogus1", "192.168.126.111": "bogus2"})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": "does-not-exist",
+							},
+						},
+					},
+				}
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should update status correctly for single-stack IPv6", func() {
+			app.Action = func(ctx *cli.Context) error {
+				fakeClusterManagerOVN.start()
+
+				egressIP := "0:0:0:0:0:feff:c0a8:8e0d"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				node2 := setupNode(node2Name, []string{"0:0:0:0:0:fedf:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(net.ParseIP(egressIP).String()))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should update status correctly for dual-stack", func() {
+			app.Action = func(ctx *cli.Context) error {
+				fakeClusterManagerOVN.start()
+
+				egressIPv4 := "192.168.126.101"
+				egressIPv6 := "0:0:0:0:0:feff:c0a8:8e0d"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus1"})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus2", "192.168.126.102": "bogus3"})
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIPv4, egressIPv6},
+					},
+				}
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP, metav1.CreateOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes).To(gomega.ConsistOf(node2.name, node1.name))
+				gomega.Expect(egressIPs).To(gomega.ConsistOf(net.ParseIP(egressIPv6).String(), net.ParseIP(egressIPv4).String()))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("syncEgressIP for dual-stack", func() {
+
+		ginkgo.It("should not update valid assignments", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIPv4 := "192.168.126.101"
+				egressIPv6 := "0:0:0:0:0:feff:c0a8:8e0d"
+
+				node1 := setupNode(node1Name, []string{"0:0:0:0:0:feff:c0a8:8e0c/64"}, map[string]string{})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.102": "bogus3"})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIPv4, egressIPv6},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: egressIPv4,
+								Node:     node2.name,
+							},
+							{
+								EgressIP: net.ParseIP(egressIPv6).String(),
+								Node:     node1.name,
+							},
+						},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+				)
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes).To(gomega.ConsistOf(eIP.Status.Items[0].Node, eIP.Status.Items[1].Node))
+				gomega.Expect(egressIPs).To(gomega.ConsistOf(eIP.Status.Items[0].EgressIP, eIP.Status.Items[1].EgressIP))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("syncEgressIP for IPv4", func() {
+
+		ginkgo.It("should update invalid assignments on duplicated node", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP1 := "192.168.126.101"
+				egressIP2 := "192.168.126.100"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{egressIP1: egressIPName, egressIP2: egressIPName})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus3"})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1, egressIP2},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: egressIP1,
+								Node:     node1.name,
+							},
+							{
+								EgressIP: egressIP2,
+								Node:     node1.name,
+							},
+						},
+					},
+				}
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+				)
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(2))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes).To(gomega.ConsistOf(node1.name, node2.name))
+				gomega.Expect(egressIPs).To(gomega.ConsistOf(eIP.Status.Items[0].EgressIP, eIP.Status.Items[1].EgressIP))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should update invalid assignments with incorrectly parsed IP", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP1 := "192.168.126.101"
+				egressIPIncorrect := "192.168.126.1000"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{"192.168.126.102": "bogus1", "192.168.126.111": "bogus2"})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus3"})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: egressIPIncorrect,
+								Node:     node1.name,
+							},
+						},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+				)
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP1))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should update invalid assignments with unhostable IP on a node", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP1 := "192.168.126.101"
+				egressIPIncorrect := "192.168.128.100"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{"192.168.126.102": "bogus1", "192.168.126.111": "bogus2"})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus3"})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: egressIPIncorrect,
+								Node:     node1.name,
+							},
+						},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+				)
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP1))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should not update valid assignment", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP1 := "192.168.126.101"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{"192.168.126.111": "bogus2"})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus3"})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: egressIP1,
+								Node:     node1.name,
+							},
+						},
+					},
+				}
+
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+				)
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node1.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP1))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("AddEgressIP for IPv4", func() {
+
+		ginkgo.It("should not create two EgressIPs with same egress IP value", func() {
+			app.Action = func(ctx *cli.Context) error {
+				egressIP1 := "192.168.126.101"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{"192.168.126.102": "bogus1", "192.168.126.111": "bogus2"})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus3"})
+
+				eIP1 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta("egressip"),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1},
+					},
+				}
+				eIP2 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta("egressip2"),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1},
+					},
+				}
+
+				fakeClusterManagerOVN.start()
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP1, metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(eIP1.Name)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP1))
+
+				_, err = fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP2, metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(eIP2.Name)).Should(gomega.Equal(0))
+
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+	})
+
+	ginkgo.Context("UpdateEgressIP for IPv4", func() {
+
+		ginkgo.It("should perform re-assingment of EgressIPs", func() {
+			app.Action = func(ctx *cli.Context) error {
+
+				egressIP := "192.168.126.101"
+				updateEgressIP := "192.168.126.10"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.41/24"}, map[string]string{"192.168.126.102": "bogus1", "192.168.126.111": "bogus2"})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{"192.168.126.68": "bogus3"})
+
+				eIP1 := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP},
+					},
+				}
+				fakeClusterManagerOVN.start()
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				_, err = fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Create(context.TODO(), &eIP1, metav1.CreateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP))
+
+				eIPToUpdate, err := fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Get(context.TODO(), eIP1.Name, metav1.GetOptions{})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				eIPToUpdate.Spec.EgressIPs = []string{updateEgressIP}
+
+				_, err = fakeClusterManagerOVN.fakeClient.EgressIPClient.K8sV1().EgressIPs().Update(context.TODO(), eIPToUpdate, metav1.UpdateOptions{})
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				getEgressIP := func() string {
+					egressIPs, _ = getEgressIPStatus(egressIPName)
+					if len(egressIPs) == 0 {
+						return "try again"
+					}
+					return egressIPs[0]
+				}
+
+				gomega.Eventually(getEgressIP).Should(gomega.Equal(updateEgressIP))
+				_, nodes = getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
+				return nil
+			}
+
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+})

--- a/go-controller/pkg/clustermanager/egressip_event_handler.go
+++ b/go-controller/pkg/clustermanager/egressip_event_handler.go
@@ -1,0 +1,263 @@
+package clustermanager
+
+import (
+	"fmt"
+	"reflect"
+
+	ocpcloudnetworkapi "github.com/openshift/api/cloudnetwork/v1"
+	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	objretry "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	cache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// egressIPClusterControllerEventHandler object handles the events
+// from retry framework for the egressIPClusterController.
+type egressIPClusterControllerEventHandler struct {
+	objretry.EventHandler
+	objType  reflect.Type
+	eIPC     *egressIPClusterController
+	syncFunc func([]interface{}) error
+}
+
+// egressIPClusterControllerEventHandler functions
+
+// AddResource adds the specified object to the cluster according to its type and
+// returns the error, if any, yielded during object creation.
+func (h *egressIPClusterControllerEventHandler) AddResource(obj interface{}, fromRetryLoop bool) error {
+	switch h.objType {
+	case factory.EgressNodeType:
+		node := obj.(*v1.Node)
+		// Initialize the allocator on every update,
+		// ovnkube-node/cloud-network-config-controller will make sure to
+		// annotate the node with the egressIPConfig, but that might have
+		// happened after we processed the ADD for that object, hence keep
+		// retrying for all UPDATEs.
+		if err := h.eIPC.initEgressIPAllocator(node); err != nil {
+			klog.Warningf("Egress node initialization error: %v", err)
+		}
+		nodeEgressLabel := util.GetNodeEgressLabel()
+		nodeLabels := node.GetLabels()
+		_, hasEgressLabel := nodeLabels[nodeEgressLabel]
+		if hasEgressLabel {
+			h.eIPC.setNodeEgressAssignable(node.Name, true)
+		}
+		isReady := h.eIPC.isEgressNodeReady(node)
+		if isReady {
+			h.eIPC.setNodeEgressReady(node.Name, true)
+		}
+		isReachable := h.eIPC.isEgressNodeReachable(node)
+		if hasEgressLabel && isReachable && isReady {
+			h.eIPC.setNodeEgressReachable(node.Name, true)
+			if err := h.eIPC.addEgressNode(node.Name); err != nil {
+				return err
+			}
+		}
+	case factory.EgressIPType:
+		eIP := obj.(*egressipv1.EgressIP)
+		return h.eIPC.reconcileEgressIP(nil, eIP)
+	case factory.CloudPrivateIPConfigType:
+		cloudPrivateIPConfig := obj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
+		return h.eIPC.reconcileCloudPrivateIPConfig(nil, cloudPrivateIPConfig)
+	default:
+		return fmt.Errorf("no add function for object type %s", h.objType)
+	}
+	return nil
+}
+
+// UpdateResource updates the specified object in the cluster to its version in newObj according
+// to its type and returns the error, if any, yielded during the object update.
+// The inRetryCache boolean argument is to indicate if the given resource is in the retryCache or not.
+func (h *egressIPClusterControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error {
+	switch h.objType {
+	case factory.EgressIPType:
+		oldEIP := oldObj.(*egressipv1.EgressIP)
+		newEIP := newObj.(*egressipv1.EgressIP)
+		return h.eIPC.reconcileEgressIP(oldEIP, newEIP)
+	case factory.EgressNodeType:
+		oldNode := oldObj.(*v1.Node)
+		newNode := newObj.(*v1.Node)
+		// Initialize the allocator on every update,
+		// ovnkube-node/cloud-network-config-controller will make sure to
+		// annotate the node with the egressIPConfig, but that might have
+		// happened after we processed the ADD for that object, hence keep
+		// retrying for all UPDATEs.
+		if err := h.eIPC.initEgressIPAllocator(newNode); err != nil {
+			klog.Warningf("Egress node initialization error: %v", err)
+		}
+		nodeEgressLabel := util.GetNodeEgressLabel()
+		oldLabels := oldNode.GetLabels()
+		newLabels := newNode.GetLabels()
+		_, oldHadEgressLabel := oldLabels[nodeEgressLabel]
+		_, newHasEgressLabel := newLabels[nodeEgressLabel]
+		// If the node is not labeled for egress assignment, just return
+		// directly, we don't really need to set the ready / reachable
+		// status on this node if the user doesn't care about using it.
+		if !oldHadEgressLabel && !newHasEgressLabel {
+			return nil
+		}
+		h.eIPC.setNodeEgressAssignable(newNode.Name, newHasEgressLabel)
+		if oldHadEgressLabel && !newHasEgressLabel {
+			klog.Infof("Node: %s has been un-labeled, deleting it from egress assignment", newNode.Name)
+			return h.eIPC.deleteEgressNode(oldNode.Name)
+		}
+		isOldReady := h.eIPC.isEgressNodeReady(oldNode)
+		isNewReady := h.eIPC.isEgressNodeReady(newNode)
+		isNewReachable := h.eIPC.isEgressNodeReachable(newNode)
+		h.eIPC.setNodeEgressReady(newNode.Name, isNewReady)
+		if !oldHadEgressLabel && newHasEgressLabel {
+			klog.Infof("Node: %s has been labeled, adding it for egress assignment", newNode.Name)
+			if isNewReady && isNewReachable {
+				h.eIPC.setNodeEgressReachable(newNode.Name, isNewReachable)
+				if err := h.eIPC.addEgressNode(newNode.Name); err != nil {
+					return err
+				}
+			} else {
+				klog.Warningf("Node: %s has been labeled, but node is not ready"+
+					" and reachable, cannot use it for egress assignment", newNode.Name)
+			}
+			return nil
+		}
+		if isOldReady == isNewReady {
+			return nil
+		}
+		if !isNewReady {
+			klog.Warningf("Node: %s is not ready, deleting it from egress assignment", newNode.Name)
+			if err := h.eIPC.deleteEgressNode(newNode.Name); err != nil {
+				return err
+			}
+		} else if isNewReady && isNewReachable {
+			klog.Infof("Node: %s is ready and reachable, adding it for egress assignment", newNode.Name)
+			h.eIPC.setNodeEgressReachable(newNode.Name, isNewReachable)
+			if err := h.eIPC.addEgressNode(newNode.Name); err != nil {
+				return err
+			}
+		}
+		return nil
+	case factory.CloudPrivateIPConfigType:
+		oldCloudPrivateIPConfig := oldObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
+		newCloudPrivateIPConfig := newObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
+		return h.eIPC.reconcileCloudPrivateIPConfig(oldCloudPrivateIPConfig, newCloudPrivateIPConfig)
+	default:
+		return fmt.Errorf("no update function for object type %s", h.objType)
+	}
+}
+
+// DeleteResource deletes the object from the cluster according to the delete logic of its resource type.
+// cachedObj is the internal cache entry for this object, used for now for pods and network policies.
+func (h *egressIPClusterControllerEventHandler) DeleteResource(obj, cachedObj interface{}) error {
+	switch h.objType {
+	case factory.EgressIPType:
+		eIP := obj.(*egressipv1.EgressIP)
+		return h.eIPC.reconcileEgressIP(eIP, nil)
+	case factory.EgressNodeType:
+		node := obj.(*v1.Node)
+		h.eIPC.deleteNodeForEgress(node)
+		nodeEgressLabel := util.GetNodeEgressLabel()
+		nodeLabels := node.GetLabels()
+		_, hasEgressLabel := nodeLabels[nodeEgressLabel]
+		if hasEgressLabel {
+			if err := h.eIPC.deleteEgressNode(node.Name); err != nil {
+				return err
+			}
+		}
+		return nil
+	case factory.CloudPrivateIPConfigType:
+		cloudPrivateIPConfig := obj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
+		return h.eIPC.reconcileCloudPrivateIPConfig(cloudPrivateIPConfig, nil)
+	default:
+		return fmt.Errorf("no delete function for object type %s", h.objType)
+	}
+}
+
+func (h *egressIPClusterControllerEventHandler) SyncFunc(objs []interface{}) error {
+	var syncFunc func([]interface{}) error
+
+	if h.syncFunc != nil {
+		// syncFunc was provided explicitly
+		syncFunc = h.syncFunc
+	} else {
+		switch h.objType {
+		case factory.EgressNodeType:
+			syncFunc = h.eIPC.initEgressNodeReachability
+		case factory.EgressIPType,
+			factory.CloudPrivateIPConfigType:
+			syncFunc = nil
+
+		default:
+			return fmt.Errorf("no sync function for object type %s", h.objType)
+		}
+	}
+	if syncFunc == nil {
+		return nil
+	}
+	return syncFunc(objs)
+}
+
+// RecordAddEvent records the add event on this object. Not used here.
+func (h *egressIPClusterControllerEventHandler) RecordAddEvent(obj interface{}) {
+}
+
+// RecordUpdateEvent records the update event on this object. Not used here.
+func (h *egressIPClusterControllerEventHandler) RecordUpdateEvent(obj interface{}) {
+}
+
+// RecordDeleteEvent records the delete event on this object. Not used here.
+func (h *egressIPClusterControllerEventHandler) RecordDeleteEvent(obj interface{}) {
+}
+
+func (h *egressIPClusterControllerEventHandler) RecordSuccessEvent(obj interface{}) {
+}
+
+// RecordErrorEvent records an error event on this object. Not used here.
+func (h *egressIPClusterControllerEventHandler) RecordErrorEvent(obj interface{}, reason string, err error) {
+}
+
+// isResourceScheduled returns true if the object has been scheduled.  Always returns true.
+func (h *egressIPClusterControllerEventHandler) IsResourceScheduled(obj interface{}) bool {
+	return true
+}
+
+// IsObjectInTerminalState returns true if the object is a in terminal state.  Always returns true.
+func (h *egressIPClusterControllerEventHandler) IsObjectInTerminalState(obj interface{}) bool {
+	return false
+}
+
+func (h *egressIPClusterControllerEventHandler) AreResourcesEqual(obj1, obj2 interface{}) (bool, error) {
+	return false, nil
+}
+
+// GetInternalCacheEntry returns the internal cache entry for this object
+func (h *egressIPClusterControllerEventHandler) GetInternalCacheEntry(obj interface{}) interface{} {
+	return nil
+}
+
+// getResourceFromInformerCache returns the latest state of the object from the informers cache
+// given an object key and its type
+func (h *egressIPClusterControllerEventHandler) GetResourceFromInformerCache(key string) (interface{}, error) {
+	var obj interface{}
+	var name string
+	var err error
+
+	_, name, err = cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split key %s: %v", key, err)
+	}
+
+	switch h.objType {
+	case factory.EgressNodeType:
+		obj, err = h.eIPC.watchFactory.GetNode(name)
+	case factory.CloudPrivateIPConfigType:
+		obj, err = h.eIPC.watchFactory.GetCloudPrivateIPConfig(name)
+	case factory.EgressIPType:
+		obj, err = h.eIPC.watchFactory.GetEgressIP(name)
+
+	default:
+		err = fmt.Errorf("object type %s not supported, cannot retrieve it from informers cache",
+			h.objType)
+	}
+	return obj, err
+}

--- a/go-controller/pkg/clustermanager/fake_cluster_manager_test.go
+++ b/go-controller/pkg/clustermanager/fake_cluster_manager_test.go
@@ -1,0 +1,65 @@
+package clustermanager
+
+import (
+	"sync"
+
+	"github.com/onsi/gomega"
+	egressip "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
+	egressipfake "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/clientset/versioned/fake"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+)
+
+type FakeClusterManager struct {
+	fakeClient   *util.OVNClusterManagerClientset
+	watcher      *factory.WatchFactory
+	eIPC         *egressIPClusterController
+	stopChan     chan struct{}
+	wg           *sync.WaitGroup
+	fakeRecorder *record.FakeRecorder
+}
+
+func NewFakeClusterManagerOVN() *FakeClusterManager {
+	return &FakeClusterManager{
+		fakeRecorder: record.NewFakeRecorder(10),
+	}
+}
+
+func (o *FakeClusterManager) start(objects ...runtime.Object) {
+	egressIPObjects := []runtime.Object{}
+	v1Objects := []runtime.Object{}
+	for _, object := range objects {
+		if _, isEgressIPObject := object.(*egressip.EgressIPList); isEgressIPObject {
+			egressIPObjects = append(egressIPObjects, object)
+		} else {
+			v1Objects = append(v1Objects, object)
+		}
+	}
+	o.fakeClient = &util.OVNClusterManagerClientset{
+		KubeClient:     fake.NewSimpleClientset(v1Objects...),
+		EgressIPClient: egressipfake.NewSimpleClientset(egressIPObjects...),
+	}
+	o.init()
+}
+
+func (o *FakeClusterManager) init() {
+	var err error
+	o.watcher, err = factory.NewClusterManagerWatchFactory(o.fakeClient)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = o.watcher.Start()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	o.stopChan = make(chan struct{})
+	o.wg = &sync.WaitGroup{}
+	o.eIPC = newEgressIPController(o.fakeClient, o.watcher, o.fakeRecorder)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func (o *FakeClusterManager) shutdown() {
+	o.watcher.Shutdown()
+	close(o.stopChan)
+	o.wg.Wait()
+}

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -166,7 +166,6 @@ func NewMasterWatchFactory(ovnClientset *util.OVNMasterClientset) (*WatchFactory
 		iFactory:             informerfactory.NewSharedInformerFactory(ovnClientset.KubeClient, resyncInterval),
 		eipFactory:           egressipinformerfactory.NewSharedInformerFactory(ovnClientset.EgressIPClient, resyncInterval),
 		efFactory:            egressfirewallinformerfactory.NewSharedInformerFactory(ovnClientset.EgressFirewallClient, resyncInterval),
-		cpipcFactory:         ocpcloudnetworkinformerfactory.NewSharedInformerFactory(ovnClientset.CloudNetworkClient, resyncInterval),
 		egressQoSFactory:     egressqosinformerfactory.NewSharedInformerFactory(ovnClientset.EgressQoSClient, resyncInterval),
 		mnpFactory:           mnpinformerfactory.NewSharedInformerFactory(ovnClientset.MultiNetworkPolicyClient, resyncInterval),
 		egressServiceFactory: egressserviceinformerfactory.NewSharedInformerFactory(ovnClientset.EgressServiceClient, resyncInterval),
@@ -252,12 +251,6 @@ func NewMasterWatchFactory(ovnClientset *util.OVNMasterClientset) (*WatchFactory
 	}
 	if config.OVNKubernetesFeature.EnableEgressFirewall {
 		wf.informers[EgressFirewallType], err = newInformer(EgressFirewallType, wf.efFactory.K8s().V1().EgressFirewalls().Informer())
-		if err != nil {
-			return nil, err
-		}
-	}
-	if util.PlatformTypeIsEgressIPCloudProvider() {
-		wf.informers[CloudPrivateIPConfigType], err = newInformer(CloudPrivateIPConfigType, wf.cpipcFactory.Cloud().V1().CloudPrivateIPConfigs().Informer())
 		if err != nil {
 			return nil, err
 		}

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -253,6 +253,7 @@ func (c *handlerCalls) getDeleted() int {
 var _ = Describe("Watch Factory Operations", func() {
 	var (
 		ovnClientset                        *util.OVNMasterClientset
+		ovnCMClientset                      *util.OVNClusterManagerClientset
 		fakeClient                          *fake.Clientset
 		egressIPFakeClient                  *egressipfake.Clientset
 		egressFirewallFakeClient            *egressfirewallfake.Clientset
@@ -307,9 +308,13 @@ var _ = Describe("Watch Factory Operations", func() {
 			KubeClient:           fakeClient,
 			EgressIPClient:       egressIPFakeClient,
 			EgressFirewallClient: egressFirewallFakeClient,
-			CloudNetworkClient:   cloudNetworkFakeClient,
 			EgressQoSClient:      egressQoSFakeClient,
 			EgressServiceClient:  egressServiceFakeClient,
+		}
+		ovnCMClientset = &util.OVNClusterManagerClientset{
+			KubeClient:         fakeClient,
+			EgressIPClient:     egressIPFakeClient,
+			CloudNetworkClient: cloudNetworkFakeClient,
 		}
 
 		pods = make([]*v1.Pod, 0)
@@ -420,6 +425,8 @@ var _ = Describe("Watch Factory Operations", func() {
 		testExisting := func(objType reflect.Type, namespace string, sel labels.Selector, priority int) {
 			if objType == EndpointSliceType {
 				wf, err = NewNodeWatchFactory(ovnClientset.GetNodeClientset(), nodeName)
+			} else if objType == CloudPrivateIPConfigType {
+				wf, err = NewClusterManagerWatchFactory(ovnCMClientset)
 			} else {
 				wf, err = NewMasterWatchFactory(ovnClientset)
 			}
@@ -442,6 +449,8 @@ var _ = Describe("Watch Factory Operations", func() {
 		testExistingFilteredHandler := func(objType reflect.Type, realObj reflect.Type, namespace string, sel labels.Selector, priority int) {
 			if objType == EndpointSliceType {
 				wf, err = NewNodeWatchFactory(ovnClientset.GetNodeClientset(), nodeName)
+			} else if objType == CloudPrivateIPConfigType {
+				wf, err = NewClusterManagerWatchFactory(ovnCMClientset)
 			} else {
 				wf, err = NewMasterWatchFactory(ovnClientset)
 			}
@@ -572,6 +581,8 @@ var _ = Describe("Watch Factory Operations", func() {
 		testExisting := func(objType reflect.Type) {
 			if objType == EndpointSliceType {
 				wf, err = NewNodeWatchFactory(ovnClientset.GetNodeClientset(), nodeName)
+			} else if objType == CloudPrivateIPConfigType {
+				wf, err = NewClusterManagerWatchFactory(ovnCMClientset)
 			} else {
 				wf, err = NewMasterWatchFactory(ovnClientset)
 			}
@@ -1648,7 +1659,7 @@ var _ = Describe("Watch Factory Operations", func() {
 		wf.RemoveEgressIPHandler(h)
 	})
 	It("responds to cloudPrivateIPConfig add/update/delete events", func() {
-		wf, err = NewMasterWatchFactory(ovnClientset)
+		wf, err = NewClusterManagerWatchFactory(ovnCMClientset)
 		Expect(err).NotTo(HaveOccurred())
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -678,6 +678,20 @@ func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclien
 // routes from the cache based on a given predicate, deletes them and removes
 // them from the provided logical router
 func DeleteLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client, routerName string, p logicalRouterStaticRoutePredicate) error {
+	var ops []libovsdb.Operation
+	var err error
+	ops, err = DeleteLogicalRouterStaticRoutesWithPredicateOps(nbClient, ops, routerName, p)
+	if err != nil {
+		return err
+	}
+	_, err = TransactAndCheck(nbClient, ops)
+	return err
+}
+
+// DeleteLogicalRouterStaticRoutesWithPredicateOps looks up logical router static
+// routes from the cache based on a given predicate, and returns the ops to delete
+// them and remove them from the provided logical router
+func DeleteLogicalRouterStaticRoutesWithPredicateOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, routerName string, p logicalRouterStaticRoutePredicate) ([]libovsdb.Operation, error) {
 	router := &nbdb.LogicalRouter{
 		Name: routerName,
 	}
@@ -700,7 +714,7 @@ func DeleteLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client
 	}
 
 	m := newModelClient(nbClient)
-	return m.Delete(opModels...)
+	return m.DeleteOps(ops, opModels...)
 }
 
 // DeleteLogicalRouterStaticRoutes deletes the logical router static routes and

--- a/go-controller/pkg/ovn/base_event_handler.go
+++ b/go-controller/pkg/ovn/base_event_handler.go
@@ -29,7 +29,6 @@ func hasResourceAnUpdateFunc(objType reflect.Type) bool {
 		factory.EgressIPPodType,
 		factory.EgressNodeType,
 		factory.EgressFwNodeType,
-		factory.CloudPrivateIPConfigType,
 		factory.LocalPodSelectorType,
 		factory.NamespaceType,
 		factory.MultiNetworkPolicyType:
@@ -92,8 +91,7 @@ func (h *baseNetworkControllerEventHandler) areResourcesEqual(objType reflect.Ty
 
 	case factory.EgressIPType,
 		factory.EgressIPNamespaceType,
-		factory.EgressNodeType,
-		factory.CloudPrivateIPConfigType:
+		factory.EgressNodeType:
 		// force update path for EgressIP resource.
 		return false, nil
 
@@ -167,9 +165,6 @@ func (h *baseNetworkControllerEventHandler) getResourceFromInformerCache(objType
 	case factory.EgressIPType:
 		obj, err = watchFactory.GetEgressIP(name)
 
-	case factory.CloudPrivateIPConfigType:
-		obj, err = watchFactory.GetCloudPrivateIPConfig(name)
-
 	case factory.MultiNetworkPolicyType:
 		obj, err = watchFactory.GetMultiNetworkPolicy(namespace, name)
 
@@ -199,7 +194,6 @@ func needsUpdateDuringRetry(objType reflect.Type) bool {
 		factory.EgressIPType,
 		factory.EgressIPPodType,
 		factory.EgressIPNamespaceType,
-		factory.CloudPrivateIPConfigType,
 		factory.MultiNetworkPolicyType:
 		return true
 	}

--- a/go-controller/pkg/ovn/controller/egress_services/egress_services_node.go
+++ b/go-controller/pkg/ovn/controller/egress_services/egress_services_node.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"sort"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
@@ -78,6 +80,89 @@ func (c *Controller) CheckNodesReachabilityIterate() {
 		node.healthClient.Disconnect()
 		c.nodesQueue.Add(node.name) // Since it is available we queue it as it might match unallocated services
 	}
+}
+
+type egressSVCDialer interface {
+	dial(ip net.IP, timeout time.Duration) bool
+}
+
+var dialer egressSVCDialer = &egressSVCDial{}
+
+type egressSVCDial struct{}
+
+// Blantant copy from: https://github.com/openshift/sdn/blob/master/pkg/network/common/egressip.go#L499-L505
+// Ping a node and return whether or not we think it is online. We do this by trying to
+// open a TCP connection to the "discard" service (port 9); if the node is offline, the
+// attempt will either time out with no response, or else return "no route to host" (and
+// we will return false). If the node is online then we presumably will get a "connection
+// refused" error; but the code below assumes that anything other than timeout or "no
+// route" indicates that the node is online.
+func (e *egressSVCDial) dial(ip net.IP, timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip.String(), "9"), timeout)
+	if conn != nil {
+		conn.Close()
+	}
+	if opErr, ok := err.(*net.OpError); ok {
+		if opErr.Timeout() {
+			return false
+		}
+		if sysErr, ok := opErr.Err.(*os.SyscallError); ok && sysErr.Err == syscall.EHOSTUNREACH {
+			return false
+		}
+	}
+	return true
+}
+
+func IsReachableViaGRPC(mgmtIPs []net.IP, healthClient healthcheck.EgressIPHealthClient, healthCheckPort, totalTimeout int) bool {
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), time.Duration(totalTimeout)*time.Second)
+	defer dialCancel()
+
+	if !healthClient.IsConnected() {
+		// gRPC session is not up. Attempt to connect and if that suceeds, we will declare node as reacheable.
+		return healthClient.Connect(dialCtx, mgmtIPs, healthCheckPort)
+	}
+
+	// gRPC session is already established. Send a probe, which will succeed, or close the session.
+	return healthClient.Probe(dialCtx)
+}
+
+func IsReachableLegacy(node string, mgmtIPs []net.IP, totalTimeout int) bool {
+	var retryTimeOut, initialRetryTimeOut time.Duration
+
+	numMgmtIPs := len(mgmtIPs)
+	if numMgmtIPs == 0 {
+		return false
+	}
+
+	switch totalTimeout {
+	// Check if we need to do node reachability check
+	case 0:
+		return true
+	case 1:
+		// Using time duration for initial retry with 700/numIPs msec and retry of 100/numIPs msec
+		// to ensure total wait time will be in range with the configured value including a sleep of 100msec between attempts.
+		initialRetryTimeOut = time.Duration(700/numMgmtIPs) * time.Millisecond
+		retryTimeOut = time.Duration(100/numMgmtIPs) * time.Millisecond
+	default:
+		// Using time duration for initial retry with 900/numIPs msec
+		// to ensure total wait time will be in range with the configured value including a sleep of 100msec between attempts.
+		initialRetryTimeOut = time.Duration(900/numMgmtIPs) * time.Millisecond
+		retryTimeOut = initialRetryTimeOut
+	}
+
+	timeout := initialRetryTimeOut
+	endTime := time.Now().Add(time.Second * time.Duration(totalTimeout))
+	for time.Now().Before(endTime) {
+		for _, ip := range mgmtIPs {
+			if dialer.dial(ip, timeout) {
+				return true
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+		timeout = retryTimeOut
+	}
+	klog.Errorf("Failed reachability check for %s", node)
+	return false
 }
 
 func (c *Controller) onNodeAdd(obj interface{}) {

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	ocpcloudnetworkapi "github.com/openshift/api/cloudnetwork/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressfirewall "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
@@ -88,7 +87,7 @@ type DefaultNetworkController struct {
 	defaultCOPPUUID string
 
 	// Controller used for programming OVN for egress IP
-	eIPC egressIPController
+	eIPC egressIPZoneController
 
 	// Controller used to handle services
 	svcController *svccontroller.Controller
@@ -120,9 +119,6 @@ type DefaultNetworkController struct {
 	nodeClusterRouterPortFailed sync.Map
 	hybridOverlayFailed         sync.Map
 	syncZoneICFailed            sync.Map
-
-	// retry framework for Cloud private IP config
-	retryCloudPrivateIPConfig *retry.RetryFramework
 
 	// variable to determine if all pods present on the node during startup have been processed
 	// updated atomically
@@ -187,19 +183,13 @@ func newDefaultNetworkControllerCommon(cnci *CommonNetworkControllerInfo,
 		},
 		externalGWCache: make(map[ktypes.NamespacedName]*externalRouteInfo),
 		exGWCacheMutex:  sync.RWMutex{},
-		eIPC: egressIPController{
-			egressIPAssignmentMutex:           &sync.Mutex{},
-			podAssignmentMutex:                &sync.Mutex{},
-			nodeIPUpdateMutex:                 &sync.Mutex{},
-			podAssignment:                     make(map[string]*podAssignmentState),
-			pendingCloudPrivateIPConfigsMutex: &sync.Mutex{},
-			pendingCloudPrivateIPConfigsOps:   make(map[string]map[string]*cloudPrivateIPConfigOp),
-			allocator:                         allocator{&sync.Mutex{}, make(map[string]*egressNode)},
-			nbClient:                          cnci.nbClient,
-			watchFactory:                      cnci.watchFactory,
-			egressIPTotalTimeout:              config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout,
-			reachabilityCheckInterval:         egressIPReachabilityCheckInterval,
-			egressIPNodeHealthCheckPort:       config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort,
+		eIPC: egressIPZoneController{
+			nodeIPUpdateMutex:  &sync.Mutex{},
+			podAssignmentMutex: &sync.Mutex{},
+			podAssignment:      make(map[string]*podAssignmentState),
+			nbClient:           cnci.nbClient,
+			watchFactory:       cnci.watchFactory,
+			nodeZoneState:      syncmap.NewSyncMap[bool](),
 		},
 		loadbalancerClusterCache:     make(map[kapi.Protocol]string),
 		clusterLoadBalancerGroupUUID: "",
@@ -235,7 +225,6 @@ func (oc *DefaultNetworkController) initRetryFramework() {
 	oc.retryEgressIPPods = oc.newRetryFramework(factory.EgressIPPodType)
 	oc.retryEgressNodes = oc.newRetryFramework(factory.EgressNodeType)
 	oc.retryEgressFwNodes = oc.newRetryFramework(factory.EgressFwNodeType)
-	oc.retryCloudPrivateIPConfig = oc.newRetryFramework(factory.CloudPrivateIPConfigType)
 	oc.retryNamespaces = oc.newRetryFramework(factory.NamespaceType)
 	oc.retryNetworkPolicies = oc.newRetryFramework(factory.PolicyType)
 }
@@ -454,11 +443,6 @@ func (oc *DefaultNetworkController) Run(ctx context.Context) error {
 		}
 		if err := WithSyncDurationMetric("egress ip", oc.WatchEgressIP); err != nil {
 			return err
-		}
-		if util.PlatformTypeIsEgressIPCloudProvider() {
-			if err := WithSyncDurationMetric("could private ip config", oc.WatchCloudPrivateIPConfig); err != nil {
-				return err
-			}
 		}
 		if config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout == 0 {
 			klog.V(2).Infof("EgressIP node reachability check disabled")
@@ -772,7 +756,23 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 
 	case factory.EgressNodeType:
 		node := obj.(*kapi.Node)
-		return h.oc.reconcileNodeForEgressIP(nil, node)
+		// Update node in zone cache; value will be true if node is local
+		// to this zone and false if its not
+		h.oc.eIPC.nodeZoneState.LockKey(node.Name)
+		h.oc.eIPC.nodeZoneState.Store(node.Name, h.oc.isLocalZoneNode(node))
+		h.oc.eIPC.nodeZoneState.UnlockKey(node.Name)
+		// add the nodeIP to the default LRP (102 priority) destination address-set
+		err := h.oc.ensureDefaultNoRerouteNodePolicies()
+		if err != nil {
+			return err
+		}
+		// add the GARP configuration for all the new nodes we get
+		// since we use the "exclude-lb-vips-from-garp": "true"
+		// we shouldn't have scale issues
+		// NOTE: Adding GARP needs to be done only during node add
+		// It is a one time operation and doesn't need to be done during
+		// node updates. It needs to be done only for nodes local to this zone
+		return h.oc.addEgressNode(node)
 
 	case factory.EgressFwNodeType:
 		node := obj.(*kapi.Node)
@@ -781,10 +781,6 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 				node.Name, err)
 			return err
 		}
-
-	case factory.CloudPrivateIPConfigType:
-		cloudPrivateIPConfig := obj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
-		return h.oc.reconcileCloudPrivateIPConfig(nil, cloudPrivateIPConfig)
 
 	case factory.NamespaceType:
 		ns, ok := obj.(*kapi.Namespace)
@@ -896,17 +892,25 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 	case factory.EgressNodeType:
 		oldNode := oldObj.(*kapi.Node)
 		newNode := newObj.(*kapi.Node)
-		return h.oc.reconcileNodeForEgressIP(oldNode, newNode)
+		// Update node in zone cache; value will be true if node is local
+		// to this zone and false if its not
+		h.oc.eIPC.nodeZoneState.LockKey(newNode.Name)
+		h.oc.eIPC.nodeZoneState.Store(newNode.Name, h.oc.isLocalZoneNode(newNode))
+		h.oc.eIPC.nodeZoneState.UnlockKey(newNode.Name)
+		// update the nodeIP in the defalt-reRoute (102 priority) destination address-set
+		if util.NodeHostAddressesAnnotationChanged(oldNode, newNode) {
+			klog.Infof("Egress IP detected IP address change for node %s. Updating no re-route policies", newNode.Name)
+			err := h.oc.ensureDefaultNoRerouteNodePolicies()
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 
 	case factory.EgressFwNodeType:
 		oldNode := oldObj.(*kapi.Node)
 		newNode := newObj.(*kapi.Node)
 		return h.oc.updateEgressFirewallForNode(oldNode, newNode)
-
-	case factory.CloudPrivateIPConfigType:
-		oldCloudPrivateIPConfig := oldObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
-		newCloudPrivateIPConfig := newObj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
-		return h.oc.reconcileCloudPrivateIPConfig(oldCloudPrivateIPConfig, newCloudPrivateIPConfig)
 
 	case factory.NamespaceType:
 		oldNs, newNs := oldObj.(*kapi.Namespace), newObj.(*kapi.Namespace)
@@ -966,7 +970,20 @@ func (h *defaultNetworkControllerEventHandler) DeleteResource(obj, cachedObj int
 
 	case factory.EgressNodeType:
 		node := obj.(*kapi.Node)
-		return h.oc.reconcileNodeForEgressIP(node, nil)
+		// remove the GARP setup for the node
+		if err := h.oc.deleteEgressNode(node); err != nil {
+			return err
+		}
+		// remove the IPs from the destination address-set of the default LRP (102)
+		err := h.oc.ensureDefaultNoRerouteNodePolicies()
+		if err != nil {
+			return err
+		}
+		// Update node in zone cache; remove the node key since node has been deleted.
+		h.oc.eIPC.nodeZoneState.LockKey(node.Name)
+		h.oc.eIPC.nodeZoneState.Delete(node.Name)
+		h.oc.eIPC.nodeZoneState.UnlockKey(node.Name)
+		return nil
 
 	case factory.EgressFwNodeType:
 		node, ok := obj.(*kapi.Node)
@@ -974,10 +991,6 @@ func (h *defaultNetworkControllerEventHandler) DeleteResource(obj, cachedObj int
 			return fmt.Errorf("could not cast obj of type %T to *knet.Node", obj)
 		}
 		return h.oc.updateEgressFirewallForNode(node, nil)
-
-	case factory.CloudPrivateIPConfigType:
-		cloudPrivateIPConfig := obj.(*ocpcloudnetworkapi.CloudPrivateIPConfig)
-		return h.oc.reconcileCloudPrivateIPConfig(cloudPrivateIPConfig, nil)
 
 	case factory.NamespaceType:
 		ns := obj.(*kapi.Namespace)
@@ -1018,8 +1031,7 @@ func (h *defaultNetworkControllerEventHandler) SyncFunc(objs []interface{}) erro
 			syncFunc = nil
 
 		case factory.EgressIPPodType,
-			factory.EgressIPType,
-			factory.CloudPrivateIPConfigType:
+			factory.EgressIPType:
 			syncFunc = nil
 
 		case factory.NamespaceType:

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -34,10 +34,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	egressFirewallDNSDefaultDuration  = 30 * time.Minute
-	egressIPReachabilityCheckInterval = 5 * time.Second
-)
+const egressFirewallDNSDefaultDuration = 30 * time.Minute
 
 // ACL logging severity levels
 type ACLLoggingLevels struct {
@@ -301,13 +298,6 @@ func (oc *DefaultNetworkController) WatchEgressFwNodes() error {
 	return err
 }
 
-// WatchCloudPrivateIPConfig starts the watching of cloudprivateipconfigs
-// resource and calls back the appropriate handler logic.
-func (oc *DefaultNetworkController) WatchCloudPrivateIPConfig() error {
-	_, err := oc.retryCloudPrivateIPConfig.WatchResource()
-	return err
-}
-
 // WatchEgressIP starts the watching of egressip resource and calls back the
 // appropriate handler logic. It also initiates the other dedicated resource
 // handlers for egress IP setup: namespaces, pods.
@@ -494,10 +484,10 @@ func (oc *DefaultNetworkController) InitEgressServiceController() (*egresssvc.Co
 		}
 
 		if hcPort == 0 {
-			return isReachableLegacy(nodeName, mgmtIPs, timeout)
+			return egresssvc.IsReachableLegacy(nodeName, mgmtIPs, timeout)
 		}
 
-		return isReachableViaGRPC(mgmtIPs, healthClient, hcPort, timeout)
+		return egresssvc.IsReachableViaGRPC(mgmtIPs, healthClient, hcPort, timeout)
 	}
 
 	return egresssvc.NewController(DefaultNetworkControllerName, oc.client, oc.nbClient, oc.addressSetFactory,

--- a/go-controller/pkg/syncmap/syncmap.go
+++ b/go-controller/pkg/syncmap/syncmap.go
@@ -140,6 +140,14 @@ func (c *SyncMap[T]) LoadOrStore(lockedKey string, newEntry T) (value T, loaded 
 	}
 }
 
+// Store sets the value for a key.
+// If key-value was already present, it will be over-written
+func (c *SyncMap[T]) Store(lockedKey string, newEntry T) {
+	c.entriesMutex.Lock()
+	defer c.entriesMutex.Unlock()
+	c.entries[lockedKey] = newEntry
+}
+
 // Delete deletes object from the entries map
 func (c *SyncMap[T]) Delete(lockedKey string) {
 	c.entriesMutex.Lock()

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -68,6 +68,8 @@ type OVNNodeClientset struct {
 
 type OVNClusterManagerClientset struct {
 	KubeClient            kubernetes.Interface
+	EgressIPClient        egressipclientset.Interface
+	CloudNetworkClient    ocpcloudnetworkclientset.Interface
 	NetworkAttchDefClient networkattchmentdefclientset.Interface
 }
 
@@ -86,6 +88,8 @@ func (cs *OVNClientset) GetMasterClientset() *OVNMasterClientset {
 func (cs *OVNClientset) GetClusterManagerClientset() *OVNClusterManagerClientset {
 	return &OVNClusterManagerClientset{
 		KubeClient:            cs.KubeClient,
+		EgressIPClient:        cs.EgressIPClient,
+		CloudNetworkClient:    cs.CloudNetworkClient,
 		NetworkAttchDefClient: cs.NetworkAttchDefClient,
 	}
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -55,7 +55,6 @@ type OVNMasterClientset struct {
 	KubeClient               kubernetes.Interface
 	EgressIPClient           egressipclientset.Interface
 	EgressFirewallClient     egressfirewallclientset.Interface
-	CloudNetworkClient       ocpcloudnetworkclientset.Interface
 	EgressQoSClient          egressqosclientset.Interface
 	MultiNetworkPolicyClient multinetworkpolicyclientset.Interface
 	EgressServiceClient      egressserviceclientset.Interface
@@ -78,7 +77,6 @@ func (cs *OVNClientset) GetMasterClientset() *OVNMasterClientset {
 		KubeClient:               cs.KubeClient,
 		EgressIPClient:           cs.EgressIPClient,
 		EgressFirewallClient:     cs.EgressFirewallClient,
-		CloudNetworkClient:       cs.CloudNetworkClient,
 		EgressQoSClient:          cs.EgressQoSClient,
 		MultiNetworkPolicyClient: cs.MultiNetworkPolicyClient,
 		EgressServiceClient:      cs.EgressServiceClient,

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1061,3 +1061,8 @@ func randStr(n int) string {
 	}
 	return string(b)
 }
+
+func isInterconnectEnabled() bool {
+	val, present := os.LookupEnv("OVN_INTERCONNECT_ENABLE")
+	return present && val == "true"
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
This PR tracks the work required to support EIP on IC environments. Here are the following pieces that need to go in:

- [x] Split egress node allocator and egressIP CRD patching into new global egressIP controller in cluster-manager
- [x] Ensure healthcheck functions needed by egressSVC for non-IC is still kept in master - pkg/ovn - pieces are moved i.e there is slight code duplication for a while until we refactor egressSVC for IC and then we should be able to consolidate the healthcheck packages into one.
- [x] Keep the NBDB configuration bits in egressip zone-controller
- [x] Do SNATs and reroutes towards joinIP for non-IC environments as is today.
When IC is enabled:
- [x] Do SNATs towards egressIP only if egressNode is local to the zone
- [x] Do reroutes towards transit switch only if pod is local to the zone
- [x] Do static routes towards joinIP only if pod is non-local to the zone but egressnode is local to the zone
- [x] Do SNATs towards nodeIP only if pod is local to the zone.
- [x] Optimize database configurations on zone level to update only changed status items.
- [x] Split reconcileCloudPrivateIPConfig correctly (done to the best of my knowledge, we have moved over cloud IP stuff over to CM) - this part needs careful reviewing
- [ ] TODO: Can be part of new PR, delete static routes when node get's deleted from gatewayCleanUP code (also this might be unnecessary since delete events are processed in reverse order of add events for the handlers that share the same object type, in this case EgressNode and Node types. However the same luxury doesn't exist for races between pods and nodes, so might be worth doing this.)
- [ ] TODO: Add a sync function for the new LRSR similar to the ones we have for the other objects, this can be done in new PR.
- [x] TODO: Fix metrics for egressIP - new PR - https://github.com/ovn-org/ovn-kubernetes/pull/3611 

**- Special notes for reviewers**
This PR does not run a multi-zone lane, so if someone wants to see a CI signal see <https://github.com/ovn-org/ovn-kubernetes/pull/3561>. Please pay extra attention to cloud private IP parts since there is no CI signal here for that. I could be easily breaking things. We at least need to add unit tests for that beast somewhere...

**- How to verify it**

- [x] Fix existing tests by splitting allocator and patch bits into cluster-manager and keeping NBDB configuration checks in egressip zone controller
- [x] Add new unit tests on egressip zone controller side to test the reroutes and static routes -> this is mainly for IC enabled cluster environments.
- [ ] TODO: Test CloudPrivateIP reconcile properly. -> test this downstream since we don't have coverage here.
- [x] All existing e2e's are passing in non-IC and IC lanes.

**- Description for the changelog**
`Support egressIPs in Interconnect mode`