### PR TITLE
WIP: ingress LB randomly fails health check

### DIFF
--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -546,8 +546,10 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceStatus{},
 					true, false,
 				)
+				epReady := true
 				ep1 := discovery.Endpoint{
-					Addresses: []string{"10.244.0.3"},
+					Addresses:  []string{"10.244.0.3"},
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -865,18 +867,22 @@ var _ = Describe("Node Operations", func() {
 					},
 					true, false,
 				)
+				epReady := true
 				ep1 := discovery.Endpoint{
-					Addresses: []string{"10.244.0.3"},
-					NodeName:  &fakeNodeName,
+					Addresses:  []string{"10.244.0.3"},
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
+					NodeName:   &fakeNodeName,
 				}
 				otherNodeName := "node2"
 				nonLocalEndpoint := discovery.Endpoint{
-					Addresses: []string{"10.244.1.3"}, // is not picked since its not local to the node
-					NodeName:  &otherNodeName,
+					Addresses:  []string{"10.244.1.3"}, // is not picked since its not local to the node
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
+					NodeName:   &otherNodeName,
 				}
 				ep2 := discovery.Endpoint{
-					Addresses: []string{"10.244.0.4"},
-					NodeName:  &fakeNodeName,
+					Addresses:  []string{"10.244.0.4"},
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
+					NodeName:   &fakeNodeName,
 				}
 				epPortName := "http"
 				epPortValue := int32(8080)
@@ -1926,8 +1932,10 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceStatus{},
 					true, false,
 				)
+				epReady := true
 				ep1 := discovery.Endpoint{
-					Addresses: []string{"10.244.0.3"},
+					Addresses:  []string{"10.244.0.3"},
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2064,9 +2072,10 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceStatus{},
 					true, false,
 				)
-
+				epReady := true
 				ep1 := discovery.Endpoint{
-					Addresses: []string{"10.244.0.3"},
+					Addresses:  []string{"10.244.0.3"},
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2210,9 +2219,10 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceStatus{},
 					true, false,
 				)
-
+				epReady := true
 				ep1 := discovery.Endpoint{
-					Addresses: []string{"192.168.18.15"}, // host-networked endpoint local to this node
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
+					Addresses:  []string{"192.168.18.15"}, // host-networked endpoint local to this node
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2354,8 +2364,10 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceStatus{},
 					true, true,
 				)
+				epReady := true
 				ep1 := discovery.Endpoint{
-					Addresses: []string{"10.244.0.3"},
+					Addresses:  []string{"10.244.0.3"},
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2500,8 +2512,10 @@ var _ = Describe("Node Operations", func() {
 					v1.ServiceStatus{},
 					true, true,
 				)
+				epReady := true
 				ep1 := discovery.Endpoint{
-					Addresses: []string{"192.168.18.15"}, // host-networked endpoint local to this node
+					Addresses:  []string{"192.168.18.15"}, // host-networked endpoint local to this node
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
 				}
 				epPort1 := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2663,9 +2677,10 @@ var _ = Describe("Node Operations", func() {
 				)
 				service.Annotations[util.EgressSVCHostAnnotation] = "mynode"
 				service.Annotations[util.EgressSVCAnnotation] = "{}"
-
+				epReady := true
 				ep1 := discovery.Endpoint{
-					Addresses: []string{"10.128.0.3"},
+					Addresses:  []string{"10.128.0.3"},
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
 				}
 				epPort := discovery.EndpointPort{
 					Name: &epPortName,
@@ -2674,7 +2689,8 @@ var _ = Describe("Node Operations", func() {
 
 				// host-networked endpoint, should not have an SNAT rule created
 				ep2 := discovery.Endpoint{
-					Addresses: []string{"192.168.18.15"},
+					Addresses:  []string{"192.168.18.15"},
+					Conditions: discovery.EndpointConditions{Ready: &epReady},
 				}
 				// endpointSlice.Endpoints is ovn-networked so this will
 				// come under !hasLocalHostNetEp case

--- a/go-controller/pkg/node/healthcheck.go
+++ b/go-controller/pkg/node/healthcheck.go
@@ -212,8 +212,12 @@ func isHostEndpoint(endpointIP string) bool {
 // discovery.EndpointSlice reports in the same slice all endpoints along with their status.
 // isEndpointReady takes an endpoint from an endpoint slice and returns true if the endpoint is
 // to be considered ready.
+// Note: API definition for nil Ready assume in the most cases Endpoint will be ready
+// https://github.com/kubernetes/api/blob/0478a3e95231398d8b380dc2a1905972be8ae1d5/discovery/v1/types.go#L131
+// However its not guaranteed either so this API just look for Ready state is true and
+// when its nil "known state" we don't assume its ready.
 func isEndpointReady(endpoint discovery.Endpoint) bool {
-	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
+	return endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready
 }
 
 // checkForStaleOVSInternalPorts checks for OVS internal ports without any ofport assigned,


### PR DESCRIPTION
It was noticed when changing LB type from default "external" to internal then back to external health check probes were failing.

The suspect here is when Endpoint is unknown state conditions.Read = nil node isn't really ready to
process traffic and could lead to dropping health
probes packets, the fix is really declare EP as ready only when conditions.Ready = true.

Signed-off-by: msherif1234 <mmahmoud@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->