### PR TITLE
Disallow ipam key on multi net cni config

### DIFF
--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -409,10 +409,6 @@ func ParseNetConf(netattachdef *nettypes.NetworkAttachmentDefinition) (*ovncnity
 	if err != nil {
 		return nil, fmt.Errorf("error parsing Network Attachment Definition %s/%s: %v", netattachdef.Namespace, netattachdef.Name, err)
 	}
-	// skip non-OVN NAD
-	if netconf.Type != "ovn-k8s-cni-overlay" {
-		return nil, ErrorAttachDefNotOvnManaged
-	}
 
 	if netconf.Name != types.DefaultNetworkName {
 		nadName := GetNADName(netattachdef.Namespace, netattachdef.Name)

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -19,7 +19,10 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 )
 
-var ErrorAttachDefNotOvnManaged = errors.New("net-attach-def not managed by OVN")
+var (
+	ErrorAttachDefNotOvnManaged = errors.New("net-attach-def not managed by OVN")
+	UnsupportedIPAMKeyError     = errors.New("IPAM key is not supported. Use OVN-K provided IPAM via the `subnets` attribute")
+)
 
 // BasicNetInfo is interface which holds basic network information
 type BasicNetInfo interface {
@@ -416,6 +419,10 @@ func ParseNetConf(netattachdef *nettypes.NetworkAttachmentDefinition) (*ovncnity
 		if netconf.NADName != nadName {
 			return nil, fmt.Errorf("net-attach-def name (%s) is inconsistent with config (%s)", nadName, netconf.NADName)
 		}
+	}
+
+	if netconf.IPAM.Type != "" {
+		return nil, fmt.Errorf("error parsing Network Attachment Definition %s/%s: %v", netattachdef.Namespace, netattachdef.Name, UnsupportedIPAMKeyError)
 	}
 
 	return netconf, nil

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/onsi/gomega"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+
 	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
@@ -219,6 +221,25 @@ func TestParseNetconf(t *testing.T) {
     }
 `,
 			expectedError: fmt.Errorf("error parsing Network Attachment Definition ns1/nad1: missing NADName in secondary network netconf tenantred"),
+		},
+		{
+			desc: "valid attachment definition for a localnet topology with a VLAN",
+			inputNetAttachDefConfigSpec: `
+    {
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "topology": "localnet",
+            "vlanID": 10,
+            "netAttachDefName": "ns1/nad1"
+    }
+`,
+			expectedNetConf: &ovncnitypes.NetConf{
+				Topology: "localnet",
+				NADName:  "ns1/nad1",
+				MTU:      1400,
+				VLANID:   10,
+				NetConf:  cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
+			},
 		},
 	}
 

--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -241,6 +241,21 @@ func TestParseNetconf(t *testing.T) {
 				NetConf:  cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
 			},
 		},
+		{
+			desc: "valid attachment definition for the default network",
+			inputNetAttachDefConfigSpec: `
+    {
+            "name": "tenantred",
+            "type": "ovn-k8s-cni-overlay",
+            "netAttachDefName": "ns1/nad1"
+    }
+`,
+			expectedNetConf: &ovncnitypes.NetConf{
+				NADName: "ns1/nad1",
+				MTU:     1400,
+				NetConf: cnitypes.NetConf{Name: "default", Type: "ovn-k8s-cni-overlay"},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->
OVN-Kubernetes on secondary networks only supports internal IPAM (i.e. implemented by OVN-K)
or no IPAM at all.

The [CNI IPAM key](https://github.com/containernetworking/cni/blob/main/SPEC.md#configuration-format) (tip: search  for ipam ..) is an optional, well-known key providing:
> Dictionary with IPAM (IP Address Management) specific values:
type (string): Refers to the filename of the IPAM plugin executable. Must not contain characters disallowed in file paths for the system (e.g. / or \).

Thus, it is pretty common for a user to attempt to define it; it currently wouldn't work - silently - which would confuse the users. 

This PR disallows the usage of this key providing an error message if it is used.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
Run the unit tests.

Attempt to provision (and use) a network-attachment-definition providing the IPAM key.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Disallow ipam key on multi net cni config