### PR TITLE
OCPBUGS-4370: Filter out IP addresses added by keepalived

### DIFF
--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/j-keck/arping"
@@ -470,6 +471,7 @@ func DeleteConntrack(ip string, port int32, protocol kapi.Protocol, ipFilterType
 }
 
 // GetNetworkInterfaceIPs returns the IP addresses for the network interface 'iface'.
+// We filter out addresses that are link local, reserved for internal use or added by keepalived.
 func GetNetworkInterfaceIPs(iface string) ([]*net.IPNet, error) {
 	link, err := netLinkOps.LinkByName(iface)
 	if err != nil {
@@ -483,7 +485,7 @@ func GetNetworkInterfaceIPs(iface string) ([]*net.IPNet, error) {
 
 	var ips []*net.IPNet
 	for _, addr := range addrs {
-		if addr.IP.IsLinkLocalUnicast() || IsAddressReservedForInternalUse(addr.IP) {
+		if addr.IP.IsLinkLocalUnicast() || IsAddressReservedForInternalUse(addr.IP) || IsAddressAddedByKeepAlived(addr) {
 			continue
 		}
 		// Ignore addresses marked as secondary or deprecated since they may
@@ -512,6 +514,13 @@ func IsAddressReservedForInternalUse(addr net.IP) bool {
 		return false
 	}
 	return subnet.Contains(addr)
+}
+
+// IsAddressAddedByKeepAlived returns true if the input interface address obtained
+// through netlink has a label that ends with ":vip", which is how keepalived
+// marks the IP addresses it adds (https://github.com/openshift/machine-config-operator/pull/3683)
+func IsAddressAddedByKeepAlived(addr netlink.Addr) bool {
+	return strings.HasSuffix(addr.Label, ":vip")
 }
 
 // GetIPv6OnSubnet when given an IPv6 address with a 128 prefix for an interface,


### PR DESCRIPTION
When we set `k8s.ovn.org/node-primary-ifaddr annotation` on the node, we simply take the first valid IP address we find on the node gateway. We already exclude link-local addresses and those in internally reserved subnets. Let's also filter out addresses added by keepalived, which are now labeled with $iface:vip.

This will make the choice of node primary IP deterministic in the case, like the following, where we have a keepalived address on `br-ex` but don't know how to distinguish it from the rest: 
```
sh-4.4# ip a show br-ex
7: br-ex: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
link/ether 00:52:12:af:f3:53 brd ff:ff:ff:ff:ff:ff
inet6 fd69::2/125 scope global dadfailed tentative <---- masquerade IP, excluded
valid_lft forever preferred_lft forever
inet6 fd2e:6f44:5dd8:c956::4/128 scope global nodad deprecated <--- real node IP, included
valid_lft forever preferred_lft 0sec
inet6 fd2e:6f44:5dd8:c956::17/128 scope global dynamic noprefixroute <---added by keepalive, INCLUDED!!
valid_lft 3017sec preferred_lft 3017sec
inet6 fe80::252:12ff:feaf:f353/64 scope link noprefixroute <--- link local, excluded
valid_lft forever preferred_lft forever
```




Depends on these PRs:
- https://github.com/openshift/baremetal-runtimecfg/pull/236
- https://github.com/openshift/machine-config-operator/pull/3683


Fixes #OCPBUGS-4370