### PR TITLE
Improve syncNodes to remove stale data

### DIFF
--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -354,7 +354,7 @@ func DeleteLogicalRouterPolicyWithPredicateOps(nbClient libovsdbclient.Client, o
 		{
 			Model:            router,
 			OnModelMutations: []interface{}{&router.Policies},
-			ErrNotFound:      true,
+			ErrNotFound:      false,
 			BulkOp:           false,
 		},
 	}
@@ -1102,7 +1102,7 @@ func DeleteNATsOps(nbClient libovsdbclient.Client, ops []libovsdb.Operation, rou
 	opModel := operationModel{
 		Model:            router,
 		OnModelMutations: []interface{}{&router.Nat},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 	opModels = append(opModels, opModel)
@@ -1140,7 +1140,8 @@ func DeleteNATsWithPredicateOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 				router.Nat = extractUUIDsFromModels(&deleted)
 				natUUIDs.Insert(router.Nat...)
 			},
-			BulkOp: true,
+			BulkOp:      true,
+			ErrNotFound: false,
 		},
 		{
 			Model:            router,

--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -218,7 +218,7 @@ func DeleteLogicalRouterPorts(nbClient libovsdbclient.Client, router *nbdb.Logic
 	opModel := operationModel{
 		Model:            router,
 		OnModelMutations: []interface{}{&router.Ports},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 	opModels = append(opModels, opModel)
@@ -708,7 +708,7 @@ func DeleteLogicalRouterStaticRoutesWithPredicateOps(nbClient libovsdbclient.Cli
 		{
 			Model:            router,
 			OnModelMutations: []interface{}{&router.StaticRoutes},
-			ErrNotFound:      true,
+			ErrNotFound:      false,
 			BulkOp:           false,
 		},
 	}

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -379,7 +379,7 @@ func DeleteLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.
 	return ops, err
 }
 
-// DeleteLogicalSwitchPortsOps deletes the provided logical switch ports and
+// DeleteLogicalSwitchPorts deletes the provided logical switch ports and
 // removes them from the provided logical switch
 func DeleteLogicalSwitchPorts(nbClient libovsdbclient.Client, sw *nbdb.LogicalSwitch, lsps ...*nbdb.LogicalSwitchPort) error {
 	ops, err := DeleteLogicalSwitchPortsOps(nbClient, nil, sw, lsps...)

--- a/go-controller/pkg/libovsdbops/switch.go
+++ b/go-controller/pkg/libovsdbops/switch.go
@@ -368,7 +368,7 @@ func DeleteLogicalSwitchPortsOps(nbClient libovsdbclient.Client, ops []libovsdb.
 	opModel := operationModel{
 		Model:            sw,
 		OnModelMutations: []interface{}{&sw.Ports},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 	opModels = append(opModels, opModel)
@@ -436,7 +436,7 @@ func DeleteLogicalSwitchPortsWithPredicateOps(nbClient libovsdbclient.Client, op
 	opModel := operationModel{
 		Model:            sw,
 		OnModelMutations: []interface{}{&sw.Ports},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 	opModels = append(opModels, opModel)

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -432,7 +432,7 @@ func (bnc *BaseNetworkController) deleteNodeLogicalNetwork(nodeName string) erro
 	}
 	err = libovsdbops.DeleteLogicalRouterPorts(bnc.nbClient, &logicalRouter, &logicalRouterPort)
 	if err != nil {
-		return fmt.Errorf("failed to delete router port %s: %v", logicalRouterPort.Name, err)
+		return fmt.Errorf("failed to delete router port %s: %w", logicalRouterPort.Name, err)
 	}
 
 	return nil

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -63,7 +63,7 @@ func initController(k8sObjects, routePolicyObjects []runtime.Object) {
 		iFactory.NamespaceInformer(),
 		iFactory.NodeCoreInformer().Lister(),
 		nbClient,
-		addressset.NewFakeAddressSetFactory(controllerName))
+		addressset.NewFakeAddressSetFactory(apbControllerName))
 	Expect(err).NotTo(HaveOccurred())
 	mgr = externalController.mgr
 	go func() {

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -56,7 +56,7 @@ func initController(k8sObjects, routePolicyObjects []runtime.Object) {
 	iFactory, err = factory.NewMasterWatchFactory(&util.OVNMasterClientset{KubeClient: fakeClient})
 	Expect(err).NotTo(HaveOccurred())
 	iFactory.Start()
-	externalController, err = NewExternalMasterController(controllerName, fakeClient,
+	externalController, err = NewExternalMasterController(fakeClient,
 		fakeRouteClient,
 		stopChan,
 		iFactory.PodCoreInformer(),

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -38,10 +38,6 @@ const (
 	maxRetries     = 15
 )
 
-var (
-	controllerName string
-)
-
 // Admin Policy Based Route services
 
 type ExternalGatewayMasterController struct {
@@ -78,7 +74,6 @@ type ExternalGatewayMasterController struct {
 }
 
 func NewExternalMasterController(
-	parentControllerName string,
 	client kubernetes.Interface,
 	apbRoutePolicyClient adminpolicybasedrouteclient.Interface,
 	stopCh <-chan struct{},
@@ -89,7 +84,6 @@ func NewExternalMasterController(
 	addressSetFactory addressset.AddressSetFactory,
 ) (*ExternalGatewayMasterController, error) {
 
-	controllerName = parentControllerName
 	routePolicyInformer := adminpolicybasedrouteinformer.NewSharedInformerFactory(apbRoutePolicyClient, resyncInterval)
 	externalRouteInformer := routePolicyInformer.K8s().V1().AdminPolicyBasedExternalRoutes()
 	externalGWCache := make(map[ktypes.NamespacedName]*ExternalRouteInfo)

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -34,8 +34,9 @@ import (
 )
 
 const (
-	resyncInterval = 0
-	maxRetries     = 15
+	resyncInterval    = 0
+	maxRetries        = 15
+	apbControllerName = "apb-external-route-controller"
 )
 
 // Admin Policy Based Route services
@@ -95,6 +96,7 @@ func NewExternalMasterController(
 		addressSetFactory: addressSetFactory,
 		externalGWCache:   externalGWCache,
 		exGWCacheMutex:    exGWCacheMutex,
+		controllerName:    apbControllerName,
 	}
 
 	c := &ExternalGatewayMasterController{

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -29,6 +29,10 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
+const (
+	controllerName = "apb-external-route-controller"
+)
+
 type networkClient interface {
 	deleteGatewayIPs(namespaceName string, toBeDeletedGWIPs, toBeKept sets.Set[string]) error
 	addGatewayIPs(pod *v1.Pod, egress gatewayInfoList) error

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -29,10 +29,6 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
-const (
-	controllerName = "apb-external-route-controller"
-)
-
 type networkClient interface {
 	deleteGatewayIPs(namespaceName string, toBeDeletedGWIPs, toBeKept sets.Set[string]) error
 	addGatewayIPs(pod *v1.Pod, egress gatewayInfoList) error
@@ -48,6 +44,7 @@ type northBoundClient struct {
 	addressSetFactory addressset.AddressSetFactory
 	externalGWCache   map[ktypes.NamespacedName]*ExternalRouteInfo
 	exGWCacheMutex    *sync.RWMutex
+	controllerName    string
 }
 
 type conntrackClient struct {
@@ -80,7 +77,7 @@ func (nb *northBoundClient) delAllHybridRoutePolicies() error {
 
 	// nuke all the address-sets.
 	// if we fail to remove LRP's above, we don't attempt to remove ASes due to dependency constraints.
-	predicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetHybridNodeRoute, controllerName, nil)
+	predicateIDs := libovsdbops.NewDbObjectIDs(libovsdbops.AddressSetHybridNodeRoute, nb.controllerName, nil)
 	asPred := libovsdbops.GetPredicate[*nbdb.AddressSet](predicateIDs, nil)
 	err = libovsdbops.DeleteAddressSetsWithPredicate(nb.nbClient, asPred)
 	if err != nil {
@@ -265,7 +262,7 @@ func (nb *northBoundClient) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddr
 func (nb *northBoundClient) addHybridRoutePolicyForPod(podIP net.IP, node string) error {
 	if config.Gateway.Mode == config.GatewayModeLocal {
 		// Add podIP to the node's address_set.
-		asIndex := getHybridRouteAddrSetDbIDs(node, controllerName)
+		asIndex := getHybridRouteAddrSetDbIDs(node, nb.controllerName)
 		as, err := nb.addressSetFactory.EnsureAddressSet(asIndex)
 		if err != nil {
 			return fmt.Errorf("cannot ensure that addressSet for node %s exists %v", node, err)
@@ -538,7 +535,7 @@ func (nb *northBoundClient) deleteLogicalRouterStaticRoute(podIP, mask, gw, gr s
 func (nb *northBoundClient) delHybridRoutePolicyForPod(podIP net.IP, node string) error {
 	if config.Gateway.Mode == config.GatewayModeLocal {
 		// Delete podIP from the node's address_set.
-		asIndex := getHybridRouteAddrSetDbIDs(node, controllerName)
+		asIndex := getHybridRouteAddrSetDbIDs(node, nb.controllerName)
 		as, err := nb.addressSetFactory.EnsureAddressSet(asIndex)
 		if err != nil {
 			return fmt.Errorf("cannot Ensure that addressSet for node %s exists %v", node, err)

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -168,7 +168,6 @@ func newDefaultNetworkControllerCommon(cnci *CommonNetworkControllerInfo,
 		zoneChassisHandler = zoneic.NewZoneChassisHandler(cnci.sbClient)
 	}
 	apbExternalRouteController, err := apbroutecontroller.NewExternalMasterController(
-		DefaultNetworkControllerName,
 		cnci.client,
 		cnci.kube.APBRouteClient,
 		defaultStopChan,

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -6,8 +6,10 @@ import (
 	"strconv"
 	"strings"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/pkg/errors"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
@@ -26,7 +28,7 @@ func (oc *DefaultNetworkController) gatewayCleanup(nodeName string) error {
 	var nextHops []net.IP
 
 	gwIPAddrs, err := util.GetLRPAddrs(oc.nbClient, types.GWRouterToJoinSwitchPrefix+gatewayRouter)
-	if err != nil {
+	if err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
 		return err
 	}
 

--- a/go-controller/pkg/ovn/gateway_cleanup.go
+++ b/go-controller/pkg/ovn/gateway_cleanup.go
@@ -1,6 +1,7 @@
 package ovn
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -9,7 +10,6 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
-	"github.com/pkg/errors"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -904,12 +904,13 @@ func (oc *DefaultNetworkController) addUpdateRemoteNodeEvent(node *kapi.Node, sy
 		if err := oc.cleanupNodeResources(node.Name); err != nil {
 			return fmt.Errorf("error cleaning up the local resources for the remote node %s, err : %w", node.Name, err)
 		}
+		oc.localZoneNodes.Delete(node.Name)
 	}
 
 	var err error
 	if syncZoneIC && config.OVNKubernetesFeature.EnableInterconnect {
 		// Call zone chassis handler's AddRemoteZoneNode function to creates
-		// the remote chassis for the remote zone node node in the SB DB or mark
+		// the remote chassis for the remote zone node in the SB DB or mark
 		// the entry as remote if it was local chassis earlier
 		if err = oc.zoneChassisHandler.AddRemoteZoneNode(node); err != nil {
 			err = fmt.Errorf("adding or updating remote node %s failed, err - %w", node.Name, err)
@@ -925,6 +926,7 @@ func (oc *DefaultNetworkController) addUpdateRemoteNodeEvent(node *kapi.Node, sy
 			}
 		}
 	}
+
 	return err
 }
 

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -28,6 +29,7 @@ import (
 	libovsdbtest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing/libovsdb"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -1383,20 +1385,18 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			err = oc.syncGatewayLogicalNetwork(&testNode, l3GatewayConfig, []*net.IPNet{subnet}, nodeHostAddrs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// Delete the node's gateway Logical Router Port to force an error. But save
-			// it first so we can add it back to let the delete proceed after we know the
-			// retry was successful
-			gatewayRouter := types.GWRouterPrefix + node1.Name
-			lr := &nbdb.LogicalRouter{Name: gatewayRouter}
-			lrp := &nbdb.LogicalRouterPort{Name: types.GWRouterToJoinSwitchPrefix + gatewayRouter}
-			lrp, err = libovsdbops.GetLogicalRouterPort(nbClient, lrp)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = libovsdbops.DeleteLogicalRouterPorts(nbClient, lr, lrp)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// inject transient problem, nbdb is down
+			oc.nbClient.Close()
+			gomega.Eventually(func() bool {
+				return oc.nbClient.Connected()
+			}).Should(gomega.BeFalse())
 
 			// Node delete will fail with Failed to delete node node1,
 			err = fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// sleep long enough for TransactWithRetry to fail, causing LS (and other rows related to node) delete to fail
+			time.Sleep(types.OVSDBTimeout + time.Second)
 
 			// check the retry entry for this node
 			ginkgo.By("retry entry: old obj should not be nil, new obj should be nil")
@@ -1407,13 +1407,74 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 				gomega.BeNil(),             // newObj should be nil
 			)
 
-			// Add the LRP back to allow the delete the continue
-			err = libovsdbops.CreateOrUpdateLogicalRouterPort(nbClient,
-				lr, lrp, nil, &lrp.MAC, &lrp.Networks, &lrp.ExternalIDs)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// reconnect nbdb
+			connCtx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+			defer cancel()
+			resetNBClient(connCtx, oc.nbClient)
+
+			// reset backoff for immediate retry
 			retry.SetRetryObjWithNoBackoff(node1.Name, oc.retryNodes)
 			oc.retryNodes.RequestRetryObjs() // retry the failed entry
 
+			retry.CheckRetryObjectEventually(testNode.Name, false, oc.retryNodes)
+			return nil
+		}
+
+		err := app.Run([]string{
+			app.Name,
+			"-cluster-subnets=" + clusterCIDR,
+			"--init-gateways",
+			"--nodeport",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("delete a partially constructed node", func() {
+		app.Action = func(ctx *cli.Context) error {
+			_, err := config.InitConfig(ctx, nil, nil)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			startFakeController(oc, wg)
+
+			subnet := ovntest.MustParseIPNet(node1.NodeSubnet)
+			err = oc.syncGatewayLogicalNetwork(&testNode, l3GatewayConfig, []*net.IPNet{subnet}, nodeHostAddrs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Delete the node's gateway Logical Router Port to force node delete to handle a
+			// partially removed OVN DB
+			gatewayRouter := types.GWRouterPrefix + node1.Name
+			lr := &nbdb.LogicalRouter{Name: gatewayRouter}
+			lrp := &nbdb.LogicalRouterPort{Name: types.GWRouterToJoinSwitchPrefix + gatewayRouter}
+			lrp, err = libovsdbops.GetLogicalRouterPort(nbClient, lrp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = libovsdbops.DeleteLogicalRouterPorts(nbClient, lr, lrp)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			_, err = libovsdbops.GetLogicalSwitch(nbClient, &nbdb.LogicalSwitch{Name: node1.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			externalSwitch := types.ExternalSwitchPrefix + node1.Name
+			_, err = libovsdbops.GetLogicalSwitch(nbClient, &nbdb.LogicalSwitch{Name: externalSwitch})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Node delete should not fail
+			err = fakeClient.KubeClient.CoreV1().Nodes().Delete(context.TODO(), testNode.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			gomega.Eventually(func() bool {
+				_, err := libovsdbops.GetLogicalSwitch(nbClient, &nbdb.LogicalSwitch{Name: node1.Name})
+				return errors.Is(err, libovsdbclient.ErrNotFound)
+			}, 10).Should(gomega.BeTrue())
+
+			gomega.Eventually(func() bool {
+				_, err := libovsdbops.GetLogicalSwitch(nbClient, &nbdb.LogicalSwitch{Name: externalSwitch})
+				return errors.Is(err, libovsdbclient.ErrNotFound)
+			}, 10).Should(gomega.BeTrue())
+
+			gomega.Eventually(func() bool {
+				_, err = libovsdbops.GetLogicalRouter(nbClient, &nbdb.LogicalRouter{Name: gatewayRouter})
+				return errors.Is(err, libovsdbclient.ErrNotFound)
+			}, 10).Should(gomega.BeTrue())
+
+			// check the retry entry for this node
 			retry.CheckRetryObjectEventually(testNode.Name, false, oc.retryNodes)
 			return nil
 		}
@@ -1587,22 +1648,109 @@ func newNodeSNAT(uuid, logicalIP, externalIP string) *nbdb.NAT {
 
 func TestController_syncNodes(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	node1Name := "node1"
+	nodeRmName := "deleteMeNode"
+
 	tests := []struct {
 		name         string
+		initialNBDB  []libovsdbtest.TestData
+		expectedNBDB []libovsdbtest.TestData
 		initialSBDB  []libovsdbtest.TestData
 		expectedSBDB []libovsdbtest.TestData
 	}{
 		{
+			name: "removes node 2, leaves node 1 alone",
+			initialNBDB: []libovsdbtest.TestData{
+				&nbdb.LogicalSwitch{
+					Name:        node1Name,
+					UUID:        node1Name + "-UUID",
+					OtherConfig: map[string]string{"subnet": "1.2.3.4/24"},
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.ExternalSwitchPrefix + node1Name,
+					UUID: types.ExternalSwitchPrefix + node1Name + "-UUID",
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + node1Name,
+					UUID: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + node1Name + "-UUID",
+				},
+				&nbdb.LogicalRouter{
+					Name: types.GWRouterPrefix + node1Name,
+					UUID: types.GWRouterPrefix + node1Name + "-UUID",
+				},
+				// these should be deleted
+				&nbdb.LogicalSwitch{
+					Name:        nodeRmName,
+					UUID:        nodeRmName + "-UUID",
+					OtherConfig: map[string]string{"subnet": "1.2.3.5/24"},
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.ExternalSwitchPrefix + nodeRmName,
+					UUID: types.ExternalSwitchPrefix + nodeRmName + "-UUID",
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeRmName,
+					UUID: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + nodeRmName + "-UUID",
+				},
+				&nbdb.LogicalRouter{
+					Name: types.GWRouterPrefix + nodeRmName,
+					UUID: types.GWRouterPrefix + nodeRmName + "-UUID",
+				},
+			},
+			expectedNBDB: []libovsdbtest.TestData{
+				&nbdb.LogicalSwitch{
+					Name:        node1Name,
+					UUID:        node1Name + "-UUID",
+					OtherConfig: map[string]string{"subnet": "1.2.3.4/24"},
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.ExternalSwitchPrefix + node1Name,
+					UUID: types.ExternalSwitchPrefix + node1Name + "-UUID",
+				},
+				&nbdb.LogicalSwitch{
+					Name: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + node1Name,
+					UUID: types.EgressGWSwitchPrefix + types.ExternalSwitchPrefix + node1Name + "-UUID",
+				},
+				&nbdb.LogicalRouter{
+					Name: types.GWRouterPrefix + node1Name,
+					UUID: types.GWRouterPrefix + node1Name + "-UUID",
+				},
+			},
+		},
+		{
+			name: "removes node that only had external logical switch left behind",
+			initialNBDB: []libovsdbtest.TestData{
+				// left-over external logical switch
+				&nbdb.LogicalSwitch{
+					Name: types.ExternalSwitchPrefix + nodeRmName,
+					UUID: types.ExternalSwitchPrefix + nodeRmName + "-UUID",
+				},
+			},
+			expectedNBDB: []libovsdbtest.TestData{},
+		},
+		{
+			name: "removes node that only had external gw logical router left behind",
+			initialNBDB: []libovsdbtest.TestData{
+				// left-over gateway router
+				&nbdb.LogicalRouter{
+					Name: types.GWRouterPrefix + nodeRmName,
+					UUID: types.GWRouterPrefix + nodeRmName + "-UUID",
+				},
+			},
+			expectedNBDB: []libovsdbtest.TestData{},
+		},
+		{
 			name: "removes stale chassis and chassis private",
 			initialSBDB: []libovsdbtest.TestData{
-				&sbdb.Chassis{Name: "chassis-node1", Hostname: "node1"},
+				&sbdb.Chassis{Name: "chassis-node1", Hostname: node1Name},
 				&sbdb.ChassisPrivate{Name: "chassis-node1"},
-				&sbdb.Chassis{Name: "chassis-node2", Hostname: "node2"},
+				&sbdb.Chassis{Name: "chassis-node2", Hostname: nodeRmName},
 				&sbdb.ChassisPrivate{Name: "chassis-node2"},
 				&sbdb.ChassisPrivate{Name: "chassis-node3"},
 			},
 			expectedSBDB: []libovsdbtest.TestData{
-				&sbdb.Chassis{Name: "chassis-node1", Hostname: "node1"},
+				&sbdb.Chassis{Name: "chassis-node1", Hostname: node1Name},
 				&sbdb.ChassisPrivate{Name: "chassis-node1"},
 			},
 		},
@@ -1637,6 +1785,7 @@ func TestController_syncNodes(t *testing.T) {
 			defer f.Shutdown()
 
 			dbSetup := libovsdbtest.TestSetup{
+				NBData: tt.initialNBDB,
 				SBData: tt.initialSBDB,
 			}
 			nbClient, sbClient, libovsdbCleanup, err := libovsdbtest.NewNBSBTestHarness(dbSetup)
@@ -1660,13 +1809,26 @@ func TestController_syncNodes(t *testing.T) {
 				t.Fatalf("%s: Error on syncNodes: %v", tt.name, err)
 			}
 
-			matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedSBDB)
-			match, err := matcher.Match(sbClient)
-			if err != nil {
-				t.Fatalf("%s: matcher error: %v", tt.name, err)
+			if tt.expectedNBDB != nil {
+				matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedNBDB)
+				match, err := matcher.Match(nbClient)
+				if err != nil {
+					t.Fatalf("%s: NB matcher error: %v", tt.name, err)
+				}
+				if !match {
+					t.Fatalf("%s: NB DB state did not match: %s", tt.name, matcher.FailureMessage(sbClient))
+				}
 			}
-			if !match {
-				t.Fatalf("%s: DB state did not match: %s", tt.name, matcher.FailureMessage(sbClient))
+
+			if tt.expectedSBDB != nil {
+				matcher := libovsdbtest.HaveDataIgnoringUUIDs(tt.expectedSBDB)
+				match, err := matcher.Match(sbClient)
+				if err != nil {
+					t.Fatalf("%s: SB matcher error: %v", tt.name, err)
+				}
+				if !match {
+					t.Fatalf("%s: SB DB state did not match: %s", tt.name, matcher.FailureMessage(sbClient))
+				}
 			}
 		})
 	}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -135,9 +135,11 @@ func (oc *DefaultNetworkController) ensurePod(oldPod, pod *kapi.Pod, addPort boo
 	}
 
 	if oc.isPodScheduledinLocalZone(pod) {
+		klog.V(5).Infof("Ensuring zone local for Pod %s/%s in node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
 		return oc.ensureLocalZonePod(oldPod, pod, addPort)
 	}
 
+	klog.V(5).Infof("Ensuring zone remote for Pod %s/%s in node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
 	return oc.ensureRemoteZonePod(oldPod, pod, addPort)
 }
 

--- a/go-controller/pkg/util/net.go
+++ b/go-controller/pkg/util/net.go
@@ -56,7 +56,7 @@ func GetLRPAddrs(nbClient client.Client, portName string) ([]*net.IPNet, error) 
 	lrp := &nbdb.LogicalRouterPort{Name: portName}
 	lrp, err := libovsdbops.GetLogicalRouterPort(nbClient, lrp)
 	if err != nil {
-		return nil, fmt.Errorf("unable to find router port %s: %w", portName, err)
+		return nil, fmt.Errorf("failed to get router port %s: %w", portName, err)
 	}
 	gwLRPIPs := []*net.IPNet{}
 	for _, network := range lrp.Networks {


### PR DESCRIPTION
Partial removal of nodes can leave OVN database with the gateway logical router and external logical switch of the removed node. This commit improves syncNode functionality, so these cases are taken into consideration.

When deleting a port from a logical switch or router, it is possible that the logical switch or router themselves have been deleted. This commit changes the behavior of delete so it is not an error when if that happens.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-13744
