### PR TITLE
Fix e2e etp=local flake happening in LGW mode lanes

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -824,6 +824,8 @@ spec:
 
 		ginkgo.By("Scale down endpoints of service: " + svcName + " to ensure iptable rules are also getting recreated correctly")
 		framework.RunKubectlOrDie("default", "scale", "deployment", backendName, "--replicas=3")
+		err = framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, svcName, 3, time.Second, time.Second*120)
+		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an endpoint, err: %v", svcName, err))
 
 		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly
 		// number of iptable rules should have decreased by 1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
This PR attempts to fix the flakes we are seeing in CI around:
```
[Fail] Load Balancer Service Tests with MetalLB [It] Should ensure load balancer service works with 0 node ports when ETP=local 
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/service.go:831

[Fail] Load Balancer Service Tests with MetalLB [It] Should ensure load balancer service works with 0 node ports when ETP=local 
/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/service.go:831
```
Closes #3490 

**- Special notes for reviewers**
For unknown reasons, during the kube rebase, we just decided to flip from sorting the list of endpoints to not sorting it? : https://github.com/ovn-org/ovn-kubernetes/pull/3401/commits/3850450829db65ef15fe308896036897339757a7#diff-d3aa58d9b58a0a09264f072df46ab01d0501eb508c4656411ae2dc1ac68fb3c4L579 
The allocateLBNodePorts feature depends on the list being sorted, else our logic is skewed and the random probability model we use to generate iptables gets skewed up as well. So during endpoints update and such we will behave badly and have left over DNATs towards pods that don't exist anymore which will lead to black-holing the traffic.

**- How to verify it**
Glad we added e2e's with metalLB for that feature which helped us catch this. This is a bug and will need to be backported to 4.13 downstream.


**- Description for the changelog**
`ALWAYS SORT THE LIST OF LOCAL ENDPOINTS when generating iptable rules`