### PR TITLE
Ensure Routes are Restored to new vNIC fixes #3119

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_windows.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_windows.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 
+	ps "github.com/bhendo/go-powershell"
+	psBackend "github.com/bhendo/go-powershell/backend"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
@@ -128,22 +130,30 @@ func ensureBaseNetwork() error {
 		return fmt.Errorf("unable to generate a schema to create a base overlay network, error: %v", err)
 	}
 
+	shell, err := ps.New(&psBackend.Local{})
+	if err != nil {
+		return err
+	}
+	defer shell.Exit()
+
+	klog.Infof("Retrieving routes to cache prior network creation")
+	if _, stderr, err := shell.Execute("$routes = Get-NetRoute -AddressFamily IPv4 | select InterfaceIndex,DestinationPrefix,NextHop,RouteMetric"); err != nil {
+		return fmt.Errorf("unable to retrieve routes, this is fatal. %v: %v", stderr, err)
+	}
+
 	klog.Infof("Base network creation may take up to a minute to complete...")
 	// Create the base network from schema object
 	if _, err = baseNetworkSchema.Create(); err != nil {
 		return fmt.Errorf("unable to create the base overlay network, error: %v", err)
 	}
 
+	klog.Infof("Network created. Repopulating routes")
+
 	// Workaround for a limitation in the Windows HNS service. We need
 	// to manually duplicate persistent routes that used to be on the
 	// physical network interface to the newly created host vNIC
-	if err = DuplicatePersistentIPRoutes(); err != nil {
-		return fmt.Errorf("unable to refresh the persistent IP routes, error: %v", err)
-	}
-	// Duplicate link-local addresses to the newly created host vNIC
-	klog.Infof("Forwarding routes associated with link-local addresses in the physical interface to the vNIC")
-	if err = DuplicateLinkLocalIPRoutes(); err != nil {
-		return fmt.Errorf("unable to refresh the link-local IP routes, error: %v", err)
+	if err = DuplicateIPv4Routes(shell); err != nil {
+		return fmt.Errorf("unable to refresh the routes, error: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
fixes #3119

During the network creation a vnic is created however the routes from the parent vnic are not moved over to the associated vnic resulting in a network outage. This PR fixes this by caching the routes prior the creation so they can be restored after the network creation and associated to the new vnic. Netsh was also replaced with a more appropriate Powershell Cmdlet. One spelling mistake was resolved. 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
@aravindhp can you provide the details on how this was tested?

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Caches routes prior to network creation and applies them to the newly created vnic