### PR TITLE
NextIP returns the wrong IP for IPv6 address with leading zeros

### DIFF
--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -21,7 +21,11 @@ var NoIPError = errors.New("no IP available")
 // NextIP returns IP incremented by 1
 func NextIP(ip net.IP) net.IP {
 	i := ipToInt(ip)
-	return intToIP(i.Add(i, big.NewInt(1)))
+	iplen := 4
+	if utilnet.IsIPv6(ip) {
+		iplen = 16
+	}
+	return intToIP(i.Add(i, big.NewInt(1)), iplen)
 }
 
 func ipToInt(ip net.IP) *big.Int {
@@ -31,8 +35,10 @@ func ipToInt(ip net.IP) *big.Int {
 	return big.NewInt(0).SetBytes(ip.To16())
 }
 
-func intToIP(i *big.Int) net.IP {
-	return net.IP(i.Bytes())
+func intToIP(i *big.Int, iplen int) net.IP {
+	b := i.Bytes()
+	b = append(make([]byte, iplen-len(b)), b...)
+	return net.IP(b)
 }
 
 // ExtractPortAddresses returns the MAC and IPs of the given logical switch port

--- a/go-controller/pkg/util/net_unit_test.go
+++ b/go-controller/pkg/util/net_unit_test.go
@@ -41,6 +41,11 @@ func TestNextIP(t *testing.T) {
 			expOutput: "255.0.0.0",
 		},
 		{
+			desc:      "IPv6: test increment of leading zeros",
+			input:     "10:100:200:2::",
+			expOutput: "10:100:200:2::1",
+		},
+		{
 			desc:      "IPv6: test increment of eight hextet",
 			input:     "2001:db8::ffff",
 			expOutput: "2001:db8::1:0",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->