### PR TITLE
network-controller: assume multicast/IGMP_Group is supported by OVN

### DIFF
--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -201,8 +201,9 @@ func NewNetworkControllerManager(ovnClient *util.OVNClientset, identity string, 
 		sbClient:     libovsdbOvnSBClient,
 		podRecorder:  &podRecorder,
 
-		wg:       wg,
-		identity: identity,
+		wg:               wg,
+		identity:         identity,
+		multicastSupport: config.EnableMulticast,
 	}
 
 	var err error
@@ -228,17 +229,6 @@ func (cm *networkControllerManager) configureSCTPSupport() error {
 	}
 	cm.SCTPSupport = hasSCTPSupport
 	return nil
-}
-
-func (cm *networkControllerManager) configureMulticastSupport() {
-	cm.multicastSupport = config.EnableMulticast
-	if cm.multicastSupport {
-		if _, _, err := util.RunOVNSbctl("--columns=_uuid", "list", "IGMP_Group"); err != nil {
-			klog.Warningf("Multicast support enabled, however version of OVN in use does not support IGMP Group. " +
-				"Disabling Multicast Support")
-			cm.multicastSupport = false
-		}
-	}
 }
 
 func (cm *networkControllerManager) configureSvcTemplateSupport() {
@@ -361,7 +351,6 @@ func (cm *networkControllerManager) Start(ctx context.Context) error {
 		return err
 	}
 
-	cm.configureMulticastSupport()
 	cm.configureSvcTemplateSupport()
 	cm.enableACLLoggingSupport()
 


### PR DESCRIPTION
OVN has multicast support since 2.12 long long ago; we don't need to check the Southbound for it anymore.

Multicast will still be disabled if turned off via config or for secondary networks.