### PR TITLE
Delete IGMP Groups when deleting stale chassis.

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift/api v0.0.0-20221004161420-ef2c62cf20d0
 	github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e
-	github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5
+	github.com/ovn-org/libovsdb v0.6.1-0.20230203213244-a6a173993830
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/client_model v0.2.0

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -635,8 +635,8 @@ github.com/openshift/api v0.0.0-20221004161420-ef2c62cf20d0/go.mod h1:JRz+ZvTqu9
 github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e h1:ab+BJg7h50pi2/rbMkDSXfYx8w80HLmr7NBs8H1hEvU=
 github.com/openshift/client-go v0.0.0-20220915152853-9dfefb19db2e/go.mod h1:e+TTiBDGWB3O3p3iAzl054x3cZDWhrZ5+jxJRCdEFkA=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5 h1:Cw0JXIHSGp8etz5/P7zNQ0tCMmTljBGBr8Rn2P1PuzQ=
-github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5/go.mod h1:S/+Hux9//oB7yLaPsUKnXTzZc6S1C4a9HP0UifXfKz0=
+github.com/ovn-org/libovsdb v0.6.1-0.20230203213244-a6a173993830 h1:eV+OMJFLtayfrYTCEBIsxvuMV0HK6KPWCqIUdaxoIwQ=
+github.com/ovn-org/libovsdb v0.6.1-0.20230203213244-a6a173993830/go.mod h1:S/+Hux9//oB7yLaPsUKnXTzZc6S1C4a9HP0UifXfKz0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
@@ -1069,8 +1069,6 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -102,6 +102,7 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 
 	// Only Monitor Required SBDB tables to reduce memory overhead
 	chassisPrivate := sbdb.ChassisPrivate{}
+	igmpGroup := sbdb.IGMPGroup{}
 	_, err = c.Monitor(ctx,
 		c.NewMonitor(
 			// used by unidling controller
@@ -112,6 +113,8 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 			client.WithTable(&sbdb.Chassis{}),
 			// used by node sync, only interested in names
 			client.WithTable(&chassisPrivate, &chassisPrivate.Name),
+			// used by node sync, only interested in Chassis reference
+			client.WithTable(&igmpGroup, &igmpGroup.Chassis),
 			// used for metrics
 			client.WithTable(&sbdb.SBGlobal{}),
 			// used for metrics

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -54,6 +54,8 @@ func getUUID(model model.Model) string {
 		return t.UUID
 	case *sbdb.ChassisPrivate:
 		return t.UUID
+	case *sbdb.IGMPGroup:
+		return t.UUID
 	case *sbdb.MACBinding:
 		return t.UUID
 	case *sbdb.SBGlobal:
@@ -106,6 +108,8 @@ func setUUID(model model.Model, uuid string) {
 	case *sbdb.Chassis:
 		t.UUID = uuid
 	case *sbdb.ChassisPrivate:
+		t.UUID = uuid
+	case *sbdb.IGMPGroup:
 		t.UUID = uuid
 	case *sbdb.MACBinding:
 		t.UUID = uuid
@@ -212,6 +216,10 @@ func copyIndexes(model model.Model) model.Model {
 			UUID: t.UUID,
 			Name: t.Name,
 		}
+	case *sbdb.IGMPGroup:
+		return &sbdb.IGMPGroup{
+			UUID: t.UUID,
+		}
 	case *sbdb.MACBinding:
 		return &sbdb.MACBinding{
 			UUID:        t.UUID,
@@ -273,6 +281,8 @@ func getListFromModel(model model.Model) interface{} {
 		return &[]*sbdb.Chassis{}
 	case *sbdb.ChassisPrivate:
 		return &[]*sbdb.ChassisPrivate{}
+	case *sbdb.IGMPGroup:
+		return &[]*sbdb.IGMPGroup{}
 	case *sbdb.MACBinding:
 		return &[]*sbdb.MACBinding{}
 	case *nbdb.QoS:

--- a/go-controller/pkg/testing/libovsdb/libovsdb.go
+++ b/go-controller/pkg/testing/libovsdb/libovsdb.go
@@ -17,6 +17,7 @@ import (
 	guuid "github.com/google/uuid"
 	"github.com/mitchellh/copystructure"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/database"
 	"github.com/ovn-org/libovsdb/mapper"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
@@ -188,7 +189,7 @@ func newNBServer(cfg config.OvnAuthConfig, data []TestData) (*server.OvsdbServer
 	return newOVSDBServer(cfg, dbModel, schema, data)
 }
 
-func updateData(db server.Database, dbModel model.ClientDBModel, schema ovsdb.DatabaseSchema, data []TestData) error {
+func updateData(db database.Database, dbModel model.ClientDBModel, schema ovsdb.DatabaseSchema, data []TestData) error {
 	dbName := dbModel.Name()
 	m := mapper.NewMapper(schema)
 	updates := ovsdb.TableUpdates2{}
@@ -264,7 +265,7 @@ func newOVSDBServer(cfg config.OvnAuthConfig, dbModel model.ClientDBModel, schem
 	}
 	serverSchema := serverdb.Schema()
 
-	db := server.NewInMemoryDatabase(map[string]model.ClientDBModel{
+	db := database.NewInMemoryDatabase(map[string]model.ClientDBModel{
 		schema.Name:       dbModel,
 		serverSchema.Name: serverDBModel,
 	})

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/cache/uuidset.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/cache/uuidset.go
@@ -24,6 +24,18 @@ func (s uuidset) has(uuid string) bool {
 	return ok
 }
 
+func (s uuidset) equals(o uuidset) bool {
+	if len(s) != len(o) {
+		return false
+	}
+	for uuid := range s {
+		if !o.has(uuid) {
+			return false
+		}
+	}
+	return true
+}
+
 func (s uuidset) getAny() string {
 	for k := range s {
 		return k

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/database/database.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/database/database.go
@@ -1,4 +1,4 @@
-package server
+package database
 
 import (
 	"fmt"

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/database/errors.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/database/errors.go
@@ -1,4 +1,4 @@
-package server
+package database
 
 import (
 	"fmt"

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/database/mutate.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/database/mutate.go
@@ -1,4 +1,4 @@
-package server
+package database
 
 import (
 	"reflect"

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/database/transaction.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/database/transaction.go
@@ -1,97 +1,148 @@
-package server
+package database
 
 import (
 	"fmt"
 	"reflect"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/ovn-org/libovsdb/cache"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"
 )
 
-func (o *OvsdbServer) transact(name string, operations []ovsdb.Operation) ([]ovsdb.OperationResult, ovsdb.TableUpdates2) {
-	o.modelsMutex.Lock()
-	dbModel := o.models[name]
-	o.modelsMutex.Unlock()
-	transaction := o.NewTransaction(dbModel, name, o.db)
+type Transaction struct {
+	ID          uuid.UUID
+	Cache       *cache.TableCache
+	DeletedRows map[string]struct{}
+	Model       model.DatabaseModel
+	DbName      string
+	Database    Database
+}
 
-	results := []ovsdb.OperationResult{}
+func NewTransaction(model model.DatabaseModel, dbName string, database Database, logger *logr.Logger) Transaction {
+	if logger != nil {
+		l := logger.WithName("transaction")
+		logger = &l
+	}
+	cache, err := cache.NewTableCache(model, nil, logger)
+	if err != nil {
+		panic(err)
+	}
+	return Transaction{
+		ID:          uuid.New(),
+		Cache:       cache,
+		DeletedRows: make(map[string]struct{}),
+		Model:       model,
+		DbName:      dbName,
+		Database:    database,
+	}
+}
+
+func (t *Transaction) Transact(operations []ovsdb.Operation) ([]*ovsdb.OperationResult, ovsdb.TableUpdates2) {
+	results := []*ovsdb.OperationResult{}
 	updates := make(ovsdb.TableUpdates2)
 
-	// simple case: database name does not exist
-	if !o.db.Exists(name) {
-		r := ovsdb.OperationResult{
-			Error: "database does not exist",
-		}
-		for range operations {
-			results = append(results, r)
-		}
-		return results, updates
-	}
-
+	var r ovsdb.OperationResult
 	for _, op := range operations {
+		// if we had a previous error, just append a nil result for every op
+		// after that
+		if r.Error != "" {
+			results = append(results, nil)
+			continue
+		}
+
+		// simple case: database name does not exist
+		if !t.Database.Exists(t.DbName) {
+			r = ovsdb.OperationResult{
+				Error: "database does not exist",
+			}
+			results = append(results, &r)
+			continue
+		}
+
 		switch op.Op {
 		case ovsdb.OperationInsert:
-			r, tu := transaction.Insert(op.Table, op.UUIDName, op.Row)
-			results = append(results, r)
+			var tu ovsdb.TableUpdates2
+			r, tu = t.Insert(op.Table, op.UUIDName, op.Row)
 			if tu != nil {
 				updates.Merge(tu)
-				if err := transaction.Cache.Populate2(tu); err != nil {
+				if err := t.Cache.Populate2(tu); err != nil {
 					panic(err)
 				}
 			}
 		case ovsdb.OperationSelect:
-			r := transaction.Select(op.Table, op.Where, op.Columns)
-			results = append(results, r)
+			r = t.Select(op.Table, op.Where, op.Columns)
 		case ovsdb.OperationUpdate:
-			r, tu := transaction.Update(name, op.Table, op.Where, op.Row)
-			results = append(results, r)
+			var tu ovsdb.TableUpdates2
+			r, tu = t.Update(op.Table, op.Where, op.Row)
 			if tu != nil {
 				updates.Merge(tu)
-				if err := transaction.Cache.Populate2(tu); err != nil {
+				if err := t.Cache.Populate2(tu); err != nil {
 					panic(err)
 				}
 			}
 		case ovsdb.OperationMutate:
-			r, tu := transaction.Mutate(name, op.Table, op.Where, op.Mutations)
-			results = append(results, r)
+			var tu ovsdb.TableUpdates2
+			r, tu = t.Mutate(op.Table, op.Where, op.Mutations)
 			if tu != nil {
 				updates.Merge(tu)
-				if err := transaction.Cache.Populate2(tu); err != nil {
+				if err := t.Cache.Populate2(tu); err != nil {
 					panic(err)
 				}
 			}
 		case ovsdb.OperationDelete:
-			r, tu := transaction.Delete(name, op.Table, op.Where)
-			results = append(results, r)
+			var tu ovsdb.TableUpdates2
+			r, tu = t.Delete(op.Table, op.Where)
 			if tu != nil {
 				updates.Merge(tu)
-				if err := transaction.Cache.Populate2(tu); err != nil {
+				if err := t.Cache.Populate2(tu); err != nil {
 					panic(err)
 				}
 			}
 		case ovsdb.OperationWait:
-			r := transaction.Wait(name, op.Table, op.Timeout, op.Where, op.Columns, op.Until, op.Rows)
-			results = append(results, r)
+			r = t.Wait(op.Table, op.Timeout, op.Where, op.Columns, op.Until, op.Rows)
 		case ovsdb.OperationCommit:
 			durable := op.Durable
-			r := transaction.Commit(name, op.Table, *durable)
-			results = append(results, r)
+			r = t.Commit(op.Table, *durable)
 		case ovsdb.OperationAbort:
-			r := transaction.Abort(name, op.Table)
-			results = append(results, r)
+			r = t.Abort(op.Table)
 		case ovsdb.OperationComment:
-			r := transaction.Comment(name, op.Table, *op.Comment)
-			results = append(results, r)
+			r = t.Comment(op.Table, *op.Comment)
 		case ovsdb.OperationAssert:
-			r := transaction.Assert(name, op.Table, *op.Lock)
-			results = append(results, r)
+			r = t.Assert(op.Table, *op.Lock)
 		default:
-			return nil, updates
+			e := ovsdb.NotSupported{}
+			r = ovsdb.OperationResult{
+				Error: e.Error(),
+			}
+		}
+
+		result := r
+		results = append(results, &result)
+	}
+
+	// if an operation failed, no need to do any further validation
+	if r.Error != "" {
+		return results, updates
+	}
+
+	// check index constraints
+	if err := t.checkIndexes(); err != nil {
+		if indexExists, ok := err.(*cache.ErrIndexExists); ok {
+			e := ovsdb.ConstraintViolation{}
+			results = append(results, &ovsdb.OperationResult{
+				Error:   e.Error(),
+				Details: newIndexExistsDetails(*indexExists),
+			})
+		} else {
+			results = append(results, &ovsdb.OperationResult{
+				Error: err.Error(),
+			})
 		}
 	}
+
 	return results, updates
 }
 
@@ -110,13 +161,18 @@ func (t *Transaction) rowsFromTransactionCacheAndDatabase(table string, where []
 	for rowUUID, row := range rows {
 		if txnRow, found := txnRows[rowUUID]; found {
 			rows[rowUUID] = txnRow
+			// delete txnRows so that only inserted rows remain in txnRows
+			delete(txnRows, rowUUID)
 		} else {
 			// warm the transaction cache with the current contents of the row
 			if err := t.Cache.Table(table).Create(rowUUID, row, false); err != nil {
 				return nil, fmt.Errorf("failed warming transaction cache row %s %v for table %s: %v", rowUUID, row, table, err)
 			}
-			txnRows[rowUUID] = row
 		}
+	}
+	// add rows that have been inserted in this transaction
+	for rowUUID, row := range txnRows {
+		rows[rowUUID] = row
 	}
 	// exclude deleted rows
 	for rowUUID := range t.DeletedRows {
@@ -125,15 +181,43 @@ func (t *Transaction) rowsFromTransactionCacheAndDatabase(table string, where []
 	return rows, nil
 }
 
-func (t *Transaction) checkIndexes(table string, model model.Model) error {
-	// check for index conflicts. First check on transaction cache, followed by
-	// the database's
-	targetTable := t.Cache.Table(table)
-	err := targetTable.IndexExists(model)
-	if err == nil {
-		err = t.Database.CheckIndexes(t.DbName, table, model)
+// checkIndexes checks that there are no index conflicts:
+// - no duplicate indexes among any two rows operated with in the transaction
+// - no duplicate indexes of any transaction row with any database row
+func (t *Transaction) checkIndexes() error {
+	// check for index conflicts.
+	tables := t.Cache.Tables()
+	for _, table := range tables {
+		tc := t.Cache.Table(table)
+		for _, row := range tc.RowsShallow() {
+			err := tc.IndexExists(row)
+			if err != nil {
+				return err
+			}
+			err = t.Database.CheckIndexes(t.DbName, table, row)
+			errIndexExists, isErrIndexExists := err.(*cache.ErrIndexExists)
+			if err == nil {
+				continue
+			}
+			if !isErrIndexExists {
+				return err
+			}
+			for _, existing := range errIndexExists.Existing {
+				if _, isDeleted := t.DeletedRows[existing]; isDeleted {
+					// this model is deleted in the transaction, ignore it
+					continue
+				}
+				if tc.HasRow(existing) {
+					// this model is updated in the transaction and was not
+					// detected as a duplicate, so an index must have been
+					// updated, ignore it
+					continue
+				}
+				return err
+			}
+		}
 	}
-	return err
+	return nil
 }
 
 func (t *Transaction) Insert(table string, rowUUID string, row ovsdb.Row) (ovsdb.OperationResult, ovsdb.TableUpdates2) {
@@ -179,20 +263,6 @@ func (t *Transaction) Insert(table string, rowUUID string, row ovsdb.Row) (ovsdb
 		}, nil
 	}
 
-	// check for index conflicts
-	if err := t.checkIndexes(table, model); err != nil {
-		if indexExists, ok := err.(*cache.ErrIndexExists); ok {
-			e := ovsdb.ConstraintViolation{}
-			return ovsdb.OperationResult{
-				Error:   e.Error(),
-				Details: newIndexExistsDetails(*indexExists),
-			}, nil
-		}
-		return ovsdb.OperationResult{
-			Error: err.Error(),
-		}, nil
-	}
-
 	result := ovsdb.OperationResult{
 		UUID: ovsdb.UUID{GoUUID: rowUUID},
 	}
@@ -233,7 +303,7 @@ func (t *Transaction) Select(table string, where []ovsdb.Condition, columns []st
 	}
 }
 
-func (t *Transaction) Update(database, table string, where []ovsdb.Condition, row ovsdb.Row) (ovsdb.OperationResult, ovsdb.TableUpdates2) {
+func (t *Transaction) Update(table string, where []ovsdb.Condition, row ovsdb.Row) (ovsdb.OperationResult, ovsdb.TableUpdates2) {
 	dbModel := t.Model
 	m := dbModel.Mapper
 	schema := dbModel.Schema.Table(table)
@@ -327,20 +397,6 @@ func (t *Transaction) Update(database, table string, where []ovsdb.Condition, ro
 			panic(err)
 		}
 
-		// check for index conflicts
-		if err := t.checkIndexes(table, new); err != nil {
-			if indexExists, ok := err.(*cache.ErrIndexExists); ok {
-				e := ovsdb.ConstraintViolation{}
-				return ovsdb.OperationResult{
-					Error:   e.Error(),
-					Details: newIndexExistsDetails(*indexExists),
-				}, nil
-			}
-			return ovsdb.OperationResult{
-				Error: err.Error(),
-			}, nil
-		}
-
 		tableUpdate.AddRowUpdate(uuid, &ovsdb.RowUpdate2{
 			Modify: &rowDelta,
 			Old:    &oldRow,
@@ -355,7 +411,7 @@ func (t *Transaction) Update(database, table string, where []ovsdb.Condition, ro
 		}
 }
 
-func (t *Transaction) Mutate(database, table string, where []ovsdb.Condition, mutations []ovsdb.Mutation) (ovsdb.OperationResult, ovsdb.TableUpdates2) {
+func (t *Transaction) Mutate(table string, where []ovsdb.Condition, mutations []ovsdb.Mutation) (ovsdb.OperationResult, ovsdb.TableUpdates2) {
 	dbModel := t.Model
 	m := dbModel.Mapper
 	schema := dbModel.Schema.Table(table)
@@ -452,20 +508,6 @@ func (t *Transaction) Mutate(database, table string, where []ovsdb.Condition, mu
 			}
 		}
 
-		// check indexes
-		if err := t.checkIndexes(table, new); err != nil {
-			if indexExists, ok := err.(*cache.ErrIndexExists); ok {
-				e := ovsdb.ConstraintViolation{}
-				return ovsdb.OperationResult{
-					Error:   e.Error(),
-					Details: newIndexExistsDetails(*indexExists),
-				}, nil
-			}
-			return ovsdb.OperationResult{
-				Error: err.Error(),
-			}, nil
-		}
-
 		newRow, err := m.NewRow(newInfo)
 		if err != nil {
 			panic(err)
@@ -485,7 +527,7 @@ func (t *Transaction) Mutate(database, table string, where []ovsdb.Condition, mu
 		}
 }
 
-func (t *Transaction) Delete(database, table string, where []ovsdb.Condition) (ovsdb.OperationResult, ovsdb.TableUpdates2) {
+func (t *Transaction) Delete(table string, where []ovsdb.Condition) (ovsdb.OperationResult, ovsdb.TableUpdates2) {
 	dbModel := t.Model
 	m := dbModel.Mapper
 	tableUpdate := make(ovsdb.TableUpdate2)
@@ -515,7 +557,7 @@ func (t *Transaction) Delete(database, table string, where []ovsdb.Condition) (o
 		}
 }
 
-func (t *Transaction) Wait(database, table string, timeout *int, where []ovsdb.Condition, columns []string, until string, rows []ovsdb.Row) ovsdb.OperationResult {
+func (t *Transaction) Wait(table string, timeout *int, where []ovsdb.Condition, columns []string, until string, rows []ovsdb.Row) ovsdb.OperationResult {
 	start := time.Now()
 
 	if until != "!=" && until != "==" {
@@ -614,22 +656,22 @@ Loop:
 	return ovsdb.OperationResult{Error: e.Error()}
 }
 
-func (t *Transaction) Commit(database, table string, durable bool) ovsdb.OperationResult {
+func (t *Transaction) Commit(table string, durable bool) ovsdb.OperationResult {
 	e := ovsdb.NotSupported{}
 	return ovsdb.OperationResult{Error: e.Error()}
 }
 
-func (t *Transaction) Abort(database, table string) ovsdb.OperationResult {
+func (t *Transaction) Abort(table string) ovsdb.OperationResult {
 	e := ovsdb.NotSupported{}
 	return ovsdb.OperationResult{Error: e.Error()}
 }
 
-func (t *Transaction) Comment(database, table string, comment string) ovsdb.OperationResult {
+func (t *Transaction) Comment(table string, comment string) ovsdb.OperationResult {
 	e := ovsdb.NotSupported{}
 	return ovsdb.OperationResult{Error: e.Error()}
 }
 
-func (t *Transaction) Assert(database, table, lock string) ovsdb.OperationResult {
+func (t *Transaction) Assert(table, lock string) ovsdb.OperationResult {
 	e := ovsdb.NotSupported{}
 	return ovsdb.OperationResult{Error: e.Error()}
 }

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/mapper/mapper.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/mapper/mapper.go
@@ -315,18 +315,3 @@ func (m Mapper) equalIndexes(one, other *Info, indexes ...string) (bool, error) 
 	}
 	return false, nil
 }
-
-// NewMonitorRequest returns a monitor request for the provided tableName
-// If fields is provided, the request will be constrained to the provided columns
-// If no fields are provided, all columns will be used
-func (m *Mapper) NewMonitorRequest(data *Info, fields []string) (*ovsdb.MonitorRequest, error) {
-	var columns []string
-	if len(fields) > 0 {
-		columns = append(columns, fields...)
-	} else {
-		for c := range data.Metadata.TableSchema.Columns {
-			columns = append(columns, c)
-		}
-	}
-	return &ovsdb.MonitorRequest{Columns: columns, Select: ovsdb.NewDefaultMonitorSelect()}, nil
-}

--- a/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
+++ b/go-controller/vendor/github.com/ovn-org/libovsdb/ovsdb/serverdb/database.go
@@ -30,6 +30,14 @@ type Database struct {
 	Sid       *string       `ovsdb:"sid"`
 }
 
+func (a *Database) GetUUID() string {
+	return a.UUID
+}
+
+func (a *Database) GetCid() *string {
+	return a.Cid
+}
+
 func copyDatabaseCid(a *string) *string {
 	if a == nil {
 		return nil
@@ -46,6 +54,14 @@ func equalDatabaseCid(a, b *string) bool {
 		return true
 	}
 	return *a == *b
+}
+
+func (a *Database) GetConnected() bool {
+	return a.Connected
+}
+
+func (a *Database) GetIndex() *int {
+	return a.Index
 }
 
 func copyDatabaseIndex(a *int) *int {
@@ -66,6 +82,22 @@ func equalDatabaseIndex(a, b *int) bool {
 	return *a == *b
 }
 
+func (a *Database) GetLeader() bool {
+	return a.Leader
+}
+
+func (a *Database) GetModel() DatabaseModel {
+	return a.Model
+}
+
+func (a *Database) GetName() string {
+	return a.Name
+}
+
+func (a *Database) GetSchema() *string {
+	return a.Schema
+}
+
 func copyDatabaseSchema(a *string) *string {
 	if a == nil {
 		return nil
@@ -82,6 +114,10 @@ func equalDatabaseSchema(a, b *string) bool {
 		return true
 	}
 	return *a == *b
+}
+
+func (a *Database) GetSid() *string {
+	return a.Sid
 }
 
 func copyDatabaseSid(a *string) *string {

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -283,10 +283,11 @@ github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetw
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1
 github.com/openshift/client-go/cloudnetwork/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1
-# github.com/ovn-org/libovsdb v0.6.1-0.20221101143603-8f21d188c3a5
+# github.com/ovn-org/libovsdb v0.6.1-0.20230203213244-a6a173993830
 ## explicit; go 1.18
 github.com/ovn-org/libovsdb/cache
 github.com/ovn-org/libovsdb/client
+github.com/ovn-org/libovsdb/database
 github.com/ovn-org/libovsdb/mapper
 github.com/ovn-org/libovsdb/model
 github.com/ovn-org/libovsdb/ovsdb


### PR DESCRIPTION
IGMPGroup has a weak link to chassis, deleting multiple chassis may result in IGMP_Groups with identical values on columns "address", "datapath", and "chassis", when "chassis" goes empty

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>

Error message example:
```
error:constraint violation Details:Transaction causes multiple rows in "IGMP_Group" table to have identical values 
(mrouters, 038b16fa-6aba-4244-9d4f-00a1e2cbf9a2, and []) for index on columns "address", "datapath", and "chassis".  
First row, with UUID 7e9a18fa-e58c-4547-a7cb-afa934b6cdc9, had the following index values before the transaction: 
mrouters, 038b16fa-6aba-4244-9d4f-00a1e2cbf9a2, and d9755997-e909-4d0c-8770-82a902d69a90.  Second row, with 
UUID 84da3622-3ac7-41f0-a6b5-536a2d5f9137, had the following index values before the transaction: mrouters, 
038b16fa-6aba-4244-9d4f-00a1e2cbf9a2, and 578d4dd9-cc02-4bcc-8a9c-08dcc3a94190. UUID:{GoUUID:} Rows:[]}] 
```
