### PR TITLE
Fix syncEgressFirewall (truncate ACL names) and SetupMaster (stop recreating cluster-wide PGs)

### DIFF
--- a/go-controller/pkg/libovsdbops/acl.go
+++ b/go-controller/pkg/libovsdbops/acl.go
@@ -102,6 +102,11 @@ func CreateOrUpdateACLsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operat
 	for i := range acls {
 		// can't use i in the predicate, for loop replaces it in-memory
 		acl := acls[i]
+		// ensure names are truncated (let's cover our bases from snippets that don't call BuildACL and call this directly)
+		if acl.Name != nil {
+			// node ACLs won't have names set
+			*acl.Name = fmt.Sprintf("%.63s", *acl.Name)
+		}
 		opModel := operationModel{
 			Model:          acl,
 			ModelPredicate: func(item *nbdb.ACL) bool { return isEquivalentACL(item, acl) },

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -1406,18 +1406,10 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
-					// NOTE1: syncEgressFirewall is not calling libovsdbops.BuildACL and directly calls CreateOrUpdateACLs
-					// it doesn't truncate long names for acls if they are over 63 and we run into errors:
-					// E0228 09:54:13.167495       1 factory.go:567] Failed (will retry) in processExisting [0xc00176a000]:
-					// unable to update ACL information (direction and logging) during resync operation, err: error in transact
-					// with ops constraint violation: "egressFirewall_allow-traffic-apache-server-on-lbdns-node-run1-1_9999"
-					// length 68 is greater than maximum allowed length 63]: 1 ovsdb operations failed
-					// NOTE2: This is not caught by testing because our test server
-					// is not smart enough. See https://github.com/ovn-org/libovsdb/issues/338
+					// NOTE: syncEgressFirewall is not calling libovsdbops.BuildACL and directly calls CreateOrUpdateACLs
+					// This part of test ensures syncEgressFirewall code path is tested well and that we truncate the ACL names correctly
 					err = fakeOVN.controller.syncEgressFirewall([]interface{}{*egressFirewall})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					*ipv4ACL1.Name = buildEgressFwAclName(namespace1.Name, t.EgressFirewallStartPriority)   // we end up resetting the name to long value
-					*ipv4ACL2.Name = buildEgressFwAclName(namespace1.Name, t.EgressFirewallStartPriority-1) // we end up resetting the name to long value
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 					err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).Delete(context.TODO(), egressFirewall.Name, *metav1.NewDeleteOptions(0))


### PR DESCRIPTION
This commit ensures we truncate names as a precaution
also in CreateOrUpdateACLsOps so that our bases are
covered since not all code snippets call BuildACL
directly

NOTE: The first commit adds a test to showcase that we actually weren't truncating. Test server is not smart enough to scream like real ovsdb server so it won't complain :/ See https://github.com/ovn-org/libovsdb/issues/338.
Second commit does the fix and changes the test case