### PR TITLE
hybrid overlay cleanup 

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -53,8 +53,8 @@ type NodeController struct {
 	// channel to indicate we need to update flows immediately
 	flowChan chan struct{}
 
-	nodeLister listers.NodeLister
-	podLister  listers.PodLister
+	nodeLister     listers.NodeLister
+	localPodLister listers.PodLister
 }
 
 // newNodeController returns a node handler that listens for node events
@@ -66,18 +66,18 @@ func newNodeController(
 	_ kube.Interface,
 	nodeName string,
 	nodeLister listers.NodeLister,
-	podLister listers.PodLister,
+	localPodLister listers.PodLister,
 ) (nodeController, error) {
 
 	node := &NodeController{
-		nodeName:   nodeName,
-		initState:  new(uint32),
-		vxlanPort:  uint16(config.HybridOverlay.VXLANPort),
-		flowCache:  make(map[string]*flowCacheEntry),
-		flowMutex:  sync.Mutex{},
-		flowChan:   make(chan struct{}, 1),
-		nodeLister: nodeLister,
-		podLister:  podLister,
+		nodeName:       nodeName,
+		initState:      new(uint32),
+		vxlanPort:      uint16(config.HybridOverlay.VXLANPort),
+		flowCache:      make(map[string]*flowCacheEntry),
+		flowMutex:      sync.Mutex{},
+		flowChan:       make(chan struct{}, 1),
+		nodeLister:     nodeLister,
+		localPodLister: localPodLister,
 	}
 	atomic.StoreUint32(node.initState, hotypes.InitialStartup)
 	return node, nil
@@ -274,7 +274,7 @@ func (n *NodeController) AddNode(node *kapi.Node) error {
 		err = n.hybridOverlayNodeUpdate(node)
 	}
 	if atomic.LoadUint32(n.initState) == hotypes.DistributedRouterInitialized {
-		pods, err := n.podLister.List(labels.Everything())
+		pods, err := n.localPodLister.List(labels.Everything())
 		if err != nil {
 			return fmt.Errorf("cannot fully initialize node %s for hybrid overlay, cannot list pods: %v", n.nodeName, err)
 		}

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -112,16 +112,6 @@ func (n *NodeController) AddPod(pod *kapi.Pod) error {
 	// if the IP/MAC or Annotations have changed
 	ignoreLearn := true
 
-	if atomic.LoadUint32(n.initState) == hotypes.InitialStartup {
-		node, err := n.nodeLister.Get(n.nodeName)
-		if err != nil {
-			return fmt.Errorf("hybrid overlay not initialized on %s, and failed to get node data: %v",
-				n.nodeName, err)
-		}
-		if err = n.EnsureHybridOverlayBridge(node); err != nil {
-			return fmt.Errorf("failed to ensure hybrid overlay in pod handler: %v", err)
-		}
-	}
 	if n.drMAC == nil || n.drIP == nil {
 		return fmt.Errorf("empty values for DR MAC: %s or DR IP: %s on node %s", n.drMAC, n.drIP, n.nodeName)
 	}
@@ -278,7 +268,6 @@ func (n *NodeController) AddNode(node *kapi.Node) error {
 		if err != nil {
 			return fmt.Errorf("cannot fully initialize node %s for hybrid overlay, cannot list pods: %v", n.nodeName, err)
 		}
-
 		for _, pod := range pods {
 			err := n.AddPod(pod)
 			if err != nil {


### PR DESCRIPTION
This PR is includes two items of cleanup to the hybrid overlay.


First, in https://github.com/ovn-org/ovn-kubernetes/pull/3595 I mentioned that I would be cleaning up the podLister naming to be more explicit in this comment https://github.com/ovn-org/ovn-kubernetes/pull/3595#discussion_r1195574769. The first commit makes that naming explicit changing the names in the hybrid overlay from podInformer  to localPodInformer and podLister to localPodLister. 

Second, there is initialization code in AddPod() that is not required. PR https://github.com/ovn-org/ovn-kubernetes/pull/3595 added the localPodLister so as soon as the drIP and drMAC are set on the node there is a node update event that will use the new localPodLister in the hybrid overlay node controller to get all nodes and wire them for hybrid overlay. We should never get to the point of EnsuringHybridOverlayBridge in AddPod()

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->