### PR TITLE
Call SyncEndpoints from AddService

### DIFF
--- a/go-controller/pkg/node/healthcheck_service.go
+++ b/go-controller/pkg/node/healthcheck_service.go
@@ -43,7 +43,20 @@ func (l *loadBalancerHealthChecker) AddService(svc *kapi.Service) error {
 		defer l.Unlock()
 		name := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
 		l.services[name] = uint16(svc.Spec.HealthCheckNodePort)
-		return l.server.SyncServices(l.services)
+		if err := l.server.SyncServices(l.services); err != nil {
+			return fmt.Errorf("unable to sync service %v; err: %v", name, err)
+		}
+		epSlices, err := l.watchFactory.GetEndpointSlices(svc.Namespace, svc.Name)
+		if err != nil {
+			return fmt.Errorf("could not fetch endpointslices "+
+				"for service %s/%s during health check update service: %v",
+				svc.Namespace, svc.Name, err)
+		}
+		namespacedName := ktypes.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
+		l.endpoints[namespacedName] = l.CountLocalReadyEndpointAddresses(epSlices)
+		if err = l.server.SyncEndpoints(l.endpoints); err != nil {
+			return fmt.Errorf("unable to sync endpoint slice %v; err: %v", name, err)
+		}
 	}
 	return nil
 }
@@ -59,20 +72,6 @@ func (l *loadBalancerHealthChecker) UpdateService(old, new *kapi.Service) error 
 		if err = l.AddService(new); err != nil {
 			errors = append(errors, err)
 		}
-		epSlices, err := l.watchFactory.GetEndpointSlices(new.Namespace, new.Name)
-		if err != nil {
-			errors = append(errors, fmt.Errorf("could not fetch endpointslices "+
-				"for service %s/%s during health check update service: %v",
-				new.Namespace, new.Name, err))
-			return apierrors.NewAggregate(errors)
-		}
-		namespacedName := ktypes.NamespacedName{Namespace: new.Namespace, Name: new.Name}
-		l.Lock()
-		l.endpoints[namespacedName] = l.CountLocalReadyEndpointAddresses(epSlices)
-		if err = l.server.SyncEndpoints(l.endpoints); err != nil {
-			errors = append(errors, err)
-		}
-		l.Unlock()
 	}
 	if old.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeLocal &&
 		new.Spec.ExternalTrafficPolicy == kapi.ServiceExternalTrafficPolicyTypeCluster {


### PR DESCRIPTION
**- What this PR does and why is it needed**
There is a race condition observed when the
endpointslice is added before the service.
We will not pass https://github.com/ovn-org/ovn-kubernetes/blob/e7a92dbdab7d2f0c056ae2c6e549140c1809c7c0/go-controller/pkg/node/healthcheck_service.go#L131 this check and hence will not call `syncEndPointSlices` since service doesn't exist yet. Later when we do
AddService, we were not calling syncEndpoints and so we end up in a situation where the localEndpoints count is not updated.

This PR fixes that by moving the logic to call syncEndpoints to AddService. In the reverse case of endpointslice being added after the service, its possible we call the syncEndpoints from two places - both AddService and AddEndpointSlice, but better to be functionally correct and avoid race before worrying about performance...

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- Special notes for reviewers**
Hard to capture in a unit test since this is solely dependent on the order of event's arrival

**- How to verify it**
Manually create a LB service type and then recreate the LB a couple of times till race is hit.

**- Description for the changelog**
`Fix race condition when EPS is created before the SVC in node healthchecker`