### PR TITLE
OCPBUGS-6947: Check the "Serving" field for endpoints

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -18,6 +18,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -570,7 +571,7 @@ func (npw *nodePortWatcher) AddService(service *kapi.Service) error {
 		nodeIPs := npw.nodeIPManager.ListAddresses()
 		hasLocalHostNetworkEp = hasLocalHostNetworkEndpoints(epSlices, nodeIPs)
 	}
-	localEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, service)
 	// If something didn't already do it add correct Service rules
 	if exists := npw.addOrSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndpoints); !exists {
 		klog.V(5).Infof("Service Add %s event in namespace %s came before endpoint event setting svcConfig",
@@ -718,7 +719,7 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 		}
 		nodeIPs := npw.nodeIPManager.ListAddresses()
 		hasLocalHostNetworkEp := hasLocalHostNetworkEndpoints(epSlices, nodeIPs)
-		localEndPoints := npw.GetLocalEndpointAddresses(epSlices)
+		localEndPoints := npw.GetLocalEndpointAddresses(epSlices, service)
 		npw.getAndSetServiceInfo(name, service, hasLocalHostNetworkEp, localEndPoints)
 		// Delete OF rules for service if they exist
 		if err = npw.updateServiceFlowCache(service, false, hasLocalHostNetworkEp); err != nil {
@@ -808,11 +809,11 @@ func (npw *nodePortWatcher) AddEndpointSlice(epSlice *discovery.EndpointSlice) e
 	if err != nil {
 		klog.V(5).Infof("Could not fetch endpointslices for service %s/%s during endpointSliceAdd", svc.Name, svc.Namespace)
 	}
-	localEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
 	// Here we make sure the correct rules are programmed whenever an AddEndpointSlice event is
 	// received, only alter flows if we need to, i.e if cache wasn't set or if it was and
 	// hasLocalHostNetworkEp or localEndpoints state (for LB svc where NPs=0) changed, to prevent flow churn
-	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := serviceNamespacedNameFromEndpointSlice(epSlice)
 	if err != nil {
 		return fmt.Errorf("cannot add %s/%s to nodePortWatcher: %v", epSlice.Namespace, epSlice.Name, err)
 	}
@@ -853,15 +854,21 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 
 	klog.V(5).Infof("Deleting endpointslice %s in namespace %s", epSlice.Name, epSlice.Namespace)
 	// remove rules for endpoints and add back normal ones
-	namespacedName, err := namespacedNameFromEPSlice(epSlice)
+	namespacedName, err := serviceNamespacedNameFromEndpointSlice(epSlice)
 	if err != nil {
 		return fmt.Errorf("cannot delete %s/%s from nodePortWatcher: %v", epSlice.Namespace, epSlice.Name, err)
 	}
 	epSlices, err := npw.watchFactory.GetEndpointSlices(epSlice.Namespace, epSlice.Labels[discovery.LabelServiceName])
 	if err != nil {
-		return fmt.Errorf("could not fetch endpointslices for service %s during endpointSliceDelete", namespacedName)
+		return fmt.Errorf("could not fetch endpointslices for service %s during endpointSliceDelete: %v", namespacedName, err)
 	}
-	localEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+
+	svc, err := npw.watchFactory.GetService(namespacedName.Namespace, namespacedName.Name)
+	if err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("error while retrieving service for endpointslice %s/%s during delete: %v",
+			epSlice.Namespace, epSlice.Name, err)
+	}
+	localEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
 	if svcConfig, exists := npw.updateServiceInfo(namespacedName, nil, &hasLocalHostNetworkEp, localEndpoints); exists {
 		// Lock the cache mutex here so we don't miss a service delete during an endpoint delete
 		// we have to do this because deleting and adding iptables rules is slow.
@@ -880,11 +887,14 @@ func (npw *nodePortWatcher) DeleteEndpointSlice(epSlice *discovery.EndpointSlice
 }
 
 // GetLocalEndpointAddresses returns a list of endpoints that are local to the node
-func (npw *nodePortWatcher) GetLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice) sets.String {
+func (npw *nodePortWatcher) GetLocalEndpointAddresses(endpointSlices []*discovery.EndpointSlice, service *kapi.Service) sets.String {
 	localEndpoints := sets.NewString()
+	includeTerminating := service != nil && service.Spec.PublishNotReadyAddresses
 	for _, endpointSlice := range endpointSlices {
 		for _, endpoint := range endpointSlice.Endpoints {
-			if isEndpointReady(endpoint) && endpoint.NodeName != nil && *endpoint.NodeName == npw.nodeIPManager.nodeName {
+			if util.IsEndpointValid(endpoint, includeTerminating) &&
+				endpoint.NodeName != nil &&
+				*endpoint.NodeName == npw.nodeIPManager.nodeName {
 				localEndpoints.Insert(endpoint.Addresses...)
 			}
 		}
@@ -892,10 +902,11 @@ func (npw *nodePortWatcher) GetLocalEndpointAddresses(endpointSlices []*discover
 	return localEndpoints
 }
 
-func getEndpointAddresses(endpointSlice *discovery.EndpointSlice) []string {
+func getEndpointAddresses(endpointSlice *discovery.EndpointSlice, service *kapi.Service) []string {
 	endpointsAddress := make([]string, 0)
+	includeTerminating := service != nil && service.Spec.PublishNotReadyAddresses
 	for _, endpoint := range endpointSlice.Endpoints {
-		if isEndpointReady(endpoint) {
+		if util.IsEndpointValid(endpoint, includeTerminating) {
 			for _, ip := range endpoint.Addresses {
 				endpointsAddress = append(endpointsAddress, utilnet.ParseIPSloppy(ip).String())
 			}
@@ -911,18 +922,24 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	var err error
 	var errors []error
 
-	oldEpAddr := getEndpointAddresses(oldEpSlice)
-	newEpAddr := getEndpointAddresses(newEpSlice)
+	namespacedName, err := serviceNamespacedNameFromEndpointSlice(newEpSlice)
+	if err != nil {
+		return fmt.Errorf("cannot update %s/%s in nodePortWatcher: %v", newEpSlice.Namespace, newEpSlice.Name, err)
+	}
+	svc, err := npw.watchFactory.GetService(namespacedName.Namespace, namespacedName.Name)
+	if err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("error while retrieving service for endpointslice %s/%s during update: %v",
+			oldEpSlice.Namespace, oldEpSlice.Name, err)
+	}
+
+	oldEpAddr := getEndpointAddresses(oldEpSlice, svc)
+	newEpAddr := getEndpointAddresses(newEpSlice, svc)
 	if reflect.DeepEqual(oldEpAddr, newEpAddr) {
 		return nil
 	}
 
 	klog.V(5).Infof("Updating endpointslice %s in namespace %s", oldEpSlice.Name, oldEpSlice.Namespace)
 
-	namespacedName, err := namespacedNameFromEPSlice(newEpSlice)
-	if err != nil {
-		return fmt.Errorf("cannot update %s/%s in nodePortWatcher: %v", newEpSlice.Namespace, newEpSlice.Name, err)
-	}
 	var serviceInfo *serviceConfig
 	var exists bool
 	if serviceInfo, exists = npw.getServiceInfo(namespacedName); !exists {
@@ -948,7 +965,8 @@ func (npw *nodePortWatcher) UpdateEndpointSlice(oldEpSlice, newEpSlice *discover
 	if err != nil {
 		klog.V(5).Infof("Could not fetch endpointslices for service %s during endpointSliceDelete", namespacedName)
 	}
-	newLocalEndpoints := npw.GetLocalEndpointAddresses(epSlices)
+
+	newLocalEndpoints := npw.GetLocalEndpointAddresses(epSlices, svc)
 	if hasLocalHostNetworkEpOld != hasLocalHostNetworkEpNew ||
 		(serviceInfo != nil && !reflect.DeepEqual(serviceInfo.localEndpoints, newLocalEndpoints)) {
 		if err = npw.DeleteEndpointSlice(oldEpSlice); err != nil {

--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -64,7 +64,7 @@ var protos = []v1.Protocol{
 func buildServiceLBConfigs(service *v1.Service, endpointSlices []*discovery.EndpointSlice) (perNodeConfigs []lbConfig, clusterConfigs []lbConfig) {
 	// For each svcPort, determine if it will be applied per-node or cluster-wide
 	for _, svcPort := range service.Spec.Ports {
-		eps := util.GetLbEndpoints(endpointSlices, svcPort)
+		eps := util.GetLbEndpoints(endpointSlices, svcPort, service.Spec.PublishNotReadyAddresses)
 
 		// if ExternalTrafficPolicy or InternalTrafficPolicy is local, then we need to do things a bit differently
 		externalTrafficLocal := (service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal)

--- a/go-controller/pkg/ovn/multicast.go
+++ b/go-controller/pkg/ovn/multicast.go
@@ -81,12 +81,12 @@ func getMcastACLName(nsORpg, mcastSuffix string) string {
 }
 
 // Creates a policy to allow multicast traffic within 'ns':
-// - a port group containing all logical ports associated with 'ns'
-// - one "from-lport" ACL allowing egress multicast traffic from the pods
-//   in 'ns'
-// - one "to-lport" ACL allowing ingress multicast traffic to pods in 'ns'.
-//   This matches only traffic originated by pods in 'ns' (based on the
-//   namespace address set).
+//   - a port group containing all logical ports associated with 'ns'
+//   - one "from-lport" ACL allowing egress multicast traffic from the pods
+//     in 'ns'
+//   - one "to-lport" ACL allowing ingress multicast traffic to pods in 'ns'.
+//     This matches only traffic originated by pods in 'ns' (based on the
+//     namespace address set).
 func (oc *DefaultNetworkController) createMulticastAllowPolicy(ns string, nsInfo *namespaceInfo) error {
 	portGroupName := hashedPortGroup(ns)
 
@@ -151,10 +151,11 @@ func deleteMulticastAllowPolicy(nbClient libovsdbclient.Client, ns string) error
 }
 
 // Creates a global default deny multicast policy:
-// - one ACL dropping egress multicast traffic from all pods: this is to
-//   protect OVN controller from processing IP multicast reports from nodes
-//   that are not allowed to receive multicast traffic.
-// - one ACL dropping ingress multicast traffic to all pods.
+//   - one ACL dropping egress multicast traffic from all pods: this is to
+//     protect OVN controller from processing IP multicast reports from nodes
+//     that are not allowed to receive multicast traffic.
+//   - one ACL dropping ingress multicast traffic to all pods.
+//
 // Caller must hold the namespace's namespaceInfo object lock.
 func (oc *DefaultNetworkController) createDefaultDenyMulticastPolicy() error {
 	match := getMulticastACLMatch()

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -530,11 +530,12 @@ func ParseNetConf(netattachdef *nettypes.NetworkAttachmentDefinition) (*ovncnity
 // and return the matching NetworkSelectionElement if any exists.
 //
 // Return value:
-//    bool: if this Pod is on this Network; true or false
-//    map[string]*nettypes.NetworkSelectionElement: all NetworkSelectionElement that pod is requested
-//        for the specified network, key is NADName. Note multiple NADs of the same network are allowed
-//        on one pod, as long as they are of different NADName.
-//    error:  error in case of failure
+//
+//	bool: if this Pod is on this Network; true or false
+//	map[string]*nettypes.NetworkSelectionElement: all NetworkSelectionElement that pod is requested
+//	    for the specified network, key is NADName. Note multiple NADs of the same network are allowed
+//	    on one pod, as long as they are of different NADName.
+//	error:  error in case of failure
 func GetPodNADToNetworkMapping(pod *kapi.Pod, nInfo NetInfo) (bool, map[string]*nettypes.NetworkSelectionElement, error) {
 	if pod.Spec.HostNetwork {
 		return false, nil, nil

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -21,6 +21,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -348,4 +349,31 @@ func UpdateNodeSwitchExcludeIPs(nbClient libovsdbclient.Client, nodeName string,
 	}
 
 	return nil
+}
+
+// IsEndpointReady takes as input an endpoint from an endpoint slice and returns true if the endpoint is
+// to be considered ready. Considering as ready an endpoint with Conditions.Ready==nil
+// as per doc: "In most cases consumers should interpret this unknown state as ready"
+// https://github.com/kubernetes/api/blob/0478a3e95231398d8b380dc2a1905972be8ae1d5/discovery/v1/types.go#L129-L131
+func IsEndpointReady(endpoint discovery.Endpoint) bool {
+	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
+}
+
+// IsEndpointServing takes as input an endpoint from an endpoint slice and returns true if the endpoint is
+// to be considered serving. Falling back to IsEndpointReady when Serving field is nil, as per doc:
+// "If nil, consumers should defer to the ready condition.
+// https://github.com/kubernetes/api/blob/0478a3e95231398d8b380dc2a1905972be8ae1d5/discovery/v1/types.go#L138-L139
+func IsEndpointServing(endpoint discovery.Endpoint) bool {
+	if endpoint.Conditions.Serving != nil {
+		return *endpoint.Conditions.Serving
+	} else {
+		return IsEndpointReady(endpoint)
+	}
+}
+
+// IsEndpointValid takes as input an endpoint from an endpoint slice and a boolean that indicates whether to include
+// all terminating endpoints, as per the PublishNotReadyAddresses feature in kubernetes service spec. It always returns true
+// if includeTerminating is true and falls back to IsEndpointServing otherwise.
+func IsEndpointValid(endpoint discovery.Endpoint, includeTerminating bool) bool {
+	return includeTerminating || IsEndpointServing(endpoint)
 }


### PR DESCRIPTION
Master, node and healthcheck code looked up the Ready field in endpoints inside endpointslices, in line with the previous implementation that dealt with the older and less fine-grained Endpoints resource, that only distinguished between ready and not ready. Healthchecks should indeed rely on the Ready field, while node and master could look up the "Serving" field, so that we won't prematurely refuse incoming connections to an endpoint that is scheduled to be terminating but is still up and running.

Making a special case for services with PublishNotReadyAddresses set, as their endpoints should always be considered ready, even if terminating. A couple of upstream kubernetes tests use this feature in 1.26.

More context in this comment from the jira bug: 
https://issues.redhat.com/browse/OCPBUGS-6947?focusedCommentId=21727895&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21727895

Fixes #OCPBUGS-6947