### PR TITLE
Multi homing l2 topology optional ipam

### DIFF
--- a/go-controller/pkg/cni/helper_linux.go
+++ b/go-controller/pkg/cni/helper_linux.go
@@ -381,8 +381,13 @@ func ConfigureOVS(ctx context.Context, namespace, podName, hostIfaceName string,
 		fmt.Sprintf("external_ids:attached_mac=%s", ifInfo.MAC),
 		fmt.Sprintf("external_ids:iface-id=%s", ifaceID),
 		fmt.Sprintf("external_ids:iface-id-ver=%s", initialPodUID),
-		fmt.Sprintf("external_ids:ip_addresses=%s", strings.Join(ipStrs, ",")),
 		fmt.Sprintf("external_ids:sandbox=%s", sandboxID),
+	}
+
+	// IPAM is optional for secondary flatL2 networks; thus, the ifaces may not
+	// have IP addresses.
+	if len(ifInfo.IPs) > 0 {
+		ovsArgs = append(ovsArgs, fmt.Sprintf("external_ids:ip_addresses=%s", strings.Join(ipStrs, ",")))
 	}
 
 	if len(ifInfo.VfNetdevName) != 0 {

--- a/go-controller/pkg/node/node_dpu_test.go
+++ b/go-controller/pkg/node/node_dpu_test.go
@@ -28,21 +28,29 @@ func genOVSFindCmd(table, column, condition string) string {
 }
 
 func genOVSAddPortCmd(hostIfaceName, ifaceID, mac, ip, sandboxID, podUID string) string {
+	ipAddrExtID := ""
+	if ip != "" {
+		ipAddrExtID = fmt.Sprintf("external_ids:ip_addresses=%s ", ip)
+	}
 	return fmt.Sprintf("ovs-vsctl --timeout=30 add-port br-int %s other_config:transient=true "+
 		"-- set interface %s external_ids:attached_mac=%s "+
-		"external_ids:iface-id=%s external_ids:iface-id-ver=%s external_ids:ip_addresses=%s external_ids:sandbox=%s "+
+		"external_ids:iface-id=%s external_ids:iface-id-ver=%s %sexternal_ids:sandbox=%s "+
 		"-- --if-exists remove interface %s external_ids k8s.ovn.org/network "+
 		"-- --if-exists remove interface %s external_ids k8s.ovn.org/nad",
-		hostIfaceName, hostIfaceName, mac, ifaceID, podUID, ip, sandboxID, hostIfaceName, hostIfaceName)
+		hostIfaceName, hostIfaceName, mac, ifaceID, podUID, ipAddrExtID, sandboxID, hostIfaceName, hostIfaceName)
 }
 
 func genOVSAddPortCmdWithNetdev(hostIfaceName, netdev, ifaceID, mac, ip, sandboxID, podUID string) string {
+	ipAddrExtID := ""
+	if ip != "" {
+		ipAddrExtID = fmt.Sprintf("external_ids:ip_addresses=%s ", ip)
+	}
 	return fmt.Sprintf("ovs-vsctl --timeout=30 add-port br-int %s other_config:transient=true "+
 		"-- set interface %s external_ids:attached_mac=%s "+
-		"external_ids:iface-id=%s external_ids:iface-id-ver=%s external_ids:ip_addresses=%s external_ids:sandbox=%s external_ids:vf-netdev-name=%s "+
+		"external_ids:iface-id=%s external_ids:iface-id-ver=%s %sexternal_ids:sandbox=%s external_ids:vf-netdev-name=%s "+
 		"-- --if-exists remove interface %s external_ids k8s.ovn.org/network "+
 		"-- --if-exists remove interface %s external_ids k8s.ovn.org/nad",
-		hostIfaceName, hostIfaceName, mac, ifaceID, podUID, ip, sandboxID, netdev, hostIfaceName, hostIfaceName)
+		hostIfaceName, hostIfaceName, mac, ifaceID, podUID, ipAddrExtID, sandboxID, netdev, hostIfaceName, hostIfaceName)
 }
 
 func genOVSDelPortCmd(portName string) string {

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -705,3 +705,7 @@ func (bnc *BaseNetworkController) recordNodeErrorEvent(node *kapi.Node, nodeErr 
 	klog.V(5).Infof("Posting %s event for Node %s: %v", kapi.EventTypeWarning, node.Name, nodeErr)
 	bnc.recorder.Eventf(nodeRef, kapi.EventTypeWarning, "ErrorReconcilingNode", nodeErr.Error())
 }
+
+func (bnc *BaseNetworkController) doesNetworkRequireIPAM() bool {
+	return !(bnc.TopologyType() == types.Layer2Topology && len(bnc.Subnets()) == 0)
+}

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -54,7 +54,7 @@ func (bnc *BaseNetworkController) allocatePodIPs(pod *kapi.Pod,
 				"condition. Pod: %s/%s, node: %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
 		}
 	}
-	if err := bnc.waitForNodeLogicalSwitchInCache(switchName); err != nil {
+	if err := bnc.waitForNodeLogicalSwitchSubnetsInCache(switchName); err != nil {
 		return expectedLogicalPortName, fmt.Errorf("failed to wait for switch %s to be added to cache. IP allocation may fail!",
 			switchName)
 	}
@@ -316,10 +316,11 @@ func (bnc *BaseNetworkController) waitForNodeLogicalSwitch(switchName string) (*
 	return ls, nil
 }
 
-func (bnc *BaseNetworkController) waitForNodeLogicalSwitchInCache(switchName string) error {
-	// Wait for the node logical switch to be created by the ClusterController.
+func (bnc *BaseNetworkController) waitForNodeLogicalSwitchSubnetsInCache(switchName string) error {
+	// Wait for the node logical switch with IPAM to be created by the ClusterController
 	// The node switch will be created when the node's logical network infrastructure
 	// is created by the node watch.
+	// This function is only invoked when IPAM is required.
 	var subnets []*net.IPNet
 	if err := wait.PollImmediate(30*time.Millisecond, 30*time.Second, func() (bool, error) {
 		subnets = bnc.lsManager.GetSwitchSubnets(switchName)

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -110,6 +110,7 @@ type NetConfInfo interface {
 	CompareNetConf(NetConfInfo) bool
 	TopologyType() string
 	MTU() int
+	Subnets() []string
 }
 
 // DefaultNetConfInfo is structure which holds specific default network information
@@ -134,6 +135,11 @@ func (defaultNetConfInfo *DefaultNetConfInfo) TopologyType() string {
 // MTU returns the defaultNetConfInfo's MTU value
 func (defaultNetConfInfo *DefaultNetConfInfo) MTU() int {
 	return config.Default.MTU
+}
+
+// Subnets returns the defaultNetConfInfo's Subnets value
+func (defaultNetConfInfo *DefaultNetConfInfo) Subnets() []string {
+	return []string{config.Default.RawClusterSubnets}
 }
 
 func isSubnetsStringEqual(subnetsString, newSubnetsString string) bool {
@@ -241,6 +247,10 @@ func (layer3NetConfInfo *Layer3NetConfInfo) MTU() int {
 	return layer3NetConfInfo.mtu
 }
 
+func (layer3NetConfInfo *Layer3NetConfInfo) Subnets() []string {
+	return strings.Split(layer3NetConfInfo.subnets, ",")
+}
+
 // Layer2NetConfInfo is structure which holds specific secondary layer2 network information
 type Layer2NetConfInfo struct {
 	subnets        string
@@ -303,9 +313,6 @@ func verifyExcludeIPs(subnetsString string, excludeSubnetsString string) ([]*net
 	if err != nil {
 		return nil, nil, fmt.Errorf("subnets %s is invalid: %v", subnetsString, err)
 	}
-	if len(clusterSubnets) == 0 {
-		return nil, nil, fmt.Errorf("subnets is not defined")
-	}
 
 	excludeSubnets, err := parseSubnetsString(excludeSubnetsString)
 	if err != nil {
@@ -335,6 +342,14 @@ func (layer2NetConfInfo *Layer2NetConfInfo) TopologyType() string {
 
 func (layer2NetConfInfo *Layer2NetConfInfo) MTU() int {
 	return layer2NetConfInfo.mtu
+}
+
+func (layer2NetConfInfo *Layer2NetConfInfo) Subnets() []string {
+	subnets := strings.Split(layer2NetConfInfo.subnets, ",")
+	if len(subnets) == 1 && strings.TrimSpace(subnets[0]) == "" {
+		return nil
+	}
+	return subnets
 }
 
 // GetNADName returns key of NetAttachDefInfo.NetAttachDefs map, also used as Pod annotation key

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -170,10 +170,9 @@ func UnmarshalPodAnnotation(annotations map[string]string, nadName string) (*Pod
 	}
 
 	if len(a.IPs) == 0 {
-		if a.IP == "" {
-			return nil, fmt.Errorf("bad annotation data (neither ip_address nor ip_addresses is set)")
+		if a.IP != "" {
+			a.IPs = append(a.IPs, a.IP)
 		}
-		a.IPs = append(a.IPs, a.IP)
 	} else if a.IP != "" && a.IP != a.IPs[0] {
 		return nil, fmt.Errorf("bad annotation data (ip_address and ip_addresses conflict)")
 	}

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -143,11 +143,6 @@ func TestUnmarshalPodAnnotation(t *testing.T) {
 			errMatch:    fmt.Errorf("failed to parse pod MAC"),
 		},
 		{
-			desc:        "verify error thrown when neither ip_addresses nor ip_address is set",
-			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"0a:58:fd:98:00:01"}}`},
-			errMatch:    fmt.Errorf("bad annotation data (neither ip_address nor ip_addresses is set)"),
-		},
-		{
 			desc:        "test path when ip_addresses is empty and ip_address is set",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":null,"mac_address":"0a:58:fd:98:00:01", "ip_address":"192.168.0.11/24"}}`},
 		},
@@ -198,6 +193,10 @@ func TestUnmarshalPodAnnotation(t *testing.T) {
 		{
 			desc:        "verify successful unmarshal of pod annotation",
 			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.5/24"],"mac_address":"0a:58:fd:98:00:01","gateway_ips":["192.168.0.1"],"routes":[{"dest":"192.168.1.0/24","nextHop":"192.168.1.1"}],"ip_address":"192.168.0.5/24","gateway_ip":"192.168.0.1"}}`},
+		},
+		{
+			desc:        "verify successful unmarshal of pod annotation when *only* the MAC address is present",
+			inpAnnotMap: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"mac_address":"0a:58:fd:98:00:01"}}`},
 		},
 	}
 	for i, tc := range tests {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR allows users to create flat L2 secondary networks without IPAM to be used by multi-homed pods.

This is useful especially for virtualization scenarios, where users manage IP addresses on their own - and thus enables KubeVirt to lift and shift existing VMs from traditional virtualization / cloud technologies.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->
These are the relevant contents of the NB database:
```
_uuid               : aecf79fd-efd1-48f8-980c-456b06d9efbb
acls                : []
copp                : []
dns_records         : []
external_ids        : {k8s-ovn-topo-version="5", "k8s.ovn.org/network"=l2-network, "k8s.ovn.org/topology"=layer2}
forwarding_groups   : []
load_balancer       : []
load_balancer_group : []
name                : l2.network_ovn_layer2_switch
other_config        : {}
ports               : [82807b8f-ecef-429d-bc0d-017b10ca90b9, 9ca08d6b-92ee-4de0-8989-3a72103fad21]
qos_rules           : []
[root@ovn-control-plane ~]# ovn-nbctl list logical_switch_port 82807b8f-ecef-429d-bc0d-017b10ca90b9, 9ca08d6b-92ee-4de0-8989-3a72103fad21

[root@ovn-control-plane ~]# ovn-nbctl list logical_switch_port 82807b8f-ecef-429d-bc0d-017b10ca90b9 9ca08d6b-92ee-4de0-8989-3a72103fad21
_uuid               : 82807b8f-ecef-429d-bc0d-017b10ca90b9
addresses           : ["ae:0f:03:9c:74:03"]
dhcpv4_options      : []
dhcpv6_options      : []
dynamic_addresses   : []
enabled             : []
external_ids        : {"k8s.ovn.org/nad"="default/l2-network", "k8s.ovn.org/network"=l2-network, "k8s.ovn.org/topology"=layer2, namespace=default, pod="true"}
ha_chassis_group    : []
mirror_rules        : []
name                : default.l2.network_default_bigpod
options             : {iface-id-ver="c1482978-b30e-4764-a4b6-804d6d8d74fe", requested-chassis=ovn-worker2}
parent_name         : []
port_security       : ["ae:0f:03:9c:74:03"]
tag                 : []
tag_request         : []
type                : ""
up                  : true

_uuid               : 9ca08d6b-92ee-4de0-8989-3a72103fad21
addresses           : ["6a:5b:3d:03:a0:9d"]
dhcpv4_options      : []
dhcpv6_options      : []
dynamic_addresses   : []
enabled             : []
external_ids        : {"k8s.ovn.org/nad"="default/l2-network", "k8s.ovn.org/network"=l2-network, "k8s.ovn.org/topology"=layer2, namespace=default, pod="true"}
ha_chassis_group    : []
mirror_rules        : []
name                : default.l2.network_default_tinypod
options             : {iface-id-ver="578c0366-0ce7-44a6-ae1a-750cd12d6a04", requested-chassis=ovn-worker}
parent_name         : []
port_security       : ["6a:5b:3d:03:a0:9d"]
tag                 : []
tag_request         : []
type                : ""
up                  : true
```

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Two new tests were added to the multi-homing lane:
- assert a pod can reach the ready phase when using a secondary attachment without a defined subnet
- assert traffic works between two pods connected via a secondary attachment without a defined subnet. These pods IPs were setup using static IPs via kubectl.

This can also be tested manually by provisioning the following yaml:
```yaml
---
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: l2-network
spec:
  config: |2
    {
            "cniVersion": "0.3.1",
            "name": "l2-network",
            "type": "ovn-k8s-cni-overlay",
            "topology":"layer2",
            "mtu": 1300,
            "netAttachDefName": "default/l2-network"
    }
---
apiVersion: v1
kind: Pod
metadata:
  annotations:
    k8s.v1.cni.cncf.io/networks: l2-network
  name: tinypod
spec:
  containers:
  - args:
    - pause
    image: k8s.gcr.io/e2e-test-images/agnhost:2.36
    imagePullPolicy: IfNotPresent
    name: agnhost-container
    securityContext:
      privileged: true # needed so you can add the IP from within the pod
---
apiVersion: v1
kind: Pod
metadata:
  annotations:
    k8s.v1.cni.cncf.io/networks: l2-network
  name: bigpod
spec:
  containers:
  - args:
    - pause
    image: k8s.gcr.io/e2e-test-images/agnhost:2.36
    imagePullPolicy: IfNotPresent
    name: agnhost-container
    securityContext:
      privileged: true # needed so you can add the IP from within the pod
```

Then configure IPs in the containers, and ping between them:
```bash
kubectl exec bigpod -- ip addr add 192.168.200.10/24 dev net1
kubectl exec tinypod -- ip addr add 192.168.200.20/24 dev net1

kubectl exec tinypod -- ip a show net1
3: net1@if15: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1300 qdisc noqueue state UP group default 
    link/ether aa:84:55:80:ff:56 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 192.168.200.20/24 scope global net1
       valid_lft forever preferred_lft forever
    inet6 fe80::a884:55ff:fe80:ff56/64 scope link 
       valid_lft forever preferred_lft forever

kubectl exec bigpod -- ip a show net1
3: net1@if14: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1300 qdisc noqueue state UP group default 
    link/ether c6:95:0d:51:03:54 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 192.168.200.10/24 scope global net1
       valid_lft forever preferred_lft forever
    inet6 fe80::c495:dff:fe51:354/64 scope link 
       valid_lft forever preferred_lft forever

kubectl exec tinypod -- ping -c 4 192.168.200.10
PING 192.168.200.10 (192.168.200.10): 56 data bytes
64 bytes from 192.168.200.10: seq=0 ttl=64 time=0.055 ms
64 bytes from 192.168.200.10: seq=1 ttl=64 time=0.059 ms
64 bytes from 192.168.200.10: seq=2 ttl=64 time=0.146 ms
64 bytes from 192.168.200.10: seq=3 ttl=64 time=0.135 ms

--- 192.168.200.10 ping statistics ---
4 packets transmitted, 4 packets received, 0% packet loss
round-trip min/avg/max = 0.055/0.098/0.146 ms
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Optional subnets for flatL2 multi-homed networks.