### PR TITLE
network controller: Remove the node name from local zone nodes cache.

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -901,6 +901,9 @@ install_ovn_multiple_nodes_zones() {
   n=1
   for node in $KIND_NODES; do
     zone="zone-${zone_idx}"
+    if [ "${zone}" == "zone-1" ]; then
+      zone="global"
+    fi
     kubectl label node "${node}" k8s.ovn.org/zone-name=${zone} --overwrite
     if [ "${n}" == "1" ]; then
       # Mark 1st node of each zone as zone control plane


### PR DESCRIPTION
When a node moves from a local zone to a remote zone, remove the node name from the default network controller's 'localZoneNodes' Sync Map. Without this ovnkube network controller will be in a continuous retry loop as the next attempt to cleanup the node resources will fail. Also ignore the error in cleanup.  Its possible that a node may move zones even before all the resources (like node router port connecting to the GW router) are created.

Fixes: 8aa14239e4b1("network-controller-manager: Create interconnect resources.")

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->