### PR TITLE
Flush route cache from all nodes

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -242,6 +242,7 @@ func configureSvcRouteViaInterface(iface string, gwIPs []net.IP) error {
 			return fmt.Errorf("unable to find gateway IP for subnet: %v, found IPs: %v", subnet, gwIPs)
 		}
 
+		// Remove MTU from service route once https://bugzilla.redhat.com/show_bug.cgi?id=2169839 is fixed.
 		mtu := config.Default.MTU
 		if config.Default.RoutableMTU != 0 {
 			mtu = config.Default.RoutableMTU


### PR DESCRIPTION
Until we fix bug https://bugzilla.redhat.com/show_bug.cgi?id=2169839 we cannot remove the MTU from the service route.

We also have https://issues.redhat.com/browse/OCPBUGS-7609 that is plugin agnostic but a potential issue that is hard to solve. In the interim since the host->other NodePort flow is a rare use case, let's flush the routes from cache in our e2e tests for now. This will also be the recommended workaround for users who want to use UDP+frag in our setups within 5 mins after a node->otherNodePort traffic flow.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->