### PR TITLE
Fix panic if nadController is nil

### DIFF
--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -418,7 +418,9 @@ func (cm *networkControllerManager) Stop() {
 	// then stops each network controller associated with net-attach-def; it is ok
 	// to call GetAllControllers here as net-attach-def controller has been stopped,
 	// and no more change of network controllers
-	for _, oc := range cm.nadController.GetAllNetworkControllers() {
-		oc.Stop()
+	if cm.nadController != nil {
+		for _, oc := range cm.nadController.GetAllNetworkControllers() {
+			oc.Stop()
+		}
 	}
 }


### PR DESCRIPTION
When multi network feature is not enabled,
the nadController will be nil. So while stopping
the controllers, we need to check if nadController is nil or not, else we'll panic.

panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x193c7ee]
```
goroutine 1 [running]:
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-controller-manager.(*netAttachDefinitionController).GetAllNetworkControllers(0x0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/network-controller-manager/network_attach_def_controller.go:307 +0x2e
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/network-controller-manager.(*networkControllerManager).Stop(0xc000540210)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/network-controller-manager/network_controller_manager.go:421 +0x5c
main.runOvnKube(0xc0004baa80, 0xc0004baa80?)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/cmd/ovnkube/ovnkube.go:314 +0xbc5
main.main.func1(0xc0003a4800?)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/cmd/ovnkube/ovnkube.go:108 +0x1d
github.com/urfave/cli/v2.(*App).RunContext(0xc0000d8d80, {0x2148e48?, 0xc00051b740}, {0xc000006a00, 0x27, 0x28})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/vendor/github.com/urfave/cli/v2/app.go:315 +0x9f5
main.main()
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/cmd/ovnkube/ovnkube.go:132 +0xba9
```
Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->