### PR TITLE
testing: add CreateTestData() method for libovsdb test server

### DIFF
--- a/go-controller/pkg/metrics/master_test.go
+++ b/go-controller/pkg/metrics/master_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func setupOvn(nbData libovsdbtest.TestSetup) (client.Client, client.Client, *libovsdbtest.Cleanup) {
+func setupOvn(nbData libovsdbtest.TestSetup) (client.Client, client.Client, *libovsdbtest.Context) {
 	nbClient, sbClient, cleanup, err := libovsdbtest.NewNBSBTestHarness(nbData)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	return sbClient, nbClient, cleanup
@@ -56,7 +56,7 @@ var _ = ginkgo.Describe("Config Duration Operations", func() {
 		instance       *ConfigDurationRecorder
 		k              *kube.Kube
 		nbClient       client.Client
-		cleanup        *libovsdbtest.Cleanup
+		cleanup        *libovsdbtest.Context
 		stop           chan struct{}
 		testNamespaceA = "testnamespacea"
 		testPodNameA   = "testpoda"

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -62,7 +62,7 @@ var _ = ginkgo.Describe("OVN Address Set operations", func() {
 	var (
 		app             *cli.App
 		asFactory       AddressSetFactory
-		libovsdbCleanup *libovsdbtest.Cleanup
+		libovsdbCleanup *libovsdbtest.Context
 		addrsetDbIDs    = getNamespaceAddrSetDbIDs(addrsetName, controllerName)
 	)
 

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -44,7 +44,7 @@ var (
 	stopChan           chan (struct{})
 	initialDB          libovsdbtest.TestSetup
 	nbClient           libovsdbclient.Client
-	nbsbCleanup        *libovsdbtest.Cleanup
+	nbsbCleanup        *libovsdbtest.Context
 	fakeRouteClient    *adminpolicybasedrouteclient.Clientset
 	fakeClient         *fake.Clientset
 	mgr                *externalPolicyManager

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -40,7 +40,7 @@ type serviceController struct {
 	*Controller
 	serviceStore       cache.Store
 	endpointSliceStore cache.Store
-	libovsdbCleanup    *libovsdbtest.Cleanup
+	libovsdbCleanup    *libovsdbtest.Context
 }
 
 func newController() (*serviceController, error) {

--- a/go-controller/pkg/ovn/controller/unidling/unidle_test.go
+++ b/go-controller/pkg/ovn/controller/unidling/unidle_test.go
@@ -30,7 +30,7 @@ func TestUnidlingContoller(t *testing.T) {
 }
 
 var _ = Describe("Unidling Controller", func() {
-	var cleanup *libovsdbtest.Cleanup
+	var cleanup *libovsdbtest.Context
 
 	BeforeEach(func() {
 		cleanup = nil

--- a/go-controller/pkg/ovn/hybrid_test.go
+++ b/go-controller/pkg/ovn/hybrid_test.go
@@ -144,7 +144,7 @@ var _ = ginkgo.Describe("Hybrid SDN Master Operations", func() {
 		stopChan        chan struct{}
 		wg              *sync.WaitGroup
 		fexec           *ovntest.FakeExec
-		libovsdbCleanup *libovsdbtest.Cleanup
+		libovsdbCleanup *libovsdbtest.Context
 
 		f *factory.WatchFactory
 	)

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -883,7 +883,7 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 
 		nbClient        libovsdbclient.Client
 		sbClient        libovsdbclient.Client
-		libovsdbCleanup *libovsdbtest.Cleanup
+		libovsdbCleanup *libovsdbtest.Context
 
 		dbSetup        libovsdbtest.TestSetup
 		node1          tNode

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -70,7 +70,7 @@ type FakeOVN struct {
 	nbClient     libovsdbclient.Client
 	sbClient     libovsdbclient.Client
 	dbSetup      libovsdbtest.TestSetup
-	nbsbCleanup  *libovsdbtest.Cleanup
+	nbsbCleanup  *libovsdbtest.Context
 	egressQoSWg  *sync.WaitGroup
 	egressSVCWg  *sync.WaitGroup
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1985,7 +1985,7 @@ func getAllowFromNodeStaleACL(nodeName, mgmtIP string, logicalSwitch *nbdb.Logic
 // here only low-level operation are tested (directly calling updateStaleNetpolNodeACLs)
 var _ = ginkgo.Describe("OVN AllowFromNode ACL low-level operations", func() {
 	var (
-		nbCleanup     *libovsdbtest.Cleanup
+		nbCleanup     *libovsdbtest.Context
 		logicalSwitch *nbdb.LogicalSwitch
 	)
 

--- a/go-controller/pkg/ovn/zone_interconnect/chassis_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/chassis_handler_test.go
@@ -19,7 +19,7 @@ import (
 var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 	var (
 		app             *cli.App
-		libovsdbCleanup *libovsdbtest.Cleanup
+		libovsdbCleanup *libovsdbtest.Context
 		testNode1       corev1.Node
 		testNode2       corev1.Node
 		testNode3       corev1.Node

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler_test.go
@@ -252,7 +252,7 @@ func checkInterconnectResources(zone string, netName string, nbClient libovsdbcl
 var _ = ginkgo.Describe("Zone Interconnect Operations", func() {
 	var (
 		app                *cli.App
-		libovsdbCleanup    *libovsdbtest.Cleanup
+		libovsdbCleanup    *libovsdbtest.Context
 		testNode1          corev1.Node
 		testNode2          corev1.Node
 		testNode3          corev1.Node


### PR DESCRIPTION
Let testcases use a globally created libovsdb test harness from BeforeEach() and update the database with test-specific data in the test, rather than each testcase creating its own harness.