### PR TITLE
Always use OVN's iface-id-ver option in non-DPUHost mode

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -98,7 +98,7 @@ func (pr *PodRequest) checkOrUpdatePodUID(pod *kapi.Pod) error {
 	return nil
 }
 
-func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet, useOVSExternalIDs bool) (*Response, error) {
+func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Response, error) {
 	namespace := pr.PodNamespace
 	podName := pr.PodName
 	if namespace == "" || podName == "" {
@@ -137,7 +137,7 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet, useOVS
 		return nil, err
 	}
 
-	podInterfaceInfo, err := PodAnnotation2PodInfo(annotations, podNADAnnotation, useOVSExternalIDs, pr.PodUID, netdevName,
+	podInterfaceInfo, err := PodAnnotation2PodInfo(annotations, podNADAnnotation, pr.PodUID, netdevName,
 		pr.nadName, pr.netName, pr.CNIConf.MTU)
 	if err != nil {
 		return nil, err
@@ -247,7 +247,7 @@ func (pr *PodRequest) cmdCheck() error {
 // Argument '*PodRequest' encapsulates all the necessary information
 // kclient is passed in so that clientset can be reused from the server
 // Return value is the actual bytes to be sent back without further processing.
-func HandlePodRequest(request *PodRequest, clientset *ClientSet, useOVSExternalIDs bool, kubeAuth *KubeAPIAuth) ([]byte, error) {
+func HandlePodRequest(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth) ([]byte, error) {
 	var result, resultForLogging []byte
 	var response *Response
 	var err, err1 error
@@ -255,7 +255,7 @@ func HandlePodRequest(request *PodRequest, clientset *ClientSet, useOVSExternalI
 	klog.Infof("%s %s starting CNI request %+v", request, request.Command, request)
 	switch request.Command {
 	case CNIAdd:
-		response, err = request.cmdAdd(kubeAuth, clientset, useOVSExternalIDs)
+		response, err = request.cmdAdd(kubeAuth, clientset)
 	case CNIDel:
 		response, err = request.cmdDel(clientset)
 	case CNICheck:

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -49,23 +48,16 @@ import (
 // started.
 
 // NewCNIServer creates and returns a new Server object which will listen on a socket in the given path
-func NewCNIServer(useOVSExternalIDs bool, factory factory.NodeWatchFactory, kclient kubernetes.Interface) (*Server, error) {
+func NewCNIServer(factory factory.NodeWatchFactory, kclient kubernetes.Interface) (*Server, error) {
 	if config.OvnKubeNode.Mode == types.NodeModeDPU {
 		return nil, fmt.Errorf("unsupported ovnkube-node mode for CNI server: %s", config.OvnKubeNode.Mode)
 	}
 	router := mux.NewRouter()
 
-	// we use atomic lib to store port binding mode state, so use int32 to represent bool
-	var ovnPortBinding int32
-	if useOVSExternalIDs {
-		ovnPortBinding = 1
-	}
-
 	s := &Server{
 		Server: http.Server{
 			Handler: router,
 		},
-		useOVSExternalIDs: ovnPortBinding,
 		clientSet: &ClientSet{
 			podLister: corev1listers.NewPodLister(factory.LocalPodInformer().GetIndexer()),
 			kclient:   kclient,
@@ -220,11 +212,7 @@ func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 	}
 	defer req.cancel()
 
-	useOVSExternalIDs := false
-	if atomic.LoadInt32(&s.useOVSExternalIDs) > 0 {
-		useOVSExternalIDs = true
-	}
-	result, err := s.handlePodRequestFunc(req, s.clientSet, useOVSExternalIDs, s.kubeAuth)
+	result, err := s.handlePodRequestFunc(req, s.clientSet, s.kubeAuth)
 	if err != nil {
 		// Prefix error with request information for easier debugging
 		return nil, fmt.Errorf("%s %v", req, err)
@@ -248,9 +236,4 @@ func (s *Server) handleCNIMetrics(w http.ResponseWriter, r *http.Request) {
 	if _, err := w.Write([]byte{}); err != nil {
 		klog.Warningf("Error writing %s HTTP response for metrics post", err)
 	}
-}
-
-func (s *Server) EnableOVNPortUpSupport() {
-	atomic.StoreInt32(&s.useOVSExternalIDs, 1)
-	klog.Info("OVN Port Binding support now enabled in CNI Server")
 }

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -47,7 +47,7 @@ func clientDoCNI(t *testing.T, client *http.Client, req *Request) ([]byte, int) 
 
 var expectedResult cnitypes.Result
 
-func serverHandleCNI(request *PodRequest, clientset *ClientSet, useOVSExternalIDs bool, kubeAuth *KubeAPIAuth) ([]byte, error) {
+func serverHandleCNI(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth) ([]byte, error) {
 	if request.Command == CNIAdd {
 		return json.Marshal(&expectedResult)
 	} else if request.Command == CNIDel || request.Command == CNIUpdate || request.Command == CNICheck {
@@ -89,7 +89,7 @@ func TestCNIServer(t *testing.T) {
 		t.Fatalf("failed to start watch factory: %v", err)
 	}
 
-	s, err := NewCNIServer(false, wf, fakeClient)
+	s, err := NewCNIServer(wf, fakeClient)
 	if err != nil {
 		t.Fatalf("error creating CNI server: %v", err)
 	}

--- a/go-controller/pkg/cni/ovs.go
+++ b/go-controller/pkg/cni/ovs.go
@@ -267,9 +267,9 @@ func waitForPodInterface(ctx context.Context, ifInfo *PodInterfaceInfo,
 	var ofPort int
 	var err error
 
-	mac := ifInfo.MAC.String()
-	ifAddrs := ifInfo.IPs
-	checkExternalIDs := ifInfo.CheckExtIDs
+	// DPUHost mode can't use OVS external IDs for port-up detection because
+	// there is no ovn-controller running in DPUHost mode to set port-up
+	checkExternalIDs := !ifInfo.IsDPUHostMode
 	if checkExternalIDs {
 		detail = " (ovn-installed)"
 	} else {
@@ -278,6 +278,9 @@ func waitForPodInterface(ctx context.Context, ifInfo *PodInterfaceInfo,
 			return err
 		}
 	}
+
+	mac := ifInfo.MAC.String()
+	ifAddrs := ifInfo.IPs
 	for {
 		select {
 		case <-ctx.Done():

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -46,7 +46,6 @@ type PodInterfaceInfo struct {
 	RoutableMTU          int    `json:"routable-mtu"`
 	Ingress              int64  `json:"ingress"`
 	Egress               int64  `json:"egress"`
-	CheckExtIDs          bool   `json:"check-external-ids"`
 	IsDPUHostMode        bool   `json:"is-dpu-host-mode"`
 	PodUID               string `json:"pod-uid"`
 	NetdevName           string `json:"vf-netdev-name"`
@@ -159,7 +158,7 @@ type PodRequest struct {
 	nadName string
 }
 
-type podRequestFunc func(request *PodRequest, clientset *ClientSet, useOVSExternalIDs bool, kubeAuth *KubeAPIAuth) ([]byte, error)
+type podRequestFunc func(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth) ([]byte, error)
 
 type PodInfoGetter interface {
 	getPod(namespace, name string) (*kapi.Pod, error)
@@ -183,7 +182,6 @@ func NewClientSet(kclient kubernetes.Interface, podLister corev1listers.PodListe
 type Server struct {
 	http.Server
 	handlePodRequestFunc podRequestFunc
-	useOVSExternalIDs    int32
 	clientSet            *ClientSet
 	kubeAuth             *KubeAPIAuth
 }

--- a/go-controller/pkg/cni/utils.go
+++ b/go-controller/pkg/cni/utils.go
@@ -98,7 +98,7 @@ func GetPodWithAnnotations(ctx context.Context, getter PodInfoGetter,
 }
 
 // PodAnnotation2PodInfo creates PodInterfaceInfo from Pod annotations and additional attributes
-func PodAnnotation2PodInfo(podAnnotation map[string]string, podNADAnnotation *util.PodAnnotation, checkExtIDs bool, podUID,
+func PodAnnotation2PodInfo(podAnnotation map[string]string, podNADAnnotation *util.PodAnnotation, podUID,
 	netdevname, nadName, netName string, mtu int) (*PodInterfaceInfo, error) {
 	var err error
 	// get pod's annotation of the given NAD if it is not available
@@ -123,7 +123,6 @@ func PodAnnotation2PodInfo(podAnnotation map[string]string, podNADAnnotation *ut
 		RoutableMTU:          config.Default.RoutableMTU, // TBD, configurable for secondary network?
 		Ingress:              ingress,
 		Egress:               egress,
-		CheckExtIDs:          checkExtIDs,
 		IsDPUHostMode:        config.OvnKubeNode.Mode == types.NodeModeDPUHost,
 		PodUID:               podUID,
 		NetdevName:           netdevname,
@@ -134,7 +133,7 @@ func PodAnnotation2PodInfo(podAnnotation map[string]string, podNADAnnotation *ut
 	return podInterfaceInfo, nil
 }
 
-//START taken from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/types/pod_update.go
+// START taken from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/types/pod_update.go
 const (
 	ConfigSourceAnnotationKey = "kubernetes.io/config.source"
 	// ApiserverSource identifies updates from Kubernetes API Server.

--- a/go-controller/pkg/cni/utils_test.go
+++ b/go-controller/pkg/cni/utils_test.go
@@ -254,40 +254,28 @@ var _ = Describe("CNI Utils tests", func() {
 		podUID := "4d06bae8-9c38-41f6-945c-f92320e782e4"
 		It("Creates PodInterfaceInfo in NodeModeFull mode", func() {
 			config.OvnKubeNode.Mode = ovntypes.NodeModeFull
-			pif, err := PodAnnotation2PodInfo(podAnnot, nil, false, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
+			pif, err := PodAnnotation2PodInfo(podAnnot, nil, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.IsDPUHostMode).To(BeFalse())
 		})
 
 		It("Creates PodInterfaceInfo in NodeModeDPUHost mode", func() {
 			config.OvnKubeNode.Mode = ovntypes.NodeModeDPUHost
-			pif, err := PodAnnotation2PodInfo(podAnnot, nil, false, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
+			pif, err := PodAnnotation2PodInfo(podAnnot, nil, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.IsDPUHostMode).To(BeTrue())
 		})
 
-		It("Creates PodInterfaceInfo with checkExtIDs false", func() {
-			pif, err := PodAnnotation2PodInfo(podAnnot, nil, false, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pif.CheckExtIDs).To(BeFalse())
-		})
-
-		It("Creates PodInterfaceInfo with checkExtIDs true", func() {
-			pif, err := PodAnnotation2PodInfo(podAnnot, nil, true, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pif.CheckExtIDs).To(BeTrue())
-		})
-
 		It("Creates PodInterfaceInfo with EnableUDPAggregation", func() {
 			config.Default.EnableUDPAggregation = true
-			pif, err := PodAnnotation2PodInfo(podAnnot, nil, false, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
+			pif, err := PodAnnotation2PodInfo(podAnnot, nil, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.EnableUDPAggregation).To(BeTrue())
 		})
 
 		It("Creates PodInterfaceInfo without EnableUDPAggregation", func() {
 			config.Default.EnableUDPAggregation = false
-			pif, err := PodAnnotation2PodInfo(podAnnot, nil, false, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
+			pif, err := PodAnnotation2PodInfo(podAnnot, nil, podUID, "", ovntypes.DefaultNetworkName, ovntypes.DefaultNetworkName, config.Default.MTU)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pif.EnableUDPAggregation).To(BeFalse())
 		})

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -453,7 +453,6 @@ type OvnKubeNodeConfig struct {
 	DPResourceDeviceIdsMap map[string][]string
 	MgmtPortNetdev         string `gcfg:"mgmt-port-netdev"`
 	MgmtPortDPResourceName string `gcfg:"mgmt-port-dp-resource-name"`
-	DisableOVNIfaceIdVer   bool   `gcfg:"disable-ovn-iface-id-ver"`
 }
 
 // ClusterManagerConfig holds configuration for ovnkube-cluster-manager
@@ -522,6 +521,8 @@ var (
 	initGateways bool
 	// legacy gateway-local CLI option
 	gatewayLocal bool
+	// legacy disable-ovn-iface-id-ver CLI option
+	disableOVNIfaceIDVer bool
 )
 
 func init() {
@@ -1379,11 +1380,9 @@ var OvnKubeNodeFlags = []cli.Flag{
 		Destination: &cliConfig.OvnKubeNode.MgmtPortDPResourceName,
 	},
 	&cli.BoolFlag{
-		Name: "disable-ovn-iface-id-ver",
-		Usage: "if iface-id-ver option is not enabled in ovn, set this flag to True " +
-			"(depends on ovn version, minimal required is 21.09)",
-		Value:       OvnKubeNode.DisableOVNIfaceIdVer,
-		Destination: &cliConfig.OvnKubeNode.DisableOVNIfaceIdVer,
+		Name:        "disable-ovn-iface-id-ver",
+		Usage:       "Deprecated; iface-id-ver is always enabled",
+		Destination: &disableOVNIfaceIDVer,
 	},
 }
 

--- a/go-controller/pkg/node/base_node_network_controller_dpu_test.go
+++ b/go-controller/pkg/node/base_node_network_controller_dpu_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Node DPU tests", func() {
 
 		kubeMock = kubemocks.Interface{}
 		factoryMock = factorymocks.NodeWatchFactory{}
-		cnnci := newCommonNodeNetworkControllerInfo(nil, &kubeMock, &factoryMock, nil, "", false)
+		cnnci := newCommonNodeNetworkControllerInfo(nil, &kubeMock, &factoryMock, nil, "")
 		dnnc = newDefaultNodeNetworkController(cnnci, nil, nil)
 
 		podNamespaceLister = v1mocks.PodNamespaceLister{}

--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -721,7 +721,7 @@ func shareGatewayInterfaceDPUHostTest(app *cli.App, testNS ns.NetNS, uplinkName,
 		err = wf.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		cnnci := NewCommonNodeNetworkControllerInfo(nil, wf, nil, nodeName, false)
+		cnnci := NewCommonNodeNetworkControllerInfo(nil, wf, nil, nodeName)
 		nc := newDefaultNodeNetworkController(cnnci, stop, wg)
 		// must run route manager manually which is usually started with nc.Start()
 		wg.Add(1)

--- a/go-controller/pkg/node/ovn_test.go
+++ b/go-controller/pkg/node/ovn_test.go
@@ -79,7 +79,7 @@ func (o *FakeOVNNode) init() {
 	o.watcher, err = factory.NewNodeWatchFactory(o.fakeClient, fakeNodeName)
 	Expect(err).NotTo(HaveOccurred())
 
-	cnnci := NewCommonNodeNetworkControllerInfo(o.fakeClient.KubeClient, o.watcher, o.recorder, fakeNodeName, false)
+	cnnci := NewCommonNodeNetworkControllerInfo(o.fakeClient.KubeClient, o.watcher, o.recorder, fakeNodeName)
 	o.nc = newDefaultNodeNetworkController(cnnci, o.stopChan, o.wg)
 	// watcher is started by nodeNetworkControllerManager, not by nodeNetworkcontroller, so start it here.
 	o.watcher.Start()

--- a/go-controller/pkg/util/ovn.go
+++ b/go-controller/pkg/util/ovn.go
@@ -6,7 +6,6 @@ package util
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	ocpconfigapi "github.com/openshift/api/config/v1"
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
@@ -46,22 +45,4 @@ func PlatformTypeIsEgressIPCloudProvider() bool {
 		config.Kubernetes.PlatformType == string(ocpconfigapi.GCPPlatformType) ||
 		config.Kubernetes.PlatformType == string(ocpconfigapi.AzurePlatformType) ||
 		config.Kubernetes.PlatformType == string(ocpconfigapi.OpenStackPlatformType)
-}
-
-// GetOVNIfUpCheckMode returns true if OVN supports Port_Binding.up
-//
-// Starting with v21.03.0 OVN sets OVS.Interface.external-id:ovn-installed
-// and OVNSB.Port_Binding.up when all OVS flows associated to a
-// logical port have been successfully programmed.
-// OVS.Interface.external-id:ovn-installed can only be used correctly
-// in a combination with OVS.Interface.external-id:iface-id-ver
-func GetOVNIfUpCheckMode() (bool, error) {
-	if _, stderr, err := RunOVNSbctl("--columns=up", "list", "Port_Binding"); err != nil {
-		if strings.Contains(stderr, "does not contain a column") {
-			return false, nil
-		}
-		return false, fmt.Errorf("failed to check if port_binding is supported in OVN, stderr: %q, error: %v",
-			stderr, err)
-	}
-	return true, nil
 }


### PR DESCRIPTION
iface-id-ver was added in OVN 21.09; all ovn-kubernetes users should *definitely* be using a much newer OVN. So we can remove all the complicated logic around detecting if OVN supports it, and just assume we can always use it unless we're in DPUHost mode.

@bn222 @trozet 