### PR TITLE
Node healthz server: return unhealthy when ovnk node pod is to be deleted

### DIFF
--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -214,6 +214,11 @@ spec:
             configMapKeyRef:
               name: ovn-config
               key: host_network_namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
 
         readinessProbe:
           exec:

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -134,7 +134,9 @@ func (ncm *nodeNetworkControllerManager) Start(ctx context.Context) (err error) 
 		}, time.Minute, ncm.stopChan)
 	}
 
-	ncm.defaultNodeNetworkController = node.NewDefaultNodeNetworkController(ncm.newCommonNetworkControllerInfo())
+	if ncm.defaultNodeNetworkController, err = node.NewDefaultNodeNetworkController(ncm.newCommonNetworkControllerInfo()); err != nil {
+		return err
+	}
 	err = ncm.defaultNodeNetworkController.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to start default network controller: %v", err)

--- a/go-controller/pkg/node/healthcheck_node.go
+++ b/go-controller/pkg/node/healthcheck_node.go
@@ -3,9 +3,12 @@ package node
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/pkg/errors"
 
 	kapi "k8s.io/api/core/v1"
@@ -15,48 +18,84 @@ import (
 	"k8s.io/utils/clock"
 )
 
+var updateInterval time.Duration = 500 * time.Millisecond
+
 type proxierHealthUpdater struct {
-	address  string
-	nodeRef  *kapi.ObjectReference
-	recorder record.EventRecorder
-	c        clock.Clock
-	healthy  bool
+	address      string
+	nodeRef      *kapi.ObjectReference
+	recorder     record.EventRecorder
+	c            clock.Clock
+	healthy      bool
+	lastCalled   time.Time
+	lastUpdated  time.Time
+	watchFactory factory.NodeWatchFactory
+	nsn          ktypes.NamespacedName
 }
 
 // newNodeProxyHealthzServer creates and returns a new proxier health server
 // if the HealthzBindAddress configuration is set. Cloud load balancers use this
 // health check to determine if the node is available for services with ClusterIP
 // traffic policy.
-func newNodeProxyHealthzServer(nodeName, address string, eventRecorder record.EventRecorder) *proxierHealthUpdater {
+func newNodeProxyHealthzServer(nodeName, address string, eventRecorder record.EventRecorder, wf factory.NodeWatchFactory) (*proxierHealthUpdater, error) {
+	podName := os.Getenv("POD_NAME")
+	if len(podName) == 0 {
+		return nil, fmt.Errorf("found empty env variable POD_NAME")
+	}
 	return &proxierHealthUpdater{
-		address:  address,
-		recorder: eventRecorder,
-		c:        clock.RealClock{},
-		healthy:  true,
+		address:     address,
+		recorder:    eventRecorder,
+		c:           clock.RealClock{},
+		healthy:     true,
+		lastUpdated: time.Time{},
 		nodeRef: &kapi.ObjectReference{
 			Kind:      "Node",
 			Name:      nodeName,
 			UID:       ktypes.UID(nodeName),
 			Namespace: "",
 		},
+		nsn: ktypes.NamespacedName{
+			Namespace: config.Kubernetes.OVNConfigNamespace,
+			Name:      podName},
+		watchFactory: wf,
+	}, nil
+}
+
+func (phu *proxierHealthUpdater) isOvnkNodePodTerminating() bool {
+	pod, err := phu.watchFactory.GetPod(phu.nsn.Namespace, phu.nsn.Name)
+	if err != nil {
+		klog.Errorf("Could not retrieve pod %s/%s: %v", phu.nsn.Namespace, phu.nsn.Name, err)
+		return false
 	}
+	return pod.DeletionTimestamp != nil
+}
+
+// isOvnkNodePodHealthy runs isOvnkNodePodTerminating at most every 500 ms and returns true
+// if the ovnkube node pod is not set for deletion.
+func (phu *proxierHealthUpdater) isOvnkNodePodHealthy() bool {
+	now := phu.c.Now()
+	phu.lastCalled = now
+	if phu.lastUpdated != (time.Time{}) && now.Sub(phu.lastUpdated) < updateInterval {
+		return phu.healthy
+	}
+	phu.healthy = !phu.isOvnkNodePodTerminating()
+	phu.lastUpdated = now
+	return phu.healthy
 }
 
 func (phu *proxierHealthUpdater) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	resp.Header().Set("Content-Type", "application/json")
 	resp.Header().Set("X-Content-Type-Options", "nosniff")
-	if phu.healthy {
+	if phu.isOvnkNodePodHealthy() {
 		resp.WriteHeader(http.StatusOK)
 	} else {
 		resp.WriteHeader(http.StatusServiceUnavailable)
 	}
-	now := phu.c.Now()
-	fmt.Fprintf(resp, `{"lastUpdated": %q,"currentTime": %q}`, now, now)
+
+	fmt.Fprintf(resp, `{"lastUpdated": %q,"currentTime": %q}`, phu.lastUpdated, phu.lastCalled)
 }
 
 // serveNodeProxyHealthz initializes and runs the healthz server. It will always
 // report healthy while the node process is running.
-// TODO: connect node health to something useful
 func (phu *proxierHealthUpdater) Start(stopChan chan struct{}, wg *sync.WaitGroup) {
 	serveMux := http.NewServeMux()
 	serveMux.Handle("/healthz", phu)

--- a/go-controller/pkg/node/healthcheck_node_test.go
+++ b/go-controller/pkg/node/healthcheck_node_test.go
@@ -3,51 +3,135 @@ package node
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 )
 
+const healthzAddress string = "127.0.0.1:10256"
+
+var ovnkNodePodName string = "ovnkube-node-test"
+var nodeName string = "test-node"
+
+func newFakeOvnkNodePod(deletionTimestamp *metav1.Time) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              ovnkNodePodName,
+			UID:               types.UID(ovnkNodePodName),
+			Namespace:         config.Kubernetes.OVNConfigNamespace,
+			DeletionTimestamp: deletionTimestamp,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "ovnkube-node",
+					Image: "ovnkube-image",
+				},
+			},
+			NodeName: nodeName,
+		},
+	}
+}
+
+func initWatchFactoryWithObjects(objects ...runtime.Object) *factory.WatchFactory {
+	v1Objects := []runtime.Object{}
+	for _, object := range objects {
+		v1Objects = append(v1Objects, object)
+	}
+	fakeClient := &util.OVNNodeClientset{
+		KubeClient: fake.NewSimpleClientset(v1Objects...),
+	}
+
+	watcher, err := factory.NewNodeWatchFactory(fakeClient, nodeName)
+	Expect(err).NotTo(HaveOccurred())
+	watcher.Start()
+	return watcher
+}
+
+func checkResponse(address string, expectedStatusCode int) {
+	// Try a few times to make sure the server is listening,
+	// there's a small race between when Start() returns and
+	// the ListenAndServe() is actually active
+	var err error
+	for i := 0; i < 5; i++ {
+		resp, err := http.Get(fmt.Sprintf("http://%s/healthz", address))
+		if err == nil {
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(expectedStatusCode))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	Expect(err).NotTo(HaveOccurred())
+}
+
 var _ = Describe("Node healthcheck tests", func() {
 	var (
-		wg     *sync.WaitGroup
-		stopCh chan struct{}
+		wg           *sync.WaitGroup
+		stopCh       chan struct{}
+		watchFactory *factory.WatchFactory
 	)
 
 	BeforeEach(func() {
 		stopCh = make(chan struct{})
 		wg = &sync.WaitGroup{}
+		os.Setenv("POD_NAME", ovnkNodePodName)
 	})
 
 	AfterEach(func() {
 		close(stopCh)
 		wg.Wait()
+		watchFactory.Shutdown()
 	})
 
 	Context("node proxy healthz server is started", func() {
 		It("it reports healthy", func() {
 			recorder := record.NewFakeRecorder(10)
-			const addr string = "127.0.0.1:10256"
-			hzs := newNodeProxyHealthzServer("some-node", addr, recorder)
+
+			watchFactory = initWatchFactoryWithObjects(
+				&v1.PodList{
+					Items: []v1.Pod{
+						*newFakeOvnkNodePod(nil),
+					},
+				})
+
+			hzs, err := newNodeProxyHealthzServer(nodeName, healthzAddress, recorder, watchFactory)
+			Expect(err).NotTo(HaveOccurred())
+
 			hzs.Start(stopCh, wg)
 
-			// Try a few times to make sure the server is listening,
-			// there's a small race between when Start() returns and
-			// the ListenAndServe() is actually active
-			var err error
-			for i := 0; i < 5; i++ {
-				resp, err := http.Get(fmt.Sprintf("http://%s/healthz", addr))
-				if err == nil {
-					defer resp.Body.Close()
-					Expect(resp.StatusCode).To(Equal(http.StatusOK))
-				}
-				time.Sleep(50 * time.Millisecond)
-			}
+			checkResponse(healthzAddress, http.StatusOK)
+		})
+
+		It("it reports unhealthy", func() {
+			// ovnk node pod is set for deletion: healthz should report unhealthy
+			recorder := record.NewFakeRecorder(10)
+			now := metav1.Now()
+			watchFactory = initWatchFactoryWithObjects(
+				&v1.PodList{
+					Items: []v1.Pod{
+						*newFakeOvnkNodePod(&now),
+					},
+				})
+
+			hzs, err := newNodeProxyHealthzServer(nodeName, healthzAddress, recorder, watchFactory)
 			Expect(err).NotTo(HaveOccurred())
+
+			hzs.Start(stopCh, wg)
+
+			checkResponse(healthzAddress, http.StatusServiceUnavailable)
 		})
 	})
 })


### PR DESCRIPTION
In the node healthz server, leveraged by cloud load balancers to check the node health for services with ExternalTrafficPolicy=Cluster, respond negatively to health checks as soon as the ovnk node pod is to be deleted, by inspecting the pod DeletionTimestamp.  This is what the endpointslice controller in KCM looks up when deciding whether an endpoint is terminating: https://github.com/kubernetes/kubernetes/blob/e706788455e99c77627c4ec88e1ec95e4fece54c/pkg/controller/endpointslice/utils.go#L43

The purpose is to allow cloud load balancers to have a little more time to update their list of healthy nodes before the node actually stops forwarding traffic altogether.

These changes complement https://issues.redhat.com/browse/OCPBUGS-7158,  should help https://issues.redhat.com/browse/OCPBUGS-6796 and are part of the solution for https://issues.redhat.com/browse/OCPBUGS-7359

Counterpart changes in CNO: https://github.com/openshift/cluster-network-operator/pull/1715