### PR TITLE
Fix policy ip helper funcs

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1131,6 +1131,8 @@ func (nc *DefaultNodeNetworkController) syncConntrackForExternalGateways(newNs *
 		podIPs, err := util.GetPodIPsOfNetwork(pod, &util.DefaultNetInfo{})
 		if err != nil {
 			errors = append(errors, fmt.Errorf("unable to fetch IP for pod %s/%s: %v", pod.Namespace, pod.Name, err))
+		} else if len(podIPs) == 0 {
+			errors = append(errors, fmt.Errorf("no IP addresses for default network for pod %s/%s", pod.Namespace, pod.Name))
 		}
 		for _, podIP := range podIPs { // flush conntrack only for UDP
 			// for this pod, we check if the conntrack entry has a label that is not in the provided allowlist of MACs

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -709,22 +709,8 @@ func (bnc *BaseNetworkController) getPodNADNames(pod *kapi.Pod) []string {
 	if !bnc.IsSecondary() {
 		return []string{types.DefaultNetworkName}
 	}
-	on, networkMap, err := util.GetPodNADToNetworkMapping(pod, bnc.NetInfo)
-	// skip pods that are not on this network
-	if err != nil || !on {
-		if err != nil {
-			// if we are not able to determine if this pod is on this network continue processing the
-			// remaining pods anyway, hopefully the pod will be handled in a future pod update event.
-			klog.Warningf("Failed to determine if pod %s/%s is on network %s: %v",
-				pod.Namespace, pod.Name, bnc.GetNetworkName(), err)
-		}
-		return []string{}
-	}
-	nadNames := make([]string, 0, len(networkMap))
-	for nadName := range networkMap {
-		nadNames = append(nadNames, nadName)
-	}
-	return nadNames
+	podNadNames, _ := util.PodNadNames(pod, bnc.NetInfo)
+	return podNadNames
 }
 
 // getClusterPortGroupName gets network scoped port group hash name; base is either

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -353,7 +353,6 @@ func (bnc *BaseNetworkController) getAllNamespacePodAddresses(ns string) []net.I
 	if !bnc.doesNetworkRequireIPAM() {
 		return nil
 	}
-
 	var ips []net.IP
 	// Get all the pods in the namespace and append their IP to the address_set
 	existingPods, err := bnc.watchFactory.GetPods(ns)

--- a/go-controller/pkg/ovn/base_network_controller_pods.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods.go
@@ -298,6 +298,9 @@ func (bnc *BaseNetworkController) findPodWithIPAddresses(needleIPs []net.IP) (*k
 		haystackPodAddrs, err := util.GetPodIPsOfNetwork(p, bnc.NetInfo)
 		if err != nil {
 			continue
+		} else if len(haystackPodAddrs) == 0 && bnc.doesNetworkRequireIPAM() {
+			klog.Warningf("No pod IP addresses for pod %s/%s on secondary network %s", p.Namespace, p.Name, bnc.GetNetworkName())
+			continue
 		}
 
 		for _, haystackPodAddr := range haystackPodAddrs {

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -154,6 +154,10 @@ func (oc *DefaultNetworkController) createASForEgressQoSRule(podSelector metav1.
 			if err != nil {
 				return nil, nil, err
 			}
+			if len(podIPs) == 0 {
+				klog.Warningf("No pod IPs for default network")
+				continue
+			}
 			podsCache.Store(pod.Name, podIPs)
 			podsIps = append(podsIps, podIPs...)
 		}

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -258,15 +258,11 @@ func GetPodCIDRsWithFullMask(pod *v1.Pod, nInfo NetInfo) ([]*net.IPNet, error) {
 	}
 	ips := make([]*net.IPNet, 0, len(podIPs))
 	for _, podIP := range podIPs {
-		podIPStr := podIP.String()
-		mask := GetIPFullMask(podIPStr)
-		_, ipnet, err := net.ParseCIDR(podIPStr + mask)
-		if err != nil {
-			// this should not happen;
-			klog.Warningf("Failed to parse pod IP %v err: %v", podIP, err)
-			continue
+		ipNet := net.IPNet{
+			IP:   podIP,
+			Mask: GetFullNetMask(podIP),
 		}
-		ips = append(ips, ipnet)
+		ips = append(ips, &ipNet)
 	}
 	return ips, nil
 }

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -275,48 +275,17 @@ func GetPodCIDRsWithFullMask(pod *v1.Pod, nInfo NetInfo) ([]*net.IPNet, error) {
 // and then falling back to the Pod Status IPs. This function is intended to
 // also return IPs for HostNetwork and other non-OVN-IPAM-ed pods.
 func GetPodIPsOfNetwork(pod *v1.Pod, nInfo NetInfo) ([]net.IP, error) {
-	ips := []net.IP{}
-	networkMap := map[string]*nadapi.NetworkSelectionElement{}
-	if !nInfo.IsSecondary() {
-		// default network, Pod annotation is under the name of DefaultNetworkName
-		networkMap[types.DefaultNetworkName] = nil
-	} else {
-		var err error
-		var on bool
+	if nInfo.IsSecondary() {
+		return SecondaryNetworkPodIPs(pod, nInfo)
+	}
+	return DefaultNetworkPodIPs(pod)
+}
 
-		on, networkMap, err = GetPodNADToNetworkMapping(pod, nInfo)
-		if err != nil {
-			return nil, err
-		} else if !on {
-			// the pod is not attached to this specific network, don't return error
-			return []net.IP{}, nil
-		}
-	}
-	for nadName := range networkMap {
-		annotation, _ := UnmarshalPodAnnotation(pod.Annotations, nadName)
-		if annotation != nil {
-			// Use the OVN annotation if valid
-			for _, ip := range annotation.IPs {
-				ips = append(ips, ip.IP)
-			}
-			// An OVN annotation should never have empty IPs, but just in case
-			if len(ips) == 0 {
-				klog.Warningf("No IPs found in existing OVN annotation for NAD %s! Pod Name: %s, Annotation: %#v",
-					nadName, pod.Name, annotation)
-			}
-		}
-	}
-	if len(ips) != 0 {
+func DefaultNetworkPodIPs(pod *v1.Pod) ([]net.IP, error) {
+	ips := networkPodIPs(pod, types.DefaultNetworkName)
+	if len(ips) > 0 {
 		return ips, nil
 	}
-
-	if nInfo.IsSecondary() {
-		return []net.IP{}, fmt.Errorf("no pod annotation of pod %s/%s found for network %s",
-			pod.Namespace, pod.Name, nInfo.GetNetworkName())
-	}
-
-	// Otherwise, default network, if the annotation is not valid try to use Kube API pod IPs
-	ips = make([]net.IP, 0, len(pod.Status.PodIPs))
 	for _, podIP := range pod.Status.PodIPs {
 		ip := utilnet.ParseIPSloppy(podIP.IP)
 		if ip == nil {
@@ -325,7 +294,6 @@ func GetPodIPsOfNetwork(pod *v1.Pod, nInfo NetInfo) ([]net.IP, error) {
 		}
 		ips = append(ips, ip)
 	}
-
 	if len(ips) > 0 {
 		return ips, nil
 	}
@@ -338,6 +306,49 @@ func GetPodIPsOfNetwork(pod *v1.Pod, nInfo NetInfo) ([]net.IP, error) {
 	}
 
 	return []net.IP{ip}, nil
+}
+
+func SecondaryNetworkPodIPs(pod *v1.Pod, networkInfo NetInfo) ([]net.IP, error) {
+	ips := []net.IP{}
+	podNadNames, err := PodNadNames(pod, networkInfo)
+	if err != nil {
+		return nil, err
+	}
+	for _, nadName := range podNadNames {
+		ips = append(ips, networkPodIPs(pod, nadName)...)
+	}
+	return ips, nil
+}
+
+func PodNadNames(pod *v1.Pod, netinfo NetInfo) ([]string, error) {
+	on, networkMap, err := GetPodNADToNetworkMapping(pod, netinfo)
+	// skip pods that are not on this network
+	if err != nil {
+		return nil, err
+	} else if !on {
+		// if we are not able to determine if this pod is on this network continue processing the
+		// remaining pods anyway, hopefully the pod will be handled in a future pod update event.
+		klog.Warningf("Failed to determine if pod %s/%s is on network %s: %v",
+			pod.Namespace, pod.Name, netinfo.GetNetworkName(), err)
+		return []string{}, nil
+	}
+	nadNames := make([]string, 0, len(networkMap))
+	for nadName := range networkMap {
+		nadNames = append(nadNames, nadName)
+	}
+	return nadNames, nil
+}
+
+func networkPodIPs(pod *v1.Pod, nadName string) []net.IP {
+	var ips []net.IP
+	annotation, _ := UnmarshalPodAnnotation(pod.Annotations, nadName)
+	if annotation != nil {
+		// Use the OVN annotation if valid
+		for _, ip := range annotation.IPs {
+			ips = append(ips, ip.IP)
+		}
+	}
+	return ips
 }
 
 // GetK8sPodDefaultNetworkSelection get pod default network from annotations

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -342,10 +342,12 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 						assert.Contains(t, e.Error(), tc.errMatch.Error())
 					}
 				} else {
-					podIPStr := tc.outExp[0].String()
-					mask := GetIPFullMask(podIPStr)
-					_, ipnet, _ := net.ParseCIDR(podIPStr + mask)
-					assert.Equal(t, []*net.IPNet{ipnet}, res2)
+					expectedIP := tc.outExp[0]
+					ipNet := net.IPNet{
+						IP:   expectedIP,
+						Mask: GetFullNetMask(expectedIP),
+					}
+					assert.Equal(t, []*net.IPNet{&ipNet}, res2)
 				}
 			}
 		})

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -7,12 +7,15 @@ import (
 	"reflect"
 	"testing"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
 )
 
 func TestMarshalPodAnnotation(t *testing.T) {
@@ -216,6 +219,11 @@ func TestUnmarshalPodAnnotation(t *testing.T) {
 }
 
 func TestGetPodIPsOfNetwork(t *testing.T) {
+	const (
+		secondaryNetworkIPAddr = "200.200.200.200"
+		namespace              = "ns1"
+		secondaryNetworkName   = "bluetenant"
+	)
 	tests := []struct {
 		desc        string
 		inpPod      *v1.Pod
@@ -231,7 +239,7 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 			errExp: true,
 		},*/
 		{
-			desc: "test when pod annotation is non-nil",
+			desc: "test when pod annotation is non-nil for the default cluster network",
 			inpPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.1/24"],"mac_address":"0a:58:fd:98:00:01"}}`},
@@ -280,6 +288,32 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 			networkInfo: &DefaultNetInfo{},
 			errMatch:    ErrNoPodIPFound,
 		},
+		{
+			desc: "test when pod annotation is non-nil for a secondary network",
+			inpPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[{"name": %q, "namespace": %q}]`, secondaryNetworkName, namespace),
+						"k8s.ovn.org/pod-networks":    fmt.Sprintf(`{%q:{"ip_addresses":["%s/24"],"mac_address":"0a:58:fd:98:00:01"}}`, GetNADName(namespace, secondaryNetworkName), secondaryNetworkIPAddr),
+					},
+				},
+			},
+			networkInfo: newDummyNetInfo(namespace, secondaryNetworkName),
+			outExp:      []net.IP{ovntest.MustParseIP(secondaryNetworkIPAddr)},
+		},
+		{
+			desc: "test when pod annotation is non-nil for a secondary network",
+			inpPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[{"name": %q, "namespace": %q}]`, secondaryNetworkName, namespace),
+						"k8s.ovn.org/pod-networks":    "{}",
+					},
+				},
+			},
+			networkInfo: newDummyNetInfo(namespace, secondaryNetworkName),
+			outExp:      []net.IP{},
+		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
@@ -296,22 +330,32 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.outExp, res1)
 			}
-			res2, e := GetPodCIDRsWithFullMask(tc.inpPod, tc.networkInfo)
-			t.Log(res2, e)
-			if tc.errAssert {
-				assert.Error(t, e)
-			} else if tc.errMatch != nil {
-				if errors.Is(tc.errMatch, ErrNoPodIPFound) {
-					assert.ErrorIs(t, e, ErrNoPodIPFound)
+			if len(tc.outExp) > 0 {
+				res2, e := GetPodCIDRsWithFullMask(tc.inpPod, tc.networkInfo)
+				t.Log(res2, e)
+				if tc.errAssert {
+					assert.Error(t, e)
+				} else if tc.errMatch != nil {
+					if errors.Is(tc.errMatch, ErrNoPodIPFound) {
+						assert.ErrorIs(t, e, ErrNoPodIPFound)
+					} else {
+						assert.Contains(t, e.Error(), tc.errMatch.Error())
+					}
 				} else {
-					assert.Contains(t, e.Error(), tc.errMatch.Error())
+					podIPStr := tc.outExp[0].String()
+					mask := GetIPFullMask(podIPStr)
+					_, ipnet, _ := net.ParseCIDR(podIPStr + mask)
+					assert.Equal(t, []*net.IPNet{ipnet}, res2)
 				}
-			} else {
-				podIPStr := tc.outExp[0].String()
-				mask := GetIPFullMask(podIPStr)
-				_, ipnet, _ := net.ParseCIDR(podIPStr + mask)
-				assert.Equal(t, []*net.IPNet{ipnet}, res2)
 			}
 		})
 	}
+}
+
+func newDummyNetInfo(namespace, networkName string) NetInfo {
+	netInfo, _ := newLayer2NetConfInfo(&ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{Name: networkName},
+	})
+	netInfo.AddNAD(GetNADName(namespace, networkName))
+	return netInfo
 }

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -74,6 +74,21 @@ func GetIPFullMask(ip string) string {
 	return IPv4FullMask
 }
 
+// GetFullNetMask returns a 32 bit netmask for IPv4 addresses and a 128 bit netmask for IPv6 addresses
+func GetFullNetMask(ip net.IP) net.IPMask {
+	const (
+		// IPv4FullMask is the maximum prefix mask for an IPv4 address
+		IPv4FullMask = 32
+		// IPv6FullMask is the maximum prefix mask for an IPv6 address
+		IPv6FullMask = 128
+	)
+
+	if utilnet.IsIPv6(ip) {
+		return net.CIDRMask(IPv6FullMask, IPv6FullMask)
+	}
+	return net.CIDRMask(IPv4FullMask, IPv4FullMask)
+}
+
 // GetLegacyK8sMgmtIntfName returns legacy management ovs-port name
 func GetLegacyK8sMgmtIntfName(nodeName string) string {
 	if len(nodeName) > 11 {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
Honoring my refactor promise made on https://github.com/ovn-org/ovn-kubernetes/pull/3574#issuecomment-1559789616

The `GetPodIPsOfNetwork` function is printing warnings when the pod IPs cannot be retrieved / are not present. The latter is normal for IPAM-less network attachments, thus it should be the function's caller to shout the warning when needed.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->