### PR TITLE
Make --gateway-nexthop support dual-stack

### DIFF
--- a/go-controller/pkg/node/gateway_init.go
+++ b/go-controller/pkg/node/gateway_init.go
@@ -140,20 +140,42 @@ func getGatewayNextHops() ([]net.IP, string, error) {
 		needIPv6NextHop = true
 	}
 
-	// FIXME DUAL-STACK: config.Gateway.NextHop should be a slice of nexthops
 	if config.Gateway.NextHop != "" {
-		// Parse NextHop to make sure it is valid before using. Return error if not valid.
-		nextHop := net.ParseIP(config.Gateway.NextHop)
-		if nextHop == nil {
-			return nil, "", fmt.Errorf("failed to parse configured next-hop: %s", config.Gateway.NextHop)
+		nextHopsRaw := strings.Split(config.Gateway.NextHop, ",")
+		if len(nextHopsRaw) > 2 {
+			return nil, "", fmt.Errorf("unexpected next-hops are provided, more than 2 next-hops is not allowed: %s", config.Gateway.NextHop)
 		}
-		if config.IPv4Mode && !utilnet.IsIPv6(nextHop) {
-			gatewayNextHops = append(gatewayNextHops, nextHop)
-			needIPv4NextHop = false
-		}
-		if config.IPv6Mode && utilnet.IsIPv6(nextHop) {
-			gatewayNextHops = append(gatewayNextHops, nextHop)
-			needIPv6NextHop = false
+		for _, nh := range nextHopsRaw {
+			// Parse NextHop to make sure it is valid before using. Return error if not valid.
+			nextHop := net.ParseIP(nh)
+			if nextHop == nil {
+				return nil, "", fmt.Errorf("failed to parse configured next-hop: %s", config.Gateway.NextHop)
+			}
+			if config.IPv4Mode {
+				if needIPv4NextHop {
+					if !utilnet.IsIPv6(nextHop) {
+						gatewayNextHops = append(gatewayNextHops, nextHop)
+						needIPv4NextHop = false
+					}
+				} else {
+					if !utilnet.IsIPv6(nextHop) {
+						return nil, "", fmt.Errorf("only one IPv4 next-hop is allowed: %s", config.Gateway.NextHop)
+					}
+				}
+			}
+
+			if config.IPv6Mode {
+				if needIPv6NextHop {
+					if utilnet.IsIPv6(nextHop) {
+						gatewayNextHops = append(gatewayNextHops, nextHop)
+						needIPv6NextHop = false
+					}
+				} else {
+					if utilnet.IsIPv6(nextHop) {
+						return nil, "", fmt.Errorf("only one IPv6 next-hop is allowed: %s", config.Gateway.NextHop)
+					}
+				}
+			}
 		}
 	}
 	gatewayIntf := config.Gateway.Interface

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -58,7 +58,7 @@ func getDefaultGatewayInterfaceByFamily(family int, gwIface string) (string, net
 	gwIfIdx := 0
 	// gw interface provided
 	if len(gwIface) > 0 {
-		link, err := netlink.LinkByName(gwIface)
+		link, err := util.GetNetLinkOps().LinkByName(gwIface)
 		if err != nil {
 			return "", nil, fmt.Errorf("error looking up gw interface: %q, error: %w", gwIface, err)
 		}
@@ -69,7 +69,7 @@ func getDefaultGatewayInterfaceByFamily(family int, gwIface string) (string, net
 		klog.Infof("Provided gateway interface %q, found as index: %d", gwIface, gwIfIdx)
 	}
 
-	routeList, err := netlink.RouteListFiltered(family, filter, mask)
+	routeList, err := util.GetNetLinkOps().RouteListFiltered(family, filter, mask)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "failed to get routing table in node")
 	}
@@ -78,7 +78,7 @@ func getDefaultGatewayInterfaceByFamily(family int, gwIface string) (string, net
 	for _, r := range routes {
 		// no multipath
 		if len(r.MultiPath) == 0 {
-			intfLink, err := netlink.LinkByIndex(r.LinkIndex)
+			intfLink, err := util.GetNetLinkOps().LinkByIndex(r.LinkIndex)
 			if err != nil {
 				klog.Warningf("Failed to get interface link for route %v : %v", r, err)
 				continue
@@ -104,7 +104,7 @@ func getDefaultGatewayInterfaceByFamily(family int, gwIface string) (string, net
 		// TODO: revisit for full multipath support
 		// xref: https://github.com/vishvananda/netlink/blob/6ffafa9fc19b848776f4fd608c4ad09509aaacb4/route.go#L137-L145
 		for _, nh := range r.MultiPath {
-			intfLink, err := netlink.LinkByIndex(nh.LinkIndex)
+			intfLink, err := util.GetNetLinkOps().LinkByIndex(nh.LinkIndex)
 			if err != nil {
 				klog.Warningf("Failed to get interface link for route %v : %v", nh, err)
 				continue


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Users can specify IPV4 and IPv6 gateway nexthop for dual-stack cluster with '--gateway-nexthop=<ipv4_addr>,<ipv6_addr>'

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->