### PR TITLE
Enable LDFLAGS when building ovnk binaries

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -5,6 +5,8 @@ BINDIR ?= ${PREFIX}/bin
 CNIBINDIR ?= ${DESTDIR}/opt/cni/bin
 GCFLAGS ?=
 export GCFLAGS
+LDFLAGS ?=
+export LDFLAGS
 PKGS ?=
 GOPATH ?= $(shell go env GOPATH)
 TEST_REPORT_DIR?=$(CURDIR)/_artifacts
@@ -36,6 +38,8 @@ export NOROOT
 #   make all GCFLAGS=all="-N -l"
 #       (disables compiler optimization and inlining to aid source debugging tools
 #        like delve)
+#   make all LDFLAGS="-w -s"
+#       (disables symbol table and DWARF generation when building ovnk binaries)
 
 all build:
 	hack/build-go.sh cmd/ovnkube cmd/ovn-k8s-cni-overlay cmd/ovn-kube-util hybrid-overlay/cmd/hybrid-overlay-node cmd/ovndbchecker cmd/ovnkube-trace

--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -32,7 +32,8 @@ build_binaries() {
                 -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.Branch=${GIT_BRANCH} \
                 -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.BuildUser=${BUILD_USER} \
                 -X ${OVN_KUBE_GO_PACKAGE}/pkg/config.BuildDate=${BUILD_DATE} \
-                -X k8s.io/client-go/pkg/version.gitVersion=${K8S_CLIENT_VERSION}" \
+                -X k8s.io/client-go/pkg/version.gitVersion=${K8S_CLIENT_VERSION} \
+		`if [ "$binbase" != "ovnkube" ]; then echo ${LDFLAGS}; fi`" \
             -o "${OVN_KUBE_OUTPUT_BINPATH}/${binbase}"\
             "./${bin}"
     done
@@ -51,7 +52,8 @@ build_windows_binaries() {
         GOOS=windows GOARCH=amd64 go build -v \
             -mod vendor \
             -gcflags "${GCFLAGS}" \
-            -ldflags "-B ${BUILDID}" \
+            -ldflags "-B ${BUILDID} \
+		`if [ "$binbase" != "ovnkube" ]; then echo ${LDFLAGS}; fi`" \
             -o "${OVN_KUBE_OUTPUT_BINPATH_WINDOWS}/${binbase}.exe"\
             "./${bin}"
     done


### PR DESCRIPTION
LDFLAGS="-w -s" reduces ~10M size for each ovnk binary

w/ LDFLAGS="-w -s":
-rwxrwxr-x. 1 root root  37M Feb  7 10:20 hybrid-overlay-node 
-rwxrwxr-x. 1 root root  35M Feb  7 10:20 ovndbchecker 
-rwxrwxr-x. 1 root root  35M Feb  7 10:20 ovn-k8s-cni-overlay 
-rwxrwxr-x. 1 root root  45M Feb  7 10:20 ovnkube
-rwxrwxr-x. 1 root root  30M Feb  7 10:21 ovnkube-trace 
-rwxrwxr-x. 1 root root  31M Feb  7 10:20 ovn-kube-util

w/o LDFLAGS="-w -s":

-rwxrwxr-x. 1 root root  52M Feb  7 10:28 hybrid-overlay-node 
-rwxrwxr-x. 1 root root  49M Feb  7 10:28 ovndbchecker 
-rwxrwxr-x. 1 root root  50M Feb  7 10:28 ovn-k8s-cni-overlay 
-rwxrwxr-x. 1 root root  64M Feb  7 10:28 ovnkube
-rwxrwxr-x. 1 root root  42M Feb  7 10:28 ovnkube-trace 
-rwxrwxr-x. 1 root root  44M Feb  7 10:28 ovn-kube-util

Signed-off-by: Zenghui Shi <zshi@redhat.com>