### PR TITLE
services: Don't try to list/cleanup templates when OVN doesn't suppor…

### DIFF
--- a/go-controller/pkg/ovn/controller/services/repair.go
+++ b/go-controller/pkg/ovn/controller/services/repair.go
@@ -50,7 +50,7 @@ func newRepair(serviceLister corelisters.ServiceLister, nbClient libovsdbclient.
 }
 
 // runBeforeSync performs some cleanup of stale LBs and other miscellaneous setup.
-func (r *repair) runBeforeSync() {
+func (r *repair) runBeforeSync(useTemplates bool) {
 	// no need to lock, single-threaded.
 
 	startTime := time.Now()
@@ -68,9 +68,15 @@ func (r *repair) runBeforeSync() {
 	}
 
 	// Find all templates.
-	allTemplates, err := listSvcTemplates(r.nbClient)
-	if err != nil {
-		klog.Errorf("Unable to get templates for repair: %v", err)
+	allTemplates := TemplateMap{}
+
+	if useTemplates {
+		var err error
+
+		allTemplates, err = listSvcTemplates(r.nbClient)
+		if err != nil {
+			klog.Errorf("Unable to get templates for repair: %v", err)
+		}
 	}
 
 	// Find all load-balancers associated with Services

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -197,7 +197,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair, useLBGr
 		// Run the repair controller only once
 		// it keeps in sync Kubernetes and OVN
 		// and handles removal of stale data on upgrades
-		c.repair.runBeforeSync()
+		c.repair.runBeforeSync(c.useTemplates)
 	}
 
 	if err := c.initTopLevelCache(); err != nil {
@@ -272,9 +272,13 @@ func (c *Controller) initTopLevelCache() error {
 	defer c.alreadyAppliedRWLock.Unlock()
 
 	// First list all the templates.
-	allTemplates, err := listSvcTemplates(c.nbClient)
-	if err != nil {
-		return fmt.Errorf("failed to load templates: %w", err)
+	allTemplates := TemplateMap{}
+
+	if c.useTemplates {
+		allTemplates, err = listSvcTemplates(c.nbClient)
+		if err != nil {
+			return fmt.Errorf("failed to load templates: %w", err)
+		}
 	}
 
 	// Then list all load balancers and their respective services.

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -662,9 +662,13 @@ func (oc *DefaultNetworkController) syncChassis(nodes []*kapi.Node) error {
 		return fmt.Errorf("failed to get chassis private list: %v", err)
 	}
 
-	templateVarList, err := libovsdbops.ListTemplateVar(oc.nbClient)
-	if err != nil {
-		return fmt.Errorf("failed to get template var list: error: %v", err)
+	templateVarList := []*nbdb.ChassisTemplateVar{}
+
+	if oc.svcTemplateSupport {
+		templateVarList, err = libovsdbops.ListTemplateVar(oc.nbClient)
+		if err != nil {
+			return fmt.Errorf("failed to get template var list: error: %w", err)
+		}
 	}
 
 	chassisHostNameMap := map[string]*sbdb.Chassis{}


### PR DESCRIPTION
…t that.

Spotted in upstream ovn-org/ovn CI when running against ovn versions <=22.09 which don't support component templates:

https://github.com/ovn-org/ovn/actions/runs/4628617882

Reported error:
  failed to sync chassis: error: failed to get template var list: error:
  Wrong parameter type (*nbdb.ChassisTemplateVar): Model not found in
  Database Model

Fixes: 4b3475abb4a2 ("services: Use OVN template load balancers for NodePort services.")
