### PR TITLE
fix hybrid overlay test flakes by removing periodic syncflows from

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux_test.go
@@ -409,6 +409,10 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			linuxNode, okay := n.controller.(*NodeController)
+			Expect(okay).To(BeTrue())
+			// setting the flowCacheSyncPeriod to 1 hour effectively disabling for testing
+			linuxNode.flowCacheSyncPeriod = 1 * time.Hour
 
 			addEnsureHybridOverlayBridgeMocks(nlMock, thisNodeDRIP, "")
 
@@ -424,8 +428,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				n.Run(stopChan)
 			}()
 
-			linuxNode, okay := n.controller.(*NodeController)
-			Expect(okay).To(BeTrue())
 			Eventually(func() bool {
 				return atomic.LoadUint32(linuxNode.initState) == hotypes.PodsInitialized
 			}, 2).Should(BeTrue())
@@ -468,6 +470,10 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			linuxNode, okay := n.controller.(*NodeController)
+			Expect(okay).To(BeTrue())
+			// setting the flowCacheSyncPeriod to 1 hour effectively disabling for testing
+			linuxNode.flowCacheSyncPeriod = 1 * time.Hour
 
 			addEnsureHybridOverlayBridgeMocks(nlMock, thisNodeDRIP, "")
 			// initial flowSync
@@ -482,8 +488,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				n.Run(stopChan)
 			}()
 
-			linuxNode, okay := n.controller.(*NodeController)
-			Expect(okay).To(BeTrue())
 			Eventually(func() bool {
 				return atomic.LoadUint32(linuxNode.initState) == hotypes.PodsInitialized
 			}, 2).Should(BeTrue())
@@ -635,6 +639,10 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			linuxNode, okay := n.controller.(*NodeController)
+			Expect(okay).To(BeTrue())
+			// setting the flowCacheSyncPeriod to 1 hour effectively disabling for testing
+			linuxNode.flowCacheSyncPeriod = 1 * time.Hour
 
 			addEnsureHybridOverlayBridgeMocks(nlMock, thisNodeDRIP, "")
 			// initial flowSync
@@ -649,8 +657,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				n.Run(stopChan)
 			}()
 
-			linuxNode, okay := n.controller.(*NodeController)
-			Expect(okay).To(BeTrue())
 			Eventually(func() bool {
 				return atomic.LoadUint32(linuxNode.initState) == hotypes.PodsInitialized
 			}, 2).Should(BeTrue())
@@ -732,6 +738,10 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			linuxNode, okay := n.controller.(*NodeController)
+			Expect(okay).To(BeTrue())
+			// setting the flowCacheSyncPeriod to 1 hour effectively disabling for testing
+			linuxNode.flowCacheSyncPeriod = 1 * time.Hour
 
 			addEnsureHybridOverlayBridgeMocks(nlMock, thisNodeDRIP, "")
 			// add the mock commands for the update
@@ -748,8 +758,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				n.Run(stopChan)
 			}()
 
-			linuxNode, okay := n.controller.(*NodeController)
-			Expect(okay).To(BeTrue())
 			Eventually(func() bool {
 				return atomic.LoadUint32(linuxNode.initState) == hotypes.PodsInitialized
 			}, 2).Should(BeTrue())
@@ -869,6 +877,10 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				informer.NewTestEventHandler,
 			)
 			Expect(err).NotTo(HaveOccurred())
+			linuxNode, okay := n.controller.(*NodeController)
+			Expect(okay).To(BeTrue())
+			// setting the flowCacheSyncPeriod to 1 hour effectively disabling for testing
+			linuxNode.flowCacheSyncPeriod = 1 * time.Hour
 
 			addEnsureHybridOverlayBridgeMocks(nlMock, thisNodeDRIP, "")
 			// initial flowSync
@@ -883,8 +895,6 @@ var _ = Describe("Hybrid Overlay Node Linux Operations", func() {
 				n.Run(stopChan)
 			}()
 
-			linuxNode, okay := n.controller.(*NodeController)
-			Expect(okay).To(BeTrue())
 			Eventually(func() bool {
 				return atomic.LoadUint32(linuxNode.initState) == hotypes.PodsInitialized
 			}, 2).Should(BeTrue())


### PR DESCRIPTION
testing

make the timeout for the periodic syncing of the ovs flows so high during testing that there will be no impact and this should eliminate testing flakes

Reported as: https://issues.redhat.com/browse/OCPBUGS-13979
Fixes: https://github.com/ovn-org/ovn-kubernetes/issues/3506

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->