### PR TITLE
Print ovnkube node exit error

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -285,6 +285,7 @@ func runOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 		start := time.Now()
 		n := ovnnode.NewNode(ovnClientset.KubeClient, nodeWatchFactory, node, stopChan, wg, nodeEventRecorder)
 		if err := n.Start(ctx.Context); err != nil {
+			klog.Errorf("Failed to start ovnkube node: %v", err)
 			return err
 		}
 		end := time.Since(start)


### PR DESCRIPTION
When running ovnkube master and node in a single process,
ovnkube node fails silently (doesn't exit) if there is error starting
node since the ovnkube master keeps running and prevents
the process from exiting. This commit adds a log message for
easy debugging when ovnkube node fails but ovnkube master
doesn't fail.
