### PR TITLE
unidling: Workaround for OVN LB `reject=false` `event=false`

### DIFF
--- a/go-controller/pkg/ovn/controller/services/lb_config.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config.go
@@ -484,6 +484,13 @@ func lbOpts(service *v1.Service) LBOpts {
 
 		if unidling.IsOnGracePeriod(service) {
 			lbOptions.Reject = false
+
+			// Setting to true even if we don't need empty_lb_events from OVN during grace period
+			// because OVN does not support having
+			// <no_backends> event=false reject=false
+			// Remove the following line when https://bugzilla.redhat.com/show_bug.cgi?id=2177173
+			// is fixed
+			lbOptions.EmptyLBEvents = true
 		}
 	}
 

--- a/go-controller/pkg/ovn/controller/services/lb_config_test.go
+++ b/go-controller/pkg/ovn/controller/services/lb_config_test.go
@@ -1942,7 +1942,7 @@ func Test_idledServices(t *testing.T) {
 			},
 			expected: LBOpts{
 				Reject:        false,
-				EmptyLBEvents: false,
+				EmptyLBEvents: true,
 			},
 		},
 		{

--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -160,6 +160,8 @@ var _ = ginkgo.Describe("Unidling", func() {
 		})
 
 		ginkgo.It("Should not generate a NeedPods event when removing the annotation", func() {
+			ginkgo.Skip("Not supported by OVN: Enable back when https://bugzilla.redhat.com/show_bug.cgi?id=2177173 is fixed")
+
 			_, err := jig.UpdateService(func(service *v1.Service) {
 				service.Annotations = nil
 			})

--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -145,7 +146,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 			})
 			serviceAddress := net.JoinHostPort(serviceName, strconv.Itoa(port))
 			framework.Logf("waiting up to %v to connect to %v", e2eservice.KubeProxyEndpointLagTimeout, serviceAddress)
-			cmd = fmt.Sprintf("/agnhost connect --timeout=3s %s", serviceAddress)
+			cmd = fmt.Sprintf("/agnhost connect --timeout=10s %s", serviceAddress)
 		})
 
 		ginkgo.It("Should generate a NeedPods event for traffic destined to idled services", func() {
@@ -198,6 +199,29 @@ var _ = ginkgo.Describe("Unidling", func() {
 			gomega.Eventually(func() bool {
 				return hittingGeneratesNewEvents(service, cs, clientPod, cmd)
 			}, 10*time.Second, 1*time.Second).Should(gomega.Equal(true), "New events are not generated")
+		})
+
+		ginkgo.It("Should connect to an unidled backend at the first attempt", func() {
+
+			// Simulate service unidling
+			_, err := jig.UpdateService(func(service *v1.Service) {
+				service.Annotations = nil
+			})
+			framework.ExpectNoError(err)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer ginkgo.GinkgoRecover()
+				wg.Done()
+
+				time.Sleep(time.Second)
+				createBackend(f, serviceName, namespace, node, jig.Labels, port)
+			}()
+			wg.Wait()
+
+			// Connecting to the service should work at the first attempt
+			gomega.Expect(checkService(clientPod, cmd)).To(gomega.Equal(works))
 		})
 	})
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->
**- What this PR does and why is it needed**

Ensure pods can connect to an idled ClusterIP
service at the first attempt without getting
any TCP Reject or connection timeout.



<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

The test currently fails, as the TCP connection from the execpod to the service gets conntracked when there is no endpoint available:

```
[root@ovn-control-plane ~]# ovs-dpctl -t 1618  dump-conntrack  | grep 10.244

// what is happening ()
tcp,orig=(src=10.244.2.8,dst=10.96.207.68,sport=41338,dport=80),reply=(src=10.96.207.68,dst=10.244.2.8,sport=80,dport=41338),zone=9,mark=2,protoinfo=(state=SYN_SENT)
tcp,orig=(src=10.244.2.8,dst=10.96.207.68,sport=41338,dport=80),reply=(src=10.96.207.68,dst=10.244.2.8,sport=80,dport=41338),zone=7,mark=6,protoinfo=(state=SYN_SENT)

// how it should be
tcp,orig=(src=10.244.2.12,dst=10.96.35.190,sport=51656,dport=80),reply=(src=10.244.2.13,dst=10.244.2.12,sport=80,dport=51656),zone=9,mark=2,protoinfo=(state=TIME_WAIT)
tcp,orig=(src=10.244.2.12,dst=10.244.2.13,sport=51656,dport=80),reply=(src=10.244.2.13,dst=10.244.2.12,sport=80,dport=51656),zone=12,protoinfo=(state=TIME_WAIT)
```

*Note1*: Flushing conntrack (`ovs-dpctl -t 1618  flush-conntrack`) while the client tries to connect to the service makes the connection to establish.

*Note2*: Bad conntrack state can be due to `ct_lb_mark(backend=)`  flows:

```
// No backend (10.96.243.177 is the service ClusterIP, duplicated lines omitted)
[root@ovn-control-plane ~]# ovn-sbctl dump-flows | grep "10.96.243.177"
  table=5 (lr_in_defrag       ), priority=110  , match=(ip && ip4.dst == 10.96.243.177 && tcp), action=(reg0 = 10.96.243.177; reg9[16..31] = tcp.dst; ct_dnat;)
  table=7 (lr_in_dnat         ), priority=120  , match=(ct.est && !ct.rel && ip4 && reg0 == 10.96.243.177 && tcp && reg9[16..31] == 80 && ct_mark.natted == 1), action=(flags.force_snat_for_lb = 1; next;)
  table=7 (lr_in_dnat         ), priority=120  , match=(ct.new && !ct.rel && ip4 && reg0 == 10.96.243.177 && tcp && reg9[16..31] == 80), action=(flags.force_snat_for_lb = 1; ct_lb_mark(backends=; force_snat);)

  table=6 (ls_in_pre_stateful ), priority=120  , match=(ip4.dst == 10.96.243.177 && tcp.dst == 80), action=(reg1 = 10.96.243.177; reg2[0..15] = 80; ct_lb_mark;)
  table=12(ls_in_lb           ), priority=120  , match=(ct.new && ip4.dst == 10.96.243.177 && tcp.dst == 80), action=(reg0[1] = 0; ct_lb_mark(backends=);)
```



**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->