### PR TITLE
Remove stale egressip status entry

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1047,6 +1047,64 @@ func (eIPC *egressIPClusterController) reconcileEgressIP(old, new *egressipv1.Eg
 	return nil
 }
 
+// syncEgressIPs This method takes care syncing stale data in the egress ip status
+// with cloud private ip config upon master reboot cases. cloud private ip config
+// entry would have been deleted when master was down whereas egress ip status
+// was not updated for the deleted entry in an error scenario. Hence this method
+// ensures egress ip status is upto date with available cloud private ip config
+// entry.
+func (eIPC *egressIPClusterController) syncEgressIPs(ips []interface{}) error {
+	if !util.PlatformTypeIsEgressIPCloudProvider() {
+		return nil
+	}
+	cloudPrivateIPConfigMap, err := eIPC.getCloudPrivateIPConfigMap()
+	if err != nil {
+		return fmt.Errorf("syncEgressIPs unable to get cloud private ip config: %w", err)
+	}
+	egressIPs, err := eIPC.kube.GetEgressIPs()
+	if err != nil {
+		return fmt.Errorf("syncEgressIPs unable to get Egress IPs: %w", err)
+	}
+	for _, egressIP := range egressIPs.Items {
+		updatedStatus := []egressipv1.EgressIPStatusItem{}
+		cloudPrivateIPNotFoundOrInvalid := false
+		for _, status := range egressIP.Status.Items {
+			cloudPrivateIPConfigName := ipStringToCloudPrivateIPConfigName(status.EgressIP)
+			if nodeName, exists := cloudPrivateIPConfigMap[cloudPrivateIPConfigName]; exists && status.Node == nodeName {
+				updatedStatus = append(updatedStatus, status)
+			} else {
+				// Set cloudPrivateIPNotFoundOrInvalid flag to true because egress ip entry not found or not set with
+				// correct node name in cloud private ip config object.
+				cloudPrivateIPNotFoundOrInvalid = true
+			}
+		}
+		if cloudPrivateIPNotFoundOrInvalid {
+			// There could be one or more stale entry found in egress ip object, remove it by patching egressip
+			// object with updated status.
+			err = eIPC.patchReplaceEgressIPStatus(egressIP.Name, updatedStatus)
+			if err != nil {
+				return fmt.Errorf("syncEgressIPs unable to update EgressIP status: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// getCloudPrivateIPConfigMap returns cloud private ip config map cotaining ip address the key and
+// assigned node node name as the value. This method is intended to be invoked only in the case of
+// cloud environment.
+func (eIPC *egressIPClusterController) getCloudPrivateIPConfigMap() (map[string]string, error) {
+	cloudPrivateIPConfigMap := make(map[string]string)
+	cloudPrivateIPConfigs, err := eIPC.kube.GetCloudPrivateIPConfigs()
+	if err != nil {
+		return nil, err
+	}
+	for _, cloudPrivateIPConfig := range cloudPrivateIPConfigs.Items {
+		cloudPrivateIPConfigMap[cloudPrivateIPConfig.Name] = cloudPrivateIPConfig.Status.Node
+	}
+	return cloudPrivateIPConfigMap, nil
+}
+
 // assignEgressIPs is the main assignment algorithm for egress IPs to nodes.
 // Specifically we have a couple of hard constraints: a) the subnet of the node
 // must be able to host the egress IP b) the egress IP cannot be a node IP c)

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	ocpcloudnetworkapi "github.com/openshift/api/cloudnetwork/v1"
+	ocpconfigapi "github.com/openshift/api/config/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressipv1 "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
@@ -89,6 +91,17 @@ func newNamespace(namespace string) *v1.Namespace {
 var egressPodLabel = map[string]string{"egress": "needed"}
 
 func newEgressIPMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		UID:  k8stypes.UID(name),
+		Name: name,
+		Labels: map[string]string{
+			"name": name,
+		},
+	}
+}
+
+func newCloudPrivateIPConfigMeta(egressIP string) metav1.ObjectMeta {
+	name := ipStringToCloudPrivateIPConfigName(egressIP)
 	return metav1.ObjectMeta{
 		UID:  k8stypes.UID(name),
 		Name: name,
@@ -2186,6 +2199,71 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				return nil
 			}
 
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("ensure egressIP status is in sync with cloud private ip config", func() {
+			app.Action = func(ctx *cli.Context) error {
+				config.OVNKubernetesFeature.EnableInterconnect = true
+				config.Kubernetes.PlatformType = string(ocpconfigapi.AWSPlatformType)
+
+				egressIP1 := "192.168.126.101"
+				egressIP2 := "192.168.126.100"
+
+				node1 := setupNode(node1Name, []string{"192.168.126.12/24"}, map[string]string{egressIP1: egressIPName})
+				node2 := setupNode(node2Name, []string{"192.168.126.51/24"}, map[string]string{egressIP2: egressIPName})
+
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{egressIP1, egressIP2},
+					},
+					Status: egressipv1.EgressIPStatus{
+						Items: []egressipv1.EgressIPStatusItem{
+							{
+								EgressIP: egressIP1,
+								Node:     node1.name,
+							},
+							{
+								EgressIP: egressIP2,
+								Node:     node2.name,
+							},
+						},
+					},
+				}
+				cloudPrivateIPConfig := ocpcloudnetworkapi.CloudPrivateIPConfig{
+					ObjectMeta: newCloudPrivateIPConfigMeta(egressIP2),
+					Spec:       ocpcloudnetworkapi.CloudPrivateIPConfigSpec{Node: node2Name},
+					Status: ocpcloudnetworkapi.CloudPrivateIPConfigStatus{Node: node2Name,
+						Conditions: []metav1.Condition{{Status: metav1.ConditionTrue, Type: string(ocpcloudnetworkapi.Assigned)}}},
+				}
+				fakeClusterManagerOVN.start(
+					&egressipv1.EgressIPList{
+						Items: []egressipv1.EgressIP{eIP},
+					},
+					&ocpcloudnetworkapi.CloudPrivateIPConfigList{
+						Items: []ocpcloudnetworkapi.CloudPrivateIPConfig{cloudPrivateIPConfig},
+					},
+				)
+
+				fakeClusterManagerOVN.eIPC.allocator.cache[node1.name] = &node1
+				fakeClusterManagerOVN.eIPC.allocator.cache[node2.name] = &node2
+
+				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				_, err = fakeClusterManagerOVN.eIPC.WatchCloudPrivateIPConfig()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				// Since there is no assignment of cloud private ip for one of the egress ip.
+				// syncEgressIPs removes stale entry from egress ip object status and check
+				// if that is done properly or not.
+				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
+				egressIPs, nodes := getEgressIPStatus(egressIPName)
+				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))
+				gomega.Expect(egressIPs[0]).To(gomega.Equal(egressIP2))
+
+				return nil
+			}
 			err := app.Run([]string{app.Name})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -2255,8 +2255,8 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				_, err = fakeClusterManagerOVN.eIPC.WatchCloudPrivateIPConfig()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				// Since there is no assignment of cloud private ip for one of the egress ip.
-				// syncEgressIPs removes stale entry from egress ip object status and check
-				// if that is done properly or not.
+				// syncCloudPrivateIPConfigs removes stale entry from egress ip object status
+				// and check if that is done properly or not.
 				gomega.Eventually(getEgressIPStatusLen(egressIPName)).Should(gomega.Equal(1))
 				egressIPs, nodes := getEgressIPStatus(egressIPName)
 				gomega.Expect(nodes[0]).To(gomega.Equal(node2.name))

--- a/go-controller/pkg/clustermanager/egressip_event_handler.go
+++ b/go-controller/pkg/clustermanager/egressip_event_handler.go
@@ -181,6 +181,8 @@ func (h *egressIPClusterControllerEventHandler) SyncFunc(objs []interface{}) err
 		syncFunc = h.syncFunc
 	} else {
 		switch h.objType {
+		case factory.EgressIPType:
+			syncFunc = h.eIPC.syncEgressIPs
 		case factory.EgressNodeType:
 			syncFunc = h.eIPC.initEgressNodeReachability
 		case factory.EgressIPType,

--- a/go-controller/pkg/clustermanager/egressip_event_handler.go
+++ b/go-controller/pkg/clustermanager/egressip_event_handler.go
@@ -182,12 +182,11 @@ func (h *egressIPClusterControllerEventHandler) SyncFunc(objs []interface{}) err
 	} else {
 		switch h.objType {
 		case factory.EgressIPType:
-			syncFunc = h.eIPC.syncEgressIPs
+			syncFunc = nil
 		case factory.EgressNodeType:
 			syncFunc = h.eIPC.initEgressNodeReachability
-		case factory.EgressIPType,
-			factory.CloudPrivateIPConfigType:
-			syncFunc = nil
+		case factory.CloudPrivateIPConfigType:
+			syncFunc = h.eIPC.syncCloudPrivateIPConfigs
 
 		default:
 			return fmt.Errorf("no sync function for object type %s", h.objType)

--- a/go-controller/pkg/clustermanager/fake_cluster_manager_test.go
+++ b/go-controller/pkg/clustermanager/fake_cluster_manager_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 
 	"github.com/onsi/gomega"
+	ocpcloudnetworkapi "github.com/openshift/api/cloudnetwork/v1"
+	cloudservicefake "github.com/openshift/client-go/cloudnetwork/clientset/versioned/fake"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager/egressservice"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	egressip "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1"
@@ -40,11 +42,14 @@ func (o *FakeClusterManager) start(objects ...runtime.Object) {
 	egressIPObjects := []runtime.Object{}
 	egressSvcObjects := []runtime.Object{}
 	v1Objects := []runtime.Object{}
+	cloudObjects := []runtime.Object{}
 	for _, object := range objects {
 		if _, isEgressIPObject := object.(*egressip.EgressIPList); isEgressIPObject {
 			egressIPObjects = append(egressIPObjects, object)
 		} else if _, isEgressSVCObj := object.(*egresssvc.EgressServiceList); isEgressSVCObj {
 			egressSvcObjects = append(egressSvcObjects, object)
+		} else if _, isCloudPrivateIPConfig := object.(*ocpcloudnetworkapi.CloudPrivateIPConfigList); isCloudPrivateIPConfig {
+			cloudObjects = append(cloudObjects, object)
 		} else {
 			v1Objects = append(v1Objects, object)
 		}
@@ -53,6 +58,7 @@ func (o *FakeClusterManager) start(objects ...runtime.Object) {
 		KubeClient:          fake.NewSimpleClientset(v1Objects...),
 		EgressIPClient:      egressipfake.NewSimpleClientset(egressIPObjects...),
 		EgressServiceClient: egresssvcfake.NewSimpleClientset(egressSvcObjects...),
+		CloudNetworkClient:  cloudservicefake.NewSimpleClientset(cloudObjects...),
 	}
 	o.init()
 }

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -396,6 +396,13 @@ func (k *KubeOVN) GetEgressIPs() (*egressipv1.EgressIPList, error) {
 	})
 }
 
+// GetCloudPrivateIPConfigs returns the list of all CloudPrivateIPConfig objects from kubernetes
+func (k *KubeOVN) GetCloudPrivateIPConfigs() (*ocpcloudnetworkapi.CloudPrivateIPConfigList, error) {
+	return k.CloudNetworkClient.CloudV1().CloudPrivateIPConfigs().List(context.TODO(), metav1.ListOptions{
+		ResourceVersion: "0",
+	})
+}
+
 // GetEgressFirewalls returns the list of all EgressFirewall objects from kubernetes
 func (k *KubeOVN) GetEgressFirewalls() (*egressfirewall.EgressFirewallList, error) {
 	return k.EgressFirewallClient.K8sV1().EgressFirewalls(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -396,13 +396,6 @@ func (k *KubeOVN) GetEgressIPs() (*egressipv1.EgressIPList, error) {
 	})
 }
 
-// GetCloudPrivateIPConfigs returns the list of all CloudPrivateIPConfig objects from kubernetes
-func (k *KubeOVN) GetCloudPrivateIPConfigs() (*ocpcloudnetworkapi.CloudPrivateIPConfigList, error) {
-	return k.CloudNetworkClient.CloudV1().CloudPrivateIPConfigs().List(context.TODO(), metav1.ListOptions{
-		ResourceVersion: "0",
-	})
-}
-
 // GetEgressFirewalls returns the list of all EgressFirewall objects from kubernetes
 func (k *KubeOVN) GetEgressFirewalls() (*egressfirewall.EgressFirewallList, error) {
 	return k.EgressFirewallClient.K8sV1().EgressFirewalls(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{


### PR DESCRIPTION
This commit ensures egress IP status is in sync with cloud private IP config on a restarted ovnk master because stale entry is noticed in the egress IP status though cloud private IP config entry is not present for the given egress IP.  This might have happened while processing cloud private IP config delete event, an error is thrown because of bug fixed in PR: https://github.com/ovn-org/ovn-kubernetes/pull/3371.