### PR TITLE
Fix stale SNAT entries for completed pods

### DIFF
--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -216,7 +216,7 @@ func (oc *DefaultNetworkController) updateNamespace(old, newer *kapi.Namespace) 
 				errors = append(errors, fmt.Errorf("failed to get all the pods (%v)", err))
 			}
 			for _, pod := range existingPods {
-				if !oc.isPodScheduledinLocalZone(pod) {
+				if !oc.isPodScheduledinLocalZone(pod) && !util.PodNeedsSNAT(pod) {
 					continue
 				}
 				podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, types.DefaultNetworkName)

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -324,6 +324,12 @@ func GetNodePrimaryIP(node *kapi.Node) (string, error) {
 		kapi.NodeInternalIP, kapi.NodeExternalIP)
 }
 
+// PodNeedsSNAT returns true if the given pod is eligible to setup snat entry
+// in ovn for its egress traffic outside cluster, otherwise returns false.
+func PodNeedsSNAT(pod *kapi.Pod) bool {
+	return PodScheduled(pod) && !PodWantsHostNetwork(pod) && !PodCompleted(pod)
+}
+
 // PodWantsHostNetwork returns if the given pod is hostNetworked or not to determine if networking
 // needs to be setup
 func PodWantsHostNetwork(pod *kapi.Pod) bool {


### PR DESCRIPTION
In case of completed pod case, egress ip module is handling pod add, egressip events as usual and when logical port is found, it proceeds with programming SNAT and LRP for pod ip address which is not required. Also when pod is done or completed, then it's not required to recreate SNAT entry referring to node ip address. Hence this commit addresses these two issues so that no stale or duplicate SNAT entries present for a pod.