### PR TITLE
Consolidate dualstack conversion jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -522,6 +522,7 @@ jobs:
 
     - name: Run Dual-Stack Tests
       run: |
+        DUALSTACK_CONVERSION="true"
         KIND_IPV4_SUPPORT="true"
         KIND_IPV6_SUPPORT="true"
         make -C test shard-test WHAT="Networking Granular Checks\|DualStack"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -470,16 +470,14 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix:
-        gateway-mode: [local, shared]
     needs: [ build-pr ]
     env:
-      JOB_NAME: "DualStack-conversion-${{ matrix.gateway-mode }}"
+      JOB_NAME: "DualStack-conversion-shared"
       OVN_HA: "true"
       KIND_IPV4_SUPPORT: "true"
       KIND_IPV6_SUPPORT: "false"
       OVN_HYBRID_OVERLAY_ENABLE: "false"
-      OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
+      OVN_GATEWAY_MODE: "shared"
       OVN_MULTICAST_ENABLE:  "false"
     steps:
 
@@ -517,10 +515,6 @@ jobs:
       run: |
         export OVN_IMAGE="ovn-daemonset-f:pr"
         make -C test install-kind
-
-    - name: Run Single-Stack Tests
-      run: |
-        make -C test shard-test WHAT="Networking Granular Checks"
 
     - name: Convert IPv4 cluster to Dual Stack
       run: |

--- a/contrib/kind-dual-stack-conversion.sh
+++ b/contrib/kind-dual-stack-conversion.sh
@@ -283,3 +283,6 @@ for n in $NODES; do
     docker exec $n curl --connect-timeout 5 $ip
   done
 done
+
+# Give some time for everything to settle
+sleep 60

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,6 +5,7 @@ JOB_NAME?="$@"
 # IPv6 only network, set appropriately to skip related tests.
 KIND_IPV4_SUPPORT?=false
 KIND_IPV6_SUPPORT?=false
+DUALSTACK_CONVERSION?=false
 
 .PHONY: install-kind
 install-kind:
@@ -22,6 +23,7 @@ shard-%:
 	E2E_REPORT_PREFIX=$(JOB_NAME)_ \
 	KIND_IPV4_SUPPORT=$(KIND_IPV4_SUPPORT) \
 	KIND_IPV6_SUPPORT=$(KIND_IPV6_SUPPORT) \
+	DUALSTACK_CONVERSION=$(DUALSTACK_CONVERSION) \
 	./scripts/e2e-kind.sh $@ $(WHAT)
 
 .PHONY: control-plane

--- a/test/scripts/e2e-kind.sh
+++ b/test/scripts/e2e-kind.sh
@@ -96,6 +96,10 @@ DUALSTACK_ONLY_TESTS="
 \[Feature:.*DualStack.*\]
 "
 
+DUALSTACK_CONVERSION_TESTS="
+should function for service endpoints using hostNetwork
+"
+
 # Github CI doesn´t offer IPv6 connectivity, so always skip IPv6 only tests.
 #  See: https://github.com/ovn-org/ovn-kubernetes/issues/1522
 SKIPPED_TESTS=$SKIPPED_TESTS$IPV6_ONLY_TESTS
@@ -114,6 +118,11 @@ fi
 # If not DualStack, skip DualStack tests
 if [ "$KIND_IPV4_SUPPORT" == false ] || [ "$KIND_IPV6_SUPPORT" == false ]; then
 	SKIPPED_TESTS=$SKIPPED_TESTS$DUALSTACK_ONLY_TESTS
+fi
+
+# If dulastack conversion, skip certain tests due to unknown flakes upstream (FIXME)
+if [ "DUALSTACK_CONVERSION" == true ]; then
+  SKIPPED_TESTS=$SKIPPED_TESTS$DUALSTACK_CONVERSION_TESTS
 fi
 
 SKIPPED_TESTS="$(groomTestList "${SKIPPED_TESTS}")"


### PR DESCRIPTION
The dualstack jobs are flaky, and keep causing red CI. These jobs are not really valuable as we do not find many bugs from them. We have tried multiple times to root cause why the flakes happen, but to no success.

Changes-Include:
 - Remove running local gateway mode conversion. There should not be any real difference anymore between the two modes that affect dualstack.
 - Add a sleep after conversion. This may help with letting the system settle after conversion before tests are executed.
 - Stop running CI tests before and after conversion. We already have a dualstack and single IP family jobs that will run conformance tests. We only need to run after conversion.
 - Skip test that always flakes for dualstack conversion: should function for service endpoints using hostNetwork

Signed-off-by: Tim Rozet <trozet@redhat.com>

