### PR TITLE
Configure underlay secondary net localnet

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1066,11 +1066,11 @@ docker_create_second_interface() {
   echo "adding second interfaces to nodes"
 
   # Create the network as dual stack, regardless of the type of the deployment. Ignore if already exists.
-  docker network create --ipv6 --driver=bridge kindexgw --subnet=172.19.0.0/16 --subnet=fc00:f853:ccd:e798::/64 || true
+  "$OCI_BIN" network create --ipv6 --driver=bridge kindexgw --subnet=172.19.0.0/16 --subnet=fc00:f853:ccd:e798::/64 || true
 
   KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
   for n in $KIND_NODES; do
-    docker network connect kindexgw "$n"
+    "$OCI_BIN" network connect kindexgw "$n"
   done
 }
 

--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -321,8 +321,7 @@ parse_args() {
                                                 ;;
             --isolated )                        OVN_ISOLATED=true
                                                 ;;
-            -mne | --multi-network-enable )     shift
-                                                ENABLE_MULTI_NET=true
+            -mne | --multi-network-enable )     ENABLE_MULTI_NET=true
                                                 ;;
             --delete )                          delete
                                                 exit

--- a/test/e2e/localnet-underlay.go
+++ b/test/e2e/localnet-underlay.go
@@ -1,0 +1,163 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+const (
+	bridgeName = "ovsbr1"
+	add        = "add-br"
+	del        = "del-br"
+)
+
+func setupUnderlay(ovsPods []v1.Pod, portName string, nadConfig networkAttachmentConfig) error {
+	for _, ovsPod := range ovsPods {
+		if err := addOVSBridge(ovsPod.Name, bridgeName); err != nil {
+			return err
+		}
+
+		if nadConfig.vlanID > 0 {
+			if err := ovsEnableVLANAccessPort(ovsPod.Name, bridgeName, portName, nadConfig.vlanID); err != nil {
+				return err
+			}
+		} else {
+			if err := ovsAttachPortToBridge(ovsPod.Name, bridgeName, portName); err != nil {
+				return err
+			}
+		}
+
+		if err := configureBridgeMappings(
+			ovsPod.Name,
+			defaultNetworkBridgeMapping(),
+			bridgeMapping(nadConfig.attachmentName(), bridgeName),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func teardownUnderlay(ovsPods []v1.Pod) error {
+	for _, ovsPod := range ovsPods {
+		if err := removeOVSBridge(ovsPod.Name, bridgeName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ovsPods(clientSet clientset.Interface) []v1.Pod {
+	const (
+		ovnKubernetesNamespace = "ovn-kubernetes"
+		ovsNodeLabel           = "app=ovs-node"
+	)
+	pods, err := clientSet.CoreV1().Pods(ovnKubernetesNamespace).List(
+		context.Background(),
+		metav1.ListOptions{LabelSelector: ovsNodeLabel},
+	)
+	if err != nil {
+		return nil
+	}
+	return pods.Items
+}
+
+func addOVSBridge(ovnNodeName string, bridgeName string) error {
+	_, err := runCommand(ovsBridgeCommand(ovnNodeName, add, bridgeName)...)
+	if err != nil {
+		return fmt.Errorf("failed to ADD OVS bridge %s: %v", bridgeName, err)
+	}
+	return nil
+}
+
+func removeOVSBridge(ovnNodeName string, bridgeName string) error {
+	_, err := runCommand(ovsBridgeCommand(ovnNodeName, del, bridgeName)...)
+	if err != nil {
+		return fmt.Errorf("failed to DELETE OVS bridge %s: %v", bridgeName, err)
+	}
+	return nil
+}
+
+func ovsBridgeCommand(ovnNodeName string, addOrDeleteCmd string, bridgeName string) []string {
+	return []string{
+		"kubectl", "-n", "ovn-kubernetes", "exec", ovnNodeName, "--",
+		"ovs-vsctl", addOrDeleteCmd, bridgeName,
+	}
+}
+
+func ovsAttachPortToBridge(ovsNodeName string, bridgeName string, portName string) error {
+	cmd := []string{
+		"kubectl", "-n", "ovn-kubernetes", "exec", ovsNodeName, "--",
+		"ovs-vsctl", "add-port", bridgeName, portName,
+	}
+
+	if _, err := runCommand(cmd...); err != nil {
+		return fmt.Errorf("failed to add port %s to OVS bridge %s: %v", portName, bridgeName, err)
+	}
+
+	return nil
+}
+
+func ovsEnableVLANAccessPort(ovsNodeName string, bridgeName string, portName string, vlanID int) error {
+	cmd := []string{
+		"kubectl", "-n", "ovn-kubernetes", "exec", ovsNodeName, "--",
+		"ovs-vsctl", "add-port", bridgeName, portName, fmt.Sprintf("tag=%d", vlanID), "vlan_mode=access",
+	}
+
+	if _, err := runCommand(cmd...); err != nil {
+		return fmt.Errorf("failed to add port %s to OVS bridge %s: %v", portName, bridgeName, err)
+	}
+
+	return nil
+}
+
+type BridgeMapping struct {
+	physnet   string
+	ovsBridge string
+}
+
+func (bm BridgeMapping) String() string {
+	return fmt.Sprintf("%s:%s", bm.physnet, bm.ovsBridge)
+}
+
+type BridgeMappings []BridgeMapping
+
+func (bms BridgeMappings) String() string {
+	return strings.Join(Map(bms, func(bm BridgeMapping) string { return bm.String() }), ",")
+}
+
+func Map[T, V any](items []T, fn func(T) V) []V {
+	result := make([]V, len(items))
+	for i, t := range items {
+		result[i] = fn(t)
+	}
+	return result
+}
+
+func configureBridgeMappings(ovnNodeName string, mappings ...BridgeMapping) error {
+	mappingsString := fmt.Sprintf("external_ids:ovn-bridge-mappings=%s", BridgeMappings(mappings).String())
+	cmd := []string{"kubectl", "-n", "ovn-kubernetes", "exec", ovnNodeName,
+		"--", "ovs-vsctl", "set", "open", ".", mappingsString,
+	}
+	_, err := runCommand(cmd...)
+	return err
+}
+
+func defaultNetworkBridgeMapping() BridgeMapping {
+	return BridgeMapping{
+		physnet:   "physnet",
+		ovsBridge: "breth0",
+	}
+}
+
+func bridgeMapping(physnet, ovsBridge string) BridgeMapping {
+	return BridgeMapping{
+		physnet:   physnet,
+		ovsBridge: ovsBridge,
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
This PR adds localnet multi-network underlay configuration to the e2e tests. Up to now, those executed the pods in the same node, and thus the test didn't check anything other than it is possible to schedule pods attaching to those networks.

This PR ensures the pods are scheduled on different nodes, which means the traffic between the workloads will use the physical underlay between them.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->