### PR TITLE
Start to remove the fakeAddressSet

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -88,7 +88,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOVN = NewFakeOVN()
+		fakeOVN = NewFakeOVN(true)
 		clusterPortGroup = newClusterPortGroup()
 		nodeSwitch = &nbdb.LogicalSwitch{
 			UUID: node1Name + "-UUID",
@@ -1121,7 +1121,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 		app.Flags = config.Flags
 
 		dbSetup := libovsdbtest.TestSetup{}
-		fakeOVN = NewFakeOVN()
+		fakeOVN = NewFakeOVN(true)
 		a := newObjectMeta(node1Name, "")
 		a.Labels = nodeLabel
 		node1 := v1.Node{

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -77,6 +77,16 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = fakeOVN.controller.WatchEgressFirewall()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		for _, namespace := range namespaces {
+			namespaceASip4, namespaceASip6 := buildNamespaceAddressSets(namespace.Name, []net.IP{})
+			if config.IPv4Mode {
+				initialData = append(initialData, namespaceASip4)
+			}
+			if config.IPv6Mode {
+				initialData = append(initialData, namespaceASip6)
+			}
+		}
 	}
 
 	ginkgo.BeforeEach(func() {
@@ -88,7 +98,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOVN = NewFakeOVN(true)
+		fakeOVN = NewFakeOVN(false)
 		clusterPortGroup = newClusterPortGroup()
 		nodeSwitch = &nbdb.LogicalSwitch{
 			UUID: node1Name + "-UUID",
@@ -151,6 +161,9 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					purgeACL2.UUID = "purgeACL2-UUID"
 
 					namespace1 := *newNamespace("namespace1")
+
+					namespace1ASip4, _ := buildNamespaceAddressSets(namespace1.Name, []net.IP{})
+
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
 							Type: "Allow",
@@ -203,6 +216,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							joinSwitch,
 							clusterRouter,
 							clusterPortGroup,
+							namespace1ASip4,
 						},
 					}
 
@@ -234,6 +248,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						joinSwitch,
 						clusterRouter,
 						clusterPortGroup,
+						namespace1ASip4,
 					}
 
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
@@ -513,10 +528,14 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				app.Action = func(ctx *cli.Context) error {
 					expectedOVNClusterRouter := newOVNClusterRouter()
 					expectedClusterPortGroup := newClusterPortGroup()
+					namespace1 := *newNamespace("namespace1")
+
+					namespace1ASip4, _ := buildNamespaceAddressSets(namespace1.Name, []net.IP{})
 
 					initialTestData := []libovsdbtest.TestData{
 						expectedOVNClusterRouter,
 						expectedClusterPortGroup,
+						namespace1ASip4,
 					}
 					dbSetup := libovsdbtest.TestSetup{
 						NBData: initialTestData,
@@ -525,7 +544,6 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					labelKey := "name"
 					labelValue := "test"
 					selector := metav1.LabelSelector{MatchLabels: map[string]string{labelKey: labelValue}}
-					namespace1 := *newNamespace("namespace1")
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
 							Type: "Allow",
@@ -600,7 +618,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					// new ACL will be added to the port group
 					expectedClusterPortGroup.ACLs = []string{ipv4ACL.UUID}
-					expectedDatabaseState := []libovsdb.TestData{expectedClusterPortGroup, ipv4ACL, expectedOVNClusterRouter}
+					expectedDatabaseState := []libovsdb.TestData{expectedClusterPortGroup, ipv4ACL, expectedOVNClusterRouter, namespace1ASip4}
 
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
@@ -625,6 +643,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				config.Gateway.Mode = gwMode
 				app.Action = func(ctx *cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
+					namespace1ASip4, _ := buildNamespaceAddressSets(namespace1.Name, []net.IP{})
+
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
 							Type: "Allow",
@@ -639,7 +659,6 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							},
 						},
 					})
-
 					fakeOVN.startWithDBSetup(dbSetup,
 						&egressfirewallapi.EgressFirewallList{
 							Items: []egressfirewallapi.EgressFirewall{
@@ -683,7 +702,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 
 					// new ACL will be added to the port group
 					clusterPortGroup.ACLs = []string{ipv4ACL.UUID}
-					expectedDatabaseState := append(initialData, ipv4ACL)
+					expectedDatabaseState := append(initialData, ipv4ACL, namespace1ASip4)
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 					ginkgo.By("Bringing down NBDB")
@@ -716,7 +735,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					// ACL should be removed from the port group after egfw is deleted
 					clusterPortGroup.ACLs = []string{}
 					// this ACL will be deleted when test server starts deleting dereferenced ACLs
-					expectedDatabaseState = append(initialData, ipv4ACL)
+					expectedDatabaseState = append(initialData, ipv4ACL, namespace1ASip4)
 
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 					// check the cache no longer has the entry
@@ -894,6 +913,14 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						labelValue := "test"
 						selector := metav1.LabelSelector{MatchLabels: map[string]string{labelKey: labelValue}}
 						namespace1 := *newNamespace("namespace1")
+						namespaceASip4, namespaceASip6 := buildNamespaceAddressSets(namespace1.Name, []net.IP{})
+						if config.IPv4Mode {
+							initialData = append(initialData, namespaceASip4)
+						}
+						if config.IPv6Mode {
+							initialData = append(initialData, namespaceASip6)
+						}
+
 						egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 							{
 								Type: "Allow",
@@ -1121,7 +1148,7 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 		app.Flags = config.Flags
 
 		dbSetup := libovsdbtest.TestSetup{}
-		fakeOVN = NewFakeOVN(true)
+		fakeOVN = NewFakeOVN(false)
 		a := newObjectMeta(node1Name, "")
 		a.Labels = nodeLabel
 		node1 := v1.Node{

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -46,7 +46,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN()
+		fakeOvn = NewFakeOVN(true)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -245,7 +245,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN()
+		fakeOvn = NewFakeOVN(true)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/go-controller/pkg/ovn/egressqos_test.go
+++ b/go-controller/pkg/ovn/egressqos_test.go
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOVN = NewFakeOVN()
+		fakeOVN = NewFakeOVN(true)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -59,7 +59,7 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOVN = NewFakeOVN()
+		fakeOVN = NewFakeOVN(true)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -342,7 +342,7 @@ var _ = ginkgo.Describe("Gateway Init Operations", func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
 
-		fakeOvn = NewFakeOVN()
+		fakeOvn = NewFakeOVN(true)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/go-controller/pkg/ovn/multicast_test.go
+++ b/go-controller/pkg/ovn/multicast_test.go
@@ -342,7 +342,7 @@ var _ = ginkgo.Describe("OVN Multicast with IP Address Family", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN()
+		fakeOvn = NewFakeOVN(true)
 		gomegaFormatMaxLength = format.MaxLength
 		format.MaxLength = 0
 	})

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -86,7 +86,7 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 		err := config.PrepareTestConfig()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		fakeOvn = NewFakeOVN()
+		fakeOvn = NewFakeOVN(true)
 		wg = &sync.WaitGroup{}
 	})
 

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -2,10 +2,12 @@ package ovn
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -67,6 +69,14 @@ func newNamespace(namespace string) *v1.Namespace {
 
 func getNsAddrSetHashNames(ns string) (string, string) {
 	return addressset.GetHashNamesForAS(getNamespaceAddrSetDbIDs(ns, DefaultNetworkControllerName))
+}
+
+func buildNamespaceAddressSets(namespace string, ips []net.IP) (*nbdb.AddressSet, *nbdb.AddressSet) {
+	v4set, v6set := addressset.GetDbObjsForAS(getNamespaceAddrSetDbIDs(namespace, "default-network-controller"), ips)
+
+	v4set.UUID = fmt.Sprintf("%s-ipv4-addrSet", namespace)
+	v6set.UUID = fmt.Sprintf("%s-ipv6-addrSet", namespace)
+	return v4set, v6set
 }
 
 var _ = ginkgo.Describe("OVN Namespace Operations", func() {

--- a/go-controller/pkg/ovn/pod_selector_address_set_test.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set_test.go
@@ -45,7 +45,7 @@ var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
 	ginkgo.BeforeEach(func() {
 		// Restore global default values before each testcase
 		config.PrepareTestConfig()
-		fakeOvn = NewFakeOVN()
+		fakeOvn = NewFakeOVN(true)
 		initialData := getHairpinningACLsV4AndPortGroup()
 		initialDB = libovsdbtest.TestSetup{
 			NBData: initialData,

--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -248,7 +248,7 @@ var _ = ginkgo.Describe("OVN Pod Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN()
+		fakeOvn = NewFakeOVN(true)
 		initialDB = libovsdbtest.TestSetup{
 			NBData: []libovsdbtest.TestData{
 				&nbdb.LogicalSwitch{

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -527,7 +527,7 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 		app.Name = "test"
 		app.Flags = config.Flags
 
-		fakeOvn = NewFakeOVN()
+		fakeOvn = NewFakeOVN(true)
 
 		gomegaFormatMaxLength = format.MaxLength
 		format.MaxLength = 0


### PR DESCRIPTION
The FakeAddressSetFactory and by extension FakeAddressSet where created back when we where testing using ovn commands as a way to see the addresssets and how they change over time. Since the introduction of libovsdb and the ovn database used for testing we no longer need FakeAddressSetFactory to see how the addressSets change. we can query the database itself. 

Since addressSets are used in wide areas of the code I made this PR so that we can remove the useage of FakeAddressSetFactory over time and not require one large PR that removes the whole thing. 

This PR just removes the FakeAddressSet from egressfirewall_test.go







<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->