### PR TITLE
cni: Initialize OVS exec runner on CmdDel CNI request

### DIFF
--- a/go-controller/pkg/cni/cnishim.go
+++ b/go-controller/pkg/cni/cnishim.go
@@ -282,6 +282,16 @@ func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
 			return err
 		}
 		defer pr.cancel()
+
+		if !response.PodIFInfo.IsDPUHostMode {
+			// Initialize OVS exec runner; find OVS binaries that the CNI code uses.
+			if err := SetExec(kexec.New()); err != nil {
+				err = fmt.Errorf("failed to initialize OVS exec runner: %v", err)
+				klog.Error(err.Error())
+				return err
+			}
+		}
+
 		err = pr.UnconfigureInterface(response.PodIFInfo)
 	}
 	return err


### PR DESCRIPTION
Exec runner set during CmdAdd CNI request is not seen by CmdDel, hence should be set inplace.

Fixes: db56394dbda5 ("node/cni: initialize OVS exec runner early to prevent races")
Fixes: 39d1dc85a710 ("initialize OVS exec runner when ovnkube-node is in unprivileged mode")