### PR TITLE
docs, multi-homing: fix localnet topology typo

### DIFF
--- a/docs/multi-homing.md
+++ b/docs/multi-homing.md
@@ -151,7 +151,7 @@ localnet network.
 #### Network Configuration reference
 - `name` (string, required): the name of the network.
 - `type` (string, required): "ovn-k8s-cni-overlay".
-- `topology` (string, required): "layer2".
+- `topology` (string, required): "localnet".
 - `subnets` (string, optional): a comma separated list of subnets. When multiple subnets
   are provided, the user will get an IP from each subnet.
 - `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
The configuration reference for localnet topology mistakenly stated `layer2`. It should feature `localnet` instead.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->