### PR TITLE
DNM: increase retries for net-attach-def-controller

### DIFF
--- a/go-controller/pkg/network-controller-manager/network_attach_def_controller.go
+++ b/go-controller/pkg/network-controller-manager/network_attach_def_controller.go
@@ -39,7 +39,7 @@ const (
 	avoidResync     = 0
 	numberOfWorkers = 2
 	qps             = 15
-	maxRetries      = 10
+	maxRetries      = 100
 )
 
 type BaseNetworkController interface {
@@ -130,7 +130,7 @@ func (nadController *netAttachDefinitionController) Run(stopChan <-chan struct{}
 		klog.Infof("Shutting down controller %s", controllerName)
 		nadController.queue.ShutDown()
 	}()
-
+	klog.Infof("Running with %d maxRetries", maxRetries)
 	nadController.nadFactory.Start(stopChan)
 	klog.Infof("Starting controller %s", controllerName)
 	if !cache.WaitForNamedCacheSync(controllerName, stopChan, nadController.netAttachDefSynced) {

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -73,7 +73,7 @@ var _ = Describe("Multi Homing", func() {
 					return v1.PodFailed
 				}
 				return updatedPod.Status.Phase
-			}, 2*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
+			}, 5*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
 		},
 			table.Entry(
 				"when attaching to an L3 - routed - network",
@@ -166,7 +166,7 @@ var _ = Describe("Multi Homing", func() {
 						return v1.PodFailed
 					}
 					return updatedPod.Status.Phase
-				}, 2*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
+				}, 5*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
 
 				pod, err := cs.CoreV1().Pods(f.Namespace.Name).Get(context.Background(), serverPod.GetName(), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -200,7 +200,7 @@ var _ = Describe("Multi Homing", func() {
 						return v1.PodFailed
 					}
 					return updatedPod.Status.Phase
-				}, 2*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
+				}, 5*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
 
 				if netConfig.cidr == "" {
 					By("configuring static IP addresses in the pods")
@@ -225,7 +225,7 @@ var _ = Describe("Multi Homing", func() {
 					}
 
 					return fmt.Errorf("pod not running. /me is sad")
-				}, 2*time.Minute, 6*time.Second).Should(Succeed())
+				}, 5*time.Minute, 6*time.Second).Should(Succeed())
 			},
 			table.Entry(
 				"can communicate over an L2 secondary network when the pods are scheduled in different nodes",
@@ -345,7 +345,7 @@ var _ = Describe("Multi Homing", func() {
 					return v1.PodFailed
 				}
 				return updatedPod.Status.Phase
-			}, 2*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
+			}, 5*time.Minute, 6*time.Second).Should(Equal(v1.PodRunning))
 		})
 
 		It("features two different IPs from the same subnet", func() {


### PR DESCRIPTION
This should show if increasing the retry periods would be enough to address the flake issues.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR would show us if tinkering w/ the retry period would address the flakes on the multi-homing lane.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->