### PR TITLE
[wip] ovn: fix flake in external gateway test

### DIFF
--- a/go-controller/pkg/ovn/external_gateway_test.go
+++ b/go-controller/pkg/ovn/external_gateway_test.go
@@ -2883,9 +2883,9 @@ func deleteNamespace(namespaceName string, fakeClient kubernetes.Interface) {
 
 func (o *FakeOVN) RunAPBExternalPolicyController() {
 	klog.Warningf("#### [%p] INIT Admin Policy Based External Controller", o)
-	o.controller.wg.Add(1)
+	o.wg.Add(1)
 	go func() {
-		defer o.controller.wg.Done()
+		defer o.wg.Done()
 		o.controller.apbExternalRouteController.Run(5)
 	}()
 }


### PR DESCRIPTION
The test doesn't use the right WaitGroup to ensure that the APBExternalPolicyController's Run() function has returned before allowing the next test to proceed.