### PR TITLE
Emit node events only when retry failure

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -668,6 +668,10 @@ func (h *defaultNetworkControllerEventHandler) RecordErrorEvent(obj interface{},
 		pod := obj.(*kapi.Pod)
 		klog.V(5).Infof("Recording error event on pod %s/%s", pod.Namespace, pod.Name)
 		h.oc.recordPodEvent(reason, err, pod)
+	case factory.NodeType:
+		node := obj.(*kapi.Node)
+		klog.V(5).Infof("Recording error event for node %s", node.Name)
+		h.oc.recordNodeEvent(reason, err, node)
 	}
 }
 

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -758,9 +758,7 @@ func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSy
 			if nSyncs.syncZoneIC {
 				oc.syncZoneICFailed.Store(node.Name, true)
 			}
-			err = fmt.Errorf("nodeAdd: error adding node %q: %w", node.Name, err)
-			oc.recordNodeErrorEvent(node, err)
-			return err
+			return fmt.Errorf("nodeAdd: error adding node %q: %w", node.Name, err)
 		}
 		oc.addNodeFailed.Delete(node.Name)
 	}
@@ -856,13 +854,7 @@ func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSy
 			}
 		}
 	}
-
-	err = kerrors.NewAggregate(errs)
-	if err != nil {
-		oc.recordNodeErrorEvent(node, err)
-	}
-
-	return err
+	return kerrors.NewAggregate(errs)
 }
 
 func (oc *DefaultNetworkController) addUpdateRemoteNodeEvent(node *kapi.Node, syncZoneIC bool) error {
@@ -897,7 +889,6 @@ func (oc *DefaultNetworkController) addUpdateRemoteNodeEvent(node *kapi.Node, sy
 			}
 		}
 	}
-
 	return err
 }
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1342,18 +1342,6 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				gomega.BeNil(),             // oldObj should be nil
 				gomega.Not(gomega.BeNil()), // newObj should not be nil
 			)
-
-			// check that a node event was posted
-			gomega.Eventually(func() []string {
-				eventsLock.Lock()
-				defer eventsLock.Unlock()
-				eventsCopy := make([]string, 0, len(events))
-				for _, e := range events {
-					eventsCopy = append(eventsCopy, e)
-				}
-				return eventsCopy
-			}, 10).Should(gomega.ContainElement(gomega.ContainSubstring("Warning ErrorReconcilingNode error creating gateway for node node1")))
-
 			connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
 			defer cancel()
 			ginkgo.By("bring up NBDB")

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -109,6 +109,16 @@ func (oc *DefaultNetworkController) recordPodEvent(reason string, addErr error, 
 	}
 }
 
+func (oc *DefaultNetworkController) recordNodeEvent(reason string, addErr error, node *kapi.Node) {
+	nodeRef, err := ref.GetReference(scheme.Scheme, node)
+	if err != nil {
+		klog.Errorf("Couldn't get a reference to node %s to post an event: '%v'", node.Name, err)
+	} else {
+		klog.V(5).Infof("Posting a %s event for node %s", kapi.EventTypeWarning, node.Name)
+		oc.recorder.Eventf(nodeRef, kapi.EventTypeWarning, reason, addErr.Error())
+	}
+}
+
 func exGatewayAnnotationsChanged(oldPod, newPod *kapi.Pod) bool {
 	return oldPod.Annotations[util.RoutingNamespaceAnnotation] != newPod.Annotations[util.RoutingNamespaceAnnotation] ||
 		oldPod.Annotations[util.RoutingNetworkAnnotation] != newPod.Annotations[util.RoutingNetworkAnnotation] ||

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -233,6 +233,10 @@ func (r *RetryFramework) resourceRetry(objKey string, now time.Time) {
 				r.ResourceHandler.ObjType, objKey)
 			r.DeleteRetryObj(key)
 			metrics.MetricResourceRetryFailuresCount.Inc()
+			if entry.newObj != nil {
+				r.ResourceHandler.RecordErrorEvent(entry.newObj, "RetryFailed",
+					fmt.Errorf("failed to reconcile and retried %d times for object: %v", MaxFailedAttempts, entry.newObj))
+			}
 			return
 		}
 		forceRetry := false


### PR DESCRIPTION
Nodes obj is configured via distributed software
components and previous to this patch, we are
sending numerous kubernetes events of error level warning when infact everything is proceeding normally..

Only emit warning events when we fail to configure a node. This is after 15 retry attempts - ~7m currently.

We continue logging every node add/update/delete failure to logs.
