### PR TITLE
Fix APB External Route flaky unit test

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
@@ -103,39 +103,35 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(
 				Equal(
 					&namespaceInfo{
-						policies:        sets.New(multipleNamespacesPolicy.Name),
-						staticGateways:  gatewayInfoList{},
-						dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+						Policies:        sets.New(multipleNamespacesPolicy.Name),
+						StaticGateways:  gatewayInfoList{},
+						DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 					}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(
 				Equal(
 					&namespaceInfo{
-						policies:        sets.New(multipleNamespacesPolicy.Name),
-						staticGateways:  gatewayInfoList{},
-						dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+						Policies:        sets.New(multipleNamespacesPolicy.Name),
+						StaticGateways:  gatewayInfoList{},
+						DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 					}))
 			_, err := fakeClient.CoreV1().Pods(pod1.Namespace).Create(context.Background(), pod1, v1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(
 				Equal(
 					&namespaceInfo{
-						policies:       sets.New(multipleNamespacesPolicy.Name),
-						staticGateways: gatewayInfoList{},
-						dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-							{Namespace: "default", Name: pod1.Name}: {
-								gws: sets.New(pod1.Status.PodIPs[0].IP),
-							},
+						Policies:       sets.New(multipleNamespacesPolicy.Name),
+						StaticGateways: gatewayInfoList{},
+						DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+							{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 						},
 					}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(
 				Equal(
 					&namespaceInfo{
-						policies:       sets.New(multipleNamespacesPolicy.Name),
-						staticGateways: gatewayInfoList{},
-						dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-							{Namespace: "default", Name: pod1.Name}: {
-								gws: sets.New(pod1.Status.PodIPs[0].IP),
-							},
+						Policies:       sets.New(multipleNamespacesPolicy.Name),
+						StaticGateways: gatewayInfoList{},
+						DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+							{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 						}}))
 
 		})
@@ -157,9 +153,9 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(
 				Equal(
 					&namespaceInfo{
-						policies:        sets.New(noMatchPolicy.Name),
-						staticGateways:  gatewayInfoList{},
-						dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+						Policies:        sets.New(noMatchPolicy.Name),
+						StaticGateways:  gatewayInfoList{},
+						DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 					}))
 
 		})
@@ -172,21 +168,19 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(
 				Equal(
 					&namespaceInfo{
-						policies:        sets.New(overlappingPolicy.Name, dynamicPolicy.Name),
-						staticGateways:  gatewayInfoList{},
-						dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+						Policies:        sets.New(overlappingPolicy.Name, dynamicPolicy.Name),
+						StaticGateways:  gatewayInfoList{},
+						DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 					}))
 			_, err := fakeClient.CoreV1().Pods(pod1.Namespace).Create(context.Background(), pod1, v1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(
 				Equal(
 					&namespaceInfo{
-						policies:       sets.New(overlappingPolicy.Name, dynamicPolicy.Name),
-						staticGateways: gatewayInfoList{},
-						dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-							{Namespace: "default", Name: pod1.Name}: {
-								gws: sets.New(pod1.Status.PodIPs[0].IP),
-							},
+						Policies:       sets.New(overlappingPolicy.Name, dynamicPolicy.Name),
+						StaticGateways: gatewayInfoList{},
+						DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+							{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 						}}))
 
 		})
@@ -207,37 +201,33 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: {
-							gws: sets.New(pod1.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
 				}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicyTest2.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: {
-							gws: sets.New(pod1.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicyTest2.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
 				}))
 			deletePod(pod1, fakeClient)
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:        sets.New(dynamicPolicy.Name),
-					staticGateways:  gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+					Policies:        sets.New(dynamicPolicy.Name),
+					StaticGateways:  gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 				}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:        sets.New(dynamicPolicyTest2.Name),
-					staticGateways:  gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+					Policies:        sets.New(dynamicPolicyTest2.Name),
+					StaticGateways:  gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 				}))
 		})
 
@@ -255,9 +245,9 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:        sets.New(noMatchPolicy.Name),
-					staticGateways:  gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+					Policies:        sets.New(noMatchPolicy.Name),
+					StaticGateways:  gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 				}))
 			deletePod(pod1, fakeClient)
 			Eventually(func() bool {
@@ -268,9 +258,9 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:        sets.New(noMatchPolicy.Name),
-					staticGateways:  gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+					Policies:        sets.New(noMatchPolicy.Name),
+					StaticGateways:  gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 				}))
 		})
 
@@ -282,12 +272,10 @@ var _ = Describe("OVN External Gateway policy", func() {
 
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(overlappingPolicy.Name, dynamicPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: {
-							gws: sets.New(pod2.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(overlappingPolicy.Name, dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
 				}))
 		})
@@ -301,19 +289,17 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:        sets.New(dynamicPolicy.Name),
-					staticGateways:  gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+					Policies:        sets.New(dynamicPolicy.Name),
+					StaticGateways:  gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 				}))
 			updatePodLabels(unmatchPod, pod1.Labels, fakeClient)
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: unmatchPod.Name}: {
-							gws: sets.New(unmatchPod.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: unmatchPod.Name}: newGatewayInfo(sets.New(unmatchPod.Status.PodIPs[0].IP), false),
 					},
 				}))
 		})
@@ -325,12 +311,10 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name, overlappingPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: {
-							gws: sets.New(pod2.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name, overlappingPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
 				}))
 			updatePodLabels(pod2, map[string]string{"duplicated": "true"}, fakeClient)
@@ -343,12 +327,10 @@ var _ = Describe("OVN External Gateway policy", func() {
 			}, 2, 2).Should(BeTrue())
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name, overlappingPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: {
-							gws: sets.New(pod2.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name, overlappingPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
 				}))
 		})
@@ -359,42 +341,34 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: {
-							gws: sets.New(pod2.Status.PodIPs[0].IP),
-						},
-						{Namespace: "default", Name: pod3.Name}: {
-							gws: sets.New(pod3.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
+						{Namespace: "default", Name: pod3.Name}: newGatewayInfo(sets.New(pod3.Status.PodIPs[0].IP), false),
 					},
 				}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:        sets.New(dynamicPolicyForTest2Only.Name),
-					staticGateways:  gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+					Policies:        sets.New(dynamicPolicyForTest2Only.Name),
+					StaticGateways:  gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 				}))
 			updatePodLabels(pod2, map[string]string{"duplicated": "true"}, fakeClient)
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod3.Name}: {
-							gws: sets.New(pod3.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod3.Name}: newGatewayInfo(sets.New(pod3.Status.PodIPs[0].IP), false),
 					},
 				}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicyForTest2Only.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: {
-							gws: sets.New(pod2.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicyForTest2Only.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
 				}))
 		})
@@ -404,26 +378,20 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: {
-							gws: sets.New(pod1.Status.PodIPs[0].IP),
-						},
-						{Namespace: "default", Name: pod2.Name}: {
-							gws: sets.New(pod2.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
+						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
 				}))
 			updatePodLabels(pod1, map[string]string{}, fakeClient)
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5, 1).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: {
-							gws: sets.New(pod2.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
 				}))
 		})
@@ -433,40 +401,34 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: {
-							gws: sets.New(pod1.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
 				}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicyForTest2Only.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: {
-							gws: sets.New(pod1.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicyForTest2Only.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
 				}))
 			updatePodLabels(pod1, map[string]string{"key": "pod"}, fakeClient)
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:       sets.New(dynamicPolicy.Name),
-					staticGateways: gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: {
-							gws: sets.New(pod1.Status.PodIPs[0].IP),
-						},
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
 				}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
 				&namespaceInfo{
-					policies:        sets.New(dynamicPolicyForTest2Only.Name),
-					staticGateways:  gatewayInfoList{},
-					dynamicGateways: map[types.NamespacedName]*gatewayInfo{},
+					Policies:        sets.New(dynamicPolicyForTest2Only.Name),
+					StaticGateways:  gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
 				}))
 		})
 

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_test.go
@@ -1,0 +1,125 @@
+package apbroute
+
+import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	// Default comparable options to bypass comparing the mux object and define a less function to sort the slices.
+	cmpOpts = []cmp.Option{
+		cmpopts.IgnoreFields(syncSet{}, "mux"),
+		cmpopts.IgnoreFields(namespaceInfo{}, "markForDelete"),
+		cmpopts.SortSlices(func(x, y interface{}) bool {
+			s1, ok1 := x.(*gatewayInfo)
+			s2, ok2 := y.(*gatewayInfo)
+			if !ok1 || !ok2 {
+				return fmt.Sprint(x) < fmt.Sprint(y)
+			}
+			return fmt.Sprint(sets.List(s1.Gateways.items)) < fmt.Sprint(sets.List(s2.Gateways.items))
+		})}
+)
+
+var _ = Describe("GatewayInfoList", func() {
+
+	var _ = Context("Inserting", func() {
+
+		It("Returns an unmodified list and the duplicated value when the inserting a slice with the same value already existing in the list", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false)}
+			res, dup, err := s1.Insert(newGatewayInfo(sets.New("1.1.1.1"), false))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(s1))
+			Expect(dup).To(BeComparableTo(sets.New("1.1.1.1")))
+		})
+
+		It("Adds a new element in the slice when no duplicates are found", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false)}
+			res, dup, err := s1.Insert(newGatewayInfo(sets.New("1.1.1.2"), false))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(BeComparableTo(gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false), newGatewayInfo(sets.New("1.1.1.2"), false)}, cmpOpts...))
+			Expect(dup).To(Equal(sets.Set[string]{}))
+		})
+
+		It("Adds a new element in the slice and returns the duplicated value found during insertion", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false)}
+			res, dup, err := s1.Insert(newGatewayInfo(sets.New("1.1.1.1", "1.1.1.2"), false))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(BeComparableTo(gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false), newGatewayInfo(sets.New("1.1.1.2"), false)}, cmpOpts...))
+			Expect(dup).To(Equal(sets.New("1.1.1.1")))
+		})
+
+		It("Adds an empty element in the slice and returns no changes in the list and no duplicates", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false)}
+			res, dup, err := s1.Insert(newGatewayInfo(sets.Set[string]{}, false))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(BeComparableTo(s1, cmpOpts...))
+			Expect(dup).To(Equal(sets.Set[string]{}))
+		})
+
+		It("Adds a new element with multiple duplicates found in one single entry in the slice", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1", "1.1.1.2"), false)}
+			res, dup, err := s1.Insert(newGatewayInfo(sets.New("1.1.1.1", "1.1.1.2", "1.1.1.3"), false))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(BeComparableTo(gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1", "1.1.1.2"), false), newGatewayInfo(sets.New("1.1.1.3"), false)}, cmpOpts...))
+			Expect(dup).To(Equal(sets.New("1.1.1.2", "1.1.1.1")))
+		})
+
+		It("Adds a new element with multiple duplicates found in two different entries in the slice", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false), newGatewayInfo(sets.New("1.1.1.2"), false)}
+			res, dup, err := s1.Insert(newGatewayInfo(sets.New("1.1.1.1", "1.1.1.2", "1.1.1.3"), false))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(BeComparableTo(gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false), newGatewayInfo(sets.New("1.1.1.2"), false), newGatewayInfo(sets.New("1.1.1.3"), false)}, cmpOpts...))
+			Expect(dup).To(Equal(sets.New("1.1.1.2", "1.1.1.1")))
+		})
+
+		It("Returns the same gatewayInfoList when adding a slice of gatewayInfos containing only duplicated IPs", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1", "1.1.1.3"), false), newGatewayInfo(sets.New("1.1.1.2"), false)}
+			res, dup, err := s1.Insert(
+				newGatewayInfo(sets.New("1.1.1.2", "1.1.1.1"), false),
+				newGatewayInfo(sets.New("1.1.1.1"), false),
+				newGatewayInfo(sets.New("1.1.1.3"), false),
+				newGatewayInfo(sets.New("1.1.1.1", "1.1.1.2"), false))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(BeComparableTo(s1, cmpOpts...))
+			Expect(dup).To(Equal(sets.New("1.1.1.2", "1.1.1.1", "1.1.1.3")))
+		})
+
+		It("Fails to insert when providing an IP with a different BFD state to the one already stored in the gatewayInfo", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false)}
+			_, _, err := s1.Insert(newGatewayInfo(sets.New("1.1.1.1"), true))
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(fmt.Errorf("attempting to insert duplicated IP 1.1.1.1 with different BFD states: enabled/disabled")))
+		})
+	})
+
+	var _ = Context("Deleting", func() {
+		It("deletes an existing element from the slice", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1"), false), newGatewayInfo(sets.New("1.1.1.2"), false)}
+			ret := s1.Delete(newGatewayInfo(sets.New("1.1.1.1"), false))
+			Expect(ret).To(BeEquivalentTo(gatewayInfoList{newGatewayInfo(sets.New("1.1.1.2"), false)}))
+		})
+
+		It("fails to delete an element that does not have a match in the slice", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.2"), false)}
+			ret := s1.Delete(newGatewayInfo(sets.New("1.1.1.1"), false))
+			Expect(ret).To(BeEquivalentTo(s1))
+		})
+
+		It("fails to delete an element that matches only a subset of one of the elements in the slice", func() {
+			s1 := gatewayInfoList{newGatewayInfo(sets.New("1.1.1.1", "1.1.1.2"), false)}
+			ret := s1.Delete(newGatewayInfo(sets.New("1.1.1.1"), false))
+			Expect(ret).To(BeEquivalentTo(s1))
+		})
+
+		It("NOP when the slice is empty", func() {
+			s1 := gatewayInfoList{}
+			ret := s1.Delete(newGatewayInfo(sets.New("1.1.1.1"), false))
+			Expect(ret).To(BeEmpty())
+		})
+	})
+})

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -384,17 +384,10 @@ func (c *ExternalGatewayMasterController) syncNamespace(namespace *v1.Namespace)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) || !namespace.DeletionTimestamp.IsZero() {
 		// DELETE use case
 		klog.Infof("Deleting namespace reference %s", namespace.Name)
-		_, found := c.mgr.getNamespaceInfoFromCache(namespace.Name)
-		if !found {
-			// namespace is not a recipient for policies
-			return nil
-		}
-		c.mgr.deleteNamespaceInfoInCache(namespace.Name)
-		c.mgr.unlockNamespaceInfoCache(namespace.Name)
-		return nil
+		return c.mgr.processDeleteNamespace(namespace.Name)
 	}
 	matches, err := c.mgr.getPoliciesForNamespace(namespace.Name)
 	if err != nil {
@@ -405,31 +398,32 @@ func (c *ExternalGatewayMasterController) syncNamespace(namespace *v1.Namespace)
 		// it's not a namespace being cached already and it is not a target for policies, nothing to do
 		return nil
 	}
+
+	defer c.mgr.unlockNamespaceInfoCache(namespace.Name)
+	if found && cacheInfo.markForDelete {
+		// namespace exists and has been marked for deletion, this means there should be an event to complete deleting the namespace.
+		// wait for the namespace to be deleted before recreating it in the cache.
+		return fmt.Errorf("cannot add namespace %s because it is currently being deleted", namespace.Name)
+	}
+
 	if !found {
 		// ADD use case
 		// new namespace or namespace updated its labels and now match a routing policy
-		defer c.mgr.unlockNamespaceInfoCache(namespace.Name)
 		cacheInfo = c.mgr.newNamespaceInfoInCache(namespace.Name)
-		cacheInfo.policies = matches
+		cacheInfo.Policies = matches
 		return c.mgr.processAddNamespace(namespace, cacheInfo)
 	}
 
-	if !cacheInfo.policies.Equal(matches) {
+	if !cacheInfo.Policies.Equal(matches) {
 		// UPDATE use case
 		// policies differ, need to reconcile them
-		defer c.mgr.unlockNamespaceInfoCache(namespace.Name)
-		err = c.mgr.processUpdateNamespace(namespace.Name, cacheInfo.policies, matches, cacheInfo)
+		err = c.mgr.processUpdateNamespace(namespace.Name, cacheInfo.Policies, matches, cacheInfo)
 		if err != nil {
 			return err
 		}
-		if cacheInfo.policies.Len() == 0 {
-			c.mgr.deleteNamespaceInfoInCache(namespace.Name)
-		}
 		return nil
 	}
-	c.mgr.unlockNamespaceInfoCache(namespace.Name)
 	return nil
-
 }
 
 func (c *ExternalGatewayMasterController) onPodAdd(obj interface{}) {
@@ -522,10 +516,10 @@ func (c *ExternalGatewayMasterController) updateStatusAPBExternalRoute(routeName
 	gwIPs := sets.New[string]()
 	if processedError == nil {
 		for _, static := range processedPolicy.staticGateways {
-			gwIPs = gwIPs.Union(static.gws)
+			gwIPs = gwIPs.Insert(static.Gateways.UnsortedList()...)
 		}
 		for _, dynamic := range processedPolicy.dynamicGateways {
-			gwIPs = gwIPs.Union(dynamic.gws)
+			gwIPs = gwIPs.Insert(dynamic.Gateways.UnsortedList()...)
 		}
 	}
 	updateStatus(routePolicy, strings.Join(sets.List(gwIPs), ","), processedError)

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -219,9 +219,9 @@ func (nb *northBoundClient) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddr
 		for _, gateway := range gateways {
 			// TODO (trozet): use the go bindings here and batch commands
 			// validate the ip and gateway belong to the same address family
-			gws, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(podIPNet.IP), gateway.gws.UnsortedList())
+			gws, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(podIPNet.IP), gateway.Gateways.UnsortedList())
 			if err != nil {
-				klog.Warningf("Address families for the pod address %s and gateway %s did not match", podIPNet.IP.String(), gateway.gws)
+				klog.Warningf("Address families for the pod address %s and gateway %s did not match", podIPNet.IP.String(), gateway.Gateways)
 				continue
 			}
 			podIP := podIPNet.IP.String()
@@ -232,7 +232,7 @@ func (nb *northBoundClient) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddr
 					continue
 				}
 				mask := util.GetIPFullMask(podIP)
-				if err := nb.createOrUpdateBFDStaticRoute(gateway.bfdEnabled, gw, podIP, gr, port, mask); err != nil {
+				if err := nb.createOrUpdateBFDStaticRoute(gateway.BFDEnabled, gw, podIP, gr, port, mask); err != nil {
 					return err
 				}
 				if routeInfo.PodExternalRoutes[podIP] == nil {

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -1033,6 +1033,11 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			f := wrappedTestFramework(svcname)
 
 			ginkgo.BeforeEach(func() {
+				if isInterconnectEnabled() {
+					skipper.Skipf(
+						"APB External Route is not yet supported with multiple zones interconnect deployment",
+					)
+				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
@@ -1179,6 +1184,11 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			var addressesv4, addressesv6 gatewayTestIPs
 
 			ginkgo.BeforeEach(func() {
+				if isInterconnectEnabled() {
+					skipper.Skipf(
+						"APB External Route is not yet supported with multiple zones interconnect deployment",
+					)
+				}
 				// retrieve worker node names
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
 				framework.ExpectNoError(err)
@@ -1325,6 +1335,11 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			)
 
 			ginkgo.BeforeEach(func() {
+				if isInterconnectEnabled() {
+					skipper.Skipf(
+						"APB External Route is not yet supported with multiple zones interconnect deployment",
+					)
+				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err = e2enode.GetBoundedReadySchedulableNodes(clientSet, 3)
@@ -1546,6 +1561,11 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 				f := wrappedTestFramework(svcname)
 
 				ginkgo.BeforeEach(func() {
+					if isInterconnectEnabled() {
+						skipper.Skipf(
+							"APB External Route is not yet supported with multiple zones interconnect deployment",
+						)
+					}
 					clientSet = f.ClientSet // so it can be used in AfterEach
 					// retrieve worker node names
 					nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
@@ -1746,6 +1766,11 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 				var addressesv4, addressesv6 gatewayTestIPs
 
 				ginkgo.BeforeEach(func() {
+					if isInterconnectEnabled() {
+						skipper.Skipf(
+							"APB External Route is not yet supported with multiple zones interconnect deployment",
+						)
+					}
 					nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
 					framework.ExpectNoError(err)
 					if len(nodes.Items) < 3 {
@@ -1953,6 +1978,11 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			f := wrappedTestFramework(svcname)
 
 			ginkgo.BeforeEach(func() {
+				if isInterconnectEnabled() {
+					skipper.Skipf(
+						"APB External Route is not yet supported with multiple zones interconnect deployment",
+					)
+				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
@@ -2103,6 +2133,11 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			)
 
 			ginkgo.BeforeEach(func() {
+				if isInterconnectEnabled() {
+					skipper.Skipf(
+						"APB External Route is not yet supported with multiple zones interconnect deployment",
+					)
+				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err = e2enode.GetBoundedReadySchedulableNodes(clientSet, 3)


### PR DESCRIPTION
* Fixes a flaky test in the Admin Policy Based External Route unit test by adding logic to wait for the CR to be reconciled before comparing slices and also aligning the test with the expected behavior based on the test description (currently it not only removed a duplicated IP but also changed one, this is not aligned with the test description as it does not expect changes in the IP slice).
~~* Added Equal() functions to gatewayInfoList, gatewayInfo and namespaceInfo to support test scenarios~~
* Removed sorting functions in gatewayInfoList as they were not clear how they would sort the struct and were only used in test scenarios. They have been replaced by the Equal() functions.
* Added tests for `Insert` `Delete`  for `gatewayInfoList`
* Changed to use `cmpOpts` to validate comparing `namespaceInfo` objects, instead of relaying on implementing `Equal()`
or the sort interface. This change makes sense since both the `Equal()` and sorting functions were only used for testing and were not required in the business logic.
* Added a mutex in the `gatewayInfo` struct to control access to the set that contains the IPs after catching a DATA RACE error in a CI/CD run for this PR.


@jcaamano PTAL.