### PR TITLE
Multi policies ipamless ipblock

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_multipolicy_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_multipolicy_test.go
@@ -1,0 +1,214 @@
+package ovn
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
+	netplumbersv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+)
+
+var _ = Describe("convertMultiNetPolicyToNetPolicy", func() {
+	const policyName = "pol33"
+
+	var nci *CommonNetworkControllerInfo
+
+	BeforeEach(func() {
+		nci = &CommonNetworkControllerInfo{nbClient: nil}
+	})
+
+	It("translates an IPAM policy with namespace selectors", func() {
+		nInfo, err := util.ParseNADInfo(ipamNetAttachDef())
+		Expect(err).NotTo(HaveOccurred())
+		bnc := NewSecondaryLayer2NetworkController(nci, nInfo)
+		Expect(bnc.convertMultiNetPolicyToNetPolicy(multiNetPolicyWithNamespaceSelector(policyName))).To(
+			Equal(
+				&netv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: policyName},
+					Spec: netv1.NetworkPolicySpec{
+						Ingress: []netv1.NetworkPolicyIngressRule{
+							{
+								From:  []netv1.NetworkPolicyPeer{{NamespaceSelector: sameLabelsEverywhere()}},
+								Ports: []netv1.NetworkPolicyPort{},
+							},
+						},
+						Egress:      []netv1.NetworkPolicyEgressRule{},
+						PolicyTypes: []netv1.PolicyType{},
+					},
+				}))
+	})
+
+	It("translates an IPAM policy with pod selectors", func() {
+		nInfo, err := util.ParseNADInfo(ipamNetAttachDef())
+		Expect(err).NotTo(HaveOccurred())
+		bnc := NewSecondaryLayer2NetworkController(nci, nInfo)
+		Expect(bnc.convertMultiNetPolicyToNetPolicy(multiNetPolicyWithPodSelector(policyName))).To(
+			Equal(
+				&netv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: policyName},
+					Spec: netv1.NetworkPolicySpec{
+						Ingress: []netv1.NetworkPolicyIngressRule{
+							{
+								From:  []netv1.NetworkPolicyPeer{{PodSelector: sameLabelsEverywhere()}},
+								Ports: []netv1.NetworkPolicyPort{},
+							},
+						},
+						Egress:      []netv1.NetworkPolicyEgressRule{},
+						PolicyTypes: []netv1.PolicyType{},
+					},
+				}))
+	})
+
+	It("translates an IPAM policy with `ipBlock` selectors", func() {
+		nInfo, err := util.ParseNADInfo(ipamNetAttachDef())
+		Expect(err).NotTo(HaveOccurred())
+		bnc := NewSecondaryLayer2NetworkController(nci, nInfo)
+		Expect(bnc.convertMultiNetPolicyToNetPolicy(multiNetPolicyWithIPBlock())).To(Equal(
+			&netv1.NetworkPolicy{
+				Spec: netv1.NetworkPolicySpec{
+					Ingress: []netv1.NetworkPolicyIngressRule{
+						{
+							From:  []netv1.NetworkPolicyPeer{{IPBlock: &netv1.IPBlock{CIDR: "10.10.0.0/16"}}},
+							Ports: []netv1.NetworkPolicyPort{},
+						},
+					},
+					Egress:      []netv1.NetworkPolicyEgressRule{},
+					PolicyTypes: []netv1.PolicyType{},
+				},
+			},
+		))
+	})
+
+	It("translates an IPAM-less policy with `ipBlock` selectors", func() {
+		nInfo, err := util.ParseNADInfo(ipamlessNetAttachDef())
+		Expect(err).NotTo(HaveOccurred())
+		bnc := NewSecondaryLayer2NetworkController(nci, nInfo)
+		Expect(bnc.convertMultiNetPolicyToNetPolicy(multiNetPolicyWithIPBlock())).To(
+			Equal(
+				&netv1.NetworkPolicy{
+					Spec: netv1.NetworkPolicySpec{
+						Ingress: []netv1.NetworkPolicyIngressRule{
+							{
+								From:  []netv1.NetworkPolicyPeer{{IPBlock: &netv1.IPBlock{CIDR: "10.10.0.0/16"}}},
+								Ports: []netv1.NetworkPolicyPort{},
+							},
+						},
+						Egress:      []netv1.NetworkPolicyEgressRule{},
+						PolicyTypes: []netv1.PolicyType{},
+					},
+				},
+			))
+	})
+
+	It("*fails* to translate an IPAM-less policy with pod selector peers", func() {
+		nInfo, err := util.ParseNADInfo(ipamlessNetAttachDef())
+		Expect(err).NotTo(HaveOccurred())
+		bnc := NewSecondaryLayer2NetworkController(nci, nInfo)
+		_, err = bnc.convertMultiNetPolicyToNetPolicy(multiNetPolicyWithPodSelector(policyName))
+		Expect(err).To(
+			MatchError(
+				MatchRegexp(fmt.Sprintf("invalid peer .* in multi-network policy %s; IPAM-less networks can only have `ipBlock` peers", policyName))))
+	})
+
+	It("translates an IPAM-less policy with namespace selector peers", func() {
+		nInfo, err := util.ParseNADInfo(ipamlessNetAttachDef())
+		Expect(err).NotTo(HaveOccurred())
+		bnc := NewSecondaryLayer2NetworkController(nci, nInfo)
+		_, err = bnc.convertMultiNetPolicyToNetPolicy(multiNetPolicyWithNamespaceSelector(policyName))
+		Expect(err).To(MatchError(
+			MatchRegexp(fmt.Sprintf("invalid peer .* in multi-network policy %s; IPAM-less networks can only have `ipBlock` peers", policyName))))
+	})
+})
+
+func sameLabelsEverywhere() *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchLabels: map[string]string{"George": "Costanza"},
+	}
+}
+
+func ipamNetAttachDef() *netplumbersv1.NetworkAttachmentDefinition {
+	return &netplumbersv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flatl2",
+			Namespace: "default",
+		},
+		Spec: netplumbersv1.NetworkAttachmentDefinitionSpec{
+			Config: `{
+        "cniVersion": "0.4.0",
+        "name": "flatl2",
+        "netAttachDefName": "default/flatl2",
+        "topology": "layer2",
+        "type": "ovn-k8s-cni-overlay",
+        "subnets": "192.100.200.0/24"
+    }`,
+		},
+	}
+}
+
+func ipamlessNetAttachDef() *netplumbersv1.NetworkAttachmentDefinition {
+	return &netplumbersv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flatl2",
+			Namespace: "default",
+		},
+		Spec: netplumbersv1.NetworkAttachmentDefinitionSpec{
+			Config: `{
+        "cniVersion": "0.4.0",
+        "name": "flatl2",
+        "netAttachDefName": "default/flatl2",
+        "topology": "layer2",
+        "type": "ovn-k8s-cni-overlay"
+    }`,
+		},
+	}
+}
+func multiNetPolicyWithIPBlock() *v1beta1.MultiNetworkPolicy {
+	return &v1beta1.MultiNetworkPolicy{
+		Spec: v1beta1.MultiNetworkPolicySpec{
+			Ingress: []v1beta1.MultiNetworkPolicyIngressRule{
+				{
+					From: []v1beta1.MultiNetworkPolicyPeer{
+						{
+							IPBlock: &v1beta1.IPBlock{
+								CIDR: "10.10.0.0/16",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func multiNetPolicyWithPodSelector(policyName string) *v1beta1.MultiNetworkPolicy {
+	return &v1beta1.MultiNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: policyName},
+		Spec: v1beta1.MultiNetworkPolicySpec{
+			Ingress: []v1beta1.MultiNetworkPolicyIngressRule{
+				{
+					From: []v1beta1.MultiNetworkPolicyPeer{{PodSelector: sameLabelsEverywhere()}},
+				},
+			},
+		},
+	}
+}
+
+func multiNetPolicyWithNamespaceSelector(policyName string) *v1beta1.MultiNetworkPolicy {
+	return &v1beta1.MultiNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: policyName},
+		Spec: v1beta1.MultiNetworkPolicySpec{
+			Ingress: []v1beta1.MultiNetworkPolicyIngressRule{
+				{
+					From: []v1beta1.MultiNetworkPolicyPeer{{NamespaceSelector: sameLabelsEverywhere()}},
+				},
+			},
+		},
+	}
+}

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -66,9 +66,8 @@ func getNamespaceAddrSetDbIDs(namespaceName, controller string) *libovsdbops.DbO
 func (bnc *BaseNetworkController) WatchNamespaces() error {
 	if bnc.IsSecondary() {
 		// For secondary networks, we don't have to watch namespace events if
-		// multi-network policy support is not enabled. We don't support
-		// multi-network policy for IPAM-less secondary networks either.
-		if !util.IsMultiNetworkPoliciesSupportEnabled() || !bnc.doesNetworkRequireIPAM() {
+		// multi-network policy support is not enabled.
+		if !util.IsMultiNetworkPoliciesSupportEnabled() {
 			return nil
 		}
 	}

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -349,6 +349,10 @@ func (bnc *BaseNetworkController) updateNamespaceAclLogging(ns, aclAnnotation st
 }
 
 func (bnc *BaseNetworkController) getAllNamespacePodAddresses(ns string) []net.IP {
+	if !bnc.doesNetworkRequireIPAM() {
+		return nil
+	}
+
 	var ips []net.IP
 	// Get all the pods in the namespace and append their IP to the address_set
 	existingPods, err := bnc.watchFactory.GetPods(ns)

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -479,7 +479,10 @@ func (bnc *BaseNetworkController) podExpectedInLogicalCache(pod *kapi.Pod) bool 
 	if err != nil {
 		return false
 	}
-	return !util.PodWantsHostNetwork(pod) && !bnc.lsManager.IsNonHostSubnetSwitch(switchName) && !util.PodCompleted(pod)
+	return !util.PodWantsHostNetwork(pod) &&
+		!(bnc.lsManager.IsNonHostSubnetSwitch(switchName) &&
+			bnc.doesNetworkRequireIPAM()) &&
+		!util.PodCompleted(pod)
 }
 
 func (bnc *BaseNetworkController) getExpectedSwitchName(pod *kapi.Pod) (string, error) {

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -70,7 +70,10 @@ func (bsnc *BaseSecondaryNetworkController) AddSecondaryNetworkResourceCommon(ob
 			return nil
 		}
 
-		np := convertMultiNetPolicyToNetPolicy(mp)
+		np, err := bsnc.convertMultiNetPolicyToNetPolicy(mp)
+		if err != nil {
+			return err
+		}
 		if err := bsnc.addNetworkPolicy(np); err != nil {
 			klog.Infof("MultiNetworkPolicy add failed for %s/%s, will try again later: %v",
 				mp.Namespace, mp.Name, err)
@@ -114,7 +117,10 @@ func (bsnc *BaseSecondaryNetworkController) UpdateSecondaryNetworkResourceCommon
 		newShouldApply := bsnc.shouldApplyMultiPolicy(newMp)
 		if oldShouldApply {
 			// this multi-netpol no longer applies to this network controller, delete it
-			np := convertMultiNetPolicyToNetPolicy(oldMp)
+			np, err := bsnc.convertMultiNetPolicyToNetPolicy(oldMp)
+			if err != nil {
+				return err
+			}
 			if err := bsnc.deleteNetworkPolicy(np); err != nil {
 				klog.Infof("MultiNetworkPolicy delete failed for %s/%s, will try again later: %v",
 					oldMp.Namespace, oldMp.Name, err)
@@ -123,7 +129,10 @@ func (bsnc *BaseSecondaryNetworkController) UpdateSecondaryNetworkResourceCommon
 		}
 		if newShouldApply {
 			// now this multi-netpol applies to this network controller
-			np := convertMultiNetPolicyToNetPolicy(newMp)
+			np, err := bsnc.convertMultiNetPolicyToNetPolicy(newMp)
+			if err != nil {
+				return err
+			}
 			if err := bsnc.addNetworkPolicy(np); err != nil {
 				klog.Infof("MultiNetworkPolicy add failed for %s/%s, will try again later: %v",
 					newMp.Namespace, newMp.Name, err)
@@ -161,7 +170,10 @@ func (bsnc *BaseSecondaryNetworkController) DeleteSecondaryNetworkResourceCommon
 		if !ok {
 			return fmt.Errorf("could not cast %T object to *multinetworkpolicyapi.MultiNetworkPolicy", obj)
 		}
-		np := convertMultiNetPolicyToNetPolicy(mp)
+		np, err := bsnc.convertMultiNetPolicyToNetPolicy(mp)
+		if err != nil {
+			return err
+		}
 		// delete this policy regardless it applies to this network controller, in case of missing update event
 		if err := bsnc.deleteNetworkPolicy(np); err != nil {
 			klog.Infof("MultiNetworkPolicy delete failed for %s/%s, will try again later: %v",

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -533,12 +533,6 @@ func (bsnc *BaseSecondaryNetworkController) WatchMultiNetworkPolicy() error {
 		return nil
 	}
 
-	// if this network does not have ipam, network policy is not supported.
-	if !bsnc.doesNetworkRequireIPAM() {
-		klog.Infof("Network policy is not supported on network %s", bsnc.GetNetworkName())
-		return nil
-	}
-
 	if bsnc.policyHandler != nil {
 		return nil
 	}

--- a/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
+++ b/go-controller/pkg/ovn/base_secondary_layer2_network_controller.go
@@ -169,7 +169,7 @@ func (oc *BaseSecondaryLayer2NetworkController) initRetryFramework() {
 	// For secondary networks, we don't have to watch namespace events if
 	// multi-network policy support is not enabled. We don't support
 	// multi-network policy for IPAM-less secondary networks either.
-	if util.IsMultiNetworkPoliciesSupportEnabled() && oc.doesNetworkRequireIPAM() {
+	if util.IsMultiNetworkPoliciesSupportEnabled() {
 		oc.retryNamespaces = oc.newRetryFramework(factory.NamespaceType)
 		oc.retryNetworkPolicies = oc.newRetryFramework(factory.MultiNetworkPolicyType)
 	}

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -29,7 +29,7 @@ func getNetCIDRSubnet(netCIDR string) (string, error) {
 	} else if len(subStrings) == 2 {
 		return netCIDR, nil
 	}
-	return "", fmt.Errorf("invalid network cidr %s", netCIDR)
+	return "", fmt.Errorf("invalid network cidr: %q", netCIDR)
 }
 
 type networkAttachmentConfig struct {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR adds support for multi-network policies for secondary networks whose peers are of IPBlock type.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Run the multi-net tests.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add support for multi-network policies for secondary networks whose peers are of IPBlock type.