### PR TITLE
Allow external gateway bridge without uplink port In local gateway mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -399,6 +399,7 @@ jobs:
       ENABLE_MULTI_NET: "${{ matrix.target == 'multi-homing' }}"
       OVN_SEPARATE_CLUSTER_MANAGER: "${{ matrix.separate-cluster-manager == 'true' }}"
       OVN_COMPACT_MODE: "${{ matrix.target == 'compact-mode' }}"
+      OVN_DUMMY_GATEWAY_BRIDGE: "${{ matrix.target == 'compact-mode' }}"
     steps:
 
     - name: Free up disk space

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -249,6 +249,8 @@ parse_args() {
                                                 fi
                                                 OVN_GATEWAY_MODE=$1
                                                 ;;
+            -dgb | --dummy-gateway-bridge)      OVN_DUMMY_GATEWAY_BRIDGE=true
+                                                ;;
             -ov | --ovn-image )           	    shift
                                           	    OVN_IMAGE=$1
                                           	    ;;
@@ -361,6 +363,7 @@ print_params() {
      echo "KIND_ALLOW_SYSTEM_WRITES = $KIND_ALLOW_SYSTEM_WRITES"
      echo "KIND_EXPERIMENTAL_PROVIDER = $KIND_EXPERIMENTAL_PROVIDER"
      echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
+     echo "OVN_DUMMY_GATEWAY_BRIDGE = $OVN_DUMMY_GATEWAY_BRIDGE"
      echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
      echo "OVN_DISABLE_SNAT_MULTIPLE_GWS = $OVN_DISABLE_SNAT_MULTIPLE_GWS"
      echo "OVN_DISABLE_FORWARDING = $OVN_DISABLE_FORWARDING"
@@ -543,9 +546,13 @@ set_default_params() {
   OVN_DEPLOY_PODS=${OVN_DEPLOY_PODS:-"ovnkube-master ovnkube-node"}
   OVN_METRICS_SCALE_ENABLE=${OVN_METRICS_SCALE_ENABLE:-false}
   OVN_ISOLATED=${OVN_ISOLATED:-false}
-  OVN_GATEWAY_OPTS=""
+  OVN_GATEWAY_OPTS=${OVN_GATEWAY_OPTS:-""}
   if [ "$OVN_ISOLATED" == true ]; then
     OVN_GATEWAY_OPTS="--gateway-interface=eth0"
+  fi
+  OVN_DUMMY_GATEWAY_BRIDGE=${OVN_DUMMY_GATEWAY_BRIDGE:-false}
+  if [ "$OVN_DUMMY_GATEWAY_BRIDGE" == true ]; then
+    OVN_GATEWAY_OPTS="--allow-no-uplink --gateway-interface=br-ex"
   fi
   ENABLE_MULTI_NET=${ENABLE_MULTI_NET:-false}
   OVN_SEPARATE_CLUSTER_MANAGER=${OVN_SEPARATE_CLUSTER_MANAGER:-false}
@@ -780,6 +787,7 @@ create_ovn_kube_manifests() {
     --net-cidr="${NET_CIDR}" \
     --svc-cidr="${SVC_CIDR}" \
     --gateway-mode="${OVN_GATEWAY_MODE}" \
+    --dummy-gateway-bridge="${OVN_DUMMY_GATEWAY_BRIDGE}" \
     --gateway-options="${OVN_GATEWAY_OPTS}" \
     --enable-ipsec="${ENABLE_IPSEC}" \
     --hybrid-enabled="${OVN_HYBRID_OVERLAY_ENABLE}" \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -31,6 +31,7 @@ OVN_SVC_CIDR=""
 OVN_K8S_APISERVER=""
 OVN_GATEWAY_MODE=""
 OVN_GATEWAY_OPTS=""
+OVN_DUMMY_GATEWAY_BRIDGE=""
 OVN_DB_REPLICAS=""
 OVN_MTU=""
 OVN_SSL_ENABLE=""
@@ -107,6 +108,9 @@ while [ "$1" != "" ]; do
     ;;
   --gateway-options)
     OVN_GATEWAY_OPTS=$VALUE
+    ;;
+  --dummy-gateway-bridge)
+    OVN_DUMMY_GATEWAY_BRIDGE=$VALUE
     ;;
   --enable-ipsec)
     ENABLE_IPSEC=$VALUE
@@ -328,6 +332,9 @@ echo "ovn_gateway_mode: ${ovn_gateway_mode}"
 ovn_gateway_opts=${OVN_GATEWAY_OPTS}
 echo "ovn_gateway_opts: ${ovn_gateway_opts}"
 
+ovn_dummy_gateway_bridge=${OVN_DUMMY_GATEWAY_BRIDGE}
+echo "ovn_dummy_gateway_bridge: ${ovn_dummy_gateway_bridge}"
+
 enable_ipsec=${ENABLE_IPSEC:-false}
 echo "enable_ipsec: ${enable_ipsec}"
 
@@ -450,6 +457,7 @@ ovn_image=${ovnkube_image} \
   ovn_unprivileged_mode=${ovn_unprivileged_mode} \
   ovn_gateway_mode=${ovn_gateway_mode} \
   ovn_gateway_opts=${ovn_gateway_opts} \
+  ovn_dummy_gateway_bridge=${ovn_dummy_gateway_bridge} \
   ovnkube_node_loglevel=${node_loglevel} \
   ovn_loglevel_controller=${ovn_loglevel_controller} \
   ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
@@ -495,6 +503,7 @@ ovn_image=${image} \
   ovn_unprivileged_mode=${ovn_unprivileged_mode} \
   ovn_gateway_mode=${ovn_gateway_mode} \
   ovn_gateway_opts=${ovn_gateway_opts} \
+  ovn_dummy_gateway_bridge=${ovn_dummy_gateway_bridge} \
   ovnkube_node_loglevel=${node_loglevel} \
   ovn_loglevel_controller=${ovn_loglevel_controller} \
   ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
@@ -550,6 +559,8 @@ ovn_image=${ovnkube_image} \
   ovn_ssl_en=${ovn_ssl_en} \
   ovn_master_count=${ovn_master_count} \
   ovn_gateway_mode=${ovn_gateway_mode} \
+  ovn_gateway_opts=${ovn_gateway_opts} \
+  ovn_dummy_gateway_bridge=${ovn_dummy_gateway_bridge} \
   ovn_ex_gw_networking_interface=${ovn_ex_gw_networking_interface} \
   ovn_stateless_netpol_enable=${ovn_netpol_acl_enable} \
   ovnkube_compact_mode_enable=${ovnkube_compact_mode_enable} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1047,7 +1047,7 @@ ovn-master() {
     ${init_node_flags} \
     --cluster-subnets ${net_cidr} --k8s-service-cidr=${svc_cidr} \
     --nb-address=${ovn_nbdb} --sb-address=${ovn_sbdb} \
-    --gateway-mode=${ovn_gateway_mode} \
+    --gateway-mode=${ovn_gateway_mode} ${ovn_gateway_opts} \
     --loglevel=${ovnkube_loglevel} \
     --logfile-maxsize=${ovnkube_logfile_maxsize} \
     --logfile-maxbackups=${ovnkube_logfile_maxbackups} \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -138,6 +138,18 @@ spec:
             add:
             - NET_ADMIN
           {% endif %}
+        {% if ovn_dummy_gateway_bridge=="true" %}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                #!/bin/bash
+                ovs-vsctl --may-exist add-br br-ex
+                ip a a dev br-ex 10.44.0.1/32 || /bin/true
+        {% endif %}
         {% else %}
         command: ["/root/ovnkube.sh", "ovn-master"]
         securityContext:
@@ -259,6 +271,8 @@ spec:
           value: "{{ ovn_ssl_en }}"
         - name: OVN_GATEWAY_MODE
           value: "{{ ovn_gateway_mode }}"
+        - name: OVN_GATEWAY_OPTS
+          value: "{{ ovn_gateway_opts }}"
         - name: OVN_MULTICAST_ENABLE
           value: "{{ ovn_multicast_enable }}"
         - name: OVN_ACL_LOGGING_RATE_LIMIT

--- a/dist/templates/ovnkube-node.yaml.j2
+++ b/dist/templates/ovnkube-node.yaml.j2
@@ -39,7 +39,18 @@ spec:
       - name: ovnkube-node
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
-
+        {% if ovn_dummy_gateway_bridge=="true" %}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                #!/bin/bash
+                ovs-vsctl --may-exist add-br br-ex
+                ip a a dev br-ex 10.44.0.1/32 || /bin/true
+        {% endif %}
         command: ["/root/ovnkube.sh", "ovn-node"]
 
         securityContext:

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -406,6 +406,8 @@ type GatewayConfig struct {
 	SingleNode bool `gcfg:"single-node"`
 	// DisableForwarding (enabled by default) controls if forwarding is allowed on OVNK controlled interfaces
 	DisableForwarding bool `gcfg:"disable-forwarding"`
+	// AllowNoUplink (disabled by default) controls if the external gateway bridge without an uplink port is allowed in local gateway mode.
+	AllowNoUplink bool `gcfg:"allow-no-uplink"`
 }
 
 // OvnAuthConfig holds client authentication and location details for
@@ -1272,6 +1274,11 @@ var OVNGatewayFlags = []cli.Flag{
 		Usage: "Enable single node optimizations. " +
 			"Single node indicates a one node cluster and allows to simplify ovn-kubernetes gateway logic",
 		Destination: &cliConfig.Gateway.SingleNode,
+	},
+	&cli.BoolFlag{
+		Name:        "allow-no-uplink",
+		Usage:       "Allow the external gateway bridge without an uplink port in local gateway mode",
+		Destination: &cliConfig.Gateway.AllowNoUplink,
 	},
 	// Deprecated CLI options
 	&cli.BoolFlag{

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -204,6 +204,7 @@ v6-join-subnet=fd90::/64
 router-subnet=10.50.0.0/16
 single-node=false
 disable-forwarding=true
+allow-no-uplink=false
 
 [hybridoverlay]
 enabled=true
@@ -310,6 +311,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal(""))
 			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
 			gomega.Expect(Gateway.DisableForwarding).To(gomega.BeFalse())
+			gomega.Expect(Gateway.AllowNoUplink).To(gomega.BeFalse())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(1))
 			gomega.Expect(OVNKubernetesFeature.EgressIPNodeHealthCheckPort).To(gomega.Equal(0))
 			gomega.Expect(OVNKubernetesFeature.EnableMultiNetwork).To(gomega.BeFalse())
@@ -625,6 +627,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.50.0.0/16"))
 			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
 			gomega.Expect(Gateway.DisableForwarding).To(gomega.BeTrue())
+			gomega.Expect(Gateway.AllowNoUplink).To(gomega.BeFalse())
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(3))
@@ -713,6 +716,7 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal("10.55.0.0/16"))
 			gomega.Expect(Gateway.SingleNode).To(gomega.BeTrue())
 			gomega.Expect(Gateway.DisableForwarding).To(gomega.BeTrue())
+			gomega.Expect(Gateway.AllowNoUplink).To(gomega.BeTrue())
 
 			gomega.Expect(HybridOverlay.Enabled).To(gomega.BeTrue())
 			gomega.Expect(OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout).To(gomega.Equal(5))
@@ -767,6 +771,7 @@ var _ = Describe("Config Operations", func() {
 			"-gateway-router-subnet=10.55.0.0/16",
 			"-single-node",
 			"-disable-forwarding",
+			"-allow-no-uplink",
 			"-enable-hybrid-overlay",
 			"-hybrid-overlay-cluster-subnets=11.132.0.0/14/23",
 			"-monitor-all=false",

--- a/go-controller/pkg/node/gateway.go
+++ b/go-controller/pkg/node/gateway.go
@@ -431,10 +431,15 @@ func bridgeForInterface(intfName, nodeName, physicalNetworkName string, gwIPs []
 		// gateway interface is an OVS bridge
 		uplinkName, err := getIntfName(intfName)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to find intfName for %s", intfName)
+			if config.Gateway.Mode == config.GatewayModeLocal && config.Gateway.AllowNoUplink {
+				klog.Infof("Could not find uplink for %s, setup gateway bridge with no uplink port, egress IP and egress GW will not work", intfName)
+			} else {
+				return nil, errors.Wrapf(err, "Failed to find intfName for %s", intfName)
+			}
+		} else {
+			res.uplinkName = uplinkName
 		}
 		res.bridgeName = intfName
-		res.uplinkName = uplinkName
 	}
 	var err error
 	// Now, we get IP addresses for the bridge

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -6,6 +6,7 @@ package node
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"runtime"
@@ -1733,6 +1734,126 @@ var _ = Describe("Gateway unit tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(gatewayIntf).To(Equal(ifName))
 			Expect(gatewayNextHops[0]).To(Equal(gwIPs[0]))
+		})
+
+		Context("In Local GW mode", func() {
+			ovntest.OnSupportedPlatformsIt("Finds correct gateway interface and nexthops when dummy gateway bridge is created", func() {
+				ifName := "enf1f0"
+				dummyBridgeName := "br-ex"
+				_, ipnet, err := net.ParseCIDR("0.0.0.0/0")
+				Expect(err).ToNot(HaveOccurred())
+				hostGwIPs := []net.IP{net.ParseIP("10.0.0.11")}
+				lnk := &linkMock.Link{}
+				lnkAttr := &netlink.LinkAttrs{
+					Name:  ifName,
+					Index: 5,
+				}
+				defaultRoute := &netlink.Route{
+					Dst:       ipnet,
+					LinkIndex: 5,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					Gw:        hostGwIPs[0],
+					MTU:       config.Default.MTU,
+				}
+				lnk.On("Attrs").Return(lnkAttr)
+				netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
+				netlinkMock.On("LinkByIndex", mock.Anything).Return(lnk, nil)
+				netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return([]netlink.Route{*defaultRoute}, nil)
+
+				fexec := ovntest.NewLooseCompareFakeExec()
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    fmt.Sprintf("ovs-vsctl --timeout=15 port-to-br %s", ifName),
+					Err:    fmt.Errorf(""),
+					Output: "",
+				})
+				err = util.SetExec(fexec)
+				Expect(err).NotTo(HaveOccurred())
+
+				gwIPs := []net.IP{net.ParseIP(types.V4DummyNextHopMasqueradeIP)}
+				config.Gateway.Interface = dummyBridgeName
+				config.Gateway.Mode = config.GatewayModeLocal
+				config.Gateway.AllowNoUplink = true
+
+				gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(gatewayIntf).To(Equal(dummyBridgeName))
+				Expect(gatewayNextHops[0]).To(Equal(gwIPs[0]))
+			})
+
+			ovntest.OnSupportedPlatformsIt("Finds correct gateway interface and nexthops when dummy gateway bridge is created and no default route", func() {
+				ifName := "enf1f0"
+				dummyBridgeName := "br-ex"
+				lnk := &linkMock.Link{}
+				lnkAttr := &netlink.LinkAttrs{
+					Name:  ifName,
+					Index: 5,
+				}
+
+				lnk.On("Attrs").Return(lnkAttr)
+				netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
+				netlinkMock.On("LinkByIndex", mock.Anything).Return(lnk, nil)
+				netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return([]netlink.Route{}, nil)
+
+				fexec := ovntest.NewLooseCompareFakeExec()
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    fmt.Sprintf("ovs-vsctl --timeout=15 port-to-br %s", ifName),
+					Err:    fmt.Errorf(""),
+					Output: "",
+				})
+				err := util.SetExec(fexec)
+				Expect(err).NotTo(HaveOccurred())
+
+				gwIPs := []net.IP{net.ParseIP(types.V4DummyNextHopMasqueradeIP)}
+				config.Gateway.Interface = dummyBridgeName
+				config.Gateway.Mode = config.GatewayModeLocal
+				config.Gateway.AllowNoUplink = true
+
+				gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(gatewayIntf).To(Equal(dummyBridgeName))
+				Expect(gatewayNextHops[0]).To(Equal(gwIPs[0]))
+			})
+
+			ovntest.OnSupportedPlatformsIt("Returns error when dummy gateway bridge is created without allow-no-uplink flag", func() {
+				ifName := "enf1f0"
+				dummyBridgeName := "br-ex"
+				_, ipnet, err := net.ParseCIDR("0.0.0.0/0")
+				Expect(err).ToNot(HaveOccurred())
+				hostGwIPs := []net.IP{net.ParseIP("10.0.0.11")}
+				lnk := &linkMock.Link{}
+				lnkAttr := &netlink.LinkAttrs{
+					Name:  ifName,
+					Index: 5,
+				}
+				defaultRoute := &netlink.Route{
+					Dst:       ipnet,
+					LinkIndex: 5,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					Gw:        hostGwIPs[0],
+					MTU:       config.Default.MTU,
+				}
+				lnk.On("Attrs").Return(lnkAttr)
+				netlinkMock.On("LinkByName", mock.Anything).Return(lnk, nil)
+				netlinkMock.On("LinkByIndex", mock.Anything).Return(lnk, nil)
+				netlinkMock.On("RouteListFiltered", mock.Anything, mock.Anything, mock.Anything).Return([]netlink.Route{*defaultRoute}, nil)
+
+				fexec := ovntest.NewLooseCompareFakeExec()
+				fexec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd:    fmt.Sprintf("ovs-vsctl --timeout=15 port-to-br %s", ifName),
+					Err:    fmt.Errorf(""),
+					Output: "",
+				})
+				err = util.SetExec(fexec)
+				Expect(err).NotTo(HaveOccurred())
+
+				config.Gateway.Interface = dummyBridgeName
+				config.Gateway.Mode = config.GatewayModeLocal
+
+				gatewayNextHops, gatewayIntf, err := getGatewayNextHops()
+				Expect(errors.As(err, new(*GatewayInterfaceMismatchError))).To(BeTrue())
+				Expect(gatewayIntf).To(Equal(""))
+				Expect(len(gatewayNextHops)).To(Equal(0))
+			})
 		})
 	})
 })

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1087,20 +1087,21 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 	if config.IPv4Mode {
 		// table0, Geneve packets coming from external. Skip conntrack and go directly to host
 		// if dest mac is the shared mac send directly to host.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=205, in_port=%s, dl_dst=%s, udp, udp_dst=%d, "+
-				"actions=output:%s", defaultOpenFlowCookie, ofPortPhys, bridgeMacAddress, config.Default.EncapPort,
-				ofPortHost))
-		// perform NORMAL action otherwise.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp, udp_dst=%d, "+
-				"actions=NORMAL", defaultOpenFlowCookie, ofPortPhys, config.Default.EncapPort))
+		if ofPortPhys != "" {
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=205, in_port=%s, dl_dst=%s, udp, udp_dst=%d, "+
+					"actions=output:%s", defaultOpenFlowCookie, ofPortPhys, bridgeMacAddress, config.Default.EncapPort,
+					ofPortHost))
+			// perform NORMAL action otherwise.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp, udp_dst=%d, "+
+					"actions=NORMAL", defaultOpenFlowCookie, ofPortPhys, config.Default.EncapPort))
 
-		// table0, Geneve packets coming from LOCAL. Skip conntrack and go directly to external
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp, udp_dst=%d, "+
-				"actions=output:%s", defaultOpenFlowCookie, ovsLocalPort, config.Default.EncapPort, ofPortPhys))
-
+			// table0, Geneve packets coming from LOCAL. Skip conntrack and go directly to external
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp, udp_dst=%d, "+
+					"actions=output:%s", defaultOpenFlowCookie, ovsLocalPort, config.Default.EncapPort, ofPortPhys))
+		}
 		physicalIP, err := util.MatchFirstIPNetFamily(false, bridgeIPs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine IPv4 physical IP of host: %v", err)
@@ -1141,21 +1142,23 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 				defaultOpenFlowCookie, ofPortHost, types.V4OVNMasqueradeIP, OVNMasqCTZone))
 	}
 	if config.IPv6Mode {
-		// table0, Geneve packets coming from external. Skip conntrack and go directly to host
-		// if dest mac is the shared mac send directly to host.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=205, in_port=%s, dl_dst=%s, udp6, udp_dst=%d, "+
-				"actions=output:%s", defaultOpenFlowCookie, ofPortPhys, bridgeMacAddress, config.Default.EncapPort,
-				ofPortHost))
-		// perform NORMAL action otherwise.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp6, udp_dst=%d, "+
-				"actions=NORMAL", defaultOpenFlowCookie, ofPortPhys, config.Default.EncapPort))
+		if ofPortPhys != "" {
+			// table0, Geneve packets coming from external. Skip conntrack and go directly to host
+			// if dest mac is the shared mac send directly to host.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=205, in_port=%s, dl_dst=%s, udp6, udp_dst=%d, "+
+					"actions=output:%s", defaultOpenFlowCookie, ofPortPhys, bridgeMacAddress, config.Default.EncapPort,
+					ofPortHost))
+			// perform NORMAL action otherwise.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp6, udp_dst=%d, "+
+					"actions=NORMAL", defaultOpenFlowCookie, ofPortPhys, config.Default.EncapPort))
 
-		// table0, Geneve packets coming from LOCAL. Skip conntrack and send to external
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp6, udp_dst=%d, "+
-				"actions=output:%s", defaultOpenFlowCookie, ovsLocalPort, config.Default.EncapPort, ofPortPhys))
+			// table0, Geneve packets coming from LOCAL. Skip conntrack and send to external
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=200, in_port=%s, udp6, udp_dst=%d, "+
+					"actions=output:%s", defaultOpenFlowCookie, ovsLocalPort, config.Default.EncapPort, ofPortPhys))
+		}
 
 		physicalIP, err := util.MatchFirstIPNetFamily(true, bridgeIPs)
 		if err != nil {
@@ -1233,58 +1236,60 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 
 	actions := fmt.Sprintf("output:%s", ofPortPatch)
 
-	if config.IPv4Mode {
-		// table 1, established and related connections in zone 64000 with ct_mark ctMarkOVN go to OVN
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, table=1, ip, ct_state=+trk+est, ct_mark=%s, "+
-				"actions=%s",
-				defaultOpenFlowCookie, ctMarkOVN, actions))
+	if ofPortPhys != "" {
+		if config.IPv4Mode {
+			// table 1, established and related connections in zone 64000 with ct_mark ctMarkOVN go to OVN
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=1, ip, ct_state=+trk+est, ct_mark=%s, "+
+					"actions=%s",
+					defaultOpenFlowCookie, ctMarkOVN, actions))
 
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, table=1, ip, ct_state=+trk+rel, ct_mark=%s, "+
-				"actions=%s",
-				defaultOpenFlowCookie, ctMarkOVN, actions))
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=1, ip, ct_state=+trk+rel, ct_mark=%s, "+
+					"actions=%s",
+					defaultOpenFlowCookie, ctMarkOVN, actions))
 
-		// table 1, established and related connections in zone 64000 with ct_mark ctMarkHost go to host
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, table=1, ip, ct_state=+trk+est, ct_mark=%s, "+
-				"actions=output:%s",
-				defaultOpenFlowCookie, ctMarkHost, ofPortHost))
+			// table 1, established and related connections in zone 64000 with ct_mark ctMarkHost go to host
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=1, ip, ct_state=+trk+est, ct_mark=%s, "+
+					"actions=output:%s",
+					defaultOpenFlowCookie, ctMarkHost, ofPortHost))
 
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=1, ip, ct_state=+trk+rel, ct_mark=%s, "+
+					"actions=output:%s",
+					defaultOpenFlowCookie, ctMarkHost, ofPortHost))
+		}
+
+		if config.IPv6Mode {
+			// table 1, established and related connections in zone 64000 with ct_mark ctMarkOVN go to OVN
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=1, ipv6, ct_state=+trk+est, ct_mark=%s, "+
+					"actions=%s",
+					defaultOpenFlowCookie, ctMarkOVN, actions))
+
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=1, ipv6, ct_state=+trk+rel, ct_mark=%s, "+
+					"actions=%s",
+					defaultOpenFlowCookie, ctMarkOVN, actions))
+
+			// table 1, established and related connections in zone 64000 with ct_mark ctMarkHost go to host
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=1, ip6, ct_state=+trk+est, ct_mark=%s, "+
+					"actions=output:%s",
+					defaultOpenFlowCookie, ctMarkHost, ofPortHost))
+
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, table=1, ip6, ct_state=+trk+rel, ct_mark=%s, "+
+					"actions=output:%s",
+					defaultOpenFlowCookie, ctMarkHost, ofPortHost))
+		}
+
+		// table 1, we check to see if this dest mac is the shared mac, if so send to host
 		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, table=1, ip, ct_state=+trk+rel, ct_mark=%s, "+
-				"actions=output:%s",
-				defaultOpenFlowCookie, ctMarkHost, ofPortHost))
+			fmt.Sprintf("cookie=%s, priority=10, table=1, dl_dst=%s, actions=output:%s",
+				defaultOpenFlowCookie, bridgeMacAddress, ofPortHost))
 	}
-
-	if config.IPv6Mode {
-		// table 1, established and related connections in zone 64000 with ct_mark ctMarkOVN go to OVN
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, table=1, ipv6, ct_state=+trk+est, ct_mark=%s, "+
-				"actions=%s",
-				defaultOpenFlowCookie, ctMarkOVN, actions))
-
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, table=1, ipv6, ct_state=+trk+rel, ct_mark=%s, "+
-				"actions=%s",
-				defaultOpenFlowCookie, ctMarkOVN, actions))
-
-		// table 1, established and related connections in zone 64000 with ct_mark ctMarkHost go to host
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, table=1, ip6, ct_state=+trk+est, ct_mark=%s, "+
-				"actions=output:%s",
-				defaultOpenFlowCookie, ctMarkHost, ofPortHost))
-
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, table=1, ip6, ct_state=+trk+rel, ct_mark=%s, "+
-				"actions=output:%s",
-				defaultOpenFlowCookie, ctMarkHost, ofPortHost))
-	}
-
-	// table 1, we check to see if this dest mac is the shared mac, if so send to host
-	dftFlows = append(dftFlows,
-		fmt.Sprintf("cookie=%s, priority=10, table=1, dl_dst=%s, actions=output:%s",
-			defaultOpenFlowCookie, bridgeMacAddress, ofPortHost))
 
 	// table 2, dispatch from Host -> OVN
 	dftFlows = append(dftFlows,
@@ -1336,40 +1341,43 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 
 	var dftFlows []string
 
-	// table 0, we check to see if this dest mac is the shared mac, if so flood to both ports
-	dftFlows = append(dftFlows,
-		fmt.Sprintf("cookie=%s, priority=10, table=0, in_port=%s, dl_dst=%s, actions=output:%s,output:%s",
-			defaultOpenFlowCookie, ofPortPhys, bridgeMacAddress, ofPortPatch, ofPortHost))
+	if ofPortPhys != "" {
+		// table 0, we check to see if this dest mac is the shared mac, if so flood to both ports
+		dftFlows = append(dftFlows,
+			fmt.Sprintf("cookie=%s, priority=10, table=0, in_port=%s, dl_dst=%s, actions=output:%s,output:%s",
+				defaultOpenFlowCookie, ofPortPhys, bridgeMacAddress, ofPortPatch, ofPortHost))
+	}
 
 	if config.IPv4Mode {
 		physicalIP, err := util.MatchFirstIPNetFamily(false, bridgeIPs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine IPv4 physical IP of host: %v", err)
 		}
-		// table0, packets coming from egressIP pods that have mark 1008 on them
-		// will be DNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
-		// DNATs these into egressIP prior to reaching external bridge.
-		// egressService pods will also undergo this SNAT to nodeIP since these features are tied
-		// together at the OVN policy level on the distributed router.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=105, in_port=%s, ip, pkt_mark=%s "+
-				"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)),output:%s",
-				defaultOpenFlowCookie, ofPortPatch, ovnKubeNodeSNATMark, config.Default.ConntrackZone, physicalIP.IP, ctMarkOVN, ofPortPhys))
+		if ofPortPhys != "" {
+			// table0, packets coming from egressIP pods that have mark 1008 on them
+			// will be DNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
+			// DNATs these into egressIP prior to reaching external bridge.
+			// egressService pods will also undergo this SNAT to nodeIP since these features are tied
+			// together at the OVN policy level on the distributed router.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=105, in_port=%s, ip, pkt_mark=%s "+
+					"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)),output:%s",
+					defaultOpenFlowCookie, ofPortPatch, ovnKubeNodeSNATMark, config.Default.ConntrackZone, physicalIP.IP, ctMarkOVN, ofPortPhys))
 
-		// table 0, packets coming from pods headed externally. Commit connections with ct_mark ctMarkOVN
-		// so that reverse direction goes back to the pods.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ip, "+
-				"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
-				defaultOpenFlowCookie, ofPortPatch, config.Default.ConntrackZone, ctMarkOVN, ofPortPhys))
+			// table 0, packets coming from pods headed externally. Commit connections with ct_mark ctMarkOVN
+			// so that reverse direction goes back to the pods.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ip, "+
+					"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+					defaultOpenFlowCookie, ofPortPatch, config.Default.ConntrackZone, ctMarkOVN, ofPortPhys))
 
-		// table 0, packets coming from host Commit connections with ct_mark ctMarkHost
-		// so that reverse direction goes back to the host.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ip, "+
-				"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
-				defaultOpenFlowCookie, ofPortHost, config.Default.ConntrackZone, ctMarkHost, ofPortPhys))
-
+			// table 0, packets coming from host Commit connections with ct_mark ctMarkHost
+			// so that reverse direction goes back to the host.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ip, "+
+					"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+					defaultOpenFlowCookie, ofPortHost, config.Default.ConntrackZone, ctMarkHost, ofPortPhys))
+		}
 		if config.Gateway.Mode == config.GatewayModeLocal {
 			// table 0, any packet coming from OVN send to host in LGW mode, host will take care of sending it outside if needed.
 			// exceptions are traffic for egressIP and egressGW features and ICMP related traffic which will hit the priority 100 flow instead of this.
@@ -1386,46 +1394,51 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 					"actions=ct(table=4,zone=%d)",
 					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, HostMasqCTZone))
 			// We send BFD traffic coming from OVN to outside directly using a higher priority flow
-			dftFlows = append(dftFlows,
-				fmt.Sprintf("cookie=%s, priority=650, table=0, in_port=%s, udp, tp_dst=3784, actions=output:%s",
-					defaultOpenFlowCookie, ofPortPatch, ofPortPhys))
+			if ofPortPhys != "" {
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=650, table=0, in_port=%s, udp, tp_dst=3784, actions=output:%s",
+						defaultOpenFlowCookie, ofPortPatch, ofPortPhys))
+			}
 		}
 
-		// table 0, packets coming from external. Send it through conntrack and
-		// resubmit to table 1 to know the state and mark of the connection.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ip, "+
-				"actions=ct(zone=%d, nat, table=1)", defaultOpenFlowCookie, ofPortPhys, config.Default.ConntrackZone))
+		if ofPortPhys != "" {
+			// table 0, packets coming from external. Send it through conntrack and
+			// resubmit to table 1 to know the state and mark of the connection.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ip, "+
+					"actions=ct(zone=%d, nat, table=1)", defaultOpenFlowCookie, ofPortPhys, config.Default.ConntrackZone))
+		}
 	}
 	if config.IPv6Mode {
 		physicalIP, err := util.MatchFirstIPNetFamily(true, bridgeIPs)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine IPv6 physical IP of host: %v", err)
 		}
-		// table0, packets coming from egressIP pods that have mark 1008 on them
-		// will be DNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
-		// DNATs these into egressIP prior to reaching external bridge.
-		// egressService pods will also undergo this SNAT to nodeIP since these features are tied
-		// together at the OVN policy level on the distributed router.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=105, in_port=%s, ipv6, pkt_mark=%s "+
-				"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)),output:%s",
-				defaultOpenFlowCookie, ofPortPatch, ovnKubeNodeSNATMark, config.Default.ConntrackZone, physicalIP.IP, ctMarkOVN, ofPortPhys))
+		if ofPortPhys != "" {
+			// table0, packets coming from egressIP pods that have mark 1008 on them
+			// will be DNAT-ed a final time into nodeIP to maintain consistency in traffic even if the GR
+			// DNATs these into egressIP prior to reaching external bridge.
+			// egressService pods will also undergo this SNAT to nodeIP since these features are tied
+			// together at the OVN policy level on the distributed router.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=105, in_port=%s, ipv6, pkt_mark=%s "+
+					"actions=ct(commit, zone=%d, nat(src=%s), exec(set_field:%s->ct_mark)),output:%s",
+					defaultOpenFlowCookie, ofPortPatch, ovnKubeNodeSNATMark, config.Default.ConntrackZone, physicalIP.IP, ctMarkOVN, ofPortPhys))
 
-		// table 0, packets coming from pods headed externally. Commit connections with ct_mark ctMarkOVN
-		// so that reverse direction goes back to the pods.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ipv6, "+
-				"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
-				defaultOpenFlowCookie, ofPortPatch, config.Default.ConntrackZone, ctMarkOVN, ofPortPhys))
+			// table 0, packets coming from pods headed externally. Commit connections with ct_mark ctMarkOVN
+			// so that reverse direction goes back to the pods.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ipv6, "+
+					"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+					defaultOpenFlowCookie, ofPortPatch, config.Default.ConntrackZone, ctMarkOVN, ofPortPhys))
 
-		// table 0, packets coming from host. Commit connections with ct_mark ctMarkHost
-		// so that reverse direction goes back to the host.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ipv6, "+
-				"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
-				defaultOpenFlowCookie, ofPortHost, config.Default.ConntrackZone, ctMarkHost, ofPortPhys))
-
+			// table 0, packets coming from host. Commit connections with ct_mark ctMarkHost
+			// so that reverse direction goes back to the host.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=100, in_port=%s, ipv6, "+
+					"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+					defaultOpenFlowCookie, ofPortHost, config.Default.ConntrackZone, ctMarkHost, ofPortPhys))
+		}
 		if config.Gateway.Mode == config.GatewayModeLocal {
 			// table 0, any packet coming from OVN send to host in LGW mode, host will take care of sending it outside if needed.
 			// exceptions are traffic for egressIP and egressGW features and ICMP related traffic which will hit the priority 100 flow instead of this.
@@ -1441,18 +1454,21 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 				fmt.Sprintf("cookie=%s, priority=175, in_port=%s, sctp6, ipv6_src=%s, "+
 					"actions=ct(table=4,zone=%d)",
 					defaultOpenFlowCookie, ofPortPatch, physicalIP.IP, HostMasqCTZone))
-			// We send BFD traffic coming from OVN to outside directly using a higher priority flow
-			dftFlows = append(dftFlows,
-				fmt.Sprintf("cookie=%s, priority=650, table=0, in_port=%s, udp6, tp_dst=3784, actions=output:%s",
-					defaultOpenFlowCookie, ofPortPatch, ofPortPhys))
+			if ofPortPhys != "" {
+				// We send BFD traffic coming from OVN to outside directly using a higher priority flow
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=650, table=0, in_port=%s, udp6, tp_dst=3784, actions=output:%s",
+						defaultOpenFlowCookie, ofPortPatch, ofPortPhys))
+			}
 		}
-		// table 0, packets coming from external. Send it through conntrack and
-		// resubmit to table 1 to know the state and mark of the connection.
-		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ipv6, "+
-				"actions=ct(zone=%d, nat, table=1)", defaultOpenFlowCookie, ofPortPhys, config.Default.ConntrackZone))
+		if ofPortPhys != "" {
+			// table 0, packets coming from external. Send it through conntrack and
+			// resubmit to table 1 to know the state and mark of the connection.
+			dftFlows = append(dftFlows,
+				fmt.Sprintf("cookie=%s, priority=50, in_port=%s, ipv6, "+
+					"actions=ct(zone=%d, nat, table=1)", defaultOpenFlowCookie, ofPortPhys, config.Default.ConntrackZone))
+		}
 	}
-
 	// Egress IP is often configured on a node different from the one hosting the affected pod.
 	// Due to the fact that ovn-controllers on different nodes apply the changes independently,
 	// there is a chance that the pod traffic will reach the egress node before it configures the SNAT flows.
@@ -1474,64 +1490,70 @@ func commonFlows(subnets []*net.IPNet, bridge *bridgeConfiguration) ([]string, e
 			if utilnet.IsIPv6CIDR(subnet) {
 				ipPrefix = "ipv6"
 			}
-			// table 0, commit connections from local pods.
-			// ICNIv2 requires that local pod traffic can leave the node without SNAT.
-			dftFlows = append(dftFlows,
-				fmt.Sprintf("cookie=%s, priority=109, in_port=%s, %s, %s_src=%s"+
-					"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
-					defaultOpenFlowCookie, ofPortPatch, ipPrefix, ipPrefix, subnet, config.Default.ConntrackZone, ctMarkOVN, ofPortPhys))
-		}
-	}
-
-	actions := fmt.Sprintf("output:%s", ofPortPatch)
-
-	if config.Gateway.DisableSNATMultipleGWs {
-		// table 1, traffic to pod subnet go directly to OVN
-		for _, clusterEntry := range config.Default.ClusterSubnets {
-			cidr := clusterEntry.CIDR
-			var ipPrefix string
-			if utilnet.IsIPv6CIDR(cidr) {
-				ipPrefix = "ipv6"
-			} else {
-				ipPrefix = "ip"
+			if ofPortPhys != "" {
+				// table 0, commit connections from local pods.
+				// ICNIv2 requires that local pod traffic can leave the node without SNAT.
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=109, in_port=%s, %s, %s_src=%s"+
+						"actions=ct(commit, zone=%d, exec(set_field:%s->ct_mark)), output:%s",
+						defaultOpenFlowCookie, ofPortPatch, ipPrefix, ipPrefix, subnet, config.Default.ConntrackZone, ctMarkOVN, ofPortPhys))
 			}
-			dftFlows = append(dftFlows,
-				fmt.Sprintf("cookie=%s, priority=15, table=1, %s, %s_dst=%s, "+
-					"actions=%s",
-					defaultOpenFlowCookie, ipPrefix, ipPrefix, cidr, actions))
 		}
 	}
 
-	// table 1, we check to see if this dest mac is the shared mac, if so send to host
-	dftFlows = append(dftFlows,
-		fmt.Sprintf("cookie=%s, priority=10, table=1, dl_dst=%s, actions=output:%s",
-			defaultOpenFlowCookie, bridgeMacAddress, ofPortHost))
+	if ofPortPhys != "" {
+		actions := fmt.Sprintf("output:%s", ofPortPatch)
 
-	if config.IPv6Mode {
-		// REMOVEME(trozet) when https://bugzilla.kernel.org/show_bug.cgi?id=11797 is resolved
-		// must flood icmpv6 Route Advertisement and Neighbor Advertisement traffic as it fails to create a CT entry
-		for _, icmpType := range []int{types.RouteAdvertisementICMPType, types.NeighborAdvertisementICMPType} {
-			dftFlows = append(dftFlows,
-				fmt.Sprintf("cookie=%s, priority=14, table=1,icmp6,icmpv6_type=%d actions=FLOOD",
-					defaultOpenFlowCookie, icmpType))
+		if config.Gateway.DisableSNATMultipleGWs {
+			// table 1, traffic to pod subnet go directly to OVN
+			for _, clusterEntry := range config.Default.ClusterSubnets {
+				cidr := clusterEntry.CIDR
+				var ipPrefix string
+				if utilnet.IsIPv6CIDR(cidr) {
+					ipPrefix = "ipv6"
+				} else {
+					ipPrefix = "ip"
+				}
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=15, table=1, %s, %s_dst=%s, "+
+						"actions=%s",
+						defaultOpenFlowCookie, ipPrefix, ipPrefix, cidr, actions))
+			}
 		}
 
-		// We send BFD traffic both on the host and in ovn
+		// table 1, we check to see if this dest mac is the shared mac, if so send to host
 		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=13, table=1, in_port=%s, udp6, tp_dst=3784, actions=output:%s,output:%s",
-				defaultOpenFlowCookie, ofPortPhys, ofPortPatch, ofPortHost))
-	}
+			fmt.Sprintf("cookie=%s, priority=10, table=1, dl_dst=%s, actions=output:%s",
+				defaultOpenFlowCookie, bridgeMacAddress, ofPortHost))
 
-	if config.IPv4Mode {
-		// We send BFD traffic both on the host and in ovn
+		if config.IPv6Mode {
+			// REMOVEME(trozet) when https://bugzilla.kernel.org/show_bug.cgi?id=11797 is resolved
+			// must flood icmpv6 Route Advertisement and Neighbor Advertisement traffic as it fails to create a CT entry
+			for _, icmpType := range []int{types.RouteAdvertisementICMPType, types.NeighborAdvertisementICMPType} {
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=14, table=1,icmp6,icmpv6_type=%d actions=FLOOD",
+						defaultOpenFlowCookie, icmpType))
+			}
+			if ofPortPhys != "" {
+				// We send BFD traffic both on the host and in ovn
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=13, table=1, in_port=%s, udp6, tp_dst=3784, actions=output:%s,output:%s",
+						defaultOpenFlowCookie, ofPortPhys, ofPortPatch, ofPortHost))
+			}
+		}
+
+		if config.IPv4Mode {
+			if ofPortPhys != "" {
+				// We send BFD traffic both on the host and in ovn
+				dftFlows = append(dftFlows,
+					fmt.Sprintf("cookie=%s, priority=13, table=1, in_port=%s, udp, tp_dst=3784, actions=output:%s,output:%s",
+						defaultOpenFlowCookie, ofPortPhys, ofPortPatch, ofPortHost))
+			}
+		}
+		// table 1, all other connections do normal processing
 		dftFlows = append(dftFlows,
-			fmt.Sprintf("cookie=%s, priority=13, table=1, in_port=%s, udp, tp_dst=3784, actions=output:%s,output:%s",
-				defaultOpenFlowCookie, ofPortPhys, ofPortPatch, ofPortHost))
+			fmt.Sprintf("cookie=%s, priority=0, table=1, actions=output:NORMAL", defaultOpenFlowCookie))
 	}
-
-	// table 1, all other connections do normal processing
-	dftFlows = append(dftFlows,
-		fmt.Sprintf("cookie=%s, priority=0, table=1, actions=output:NORMAL", defaultOpenFlowCookie))
 
 	return dftFlows, nil
 }
@@ -1543,15 +1565,17 @@ func setBridgeOfPorts(bridge *bridgeConfiguration) error {
 		return fmt.Errorf("failed while waiting on patch port %q to be created by ovn-controller and "+
 			"while getting ofport. stderr: %q, error: %v", bridge.patchPort, stderr, err)
 	}
-
-	// Get ofport of physical interface
-	ofportPhys, stderr, err := util.GetOVSOfPort("get", "interface", bridge.uplinkName, "ofport")
-	if err != nil {
-		return fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
-			bridge.uplinkName, stderr, err)
-	}
 	bridge.ofPortPatch = ofportPatch
-	bridge.ofPortPhys = ofportPhys
+
+	if bridge.uplinkName != "" {
+		// Get ofport of physical interface
+		ofportPhys, stderr, err := util.GetOVSOfPort("get", "interface", bridge.uplinkName, "ofport")
+		if err != nil {
+			return fmt.Errorf("failed to get ofport of %s, stderr: %q, error: %v",
+				bridge.uplinkName, stderr, err)
+		}
+		bridge.ofPortPhys = ofportPhys
+	}
 
 	// Get ofport represeting the host. That is, host representor port in case of DPUs, ovsLocalPort otherwise.
 	if config.OvnKubeNode.Mode == types.NodeModeDPU {

--- a/go-controller/pkg/node/helper_linux.go
+++ b/go-controller/pkg/node/helper_linux.go
@@ -13,6 +13,20 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type GatewayInterfaceMismatchError struct {
+	msg string
+}
+
+func (error *GatewayInterfaceMismatchError) Error() string {
+	return error.msg
+}
+
+func newGatewayInterfaceMismatchError(format string, args ...interface{}) *GatewayInterfaceMismatchError {
+	return &GatewayInterfaceMismatchError{
+		msg: fmt.Sprintf(format, args...),
+	}
+}
+
 // getDefaultGatewayInterfaceDetails returns the interface name on
 // which the default gateway (for route to 0.0.0.0) is configured.
 // optionally pass the pre-determined gateway interface
@@ -103,7 +117,7 @@ func getDefaultGatewayInterfaceByFamily(family int, gwIface string) (string, net
 			klog.Infof("Found default gateway interface %s %s", foundIfName, r.Gw.String())
 			if len(gwIface) > 0 && gwIface != foundIfName {
 				// this should not happen, but if it did, indicates something broken with our use of the netlink lib
-				return "", nil, fmt.Errorf("mistmaching provided gw interface: %s and gateway found: %s",
+				return "", nil, newGatewayInterfaceMismatchError("mismatching provided gw interface: %s and gateway found: %s",
 					gwIface, foundIfName)
 			}
 			return foundIfName, r.Gw, nil
@@ -129,7 +143,7 @@ func getDefaultGatewayInterfaceByFamily(family int, gwIface string) (string, net
 			klog.Infof("Found default gateway interface %s %s", foundIfName, nh.Gw.String())
 			if len(gwIface) > 0 && gwIface != foundIfName {
 				// this should not happen, but if it did, indicates something broken with our use of the netlink lib
-				return "", nil, fmt.Errorf("mistmaching provided gw interface: %q and gateway found: %q",
+				return "", nil, newGatewayInterfaceMismatchError("mismatching provided gw interface: %q and gateway found: %q",
 					gwIface, foundIfName)
 			}
 			return foundIfName, nh.Gw, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Users can create the external gateway bridge without attaching a
host physical interface as the uplink port in local gateway mode.

The gateway router will use 169.254.169.4 as the default gateway.

Add a new gateway config flag 'allow-no-uplink' to controll if this
setup is allowed or not. It's disabled by default.

With this setup, egressIP and egressGW can not work.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**

1. Create an ovs bridge (e.g. br-ex)without binding any host physical interface.
2. Assign an IP address to the br-ex interface
3. Run ovnkube-node with the flag `--gateway-interface=br-ex`.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->