### PR TITLE
Minor performance fixes

### DIFF
--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -523,7 +523,6 @@ func getPolicyType(policy *knet.NetworkPolicy) (bool, bool) {
 func (oc *DefaultNetworkController) getNewLocalPolicyPorts(np *networkPolicy,
 	objs ...interface{}) (policyPortsToUUIDs map[string]string, policyPortUUIDs []string, errObjs []interface{}) {
 
-	klog.Infof("Processing NetworkPolicy %s/%s to have %d local pods...", np.namespace, np.name, len(objs))
 	policyPortUUIDs = make([]string, 0, len(objs))
 	policyPortsToUUIDs = map[string]string{}
 


### PR DESCRIPTION
Optimize deleteStaleNetpolPeerAddrSets to iterate over all acls only once.
On a random setup with 187 address sets and 6270 ACLs
initial version runs 573.911701ms
updated version runs 60.471213ms

"Processing NetworkPolicy %s/%s to have %d local pods" log is not really useful and eats ~40% of `handleLocalPodSelectorAddFunc` cpu usage