### PR TITLE
Single leader election

### DIFF
--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -3,11 +3,8 @@ package clustermanager
 import (
 	"context"
 	"sync"
-	"time"
 
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
@@ -33,15 +30,9 @@ type ClusterManager struct {
 	// unique identity for clusterManager running on different ovnkube-cluster-manager instance,
 	// used for leader election
 	identity string
-
-	// Cluster manager can be started and stopped several times concurrently.
-	// Make sure it is synchronous and idempotent.
-	isActive bool
-	sync.Mutex
 }
 
-// NewClusterManager creates a new Cluster Manager for managing the
-// cluster nodes.
+// NewClusterManager creates a new cluster manager to manage the cluster nodes.
 func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.WatchFactory,
 	identity string, wg *sync.WaitGroup, recorder record.EventRecorder) *ClusterManager {
 	defaultNetClusterController := newNetworkClusterController(ovntypes.DefaultNetworkName, config.Default.ClusterSubnets,
@@ -53,7 +44,6 @@ func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.W
 		wf:                          wf,
 		recorder:                    recorder,
 		identity:                    identity,
-		isActive:                    false,
 	}
 
 	if config.OVNKubernetesFeature.EnableMultiNetwork {
@@ -62,105 +52,10 @@ func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.W
 	return cm
 }
 
-// Start waits until this process is the leader before starting the cluster manager functions
-func (cm *ClusterManager) Start(ctx context.Context, cancel context.CancelFunc) error {
-	metrics.RegisterClusterManagerBase()
-
-	// Set up leader election process first.
-	// User lease resource lock as configmap and endpoint lock support is removed from leader election library.
-	// TODO: Remove the leader election from cluster-manager and have one single election
-	// when both cluster manager and network controller manager are running.
-	// See https://issues.redhat.com/browse/OCPBUGS-8080 for details
-	rl, err := resourcelock.New(
-		resourcelock.LeasesResourceLock,
-		config.Kubernetes.OVNConfigNamespace,
-		"ovn-kubernetes-cluster-manager",
-		cm.client.CoreV1(),
-		cm.client.CoordinationV1(),
-		resourcelock.ResourceLockConfig{
-			Identity:      cm.identity,
-			EventRecorder: cm.recorder,
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	lec := leaderelection.LeaderElectionConfig{
-		Lock:            rl,
-		LeaseDuration:   time.Duration(config.ClusterMgrHA.ElectionLeaseDuration) * time.Second,
-		RenewDeadline:   time.Duration(config.ClusterMgrHA.ElectionRenewDeadline) * time.Second,
-		RetryPeriod:     time.Duration(config.ClusterMgrHA.ElectionRetryPeriod) * time.Second,
-		ReleaseOnCancel: true,
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(ctx context.Context) {
-				klog.Infof("Won leader election; in active mode")
-				// run only on the active master node
-				if err := cm.start(ctx); err != nil {
-					klog.Error(err)
-					cancel()
-				}
-			},
-			OnStoppedLeading: func() {
-				klog.Infof("No longer leader; transitioning to standby mode")
-				// This node was leader and it lost the election.
-				// Stop all the cluster manager responsibilities
-				// and become a standby. This doesn't exit the process because
-				//    - network cluster manager may also be running in an another
-				//      leader election session and we don't want to disrupt it.
-				//    - ClusterManager can be started again if it regains leadership.
-				if err := cm.stop(); err != nil {
-					klog.Error(err)
-					cancel()
-				}
-			},
-			OnNewLeader: func(newLeaderName string) {
-				if newLeaderName != cm.identity {
-					klog.Infof("Lost the election to %s; in standby mode", newLeaderName)
-				}
-			},
-		},
-	}
-
-	leaderElector, err := leaderelection.NewLeaderElector(lec)
-	if err != nil {
-		return err
-	}
-
-	cm.wg.Add(1)
-	go func() {
-		leaderElector.Run(ctx)
-		cm.wg.Done()
-	}()
-
-	return nil
-}
-
-// Stop the cluster manager if it is active
-func (cm *ClusterManager) Stop() {
-	if err := cm.stop(); err != nil {
-		klog.Error(err)
-	}
-}
-
-// start managing the cluster operations
-// It starts the default network cluster controller
-func (cm *ClusterManager) start(ctx context.Context) error {
-	cm.Lock()
-	defer cm.Unlock()
-	if cm.isActive {
-		// Is already active and nothing to do
-		return nil
-	}
-
+// Start the cluster manager.
+func (cm *ClusterManager) Start(ctx context.Context) error {
 	klog.Info("Starting the cluster manager")
 	metrics.RegisterClusterManagerFunctional()
-
-	start := time.Now()
-	defer func() {
-		end := time.Since(start)
-		metrics.MetricClusterManagerReadyDuration.Set(end.Seconds())
-	}()
 
 	// Start and sync the watch factory to begin listening for events
 	if err := cm.wf.Start(); err != nil {
@@ -177,27 +72,15 @@ func (cm *ClusterManager) start(ctx context.Context) error {
 		}
 	}
 
-	cm.isActive = true
 	return nil
 }
 
-// stop managing the cluster operations by stopping the default
-// network cluster controller
-func (cm *ClusterManager) stop() error {
-	cm.Lock()
-	defer cm.Unlock()
-	if !cm.isActive {
-		// Is not active.  Nothing to halt.
-		return nil
-	}
-
+// Stop the cluster manager.
+func (cm *ClusterManager) Stop() {
 	klog.Info("Stopping the cluster manager")
-	metrics.UnregisterClusterManagerFunctional()
 	cm.defaultNetClusterController.Stop()
 	if config.OVNKubernetesFeature.EnableMultiNetwork {
 		cm.secondaryNetClusterManager.Stop()
 	}
-
-	cm.isActive = false
-	return nil
+	metrics.UnregisterClusterManagerFunctional()
 }

--- a/go-controller/pkg/clustermanager/clustermanager_test.go
+++ b/go-controller/pkg/clustermanager/clustermanager_test.go
@@ -94,7 +94,7 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 				defer cancel()
 				clusterManager := NewClusterManager(fakeClient, f, "identity", wg, nil)
 				gomega.Expect(clusterManager).NotTo(gomega.BeNil())
-				err = clusterManager.Start(c, cancel)
+				err = clusterManager.Start(c)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				defer clusterManager.Stop()
 
@@ -159,7 +159,7 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 				defer cancel()
 				clusterManager := NewClusterManager(fakeClient, f, "identity", wg, nil)
 				gomega.Expect(clusterManager).NotTo(gomega.BeNil())
-				err = clusterManager.Start(c, cancel)
+				err = clusterManager.Start(c)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				defer clusterManager.Stop()
 
@@ -250,7 +250,7 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 				defer cancel()
 				clusterManager := NewClusterManager(fakeClient, f, "identity", wg, nil)
 				gomega.Expect(clusterManager).NotTo(gomega.BeNil())
-				err = clusterManager.Start(c, cancel)
+				err = clusterManager.Start(c)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				defer clusterManager.Stop()
 
@@ -321,7 +321,7 @@ var _ = ginkgo.Describe("Cluster Manager", func() {
 				defer cancel()
 				clusterManager := NewClusterManager(fakeClient, f, "identity", wg, nil)
 				gomega.Expect(clusterManager).NotTo(gomega.BeNil())
-				err = clusterManager.Start(c, cancel)
+				err = clusterManager.Start(c)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				defer clusterManager.Stop()
 

--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -85,7 +85,7 @@ func (ncc *networkClusterController) initRetryFramework() {
 	ncc.retryNodes = ncc.newRetryFramework(factory.NodeType, true)
 }
 
-// Start starts the network cluster controller
+// Start the network cluster controller
 // It does the following
 //   - initializes the network subnet allocator ranges
 //     and hybrid network subnet allocator ranges if hybrid overlay is enabled.
@@ -306,7 +306,7 @@ func (ncc *networkClusterController) updateNodeSubnetAnnotationWithRetry(nodeNam
 	return nil
 }
 
-// Cleanup cleans up the subnet annotations from the node for the secondary networks
+// Cleanup the subnet annotations from the node for the secondary networks
 func (ncc *networkClusterController) Cleanup(netName string) error {
 	if !ncc.IsSecondary() {
 		return fmt.Errorf("default network can't be cleaned up")

--- a/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
+++ b/go-controller/pkg/clustermanager/secondary_network_cluster_manager.go
@@ -34,7 +34,8 @@ func newSecondaryNetworkClusterManager(ovnClient *util.OVNClusterManagerClientse
 	return sncm
 }
 
-// Start starts the secondary layer3 controller, handles all events and creates all needed logical entities
+// Start the secondary layer3 controller, handles all events and creates all
+// needed logical entities
 func (sncm *secondaryNetworkClusterManager) Start() error {
 	klog.Infof("Starting secondary network cluster manager")
 	return sncm.nadController.Start()

--- a/go-controller/pkg/metrics/cluster_manager.go
+++ b/go-controller/pkg/metrics/cluster_manager.go
@@ -95,7 +95,6 @@ func UnregisterClusterManagerFunctional() {
 	prometheus.Unregister(metricV6HostSubnetCount)
 	prometheus.Unregister(metricV4AllocatedHostSubnetCount)
 	prometheus.Unregister(metricV6AllocatedHostSubnetCount)
-
 }
 
 // RecordSubnetUsage records the number of subnets allocated for nodes

--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -21,27 +21,9 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 )
-
-type ovnkubeMasterLeaderMetrics struct{}
-
-func (ovnkubeMasterLeaderMetrics) On(string) {
-	metrics.MetricMasterLeader.Set(1)
-}
-
-func (ovnkubeMasterLeaderMetrics) Off(string) {
-	metrics.MetricMasterLeader.Set(0)
-}
-
-type ovnkubeMasterLeaderMetricsProvider struct{}
-
-func (ovnkubeMasterLeaderMetricsProvider) NewLeaderMetric() leaderelection.SwitchMetric {
-	return ovnkubeMasterLeaderMetrics{}
-}
 
 // networkControllerManager structure is the object manages all controllers for all networks
 type networkControllerManager struct {
@@ -181,90 +163,6 @@ func (cm *networkControllerManager) CleanupDeletedNetworks(allControllers []nad.
 	return nil
 }
 
-// Start waits until this process is the leader before starting master functions
-func (cm *networkControllerManager) Start(ctx context.Context, cancel context.CancelFunc) error {
-	// Set up leader election process first
-	rl, err := resourcelock.New(
-		// TODO (rravaiol) (bpickard)
-		// https://github.com/kubernetes/kubernetes/issues/107454
-		// leader election library no longer supports leader-election
-		// locks based solely on `endpoints` or `configmaps` resources.
-		// Slowly migrating to new API across three releases; with k8s 1.24
-		// we're now in the second step ('x+2') bullet from the link above).
-		// This will have to be updated for the next k8s bump: to 1.26.
-		resourcelock.LeasesResourceLock,
-		config.Kubernetes.OVNConfigNamespace,
-		"ovn-kubernetes-master",
-		cm.client.CoreV1(),
-		cm.client.CoordinationV1(),
-		resourcelock.ResourceLockConfig{
-			Identity:      cm.identity,
-			EventRecorder: cm.recorder,
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	lec := leaderelection.LeaderElectionConfig{
-		Lock:            rl,
-		LeaseDuration:   time.Duration(config.MasterHA.ElectionLeaseDuration) * time.Second,
-		RenewDeadline:   time.Duration(config.MasterHA.ElectionRenewDeadline) * time.Second,
-		RetryPeriod:     time.Duration(config.MasterHA.ElectionRetryPeriod) * time.Second,
-		ReleaseOnCancel: true,
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(ctx context.Context) {
-				klog.Infof("Won leader election; in active mode")
-				klog.Infof("Starting cluster master")
-				start := time.Now()
-				defer func() {
-					end := time.Since(start)
-					metrics.MetricMasterReadyDuration.Set(end.Seconds())
-				}()
-
-				if err = cm.start(ctx); err != nil {
-					klog.Error(err)
-					cancel()
-					return
-				}
-			},
-			OnStoppedLeading: func() {
-				//This node was leader and it lost the election.
-				// Whenever the node transitions from leader to follower,
-				// we need to handle the transition properly like clearing
-				// the cache.
-				// Note: If cluster manager LE is also running, it will
-				// exit the cluster manager too.
-				// TODO: Remove the leader election from cluster-manager and have one single election
-				// when both cluster manager and network controller manager are running.
-				// See https://issues.redhat.com/browse/OCPBUGS-8080 for details
-				klog.Infof("No longer leader; exiting")
-				cancel()
-			},
-			OnNewLeader: func(newLeaderName string) {
-				if newLeaderName != cm.identity {
-					klog.Infof("Lost the election to %s; in standby mode", newLeaderName)
-				}
-			},
-		},
-	}
-
-	leaderelection.SetProvider(ovnkubeMasterLeaderMetricsProvider{})
-	leaderElector, err := leaderelection.NewLeaderElector(lec)
-	if err != nil {
-		return err
-	}
-
-	cm.wg.Add(1)
-	go func() {
-		leaderElector.Run(ctx)
-		klog.Infof("Stopped leader election")
-		cm.wg.Done()
-	}()
-
-	return nil
-}
-
 // NewNetworkControllerManager creates a new OVN controller manager to manage all the controller for all networks
 func NewNetworkControllerManager(ovnClient *util.OVNClientset, identity string, wf *factory.WatchFactory,
 	libovsdbOvnNBClient libovsdbclient.Client, libovsdbOvnSBClient libovsdbclient.Client,
@@ -356,8 +254,9 @@ func (cm *networkControllerManager) initDefaultNetworkController() {
 	cm.defaultNetworkController = defaultController
 }
 
-// start the network controller manager
-func (cm *networkControllerManager) start(ctx context.Context) error {
+// Start the network controller manager
+func (cm *networkControllerManager) Start(ctx context.Context) error {
+	klog.Info("Starting the network controller manager")
 	cm.configureMetrics(cm.stopChan)
 
 	err := cm.configureSCTPSupport()
@@ -404,12 +303,12 @@ func (cm *networkControllerManager) Stop() {
 	// stop metric recorders
 	close(cm.stopChan)
 
-	// stops the default network controller
+	// stop the default network controller
 	if cm.defaultNetworkController != nil {
 		cm.defaultNetworkController.Stop()
 	}
 
-	// stops the NAD controller
+	// stop the NAD controller
 	if cm.nadController != nil {
 		cm.nadController.Stop()
 	}

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -101,7 +101,7 @@ func (ncm *nodeNetworkControllerManager) getOVNIfUpCheckMode() error {
 
 // Start the node network controller manager
 func (ncm *nodeNetworkControllerManager) Start(ctx context.Context) (err error) {
-	klog.Infof("OVN Kube Node initialization, Mode: %s", config.OvnKubeNode.Mode)
+	klog.Infof("Starting the node network controller manager, Mode: %s", config.OvnKubeNode.Mode)
 
 	if err = ncm.getOVNIfUpCheckMode(); err != nil {
 		return err
@@ -150,14 +150,14 @@ func (ncm *nodeNetworkControllerManager) Start(ctx context.Context) (err error) 
 
 // Stop gracefully stops all managed controllers
 func (ncm *nodeNetworkControllerManager) Stop() {
-	// stops stale ovs ports cleanup
+	// stop stale ovs ports cleanup
 	close(ncm.stopChan)
 
 	if ncm.defaultNodeNetworkController != nil {
 		ncm.defaultNodeNetworkController.Stop()
 	}
 
-	// stops the NAD controller
+	// stop the NAD controller
 	if ncm.nadController != nil {
 		ncm.nadController.Stop()
 	}

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -420,12 +420,12 @@ func createNodeManagementPorts(name string, nodeAnnotator kube.Annotator, waiter
 // Start learns the subnets assigned to it by the master controller
 // and calls the SetupNode script which establishes the logical switch
 func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
+	klog.Infof("Starting the default node network controller")
+
 	var err error
 	var node *kapi.Node
 	var subnets []*net.IPNet
 	var cniServer *cni.Server
-
-	klog.Infof("OVN Kube Node initialization, Mode: %s", config.OvnKubeNode.Mode)
 
 	// Setting debug log level during node bring up to expose bring up process.
 	// Log level is returned to configured value when bring up is complete.
@@ -689,7 +689,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		}
 	}
 
-	klog.Infof("OVN Kube Node initialized and ready.")
+	klog.Infof("Default node network controller initialized and ready.")
 	return nil
 }
 

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -262,6 +262,8 @@ func (oc *DefaultNetworkController) newRetryFrameworkWithParameters(
 
 // Start starts the default controller; handles all events and creates all needed logical entities
 func (oc *DefaultNetworkController) Start(ctx context.Context) error {
+	klog.Infof("Starting the default network controller")
+
 	// sync address sets, only required for DefaultNetworkController, since any old objects in the db without
 	// Owner set are owned by the default network controller.
 	syncer := address_set_syncer.NewAddressSetSyncer(oc.nbClient, DefaultNetworkControllerName)

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -226,7 +226,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			defer cancel()
 			clusterManager := cm.NewClusterManager(fakeClient.GetClusterManagerClientset(), f, "identity", wg, nil)
 			gomega.Expect(clusterManager).NotTo(gomega.BeNil())
-			err = clusterManager.Start(c, cancel)
+			err = clusterManager.Start(c)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer clusterManager.Stop()
 			gomega.Expect(clusterController.WatchNodes()).To(gomega.Succeed())
@@ -397,7 +397,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			defer cancel()
 			clusterManager := cm.NewClusterManager(fakeClient.GetClusterManagerClientset(), f, "identity", wg, nil)
 			gomega.Expect(clusterManager).NotTo(gomega.BeNil())
-			err = clusterManager.Start(c, cancel)
+			err = clusterManager.Start(c)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer clusterManager.Stop()
 
@@ -717,7 +717,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			defer cancel()
 			clusterManager := cm.NewClusterManager(fakeClient.GetClusterManagerClientset(), f, "identity", wg, nil)
 			gomega.Expect(clusterManager).NotTo(gomega.BeNil())
-			err = clusterManager.Start(c, cancel)
+			err = clusterManager.Start(c)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer clusterManager.Stop()
 
@@ -893,7 +893,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 			defer cancel()
 			clusterManager := cm.NewClusterManager(fakeClient.GetClusterManagerClientset(), f, "identity", wg, nil)
 			gomega.Expect(clusterManager).NotTo(gomega.BeNil())
-			err = clusterManager.Start(c, cancel)
+			err = clusterManager.Start(c)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			defer clusterManager.Stop()
 


### PR DESCRIPTION
While adding support for cluster-manager, a second leader election was
introduced in ovnkube-master.

This leads to a change of paradigm we don't want, where one
ovnkube-master is leading for some components while a different
ovnkube-master is leading for other components. Additionally, each of
them runs a full fledged informer causing more strain to the api server.

There is also a problem in that cluster-manager will not be able to
regain leadership, as its leader election does not cause the process to
exit when leadership is lost but does not resume trying to acquiere
leadership.