### PR TITLE
Fixes invalid error while getting router NATs

### DIFF
--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -997,16 +997,16 @@ func FindNATsWithPredicate(nbClient libovsdbclient.Client, predicate natPredicat
 // GetRouterNATs looks up NATs associated to the provided logical router from
 // the cache
 func GetRouterNATs(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) ([]*nbdb.NAT, error) {
-	router, err := GetLogicalRouter(nbClient, router)
+	r, err := GetLogicalRouter(nbClient, router)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get router: %s, error: %w", router.Name, err)
 	}
 
 	nats := []*nbdb.NAT{}
-	for _, uuid := range router.Nat {
+	for _, uuid := range r.Nat {
 		nat, err := GetNAT(nbClient, &nbdb.NAT{UUID: uuid})
-		if err != nil {
-			return nil, err
+		if err != nil && err != libovsdbclient.ErrNotFound {
+			return nil, fmt.Errorf("failed to lookup NAT entry with uuid: %s, error: %w", uuid, err)
 		}
 		nats = append(nats, nat)
 	}


### PR DESCRIPTION
We list all of the NATs on a router via libovsdb, then we iterate through each NAT uuid and try to fetch it via libovsdb. During the gap in time where the NATs are listed on a router, and when they are individually fetched, the NAT may have already been deleted. In this case we were breaking the loop and returning an error.

There is no guarantee that the NATs we initially fetch are the ones currently on the router. As such we should not consider this an error. Instead we should just return the NATs that still exist.

Also, make the error messages more clear so that if a generic libovsdb error is propagated we know if it was from the get router or the get NAT operations.

