### PR TITLE
Drop MgmtPortRepresentor config variable

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -453,8 +453,7 @@ type OvnKubeNodeConfig struct {
 	DPResourceDeviceIdsMap map[string][]string
 	MgmtPortNetdev         string `gcfg:"mgmt-port-netdev"`
 	MgmtPortDPResourceName string `gcfg:"mgmt-port-dp-resource-name"`
-	MgmtPortRepresentor    string
-	DisableOVNIfaceIdVer   bool `gcfg:"disable-ovn-iface-id-ver"`
+	DisableOVNIfaceIdVer   bool   `gcfg:"disable-ovn-iface-id-ver"`
 }
 
 // ClusterManagerConfig holds configuration for ovnkube-cluster-manager

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -307,7 +307,6 @@ var _ = Describe("Config Operations", func() {
 			gomega.Expect(OvnKubeNode.Mode).To(gomega.Equal(types.NodeModeFull))
 			gomega.Expect(OvnKubeNode.MgmtPortNetdev).To(gomega.Equal(""))
 			gomega.Expect(OvnKubeNode.MgmtPortDPResourceName).To(gomega.Equal(""))
-			gomega.Expect(OvnKubeNode.MgmtPortRepresentor).To(gomega.Equal(""))
 			gomega.Expect(Gateway.RouterSubnet).To(gomega.Equal(""))
 			gomega.Expect(Gateway.SingleNode).To(gomega.BeFalse())
 			gomega.Expect(Gateway.DisableForwarding).To(gomega.BeFalse())

--- a/go-controller/pkg/node/management-port-dpu.go
+++ b/go-controller/pkg/node/management-port-dpu.go
@@ -31,7 +31,7 @@ func newManagementPortRepresentor(nodeName string, hostSubnets []*net.IPNet, rep
 
 func (mp *managementPortRepresentor) Create(_ *routeManager, nodeAnnotator kube.Annotator, waiter *startupWaiter) (*managementPortConfig, error) {
 	k8sMgmtIntfName := types.K8sMgmtIntfName
-	if config.OvnKubeNode.MgmtPortRepresentor != "" {
+	if config.OvnKubeNode.Mode == types.NodeModeFull {
 		k8sMgmtIntfName += "_0"
 	}
 

--- a/go-controller/pkg/node/management-port.go
+++ b/go-controller/pkg/node/management-port.go
@@ -137,7 +137,7 @@ func (mp *managementPort) HasIpAddr() bool {
 
 func managementPortReady() (bool, error) {
 	k8sMgmtIntfName := types.K8sMgmtIntfName
-	if config.OvnKubeNode.MgmtPortRepresentor != "" {
+	if config.OvnKubeNode.MgmtPortNetdev != "" {
 		k8sMgmtIntfName += "_0"
 	}
 	// Get the OVS interface name for the Management Port

--- a/go-controller/pkg/node/management-port_dpu_test.go
+++ b/go-controller/pkg/node/management-port_dpu_test.go
@@ -20,7 +20,7 @@ import (
 func genOVSAddMgmtPortCmd(nodeName, repName string) string {
 	return fmt.Sprintf("ovs-vsctl --timeout=15 -- --may-exist add-port br-int %s -- set interface %s external-ids:iface-id=%s"+
 		" external-ids:ovn-orig-mgmt-port-rep-name=%s",
-		types.K8sMgmtIntfName, types.K8sMgmtIntfName, types.K8sPrefix+nodeName, repName)
+		types.K8sMgmtIntfName+"_0", types.K8sMgmtIntfName+"_0", types.K8sPrefix+nodeName, repName)
 }
 
 func mockOVSListInterfaceMgmtPortNotExistCmd(execMock *ovntest.FakeExec, mgmtPortName string) {
@@ -88,12 +88,12 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
-			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName+"_0").Return(
 				nil, fmt.Errorf("link not found"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
-			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(fmt.Errorf("failed to set name"))
-			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
+			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName+"_0").Return(fmt.Errorf("failed to set name"))
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName+"_0")
 
 			_, err := mgmtPortDpu.Create(nil, nodeAnnotatorMock, waiter)
 			Expect(err).To(HaveOccurred())
@@ -115,14 +115,14 @@ var _ = Describe("Mananagement port DPU tests", func() {
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
-			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName).Return(
+			netlinkOpsMock.On("LinkByName", types.K8sMgmtIntfName+"_0").Return(
 				nil, fmt.Errorf("link not found"))
 			netlinkOpsMock.On("IsLinkNotFoundError", mock.Anything).Return(true)
 			netlinkOpsMock.On("LinkSetDown", linkMock).Return(nil)
-			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName).Return(nil)
+			netlinkOpsMock.On("LinkSetName", linkMock, types.K8sMgmtIntfName+"_0").Return(nil)
 			netlinkOpsMock.On("LinkSetMTU", linkMock, config.Default.MTU).Return(nil)
 			netlinkOpsMock.On("LinkSetUp", linkMock).Return(nil)
-			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName)
+			mockOVSListInterfaceMgmtPortNotExistCmd(execMock, types.K8sMgmtIntfName+"_0")
 			execMock.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd: genOVSAddMgmtPortCmd(mgmtPortDpu.nodeName, mgmtPortDpu.repName),
 			})
@@ -130,7 +130,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			mpcfg, err := mgmtPortDpu.Create(nil, nodeAnnotatorMock, waiter)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(mpcfg.ifName).To(Equal(types.K8sMgmtIntfName))
+			Expect(mpcfg.ifName).To(Equal(types.K8sMgmtIntfName + "_0"))
 			Expect(mpcfg.link).To(Equal(linkMock))
 		})
 
@@ -146,7 +146,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			}
 			nodeAnnotatorMock.On("Set", mock.Anything, expectedMgmtPortMac.String()).Return(nil)
 			linkMock := &mocks.Link{}
-			linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: "ovn-k8s-mp0", MTU: config.Default.MTU})
+			linkMock.On("Attrs").Return(&netlink.LinkAttrs{Name: "ovn-k8s-mp0_0", MTU: config.Default.MTU})
 
 			netlinkOpsMock.On("LinkByName", "enp3s0f0v0").Return(
 				linkMock, nil)
@@ -158,7 +158,7 @@ var _ = Describe("Mananagement port DPU tests", func() {
 			mpcfg, err := mgmtPortDpu.Create(nil, nodeAnnotatorMock, waiter)
 			Expect(execMock.CalledMatchesExpected()).To(BeTrue(), execMock.ErrorDesc)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(mpcfg.ifName).To(Equal(types.K8sMgmtIntfName))
+			Expect(mpcfg.ifName).To(Equal(types.K8sMgmtIntfName + "_0"))
 			Expect(mpcfg.link).To(Equal(linkMock))
 		})
 	})


### PR DESCRIPTION
After introducing representor discovery for DPU mode MgmtPortRepresentor variable is not populated which cause ovnkube to mistakenly unconfigure management port netdevice or representor in the Full mode because it uses incorrect management interface name.
Drop this variable as obsolete and use other existing config variables to determine when management interface name should have a post-fix. Fix affected unit-tests.

Fixes: #3598