### PR TITLE
OVS Dynamic CPU Affinity

### DIFF
--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -85,7 +85,7 @@ spec:
           name: host-ovn-cert
           readOnly: true
         - mountPath: /etc/openvswitch/
-          name: host-var-lib-ovs
+          name: host-etc-ovs
           readOnly: true
         - mountPath: /etc/ovn/
           name: host-var-lib-ovs
@@ -381,6 +381,9 @@ spec:
       - name: host-var-lib-ovs
         hostPath:
           path: /var/lib/openvswitch
+      - name: host-etc-ovs
+        hostPath:
+          path: /etc/openvswitch
       {%- elif ovnkube_app_name=="ovnkube-node-dpu-host" %}
       - name: var-run-ovn
         emptyDir: {}

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/egressservice"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/controllers/upgrade"
 	nodeipt "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/ovspinning"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
 	retry "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -916,6 +917,12 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 			c.Run(1)
 		}()
 	}
+
+	nc.wg.Add(1)
+	go func() {
+		defer nc.wg.Done()
+		ovspinning.Run(nc.stopChan)
+	}()
 
 	klog.Infof("Default node network controller initialized and ready.")
 	return nil

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux.go
@@ -1,0 +1,191 @@
+//go:build linux
+// +build linux
+
+package ovspinning
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+// These variables are meant to be used in unit tests
+var tickDuration time.Duration = 10 * time.Second
+var getOvsVSwitchdPIDFn func() (string, error) = util.GetOvsVSwitchdPID
+var getOvsDBServerPIDFn func() (string, error) = util.GetOvsDBServerPID
+var featureEnablerFile string = "/etc/openvswitch/enable_dynamic_cpu_affinity"
+
+// Run monitors OVS daemon's processes (ovs-vswitchd and ovsdb-server) and sets their CPU affinity
+// masks to that of the current process.
+// This feature is enabled by the presence of a non-empty file in the path `/etc/openvswitch/enable_dynamic_cpu_affinity`
+func Run(stopCh <-chan struct{}) {
+
+	// The file must be present at startup to enable the feature
+	isFeatureEnabled, err := isFileNotEmpty(featureEnablerFile)
+	if err != nil {
+		klog.Warningf("Can't start OVS CPU affinity pinning: %v", err)
+		return
+	}
+
+	if !isFeatureEnabled {
+		klog.Info("OVS CPU affinity pinning disabled")
+		return
+	}
+
+	klog.Infof("Starting OVS daemon CPU pinning")
+	defer klog.Infof("Stopping OVS daemon CPU pinning")
+
+	var fsnotifyEvents chan fsnotify.Event
+	var fsnotifyErrors chan error
+	fileWatcher, err := createFileWatcherFor(featureEnablerFile)
+	if err != nil {
+		klog.Warningf("Can't create a watcher for %s. Pinning will not stop by deleting it: %v", featureEnablerFile, err)
+		fsnotifyEvents = make(chan fsnotify.Event)
+		fsnotifyErrors = make(chan error)
+	} else {
+		fsnotifyEvents = fileWatcher.Events
+		fsnotifyErrors = fileWatcher.Errors
+		defer fileWatcher.Close()
+	}
+
+	ticker := time.NewTicker(tickDuration)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case event, ok := <-fsnotifyEvents:
+			if !ok {
+				continue
+			}
+
+			if event.Op.Has(fsnotify.Remove) {
+				klog.Infof("File [%s] has been removed. To re-enable the feature, restart ovnkube-node", featureEnablerFile)
+				return
+			}
+
+			isFeatureEnabled, err = isFileNotEmpty(featureEnablerFile)
+			if err != nil {
+				klog.Warningf("Error while reading [%s]: %v", featureEnablerFile, err)
+				return
+			}
+
+			if !isFeatureEnabled {
+				klog.Infof("File [%s] is empty or missing. To re-enable the feature, restart ovnkube-node", featureEnablerFile)
+				return
+			}
+
+		case err, ok := <-fsnotifyErrors:
+			if ok {
+				klog.Errorf("Error watching for file [%s] changes: %s", featureEnablerFile, err)
+			}
+
+		case <-stopCh:
+			return
+
+		case <-ticker.C:
+			if !isFeatureEnabled {
+				continue
+			}
+
+			err := setOvsVSwitchdCPUAffinity()
+			if err != nil {
+				klog.Warningf("Error while aligning ovs-vswitchd CPUs to current process: %v", err)
+			}
+
+			err = setOvsDBServerCPUAffinity()
+			if err != nil {
+				klog.Warningf("Error while aligning ovsdb-server CPUs to current process: %v", err)
+			}
+		}
+	}
+}
+
+func createFileWatcherFor(filename string) (*fsnotify.Watcher, error) {
+	fileWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create filesystem watcher: %w", err)
+	}
+
+	err = fileWatcher.Add(filename)
+	if err != nil {
+		return nil, fmt.Errorf("unable to watch [%s] file: %w", filename, err)
+	}
+
+	return fileWatcher, nil
+}
+
+func isFileNotEmpty(filename string) (bool, error) {
+	f, err := os.Stat(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("can't get file information [%s]: %w", filename, err)
+	}
+
+	// get the size
+	return f.Size() > 0, nil
+}
+
+func setOvsVSwitchdCPUAffinity() error {
+
+	ovsVSwitchdPID, err := getOvsVSwitchdPIDFn()
+	if err != nil {
+		return fmt.Errorf("can't retrieve ovs-vswitchd PID: %w", err)
+	}
+
+	klog.V(5).Info("Managing ovs-vswitchd[%s] daemon CPU affinity", ovsVSwitchdPID)
+	return setProcessCPUAffinity(ovsVSwitchdPID)
+}
+
+func setOvsDBServerCPUAffinity() error {
+
+	ovsDBserverPID, err := getOvsDBServerPIDFn()
+	if err != nil {
+		return fmt.Errorf("can't retrieve ovsdb-server PID: %w", err)
+	}
+
+	klog.V(5).Infof("Managing ovsdb-server[%s] daemon CPU affinity", ovsDBserverPID)
+	return setProcessCPUAffinity(ovsDBserverPID)
+}
+
+// setProcessCPUAffinity sets the CPU affinity of the given process to the same affinity as the current process
+func setProcessCPUAffinity(targetPIDStr string) error {
+
+	targetPID, err := strconv.Atoi(targetPIDStr)
+	if err != nil {
+		return fmt.Errorf("can't convert PID[%s] to integer: %w", targetPIDStr, err)
+	}
+
+	var currentProcessCPUs unix.CPUSet
+	err = unix.SchedGetaffinity(os.Getpid(), &currentProcessCPUs)
+	if err != nil {
+		return fmt.Errorf("can't get own CPU affinity")
+	}
+
+	var targetProcessCPUs unix.CPUSet
+	err = unix.SchedGetaffinity(targetPID, &targetProcessCPUs)
+	if err != nil {
+		return fmt.Errorf("can't get process (PID:%d) CPU affinity: %w", targetPID, err)
+	}
+
+	if currentProcessCPUs == targetProcessCPUs {
+		klog.V(5).Info("Process[%d] CPU affinity already match current process's affinity %x", targetPID, currentProcessCPUs)
+		return nil
+	}
+
+	klog.Infof("Setting CPU affinity of PID(%d) to %x, was %x", targetPID, currentProcessCPUs, targetProcessCPUs)
+
+	err = unix.SchedSetaffinity(targetPID, &currentProcessCPUs)
+	if err != nil {
+		return fmt.Errorf("can't set CPU affinity of PID(%d) to %x: %w", targetPID, currentProcessCPUs, err)
+	}
+
+	return nil
+}

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
@@ -1,0 +1,187 @@
+//go:build linux
+// +build linux
+
+package ovspinning
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+func TestAlignCPUAffinity(t *testing.T) {
+
+	ovsDBPid, ovsDBStop := mockOvsdbProcess(t)
+	defer ovsDBStop()
+
+	ovsVSwitchdPid, ovsVSwitchdStop := mockOvsVSwitchdProcess(t)
+	defer ovsVSwitchdStop()
+
+	defer setTickDuration(20 * time.Millisecond)()
+	defer mockFeatureEnableFile(t, "1")()
+
+	var wg sync.WaitGroup
+	stopCh := make(chan struct{})
+	defer func() {
+		close(stopCh)
+		wg.Wait()
+	}()
+
+	wg.Add(1)
+	go func() {
+		// Be sure the system under test goroutine is finished before cleaning
+		defer wg.Done()
+		Run(stopCh)
+	}()
+
+	var initialCPUset unix.CPUSet
+	err := unix.SchedGetaffinity(os.Getpid(), &initialCPUset)
+	assert.NoError(t, err)
+
+	defer func() {
+		// Restore any previous CPU affinity value it was in place before the test
+		err = unix.SchedSetaffinity(os.Getpid(), &initialCPUset)
+		assert.NoError(t, err)
+	}()
+
+	assert.Greater(t, runtime.NumCPU(), 1)
+
+	for i := 0; i < runtime.NumCPU(); i++ {
+		var tmpCPUset unix.CPUSet
+		tmpCPUset.Set(i)
+		err = unix.SchedSetaffinity(os.Getpid(), &tmpCPUset)
+		assert.NoError(t, err)
+
+		klog.Infof("Test CPU Affinity %x", tmpCPUset)
+
+		assertPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
+		assertPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
+	}
+
+	// Disable the feature by making the enabler file empty
+	ioutil.WriteFile(featureEnablerFile, []byte(""), 0)
+	assert.NoError(t, err)
+
+	var tmpCPUset unix.CPUSet
+	tmpCPUset.Set(0)
+	err = unix.SchedSetaffinity(os.Getpid(), &tmpCPUset)
+	assert.NoError(t, err)
+
+	assertNeverPIDHasSchedAffinity(t, ovsVSwitchdPid, tmpCPUset)
+	assertNeverPIDHasSchedAffinity(t, ovsDBPid, tmpCPUset)
+}
+
+func TestIsFileNotEmpty(t *testing.T) {
+
+	defer mockFeatureEnableFile(t, "")()
+
+	result, err := isFileNotEmpty(featureEnablerFile)
+	assert.NoError(t, err)
+	assert.False(t, result)
+
+	ioutil.WriteFile(featureEnablerFile, []byte("1"), 0)
+	result, err = isFileNotEmpty(featureEnablerFile)
+	assert.NoError(t, err)
+	assert.True(t, result)
+
+	os.Remove(featureEnablerFile)
+	result, err = isFileNotEmpty(featureEnablerFile)
+	assert.NoError(t, err)
+	assert.False(t, result)
+}
+
+func mockOvsdbProcess(t *testing.T) (int, func()) {
+	ctx, stopCmd := context.WithCancel(context.Background())
+	defer stopCmd()
+
+	cmd := exec.CommandContext(ctx, "sleep", "10")
+
+	err := cmd.Start()
+	assert.NoError(t, err)
+
+	previousGetter := getOvsDBServerPIDFn
+	getOvsDBServerPIDFn = func() (string, error) {
+		return fmt.Sprintf("%d", cmd.Process.Pid), nil
+	}
+
+	return cmd.Process.Pid, func() {
+		stopCmd()
+		getOvsDBServerPIDFn = previousGetter
+	}
+}
+
+func mockOvsVSwitchdProcess(t *testing.T) (int, func()) {
+	ctx, stopCmd := context.WithCancel(context.Background())
+	defer stopCmd()
+
+	cmd := exec.CommandContext(ctx, "sleep", "10")
+
+	err := cmd.Start()
+	assert.NoError(t, err)
+
+	previousGetter := getOvsVSwitchdPIDFn
+	getOvsVSwitchdPIDFn = func() (string, error) {
+		return fmt.Sprintf("%d", cmd.Process.Pid), nil
+	}
+
+	return cmd.Process.Pid, func() {
+		stopCmd()
+		getOvsVSwitchdPIDFn = previousGetter
+	}
+}
+
+func setTickDuration(d time.Duration) func() {
+	previousValue := tickDuration
+	tickDuration = d
+
+	return func() {
+		tickDuration = previousValue
+	}
+}
+
+func mockFeatureEnableFile(t *testing.T, data string) func() {
+
+	f, err := ioutil.TempFile("", "enable_dynamic_cpu_affinity")
+	assert.NoError(t, err)
+
+	previousValue := featureEnablerFile
+	featureEnablerFile = f.Name()
+
+	ioutil.WriteFile(featureEnablerFile, []byte(data), 0)
+	assert.NoError(t, err)
+
+	return func() {
+		featureEnablerFile = previousValue
+		os.Remove(f.Name())
+	}
+}
+
+func assertPIDHasSchedAffinity(t *testing.T, pid int, expectedCPUSet unix.CPUSet) {
+	var actual unix.CPUSet
+	assert.Eventually(t, func() bool {
+		err := unix.SchedGetaffinity(pid, &actual)
+		assert.NoError(t, err)
+
+		return actual == expectedCPUSet
+	}, time.Second, 10*time.Millisecond, "pid[%d] Expected CPUSet %0x != Actual CPUSet %0x", pid, expectedCPUSet, actual)
+}
+
+func assertNeverPIDHasSchedAffinity(t *testing.T, pid int, targetCPUSet unix.CPUSet) {
+	var actual unix.CPUSet
+	assert.Never(t, func() bool {
+		err := unix.SchedGetaffinity(pid, &actual)
+		assert.NoError(t, err)
+
+		return actual == targetCPUSet
+	}, time.Second, 10*time.Millisecond, "pid[%d]  == Actual CPUSet %0x expected to be different than %0x", pid, actual, targetCPUSet)
+}

--- a/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_linux_test.go
@@ -100,6 +100,39 @@ func TestIsFileNotEmpty(t *testing.T) {
 	assert.False(t, result)
 }
 
+func TestPrintCPUSetAll(t *testing.T) {
+	var x unix.CPUSet
+	for i := 0; i < 16; i++ {
+		x.Set(i)
+	}
+
+	assert.Equal(t,
+		"0-15",
+		printCPUSet(x),
+	)
+
+	assert.Equal(t,
+		"",
+		printCPUSet(unix.CPUSet{}),
+	)
+}
+
+func TestPrintCPUSetRanges(t *testing.T) {
+	var x unix.CPUSet
+
+	x.Set(2)
+	x.Set(3)
+	x.Set(6)
+	x.Set(7)
+	x.Set(8)
+	x.Set(14)
+
+	assert.Equal(t,
+		"2-3,6-8,14",
+		printCPUSet(x),
+	)
+}
+
 func mockOvsdbProcess(t *testing.T) (int, func()) {
 	ctx, stopCmd := context.WithCancel(context.Background())
 	defer stopCmd()

--- a/go-controller/pkg/node/ovspinning/ovspinning_noop.go
+++ b/go-controller/pkg/node/ovspinning/ovspinning_noop.go
@@ -1,0 +1,12 @@
+//go:build !linux
+// +build !linux
+
+package ovspinning
+
+import (
+	"k8s.io/klog/v2"
+)
+
+func Run(_ <-chan struct{}) {
+	klog.Infof("OVS CPU pinning is supported on linux platform only")
+}

--- a/go-controller/pkg/util/ovs.go
+++ b/go-controller/pkg/util/ovs.go
@@ -605,17 +605,38 @@ func RunOVNControllerAppCtl(args ...string) (string, string, error) {
 // RunOvsVswitchdAppCtl runs an 'ovs-appctl -t /var/run/openvsiwthc/ovs-vswitchd.pid.ctl command'
 func RunOvsVswitchdAppCtl(args ...string) (string, string, error) {
 	var cmdArgs []string
-	pid, err := afero.ReadFile(AppFs, savedOVSRunDir+"ovs-vswitchd.pid")
+	pid, err := GetOvsVSwitchdPID()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get ovs-vswitch pid : %v", err)
+		return "", "", err
 	}
+
 	cmdArgs = []string{
 		"-t",
-		savedOVSRunDir + fmt.Sprintf("ovs-vswitchd.%s.ctl", strings.TrimSpace(string(pid))),
+		savedOVSRunDir + fmt.Sprintf("ovs-vswitchd.%s.ctl", pid),
 	}
 	cmdArgs = append(cmdArgs, args...)
 	stdout, stderr, err := runOVNretry(runner.appctlPath, nil, cmdArgs...)
 	return strings.Trim(strings.TrimSpace(stdout.String()), "\""), stderr.String(), err
+}
+
+// GetOvsVSwitchdPID retrieves the Process IDentifier for ovs-vswitchd daemon.
+func GetOvsVSwitchdPID() (string, error) {
+	pid, err := afero.ReadFile(AppFs, savedOVSRunDir+"ovs-vswitchd.pid")
+	if err != nil {
+		return "", fmt.Errorf("failed to get ovs-vswitch pid : %v", err)
+	}
+
+	return strings.TrimSpace(string(pid)), nil
+}
+
+// GetOvsDBServerPID retrieves the Process IDentifier for ovs-vswitchd daemon.
+func GetOvsDBServerPID() (string, error) {
+	pid, err := afero.ReadFile(AppFs, savedOVSRunDir+"ovsdb-server.pid")
+	if err != nil {
+		return "", fmt.Errorf("failed to get ovsdb-server pid : %v", err)
+	}
+
+	return strings.TrimSpace(string(pid)), nil
 }
 
 // RunIP runs a command via the iproute2 "ip" utility

--- a/test/e2e/ovspinning.go
+++ b/test/e2e/ovspinning.go
@@ -1,0 +1,31 @@
+package e2e
+
+import (
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("OVS CPU affinity pinning", func() {
+
+	f := newPrivelegedTestFramework("ovspinning")
+
+	ginkgo.It("can be enabled on specific nodes by creating enable_dynamic_cpu_affinity file", func() {
+
+		nodeWithEnabledOvsAffinityPinning := "ovn-worker2"
+
+		_, err := runCommand(containerRuntime, "exec", nodeWithEnabledOvsAffinityPinning, "bash", "-c", "echo 1 > /etc/openvswitch/enable_dynamic_cpu_affinity")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		restartOVNKubeNodePodsInParallel(f.ClientSet, ovnNamespace, "ovn-worker", "ovn-worker2")
+
+		enabledNodeLogs, err := getOVNKubePodLogsFiltered(f.ClientSet, ovnNamespace, "ovn-worker2", ".*ovspinning_linux.go.*$")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		gomega.Expect(enabledNodeLogs).To(gomega.ContainSubstring("Starting OVS daemon CPU pinning"))
+
+		disabledNodeLogs, err := getOVNKubePodLogsFiltered(f.ClientSet, ovnNamespace, "ovn-worker", ".*ovspinning_linux.go.*$")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(disabledNodeLogs).To(gomega.ContainSubstring("OVS CPU affinity pinning disabled"))
+	})
+
+})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

Make ovnkube-node manage the CPU affinity of ovs-vswitchd and ovsdb-server processes, aligning them to its affinity.
The feature is enabled when the file `/etc/openvswitch/enable_dynamic_cpu_affinity` is present and not empty on the filesystem.

This feature is useful when the kubelet is configured with `static` cpuManager policy [1] and the OVS daemon needs
more cycles to cope with a network load rise.

<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

This PR is a WIP as it needs further activation semaphore, besides the argument parameter, to activate the feature.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Allow ovnkube daemonset to control OVS CPU affinity in case of static cpuManager policy.


[1] https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy