### PR TITLE
kind ic: Fix kind deployment failure if cluster name is specified.

### DIFF
--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -683,7 +683,7 @@ ovn_image=${ovnkube_image} \
   ovn_empty_lb_events=${ovn_empty_lb_events} \
   ovn_loglevel_nb=${ovn_loglevel_nb} ovn_loglevel_sb=${ovn_loglevel_sb} \
   ovn_enable_interconnect=${ovn_enable_interconnect} \
-  j2 ../templates/ovnkube-single-node-zone.yaml.j2 -o ../yaml/ovnkube-single-node-zone.yaml
+  j2 ../templates/ovnkube-single-node-zone.yaml.j2 -o ${output_dir}/ovnkube-single-node-zone.yaml
 
 ovn_image=${ovnkube_image} \
   ovn_image_pull_policy=${image_pull_policy} \
@@ -734,7 +734,7 @@ ovn_image=${ovnkube_image} \
   ovn_empty_lb_events=${ovn_empty_lb_events} \
   ovn_loglevel_nb=${ovn_loglevel_nb} ovn_loglevel_sb=${ovn_loglevel_sb} \
   ovn_enable_interconnect=${ovn_enable_interconnect} \
-  j2 ../templates/ovnkube-zone-controller.yaml.j2 -o ../yaml/ovnkube-zone-controller.yaml
+  j2 ../templates/ovnkube-zone-controller.yaml.j2 -o ${output_dir}/ovnkube-zone-controller.yaml
 
 ovn_image=${image} \
   ovn_image_pull_policy=${image_pull_policy} \


### PR DESCRIPTION
Running "./kind.sh -ic -cn foo" is broken.  This patch fixes it.

Fixes: 3f96b2fa9294("kind: Add support for interconnect and multiple zones support.")
Fixes: 0742ee4347e7("kind: Enhance interconnect support to deploy multiple nodes in a zone.")
Reported-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->