### PR TITLE
Initialize EgressIP stopChan in cluster-manager

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -413,6 +413,7 @@ func newEgressIPController(ovnClient *util.OVNClusterManagerClientset, wf *facto
 		egressIPTotalTimeout:              config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout,
 		reachabilityCheckInterval:         egressIPReachabilityCheckInterval,
 		egressIPNodeHealthCheckPort:       config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort,
+		stopChan:                          make(chan struct{}),
 	}
 	eIPC.initRetryFramework()
 	return eIPC


### PR DESCRIPTION
Without initializing the stopChan `stopChan` will always fail with `close of nil channel`. 
Additionally removed unused fields from FakeClusterManager.

/cc @tssurya 