### PR TITLE
Fix default node network controller initialization

### DIFF
--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -264,6 +264,9 @@ func (cm *networkControllerManager) initDefaultNetworkController() error {
 	if err != nil {
 		return err
 	}
+	// Make sure we only set defaultNetworkController in case of no error,
+	// otherwise we would initialize the interface with a nil implementation
+	// which is not the same as nil interface.
 	cm.defaultNetworkController = defaultController
 	return nil
 }

--- a/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/node_network_controller_manager.go
@@ -103,6 +103,19 @@ func (ncm *nodeNetworkControllerManager) getOVNIfUpCheckMode() error {
 	return nil
 }
 
+// initDefaultNodeNetworkController creates the controller for default network
+func (ncm *nodeNetworkControllerManager) initDefaultNodeNetworkController() error {
+	defaultNodeNetworkController, err := node.NewDefaultNodeNetworkController(ncm.newCommonNetworkControllerInfo())
+	if err != nil {
+		return err
+	}
+	// Make sure we only set defaultNodeNetworkController in case of no error,
+	// otherwise we would initialize the interface with a nil implementation
+	// which is not the same as nil interface.
+	ncm.defaultNodeNetworkController = defaultNodeNetworkController
+	return nil
+}
+
 // Start the node network controller manager
 func (ncm *nodeNetworkControllerManager) Start(ctx context.Context) (err error) {
 	klog.Infof("Starting the node network controller manager, Mode: %s", config.OvnKubeNode.Mode)
@@ -138,12 +151,13 @@ func (ncm *nodeNetworkControllerManager) Start(ctx context.Context) (err error) 
 		}, time.Minute, ncm.stopChan)
 	}
 
-	if ncm.defaultNodeNetworkController, err = node.NewDefaultNodeNetworkController(ncm.newCommonNetworkControllerInfo()); err != nil {
-		return err
+	err = ncm.initDefaultNodeNetworkController()
+	if err != nil {
+		return fmt.Errorf("failed to init default node network controller: %v", err)
 	}
 	err = ncm.defaultNodeNetworkController.Start(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to start default network controller: %v", err)
+		return fmt.Errorf("failed to start default node network controller: %v", err)
 	}
 
 	// nadController is nil if multi-network is disabled


### PR DESCRIPTION
Default node network controller initialization could fail which would result
in a BaseNodeNetworkController interface initialized with a nil 
implementation which is not the same as a nil interface{}.
