### PR TITLE
Expose PfID and VfID in DPU host mode and read that in DPU mode

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -2447,11 +2447,14 @@ func buildOvnKubeNodeConfig(ctx *cli.Context, cli, file *config) error {
 			OvnKubeNode.MgmtPortNetdev, OvnKubeNode.MgmtPortDPResourceName)
 	}
 
-	// when DPU is used, management port is backed by a VF. get management port VF information
-	if OvnKubeNode.Mode == types.NodeModeDPU || OvnKubeNode.Mode == types.NodeModeDPUHost {
-		if OvnKubeNode.MgmtPortNetdev == "" && OvnKubeNode.MgmtPortDPResourceName == "" {
-			return fmt.Errorf("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must be provided")
-		}
+	// when DPU is used, management port is always backed by a representor. On the
+	// host side, it needs to be provided through --ovnkube-node-mgmt-port-netdev.
+	// On the DPU, it is derrived from the annotation exposed on the host side.
+	if OvnKubeNode.Mode == types.NodeModeDPU && !(OvnKubeNode.MgmtPortNetdev == "" && OvnKubeNode.MgmtPortDPResourceName == "") {
+		return fmt.Errorf("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must not be provided")
+	}
+	if OvnKubeNode.Mode == types.NodeModeDPUHost && OvnKubeNode.MgmtPortNetdev == "" && OvnKubeNode.MgmtPortDPResourceName == "" {
+		return fmt.Errorf("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must be provided")
 	}
 	return nil
 }

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -1682,29 +1682,25 @@ foo=bar
 			}
 			file := config{
 				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                   types.NodeModeDPU,
-					MgmtPortNetdev:         "enp1s0f0v0",
-					MgmtPortDPResourceName: "openshift.io/mgmtvf",
+					Mode: types.NodeModeDPU,
 				},
 			}
 			err := buildOvnKubeNodeConfig(nil, &cliConfig, &file)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeDPU))
-			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal("enp1s0f0v0"))
-			gomega.Expect(OvnKubeNode.MgmtPortDPResourceName).To(gomega.Equal("openshift.io/mgmtvf"))
 		})
 
 		It("Overrides value from CLI", func() {
 			cliConfig := config{
 				OvnKubeNode: OvnKubeNodeConfig{
-					Mode:                   types.NodeModeDPU,
+					Mode:                   types.NodeModeDPUHost,
 					MgmtPortNetdev:         "enp1s0f0v0",
 					MgmtPortDPResourceName: "openshift.io/mgmtvf",
 				},
 			}
 			err := buildOvnKubeNodeConfig(nil, &cliConfig, &config{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeDPU))
+			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeDPUHost))
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal("enp1s0f0v0"))
 			gomega.Expect(OvnKubeNode.MgmtPortDPResourceName).To(gomega.Equal("openshift.io/mgmtvf"))
 		})
@@ -1733,15 +1729,16 @@ foo=bar
 				"hybrid overlay is not supported with ovnkube-node mode"))
 		})
 
-		It("Fails if management port is not provided and ovnkube node mode is dpu", func() {
+		It("Fails if management port is provided and ovnkube node mode is dpu", func() {
 			cliConfig := config{
 				OvnKubeNode: OvnKubeNodeConfig{
-					Mode: types.NodeModeDPU,
+					Mode:           types.NodeModeDPU,
+					MgmtPortNetdev: "enp1s0f0v0",
 				},
 			}
 			err := buildOvnKubeNodeConfig(nil, &cliConfig, &config{})
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must be provided"))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("ovnkube-node-mgmt-port-netdev or ovnkube-node-mgmt-port-dp-resource-name must not be provided"))
 		})
 
 		It("Fails if management port is not provided and ovnkube node mode is dpu-host", func() {

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -676,7 +676,6 @@ func shareGatewayInterfaceDPUTest(app *cli.App, testNS ns.NetNS,
 		"--nodeport",
 		"--mtu=" + mtu,
 		"--ovnkube-node-mode=" + types.NodeModeDPU,
-		"--ovnkube-node-mgmt-port-netdev=pf0vf0",
 	})
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/go-controller/pkg/node/management-port-dpu.go
+++ b/go-controller/pkg/node/management-port-dpu.go
@@ -55,7 +55,7 @@ func (mp *managementPortRepresentor) Create(_ *routeManager, nodeAnnotator kube.
 		if err != nil {
 			return nil, fmt.Errorf("failed to get link device for %s. %v", mp.repName, err)
 		}
-	} else if mp.repName != k8sMgmtIntfName {
+	} else if link.Attrs().Name != k8sMgmtIntfName {
 		if err := syncMgmtPortInterface(mp.hostSubnets, k8sMgmtIntfName, false); err != nil {
 			return nil, fmt.Errorf("failed to check existing management port: %v", err)
 		}
@@ -193,7 +193,7 @@ func (mp *managementPortNetdev) Create(routeManager *routeManager, nodeAnnotator
 		if err != nil {
 			return nil, fmt.Errorf("failed to get link device for %s. %v", mp.netdevName, err)
 		}
-	} else if mp.netdevName != types.K8sMgmtIntfName {
+	} else if link.Attrs().Name != types.K8sMgmtIntfName {
 		err = syncMgmtPortInterface(mp.hostSubnets, types.K8sMgmtIntfName, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to sync management port: %v", err)

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -33,7 +33,7 @@ type ManagementPort interface {
 }
 
 // NewManagementPorts creates a new ManagementPorts
-func NewManagementPorts(nodeName string, hostSubnets []*net.IPNet) []ManagementPort {
+func NewManagementPorts(nodeName string, hostSubnets []*net.IPNet, netdevName, rep string) []ManagementPort {
 	// Kubernetes emits events when pods are created. The event will contain
 	// only lowercase letters of the hostname even though the kubelet is
 	// started with a hostname that contains lowercase and uppercase letters.
@@ -46,17 +46,17 @@ func NewManagementPorts(nodeName string, hostSubnets []*net.IPNet) []ManagementP
 
 	switch config.OvnKubeNode.Mode {
 	case types.NodeModeDPU:
-		return []ManagementPort{newManagementPortRepresentor(nodeName, hostSubnets)}
+		return []ManagementPort{newManagementPortRepresentor(nodeName, hostSubnets, rep)}
 	case types.NodeModeDPUHost:
-		return []ManagementPort{newManagementPortNetdev(hostSubnets)}
+		return []ManagementPort{newManagementPortNetdev(hostSubnets, netdevName)}
 	default:
 		// create OVS internal port or configure netdevice and its representor
 		if config.OvnKubeNode.MgmtPortNetdev == "" {
 			return []ManagementPort{newManagementPort(nodeName, hostSubnets)}
 		} else {
 			return []ManagementPort{
-				newManagementPortNetdev(hostSubnets),
-				newManagementPortRepresentor(nodeName, hostSubnets),
+				newManagementPortNetdev(hostSubnets, netdevName),
+				newManagementPortRepresentor(nodeName, hostSubnets, rep),
 			}
 		}
 	}

--- a/go-controller/pkg/node/management-port_dpu_test.go
+++ b/go-controller/pkg/node/management-port_dpu_test.go
@@ -149,10 +149,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: "ovn-k8s-mp0", MTU: config.Default.MTU})
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
-				nil, fmt.Errorf("failed to get link device"))
-			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
 				linkMock, nil)
-			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
@@ -245,16 +242,6 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			linkMock := &mocks.Link{}
 			linkMock.On("Attrs").Return(&netlink.LinkAttrs{
 				Name: "ovn-k8s-mp0", MTU: 1400, HardwareAddr: expectedMgmtPortMac})
-
-			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
-				nil, fmt.Errorf("failed to get link")).Once()
-			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
-				linkMock, nil).Once()
-			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil, nil).Once()
-			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
-			execMock.AddFakeCmdsNoOutputNoError([]string{
-				"ovs-vsctl --timeout=15 set Open_vSwitch . external-ids:ovn-orig-mgmt-port-netdev-name=" + mgmtPortDpuHost.netdevName,
-			})
 
 			// mock createPlatformManagementPort, we fail it as it covers what we want to test without the
 			// need to mock the entire flow down to routes and iptable rules.

--- a/go-controller/pkg/node/management-port_test.go
+++ b/go-controller/pkg/node/management-port_test.go
@@ -16,36 +16,36 @@ var _ = Describe("Mananagement port tests", func() {
 
 	Context("NewManagementPort Creates Management port object according to config.OvnKubeNode.Mode", func() {
 		It("Creates managementPort by default", func() {
-			mgmtPorts := NewManagementPorts("worker-node", nil)
+			mgmtPorts := NewManagementPorts("worker-node", nil, "", "")
 			Expect(len(mgmtPorts)).To(Equal(1))
 			Expect(reflect.TypeOf(mgmtPorts[0]).String()).To(Equal(reflect.TypeOf(&managementPort{}).String()))
 		})
 		It("Creates managementPortRepresentor for Ovnkube Node mode dpu", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPU
-			config.OvnKubeNode.MgmtPortNetdev = "ens1f0v0"
-			mgmtPorts := NewManagementPorts("worker-node", nil)
+			netdevName, rep := "", "ens1f0v0"
+			mgmtPorts := NewManagementPorts("worker-node", nil, netdevName, rep)
 			Expect(len(mgmtPorts)).To(Equal(1))
 			Expect(reflect.TypeOf(mgmtPorts[0]).String()).To(Equal(reflect.TypeOf(&managementPortRepresentor{}).String()))
 			port, _ := mgmtPorts[0].(*managementPortRepresentor)
-			Expect(port.repName).To(Equal("ens1f0v0"))
+			Expect(port.repName).To(Equal(rep))
 		})
 		It("Creates managementPortNetdev for Ovnkube Node mode dpu-host", func() {
 			config.OvnKubeNode.Mode = types.NodeModeDPUHost
-			mgmtPorts := NewManagementPorts("worker-node", nil)
+			mgmtPorts := NewManagementPorts("worker-node", nil, "", "")
 			Expect(len(mgmtPorts)).To(Equal(1))
 			Expect(reflect.TypeOf(mgmtPorts[0]).String()).To(Equal(reflect.TypeOf(&managementPortNetdev{}).String()))
 		})
 		It("Creates managementPortNetdev and managementPortRepresentor for Ovnkube Node mode full", func() {
 			config.OvnKubeNode.MgmtPortNetdev = "ens1f0v0"
-			mgmtPorts := NewManagementPorts("worker-node", nil)
+			mgmtPorts := NewManagementPorts("worker-node", nil, "", "")
 			Expect(len(mgmtPorts)).To(Equal(2))
 			Expect(reflect.TypeOf(mgmtPorts[0]).String()).To(Equal(reflect.TypeOf(&managementPortNetdev{}).String()))
 			Expect(reflect.TypeOf(mgmtPorts[1]).String()).To(Equal(reflect.TypeOf(&managementPortRepresentor{}).String()))
 		})
 		It("Creates managementPortNetdev and managementPortRepresentor with proper device names", func() {
-			config.OvnKubeNode.MgmtPortNetdev = "ens1f0v0"
-			config.OvnKubeNode.MgmtPortRepresentor = "ens1f0_0"
-			mgmtPorts := NewManagementPorts("worker-node", nil)
+			netdevName, rep := "ens1f0v0", "ens1f0_0"
+			config.OvnKubeNode.MgmtPortNetdev = netdevName
+			mgmtPorts := NewManagementPorts("worker-node", nil, netdevName, rep)
 			Expect(len(mgmtPorts)).To(Equal(2))
 			Expect(reflect.TypeOf(mgmtPorts[1]).String()).To(Equal(reflect.TypeOf(&managementPortRepresentor{}).String()))
 			port, _ := mgmtPorts[1].(*managementPortRepresentor)


### PR DESCRIPTION
Currently, the vf rep needs to be specified manually on the DPU side, but given a configuration on the host side, there is only one correct configuration on the DPU side. Instead of relying on the user to provide the right config on both sides, expose the config on the host side through an annotation and read that annotation from the DPU side.