### PR TITLE
Fixes usages of get pod IPs

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -709,22 +709,8 @@ func (bnc *BaseNetworkController) getPodNADNames(pod *kapi.Pod) []string {
 	if !bnc.IsSecondary() {
 		return []string{types.DefaultNetworkName}
 	}
-	on, networkMap, err := util.GetPodNADToNetworkMapping(pod, bnc.NetInfo)
-	// skip pods that are not on this network
-	if err != nil || !on {
-		if err != nil {
-			// if we are not able to determine if this pod is on this network continue processing the
-			// remaining pods anyway, hopefully the pod will be handled in a future pod update event.
-			klog.Warningf("Failed to determine if pod %s/%s is on network %s: %v",
-				pod.Namespace, pod.Name, bnc.GetNetworkName(), err)
-		}
-		return []string{}
-	}
-	nadNames := make([]string, 0, len(networkMap))
-	for nadName := range networkMap {
-		nadNames = append(nadNames, nadName)
-	}
-	return nadNames
+	podNadNames, _ := util.PodNadNames(pod, bnc.NetInfo)
+	return podNadNames
 }
 
 // getClusterPortGroupName gets network scoped port group hash name; base is either

--- a/go-controller/pkg/ovn/base_network_controller_namespace.go
+++ b/go-controller/pkg/ovn/base_network_controller_namespace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	"github.com/pkg/errors"
 
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -386,6 +387,14 @@ func (bsnc *BaseNetworkController) removeRemoteZonePodFromNamespaceAddressSet(po
 	podDesc := fmt.Sprintf("pod %s/%s/%s", bsnc.GetNetworkName(), pod.Namespace, pod.Name)
 	podIfAddrs, err := util.GetPodCIDRsWithFullMask(pod, bsnc.NetInfo)
 	if err != nil {
+		// maybe the pod is not scheduled yet or addLSP has not happened yet, so it doesn't have IPs.
+		// let us ignore deletion failures for podIPs not found because
+		// there is nothing more we can do here.
+		if errors.Is(err, util.ErrNoPodIPFound) {
+			klog.Warningf("Unable to remove remote zone pod's %s/%s IP address from the "+
+				"namespace address-set, err: %v", pod.Namespace, pod.Name, err)
+			return nil
+		}
 		return fmt.Errorf("failed to get pod ips for the pod  %s/%s : %w", pod.Namespace, pod.Name, err)
 	}
 

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -718,24 +718,24 @@ func (c *conntrackClient) deleteGatewayIPs(namespaceName string, _, toBeKept set
 		return fmt.Errorf("unable to get pods from informer: %v", err)
 	}
 
-	var errors []error
+	var errs []error
 	for _, pod := range pods {
 		pod := pod
 		podIPs, err := util.GetPodIPsOfNetwork(pod, &util.DefaultNetInfo{})
-		if err != nil {
-			errors = append(errors, fmt.Errorf("unable to fetch IP for pod %s/%s: %v", pod.Namespace, pod.Name, err))
+		if err != nil && !errors.Is(err, util.ErrNoPodIPFound) {
+			errs = append(errs, fmt.Errorf("unable to fetch IP for pod %s/%s: %v", pod.Namespace, pod.Name, err))
 		}
 		for _, podIP := range podIPs { // flush conntrack only for UDP
 			// for this pod, we check if the conntrack entry has a label that is not in the provided allowlist of MACs
 			// only caveat here is we assume egressGW served pods shouldn't have conntrack entries with other labels set
 			err := util.DeleteConntrack(podIP.String(), 0, v1.ProtocolUDP, netlink.ConntrackOrigDstIP, validNextHopMACs)
 			if err != nil {
-				errors = append(errors, fmt.Errorf("failed to delete conntrack entry for pod with IP %s: %v", podIP.String(), err))
+				errs = append(errs, fmt.Errorf("failed to delete conntrack entry for pod with IP %s: %v", podIP.String(), err))
 				continue
 			}
 		}
 	}
-	return kerrors.NewAggregate(errors)
+	return kerrors.NewAggregate(errs)
 }
 
 // addGatewayIPs is a NOP (no operation) in the conntrack client as it does not add any entry to the conntrack table.

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -713,6 +713,9 @@ func (oc *DefaultNetworkController) deletePodEgressIPAssignments(name string, st
 		return nil
 	}
 	podIPs, err := util.GetPodCIDRsWithFullMask(pod, oc.NetInfo)
+	// FIXME(trozet): this error can be ignored if ErrNoPodIPFound, but unit test:
+	// egressIP pod recreate with same name (stateful-sets) shouldn't use stale logicalPortCache entries AND stale podAssignment cache entries
+	// heavily relies on this error happening.
 	if err != nil {
 		return err
 	}

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -151,7 +151,7 @@ func (oc *DefaultNetworkController) createASForEgressQoSRule(podSelector metav1.
 		// we don't handle HostNetworked or completed pods
 		if !util.PodWantsHostNetwork(pod) && !util.PodCompleted(pod) {
 			podIPs, err := util.GetPodIPsOfNetwork(pod, oc.NetInfo)
-			if err != nil {
+			if err != nil && !errors.Is(err, util.ErrNoPodIPFound) {
 				return nil, nil, err
 			}
 			podsCache.Store(pod.Name, podIPs)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -184,14 +184,11 @@ func (oc *DefaultNetworkController) ensureLocalZonePod(oldPod, pod *kapi.Pod, ad
 // ensureRemoteZonePod tries to set up remote zone pod bits required to interconnect it.
 //   - Adds the remote pod ips to the pod namespace address set for network policy and egress gw
 //
-// It returns nil on success and error on failure; failur indicates the pod set up should be retried later.
+// It returns nil on success and error on failure; failure indicates the pod set up should be retried later.
 func (oc *DefaultNetworkController) ensureRemoteZonePod(oldPod, pod *kapi.Pod, addPort bool) error {
-	if len(pod.Status.PodIPs) < 1 {
-		return nil
-	}
 	podIfAddrs, err := util.GetPodCIDRsWithFullMask(pod, oc.NetInfo)
 	if err != nil {
-		return fmt.Errorf("failed to get pod ips for the pod  %s/%s : %w", pod.Namespace, pod.Name, err)
+		return fmt.Errorf("failed to obtain IPs to add remote pod %s/%s: %w", pod.Namespace, pod.Name, err)
 	}
 
 	if (addPort || (oldPod != nil && len(pod.Status.PodIPs) != len(oldPod.Status.PodIPs))) && !util.PodWantsHostNetwork(pod) {

--- a/go-controller/pkg/ovn/pod_selector_address_set.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set.go
@@ -363,7 +363,7 @@ func (handlerInfo *PodSelectorAddrSetHandlerInfo) deletePod(pod *v1.Pod) error {
 	if err != nil {
 		// if pod ips can't be fetched on delete, we don't expect that information about ips will ever be updated,
 		// therefore just log the error and return.
-		klog.Warningf("Failed to get pod IPs %s/%s to delete from pod selector address set: %w", pod.Namespace, pod.Name, err)
+		klog.Warningf("Could not find pod %s/%s IPs to delete from pod selector address set: %w", pod.Namespace, pod.Name, err)
 		return nil
 	}
 	return handlerInfo.addressSet.DeleteIPs(ips)

--- a/go-controller/pkg/ovn/pod_selector_address_set.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set.go
@@ -363,7 +363,7 @@ func (handlerInfo *PodSelectorAddrSetHandlerInfo) deletePod(pod *v1.Pod) error {
 	if err != nil {
 		// if pod ips can't be fetched on delete, we don't expect that information about ips will ever be updated,
 		// therefore just log the error and return.
-		klog.Infof("Failed to get pod IPs %s/%s to delete from pod selector address set: %w", pod.Namespace, pod.Name, err)
+		klog.Warningf("Failed to get pod IPs %s/%s to delete from pod selector address set: %w", pod.Namespace, pod.Name, err)
 		return nil
 	}
 	return handlerInfo.addressSet.DeleteIPs(ips)

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -274,52 +274,22 @@ func GetPodCIDRsWithFullMask(pod *v1.Pod, nInfo NetInfo) ([]*net.IPNet, error) {
 // and then falling back to the Pod Status IPs. This function is intended to
 // also return IPs for HostNetwork and other non-OVN-IPAM-ed pods.
 func GetPodIPsOfNetwork(pod *v1.Pod, nInfo NetInfo) ([]net.IP, error) {
-	ips := []net.IP{}
-	networkMap := map[string]*nadapi.NetworkSelectionElement{}
-	if !nInfo.IsSecondary() {
-		// default network, Pod annotation is under the name of DefaultNetworkName
-		networkMap[types.DefaultNetworkName] = nil
-	} else {
-		var err error
-		var on bool
+	if nInfo.IsSecondary() {
+		return SecondaryNetworkPodIPs(pod, nInfo)
+	}
+	return DefaultNetworkPodIPs(pod)
+}
 
-		on, networkMap, err = GetPodNADToNetworkMapping(pod, nInfo)
-		if err != nil {
-			return nil, err
-		} else if !on {
-			// the pod is not attached to this specific network, don't return error
-			return []net.IP{}, nil
-		}
-	}
-	for nadName := range networkMap {
-		annotation, _ := UnmarshalPodAnnotation(pod.Annotations, nadName)
-		if annotation != nil {
-			// Use the OVN annotation if valid
-			for _, ip := range annotation.IPs {
-				ips = append(ips, ip.IP)
-			}
-			// An OVN annotation should never have empty IPs, but just in case
-			if len(ips) == 0 {
-				klog.Warningf("No IPs found in existing OVN annotation for NAD %s! Pod Name: %s, Annotation: %#v",
-					nadName, pod.Name, annotation)
-			}
-		}
-	}
-	if len(ips) != 0 {
+func DefaultNetworkPodIPs(pod *v1.Pod) ([]net.IP, error) {
+	ips := getAnnotatedPodIPs(pod, types.DefaultNetworkName)
+	if len(ips) > 0 {
 		return ips, nil
 	}
-
-	if nInfo.IsSecondary() {
-		return []net.IP{}, fmt.Errorf("no pod annotation of pod %s/%s found for network %s",
-			pod.Namespace, pod.Name, nInfo.GetNetworkName())
-	}
-
 	// Otherwise, default network, if the annotation is not valid try to use Kube API pod IPs
 	ips = make([]net.IP, 0, len(pod.Status.PodIPs))
 	for _, podIP := range pod.Status.PodIPs {
 		ip := utilnet.ParseIPSloppy(podIP.IP)
 		if ip == nil {
-			klog.Warningf("Failed to parse pod IP %q", podIP)
 			continue
 		}
 		ips = append(ips, ip)
@@ -337,6 +307,49 @@ func GetPodIPsOfNetwork(pod *v1.Pod, nInfo NetInfo) ([]net.IP, error) {
 	}
 
 	return []net.IP{ip}, nil
+}
+
+func SecondaryNetworkPodIPs(pod *v1.Pod, networkInfo NetInfo) ([]net.IP, error) {
+	ips := []net.IP{}
+	podNadNames, err := PodNadNames(pod, networkInfo)
+	if err != nil {
+		return nil, err
+	}
+	for _, nadName := range podNadNames {
+		ips = append(ips, getAnnotatedPodIPs(pod, nadName)...)
+	}
+	return ips, nil
+}
+
+func PodNadNames(pod *v1.Pod, netinfo NetInfo) ([]string, error) {
+	on, networkMap, err := GetPodNADToNetworkMapping(pod, netinfo)
+	// skip pods that are not on this network
+	if err != nil {
+		return nil, err
+	} else if !on {
+		// if we are not able to determine if this pod is on this network continue processing the
+		// remaining pods anyway, hopefully the pod will be handled in a future pod update event.
+		klog.Warningf("Failed to determine if pod %s/%s is on network %s: %v",
+			pod.Namespace, pod.Name, netinfo.GetNetworkName(), err)
+		return []string{}, nil
+	}
+	nadNames := make([]string, 0, len(networkMap))
+	for nadName := range networkMap {
+		nadNames = append(nadNames, nadName)
+	}
+	return nadNames, nil
+}
+
+func getAnnotatedPodIPs(pod *v1.Pod, nadName string) []net.IP {
+	var ips []net.IP
+	annotation, _ := UnmarshalPodAnnotation(pod.Annotations, nadName)
+	if annotation != nil {
+		// Use the OVN annotation if valid
+		for _, ip := range annotation.IPs {
+			ips = append(ips, ip.IP)
+		}
+	}
+	return ips
 }
 
 // GetK8sPodDefaultNetworkSelection get pod default network from annotations

--- a/go-controller/pkg/util/pod_annotation.go
+++ b/go-controller/pkg/util/pod_annotation.go
@@ -263,8 +263,7 @@ func GetPodCIDRsWithFullMask(pod *v1.Pod, nInfo NetInfo) ([]*net.IPNet, error) {
 		_, ipnet, err := net.ParseCIDR(podIPStr + mask)
 		if err != nil {
 			// this should not happen;
-			klog.Warningf("Failed to parse pod IP %v err: %v", podIP, err)
-			continue
+			return nil, fmt.Errorf("failed to parse pod IP %v err: %w", podIP, err)
 		}
 		ips = append(ips, ipnet)
 	}

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -342,10 +342,12 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 						assert.Contains(t, e.Error(), tc.errMatch.Error())
 					}
 				} else {
-					podIPStr := tc.outExp[0].String()
-					mask := GetIPFullMask(podIPStr)
-					_, ipnet, _ := net.ParseCIDR(podIPStr + mask)
-					assert.Equal(t, []*net.IPNet{ipnet}, res2)
+					expectedIP := tc.outExp[0]
+					ipNet := net.IPNet{
+						IP:   expectedIP,
+						Mask: GetFullNetMask(expectedIP),
+					}
+					assert.Equal(t, []*net.IPNet{&ipNet}, res2)
 				}
 			}
 		})

--- a/go-controller/pkg/util/pod_annotation_unit_test.go
+++ b/go-controller/pkg/util/pod_annotation_unit_test.go
@@ -7,12 +7,15 @@ import (
 	"reflect"
 	"testing"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	ovncnitypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
-	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
 )
 
 func TestMarshalPodAnnotation(t *testing.T) {
@@ -216,6 +219,11 @@ func TestUnmarshalPodAnnotation(t *testing.T) {
 }
 
 func TestGetPodIPsOfNetwork(t *testing.T) {
+	const (
+		secondaryNetworkIPAddr = "200.200.200.200"
+		namespace              = "ns1"
+		secondaryNetworkName   = "bluetenant"
+	)
 	tests := []struct {
 		desc        string
 		inpPod      *v1.Pod
@@ -231,7 +239,7 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 			errExp: true,
 		},*/
 		{
-			desc: "test when pod annotation is non-nil",
+			desc: "test when pod annotation is non-nil for the default cluster network",
 			inpPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"k8s.ovn.org/pod-networks": `{"default":{"ip_addresses":["192.168.0.1/24"],"mac_address":"0a:58:fd:98:00:01"}}`},
@@ -280,6 +288,32 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 			networkInfo: &DefaultNetInfo{},
 			errMatch:    ErrNoPodIPFound,
 		},
+		{
+			desc: "test when pod annotation is non-nil for a secondary network",
+			inpPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[{"name": %q, "namespace": %q}]`, secondaryNetworkName, namespace),
+						"k8s.ovn.org/pod-networks":    fmt.Sprintf(`{%q:{"ip_addresses":["%s/24"],"mac_address":"0a:58:fd:98:00:01"}}`, GetNADName(namespace, secondaryNetworkName), secondaryNetworkIPAddr),
+					},
+				},
+			},
+			networkInfo: newDummyNetInfo(namespace, secondaryNetworkName),
+			outExp:      []net.IP{ovntest.MustParseIP(secondaryNetworkIPAddr)},
+		},
+		{
+			desc: "test when pod annotation is non-nil for a secondary network",
+			inpPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"k8s.v1.cni.cncf.io/networks": fmt.Sprintf(`[{"name": %q, "namespace": %q}]`, secondaryNetworkName, namespace),
+						"k8s.ovn.org/pod-networks":    "{}",
+					},
+				},
+			},
+			networkInfo: newDummyNetInfo(namespace, secondaryNetworkName),
+			outExp:      []net.IP{},
+		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%d:%s", i, tc.desc), func(t *testing.T) {
@@ -296,22 +330,32 @@ func TestGetPodIPsOfNetwork(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.outExp, res1)
 			}
-			res2, e := GetPodCIDRsWithFullMask(tc.inpPod, tc.networkInfo)
-			t.Log(res2, e)
-			if tc.errAssert {
-				assert.Error(t, e)
-			} else if tc.errMatch != nil {
-				if errors.Is(tc.errMatch, ErrNoPodIPFound) {
-					assert.ErrorIs(t, e, ErrNoPodIPFound)
+			if len(tc.outExp) > 0 {
+				res2, e := GetPodCIDRsWithFullMask(tc.inpPod, tc.networkInfo)
+				t.Log(res2, e)
+				if tc.errAssert {
+					assert.Error(t, e)
+				} else if tc.errMatch != nil {
+					if errors.Is(tc.errMatch, ErrNoPodIPFound) {
+						assert.ErrorIs(t, e, ErrNoPodIPFound)
+					} else {
+						assert.Contains(t, e.Error(), tc.errMatch.Error())
+					}
 				} else {
-					assert.Contains(t, e.Error(), tc.errMatch.Error())
+					podIPStr := tc.outExp[0].String()
+					mask := GetIPFullMask(podIPStr)
+					_, ipnet, _ := net.ParseCIDR(podIPStr + mask)
+					assert.Equal(t, []*net.IPNet{ipnet}, res2)
 				}
-			} else {
-				podIPStr := tc.outExp[0].String()
-				mask := GetIPFullMask(podIPStr)
-				_, ipnet, _ := net.ParseCIDR(podIPStr + mask)
-				assert.Equal(t, []*net.IPNet{ipnet}, res2)
 			}
 		})
 	}
+}
+
+func newDummyNetInfo(namespace, networkName string) NetInfo {
+	netInfo, _ := newLayer2NetConfInfo(&ovncnitypes.NetConf{
+		NetConf: cnitypes.NetConf{Name: networkName},
+	})
+	netInfo.AddNAD(GetNADName(namespace, networkName))
+	return netInfo
 }

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -74,6 +74,21 @@ func GetIPFullMask(ip string) string {
 	return IPv4FullMask
 }
 
+// GetFullNetMask returns a 32 bit netmask for IPv4 addresses and a 128 bit netmask for IPv6 addresses
+func GetFullNetMask(ip net.IP) net.IPMask {
+	const (
+		// IPv4FullMask is the maximum prefix mask for an IPv4 address
+		IPv4FullMask = 32
+		// IPv6FullMask is the maximum prefix mask for an IPv6 address
+		IPv6FullMask = 128
+	)
+
+	if utilnet.IsIPv6(ip) {
+		return net.CIDRMask(IPv6FullMask, IPv6FullMask)
+	}
+	return net.CIDRMask(IPv4FullMask, IPv4FullMask)
+}
+
 // GetLegacyK8sMgmtIntfName returns legacy management ovs-port name
 func GetLegacyK8sMgmtIntfName(nodeName string) string {
 	if len(nodeName) > 11 {


### PR DESCRIPTION
We were treating a failure to get IPs on a pod (because it had no IPs at the time) as an error in certain non-pod handlers. This would cause entire syncs or adding handlers to fail, when it shouldn't because once the handler/sync has been done the pod watcher will see the update event when the pod finally gets its IP address.

Also, its possible to get a delete event for a pod that never had an IP address but was scheduled.


