### PR TITLE
dualstack conversion: add some sleep between tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -517,6 +517,7 @@ jobs:
     - name: Run Single-Stack Tests
       run: |
         make -C test shard-test WHAT="Networking Granular Checks"
+        sleep 30
 
     - name: Convert IPv4 cluster to Dual Stack
       run: |
@@ -526,6 +527,7 @@ jobs:
       run: |
         KIND_IPV4_SUPPORT="true"
         KIND_IPV6_SUPPORT="true"
+        sleep 30
         make -C test shard-test WHAT="Networking Granular Checks\|DualStack"
 
     - name: Run Dual-Stack Control-Plane Tests


### PR DESCRIPTION
Workaround since when we attempt to debug and use a tmate step, just this delay seems to make the job always pass.

Signed-off-by: Tim Rozet <trozet@redhat.com>
