### PR TITLE
Update hairpinning ACLs for network policy

### DIFF
--- a/go-controller/pkg/libovsdbops/db_object_types.go
+++ b/go-controller/pkg/libovsdbops/db_object_types.go
@@ -2,7 +2,7 @@ package libovsdbops
 
 const (
 	addressSet dbObjType = iota
-	// ACL here
+	acl
 )
 
 const (
@@ -11,6 +11,7 @@ const (
 	EgressQoSOwnerType         ownerType = "EgressQoS"
 	// only used for cleanup now, as the stale owner of network policy address sets
 	NetworkPolicyOwnerType   ownerType = "NetworkPolicy"
+	NetpolDefaultOwnerType   ownerType = "NetpolDefault"
 	PodSelectorOwnerType     ownerType = "PodSelector"
 	NamespaceOwnerType       ownerType = "Namespace"
 	HybridNodeRouteOwnerType ownerType = "HybridNodeRoute"
@@ -79,4 +80,11 @@ var AddressSetEgressService = newObjectIDsType(addressSet, EgressServiceOwnerTyp
 	// cluster-wide address set name
 	ObjectNameKey,
 	AddressSetIPFamilyKey,
+})
+
+var ACLNetpolDefault = newObjectIDsType(acl, NetpolDefaultOwnerType, []ExternalIDKey{
+	// for now there is only 1 acl of this type, but we use a name in case more types are needed in the future
+	ObjectNameKey,
+	// egress or ingress
+	PolicyDirectionKey,
 })

--- a/go-controller/pkg/ovn/gress_policy.go
+++ b/go-controller/pkg/ovn/gress_policy.go
@@ -146,19 +146,11 @@ func (gp *gressPolicy) getL3MatchFromAddressSet() string {
 	if config.IPv4Mode && len(v4AddressSets) > 0 {
 		v4AddressSetStr := strings.Join(v4AddressSets, ", ")
 		v4Match = fmt.Sprintf("%s.%s == {%s}", "ip4", direction, v4AddressSetStr)
-		if gp.policyType == knet.PolicyTypeIngress {
-			v4Match = fmt.Sprintf("(%s || (%s.src == %s && %s.dst == {%s}))", v4Match, "ip4",
-				types.V4OVNServiceHairpinMasqueradeIP, "ip4", v4AddressSetStr)
-		}
 		match = v4Match
 	}
 	if config.IPv6Mode && len(v6AddressSets) > 0 {
 		v6AddressSetStr := strings.Join(v6AddressSets, ", ")
 		v6Match = fmt.Sprintf("%s.%s == {%s}", "ip6", direction, v6AddressSetStr)
-		if gp.policyType == knet.PolicyTypeIngress {
-			v6Match = fmt.Sprintf("(%s || (%s.src == %s && %s.dst == {%s}))", v6Match, "ip6",
-				types.V6OVNServiceHairpinMasqueradeIP, "ip6", v6AddressSetStr)
-		}
 		match = v6Match
 	}
 	// if at least one match is empty in dualstack mode, the non-empty one will be assigned to match

--- a/go-controller/pkg/ovn/pod_selector_address_set_test.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set_test.go
@@ -46,9 +46,9 @@ var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
 		fakeOvn = NewFakeOVN()
-
+		initialData := getHairpinningACLsV4AndPortGroup()
 		initialDB = libovsdbtest.TestSetup{
-			NBData: []libovsdbtest.TestData{},
+			NBData: initialData,
 		}
 	})
 


### PR DESCRIPTION
Always allow hairpinned traffic, since it should be the same as pod
connecting to its own ip. That allows to remove hairpinned match
condition for ingress network policies and reduce the number of ovs
flows (significantly)

Steps to reproduce here https://issues.redhat.com/browse/OCPBUGS-10839