### PR TITLE
Add Support for Hierarchical ACLs

### DIFF
--- a/go-controller/Makefile
+++ b/go-controller/Makefile
@@ -22,7 +22,7 @@ else
 CONTAINER_RUNTIME=docker
 endif
 CONTAINER_RUNNABLE ?= $(shell $(CONTAINER_RUNTIME) -v > /dev/null 2>&1; echo $$?)
-OVN_SCHEMA_VERSION ?= v23.03.0
+OVN_SCHEMA_VERSION ?= v23.06.0
 ifeq ($(NOROOT),TRUE)
 C_ARGS = -e NOROOT=TRUE
 else

--- a/go-controller/pkg/libovsdbops/acl.go
+++ b/go-controller/pkg/libovsdbops/acl.go
@@ -3,6 +3,7 @@ package libovsdbops
 import (
 	"context"
 	"fmt"
+
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	libovsdb "github.com/ovn-org/libovsdb/ovsdb"
 
@@ -21,7 +22,7 @@ func GetACLName(acl *nbdb.ACL) string {
 
 func getACLMutableFields(acl *nbdb.ACL) []interface{} {
 	return []interface{}{&acl.Action, &acl.Direction, &acl.ExternalIDs, &acl.Log, &acl.Match, &acl.Meter,
-		&acl.Name, &acl.Options, &acl.Priority, &acl.Severity}
+		&acl.Name, &acl.Options, &acl.Priority, &acl.Severity, &acl.Tier}
 }
 
 type aclPredicate func(*nbdb.ACL) bool
@@ -63,7 +64,7 @@ func FindACLs(nbClient libovsdbclient.Client, acls []*nbdb.ACL) ([]*nbdb.ACL, er
 
 // BuildACL builds an ACL with empty optional properties unset
 func BuildACL(name string, direction nbdb.ACLDirection, priority int, match string, action nbdb.ACLAction, meter string,
-	severity nbdb.ACLSeverity, log bool, externalIds map[string]string, options map[string]string) *nbdb.ACL {
+	severity nbdb.ACLSeverity, log bool, externalIds map[string]string, options map[string]string, tier int) *nbdb.ACL {
 	name = fmt.Sprintf("%.63s", name)
 
 	var realName *string
@@ -89,6 +90,7 @@ func BuildACL(name string, direction nbdb.ACLDirection, priority int, match stri
 		Meter:       realMeter,
 		ExternalIDs: externalIds,
 		Options:     options,
+		Tier:        tier,
 	}
 
 	return acl

--- a/go-controller/pkg/libovsdbops/acl_test.go
+++ b/go-controller/pkg/libovsdbops/acl_test.go
@@ -96,6 +96,23 @@ func TestCreateOrUpdateACL(t *testing.T) {
 				Severity:    &aclSev,
 			},
 		},
+		{
+			desc:       "updates Tiers to tier2",
+			initialACL: initialACL,
+			finalACL: &nbdb.ACL{
+				Action:      nbdb.ACLActionAllow,
+				Direction:   nbdb.ACLDirectionToLport,
+				ExternalIDs: nil,
+				Log:         true,
+				Match:       "match",
+				Meter:       &aclMeter,
+				Name:        &aclName,
+				Options:     map[string]string{"key": "value"},
+				Priority:    1,
+				Severity:    &aclSev,
+				Tier:        2, // default tier
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/go-controller/pkg/nbdb/acl.go
+++ b/go-controller/pkg/nbdb/acl.go
@@ -19,6 +19,7 @@ var (
 	ACLActionAllowStateless ACLAction    = "allow-stateless"
 	ACLActionDrop           ACLAction    = "drop"
 	ACLActionReject         ACLAction    = "reject"
+	ACLActionPass           ACLAction    = "pass"
 	ACLDirectionFromLport   ACLDirection = "from-lport"
 	ACLDirectionToLport     ACLDirection = "to-lport"
 	ACLSeverityAlert        ACLSeverity  = "alert"
@@ -42,6 +43,7 @@ type ACL struct {
 	Options     map[string]string `ovsdb:"options"`
 	Priority    int               `ovsdb:"priority"`
 	Severity    *ACLSeverity      `ovsdb:"severity"`
+	Tier        int               `ovsdb:"tier"`
 }
 
 func (a *ACL) GetUUID() string {
@@ -198,6 +200,10 @@ func equalACLSeverity(a, b *ACLSeverity) bool {
 	return *a == *b
 }
 
+func (a *ACL) GetTier() int {
+	return a.Tier
+}
+
 func (a *ACL) DeepCopyInto(b *ACL) {
 	*b = *a
 	b.ExternalIDs = copyACLExternalIDs(a.ExternalIDs)
@@ -234,7 +240,8 @@ func (a *ACL) Equals(b *ACL) bool {
 		equalACLName(a.Name, b.Name) &&
 		equalACLOptions(a.Options, b.Options) &&
 		a.Priority == b.Priority &&
-		equalACLSeverity(a.Severity, b.Severity)
+		equalACLSeverity(a.Severity, b.Severity) &&
+		a.Tier == b.Tier
 }
 
 func (a *ACL) EqualsModel(b model.Model) bool {

--- a/go-controller/pkg/nbdb/mirror.go
+++ b/go-controller/pkg/nbdb/mirror.go
@@ -15,8 +15,10 @@ type (
 var (
 	MirrorFilterFromLport MirrorFilter = "from-lport"
 	MirrorFilterToLport   MirrorFilter = "to-lport"
+	MirrorFilterBoth      MirrorFilter = "both"
 	MirrorTypeGre         MirrorType   = "gre"
 	MirrorTypeErspan      MirrorType   = "erspan"
+	MirrorTypeLocal       MirrorType   = "local"
 )
 
 // Mirror defines an object in Mirror table

--- a/go-controller/pkg/nbdb/model.go
+++ b/go-controller/pkg/nbdb/model.go
@@ -48,7 +48,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_Northbound",
-  "version": "7.0.0",
+  "version": "7.0.4",
   "tables": {
     "ACL": {
       "columns": {
@@ -63,7 +63,8 @@ var schema = `{
                   "allow-related",
                   "allow-stateless",
                   "drop",
-                  "reject"
+                  "reject",
+                  "pass"
                 ]
               ]
             }
@@ -168,6 +169,15 @@ var schema = `{
             },
             "min": 0,
             "max": 1
+          }
+        },
+        "tier": {
+          "type": {
+            "key": {
+              "type": "integer",
+              "minInteger": 0,
+              "maxInteger": 3
+            }
           }
         }
       }
@@ -1570,7 +1580,8 @@ var schema = `{
                 "set",
                 [
                   "from-lport",
-                  "to-lport"
+                  "to-lport",
+                  "both"
                 ]
               ]
             }
@@ -1593,7 +1604,8 @@ var schema = `{
                 "set",
                 [
                   "gre",
-                  "erspan"
+                  "erspan",
+                  "local"
                 ]
               ]
             }

--- a/go-controller/pkg/ovn/acl.go
+++ b/go-controller/pkg/ovn/acl.go
@@ -115,6 +115,7 @@ func BuildACL(dbIDs *libovsdbops.DbObjectIDs, priority int, match, action string
 		log,
 		externalIDs,
 		options,
+		types.DefaultACLTier,
 	)
 	return ACL
 }

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -143,6 +143,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						purgeIDs.GetExternalIDs(),
 						nil,
+						t.PlaceHolderACLTier,
 					)
 					purgeACL.UUID = "purgeACL-UUID"
 					// no externalIDs present => dbIDs can't be built
@@ -157,6 +158,9 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						nil,
 						nil,
+						// we should not be in a situation where we have ACLs without externalIDs
+						// but if we do have such lame ACLs then they will interfere with AdminNetPol logic
+						t.PlaceHolderACLTier,
 					)
 					purgeACL2.UUID = "purgeACL2-UUID"
 
@@ -184,6 +188,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						updateIDs.GetExternalIDs(),
 						nil,
+						t.PlaceHolderACLTier,
 					)
 					updateACL.UUID = "updateACL-UUID"
 
@@ -199,6 +204,9 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						nil,
 						nil,
+						// we should not be in a situation where we have unknown ACL that doesn't belong to any feature
+						// but if we do have such lame ACLs then they will interfere with AdminNetPol logic
+						t.PlaceHolderACLTier,
 					)
 					ignoreACL.UUID = "ignoreACL-UUID"
 
@@ -238,6 +246,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					// match shouldn't have cluster exclusion
 					asHash, _ := getNsAddrSetHashNames(namespace1.Name)
 					updateACL.Match = "(ip4.dst == 1.2.3.4/23) && ip4.src == $" + asHash
+					updateACL.Tier = t.DefaultACLTier // ensure the tier of the ACL is updated from 0 to 2
 
 					expectedDatabaseState := []libovsdb.TestData{
 						purgeACL,
@@ -290,6 +299,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv4ACL.UUID = "ipv4ACL-UUID"
 
@@ -336,6 +346,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv6ACL.UUID = "ipv6ACL-UUID"
 
@@ -389,6 +400,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					udpACL.UUID = "udpACL-UUID"
 
@@ -436,6 +448,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv4ACL.UUID = "ipv4ACL-UUID"
 
@@ -496,6 +509,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv4ACL.UUID = "ipv4ACL-UUID"
 
@@ -613,6 +627,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv4ACL.UUID = "ipv4ACL-UUID"
 
@@ -697,6 +712,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv4ACL.UUID = "ipv4ACL-UUID"
 
@@ -782,6 +798,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv4ACL.UUID = "ipv4ACL-UUID"
 
@@ -862,6 +879,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv4ACL.UUID = "ipv4ACL-UUID"
 
@@ -980,6 +998,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 							false,
 							dbIDs.GetExternalIDs(),
 							nil,
+							t.DefaultACLTier,
 						)
 						acl.UUID = "ACL-UUID"
 
@@ -1029,6 +1048,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					acl.UUID = "acl-UUID"
 
@@ -1076,6 +1096,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						aclIDs1.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv4ACL1.UUID = "ipv4ACL1-UUID"
 
@@ -1091,6 +1112,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						aclIDs2.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					ipv4ACL2.UUID = "ipv4ACL2-UUID"
 
@@ -1210,6 +1232,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						false,
 						dbIDs.GetExternalIDs(),
 						nil,
+						t.DefaultACLTier,
 					)
 					acl.UUID = "acl-UUID"
 					clusterPortGroup.ACLs = []string{acl.UUID}

--- a/go-controller/pkg/ovn/external_ids_syncer/address_set/address_set_sync_test.go
+++ b/go-controller/pkg/ovn/external_ids_syncer/address_set/address_set_sync_test.go
@@ -2,9 +2,10 @@ package address_set
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
-	"strings"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
@@ -402,6 +403,7 @@ var _ = ginkgo.Describe("OVN Address Set Syncer", func() {
 			false,
 			map[string]string{egressFirewallACLExtIdKey: "egressfirewall1"},
 			nil,
+			types.PlaceHolderACLTier,
 		)
 		acl.UUID = "acl-UUID"
 		initialDb := []libovsdbtest.TestData{acl}
@@ -437,6 +439,7 @@ var _ = ginkgo.Describe("OVN Address Set Syncer", func() {
 			map[string]string{
 				"apply-after-lb": "true",
 			},
+			types.PlaceHolderACLTier,
 		)
 		acl1.UUID = "acl1-UUID"
 		acl2 := libovsdbops.BuildACL(
@@ -450,6 +453,7 @@ var _ = ginkgo.Describe("OVN Address Set Syncer", func() {
 			false,
 			nil,
 			nil,
+			types.PlaceHolderACLTier,
 		)
 		acl2.UUID = "acl2-UUID"
 		initialDb := []libovsdbtest.TestData{acl1, acl2}
@@ -478,6 +482,7 @@ var _ = ginkgo.Describe("OVN Address Set Syncer", func() {
 			false,
 			map[string]string{egressFirewallACLExtIdKey: "egressfirewall1"},
 			nil,
+			types.PlaceHolderACLTier,
 		)
 		acl.UUID = "acl-UUID"
 		initialDb := []libovsdbtest.TestData{

--- a/go-controller/pkg/ovn/multicast_test.go
+++ b/go-controller/pkg/ovn/multicast_test.go
@@ -69,6 +69,7 @@ func getMulticastDefaultExpectedData(clusterPortGroup, clusterRtrPortGroup *nbdb
 		map[string]string{
 			"apply-after-lb": "true",
 		},
+		types.DefaultACLTier,
 	)
 	defaultDenyEgressACL.UUID = "defaultDenyEgressACL_UUID"
 
@@ -85,6 +86,7 @@ func getMulticastDefaultExpectedData(clusterPortGroup, clusterRtrPortGroup *nbdb
 		false,
 		aclIDs.GetExternalIDs(),
 		nil,
+		types.DefaultACLTier,
 	)
 	defaultDenyIngressACL.UUID = "defaultDenyIngressACL_UUID"
 	clusterPortGroup.ACLs = []string{defaultDenyEgressACL.UUID, defaultDenyIngressACL.UUID}
@@ -105,6 +107,7 @@ func getMulticastDefaultExpectedData(clusterPortGroup, clusterRtrPortGroup *nbdb
 		map[string]string{
 			"apply-after-lb": "true",
 		},
+		types.DefaultACLTier,
 	)
 	defaultAllowEgressACL.UUID = "defaultAllowEgressACL_UUID"
 
@@ -122,6 +125,7 @@ func getMulticastDefaultExpectedData(clusterPortGroup, clusterRtrPortGroup *nbdb
 		false,
 		aclIDs.GetExternalIDs(),
 		nil,
+		types.DefaultACLTier,
 	)
 	defaultAllowIngressACL.UUID = "defaultAllowIngressACL_UUID"
 	clusterRtrPortGroup.ACLs = []string{defaultAllowEgressACL.UUID, defaultAllowIngressACL.UUID}
@@ -209,6 +213,7 @@ func getMulticastPolicyExpectedData(ns string, ports []string) []libovsdb.TestDa
 		map[string]string{
 			"apply-after-lb": "true",
 		},
+		types.DefaultACLTier,
 	)
 	egressACL.UUID = ns + "mc-egress-UUID"
 
@@ -225,6 +230,7 @@ func getMulticastPolicyExpectedData(ns string, ports []string) []libovsdb.TestDa
 		false,
 		aclIDs.GetExternalIDs(),
 		nil,
+		types.DefaultACLTier,
 	)
 	ingressACL.UUID = ns + "mc-ingress-UUID"
 

--- a/go-controller/pkg/ovn/pod_selector_address_set_test.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set_test.go
@@ -3,6 +3,10 @@ package ovn
 import (
 	"context"
 	"fmt"
+	"net"
+	"runtime"
+	"time"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	"github.com/onsi/gomega"
@@ -12,9 +16,6 @@ import (
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	"net"
-	"runtime"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
@@ -319,6 +320,7 @@ var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
 			map[string]string{
 				"apply-after-lb": "true",
 			},
+			types.DefaultACLTier,
 		)
 		netpolACL.UUID = "netpolACL-UUID"
 		refPodSelIDs := getPodSelectorAddrSetDbIDs("pasName2", DefaultNetworkControllerName)
@@ -337,6 +339,7 @@ var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
 			map[string]string{
 				"apply-after-lb": "true",
 			},
+			types.DefaultACLTier,
 		)
 		podSelACL.UUID = "podSelACL-UUID"
 

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -108,6 +108,7 @@ func getDefaultDenyDataHelper(namespace string, policyTypeIngress, policyTypeEgr
 		map[string]string{
 			"apply-after-lb": "true",
 		},
+		types.DefaultACLTier,
 	)
 	egressDenyACL.UUID = aclIDs.String() + "-UUID"
 
@@ -125,6 +126,7 @@ func getDefaultDenyDataHelper(namespace string, policyTypeIngress, policyTypeEgr
 		map[string]string{
 			"apply-after-lb": "true",
 		},
+		types.DefaultACLTier,
 	)
 	egressAllowACL.UUID = aclIDs.String() + "-UUID"
 
@@ -141,6 +143,7 @@ func getDefaultDenyDataHelper(namespace string, policyTypeIngress, policyTypeEgr
 		shouldBeLogged,
 		aclIDs.GetExternalIDs(),
 		nil,
+		types.DefaultACLTier,
 	)
 	ingressDenyACL.UUID = aclIDs.String() + "-UUID"
 
@@ -156,6 +159,7 @@ func getDefaultDenyDataHelper(namespace string, policyTypeIngress, policyTypeEgr
 		false,
 		aclIDs.GetExternalIDs(),
 		nil,
+		types.DefaultACLTier,
 	)
 	ingressAllowACL.UUID = aclIDs.String() + "-UUID"
 
@@ -251,6 +255,7 @@ func getStaleDefaultACL(acls []*nbdb.ACL, namespace, policyName string) []*nbdb.
 		acl.Name = &staleName
 		acl.Options = nil
 		acl.Direction = nbdb.ACLDirectionToLport
+		acl.Tier = types.PlaceHolderACLTier
 	}
 	return acls
 }
@@ -335,6 +340,7 @@ func getGressACLs(gressIdx int, namespace, policyName string, peerNamespaces []s
 			shouldBeLogged,
 			dbIDs.GetExternalIDs(),
 			options,
+			types.DefaultACLTier,
 		)
 		acl.UUID = dbIDs.String() + "-UUID"
 		acls = append(acls, acl)
@@ -353,6 +359,7 @@ func getGressACLs(gressIdx int, namespace, policyName string, peerNamespaces []s
 			shouldBeLogged,
 			dbIDs.GetExternalIDs(),
 			options,
+			types.DefaultACLTier,
 		)
 		acl.UUID = dbIDs.String() + "-UUID"
 		acls = append(acls, acl)
@@ -370,6 +377,7 @@ func getGressACLs(gressIdx int, namespace, policyName string, peerNamespaces []s
 			shouldBeLogged,
 			dbIDs.GetExternalIDs(),
 			options,
+			types.DefaultACLTier,
 		)
 		acl.UUID = dbIDs.String() + "-UUID"
 		acls = append(acls, acl)
@@ -393,6 +401,7 @@ func getStalePolicyACL(acls []*nbdb.ACL, policyNamespace, policyName string) []*
 		acl.Direction = nbdb.ACLDirectionToLport
 		sev := nbdb.ACLSeverityInfo
 		acl.Severity = &sev
+		acl.Tier = types.PlaceHolderACLTier
 	}
 	return acls
 }
@@ -495,6 +504,7 @@ func getHairpinningACLsV4AndPortGroup() []libovsdbtest.TestData {
 		map[string]string{
 			"apply-after-lb": "true",
 		},
+		types.DefaultACLTier,
 	)
 	egressACL.UUID = "hairpinning-egress-UUID"
 	ingressIDs := fakeController.getNetpolDefaultACLDbIDs("Ingress")
@@ -509,6 +519,7 @@ func getHairpinningACLsV4AndPortGroup() []libovsdbtest.TestData {
 		false,
 		ingressIDs.GetExternalIDs(),
 		nil,
+		types.DefaultACLTier,
 	)
 	ingressACL.UUID = "hairpinning-ingress-UUID"
 	clusterPortGroup.ACLs = []string{egressACL.UUID, ingressACL.UUID}
@@ -2064,7 +2075,8 @@ func getAllowFromNodeExpectedACL(nodeName, mgmtIP string, logicalSwitch *nbdb.Lo
 		"",
 		false,
 		dbIDs.GetExternalIDs(),
-		nil)
+		nil,
+		types.DefaultACLTier)
 	nodeACL.UUID = dbIDs.String() + "-UUID"
 	if logicalSwitch != nil {
 		logicalSwitch.ACLs = []string{nodeACL.UUID}
@@ -2076,7 +2088,8 @@ func getAllowFromNodeStaleACL(nodeName, mgmtIP string, logicalSwitch *nbdb.Logic
 	acl := getAllowFromNodeExpectedACL(nodeName, mgmtIP, logicalSwitch, controllerName)
 	newName := ""
 	acl.Name = &newName
-
+	// re-setting the tier to 0 to test that the stale ACL gets updated to 2 eventually
+	acl.Tier = types.PlaceHolderACLTier
 	return acl
 }
 
@@ -2152,7 +2165,7 @@ var _ = ginkgo.Describe("OVN AllowFromNode ACL low-level operations", func() {
 			expectedData := []libovsdb.TestData{
 				logicalSwitch,
 				mgmtPort,
-				getAllowFromNodeExpectedACL(nodeName, mgmtIP, logicalSwitch, controllerName),
+				getAllowFromNodeExpectedACL(nodeName, mgmtIP, logicalSwitch, controllerName), // checks if tier get's updated from 0 to 2
 			}
 			gomega.Expect(nbClient).Should(libovsdb.HaveData(expectedData...))
 		})
@@ -2219,7 +2232,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Low-Level Operations", func() {
 		asMatch := asMatch(hashedASNames)
 		match := fmt.Sprintf("ip4.src == {%s} && outport == @%s", asMatch, pgName)
 		acl := libovsdbops.BuildACL(getACLName(aclIDs), nbdb.ACLDirectionToLport, types.DefaultAllowPriority, match,
-			nbdb.ACLActionAllowRelated, types.OvnACLLoggingMeter, aclLogging.Allow, true, aclIDs.GetExternalIDs(), nil)
+			nbdb.ACLActionAllowRelated, types.OvnACLLoggingMeter, aclLogging.Allow, true, aclIDs.GetExternalIDs(), nil,
+			types.DefaultACLTier)
 		return acl
 	}
 

--- a/go-controller/pkg/sbdb/mirror.go
+++ b/go-controller/pkg/sbdb/mirror.go
@@ -15,8 +15,10 @@ type (
 var (
 	MirrorFilterFromLport MirrorFilter = "from-lport"
 	MirrorFilterToLport   MirrorFilter = "to-lport"
+	MirrorFilterBoth      MirrorFilter = "both"
 	MirrorTypeGre         MirrorType   = "gre"
 	MirrorTypeErspan      MirrorType   = "erspan"
+	MirrorTypeLocal       MirrorType   = "local"
 )
 
 // Mirror defines an object in Mirror table

--- a/go-controller/pkg/sbdb/model.go
+++ b/go-controller/pkg/sbdb/model.go
@@ -52,7 +52,7 @@ func FullDatabaseModel() (model.ClientDBModel, error) {
 
 var schema = `{
   "name": "OVN_Southbound",
-  "version": "20.27.0",
+  "version": "20.27.2",
   "tables": {
     "Address_Set": {
       "columns": {
@@ -1202,7 +1202,8 @@ var schema = `{
                 "set",
                 [
                   "from-lport",
-                  "to-lport"
+                  "to-lport",
+                  "both"
                 ]
               ]
             }
@@ -1225,7 +1226,8 @@ var schema = `{
                 "set",
                 [
                   "gre",
-                  "erspan"
+                  "erspan",
+                  "local"
                 ]
               ]
             }

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -70,6 +70,14 @@ const (
 	// Default deny acl rule priority
 	DefaultDenyPriority = 1000
 
+	// ACL Tiers
+	// Tier 0 is currently un-used and is a placeholder tier for future use cases (can be renamed when we have a use for it).
+	// NOTE: When we upgrade from an OVN version without tiers to the new version with
+	// tiers, all values in the new ACL.Tier column will be set to 0 a.k.a placeholder tier
+	PlaceHolderACLTier = 0
+	// Default Tier for all ACLs
+	DefaultACLTier = 2
+
 	// priority of logical router policies on the OVNClusterRouter
 	EgressFirewallStartPriority           = 10000
 	MinimumReservedEgressFirewallPriority = 2000


### PR DESCRIPTION
**- What this PR does and why is it needed**
    Change all existing ACLs to tier2
    
    We have a new feature called Hierarchical
    ACLs that is introduced in OVN to enable
    support for tiered ACLs. This commit
    ensures all existing ACLs for all features
    are migrated towards tier2. By default all
    new ACLs must be added to tier2.
    
    Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

**- Special notes for reviewers**
Tiered ACLs will be used for ANP & BANP in https://github.com/ovn-org/ovn-kubernetes/pull/3659. This PR splits the initial framework addition so that its easier to review this.

- [x] Upgrades should be automatically handled, ensure the new ACLs are created with the tier field set to 2 as clusters upgrade. Added unit tests to verify this.
- [x] EDIT: Even if ACLs will be automatically updated during upgrades, we went with the option of controlled update of ACLs sorted by their priority (lowest first) to avoid network disruption. Credit to @jcaamano!

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
`Move all existing ACLs to tier2 which will be the default`