### PR TITLE
testing/exec: optionally allow for duplicates to fix Hybrid Overlay tests flakes

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -144,10 +144,12 @@ func createNode(name, os, ip string, annotations map[string]string) *v1.Node {
 }
 
 func addSyncFlows(fexec *ovntest.FakeExec) {
-	fexec.AddFakeCmdsNoOutputNoError([]string{
+	// Note: due to the async nature of when syncFlows are invoked,
+	// the fake commands here are added with allowDuplicates set to true
+	fexec.AddFakeCmdsNoOutputNoErrorMayDuplicate([]string{
 		"ovs-ofctl dump-flows --no-stats br-ext table=20",
 		"ovs-ofctl -O OpenFlow13 --bundle replace-flows br-ext -",
-	})
+	}, true)
 }
 
 func createPod(namespace, name, node, podIP, podMAC string) *v1.Pod {


### PR DESCRIPTION
Add support in FakeExec to handle cases where the expected command may happen more than once. This was causing CI flakes for Hybrid Overlay tests where periodically generated events would render duplicates that were not accounted for, but were benign to the test itself.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-13979
Fixes: #3506