### PR TITLE
ovn: assume ACL logging is always supported

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -61,8 +61,6 @@ type CommonNetworkControllerInfo struct {
 
 	// Supports OVN Template Load Balancers?
 	svcTemplateSupport bool
-	// Is ACL logging enabled while configuring meters?
-	aclLoggingEnabled bool
 
 	// Northbound database zone name to which this Controller is connected to - aka local zone
 	zone string
@@ -153,7 +151,7 @@ type BaseSecondaryNetworkController struct {
 // NewCommonNetworkControllerInfo creates CommonNetworkControllerInfo shared by controllers
 func NewCommonNetworkControllerInfo(client clientset.Interface, kube *kube.KubeOVN, wf *factory.WatchFactory,
 	recorder record.EventRecorder, nbClient libovsdbclient.Client, sbClient libovsdbclient.Client,
-	podRecorder *metrics.PodRecorder, SCTPSupport, multicastSupport, svcTemplateSupport, aclLoggingEnabled bool) (*CommonNetworkControllerInfo, error) {
+	podRecorder *metrics.PodRecorder, SCTPSupport, multicastSupport, svcTemplateSupport bool) (*CommonNetworkControllerInfo, error) {
 	zone, err := util.GetNBZone(nbClient)
 	if err != nil {
 		return nil, fmt.Errorf("error getting NB zone name : err - %w", err)
@@ -169,7 +167,6 @@ func NewCommonNetworkControllerInfo(client clientset.Interface, kube *kube.KubeO
 		SCTPSupport:        SCTPSupport,
 		multicastSupport:   multicastSupport,
 		svcTemplateSupport: svcTemplateSupport,
-		aclLoggingEnabled:  aclLoggingEnabled,
 		zone:               zone,
 	}, nil
 }

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -105,8 +105,8 @@ func (bnc *BaseNetworkController) aclLoggingUpdateNsInfo(annotation string, nsIn
 	var aclLevels ACLLoggingLevels
 	var errors []error
 
-	// If logging is disabled or if the annotation is "" or "{}", use empty strings. Otherwise, parse the annotation.
-	if bnc.aclLoggingEnabled && annotation != "" && annotation != "{}" {
+	// If the annotation is "" or "{}", use empty strings. Otherwise, parse the annotation.
+	if annotation != "" && annotation != "{}" {
 		err := json.Unmarshal([]byte(annotation), &aclLevels)
 		if err != nil {
 			// Disable Allow and Deny logging to ensure idempotency.

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -236,7 +236,6 @@ func NewOvnController(ovnClient *util.OVNMasterClientset, wf *factory.WatchFacto
 		false, // sctp support
 		false, // multicast support
 		true,  // templates support
-		true,  // acl logging enabled
 	)
 	if err != nil {
 		return nil, err
@@ -342,7 +341,6 @@ func (o *FakeOVN) NewSecondaryNetworkController(netattachdef *nettypes.NetworkAt
 			false, // sctp support
 			false, // multicast support
 			true,  // templates support
-			true,  // acl logging enabled
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
MeterBand and Meters have been supported for ACLs for a long time; any ovnkube user should be running an OVN that supports them.