### PR TITLE
Enable github actions merge group

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: ovn-ci
 
 on:
+  merge_group:
   pull_request:
     branches: [ master ]
   schedule:


### PR DESCRIPTION
This will help resolve the issue of merging a PR then requiring another PR to be rebased to ensure we test against new HEAD. PRs will be sent to a merge queue and then executed against HEAD before they are merged.

Once this commit is merged we can go enable requiring merge queue in the repo. For more info:

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

