### PR TITLE
Use PrimaryID as a client index for ACL.

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -148,6 +148,11 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 	enableMetricsOption := client.WithMetricsRegistryNamespaceSubsystem(promRegistry, "ovnkube",
 		"master_libovsdb")
 
+	// define client indexes for objects that are using dbIDs
+	dbModel.SetIndexes(map[string][]model.ClientIndex{
+		"ACL": {{Columns: []model.ColumnKey{{Column: "external_ids", Key: types.PrimaryIDKey}}}},
+	})
+
 	c, err := newClient(cfg, dbModel, stopCh, enableMetricsOption)
 	if err != nil {
 		return nil, err

--- a/go-controller/pkg/libovsdbops/acl.go
+++ b/go-controller/pkg/libovsdbops/acl.go
@@ -24,12 +24,6 @@ func getACLMutableFields(acl *nbdb.ACL) []interface{} {
 		&acl.Name, &acl.Options, &acl.Priority, &acl.Severity}
 }
 
-// checkACLPrimaryID is a temporary replacement for client indexes, matches on ExternalIDs[PrimaryIDKey].
-func checkACLPrimaryID(existing *nbdb.ACL, searched *nbdb.ACL) bool {
-	return searched.ExternalIDs != nil && existing.ExternalIDs != nil &&
-		existing.ExternalIDs[PrimaryIDKey.String()] == searched.ExternalIDs[PrimaryIDKey.String()]
-}
-
 type aclPredicate func(*nbdb.ACL) bool
 
 // FindACLsWithPredicate looks up ACLs from the cache based on a given predicate
@@ -50,7 +44,6 @@ func FindACLs(nbClient libovsdbclient.Client, acls []*nbdb.ACL) ([]*nbdb.ACL, er
 		found := []*nbdb.ACL{}
 		opModel := operationModel{
 			Model:          acl,
-			ModelPredicate: func(item *nbdb.ACL) bool { return checkACLPrimaryID(item, acl) },
 			ExistingResult: &found,
 			ErrNotFound:    false,
 			BulkOp:         false,
@@ -124,7 +117,6 @@ func CreateOrUpdateACLsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operat
 		}
 		opModel := operationModel{
 			Model:          acl,
-			ModelPredicate: func(item *nbdb.ACL) bool { return checkACLPrimaryID(item, acl) },
 			OnModelUpdates: getACLMutableFields(acl),
 			ErrNotFound:    false,
 			BulkOp:         false,
@@ -143,7 +135,6 @@ func UpdateACLsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, acl
 		acl := acls[i]
 		opModel := operationModel{
 			Model:          acl,
-			ModelPredicate: func(item *nbdb.ACL) bool { return checkACLPrimaryID(item, acl) },
 			OnModelUpdates: getACLMutableFields(acl),
 			ErrNotFound:    true,
 			BulkOp:         false,
@@ -175,7 +166,6 @@ func UpdateACLsLoggingOps(nbClient libovsdbclient.Client, ops []libovsdb.Operati
 		acl := acls[i]
 		opModel := operationModel{
 			Model:          acl,
-			ModelPredicate: func(item *nbdb.ACL) bool { return checkACLPrimaryID(item, acl) },
 			OnModelUpdates: []interface{}{&acl.Severity, &acl.Log},
 			ErrNotFound:    true,
 			BulkOp:         false,

--- a/go-controller/pkg/libovsdbops/db_object_ids.go
+++ b/go-controller/pkg/libovsdbops/db_object_ids.go
@@ -57,7 +57,7 @@ const (
 	ObjectNameKey ExternalIDKey = types.OvnK8sPrefix + "/name"
 	// PrimaryIDKey will be used as a primary index, that is unique for every db object,
 	// and can be built based on the combination of all the other ids.
-	PrimaryIDKey ExternalIDKey = types.OvnK8sPrefix + "/id"
+	PrimaryIDKey ExternalIDKey = types.PrimaryIDKey
 )
 
 // dbIDsMap is used to make sure the same ownerType is not defined twice for the same dbObjType to avoid conflicts.

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -131,6 +131,9 @@ func copyIndexes(model model.Model) model.Model {
 	case *nbdb.ACL:
 		return &nbdb.ACL{
 			UUID: t.UUID,
+			ExternalIDs: map[string]string{
+				types.PrimaryIDKey: t.ExternalIDs[types.PrimaryIDKey],
+			},
 		}
 	case *nbdb.AddressSet:
 		return &nbdb.AddressSet{

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -181,4 +181,8 @@ const (
 	Layer3Topology   = "layer3"
 	Layer2Topology   = "layer2"
 	LocalnetTopology = "localnet"
+
+	// db index keys
+	// PrimaryIDKey is used as a primary client index
+	PrimaryIDKey = OvnK8sPrefix + "/id"
 )


### PR DESCRIPTION
Based on the data from https://github.com/ovn-org/ovn-kubernetes/issues/3431 
netpol create is ~3 times faster, and restart is ~6 times faster on a test kind setup
