### PR TITLE
loadbalancer: Disable generation of neighbor responder flows for VIPs on LRs

### DIFF
--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -614,10 +614,11 @@ func nodeSwitchRouterLoadBalancerName(nodeName string, serviceNamespace string, 
 
 func servicesOptions() map[string]string {
 	return map[string]string{
-		"event":           "false",
-		"reject":          "true",
-		"skip_snat":       "false",
-		"hairpin_snat_ip": "169.254.169.5 fd69::5",
+		"event":              "false",
+		"reject":             "true",
+		"skip_snat":          "false",
+		"neighbor_responder": "none",
+		"hairpin_snat_ip":    "169.254.169.5 fd69::5",
 	}
 }
 

--- a/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
+++ b/go-controller/pkg/ovn/loadbalancer/loadbalancer.go
@@ -253,10 +253,11 @@ func buildLB(lb *LB) *nbdb.LoadBalancer {
 	}
 
 	options := map[string]string{
-		"reject":          reject,
-		"event":           event,
-		"skip_snat":       skipSNAT,
-		"hairpin_snat_ip": fmt.Sprintf("%s %s", types.V4OVNServiceHairpinMasqueradeIP, types.V6OVNServiceHairpinMasqueradeIP),
+		"reject":             reject,
+		"event":              event,
+		"skip_snat":          skipSNAT,
+		"neighbor_responder": "none",
+		"hairpin_snat_ip":    fmt.Sprintf("%s %s", types.V4OVNServiceHairpinMasqueradeIP, types.V6OVNServiceHairpinMasqueradeIP),
 	}
 
 	// Session affinity


### PR DESCRIPTION
NB.Load_Balancer.options:neighbor_responder controls generation of logical flows for routers in order to reply to ARP/ND request for a VIP.

Default value is 'reachable' that means that routers on which the load balancer is applied should reply to ARP/ND requests only for VIPs that are part of a router's subnet.

However, there seems to be no such VIPs in ovn-k setups.  And the function that is looking for them is one of the heaviest functions in ovn-northd that can take up to 30% of the northd processing.

Switching this option to 'none' should noticeably reduce load on northd in LB-heavy scenarios.

The 'none' option is available since OVN 22.12, older OVN versions will just ignore it using a default 'reachable' value.

Signed-off-by: Ilya Maximets \<i.maximets@ovn.org\>

I observed the behavior that we never have any flows generated from this processing, so we're wasting 30% of CPU time in northd for nothing.  @dceara might be a better candidate to answer why it is this way.