### PR TITLE
rm metallb repo in destroy_metallb() function

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -826,6 +826,7 @@ destroy_metallb() {
   docker stop lbclient || true # its possible the lbclient doesn't exist which is fine, ignore error
   docker stop frr || true # its possible the lbclient doesn't exist which is fine, ignore error
   docker network rm clientnet || true # its possible the clientnet network doesn't exist which is fine, ignore error
+  sudo rm -rf metallb || true # this repo is removed in install_metallb(), but in case of trouble it may still be around
 }
 
 install_multus() {


### PR DESCRIPTION
if that repo exists when re-running kind it will throw and error during the install_metallb() step when it tries to clone it. the repo is removed later in the install_metallb() step, but if something breaks or exits before that happens it could be leftover making the clone step on the next install fail. You could check if the repo folder exists before hand, but then you would not be using the latest version of the repo... or would have to add steps to pull the latest which could get more complicated if files are potentially modified. this is simple enough.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->