### PR TITLE
Support Device Plugin Resources For Mgmt Port

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -14,14 +14,14 @@ install_j2_renderer() {
 # The script renders j2 templates into yaml files in ../yaml/
 
 # ensure j2 renderer installed
-if ! command -v j2 >/dev/null 2>&1 ; then 
-  if ! command -v pip >/dev/null 2>&1 ; then 
+if ! command -v j2 >/dev/null 2>&1 ; then
+  if ! command -v pip >/dev/null 2>&1 ; then
     echo "Dependency not met: 'j2' not installed and cannot install with 'pip'"
     exit 1
   fi
   echo "'j2' not found, installing with 'pip'"
   install_j2_renderer
-fi 
+fi
 
 OVN_OUTPUT_DIR=""
 OVN_IMAGE=""
@@ -87,7 +87,7 @@ while [ "$1" != "" ]; do
   PARAM=$(echo $1 | awk -F= '{print $1}')
   VALUE=$(echo $1 | cut -d= -f2-)
   case $PARAM in
-  --output-directory) 
+  --output-directory)
     OVN_OUTPUT_DIR=$VALUE
     ;;
   --image)
@@ -264,6 +264,9 @@ while [ "$1" != "" ]; do
   --ovnkube-node-mgmt-port-netdev)
     OVNKUBE_NODE_MGMT_PORT_NETDEV=$VALUE
     ;;
+  --ovnkube-node-mgmt-port-dp-resource-name)
+    OVNKUBE_NODE_MGMT_PORT_DP_RESOURCE_NAME=$VALUE
+    ;;
   --ovnkube-config-duration-enable)
     OVNKUBE_CONFIG_DURATION_ENABLE=$VALUE
     ;;
@@ -285,14 +288,14 @@ done
 # Create the daemonsets with the desired image
 # They are expanded into daemonsets in the specified
 # output directory.
-if [ -z ${OVN_OUTPUT_DIR} ] ; then 
+if [ -z ${OVN_OUTPUT_DIR} ] ; then
   output_dir="../yaml"
-else 
+else
   output_dir=${OVN_OUTPUT_DIR}
   if [ ! -d ${OVN_OUTPUT_DIR} ]; then
     mkdir $output_dir
-  fi 
-fi 
+  fi
+fi
 echo "output_dir: $output_dir"
 
 image=${OVN_IMAGE:-"docker.io/ovnkube/ovn-daemonset:latest"}

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -301,6 +301,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.Equal(false))
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeFull))
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal(""))
+			gomega.Expect(OvnKubeNode.MgmtPortDPResourceName).To(gomega.Equal(""))
 			gomega.Expect(OvnKubeNode.MgmtPortRepresentor).To(gomega.Equal(""))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal(""))
 			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
@@ -1666,27 +1667,31 @@ foo=bar
 			}
 			file := config{
 				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:           types.NodeModeDPU,
-					MgmtPortNetdev: "enp1s0f0v0",
+					Mode:                   types.NodeModeDPU,
+					MgmtPortNetdev:         "enp1s0f0v0",
+					MgmtPortDPResourceName: "openshift.io/mgmtvf",
 				},
 			}
 			err := buildOvnKubeNodeConfig(nil, &cliConfig, &file)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeDPU))
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal("enp1s0f0v0"))
+			gomega.Expect(OvnKubeNode.MgmtPortDPResourceName).To(gomega.Equal("openshift.io/mgmtvf"))
 		})
 
 		It("Overrides value from CLI", func() {
 			cliConfig := config{
 				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:           types.NodeModeDPU,
-					MgmtPortNetdev: "enp1s0f0v0",
+					Mode:                   types.NodeModeDPU,
+					MgmtPortNetdev:         "enp1s0f0v0",
+					MgmtPortDPResourceName: "openshift.io/mgmtvf",
 				},
 			}
 			err := buildOvnKubeNodeConfig(nil, &cliConfig, &config{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeDPU))
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal("enp1s0f0v0"))
+			gomega.Expect(OvnKubeNode.MgmtPortDPResourceName).To(gomega.Equal("openshift.io/mgmtvf"))
 		})
 
 		It("Fails with unsupported mode", func() {
@@ -1721,7 +1726,7 @@ foo=bar
 			}
 			err := buildOvnKubeNodeConfig(nil, &cliConfig, &config{})
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("ovnkube-node-mgmt-port-netdev must be provided"))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must be provided"))
 		})
 
 		It("Fails if management port is not provided and ovnkube node mode is dpu-host", func() {
@@ -1732,7 +1737,7 @@ foo=bar
 			}
 			err := buildOvnKubeNodeConfig(nil, &cliConfig, &config{})
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("ovnkube-node-mgmt-port-netdev must be provided"))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must be provided"))
 		})
 
 		It("Succeeds if management netdev provided in the full mode", func() {
@@ -1740,6 +1745,22 @@ foo=bar
 				OvnKubeNode: OvnKubeNodeConfig{
 					Mode:           types.NodeModeFull,
 					MgmtPortNetdev: "ens1f0v0",
+				},
+			}
+			file := config{
+				OvnKubeNode: OvnKubeNodeConfig{
+					Mode: types.NodeModeFull,
+				},
+			}
+			err := buildOvnKubeNodeConfig(nil, &cliConfig, &file)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+
+		It("Succeeds if management port device plugin resource name provided in the full mode", func() {
+			cliConfig := config{
+				OvnKubeNode: OvnKubeNodeConfig{
+					Mode:                   types.NodeModeFull,
+					MgmtPortDPResourceName: "openshift.io/mgmtvf",
 				},
 			}
 			file := config{

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -376,6 +377,66 @@ type managementPortEntry struct {
 	config *managementPortConfig
 }
 
+// getEnvNameFromResourceName gets the device plugin env variable from the device plugin resource name.
+func getEnvNameFromResourceName(resource string) string {
+	res1 := strings.ReplaceAll(resource, ".", "_")
+	res2 := strings.ReplaceAll(res1, "/", "_")
+	return "PCIDEVICE_" + strings.ToUpper(res2)
+}
+
+// getDeviceIdsFromEnv gets the list of device IDs from the device plugin env variable.
+func getDeviceIdsFromEnv(envName string) ([]string, error) {
+	envVar := os.Getenv(envName)
+	if len(envVar) == 0 {
+		return nil, fmt.Errorf("unexpected empty env variable: %s", envName)
+	}
+	deviceIds := strings.Split(envVar, ",")
+	return deviceIds, nil
+}
+
+// handleDevicePluginResources tries to retrieve any device plugin resources passed in via arguments and device plugin env variables.
+func handleDevicePluginResources() error {
+	mgmtPortEnvName := getEnvNameFromResourceName(config.OvnKubeNode.MgmtPortDPResourceName)
+	deviceIds, err := getDeviceIdsFromEnv(mgmtPortEnvName)
+	if err != nil {
+		return err
+	}
+	// The reason why we want to store the Device Ids in a map is prepare for various features that
+	// require network resources such as the Management Port or Bypass Port. It is likely that these
+	// features share the same device pool.
+	config.OvnKubeNode.DPResourceDeviceIdsMap = make(map[string][]string)
+	config.OvnKubeNode.DPResourceDeviceIdsMap[config.OvnKubeNode.MgmtPortDPResourceName] = deviceIds
+	klog.V(5).Infof("Setting DPResourceDeviceIdsMap for %s using env %s with device IDs %v",
+		config.OvnKubeNode.MgmtPortDPResourceName, mgmtPortEnvName, deviceIds)
+	return nil
+}
+
+// reserveDeviceId takes the first device ID from a list of device IDs
+// This function will not execute during runtime, only once at startup thus there
+// is no undesirable side-effects of multiple allocations (causing pressure on the
+// garbage collector)
+func reserveDeviceId(deviceIds []string) (string, []string) {
+	ret := deviceIds[0]
+	deviceIds = deviceIds[1:]
+	return ret, deviceIds
+}
+
+// handleNetdevResources tries to retrieve any device plugin interfaces to be used by the system such as the management port.
+func handleNetdevResources(resourceName string) (string, error) {
+	var deviceId string
+	deviceIdsMap := &config.OvnKubeNode.DPResourceDeviceIdsMap
+	if len((*deviceIdsMap)[resourceName]) > 0 {
+		deviceId, (*deviceIdsMap)[resourceName] = reserveDeviceId((*deviceIdsMap)[resourceName])
+	} else {
+		return "", fmt.Errorf("insufficient device IDs for resource: %s", resourceName)
+	}
+	netdevice, err := util.GetNetdevNameFromDeviceId(deviceId)
+	if err != nil {
+		return "", err
+	}
+	return netdevice, nil
+}
+
 func createNodeManagementPorts(name string, nodeAnnotator kube.Annotator, waiter *startupWaiter,
 	subnets []*net.IPNet) ([]managementPortEntry, *managementPortConfig, error) {
 	// If netdevice name is not provided in the full mode then management port backed by OVS internal port.
@@ -493,6 +554,26 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 
 	nodeAnnotator := kube.NewNodeAnnotator(nc.Kube, node.Name)
 	waiter := newStartupWaiter()
+
+	// Use the device from environment when the DP resource name is specified.
+	if config.OvnKubeNode.MgmtPortDPResourceName != "" {
+		if err := handleDevicePluginResources(); err != nil {
+			return err
+		}
+
+		netdevice, err := handleNetdevResources(config.OvnKubeNode.MgmtPortDPResourceName)
+		if err != nil {
+			return err
+		}
+
+		if config.OvnKubeNode.MgmtPortNetdev != "" {
+			klog.Warningf("MgmtPortNetdev is set explicitly (%s), overriding with resource...",
+				config.OvnKubeNode.MgmtPortNetdev)
+		}
+		config.OvnKubeNode.MgmtPortNetdev = netdevice
+		klog.V(5).Infof("Using MgmtPortNetdev (Netdev %s) passed via resource %s",
+			config.OvnKubeNode.MgmtPortNetdev, config.OvnKubeNode.MgmtPortDPResourceName)
+	}
 
 	// Setup management ports
 	mgmtPorts, mgmtPortConfig, err := createNodeManagementPorts(nc.name, nodeAnnotator, waiter, subnets)


### PR DESCRIPTION
A new argument ovnkube-node-mgmt-port-dp-resource-name is added in this commit to pass the device plugin resource name that would be used for the mgmt port. The resource will override the existing parameter ovnkube-node-mgmt-port-netdev, if provided. 

A new DPResourceDeviceIdsMap is added in this commit to the OvnKubeNodeConfig structure to track the resources and allocated device ID that would be used for mgmt port and other future features such as bypass port.

**- What this PR does and why is it needed**
This is needed to support k8s device plugin resources to be used instead of passing in interface names.

**- Special notes for reviewers**
OvnKubeNode modified in this change.

**- How to verify it**
Extended some of the config tests.

**- Description for the changelog**
Support Device Plugin Resources For Mgmt Port