### PR TITLE
Avoid external connectivity flakes in E2E

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -511,12 +511,9 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 		// Since this is not really a test of kubernetes in any way, we
 		// leave it as a pre-test assertion, rather than a Ginko test.
 		ginkgo.By("Executing a successful http request from the external internet")
-		resp, err := http.Get("http://google.com")
+		_, err := http.Get("http://google.com")
 		if err != nil {
 			framework.Failf("Unable to connect/talk to the internet: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			framework.Failf("Unexpected error code, expected 200, got, %v (%v)", resp.StatusCode, resp)
 		}
 
 		masterPods, err := f.ClientSet.CoreV1().Pods("ovn-kubernetes").List(context.Background(), metav1.ListOptions{


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

When asserting external connectivity, it happens to consistently receive a 429 (Too Many Requests) status code from the sample website. As the test only verifies the presence of an external connection, even an error status code is a good condition to continue testing.


**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

This should avoid flakes like 

```
2023-04-28T14:19:03.3241874Z [0me2e control plane[0m [90mtest node readiness according to its defaults interface MTU size[0m 
2023-04-28T14:19:03.3242338Z   [1mshould get node ready with a big enough MTU[0m
2023-04-28T14:19:03.3242833Z   [37m/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:753[0m
2023-04-28T14:19:03.3243151Z [BeforeEach] e2e control plane
2023-04-28T14:19:03.3243534Z   /home/runner/go/pkg/mod/k8s.io/kubernetes@v1.24.0/test/e2e/framework/framework.go:187
2023-04-28T14:19:03.3243934Z [1mSTEP[0m: Creating a kubernetes client
2023-04-28T14:19:03.3244257Z Apr 28 14:19:03.323: INFO: >>> kubeConfig: /home/runner/ovn.conf
2023-04-28T14:19:03.3249495Z [1mSTEP[0m: Building a namespace api object, basename nettest
2023-04-28T14:19:03.3427557Z [1mSTEP[0m: Waiting for a default service account to be provisioned in namespace
2023-04-28T14:19:03.3456825Z [1mSTEP[0m: Waiting for kube-root-ca.crt to be provisioned in namespace
2023-04-28T14:19:03.3478827Z [BeforeEach] e2e control plane
2023-04-28T14:19:03.3479421Z   /home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/e2e.go:509
2023-04-28T14:19:03.3479903Z [1mSTEP[0m: Executing a successful http request from the external internet
2023-04-28T14:19:03.8651577Z Apr 28 14:19:03.863: FAIL: Unexpected error code, expected 200, got, 429 (&{429 Too Many Requests 429 HTTP/1.1 1 1 map[Cache-Control:[no-store, no-cache, must-revalidate] Content-Length:[3016] Content-Type:[text/html] Date:[Fri, 28 Apr 2023 14:19:03 GMT] Expires:[Fri, 01 Jan 1990 00:00:00 GMT] Pragma:[no-cache] Server:[HTTP server (unknown)] X-Xss-Protection:[0]] 0xc000ad6f00 3016 [] false false map[] 0xc000853300 <nil>})
2023-04-28T14:19:03.8652190Z 
2023-04-28T14:19:03.8652294Z Full Stack Trace
2023-04-28T14:19:03.8652616Z github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0x444405?)
2023-04-28T14:19:03.8653116Z 	/home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/leafnodes/runner.go:113 +0xb1
2023-04-28T14:19:03.8653515Z github.com/onsi/ginkgo/internal/leafnodes.(*runner).run(0xc00005e568?)
2023-04-28T14:19:03.8653934Z 	/home/runner/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/internal/leafnodes/runner.go:64 +0x125
2023-04-28T14:19:03.8654335Z github.com/onsi/ginkgo/internal/leafnodes.(*SetupNode).Run(0x300000002?)
...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->