### PR TITLE
Fix handling of DPU on node primary IP change

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -536,7 +536,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	}
 	nodeAddr := net.ParseIP(nodeAddrStr)
 	if nodeAddr == nil {
-		return fmt.Errorf("failed to parse kubernetes node IP address. %v", err)
+		return fmt.Errorf("failed to parse kubernetes node IP address. %v", nodeAddrStr)
 	}
 
 	// Make sure that the node zone matches with the Southbound db zone.

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -373,14 +373,33 @@ type bridgeConfiguration struct {
 }
 
 // updateInterfaceIPAddresses sets and returns the bridge's current ips
-func (b *bridgeConfiguration) updateInterfaceIPAddresses() ([]*net.IPNet, error) {
+func (b *bridgeConfiguration) updateInterfaceIPAddresses(node *kapi.Node) ([]*net.IPNet, error) {
 	b.Lock()
 	defer b.Unlock()
 	ifAddrs, err := getNetworkInterfaceIPAddresses(b.bridgeName)
-	if err == nil {
-		b.ips = ifAddrs
+	if err != nil {
+		return nil, err
 	}
-	return ifAddrs, err
+
+	// For DPU, here we need to use the DPU host's IP address which is the tenant cluster's
+	// host internal IP address instead of the DPU's external bridge IP address.
+	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		nodeAddrStr, err := util.GetNodePrimaryIP(node)
+		if err != nil {
+			return nil, err
+		}
+		nodeAddr := net.ParseIP(nodeAddrStr)
+		if nodeAddr == nil {
+			return nil, fmt.Errorf("failed to parse node IP address. %v", nodeAddrStr)
+		}
+		ifAddrs, err = getDPUHostPrimaryIPAddresses(nodeAddr, ifAddrs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	b.ips = ifAddrs
+	return ifAddrs, nil
 }
 
 func bridgeForInterface(intfName, nodeName, physicalNetworkName string, gwIPs []*net.IPNet) (*bridgeConfiguration, error) {

--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -227,7 +227,7 @@ func (c *addressManager) updateNodeAddressAnnotations() error {
 
 	if c.useNetlink {
 		// get updated interface IP addresses for the gateway bridge
-		ifAddrs, err = c.gatewayBridge.updateInterfaceIPAddresses()
+		ifAddrs, err = c.gatewayBridge.updateInterfaceIPAddresses(node)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The DPU needs to use the DPU host's IP address (the tenant cluster's host internal IP address) instead of the DPU's external bridge ip address for the node primary address annotations and the L3 gateway configuration.
    
An incorrect node primary address annotation and L3 gateway configuration results in broken flows when using NodePort or ClusterIP service.
    
Signed-off-by: William Zhao <wizhao@redhat.com>