### PR TITLE
e2e: Don't pin nodePort

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/types"
 	"math/rand"
 	"net"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -266,7 +267,7 @@ func createGenericPodWithLabel(f *framework.Framework, podName, nodeSelector, na
 	return createPod(f, podName, nodeSelector, namespace, command, labels)
 }
 
-func createServiceForPodsWithLabel(f *framework.Framework, namespace string, servicePort int32, targetPort string, nodePort int32, serviceType string, labels map[string]string) (string, error) {
+func createServiceForPodsWithLabel(f *framework.Framework, namespace string, servicePort int32, targetPort string, serviceType string, labels map[string]string) (string, error) {
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "service-for-pods",
@@ -283,9 +284,6 @@ func createServiceForPodsWithLabel(f *framework.Framework, namespace string, ser
 			Type:     v1.ServiceType(serviceType),
 			Selector: labels,
 		},
-	}
-	if serviceType == "NodePort" {
-		service.Spec.Ports[0].NodePort = nodePort
 	}
 	serviceClient := f.ClientSet.CoreV1().Services(namespace)
 	res, err := serviceClient.Create(context.Background(), service, metav1.CreateOptions{})

--- a/test/e2e/egressip.go
+++ b/test/e2e/egressip.go
@@ -1462,7 +1462,7 @@ spec:
 		ginkgo.By("3. Create two pods, and matching service, matching both egress firewall and egress IP")
 		createGenericPodWithLabel(f, pod1Name, pod1Node.name, f.Namespace.Name, command, podEgressLabel)
 		createGenericPodWithLabel(f, pod2Name, pod2Node.name, f.Namespace.Name, command, podEgressLabel)
-		serviceIP, err := createServiceForPodsWithLabel(f, f.Namespace.Name, servicePort, podHTTPPort, 0, "ClusterIP", podEgressLabel)
+		serviceIP, err := createServiceForPodsWithLabel(f, f.Namespace.Name, servicePort, podHTTPPort, "ClusterIP", podEgressLabel)
 		framework.ExpectNoError(err, "Step 3. Create two pods, and matching service, matching both egress firewall and egress IP, failed creating service, err: %v", err)
 
 		err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {


### PR DESCRIPTION
In the hairpin SNAT e2e test case I was pinning
the nodePort of the service created when that was not really necessary.

So when in times of flake, CI re-runs this test we run into
```
2023-03-07T09:33:02.1112035Z [1mSTEP[0m: creating a TCP service service-for-pods with type=NodePort in namespace service-hairpin-test-2286 2023-03-07T09:33:02.1162862Z Mar  7 09:33:02.116: FAIL: unable to create service: service-for-pods, err: Failed to create service service-for-pods service-hairpin-test-2286: Service "service-for-pods" is invalid: spec.ports[0].nodePort: Invalid value: 32766: provided port is already allocated 2023-03-07T09:33:02.1163500Z Unexpected error:
2023-03-07T09:33:02.1163792Z     <*errors.withStack | 0xc000f8d188>: {
2023-03-07T09:33:02.1164046Z         error: {
2023-03-07T09:33:02.1164293Z             cause: {
2023-03-07T09:33:02.1164587Z                 ErrStatus: {
2023-03-07T09:33:02.1165066Z                     TypeMeta: {Kind: "", APIVersion: ""},
2023-03-07T09:33:02.1165422Z                     ListMeta: {
2023-03-07T09:33:02.1165788Z                         SelfLink: "",
2023-03-07T09:33:02.1166216Z                         ResourceVersion: "",
2023-03-07T09:33:02.1166603Z                         Continue: "",
2023-03-07T09:33:02.1167076Z                         RemainingItemCount: nil,
2023-03-07T09:33:02.1167368Z                     },
2023-03-07T09:33:02.1167724Z                     Status: "Failure",
2023-03-07T09:33:02.1168903Z                     Message: "Service \"service-for-pods\" is invalid: spec.ports[0].nodePort: Invalid value: 32766: provided port is already allocated",
2023-03-07T09:33:02.1169419Z                     Reason: "Invalid",
2023-03-07T09:33:02.1169724Z                     Details: {
2023-03-07T09:33:02.1170235Z                         Name: "service-for-pods",
2023-03-07T09:33:02.1170621Z                         Group: "",
2023-03-07T09:33:02.1171007Z                         Kind: "Service",
2023-03-07T09:33:02.1171345Z                         UID: "",
2023-03-07T09:33:02.1171687Z                         Causes: [
2023-03-07T09:33:02.1172001Z                             {
2023-03-07T09:33:02.1172560Z                                 Type: "FieldValueInvalid",
2023-03-07T09:33:02.1173522Z                                 Message: "Invalid value: 32766: provided port is already allocated",
2023-03-07T09:33:02.1174529Z                                 Field: "spec.ports[0].nodePort",
2023-03-07T09:33:02.1174889Z                             },
2023-03-07T09:33:02.1175181Z                         ],
2023-03-07T09:33:02.1175605Z                         RetryAfterSeconds: 0,
2023-03-07T09:33:02.1175885Z                     },
2023-03-07T09:33:02.1176188Z                     Code: 422,
2023-03-07T09:33:02.1176523Z                 },
2023-03-07T09:33:02.1176734Z             },
2023-03-07T09:33:02.1177371Z             msg: "Failed to create service service-for-pods service-hairpin-test-2286",
2023-03-07T09:33:02.1177681Z         },
2023-03-07T09:33:02.1178319Z         stack: [0x170e01c, 0x1780a72, 0x76cbb1, 0x76c5a5, 0x76bc9b, 0x76f2aa, 0x76eca7, 0x78f548, 0x78f265, 0x78e905, 0x790cd2, 0x79cfe9, 0x79cdf6, 0x17914c5, 0x520182, 0x46d7e1],
2023-03-07T09:33:02.1178610Z     }
```
Let's just let random ports get assigned. Test can query the service and figure out the nodePort.
