### PR TITLE
Fix node update handling for egressfirewall

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall.go
+++ b/go-controller/pkg/ovn/egressfirewall.go
@@ -768,6 +768,9 @@ func (oc *DefaultNetworkController) updateEgressFirewallForNode(oldNode, newNode
 			}
 			modifiedRuleIDs = append(modifiedRuleIDs, rule.id)
 		}
+		if len(modifiedRuleIDs) == 0 {
+			return true
+		}
 		// update egress firewall rules
 		asIndex := getNamespaceAddrSetDbIDs(ef.namespace, oc.controllerName)
 		as, err := oc.addressSetFactory.EnsureAddressSet(asIndex)


### PR DESCRIPTION
Don't call `addEgressFirewallRules` when no rules need to be updated,
otherwise ALL egress firewall ACLs will be updated.