### PR TITLE
Add metrics pod ovs ports

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -55,3 +55,4 @@ This list is to help notify if there are additions, changes or removals to metri
 - Remove `ovnkube_master_skipped_nbctl_daemon_total` (https://github.com/ovn-org/ovn-kubernetes/pull/2707)
 - Add `ovnkube_master_egress_routing_via_host` (https://github.com/ovn-org/ovn-kubernetes/pull/2833)
 - Add `ovnkube_resource_retry_failures_total` (https://github.com/ovn-org/ovn-kubernetes/pull/3314)
+- Add `ovs_vswitchd_interfaces_total` and `ovs_vswitchd_interface_up_wait_seconds_total` (https://github.com/ovn-org/ovn-kubernetes/pull/3391)

--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -316,7 +317,9 @@ func waitForPodInterface(ctx context.Context, ifInfo *PodInterfaceInfo,
 			}
 
 			// try again later
-			time.Sleep(200 * time.Millisecond)
+			waitTime := 200 * time.Millisecond
+			time.Sleep(waitTime)
+			metrics.MetricOvsInterfaceUpWait.Add(waitTime.Seconds())
 		}
 	}
 }


### PR DESCRIPTION
This adds two metrics to track total number of OF ports and checks how many times ovnk attempted to validate whether port is up or not (ovs_interfaces_total and ovs_interface_up_wait_total). These metrics is useful to trace down issues known to be problematic.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>