### PR TITLE
Ensure loadbalancer cleanup doesn't fail

### DIFF
--- a/go-controller/pkg/libovsdbops/lbgroup.go
+++ b/go-controller/pkg/libovsdbops/lbgroup.go
@@ -60,8 +60,9 @@ func RemoveLoadBalancersFromGroupOps(nbClient libovsdbclient.Client, ops []libov
 		Model:            group,
 		ModelPredicate:   func(item *nbdb.LoadBalancerGroup) bool { return item.Name == group.Name },
 		OnModelMutations: []interface{}{&group.LoadBalancer},
-		ErrNotFound:      true,
-		BulkOp:           false,
+		// if we want to delete loadbalancer from the port group that doesn't exist, that is noop
+		ErrNotFound: false,
+		BulkOp:      false,
 	}
 
 	m := newModelClient(nbClient)

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -797,8 +797,9 @@ func RemoveLoadBalancersFromLogicalRouterOps(nbClient libovsdbclient.Client, ops
 		Model:            router,
 		ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		OnModelMutations: []interface{}{&router.LoadBalancer},
-		ErrNotFound:      true,
-		BulkOp:           false,
+		// if we want to delete loadbalancer from the router that doesn't exist, that is noop
+		ErrNotFound: false,
+		BulkOp:      false,
 	}
 
 	modelClient := newModelClient(nbClient)

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -162,8 +162,9 @@ func RemoveLoadBalancersFromLogicalSwitchOps(nbClient libovsdbclient.Client, ops
 		Model:            sw,
 		ModelPredicate:   func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelMutations: []interface{}{&sw.LoadBalancer},
-		ErrNotFound:      true,
-		BulkOp:           false,
+		// if we want to delete loadbalancer from the switch that doesn't exist, that is noop
+		ErrNotFound: false,
+		BulkOp:      false,
 	}
 
 	modelClient := newModelClient(nbClient)

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,74 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"testing"
+
+	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEnsureLBs(t *testing.T) {
+	nbClient, cleanup, err := libovsdbtest.NewNBTestHarness(libovsdbtest.TestSetup{}, nil)
+	if err != nil {
+		t.Fatalf("Error creating NB: %v", err)
+	}
+	t.Cleanup(cleanup.Cleanup)
+	lbCache, err := GetLBCache(nbClient)
+	if err != nil {
+		t.Fatalf("Error creating LB Cache: %v", err)
+	}
+	name := "foo"
+	namespace := "testns"
+	defaultExternalIDs := map[string]string{
+		"k8s.ovn.org/kind":  "Service",
+		"k8s.ovn.org/owner": fmt.Sprintf("%s/%s", namespace, name),
+	}
+	// put stale lb in the cache
+	staleLBs := []LB{
+		{
+			Name:        "Service_testns/foo_TCP_node_router_node-a",
+			ExternalIDs: defaultExternalIDs,
+			Routers:     []string{"gr-node-a", "non-exisitng-router"},
+			Switches:    []string{"non-exisitng-switch"},
+			Groups:      []string{"non-existing-group"},
+			Protocol:    "TCP",
+			Rules: []LBRule{
+				{
+					Source:  Addr{"1.2.3.4", 80},
+					Targets: []Addr{{"169.254.169.2", 8080}},
+				},
+			},
+			UUID: "test-UUID",
+		},
+	}
+	lbCache.update(staleLBs, nil)
+
+	defaultService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+		},
+	}
+	// required lb doesn't have stale router, switch, and port group reference.
+	// "gr-node-a" is listed as applied in the cache, no update operation will be generated for it.
+	LBs := []LB{
+		{
+			Name:        "Service_testns/foo_TCP_node_router_node-a",
+			ExternalIDs: defaultExternalIDs,
+			Routers:     []string{"gr-node-a"},
+			Protocol:    "TCP",
+			Rules: []LBRule{
+				{
+					Source:  Addr{"1.2.3.4", 80},
+					Targets: []Addr{{"169.254.169.2", 8080}},
+				},
+			},
+		},
+	}
+	err = EnsureLBs(nbClient, defaultService, LBs)
+	if err != nil {
+		t.Fatalf("Error EnsureLBs: %v", err)
+	}
+}


### PR DESCRIPTION
use ErrNotFound=false for operations that delete loadbalancer from swtich, router, and port group. If a given object is not found, it's noop and not error. Delete LBCache methods RemoveSwitch and RemoveRouter, since they were only used to avoid deletion error, which won't happen anymore.

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>
