### PR TITLE
node: add node healthz server for cloud load balancers

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -306,6 +306,7 @@ type KubernetesConfig struct {
 	NoHostSubnetNodes    *metav1.LabelSelector
 	HostNetworkNamespace string `gcfg:"host-network-namespace"`
 	PlatformType         string `gcfg:"platform-type"`
+	HealthzBindAddress   string `gcfg:"healthz-bind-address"`
 
 	// CompatMetricsBindAddress is overridden by the corresponding option in MetricsConfig
 	CompatMetricsBindAddress string `gcfg:"metrics-bind-address"`
@@ -976,6 +977,11 @@ var K8sFlags = []cli.Flag{
 			"Valid values can be found in: https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/vendor/github.com/openshift/api/config/v1/types_infrastructure.go#L130-L172",
 		Destination: &cliConfig.Kubernetes.PlatformType,
 		Value:       Kubernetes.PlatformType,
+	},
+	&cli.StringFlag{
+		Name:        "healthz-bind-address",
+		Usage:       "The IP address and port for the node proxy healthz server to serve on (set to '0.0.0.0:10256' or '[::]:10256' for listening in all interfaces and IP families). Disabled by default.",
+		Destination: &cliConfig.Kubernetes.HealthzBindAddress,
 	},
 }
 

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -148,6 +148,7 @@ tokenFile=/path/to/token
 cacert=/path/to/kubeca.crt
 service-cidrs=172.18.0.0/24
 no-hostsubnet-nodes=label=another-test-label
+healthz-bind-address=0.0.0.0:1234
 
 [metrics]
 bind-address=1.1.1.1:8080
@@ -289,6 +290,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal(DefaultAPIServer))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.16.1.0/24"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal(""))
+			gomega.Expect(Kubernetes.HealthzBindAddress).To(gomega.Equal(""))
 			gomega.Expect(Metrics.NodeServerPrivKey).To(gomega.Equal(""))
 			gomega.Expect(Metrics.NodeServerCert).To(gomega.Equal(""))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
@@ -571,6 +573,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.TokenFile).To(gomega.Equal("/path/to/token"))
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://1.2.3.4:6443"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.18.0.0/24"))
+			gomega.Expect(Kubernetes.HealthzBindAddress).To(gomega.Equal("0.0.0.0:1234"))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.132.0.0/14"), 23},
 			}))
@@ -658,6 +661,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Kubernetes.APIServer).To(gomega.Equal("https://4.4.3.2:8080"))
 			gomega.Expect(Kubernetes.RawServiceCIDRs).To(gomega.Equal("172.15.0.0/24"))
 			gomega.Expect(Kubernetes.RawNoHostSubnetNodes).To(gomega.Equal("test=pass"))
+			gomega.Expect(Kubernetes.HealthzBindAddress).To(gomega.Equal("0.0.0.0:4321"))
 			gomega.Expect(Default.ClusterSubnets).To(gomega.Equal([]CIDRNetworkEntry{
 				{ovntest.MustParseIPNet("10.130.0.0/15"), 24},
 			}))
@@ -754,6 +758,7 @@ var _ = Describe("Config Operations", func() {
 			"-egressip-reachability-total-timeout=5",
 			"-egressip-node-healthcheck-port=4321",
 			"-enable-multi-network=true",
+			"-healthz-bind-address=0.0.0.0:4321",
 		}
 		err = app.Run(cliArgs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/node/healthcheck_node.go
+++ b/go-controller/pkg/node/healthcheck_node.go
@@ -1,0 +1,99 @@
+package node
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	kapi "k8s.io/api/core/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+type proxierHealthUpdater struct {
+	address  string
+	nodeRef  *kapi.ObjectReference
+	recorder record.EventRecorder
+	c        clock.Clock
+	healthy  bool
+}
+
+// newNodeProxyHealthzServer creates and returns a new proxier health server
+// if the HealthzBindAddress configuration is set. Cloud load balancers use this
+// health check to determine if the node is available for services with ClusterIP
+// traffic policy.
+func newNodeProxyHealthzServer(nodeName, address string, eventRecorder record.EventRecorder) *proxierHealthUpdater {
+	return &proxierHealthUpdater{
+		address:  address,
+		recorder: eventRecorder,
+		c:        clock.RealClock{},
+		healthy:  true,
+		nodeRef: &kapi.ObjectReference{
+			Kind:      "Node",
+			Name:      nodeName,
+			UID:       ktypes.UID(nodeName),
+			Namespace: "",
+		},
+	}
+}
+
+func (phu *proxierHealthUpdater) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	resp.Header().Set("Content-Type", "application/json")
+	resp.Header().Set("X-Content-Type-Options", "nosniff")
+	if phu.healthy {
+		resp.WriteHeader(http.StatusOK)
+	} else {
+		resp.WriteHeader(http.StatusServiceUnavailable)
+	}
+	now := phu.c.Now()
+	fmt.Fprintf(resp, `{"lastUpdated": %q,"currentTime": %q}`, now, now)
+}
+
+// serveNodeProxyHealthz initializes and runs the healthz server. It will always
+// report healthy while the node process is running.
+// TODO: connect node health to something useful
+func (phu *proxierHealthUpdater) Start(stopChan chan struct{}, wg *sync.WaitGroup) {
+	serveMux := http.NewServeMux()
+	serveMux.Handle("/healthz", phu)
+	server := &http.Server{
+		Addr:    phu.address,
+		Handler: serveMux,
+	}
+
+	startedWg := &sync.WaitGroup{}
+
+	wg.Add(1)
+	startedWg.Add(1)
+	go func() {
+		defer wg.Done()
+		startedWg.Done()
+		<-stopChan
+		server.Close()
+	}()
+
+	wg.Add(1)
+	startedWg.Add(1)
+	go func() {
+		defer wg.Done()
+		startedWg.Done()
+
+		klog.V(3).InfoS("Starting node proxy healthz server", "address", phu.address)
+		for {
+			err := server.ListenAndServe()
+			if errors.Is(err, http.ErrServerClosed) {
+				return
+			}
+			msg := fmt.Sprintf("serving healthz on %s failed: %v", phu.address, err)
+			phu.recorder.Eventf(phu.nodeRef, kapi.EventTypeWarning, "FailedToStartProxierHealthcheck", "StartOVNKubernetesNode", msg)
+			klog.Errorf(msg)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	startedWg.Wait()
+}

--- a/go-controller/pkg/node/healthcheck_node_test.go
+++ b/go-controller/pkg/node/healthcheck_node_test.go
@@ -1,0 +1,53 @@
+package node
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/tools/record"
+)
+
+var _ = Describe("Node healthcheck tests", func() {
+	var (
+		wg     *sync.WaitGroup
+		stopCh chan struct{}
+	)
+
+	BeforeEach(func() {
+		stopCh = make(chan struct{})
+		wg = &sync.WaitGroup{}
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+		wg.Wait()
+	})
+
+	Context("node proxy healthz server is started", func() {
+		It("it reports healthy", func() {
+			recorder := record.NewFakeRecorder(10)
+			const addr string = "127.0.0.1:10256"
+			hzs := newNodeProxyHealthzServer("some-node", addr, recorder)
+			hzs.Start(stopCh, wg)
+
+			// Try a few times to make sure the server is listening,
+			// there's a small race between when Start() returns and
+			// the ListenAndServe() is actually active
+			var err error
+			for i := 0; i < 5; i++ {
+				resp, err := http.Get(fmt.Sprintf("http://%s/healthz", addr))
+				if err == nil {
+					defer resp.Body.Close()
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/go-controller/pkg/node/healthcheck_service.go
+++ b/go-controller/pkg/node/healthcheck_service.go
@@ -3,22 +3,18 @@ package node
 import (
 	"fmt"
 	"net"
-	"os"
 	"sync"
-	"time"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube/healthcheck"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
-	"github.com/pkg/errors"
 
 	kapi "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -205,143 +201,6 @@ func isHostEndpoint(endpointIP string) bool {
 		}
 	}
 	return true
-}
-
-type openflowManager struct {
-	defaultBridge         *bridgeConfiguration
-	externalGatewayBridge *bridgeConfiguration
-	// flow cache, use map instead of array for readability when debugging
-	flowCache     map[string][]string
-	flowMutex     sync.Mutex
-	exGWFlowCache map[string][]string
-	exGWFlowMutex sync.Mutex
-	// channel to indicate we need to update flows immediately
-	flowChan chan struct{}
-}
-
-func (c *openflowManager) updateFlowCacheEntry(key string, flows []string) {
-	c.flowMutex.Lock()
-	defer c.flowMutex.Unlock()
-	c.flowCache[key] = flows
-}
-
-func (c *openflowManager) deleteFlowsByKey(key string) {
-	c.flowMutex.Lock()
-	defer c.flowMutex.Unlock()
-	delete(c.flowCache, key)
-}
-
-func (c *openflowManager) updateExBridgeFlowCacheEntry(key string, flows []string) {
-	c.exGWFlowMutex.Lock()
-	defer c.exGWFlowMutex.Unlock()
-	c.exGWFlowCache[key] = flows
-}
-
-func (c *openflowManager) requestFlowSync() {
-	select {
-	case c.flowChan <- struct{}{}:
-		klog.V(5).Infof("Gateway OpenFlow sync requested")
-	default:
-		klog.V(5).Infof("Gateway OpenFlow sync already requested")
-	}
-}
-
-func (c *openflowManager) syncFlows() {
-	// protect gwBridge config from being updated by gw.nodeIPManager
-	c.defaultBridge.Lock()
-	defer c.defaultBridge.Unlock()
-
-	c.flowMutex.Lock()
-	defer c.flowMutex.Unlock()
-
-	flows := []string{}
-	for _, entry := range c.flowCache {
-		flows = append(flows, entry...)
-	}
-
-	_, stderr, err := util.ReplaceOFFlows(c.defaultBridge.bridgeName, flows)
-	if err != nil {
-		klog.Errorf("Failed to add flows, error: %v, stderr, %s, flows: %s", err, stderr, c.flowCache)
-	}
-
-	if c.externalGatewayBridge != nil {
-		c.exGWFlowMutex.Lock()
-		defer c.exGWFlowMutex.Unlock()
-
-		flows := []string{}
-		for _, entry := range c.exGWFlowCache {
-			flows = append(flows, entry...)
-		}
-
-		_, stderr, err := util.ReplaceOFFlows(c.externalGatewayBridge.bridgeName, flows)
-		if err != nil {
-			klog.Errorf("Failed to add flows, error: %v, stderr, %s, flows: %s", err, stderr, c.exGWFlowCache)
-		}
-	}
-}
-
-// checkDefaultOpenFlow checks for the existence of default OpenFlow rules and
-// exits if the output is not as expected
-func (c *openflowManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) {
-	doneWg.Add(1)
-	go func() {
-		defer doneWg.Done()
-		syncPeriod := 15 * time.Second
-		timer := time.NewTicker(syncPeriod)
-		defer timer.Stop()
-		for {
-			select {
-			case <-timer.C:
-				if err := checkPorts(c.defaultBridge.patchPort, c.defaultBridge.ofPortPatch,
-					c.defaultBridge.uplinkName, c.defaultBridge.ofPortPhys); err != nil {
-					klog.Errorf("Checkports failed %v", err)
-					continue
-				}
-				if c.externalGatewayBridge != nil {
-					if err := checkPorts(
-						c.externalGatewayBridge.patchPort, c.externalGatewayBridge.ofPortPatch,
-						c.externalGatewayBridge.uplinkName, c.externalGatewayBridge.ofPortPhys); err != nil {
-						klog.Errorf("Checkports failed %v", err)
-						continue
-					}
-				}
-				c.syncFlows()
-			case <-c.flowChan:
-				c.syncFlows()
-				timer.Reset(syncPeriod)
-			case <-stopChan:
-				return
-			}
-		}
-	}()
-}
-
-func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
-	// it could be that the ovn-controller recreated the patch between the host OVS bridge and
-	// the integration bridge, as a result the ofport number changed for that patch interface
-	curOfportPatch, stderr, err := util.GetOVSOfPort("--if-exists", "get", "Interface", patchIntf, "ofport")
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get ofport of %s, stderr: %q", patchIntf, stderr)
-
-	}
-	if ofPortPatch != curOfportPatch {
-		klog.Errorf("Fatal error: patch port %s ofport changed from %s to %s",
-			patchIntf, ofPortPatch, curOfportPatch)
-		os.Exit(1)
-	}
-
-	// it could be that someone removed the physical interface and added it back on the OVS host
-	// bridge, as a result the ofport number changed for that physical interface
-	curOfportPhys, stderr, err := util.GetOVSOfPort("--if-exists", "get", "interface", physIntf, "ofport")
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get ofport of %s, stderr: %q", physIntf, stderr)
-	}
-	if ofPortPhys != curOfportPhys {
-		klog.Errorf("Fatal error: phys port %s ofport changed from %s to %s",
-			physIntf, ofPortPhys, curOfportPhys)
-		os.Exit(1)
-	}
-	return nil
 }
 
 func serviceNamespacedNameFromEndpointSlice(epSlice *discovery.EndpointSlice) (ktypes.NamespacedName, error) {

--- a/go-controller/pkg/node/openflow_manager.go
+++ b/go-controller/pkg/node/openflow_manager.go
@@ -1,0 +1,149 @@
+package node
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
+
+	"k8s.io/klog/v2"
+)
+
+type openflowManager struct {
+	defaultBridge         *bridgeConfiguration
+	externalGatewayBridge *bridgeConfiguration
+	// flow cache, use map instead of array for readability when debugging
+	flowCache     map[string][]string
+	flowMutex     sync.Mutex
+	exGWFlowCache map[string][]string
+	exGWFlowMutex sync.Mutex
+	// channel to indicate we need to update flows immediately
+	flowChan chan struct{}
+}
+
+func (c *openflowManager) updateFlowCacheEntry(key string, flows []string) {
+	c.flowMutex.Lock()
+	defer c.flowMutex.Unlock()
+	c.flowCache[key] = flows
+}
+
+func (c *openflowManager) deleteFlowsByKey(key string) {
+	c.flowMutex.Lock()
+	defer c.flowMutex.Unlock()
+	delete(c.flowCache, key)
+}
+
+func (c *openflowManager) updateExBridgeFlowCacheEntry(key string, flows []string) {
+	c.exGWFlowMutex.Lock()
+	defer c.exGWFlowMutex.Unlock()
+	c.exGWFlowCache[key] = flows
+}
+
+func (c *openflowManager) requestFlowSync() {
+	select {
+	case c.flowChan <- struct{}{}:
+		klog.V(5).Infof("Gateway OpenFlow sync requested")
+	default:
+		klog.V(5).Infof("Gateway OpenFlow sync already requested")
+	}
+}
+
+func (c *openflowManager) syncFlows() {
+	// protect gwBridge config from being updated by gw.nodeIPManager
+	c.defaultBridge.Lock()
+	defer c.defaultBridge.Unlock()
+
+	c.flowMutex.Lock()
+	defer c.flowMutex.Unlock()
+
+	flows := []string{}
+	for _, entry := range c.flowCache {
+		flows = append(flows, entry...)
+	}
+
+	_, stderr, err := util.ReplaceOFFlows(c.defaultBridge.bridgeName, flows)
+	if err != nil {
+		klog.Errorf("Failed to add flows, error: %v, stderr, %s, flows: %s", err, stderr, c.flowCache)
+	}
+
+	if c.externalGatewayBridge != nil {
+		c.exGWFlowMutex.Lock()
+		defer c.exGWFlowMutex.Unlock()
+
+		flows := []string{}
+		for _, entry := range c.exGWFlowCache {
+			flows = append(flows, entry...)
+		}
+
+		_, stderr, err := util.ReplaceOFFlows(c.externalGatewayBridge.bridgeName, flows)
+		if err != nil {
+			klog.Errorf("Failed to add flows, error: %v, stderr, %s, flows: %s", err, stderr, c.exGWFlowCache)
+		}
+	}
+}
+
+// checkDefaultOpenFlow checks for the existence of default OpenFlow rules and
+// exits if the output is not as expected
+func (c *openflowManager) Run(stopChan <-chan struct{}, doneWg *sync.WaitGroup) {
+	doneWg.Add(1)
+	go func() {
+		defer doneWg.Done()
+		syncPeriod := 15 * time.Second
+		timer := time.NewTicker(syncPeriod)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				if err := checkPorts(c.defaultBridge.patchPort, c.defaultBridge.ofPortPatch,
+					c.defaultBridge.uplinkName, c.defaultBridge.ofPortPhys); err != nil {
+					klog.Errorf("Checkports failed %v", err)
+					continue
+				}
+				if c.externalGatewayBridge != nil {
+					if err := checkPorts(
+						c.externalGatewayBridge.patchPort, c.externalGatewayBridge.ofPortPatch,
+						c.externalGatewayBridge.uplinkName, c.externalGatewayBridge.ofPortPhys); err != nil {
+						klog.Errorf("Checkports failed %v", err)
+						continue
+					}
+				}
+				c.syncFlows()
+			case <-c.flowChan:
+				c.syncFlows()
+				timer.Reset(syncPeriod)
+			case <-stopChan:
+				return
+			}
+		}
+	}()
+}
+
+func checkPorts(patchIntf, ofPortPatch, physIntf, ofPortPhys string) error {
+	// it could be that the ovn-controller recreated the patch between the host OVS bridge and
+	// the integration bridge, as a result the ofport number changed for that patch interface
+	curOfportPatch, stderr, err := util.GetOVSOfPort("--if-exists", "get", "Interface", patchIntf, "ofport")
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get ofport of %s, stderr: %q", patchIntf, stderr)
+
+	}
+	if ofPortPatch != curOfportPatch {
+		klog.Errorf("Fatal error: patch port %s ofport changed from %s to %s",
+			patchIntf, ofPortPatch, curOfportPatch)
+		os.Exit(1)
+	}
+
+	// it could be that someone removed the physical interface and added it back on the OVS host
+	// bridge, as a result the ofport number changed for that physical interface
+	curOfportPhys, stderr, err := util.GetOVSOfPort("--if-exists", "get", "interface", physIntf, "ofport")
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get ofport of %s, stderr: %q", physIntf, stderr)
+	}
+	if ofPortPhys != curOfportPhys {
+		klog.Errorf("Fatal error: phys port %s ofport changed from %s to %s",
+			physIntf, ofPortPhys, curOfportPhys)
+		os.Exit(1)
+	}
+	return nil
+}


### PR DESCRIPTION
For Cluster traffic policy services every node should accept
traffic and balance to a node with an endpoint for that service.
The cloud LB periodically health checks each node to know what
nodes it can send traffic to.

For Local traffic policy the cloud LB health-checks the specific
service's port on every node to determine whether that node has
any endpoints for the service, so no node-level health checks
are needed.

GCE's legacy cloud provider hardcodes port 10256 (the default
kube-proxy port) for its node-level health checks.

kube-proxy starts a healthz server on port 10256 on every node
for Cluster traffic policy services. ovnkube didn't do that,
so in some cases the cloud LB wouldn't consider nodes healthy.

While we're here split the node healthcheck into "node" and "service"
files to make clearer what each type of health check code is
for.

Fixes: https://issues.redhat.com/browse/OCPBUGS-7158