### PR TITLE
Update modelgen version

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,32 @@
+# Developer Documentation
+
+This file aims to have information that is useful to the people contributing to this repo.
+
+## Generating ovsdb bindings using modelgen
+
+In order to generate the latest NBDB and SBDB bindings, we have a tool called `modelgen`
+which lives in the libovsdb repo: https://github.com/ovn-org/libovsdb#modelgen. It is a
+[code generator](https://go.dev/blog/generate) that uses `pkg/nbdb/gen.go` and `pkg/sbdb/gen.go`
+files to auto-generate the models and additional code like deep-copy methods.
+
+In order to use this tool do the following:
+```
+$ cd go-controller/
+$ make modelgen
+curl -sSL https://raw.githubusercontent.com/ovn-org/ovn/${OVN_SCHEMA_VERSION}/ovn-nb.ovsschema -o pkg/nbdb/ovn-nb.ovsschema
+curl -sSL https://raw.githubusercontent.com/ovn-org/ovn/${OVN_SCHEMA_VERSION}/ovn-sb.ovsschema -o pkg/sbdb/ovn-sb.ovsschema
+hack/update-modelgen.sh
+```
+
+If there are new bindings then you should see the changes being generated in the `pkg/nbdb` and
+`pkg/sbdb` parts of the repo. Include them and push a commit!
+
+NOTE1: You have to pay attention to the version of the commit hash used to download the modelgen
+client. While the client doesn't change too often it can also become outdated causing wrong
+generations. So keep in mind to re-install modelgen with latest commits and change the hash
+value in the `hack/update-modelgen.sh` file if you find it outdated.
+
+NOTE2: From time to time we always bump our fedora version of OVN used by KIND. But we oftentimes
+forget to update the `OVN_SCHEMA_VERSION` in our `Makefile` which is used to download the ovsdb schema.
+If that version seems to be outdated, probably best to update that as well and re-generate the schema
+bindings.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -30,3 +30,11 @@ NOTE2: From time to time we always bump our fedora version of OVN used by KIND. 
 forget to update the `OVN_SCHEMA_VERSION` in our `Makefile` which is used to download the ovsdb schema.
 If that version seems to be outdated, probably best to update that as well and re-generate the schema
 bindings.
+
+## Generating CRD yamls using codegen
+
+In order to generate the latest yaml files for a given CRD or to add a new CRD, once
+the `types.go` has been created according to sig-apimachinery docs, the developer can run
+`make codegen` to be able to generate all the clientgen, listers and informers for the new
+CRD along with the deep-copy methods and actual yaml files which get created in `_output/crd`
+folder and are copied over to `dist/templates` to then be used when creating a KIND cluster.

--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -56,7 +56,10 @@ else
 	RACE=1 hack/test-go.sh
 endif
 
-codegen: pkg/nbdb/ovn-nb.ovsschema pkg/sbdb/ovn-sb.ovsschema
+modelgen: pkg/nbdb/ovn-nb.ovsschema pkg/sbdb/ovn-sb.ovsschema
+	hack/update-modelgen.sh
+
+codegen:
 	hack/update-codegen.sh
 
 install:

--- a/go-controller/hack/update-codegen.sh
+++ b/go-controller/hack/update-codegen.sh
@@ -4,22 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# generate ovsdb bindings
-if  ! ( command -v modelgen > /dev/null ); then
-  echo "modelgen not found, installing github.com/ovn-org/libovsdb/cmd/modelgen"
-  olddir="${PWD}"
-  builddir="$(mktemp -d)"
-  cd "${builddir}"
-  GO111MODULE=on go install github.com/ovn-org/libovsdb/cmd/modelgen@2cbe2d093e1247d42050306dd5c9a2d6c11f2460
-  cd "${olddir}"
-  if [[ "${builddir}" == /tmp/* ]]; then #paranoia
-      rm -rf "${builddir}"
-  fi
-fi
-
-go generate ./pkg/nbdb
-go generate ./pkg/sbdb
-
 crds=$(ls pkg/crd 2> /dev/null)
 if [ -z "${crds}" ]; then
   exit

--- a/go-controller/hack/update-codegen.sh
+++ b/go-controller/hack/update-codegen.sh
@@ -73,3 +73,11 @@ echo "Editing EgressQoS CRD"
 ## We desire that only EgressQoS with the name "default" are accepted by the apiserver.
 sed -i -e':begin;$!N;s/.*metadata:\n.*type: object/&\n            properties:\n              name:\n                type: string\n                pattern: ^default$/;P;D' \
 	_output/crds/k8s.ovn.org_egressqoses.yaml
+
+echo "Copying the CRDs to dist/templates as j2 files... Add them to your commit..."
+echo "Copying egressFirewall CRD"
+cp _output/crds/k8s.ovn.org_egressfirewalls.yaml ../dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
+echo "Copying egressIP CRD"
+cp _output/crds/k8s.ovn.org_egressips.yaml ../dist/templates/k8s.ovn.org_egressips.yaml.j2
+echo "Copying egressQoS CRD"
+cp _output/crds/k8s.ovn.org_egressqoses.yaml ../dist/templates/k8s.ovn.org_egressqoses.yaml.j2

--- a/go-controller/hack/update-modelgen.sh
+++ b/go-controller/hack/update-modelgen.sh
@@ -1,0 +1,20 @@
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# generate ovsdb bindings
+if  ! ( command -v modelgen > /dev/null ); then
+  echo "modelgen not found, installing github.com/ovn-org/libovsdb/cmd/modelgen"
+  olddir="${PWD}"
+  builddir="$(mktemp -d)"
+  cd "${builddir}"
+  # ensure the hash value is not outdated, if wrong bindings are being generated re-install modelgen
+  GO111MODULE=on go install github.com/ovn-org/libovsdb/cmd/modelgen@a4f2602f585a3c2995a0abea7010b333631341d9
+  cd "${olddir}"
+  if [[ "${builddir}" == /tmp/* ]]; then #paranoia
+      rm -rf "${builddir}"
+  fi
+fi
+
+go generate ./pkg/nbdb
+go generate ./pkg/sbdb


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Running `make codegen` was using an older version of libovsdb modelgen and this was causing issues while regenerating `nbdb` and `sbdb` packages.

This PR updates the version in the make files to use a later version that includes: https://github.com/ovn-org/libovsdb/commit/a4f2602f585a3c2995a0abea7010b333631341d9
Funny enough the code however seems to be in sync so seems like whenever the last time packages were updated the version in the update-codegen file was not updated.

**- Special notes for reviewers**
PR also splits modelgen from codegen so that users have the ability to run make on them separately.


**- How to verify it**
Run `make modelgen`, everything should be clean.


**- Description for the changelog**
`Updates modelgen version`