### PR TITLE
multi-homing, policy, e2e: add requiresExtraNamespace attribute to pod config

### DIFF
--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -651,16 +651,18 @@ var _ = Describe("Multi Homing", func() {
 			table.DescribeTable(
 				"multi-network policies configure traffic allow lists",
 				func(netConfig networkAttachmentConfig, allowedClientPodConfig podConfiguration, blockedClientPodConfig podConfiguration, serverPodConfig podConfiguration, policy *mnpapi.MultiNetworkPolicy) {
-					if blockedClientPodConfig.namespace == "" {
-						blockedClientPodConfig.namespace = f.Namespace.Name
-					} else {
-						blockedClientPodConfig.namespace = extraNamespace.Name
+					blockedClientPodNamespace := f.Namespace.Name
+					if blockedClientPodConfig.requiresExtraNamespace {
+						blockedClientPodNamespace = extraNamespace.Name
 					}
-					if allowedClientPodConfig.namespace == "" {
-						allowedClientPodConfig.namespace = f.Namespace.Name
-					} else {
-						allowedClientPodConfig.namespace = extraNamespace.Name
+					blockedClientPodConfig.namespace = blockedClientPodNamespace
+
+					allowedClientPodNamespace := f.Namespace.Name
+					if allowedClientPodConfig.requiresExtraNamespace {
+						allowedClientPodNamespace = extraNamespace.Name
 					}
+					allowedClientPodConfig.namespace = allowedClientPodNamespace
+
 					serverPodConfig.namespace = f.Namespace.Name
 
 					for _, ns := range []v1.Namespace{*f.Namespace, *extraNamespace} {
@@ -927,9 +929,9 @@ var _ = Describe("Multi Homing", func() {
 						networkName: uniqueNadName("spans-multiple-namespaces"),
 					},
 					podConfiguration{
-						attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
-						name:        allowedClient(clientPodName),
-						namespace:   "pepe",
+						attachments:            []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+						name:                   allowedClient(clientPodName),
+						requiresExtraNamespace: true,
 					},
 					podConfiguration{
 						attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
@@ -961,9 +963,9 @@ var _ = Describe("Multi Homing", func() {
 						networkName: uniqueNadName("spans-multiple-namespaces"),
 					},
 					podConfiguration{
-						attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
-						name:        allowedClient(clientPodName),
-						namespace:   "pepe",
+						attachments:            []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+						name:                   allowedClient(clientPodName),
+						requiresExtraNamespace: true,
 					},
 					podConfiguration{
 						attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
@@ -995,9 +997,9 @@ var _ = Describe("Multi Homing", func() {
 						networkName: uniqueNadName("spans-multiple-namespaces"),
 					},
 					podConfiguration{
-						attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
-						name:        allowedClient(clientPodName),
-						namespace:   "pepe",
+						attachments:            []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},
+						name:                   allowedClient(clientPodName),
+						requiresExtraNamespace: true,
 					},
 					podConfiguration{
 						attachments: []nadapi.NetworkSelectionElement{{Name: secondaryNetworkName}},

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -90,13 +90,14 @@ func generateNetAttachDef(namespace, nadName, nadSpec string) *nadapi.NetworkAtt
 }
 
 type podConfiguration struct {
-	attachments  []nadapi.NetworkSelectionElement
-	containerCmd []string
-	name         string
-	namespace    string
-	nodeSelector map[string]string
-	isPrivileged bool
-	labels       map[string]string
+	attachments            []nadapi.NetworkSelectionElement
+	containerCmd           []string
+	name                   string
+	namespace              string
+	nodeSelector           map[string]string
+	isPrivileged           bool
+	labels                 map[string]string
+	requiresExtraNamespace bool
 }
 
 func generatePodSpec(config podConfiguration) *v1.Pod {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This makes the test code more explicit than it was before, and addresses the comment + promise for a short refactor done in pr [#3531 comment](https://github.com/ovn-org/ovn-kubernetes/pull/3531#discussion_r1177642261).

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->