### PR TITLE
Remove MTU on service routes

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1915,15 +1915,10 @@ func addMasqueradeRoute(netIfaceName, nodeName string, ifAddrs []*net.IPNet, wat
 		return fmt.Errorf("unable to find shared gw bridge interface: %s", netIfaceName)
 	}
 
-	mtu := config.Default.MTU
-	if config.Default.RoutableMTU != 0 {
-		mtu = config.Default.RoutableMTU
-	}
-
 	if ipv4 != nil {
 		_, masqIPNet, _ := net.ParseCIDR(fmt.Sprintf("%s/32", types.V4OVNMasqueradeIP))
 		klog.Infof("Setting OVN Masquerade route with source: %s", ipv4)
-		err = util.LinkRoutesApply(netIfaceLink, nil, []*net.IPNet{masqIPNet}, mtu, ipv4)
+		err = util.LinkRoutesApply(netIfaceLink, nil, []*net.IPNet{masqIPNet}, 0, ipv4)
 		if err != nil {
 			return fmt.Errorf("unable to add OVN masquerade route to host, error: %v", err)
 		}
@@ -1932,7 +1927,7 @@ func addMasqueradeRoute(netIfaceName, nodeName string, ifAddrs []*net.IPNet, wat
 	if ipv6 != nil {
 		_, masqIPNet, _ := net.ParseCIDR(fmt.Sprintf("%s/128", types.V6OVNMasqueradeIP))
 		klog.Infof("Setting OVN Masquerade route with source: %s", ipv6)
-		err = util.LinkRoutesApply(netIfaceLink, nil, []*net.IPNet{masqIPNet}, mtu, ipv6)
+		err = util.LinkRoutesApply(netIfaceLink, nil, []*net.IPNet{masqIPNet}, 0, ipv6)
 		if err != nil {
 			return fmt.Errorf("unable to add OVN masquerade route to host, error: %v", err)
 		}


### PR DESCRIPTION
Now that OVN is capable of sending ICMP needs frag for PMTU discovery,we
no longer need to proxy that capability in the host.

However, there seems to be a bug with this feature when trying to send
OVN a packet that is too large:
https://bugzilla.redhat.com/show_bug.cgi?id=2169839

This commit only changes to remove the MTU specified on the
169.254.169.1 route. This is the OVNMasquerade IP and is only used when
hairpinning traffic back to the node which will end up at a host network
pod. Therefore there is no reason to restrict its MTU as we are never
forwarding to an OVN networked pod in this case.

Fixes: https://github.com/ovn-org/ovn-kubernetes/issues/3419

Signed-off-by: Tim Rozet <trozet@redhat.com>
