### PR TITLE
Convert unsortedList() to sets.List()

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -93,7 +93,7 @@ func (c *addressManager) delAddr(ip net.IP) bool {
 func (c *addressManager) ListAddresses() []net.IP {
 	c.Lock()
 	defer c.Unlock()
-	addrs := c.addresses.UnsortedList()
+	addrs := sets.List(c.addresses)
 	out := make([]net.IP, 0, len(addrs))
 	for _, addr := range addrs {
 		ip := net.ParseIP(addr)

--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -613,7 +613,7 @@ func splitIPsByFamily(ips []net.IP) (v4 []net.IP, v6 []net.IP) {
 
 // Takes a slice of IPs and returns a slice with unique IPs
 func ipsToStringUnique(ips []net.IP) []string {
-	s := sets.NewString()
+	s := sets.New[string]()
 	for _, ip := range ips {
 		s.Insert(ip.String())
 	}

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -409,7 +409,7 @@ func (oc *DefaultNetworkController) deletePodGWRoutesForNamespace(pod *kapi.Pod,
 		return fmt.Errorf("failed to delete GW routes for pod %s: %w", pod.Name, err)
 	}
 	// remove the exgw podIP from the namespace's k8s.ovn.org/external-gw-pod-ips list
-	if err := util.UpdateExternalGatewayPodIPsAnnotation(oc.kube, namespace, existingGWs.UnsortedList()); err != nil {
+	if err := util.UpdateExternalGatewayPodIPsAnnotation(oc.kube, namespace, sets.List(existingGWs)); err != nil {
 		klog.Errorf("Unable to update %s/%v annotation for namespace %s: %v", util.ExternalGatewayPodIPsAnnotation, existingGWs, namespace, err)
 	}
 	return nil

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -582,7 +582,7 @@ func (oc *DefaultNetworkController) addPolicyBasedRoutes(nodeName, mgmtPortIP st
 // N+2 is fully made.
 func (oc *DefaultNetworkController) syncPolicyBasedRoutes(nodeName string, matches sets.Set[string], priority, nexthop string) error {
 	// create a map to track matches found
-	matchTracker := sets.NewString(matches.UnsortedList()...)
+	matchTracker := sets.New(sets.List(matches)...)
 
 	if priority == types.NodeSubnetPolicyPriority {
 		policies, err := oc.findPolicyBasedRoutes(priority)

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -341,7 +341,7 @@ func (oc *DefaultNetworkController) syncGatewayLogicalNetwork(node *kapi.Node, l
 		if err != nil {
 			return err
 		}
-		relevantHostIPs, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(hostIfAddr.IP), hostAddrs.UnsortedList())
+		relevantHostIPs, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(hostIfAddr.IP), sets.List(hostAddrs))
 		if err != nil && err != util.NoIPError {
 			return err
 		}

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -104,7 +104,7 @@ func (oc *DefaultNetworkController) getRoutingExternalGWs(nsInfo *namespaceInfo)
 	// return a copy of the object so it can be handled without the
 	// namespace locked
 	res.bfdEnabled = nsInfo.routingExternalGWs.bfdEnabled
-	res.gws = sets.New[string](nsInfo.routingExternalGWs.gws.UnsortedList()...)
+	res.gws = sets.New(nsInfo.routingExternalGWs.gws.UnsortedList()...)
 	return &res
 }
 
@@ -131,7 +131,7 @@ func (oc *DefaultNetworkController) getRoutingPodGWs(nsInfo *namespaceInfo) map[
 	for k, v := range nsInfo.routingExternalPodGWs {
 		item := gatewayInfo{
 			bfdEnabled: v.bfdEnabled,
-			gws:        sets.New[string](v.gws.UnsortedList()...),
+			gws:        sets.New(v.gws.UnsortedList()...),
 		}
 		res[k] = item
 	}

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -537,7 +537,7 @@ func GetNodeEgressLabel() string {
 }
 
 func SetNodeHostAddresses(nodeAnnotator kube.Annotator, addresses sets.Set[string]) error {
-	return nodeAnnotator.Set(ovnNodeHostAddresses, addresses.UnsortedList())
+	return nodeAnnotator.Set(ovnNodeHostAddresses, sets.List(addresses))
 }
 
 // ParseNodeHostAddresses returns the parsed host addresses living on a node


### PR DESCRIPTION
During the kube 1.26 bump the sets[type].List() call was deprecated and replaced with unsortedList(). This could cause some flakes as we depend on the order of the set in some cases. This fix updates the unsortedList calls to use the sets List function




**- Description for the changelog**
use sets.List instead of unsortedList 
