### PR TITLE
ovnkube-node: Remove redundant set of other_config:hwaddr

### DIFF
--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -405,7 +405,6 @@ func (b *bridgeConfiguration) updateInterfaceIPAddresses(node *kapi.Node) ([]*ne
 func bridgeForInterface(intfName, nodeName, physicalNetworkName string, gwIPs []*net.IPNet) (*bridgeConfiguration, error) {
 	res := bridgeConfiguration{}
 	gwIntf := intfName
-	bridgeCreated := false
 
 	if bridgeName, _, err := util.RunOVSVsctl("port-to-br", intfName); err == nil {
 		// This is an OVS bridge's internal port
@@ -426,7 +425,6 @@ func bridgeForInterface(intfName, nodeName, physicalNetworkName string, gwIPs []
 		res.bridgeName = bridgeName
 		res.uplinkName = intfName
 		gwIntf = bridgeName
-		bridgeCreated = true
 	} else {
 		// gateway interface is an OVS bridge
 		uplinkName, err := getIntfName(intfName)
@@ -450,8 +448,12 @@ func bridgeForInterface(intfName, nodeName, physicalNetworkName string, gwIPs []
 		}
 	}
 
-	res.interfaceID, res.macAddress, err = bridgedGatewayNodeSetup(nodeName, res.bridgeName, gwIntf,
-		physicalNetworkName, bridgeCreated)
+	res.macAddress, err = util.GetOVSPortMACAddress(gwIntf)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get MAC address for ovs port %s", gwIntf)
+	}
+
+	res.interfaceID, err = bridgedGatewayNodeSetup(nodeName, res.bridgeName, physicalNetworkName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up shared interface gateway: %v", err)
 	}

--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -15,11 +15,9 @@ import (
 	util "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-// bridgedGatewayNodeSetup makes the bridge's MAC address permanent (if needed), sets up
-// the physical network name mappings for the bridge, and returns an ifaceID
-// created from the bridge name and the node name
-func bridgedGatewayNodeSetup(nodeName, bridgeName, bridgeInterface, physicalNetworkName string,
-	syncBridgeMAC bool) (string, net.HardwareAddr, error) {
+// bridgedGatewayNodeSetup enables forwarding on bridge interface, sets up the physical network name mappings for the bridge,
+// and returns an ifaceID created from the bridge name and the node name
+func bridgedGatewayNodeSetup(nodeName, bridgeName, physicalNetworkName string) (string, error) {
 	// enable forwarding on bridge interface always
 	createForwardingRule := func(family string) error {
 		stdout, stderr, err := util.RunSysctl("-w", fmt.Sprintf("net.%s.conf.%s.forwarding=1", family, bridgeName))
@@ -31,28 +29,12 @@ func bridgedGatewayNodeSetup(nodeName, bridgeName, bridgeInterface, physicalNetw
 	}
 	if config.IPv4Mode {
 		if err := createForwardingRule("ipv4"); err != nil {
-			return "", nil, fmt.Errorf("could not add IPv4 forwarding rule: %v", err)
+			return "", fmt.Errorf("could not add IPv4 forwarding rule: %v", err)
 		}
 	}
 	if config.IPv6Mode {
 		if err := createForwardingRule("ipv6"); err != nil {
-			return "", nil, fmt.Errorf("could not add IPv6 forwarding rule: %v", err)
-		}
-	}
-	// A OVS bridge's mac address can change when ports are added to it.
-	// We cannot let that happen, so make the bridge mac address permanent.
-	macAddress, err := util.GetOVSPortMACAddress(bridgeInterface)
-	if err != nil {
-		return "", nil, err
-	}
-	if syncBridgeMAC {
-		var err error
-
-		stdout, stderr, err := util.RunOVSVsctl("set", "bridge",
-			bridgeName, "other-config:hwaddr="+macAddress.String())
-		if err != nil {
-			return "", nil, fmt.Errorf("failed to set bridge, stdout: %q, stderr: %q, "+
-				"error: %v", stdout, stderr, err)
+			return "", fmt.Errorf("could not add IPv6 forwarding rule: %v", err)
 		}
 	}
 
@@ -63,7 +45,7 @@ func bridgedGatewayNodeSetup(nodeName, bridgeName, bridgeInterface, physicalNetw
 	stdout, stderr, err := util.RunOVSVsctl("--if-exists", "get", "Open_vSwitch", ".",
 		"external_ids:ovn-bridge-mappings")
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to get ovn-bridge-mappings stderr:%s (%v)", stderr, err)
+		return "", fmt.Errorf("failed to get ovn-bridge-mappings stderr:%s (%v)", stderr, err)
 	}
 	// skip the existing mapping setting for the specified physicalNetworkName
 	mapString := ""
@@ -85,12 +67,12 @@ func bridgedGatewayNodeSetup(nodeName, bridgeName, bridgeInterface, physicalNetw
 	_, stderr, err = util.RunOVSVsctl("set", "Open_vSwitch", ".",
 		fmt.Sprintf("external_ids:ovn-bridge-mappings=%s", mapString))
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to set ovn-bridge-mappings for ovs bridge %s"+
+		return "", fmt.Errorf("failed to set ovn-bridge-mappings for ovs bridge %s"+
 			", stderr:%s (%v)", bridgeName, stderr, err)
 	}
 
 	ifaceID := bridgeName + "_" + nodeName
-	return ifaceID, macAddress, nil
+	return ifaceID, nil
 }
 
 // getNetworkInterfaceIPAddresses returns the IP addresses for the network interface 'iface'.

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -116,9 +116,6 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,
 		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set bridge breth0 other-config:hwaddr=" + eth0MAC,
-		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",
 			Output: "",
@@ -872,9 +869,6 @@ func localGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get interface breth0 mac_in_use",
 			Output: eth0MAC,
-		})
-		fexec.AddFakeCmdsNoOutputNoError([]string{
-			"ovs-vsctl --timeout=15 set bridge breth0 other-config:hwaddr=" + eth0MAC,
 		})
 		fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 			Cmd:    "ovs-vsctl --timeout=15 --if-exists get Open_vSwitch . external_ids:ovn-bridge-mappings",


### PR DESCRIPTION
Current node gateway init logic set other_config:hwaddr on the bridge twice when bridge is created:

bridgeForInterface(...)
 `-- util.NicToBridge(bridgeName)
      `-- RunOVSVsctl(...) <-- set bridge other_config:hwaddr #1
 ...
 `-- bridgedGatewayNodeSetup(...) <-- set bridge other_config:hwaddr #2

2nd set completely redundant, hence, remove it.
Move call to get MAC address up into bridgeForInterface() to simplify bridgedGatewayNodeSetup().

Signed-off-by: Dmytro Linkin <dlinkin@nvidia.com>