### PR TITLE
fix potential pod IP leak in case that addLogicalPortToNetwork() fails

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -619,6 +619,11 @@ func (bnc *BaseNetworkController) addLogicalPortToNetwork(pod *kapi.Pod, nadName
 		}
 	}
 
+	// It is possible that IPs have already been allocated for this pod and annotation has been updated, then the last
+	// addLogicalPortToNetwork() failed afterwards. In the current retry attempt, if the input pod argument got from
+	// the informer cache still lags behind, we would fail to get the updated pod annotation. Just continue to allocate
+	// new IPs and this function will eventually fail in updatePodAnnotationWithRetry() with ErrOverridePodIPs
+	// when it tries to override the pod IP annotation. Newly allocated IPs will be released then.
 	if needsIP {
 		if existingLSP != nil {
 			// try to get the MAC and IPs from existing OVN port first


### PR DESCRIPTION
when addLogicalPortToNetwork() fails after it successfully allocated pod IPs and updated the pod annotation, there is a case new pod IPs can be allocated to the pod during retry if the informer cache does not cache up with the latest pod annotation update. This would cause leak of the old IPs allocated to the pod.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->