### PR TITLE
Add logical switch and router name as client index

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -150,8 +150,9 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 
 	// define client indexes for objects that are using dbIDs
 	dbModel.SetIndexes(map[string][]model.ClientIndex{
-		nbdb.ACLTable:          {{Columns: []model.ColumnKey{{Column: "external_ids", Key: types.PrimaryIDKey}}}},
-		nbdb.LoadBalancerTable: {{Columns: []model.ColumnKey{{Column: "name"}}}},
+		nbdb.ACLTable:           {{Columns: []model.ColumnKey{{Column: "external_ids", Key: types.PrimaryIDKey}}}},
+		nbdb.LoadBalancerTable:  {{Columns: []model.ColumnKey{{Column: "name"}}}},
+		nbdb.LogicalSwitchTable: {{Columns: []model.ColumnKey{{Column: "name"}}}},
 	})
 
 	c, err := newClient(cfg, dbModel, stopCh, enableMetricsOption)

--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -153,6 +153,7 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		nbdb.ACLTable:           {{Columns: []model.ColumnKey{{Column: "external_ids", Key: types.PrimaryIDKey}}}},
 		nbdb.LoadBalancerTable:  {{Columns: []model.ColumnKey{{Column: "name"}}}},
 		nbdb.LogicalSwitchTable: {{Columns: []model.ColumnKey{{Column: "name"}}}},
+		nbdb.LogicalRouterTable: {{Columns: []model.ColumnKey{{Column: "name"}}}},
 	})
 
 	c, err := newClient(cfg, dbModel, stopCh, enableMetricsOption)

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -170,6 +170,7 @@ func copyIndexes(model model.Model) model.Model {
 	case *nbdb.LogicalRouter:
 		return &nbdb.LogicalRouter{
 			UUID: t.UUID,
+			Name: t.Name,
 		}
 	case *nbdb.LogicalRouterPolicy:
 		return &nbdb.LogicalRouterPolicy{

--- a/go-controller/pkg/libovsdbops/model.go
+++ b/go-controller/pkg/libovsdbops/model.go
@@ -187,6 +187,7 @@ func copyIndexes(model model.Model) model.Model {
 	case *nbdb.LogicalSwitch:
 		return &nbdb.LogicalSwitch{
 			UUID: t.UUID,
+			Name: t.Name,
 		}
 	case *nbdb.LogicalSwitchPort:
 		return &nbdb.LogicalSwitchPort{

--- a/go-controller/pkg/libovsdbops/model_client_test.go
+++ b/go-controller/pkg/libovsdbops/model_client_test.go
@@ -393,9 +393,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 			name: "Test create non-existing no-root by model predicate specification and parent model mutation",
 			op:   "CreateOrUpdate",
 			generateOp: func() []operationModel {
-				m := nbdb.LogicalSwitchPort{
-					Name: logicalSwitchPortTestName,
-				}
+				m := nbdb.LogicalSwitchPort{}
 				parentModel := nbdb.LogicalSwitch{
 					Name: logicalSwitchTestName,
 				}
@@ -408,8 +406,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelMutations: []interface{}{
 							&parentModel.Ports,
 						},
@@ -429,7 +426,6 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 					Ports: []string{logicalSwitchPortTestUUID},
 				},
 				&nbdb.LogicalSwitchPort{
-					Name: logicalSwitchPortTestName,
 					UUID: logicalSwitchPortTestUUID,
 				},
 			},
@@ -438,9 +434,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 			name: "Test create non-existing no-root by model predicate specification and non-existing parent model mutation",
 			op:   "CreateOrUpdate",
 			generateOp: func() []operationModel {
-				m := nbdb.LogicalSwitchPort{
-					Name: logicalSwitchPortTestName,
-				}
+				m := nbdb.LogicalSwitchPort{}
 				parentModel := nbdb.LogicalSwitch{
 					Name: logicalSwitchTestName,
 				}
@@ -453,8 +447,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelMutations: []interface{}{
 							&parentModel.Ports,
 						},
@@ -469,7 +462,6 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 					Ports: []string{logicalSwitchPortTestUUID},
 				},
 				&nbdb.LogicalSwitchPort{
-					Name: logicalSwitchPortTestName,
 					UUID: logicalSwitchPortTestUUID,
 				},
 			},
@@ -484,14 +476,11 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 				}
 				return []operationModel{
 					{
-						Model: &nbdb.LogicalSwitchPort{
-							Name: logicalSwitchPortTestName,
-						},
+						Model:          &nbdb.LogicalSwitchPort{},
 						ModelPredicate: func(lsp *nbdb.LogicalSwitchPort) bool { return lsp.Name == logicalSwitchPortTestName },
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelUpdates: []interface{}{
 							&parentModel.Ports,
 						},
@@ -511,7 +500,6 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 					Ports: []string{logicalSwitchPortTestUUID},
 				},
 				&nbdb.LogicalSwitchPort{
-					Name: logicalSwitchPortTestName,
 					UUID: logicalSwitchPortTestUUID,
 				},
 			},
@@ -534,8 +522,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelMutations: []interface{}{
 							&parentModel.Ports,
 						},
@@ -575,8 +562,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelUpdates: []interface{}{
 							&parentModel.Ports,
 						},
@@ -621,8 +607,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelUpdates: []interface{}{
 							&parentModel.Ports,
 						},
@@ -673,8 +658,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &pm,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &pm,
 						OnModelUpdates: []interface{}{
 							&pm.Ports,
 						},
@@ -727,8 +711,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &pm,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &pm,
 						OnModelMutations: []interface{}{
 							&pm.Ports,
 						},
@@ -776,8 +759,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelMutations: []interface{}{
 							&parentModel.Ports,
 						},
@@ -827,8 +809,7 @@ func TestCreateOrUpdateForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelMutations: []interface{}{
 							&parentModel.Ports,
 						},
@@ -879,14 +860,11 @@ func TestDeleteForNonRootObjects(t *testing.T) {
 				}
 				return []operationModel{
 					{
-						Model: &nbdb.LogicalSwitchPort{
-							Name: logicalSwitchPortTestName,
-						},
+						Model:          &nbdb.LogicalSwitchPort{},
 						ModelPredicate: func(lsp *nbdb.LogicalSwitchPort) bool { return lsp.Name == logicalSwitchPortTestName },
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelMutations: []interface{}{
 							&parentModel.Ports,
 						},
@@ -923,8 +901,7 @@ func TestDeleteForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelMutations: []interface{}{
 							&parentModel.Ports,
 						},
@@ -967,8 +944,7 @@ func TestDeleteForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelMutations: []interface{}{
 							&parentModel.Ports,
 						},
@@ -1053,8 +1029,7 @@ func TestDeleteForNonRootObjects(t *testing.T) {
 						},
 					},
 					{
-						Model:          &parentModel,
-						ModelPredicate: func(ls *nbdb.LogicalSwitch) bool { return ls.Name == logicalSwitchTestName },
+						Model: &parentModel,
 						OnModelMutations: []interface{}{
 							&parentModel.Ports,
 						},

--- a/go-controller/pkg/libovsdbops/qos.go
+++ b/go-controller/pkg/libovsdbops/qos.go
@@ -77,7 +77,6 @@ func AddQoSesToLogicalSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 
 	opModels := operationModel{
 		Model:            sw,
-		ModelPredicate:   func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelMutations: []interface{}{&sw.QOSRules},
 		ErrNotFound:      true,
 		BulkOp:           false,
@@ -117,7 +116,6 @@ func RemoveQoSesFromLogicalSwitchOps(nbClient libovsdbclient.Client, ops []libov
 
 	opModels := operationModel{
 		Model:            sw,
-		ModelPredicate:   func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelMutations: []interface{}{&sw.QOSRules},
 		ErrNotFound:      true,
 		BulkOp:           false,

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -21,7 +21,6 @@ func GetLogicalRouter(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter
 	found := []*nbdb.LogicalRouter{}
 	opModel := operationModel{
 		Model:          router,
-		ModelPredicate: func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		ExistingResult: &found,
 		ErrNotFound:    true,
 		BulkOp:         false,
@@ -53,7 +52,6 @@ func CreateOrUpdateLogicalRouter(nbClient libovsdbclient.Client, router *nbdb.Lo
 	}
 	opModel := operationModel{
 		Model:          router,
-		ModelPredicate: func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		OnModelUpdates: fields,
 		ErrNotFound:    false,
 		BulkOp:         false,
@@ -115,8 +113,14 @@ func DeleteLogicalRoutersWithPredicateOps(nbClient libovsdbclient.Client, ops []
 // DeleteLogicalRouterOps returns the operations to delete the provided logical router
 func DeleteLogicalRouterOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation,
 	router *nbdb.LogicalRouter) ([]libovsdb.Operation, error) {
-	return DeleteLogicalRoutersWithPredicateOps(nbClient, nil,
-		func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name })
+	opModel := operationModel{
+		Model:       router,
+		ErrNotFound: false,
+		BulkOp:      false,
+	}
+
+	m := newModelClient(nbClient)
+	return m.DeleteOps(ops, opModel)
 }
 
 // DeleteLogicalRouter deletes the provided logical router
@@ -181,7 +185,6 @@ func CreateOrUpdateLogicalRouterPort(nbClient libovsdbclient.Client, router *nbd
 	})
 	opModels = append(opModels, operationModel{
 		Model:            router,
-		ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		OnModelMutations: []interface{}{&router.Ports},
 		ErrNotFound:      true,
 		BulkOp:           false,
@@ -214,7 +217,6 @@ func DeleteLogicalRouterPorts(nbClient libovsdbclient.Client, router *nbdb.Logic
 	}
 	opModel := operationModel{
 		Model:            router,
-		ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		OnModelMutations: []interface{}{&router.Ports},
 		ErrNotFound:      true,
 		BulkOp:           false,
@@ -302,7 +304,6 @@ func CreateOrUpdateLogicalRouterPolicyWithPredicateOps(nbClient libovsdbclient.C
 		},
 		{
 			Model:            router,
-			ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 			OnModelMutations: []interface{}{&router.Policies},
 			ErrNotFound:      true,
 			BulkOp:           false,
@@ -352,7 +353,6 @@ func DeleteLogicalRouterPolicyWithPredicateOps(nbClient libovsdbclient.Client, o
 		},
 		{
 			Model:            router,
-			ModelPredicate:   func(lr *nbdb.LogicalRouter) bool { return lr.Name == router.Name },
 			OnModelMutations: []interface{}{&router.Policies},
 			ErrNotFound:      true,
 			BulkOp:           false,
@@ -397,7 +397,6 @@ func CreateOrAddNextHopsToLogicalRouterPolicyWithPredicateOps(nbClient libovsdbc
 		},
 		{
 			Model:            router,
-			ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 			OnModelMutations: []interface{}{&router.Policies},
 			ErrNotFound:      true,
 			BulkOp:           false,
@@ -443,7 +442,6 @@ func deleteNextHopsFromLogicalRouterPolicyOps(nbClient libovsdbclient.Client, op
 	if len(router.Policies) > 0 {
 		opModel := operationModel{
 			Model:            router,
-			ModelPredicate:   func(lr *nbdb.LogicalRouter) bool { return lr.Name == router.Name },
 			OnModelMutations: []interface{}{&router.Policies},
 			BulkOp:           false,
 			ErrNotFound:      false,
@@ -529,7 +527,6 @@ func DeleteLogicalRouterPolicies(nbClient libovsdbclient.Client, routerName stri
 
 	opModel := operationModel{
 		Model:            router,
-		ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		OnModelMutations: []interface{}{&router.Policies},
 		ErrNotFound:      true,
 		BulkOp:           false,
@@ -578,7 +575,6 @@ func CreateOrUpdateLogicalRouterStaticRoutesWithPredicateOps(nbClient libovsdbcl
 		},
 		{
 			Model:            router,
-			ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 			OnModelMutations: []interface{}{&router.StaticRoutes},
 			ErrNotFound:      true,
 			BulkOp:           false,
@@ -658,7 +654,6 @@ func CreateOrReplaceLogicalRouterStaticRouteWithPredicate(nbClient libovsdbclien
 		}
 		opModel := operationModel{
 			Model:            router,
-			ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 			OnModelMutations: []interface{}{&router.StaticRoutes},
 			ErrNotFound:      true,
 			BulkOp:           false,
@@ -698,7 +693,6 @@ func DeleteLogicalRouterStaticRoutesWithPredicate(nbClient libovsdbclient.Client
 		},
 		{
 			Model:            router,
-			ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 			OnModelMutations: []interface{}{&router.StaticRoutes},
 			ErrNotFound:      true,
 			BulkOp:           false,
@@ -731,7 +725,6 @@ func DeleteLogicalRouterStaticRoutes(nbClient libovsdbclient.Client, routerName 
 
 	opModel := operationModel{
 		Model:            router,
-		ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		OnModelMutations: []interface{}{&router.StaticRoutes},
 		ErrNotFound:      true,
 		BulkOp:           false,
@@ -792,7 +785,6 @@ func AddLoadBalancersToLogicalRouterOps(nbClient libovsdbclient.Client, ops []li
 	}
 	opModel := operationModel{
 		Model:            router,
-		ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		OnModelMutations: []interface{}{&router.LoadBalancer},
 		ErrNotFound:      true,
 		BulkOp:           false,
@@ -814,7 +806,6 @@ func RemoveLoadBalancersFromLogicalRouterOps(nbClient libovsdbclient.Client, ops
 	}
 	opModel := operationModel{
 		Model:            router,
-		ModelPredicate:   func(item *nbdb.LogicalRouter) bool { return item.Name == router.Name },
 		OnModelMutations: []interface{}{&router.LoadBalancer},
 		// if we want to delete loadbalancer from the router that doesn't exist, that is noop
 		ErrNotFound: false,

--- a/go-controller/pkg/libovsdbops/router_test.go
+++ b/go-controller/pkg/libovsdbops/router_test.go
@@ -249,24 +249,6 @@ func TestDeleteRoutersWithPredicateOps(t *testing.T) {
 		p            logicalRouterPredicate
 	}{
 		{
-			desc:      "remove router of specified name",
-			expectErr: false,
-			initialNbdb: libovsdbtest.TestSetup{
-				NBData: []libovsdbtest.TestData{
-					fakeRouter1.DeepCopy(),
-					fakeRouter2.DeepCopy(),
-					fakeRouter3.DeepCopy(),
-				},
-			},
-			expectedNbdb: libovsdbtest.TestSetup{
-				NBData: []libovsdbtest.TestData{
-					fakeRouter1.DeepCopy(),
-					fakeRouter3.DeepCopy(),
-				},
-			},
-			p: func(item *nbdb.LogicalRouter) bool { return item.Name == "rtr2" },
-		},
-		{
 			desc:      "remove routers of specified external_id key",
 			expectErr: false,
 			initialNbdb: libovsdbtest.TestSetup{

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -31,7 +31,6 @@ func GetLogicalSwitch(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch) (*
 	found := []*nbdb.LogicalSwitch{}
 	opModel := operationModel{
 		Model:          sw,
-		ModelPredicate: func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		ExistingResult: &found,
 		ErrNotFound:    true,
 		BulkOp:         false,
@@ -53,7 +52,6 @@ func CreateOrUpdateLogicalSwitch(nbClient libovsdbclient.Client, sw *nbdb.Logica
 	}
 	opModel := operationModel{
 		Model:          sw,
-		ModelPredicate: func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelUpdates: fields,
 		ErrNotFound:    false,
 		BulkOp:         false,
@@ -116,8 +114,14 @@ func DeleteLogicalSwitchesWithPredicateOps(nbClient libovsdbclient.Client, ops [
 // DeleteLogicalSwitchOps returns the operations to delete the provided logical switch
 func DeleteLogicalSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation,
 	swName string) ([]libovsdb.Operation, error) {
-	return DeleteLogicalSwitchesWithPredicateOps(nbClient, ops,
-		func(item *nbdb.LogicalSwitch) bool { return item.Name == swName })
+	opModel := operationModel{
+		Model:       &nbdb.LogicalSwitch{Name: swName},
+		ErrNotFound: false,
+		BulkOp:      false,
+	}
+
+	m := newModelClient(nbClient)
+	return m.DeleteOps(ops, opModel)
 }
 
 // DeleteLogicalSwitch deletes the provided logical switch
@@ -141,7 +145,6 @@ func AddLoadBalancersToLogicalSwitchOps(nbClient libovsdbclient.Client, ops []li
 	}
 	opModel := operationModel{
 		Model:            sw,
-		ModelPredicate:   func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelMutations: []interface{}{&sw.LoadBalancer},
 		ErrNotFound:      true,
 		BulkOp:           false,
@@ -160,7 +163,6 @@ func RemoveLoadBalancersFromLogicalSwitchOps(nbClient libovsdbclient.Client, ops
 	}
 	opModel := operationModel{
 		Model:            sw,
-		ModelPredicate:   func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelMutations: []interface{}{&sw.LoadBalancer},
 		// if we want to delete loadbalancer from the switch that doesn't exist, that is noop
 		ErrNotFound: false,
@@ -186,7 +188,6 @@ func AddACLsToLogicalSwitchOps(nbClient libovsdbclient.Client, ops []libovsdb.Op
 
 	opModels := operationModel{
 		Model:            sw,
-		ModelPredicate:   func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelMutations: []interface{}{&sw.ACLs},
 		ErrNotFound:      true,
 		BulkOp:           false,
@@ -302,7 +303,6 @@ func createOrUpdateLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []l
 	}
 	opModel := operationModel{
 		Model:            sw,
-		ModelPredicate:   func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelMutations: []interface{}{&sw.Ports},
 		ErrNotFound:      !createSwitch,
 		BulkOp:           false,
@@ -367,7 +367,6 @@ func DeleteLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.
 	}
 	opModel := operationModel{
 		Model:            sw,
-		ModelPredicate:   func(item *nbdb.LogicalSwitch) bool { return item.Name == sw.Name },
 		OnModelMutations: []interface{}{&sw.Ports},
 		ErrNotFound:      true,
 		BulkOp:           false,

--- a/go-controller/pkg/libovsdbops/switch_test.go
+++ b/go-controller/pkg/libovsdbops/switch_test.go
@@ -140,24 +140,6 @@ func TestDeleteSwitchesWithPredicateOps(t *testing.T) {
 		p            logicalSwitchPredicate
 	}{
 		{
-			desc:      "remove switch of specified name",
-			expectErr: false,
-			initialNbdb: libovsdbtest.TestSetup{
-				NBData: []libovsdbtest.TestData{
-					fakeSwitch1.DeepCopy(),
-					fakeSwitch2.DeepCopy(),
-					fakeSwitch3.DeepCopy(),
-				},
-			},
-			expectedNbdb: libovsdbtest.TestSetup{
-				NBData: []libovsdbtest.TestData{
-					fakeSwitch1.DeepCopy(),
-					fakeSwitch3.DeepCopy(),
-				},
-			},
-			p: func(item *nbdb.LogicalSwitch) bool { return item.Name == "sw2" },
-		},
-		{
 			desc:      "remove switches of specified external_id key",
 			expectErr: false,
 			initialNbdb: libovsdbtest.TestSetup{


### PR DESCRIPTION
For performance. Avoids running predicates to search for rows on this table where we already consider the name an index, or the alternative of having second level caches storing UUIDs.