### PR TITLE
Cleaned a few warnings in the tests

### DIFF
--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -127,7 +127,7 @@ func newEgressFirewall(name, namespace string) *egressfirewall.EgressFirewall {
 	return &egressfirewall.EgressFirewall{
 		ObjectMeta: newObjectMeta(name, namespace),
 		Spec: egressfirewall.EgressFirewallSpec{
-			[]egressfirewall.EgressFirewallRule{
+			Egress: []egressfirewall.EgressFirewallRule{
 				{
 					Type: egressfirewall.EgressFirewallRuleAllow,
 					To: egressfirewall.EgressFirewallDestination{

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -221,7 +221,7 @@ func shareGatewayInterfaceTest(app *cli.App, testNS ns.NetNS,
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		k := &kube.Kube{kubeFakeClient}
+		k := &kube.Kube{KClient: kubeFakeClient}
 
 		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 
@@ -943,7 +943,7 @@ OFPT_GET_CONFIG_REPLY (xid=0x4): frags=normal miss_send_len=0`,
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		k := &kube.Kube{kubeFakeClient}
+		k := &kube.Kube{KClient: kubeFakeClient}
 		iptV4, iptV6 := util.SetFakeIPTablesHelpers()
 
 		nodeAnnotator := kube.NewNodeAnnotator(k, existingNode.Name)

--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -68,7 +68,7 @@ func startNodePortWatcher(n *nodePortWatcher, fakeClient *util.OVNNodeClientset,
 		return err
 	}
 
-	k := &kube.Kube{fakeClient.KubeClient}
+	k := &kube.Kube{KClient: fakeClient.KubeClient}
 	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, fakeMgmtPortConfig, n.watchFactory, nil, false)
 	localHostNetEp := "192.168.18.15/32"
 	ip, _, _ := net.ParseCIDR(localHostNetEp)
@@ -100,7 +100,7 @@ func startNodePortWatcherWithRetry(n *nodePortWatcher, fakeClient *util.OVNNodeC
 		return nil, err
 	}
 
-	k := &kube.Kube{fakeClient.KubeClient}
+	k := &kube.Kube{KClient: fakeClient.KubeClient}
 	n.nodeIPManager = newAddressManagerInternal(fakeNodeName, k, fakeMgmtPortConfig, n.watchFactory, nil, false)
 	localHostNetEp := "192.168.18.15/32"
 	ip, _, _ := net.ParseCIDR(localHostNetEp)
@@ -2630,7 +2630,7 @@ var _ = Describe("Node Operations", func() {
 			app.Action = func(ctx *cli.Context) error {
 				config.Gateway.Mode = config.GatewayModeShared
 				_, cidr4, _ := net.ParseCIDR("10.128.0.0/16")
-				config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{cidr4, 24}}
+				config.Default.ClusterSubnets = []config.CIDRNetworkEntry{{CIDR: cidr4, HostSubnetLength: 24}}
 				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
 					Cmd: "ovs-ofctl show ",
 					Err: fmt.Errorf("deliberate error to fall back to output:LOCAL"),

--- a/go-controller/pkg/node/management-port_linux_test.go
+++ b/go-controller/pkg/node/management-port_linux_test.go
@@ -244,7 +244,7 @@ func testManagementPort(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.Net
 	_, err = config.InitConfig(ctx, fexec, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	nodeAnnotator := kube.NewNodeAnnotator(&kube.KubeOVN{kube.Kube{fakeClient}, egressipv1fake.NewSimpleClientset(), &egressfirewallfake.Clientset{}, nil}, existingNode.Name)
+	nodeAnnotator := kube.NewNodeAnnotator(&kube.KubeOVN{Kube: kube.Kube{KClient: fakeClient}, EIPClient: egressipv1fake.NewSimpleClientset(), EgressFirewallClient: &egressfirewallfake.Clientset{}}, existingNode.Name)
 	waiter := newStartupWaiter()
 
 	err = testNS.Do(func(ns.NetNS) error {
@@ -321,7 +321,7 @@ func testManagementPortDPU(ctx *cli.Context, fexec *ovntest.FakeExec, testNS ns.
 	_, err = config.InitConfig(ctx, fexec, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	nodeAnnotator := kube.NewNodeAnnotator(&kube.KubeOVN{kube.Kube{fakeClient}, egressipv1fake.NewSimpleClientset(), &egressfirewallfake.Clientset{}, nil}, existingNode.Name)
+	nodeAnnotator := kube.NewNodeAnnotator(&kube.KubeOVN{Kube: kube.Kube{KClient: fakeClient}, EIPClient: egressipv1fake.NewSimpleClientset(), EgressFirewallClient: &egressfirewallfake.Clientset{}}, existingNode.Name)
 	waiter := newStartupWaiter()
 
 	err = testNS.Do(func(ns.NetNS) error {

--- a/go-controller/pkg/node/node_ip_handler_linux_test.go
+++ b/go-controller/pkg/node/node_ip_handler_linux_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Node IP Handler tests", func() {
 
 		fakeBridgeConfiguration := &bridgeConfiguration{}
 
-		k := &kube.Kube{tc.fakeClient}
+		k := &kube.Kube{KClient: tc.fakeClient}
 		tc.ipManager = newAddressManagerInternal(nodeName, k, fakeMgmtPortConfig, tc.watchFactory, fakeBridgeConfiguration, false)
 
 		// We need to wait until the ipManager's goroutine runs the subscribe

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -2,10 +2,11 @@ package ovn
 
 import (
 	"context"
-	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"net"
 	"sync"
 	"time"
+
+	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -255,8 +256,10 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			fakeOvn.controller.defaultCOPPUUID, err = EnsureDefaultCOPP(fakeOvn.nbClient)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			nodeAnnotator := kube.NewNodeAnnotator(&kube.KubeOVN{kube.Kube{fakeOvn.fakeClient.KubeClient},
-				fakeOvn.fakeClient.EgressIPClient, fakeOvn.fakeClient.EgressFirewallClient, nil}, testNode.Name)
+			nodeAnnotator := kube.NewNodeAnnotator(&kube.KubeOVN{
+				Kube:                 kube.Kube{KClient: fakeOvn.fakeClient.KubeClient},
+				EIPClient:            fakeOvn.fakeClient.EgressIPClient,
+				EgressFirewallClient: fakeOvn.fakeClient.EgressFirewallClient}, testNode.Name)
 
 			vlanID := uint(1024)
 			l3Config := node1.gatewayConfig(config.GatewayModeShared, vlanID)


### PR DESCRIPTION
Fixes warnings related to `struct literal uses unkeyed fields` in the tests.

@tssurya PTAL.