### PR TITLE
multi-homing, localnet: update localnet port network name

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1168,8 +1168,19 @@ docker_create_second_disconnected_interface() {
   local bridge_name="${1:-kindexgw}"
   echo "bridge: $bridge_name"
 
+  if [ "${OCI_BIN}" = "podman" ]; then
+    # docker and podman do different things with the --internal parameter:
+    # - docker installs iptables rules to drop traffic on a different subnet
+    #   than the bridge and we don't want that.
+    # - podman does not set the bridge as default gateway and we want that.
+    # So we need it with podman but not with docker. Neither allows us to create
+    # a bridge network without IPAM which would be ideal, so perhaps the best
+    # option would be a manual setup.
+    local podman_params="--internal"
+  fi
+
   # Create the network without subnets; ignore if already exists.
-  "$OCI_BIN" network create --internal --driver=bridge "$bridge_name" || true
+  "$OCI_BIN" network create --driver=bridge ${podman_params-} "$bridge_name" || true
 
   KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
   for n in $KIND_NODES; do

--- a/go-controller/pkg/ovn/secondary_localnet_network_controller.go
+++ b/go-controller/pkg/ovn/secondary_localnet_network_controller.go
@@ -89,7 +89,7 @@ func (oc *SecondaryLocalnetNetworkController) Init() error {
 		Addresses: []string{"unknown"},
 		Type:      "localnet",
 		Options: map[string]string{
-			"network_name": oc.GetNetworkScopedName(types.LocalNetBridgeName),
+			"network_name": oc.GetNetworkName(),
 		},
 	}
 	intVlanID := int(oc.Vlan())

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -52,8 +52,6 @@ const (
 	OVNLocalnetSwitch = "ovn_localnet_switch"
 	// types.OVNLocalnetPort is the name of localnet topology localnet port
 	OVNLocalnetPort = "ovn_localnet_port"
-	// Local Bridge used for localnet topology network access
-	LocalNetBridgeName = "br-localnet"
 
 	TransitSwitch               = "transit_switch"
 	TransitSwitchToRouterPrefix = "tstor-"

--- a/test/e2e/localnet-underlay.go
+++ b/test/e2e/localnet-underlay.go
@@ -35,7 +35,7 @@ func setupUnderlay(ovsPods []v1.Pod, portName string, nadConfig networkAttachmen
 		if err := configureBridgeMappings(
 			ovsPod.Name,
 			defaultNetworkBridgeMapping(),
-			bridgeMapping(nadConfig.attachmentName(), bridgeName),
+			bridgeMapping(nadConfig.networkName, bridgeName),
 		); err != nil {
 			return err
 		}

--- a/test/e2e/localnet-underlay.go
+++ b/test/e2e/localnet-underlay.go
@@ -156,6 +156,8 @@ func defaultNetworkBridgeMapping() BridgeMapping {
 }
 
 func bridgeMapping(physnet, ovsBridge string) BridgeMapping {
+	physnet = strings.ReplaceAll(physnet, "-", ".")
+	physnet = strings.ReplaceAll(physnet, "/", ".")
 	return BridgeMapping{
 		physnet:   physnet,
 		ovsBridge: ovsBridge,

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -716,6 +716,19 @@ var _ = Describe("Multi Homing", func() {
 
 					serverPodConfig.namespace = f.Namespace.Name
 
+					if netConfig.topology == "localnet" {
+						By("setting up the localnet underlay")
+						nodes := ovsPods(cs)
+						Expect(nodes).NotTo(BeEmpty())
+						defer func() {
+							By("tearing down the localnet underlay")
+							Expect(teardownUnderlay(nodes)).To(Succeed())
+						}()
+
+						const secondaryInterfaceName = "eth1"
+						Expect(setupUnderlay(nodes, secondaryInterfaceName, netConfig)).To(Succeed())
+					}
+
 					for _, ns := range []v1.Namespace{*f.Namespace, *extraNamespace} {
 						stepInfo := fmt.Sprintf("creating the attachment configuration for namespace %q", ns.Name)
 						By(stepInfo)

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -53,10 +53,13 @@ var _ = Describe("Multi Homing", func() {
 		nadClient, err = nadclient.NewForConfig(f.ClientConfig())
 		Expect(err).NotTo(HaveOccurred())
 		mnpClient, err = mnpclient.NewForConfig(f.ClientConfig())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Context("A single pod with an OVN-K secondary network", func() {
-		table.DescribeTable("is able to get to the Running phase", func(netConfig networkAttachmentConfig, podConfig podConfiguration) {
+		table.DescribeTable("is able to get to the Running phase", func(netConfigParams networkAttachmentConfigParams, podConfig podConfiguration) {
+			netConfig := newNetworkAttachmentConfig(netConfigParams)
+
 			if netConfig.topology != "layer3" {
 				if isInterconnectEnabled() {
 					e2eskipper.Skipf(
@@ -106,7 +109,7 @@ var _ = Describe("Multi Homing", func() {
 		},
 			table.Entry(
 				"when attaching to an L3 - routed - network",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:     netCIDR(secondaryNetworkCIDR, netPrefixLengthPerNode),
 					name:     secondaryNetworkName,
 					topology: "layer3",
@@ -118,7 +121,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an L3 - routed - network with IPv6 network",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:     netCIDR(secondaryIPv6CIDR, netPrefixLengthIPv6PerNode),
 					name:     secondaryNetworkName,
 					topology: "layer3",
@@ -130,7 +133,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an L2 - switched - network",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:     secondaryFlatL2NetworkCIDR,
 					name:     secondaryNetworkName,
 					topology: "layer2",
@@ -142,7 +145,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an L2 - switched - network featuring `excludeCIDR`s",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:         secondaryFlatL2NetworkCIDR,
 					name:         secondaryNetworkName,
 					topology:     "layer2",
@@ -155,7 +158,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an L2 - switched - network without IPAM",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "layer2",
 				},
@@ -166,7 +169,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an L2 - switched - network with an IPv6 subnet",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:     secondaryIPv6CIDR,
 					name:     secondaryNetworkName,
 					topology: "layer2",
@@ -178,7 +181,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an L2 - switched - network with a dual stack configuration",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:     strings.Join([]string{secondaryFlatL2NetworkCIDR, secondaryIPv6CIDR}, ","),
 					name:     secondaryNetworkName,
 					topology: "layer2",
@@ -190,7 +193,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an localnet - switched - network",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:     secondaryLocalnetNetworkCIDR,
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -203,7 +206,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an Localnet - switched - network featuring `excludeCIDR`s",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:         secondaryLocalnetNetworkCIDR,
 					name:         secondaryNetworkName,
 					topology:     "localnet",
@@ -217,7 +220,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an localnet - switched - network without IPAM",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
 					vlanID:   localnetVLANID,
@@ -229,7 +232,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an localnet - switched - network with an IPv6 subnet",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:     secondaryIPv6CIDR,
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -242,7 +245,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"when attaching to an L2 - switched - network with a dual stack configuration",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					cidr:     strings.Join([]string{secondaryLocalnetNetworkCIDR, secondaryIPv6CIDR}, ","),
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -269,7 +272,9 @@ var _ = Describe("Multi Homing", func() {
 
 		table.DescribeTable(
 			"can communicate over the secondary network",
-			func(netConfig networkAttachmentConfig, clientPodConfig podConfiguration, serverPodConfig podConfiguration) {
+			func(netConfigParams networkAttachmentConfigParams, clientPodConfig podConfiguration, serverPodConfig podConfiguration) {
+				netConfig := newNetworkAttachmentConfig(netConfigParams)
+
 				// Skip the test if the netConfig topology is not layer3 and the deployment is multi zone
 				if netConfig.topology != "layer3" {
 					if isInterconnectEnabled() {
@@ -284,9 +289,11 @@ var _ = Describe("Multi Homing", func() {
 				serverPodConfig.namespace = f.Namespace.Name
 
 				if netConfig.topology == "localnet" {
+					By("setting up the localnet underlay")
 					nodes := ovsPods(cs)
 					Expect(nodes).NotTo(BeEmpty())
 					defer func() {
+						By("tearing down the localnet underlay")
 						Expect(teardownUnderlay(nodes)).To(Succeed())
 					}()
 
@@ -372,7 +379,7 @@ var _ = Describe("Multi Homing", func() {
 			},
 			table.Entry(
 				"can communicate over an L2 secondary network when the pods are scheduled in different nodes",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "layer2",
 					cidr:     secondaryNetworkCIDR,
@@ -391,7 +398,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an L2 - switched - secondary network with `excludeCIDR`s",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:         secondaryNetworkName,
 					topology:     "layer2",
 					cidr:         secondaryNetworkCIDR,
@@ -409,7 +416,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an L3 - routed - secondary network",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "layer3",
 					cidr:     netCIDR(secondaryNetworkCIDR, netPrefixLengthPerNode),
@@ -426,7 +433,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an L3 - routed - secondary network with IPv6 subnet",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "layer3",
 					cidr:     netCIDR(secondaryIPv6CIDR, netPrefixLengthIPv6PerNode),
@@ -443,7 +450,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an L3 - routed - secondary network with a dual stack configuration",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "layer3",
 					cidr:     strings.Join([]string{netCIDR(secondaryNetworkCIDR, netPrefixLengthPerNode), netCIDR(secondaryIPv6CIDR, netPrefixLengthIPv6PerNode)}, ","),
@@ -462,7 +469,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an L2 - switched - secondary network without IPAM",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "layer2",
 				},
@@ -480,7 +487,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an L2 secondary network without IPAM, with static IPs configured via network selection elements",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "layer2",
 				},
@@ -502,7 +509,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an L2 secondary network with an IPv6 subnet when pods are scheduled in different nodes",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "layer2",
 					cidr:     secondaryIPv6CIDR,
@@ -521,7 +528,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an L2 secondary network with a dual stack configuration",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "layer2",
 					cidr:     strings.Join([]string{secondaryFlatL2NetworkCIDR, secondaryIPv6CIDR}, ","),
@@ -540,7 +547,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an Localnet secondary network when the pods are scheduled on different nodes",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
 					cidr:     secondaryLocalnetNetworkCIDR,
@@ -560,7 +567,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an Localnet secondary network without IPAM when the pods are scheduled on different nodes",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
 					vlanID:   localnetVLANID,
@@ -581,7 +588,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an localnet secondary network without IPAM when the pods are scheduled on different nodes, with static IPs configured via network selection elements",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
 					vlanID:   localnetVLANID,
@@ -606,7 +613,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an localnet secondary network with an IPv6 subnet when pods are scheduled on different nodes",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
 					cidr:     secondaryIPv6CIDR,
@@ -626,7 +633,7 @@ var _ = Describe("Multi Homing", func() {
 			),
 			table.Entry(
 				"can communicate over an localnet secondary network with a dual stack configuration when pods are scheduled on different nodes",
-				networkAttachmentConfig{
+				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
 					cidr:     strings.Join([]string{secondaryLocalnetNetworkCIDR, secondaryIPv6CIDR}, ","),
@@ -684,7 +691,9 @@ var _ = Describe("Multi Homing", func() {
 
 			table.DescribeTable(
 				"multi-network policies configure traffic allow lists",
-				func(netConfig networkAttachmentConfig, allowedClientPodConfig podConfiguration, blockedClientPodConfig podConfiguration, serverPodConfig podConfiguration, policy *mnpapi.MultiNetworkPolicy) {
+				func(netConfigParams networkAttachmentConfigParams, allowedClientPodConfig podConfiguration, blockedClientPodConfig podConfiguration, serverPodConfig podConfiguration, policy *mnpapi.MultiNetworkPolicy) {
+					netConfig := newNetworkAttachmentConfig(netConfigParams)
+
 					// Skip the test if the netConfig topology is not layer3 and the deployment is multi zone
 					if netConfig.topology != "layer3" {
 						if isInterconnectEnabled() {
@@ -759,7 +768,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 				table.Entry(
 					"for a pure L2 overlay when the multi-net policy describes the allow-list using pod selectors",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:     secondaryNetworkName,
 						topology: "layer2",
 						cidr:     secondaryFlatL2NetworkCIDR,
@@ -796,7 +805,7 @@ var _ = Describe("Multi Homing", func() {
 				),
 				table.Entry(
 					"for a routed topology when the multi-net policy describes the allow-list using pod selectors",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:     secondaryNetworkName,
 						topology: "layer3",
 						cidr:     netCIDR(secondaryNetworkCIDR, netPrefixLengthPerNode),
@@ -833,7 +842,7 @@ var _ = Describe("Multi Homing", func() {
 				),
 				table.Entry(
 					"for a localnet topology when the multi-net policy describes the allow-list using pod selectors",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:     secondaryNetworkName,
 						topology: "localnet",
 						cidr:     secondaryLocalnetNetworkCIDR,
@@ -870,7 +879,7 @@ var _ = Describe("Multi Homing", func() {
 				),
 				table.Entry(
 					"for a pure L2 overlay when the multi-net policy describes the allow-list using IPBlock",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:     secondaryNetworkName,
 						topology: "layer2",
 						cidr:     secondaryFlatL2NetworkCIDR,
@@ -902,7 +911,7 @@ var _ = Describe("Multi Homing", func() {
 				),
 				table.Entry(
 					"for a routed topology when the multi-net policy describes the allow-list using IPBlock",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:     secondaryNetworkName,
 						topology: "layer3",
 						cidr:     netCIDR(secondaryNetworkCIDR, netPrefixLengthPerNode),
@@ -934,7 +943,7 @@ var _ = Describe("Multi Homing", func() {
 				),
 				table.Entry(
 					"for a localnet topology when the multi-net policy describes the allow-list using IPBlock",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:     secondaryNetworkName,
 						topology: "localnet",
 						cidr:     secondaryLocalnetNetworkCIDR,
@@ -966,7 +975,7 @@ var _ = Describe("Multi Homing", func() {
 				),
 				table.Entry(
 					"for a pure L2 overlay when the multi-net policy describes the allow-list via namespace selectors",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:        secondaryNetworkName,
 						topology:    "layer2",
 						cidr:        secondaryFlatL2NetworkCIDR,
@@ -1000,7 +1009,7 @@ var _ = Describe("Multi Homing", func() {
 				),
 				table.Entry(
 					"for a routed topology when the multi-net policy describes the allow-list via namespace selectors",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:        secondaryNetworkName,
 						topology:    "layer3",
 						cidr:        netCIDR(secondaryNetworkCIDR, netPrefixLengthPerNode),
@@ -1034,7 +1043,7 @@ var _ = Describe("Multi Homing", func() {
 				),
 				table.Entry(
 					"for a localnet topology when the multi-net policy describes the allow-list via namespace selectors",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:        secondaryNetworkName,
 						topology:    "localnet",
 						cidr:        secondaryLocalnetNetworkCIDR,
@@ -1069,7 +1078,7 @@ var _ = Describe("Multi Homing", func() {
 
 				table.Entry(
 					"for an IPAMless pure L2 overlay when the multi-net policy describes the allow-list using IPBlock",
-					networkAttachmentConfig{
+					networkAttachmentConfigParams{
 						name:     secondaryNetworkName,
 						topology: "layer2",
 					},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This change attempts to simplify how the network admin configures the underlay of the network to which the secondary network overlays connect to; the user must configure the OVN bridge mappings by associating the name of the physical network to the name of the desired OVS bridge.

Currently that is done via the following pattern:
`<name of phys network>_br-localnet:<name of ovs bridge>`

An example would be:
`tenantblue_br-localnet:ovsbr1`

This commit simplifies that by removing the suffix; the bridge mappings would be:
`<name of phys network>:<name of ovs bridge>`

And an example would be:
`tenantblue:ovsbr1`

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Run the e2e tests.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove the localnet port network name suffix.