### PR TITLE
Hash ExternalIDs primaryID

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -227,7 +227,7 @@ func buildAddressSet(dbIDs *libovsdbops.DbObjectIDs, ipFamily string) *nbdb.Addr
 	externalIDs := dbIDsWithIPFam.GetExternalIDs()
 	name := externalIDs[libovsdbops.PrimaryIDKey.String()]
 	as := &nbdb.AddressSet{
-		Name:        hashedAddressSet(name),
+		Name:        name,
 		ExternalIDs: externalIDs,
 	}
 	return as
@@ -236,7 +236,7 @@ func buildAddressSet(dbIDs *libovsdbops.DbObjectIDs, ipFamily string) *nbdb.Addr
 func (asf *ovnAddressSetFactory) newOvnAddressSet(addrSet *nbdb.AddressSet) *ovnAddressSet {
 	return &ovnAddressSet{
 		nbClient: asf.nbClient,
-		name:     addrSet.ExternalIDs[libovsdbops.PrimaryIDKey.String()],
+		name:     fmt.Sprintf("%+v", addrSet.ExternalIDs),
 		hashName: addrSet.Name,
 		uuid:     addrSet.UUID,
 	}

--- a/go-controller/pkg/ovn/external_ids_syncer/acl/acl_sync.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/acl/acl_sync.go
@@ -42,7 +42,7 @@ const (
 	egressFirewallACLExtIdKey = "egressFirewall"
 )
 
-type aclSyncer struct {
+type ACLSyncer struct {
 	nbClient       libovsdbclient.Client
 	controllerName string
 	// txnBatchSize is used to control how many acls will be updated with 1 db transaction.
@@ -50,8 +50,8 @@ type aclSyncer struct {
 }
 
 // controllerName is the name of the new controller that should own all acls without controller
-func NewACLSyncer(nbClient libovsdbclient.Client, controllerName string) *aclSyncer {
-	return &aclSyncer{
+func NewACLSyncer(nbClient libovsdbclient.Client, controllerName string) *ACLSyncer {
+	return &ACLSyncer{
 		nbClient:       nbClient,
 		controllerName: controllerName,
 		// create time (which is the upper bound of how much time an update can take) for 20K ACLs
@@ -61,7 +61,7 @@ func NewACLSyncer(nbClient libovsdbclient.Client, controllerName string) *aclSyn
 	}
 }
 
-func (syncer *aclSyncer) SyncACLs(existingNodes *v1.NodeList) error {
+func (syncer *ACLSyncer) SyncACLs(existingNodes *v1.NodeList) error {
 	// first, update PrimaryID to the new format (hashed)
 	if err := hash_primary_id.HashPrimaryIDACL(syncer.nbClient, syncer.txnBatchSize); err != nil {
 		return fmt.Errorf("failed to hash primaryIDs for acls: %w", err)
@@ -145,7 +145,7 @@ func (syncer *aclSyncer) SyncACLs(existingNodes *v1.NodeList) error {
 	return nil
 }
 
-func (syncer *aclSyncer) getDefaultMcastACLDbIDs(mcastType, policyDirection string) *libovsdbops.DbObjectIDs {
+func (syncer *ACLSyncer) getDefaultMcastACLDbIDs(mcastType, policyDirection string) *libovsdbops.DbObjectIDs {
 	// there are 2 types of default multicast ACLs in every direction (Ingress/Egress)
 	// DefaultDeny = deny multicast by default
 	// AllowInterNode = allow inter-node multicast
@@ -157,7 +157,7 @@ func (syncer *aclSyncer) getDefaultMcastACLDbIDs(mcastType, policyDirection stri
 
 }
 
-func (syncer *aclSyncer) getNamespaceMcastACLDbIDs(ns, policyDirection string) *libovsdbops.DbObjectIDs {
+func (syncer *ACLSyncer) getNamespaceMcastACLDbIDs(ns, policyDirection string) *libovsdbops.DbObjectIDs {
 	// namespaces ACL
 	return libovsdbops.NewDbObjectIDs(libovsdbops.ACLMulticastNamespace, syncer.controllerName,
 		map[libovsdbops.ExternalIDKey]string{
@@ -168,7 +168,7 @@ func (syncer *aclSyncer) getNamespaceMcastACLDbIDs(ns, policyDirection string) *
 
 // updateStaleMulticastACLsDbIDs updates multicast ACLs that don't have new ExternalIDs set.
 // Must be run before WatchNamespace, since namespaceSync function uses syncNsMulticast, which relies on the new IDs.
-func (syncer *aclSyncer) updateStaleMulticastACLsDbIDs(legacyACLs []*nbdb.ACL) []*nbdb.ACL {
+func (syncer *ACLSyncer) updateStaleMulticastACLsDbIDs(legacyACLs []*nbdb.ACL) []*nbdb.ACL {
 	updatedACLs := []*nbdb.ACL{}
 	for _, acl := range legacyACLs {
 		var dbIDs *libovsdbops.DbObjectIDs
@@ -220,7 +220,7 @@ func (syncer *aclSyncer) updateStaleMulticastACLsDbIDs(legacyACLs []*nbdb.ACL) [
 	return updatedACLs
 }
 
-func (syncer *aclSyncer) getAllowFromNodeACLDbIDs(nodeName, mgmtPortIP string) *libovsdbops.DbObjectIDs {
+func (syncer *ACLSyncer) getAllowFromNodeACLDbIDs(nodeName, mgmtPortIP string) *libovsdbops.DbObjectIDs {
 	return libovsdbops.NewDbObjectIDs(libovsdbops.ACLNetpolNode, syncer.controllerName,
 		map[libovsdbops.ExternalIDKey]string{
 			libovsdbops.ObjectNameKey: nodeName,
@@ -231,7 +231,7 @@ func (syncer *aclSyncer) getAllowFromNodeACLDbIDs(nodeName, mgmtPortIP string) *
 // updateStaleNetpolNodeACLs updates allow from node ACLs, that don't have new ExternalIDs based
 // on DbObjectIDs set. Allow from node acls are applied on the node switch, therefore the cleanup for deleted is not needed,
 // since acl will be deleted toegther with the node switch.
-func (syncer *aclSyncer) updateStaleNetpolNodeACLs(legacyACLs []*nbdb.ACL, existingNodes []v1.Node) []*nbdb.ACL {
+func (syncer *ACLSyncer) updateStaleNetpolNodeACLs(legacyACLs []*nbdb.ACL, existingNodes []v1.Node) []*nbdb.ACL {
 	// ACL to allow traffic from host via management port has no name or ExternalIDs
 	// The only way to find it is by exact match
 	type aclInfo struct {
@@ -271,7 +271,7 @@ func (syncer *aclSyncer) updateStaleNetpolNodeACLs(legacyACLs []*nbdb.ACL, exist
 	return updatedACLs
 }
 
-func (syncer *aclSyncer) getNetpolGressACLDbIDs(policyNamespace, policyName, policyType string,
+func (syncer *ACLSyncer) getNetpolGressACLDbIDs(policyNamespace, policyName, policyType string,
 	gressIdx, portPolicyIdx, ipBlockIdx int) *libovsdbops.DbObjectIDs {
 	return libovsdbops.NewDbObjectIDs(libovsdbops.ACLNetworkPolicy, syncer.controllerName,
 		map[libovsdbops.ExternalIDKey]string{
@@ -293,7 +293,7 @@ func (syncer *aclSyncer) getNetpolGressACLDbIDs(policyNamespace, policyName, pol
 		})
 }
 
-func (syncer *aclSyncer) updateStaleGressPolicies(legacyACLs []*nbdb.ACL) (updatedACLs []*nbdb.ACL, err error) {
+func (syncer *ACLSyncer) updateStaleGressPolicies(legacyACLs []*nbdb.ACL) (updatedACLs []*nbdb.ACL, err error) {
 	if len(legacyACLs) == 0 {
 		return
 	}
@@ -354,7 +354,7 @@ func (syncer *aclSyncer) updateStaleGressPolicies(legacyACLs []*nbdb.ACL) (updat
 	return
 }
 
-func (syncer *aclSyncer) getDefaultDenyPolicyACLIDs(ns, policyType, defaultACLType string) *libovsdbops.DbObjectIDs {
+func (syncer *ACLSyncer) getDefaultDenyPolicyACLIDs(ns, policyType, defaultACLType string) *libovsdbops.DbObjectIDs {
 	return libovsdbops.NewDbObjectIDs(libovsdbops.ACLNetpolNamespace, syncer.controllerName,
 		map[libovsdbops.ExternalIDKey]string{
 			libovsdbops.ObjectNameKey: ns,
@@ -365,7 +365,7 @@ func (syncer *aclSyncer) getDefaultDenyPolicyACLIDs(ns, policyType, defaultACLTy
 		})
 }
 
-func (syncer *aclSyncer) updateStaleDefaultDenyNetpolACLs(legacyACLs []*nbdb.ACL) (updatedACLs []*nbdb.ACL,
+func (syncer *ACLSyncer) updateStaleDefaultDenyNetpolACLs(legacyACLs []*nbdb.ACL) (updatedACLs []*nbdb.ACL,
 	deleteOps []libovsdb.Operation, err error) {
 	for _, acl := range legacyACLs {
 		// sync default Deny policies
@@ -415,7 +415,7 @@ func (syncer *aclSyncer) updateStaleDefaultDenyNetpolACLs(legacyACLs []*nbdb.ACL
 	return
 }
 
-func (syncer *aclSyncer) getEgressFirewallACLDbIDs(namespace string, ruleIdx int) *libovsdbops.DbObjectIDs {
+func (syncer *ACLSyncer) getEgressFirewallACLDbIDs(namespace string, ruleIdx int) *libovsdbops.DbObjectIDs {
 	return libovsdbops.NewDbObjectIDs(libovsdbops.ACLEgressFirewall, syncer.controllerName,
 		map[libovsdbops.ExternalIDKey]string{
 			libovsdbops.ObjectNameKey: namespace,
@@ -423,7 +423,7 @@ func (syncer *aclSyncer) getEgressFirewallACLDbIDs(namespace string, ruleIdx int
 		})
 }
 
-func (syncer *aclSyncer) updateStaleEgressFirewallACLs(legacyACLs []*nbdb.ACL) []*nbdb.ACL {
+func (syncer *ACLSyncer) updateStaleEgressFirewallACLs(legacyACLs []*nbdb.ACL) []*nbdb.ACL {
 	updatedACLs := []*nbdb.ACL{}
 	for _, acl := range legacyACLs {
 		if acl.Priority < types.MinimumReservedEgressFirewallPriority || acl.Priority > types.EgressFirewallStartPriority {

--- a/go-controller/pkg/ovn/external_ids_syncer/acl/acl_sync_test.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/acl/acl_sync_test.go
@@ -79,7 +79,7 @@ var _ = ginkgo.Describe("OVN ACL Syncer", func() {
 		controllerName = "fake-controller"
 		namespace1     = "namespace1"
 	)
-	var syncerToBuildData = aclSyncer{
+	var syncerToBuildData = ACLSyncer{
 		controllerName: controllerName,
 	}
 

--- a/go-controller/pkg/ovn/external_ids_syncer/address_set/address_set_sync_test.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/address_set/address_set_sync_test.go
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("OVN Address Set Syncer", func() {
 		anotherControllerName = "another-controller"
 		qosPriority           = 1000
 	)
-	var syncerToBuildData = addressSetsSyncer{
+	var syncerToBuildData = AddressSetsSyncer{
 		controllerName: controllerName,
 	}
 

--- a/go-controller/pkg/ovn/external_ids_syncer/hash_primary_id/hash.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/hash_primary_id/hash.go
@@ -1,0 +1,74 @@
+package hash_primary_id
+
+import (
+	"fmt"
+	"strings"
+
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util/batching"
+)
+
+func HashPrimaryIDACL(nbClient libovsdbclient.Client, batchSize int) error {
+	legacyACLSetPred := func(item *nbdb.ACL) bool {
+		// we know that old format used ":" as delimiter for IDs
+		// and new format has only alphanumerical symbols
+		return strings.Contains(item.ExternalIDs[libovsdbops.PrimaryIDKey.String()], ":")
+	}
+
+	staleACLs, err := libovsdbops.FindACLsWithPredicate(nbClient, legacyACLSetPred)
+	if err != nil {
+		return fmt.Errorf("failed to find address sets with stale primaryID: %v", err)
+	}
+
+	for _, acl := range staleACLs {
+		newID, err := libovsdbops.SyncPrimaryID(acl.ExternalIDs[libovsdbops.PrimaryIDKey.String()])
+		if err != nil {
+			return fmt.Errorf("failed to sync primaryID: %w", err)
+		}
+		acl.ExternalIDs[libovsdbops.PrimaryIDKey.String()] = newID
+	}
+
+	return batching.Batch[*nbdb.ACL](batchSize, staleACLs, func(batchACLs []*nbdb.ACL) error {
+		ops, err := libovsdbops.UpdateACLsOps(nbClient, nil, batchACLs...)
+		fmt.Printf("OPS: %+v", ops)
+		if err != nil {
+			return fmt.Errorf("failed to get update acl ops: %v", err)
+		}
+		_, err = libovsdbops.TransactAndCheck(nbClient, ops)
+		if err != nil {
+			return fmt.Errorf("failed to transact update acl ops: %v", err)
+		}
+		return nil
+	})
+}
+
+func HashPrimaryIDAddrSet(nbClient libovsdbclient.Client, batchSize int) error {
+	legacyAddrSetPred := func(item *nbdb.AddressSet) bool {
+		// we know that old format used ":" as delimiter for IDs
+		// and new format has only alphanumerical symbols
+		return strings.Contains(item.ExternalIDs[libovsdbops.PrimaryIDKey.String()], ":")
+	}
+
+	staleAddrSets, err := libovsdbops.FindAddressSetsWithPredicate(nbClient, legacyAddrSetPred)
+	if err != nil {
+		return fmt.Errorf("failed to find address sets with stale primaryID: %v", err)
+	}
+
+	for _, addrSet := range staleAddrSets {
+		newID, err := libovsdbops.SyncPrimaryID(addrSet.ExternalIDs[libovsdbops.PrimaryIDKey.String()])
+		if err != nil {
+			return fmt.Errorf("failed to sync primaryID: %w", err)
+		}
+		addrSet.ExternalIDs[libovsdbops.PrimaryIDKey.String()] = newID
+	}
+
+	return batching.Batch[*nbdb.AddressSet](batchSize, staleAddrSets, func(batchAddrSets []*nbdb.AddressSet) error {
+		err := libovsdbops.CreateOrUpdateAddressSets(nbClient, batchAddrSets...)
+		if err != nil {
+			return fmt.Errorf("failed to update address sets: %v", err)
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
PrimaryID was a combination of all the other ExternalIDs, we can save some space in the db by hashing it.
e.g. what previously was
```
external_ids        : {
    "k8s.ovn.org/id"="default-network-controller:EgressFirewall:default:1", 
    "k8s.ovn.org/name"=default, 
    "k8s.ovn.org/owner-controller"=default-network-controller, 
    "k8s.ovn.org/owner-type"=EgressFirewall, 
    rule-idx="1"
}
```
will look something like
```
external_ids        : {
    "k8s.ovn.org/id"=a5272457940446250407, 
    "k8s.ovn.org/name"=default, 
    "k8s.ovn.org/owner-controller"=default-network-controller, 
    "k8s.ovn.org/owner-type"=EgressFirewall, 
    rule-idx="1"
}
```
This change may also improve the performance if primaryID is used as a client index (but I didn't test that)
That should also allow to point PrimaryID to another indexed column for some tables in the future (e.g. AddressSet.Name)