### PR TITLE
Fix panic when node is deleted and state is also not present

### DIFF
--- a/go-controller/pkg/ovn/controller/egress_services/egress_services_node.go
+++ b/go-controller/pkg/ovn/controller/egress_services/egress_services_node.go
@@ -198,6 +198,11 @@ func (c *Controller) syncNode(key string) error {
 			}
 			delete(c.nodes, nodeName)
 			state.healthClient.Disconnect()
+		} else {
+			// we don't have a node at this point (node deleted?) and we don't have its cache
+			// entry (state==nil) as well. Maybe state was deleted when node became nodeReady or unreachable
+			// nothing to sync here
+			return nil
 		}
 
 		return c.deleteNoRerouteNodePolicies(c.addressSetFactory, nodeName, state.v4InternalNodeIP, state.v6InternalNodeIP)


### PR DESCRIPTION
It can happen that node got deleted, but then
we have already deleted nodeState from the cache
because node was not ready or not reachable?
In those cases do nothing and return from syncNode since we can neither remove the address-set nodeIPs from the route nor add the node.

```
E0201 17:09:28.513834       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 568 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1b67100?, 0x3059000})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000d3cbf0?})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x75
panic({0x1b67100, 0x3059000})
	/usr/lib/golang/src/runtime/panic.go:884 +0x212
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/egress_services.(*Controller).syncNode(0xc0002b64b0, {0xc001298c20, 0x1b})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/ovn/controller/egress_services/egress_services_node.go:203 +0xceb
```

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->