### PR TITLE
Rename ovnkube-network-controller-manager to ovnkube-controller

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -21,7 +21,7 @@ need to be made aware of it by following the instructions below.
 OVN CNI requires several TCP and UDP ports to be opened on each of the node
 that is part of the K8s cluster.
 
- 1. The node on which ovnkube-master or ovnkube-network-controller-manager runs, open following ports:
+ 1. The node on which ovnkube-master or ovnkube-controller runs, open following ports:
     ```text
     TCP:
       port 9409 (prometheus port to export ovnkube-master metrics)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/k8s
 kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/ovnkube-db.yaml
 
 # Run ovnkube-master deployment
-# To run ovnkube-master deployment with both cluster manager and network controller manager as one container)
+# To run ovnkube-master deployment with both cluster manager and ovnkube controller as one container)
 kubectl create -f $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/yaml/ovnkube-master.yaml
 
 # Run ovnkube daemonset for nodes

--- a/dist/templates/ovnkube-monitor.yaml.j2
+++ b/dist/templates/ovnkube-monitor.yaml.j2
@@ -1,5 +1,5 @@
 # define ServiceMontior and Service resources for ovnkube-cluster-manager,
-# ovnkube-master (or ovnkube-network-controller-manager), ovnkube-node and ovnkube-db (required for prometheus monitoring)
+# ovnkube-master (or ovnkube-controller), ovnkube-node and ovnkube-db (required for prometheus monitoring)
 
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -241,7 +241,7 @@ spec:
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
 
-        command: ["/root/ovnkube.sh", "ovn-network-controller-manager"]
+        command: ["/root/ovnkube.sh", "ovnkube-controller"]
 
         securityContext:
           runAsUser: 0

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -1,7 +1,7 @@
 ---
 # ovnkube-zone-controller
 # daemonset version 3
-# starts zone controller daemons - ovn dbs, ovn-northd and ovnkube-network-controller-manager containers
+# starts zone controller daemons - ovn dbs, ovn-northd and ovnkube-controller containers
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -257,7 +257,7 @@ spec:
         image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
         imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
 
-        command: ["/root/ovnkube.sh", "ovn-network-controller-manager"]
+        command: ["/root/ovnkube.sh", "ovnkube-controller"]
 
         securityContext:
           runAsUser: 0

--- a/docs/ha.md
+++ b/docs/ha.md
@@ -76,11 +76,11 @@ sudo ovs-appctl -t /var/run/openvswitch/ovnsb_db.ctl \
 
 ## ovnkube master HA setup
 
-ovnkube master has 2 main components - cluster-manager and network-controller-manager.
+ovnkube master has 2 main components - cluster-manager and ovnkube-controller.
 
 Starting ovnkube with '-init-master', runs both the components.  It is also possible
 to run these components individually by starting 2 ovnkube's one with '-init-cluster-manager'
-and the other with '-init-network-controller-manager'.
+and the other with '-init-ovnkube-controller'.
 
 On the master nodes, we can either
    * start ovnkube with '-init-master'
@@ -105,25 +105,25 @@ nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml \
  -nb-address="${ovn_nb}" \
  -sb-address="${ovn_sb}"  2>&1 &
 
- * start 'ovnkube -init-cluster-manager' and 'ovnkube -init-network-controller-manager'
+ * start 'ovnkube -init-cluster-manager' and 'ovnkube -init-ovnkube-controller'
    This should be a deployment with these 2 as containers
 
 Eg.
 
 
 ovnkube master supports running in 3 modes.
-init-master mode, init-cluster-manager mode or init-network-controller-manager
+init-master mode, init-cluster-manager mode or init-ovnkube-controller
 mode.  If ovnkube is run with "-init-master" mode, then there is
 no need to run the other modes because master mode enables both cluster-manager
-and network-controller-manager.  If the user desires to run cluster-manager
-and network-controller-manager separately, then it is possible to do
+and ovnkube-controller.  If the user desires to run cluster-manager
+and ovnkube-controller separately, then it is possible to do
 so by running 
 
 nohup sudo ovnkube -k8s-kubeconfig kubeconfig.yaml \
  -loglevel=4 \
  -k8s-apiserver="http://$K8S_APISERVER_IP:8080" \
  -logfile="/var/log/openvswitch/ovnkube.log" \
- -init-network-controller-manager="$NODENAME" -cluster-subnets="$CLUSTER_IP_SUBNET" \
+ -init-ovnkube-controller="$NODENAME" -cluster-subnets="$CLUSTER_IP_SUBNET" \
  -init-node="$NODENAME" \
  -k8s-service-cidr="$SERVICE_IP_SUBNET" \
  -k8s-token="$TOKEN" \

--- a/go-controller/README.md
+++ b/go-controller/README.md
@@ -39,11 +39,11 @@ Usage:
   -cluster-subnets string
      cluster wide IP subnet to use (default: 11.11.0.0/16)
   -init-master string
-     initialize master which enables both cluster manager (allocates node subnets) and network controller manager (which watches pods/nodes/services/policies and creates OVN db resources), requires the hostname as argument
+     initialize master which enables both cluster manager (allocates node subnets) and ovnkube controller (which watches pods/nodes/services/policies and creates OVN db resources), requires the hostname as argument
   -init-cluster-manager string
      initialize cluster manager that watches nodes (allocates subnet for each node from the cluster-subnets), requires the hostname as argument and doesn't connect to the OVN dbs.
-  -init-network-controller-manager string
-     initialize network-controller-manager (which watches pods/nodes/services/policies and create OVN db resources), requires the hostname as argument.
+  -init-ovnkube-controller string
+     initialize ovnkube-controller (which watches pods/nodes/services/policies and create OVN db resources), requires the hostname as argument.
   -init-node string
      initialize node, requires the name that node is registered with in kubernetes cluster
   -cleanup-node string
@@ -154,7 +154,7 @@ server-cacert=path/to/server-ca.crt
 
 ## Example
 
-#### Initialize the master (both cluster manager and network controller manager)
+#### Initialize the master (both cluster manager and ovnkube controller)
 
 ```
 ovnkube --init-master <master-host-name> \
@@ -165,14 +165,14 @@ ovnkube --init-master <master-host-name> \
 ```
 
 The aforementioned master ovnkube controller will enable both the cluster manager (which watches nodes and allocates node subnets)
-and network controller manager which initialize the central master logical router and establish the watcher loops for the following:
+and ovnkube controller which initialize the central master logical router and establish the watcher loops for the following:
  - nodes: as new nodes are born and init-node is called, the logical switches will be created automatically by giving out IPAM for the respective nodes
  - pods: as new pods are born, allocate the logical port with dynamic addressing from the switch it belongs to
  - services/endpoints: as new endpoints of services are born, create/update the logical load balancer on all logical switches
  - network policies and a few other k8s resources
 
 
-#### Initialize the cluster manager and network controller manager separately
+#### Initialize the cluster manager and ovnkube controller separately
 
 ```
 ovnkube --init-cluster-manager <master-host-name> \
@@ -186,14 +186,14 @@ The aforementioned ovnkube cluster manager will establish the watcher loops for 
  - nodes: as new nodes are born and init-node is called, the subnet IPAM is allocated for the respective nodes
 
 ```
-ovnkube --init-network-controller-manager <master-host-name> \
+ovnkube --init-ovnkube-controller <master-host-name> \
 	--k8s-cacert <path to the cacert file> \
 	--k8s-token <token string for authentication with kube apiserver> \
 	--k8s-apiserver <url to the kube apiserver e.g. https://10.11.12.13.8443> \
 	--cluster-subnets <cidr representing the global pod network e.g. 192.168.0.0/16>
 ```
 
-The aforementioned ovnkube network controller manager will initialize the central master logical router and establish the watcher loops for the following:
+The aforementioned ovnkube controller will initialize the central master logical router and establish the watcher loops for the following:
  - nodes: as new nodes are born and init-node is called, the logical switches will be created automatically by giving out IPAM for the respective nodes
  - pods: as new pods are born, allocate the logical port with dynamic addressing from the switch it belongs to
  - services/endpoints: as new endpoints of services are born, create/update the logical load balancer on all logical switches

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -178,10 +178,10 @@ func setupPIDFile(pidfile string) error {
 
 // ovnkubeRunMode object stores the run mode of the ovnkube
 type ovnkubeRunMode struct {
-	networkControllerManager bool // network controller manager (--init-network-controller-manager or --init-master) is enabled
-	clusterManager           bool // cluster manager (--init-cluster-manager or --init-master) is enabled
-	node                     bool // node (--init-node) is enabled
-	cleanupNode              bool // cleanup (--cleanup-node) is enabled
+	ovnkubeController bool // ovnkube controller (--init-ovnkube-controller or --init-master) is enabled
+	clusterManager    bool // cluster manager (--init-cluster-manager or --init-master) is enabled
+	node              bool // node (--init-node) is enabled
+	cleanupNode       bool // cleanup (--cleanup-node) is enabled
 
 	// Along with the run mode, an identity is provided that uniquely identifies
 	// this instance vs other instances that might be running in the cluster.
@@ -193,22 +193,22 @@ type ovnkubeRunMode struct {
 // determineOvnkubeRunMode determines the run modes of ovnkube
 // based on the init flags set.  It is possible to run ovnkube in
 // multiple modes.  Allowed multiple modes are:
-//   - master (controller manager + cluster manager) + node
-//   - network controller manager + cluster manager
-//   - network controller manager + node
+//   - master (ovnkube controller + cluster manager) + node
+//   - ovnkube controller + cluster manager
+//   - ovnkube controller + node
 func determineOvnkubeRunMode(ctx *cli.Context) (*ovnkubeRunMode, error) {
 	mode := &ovnkubeRunMode{}
 
 	master := ctx.String("init-master")
 	cm := ctx.String("init-cluster-manager")
-	nm := ctx.String("init-network-controller-manager")
+	ovnkController := ctx.String("init-ovnkube-controller")
 	node := ctx.String("init-node")
 	cleanup := ctx.String("cleanup-node")
 
 	if master != "" {
-		// If init-master is set, then both network controller manager and cluster manager
+		// If init-master is set, then both ovnkube controller and cluster manager
 		// are enabled
-		mode.networkControllerManager = true
+		mode.ovnkubeController = true
 		mode.clusterManager = true
 	}
 
@@ -216,8 +216,8 @@ func determineOvnkubeRunMode(ctx *cli.Context) (*ovnkubeRunMode, error) {
 		mode.clusterManager = true
 	}
 
-	if nm != "" {
-		mode.networkControllerManager = true
+	if ovnkController != "" {
+		mode.ovnkubeController = true
 	}
 
 	if node != "" {
@@ -228,19 +228,19 @@ func determineOvnkubeRunMode(ctx *cli.Context) (*ovnkubeRunMode, error) {
 		mode.cleanupNode = true
 	}
 
-	if mode.cleanupNode && (mode.clusterManager || mode.networkControllerManager || mode.node) {
+	if mode.cleanupNode && (mode.clusterManager || mode.ovnkubeController || mode.node) {
 		return nil, fmt.Errorf("cannot run cleanup-node mode along with any other mode")
 	}
 
-	if !mode.clusterManager && !mode.networkControllerManager && !mode.node && !mode.cleanupNode {
+	if !mode.clusterManager && !mode.ovnkubeController && !mode.node && !mode.cleanupNode {
 		return nil, fmt.Errorf("need to specify a mode for ovnkube")
 	}
 
-	if !mode.networkControllerManager && mode.clusterManager && mode.node {
+	if !mode.ovnkubeController && mode.clusterManager && mode.node {
 		return nil, fmt.Errorf("cannot run in both cluster manager and node mode")
 	}
 
-	identities := sets.NewString(master, cm, nm, node, cleanup)
+	identities := sets.NewString(master, cm, ovnkController, node, cleanup)
 	identities.Delete("")
 	if identities.Len() != 1 {
 		return nil, fmt.Errorf("provided no identity or different identities for different modes")
@@ -297,7 +297,7 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	}
 
 	// no need for leader election in node mode
-	if !runMode.clusterManager && !runMode.networkControllerManager {
+	if !runMode.clusterManager && !runMode.ovnkubeController {
 		return runOvnKube(ctx.Context, runMode, ovnClientset, eventRecorder)
 	}
 
@@ -309,10 +309,10 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	var haConfig *config.HAConfig
 	var name string
 	switch {
-	case runMode.networkControllerManager && runMode.clusterManager:
+	case runMode.ovnkubeController && runMode.clusterManager:
 		metrics.RegisterClusterManagerBase()
 		fallthrough
-	case runMode.networkControllerManager:
+	case runMode.ovnkubeController:
 		metrics.RegisterMasterBase()
 		haConfig = &config.MasterHA
 		name = networkControllerManagerLockName()
@@ -419,9 +419,9 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	var masterWatchFactory *factory.WatchFactory
 	var err error
 
-	if runMode.networkControllerManager {
+	if runMode.ovnkubeController {
 		// create factory and start the controllers asked for
-		masterWatchFactory, err = factory.NewNCMWatchFactory(ovnClientset.GetNetworkControllerManagerClientset())
+		masterWatchFactory, err = factory.NewOVNKubeControllerWatchFactory(ovnClientset.GetOVNKubeControllerClientset())
 		if err != nil {
 			return err
 		}
@@ -430,7 +430,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 
 	if runMode.clusterManager {
 		var clusterManagerWatchFactory *factory.WatchFactory
-		if runMode.networkControllerManager {
+		if runMode.ovnkubeController {
 			// if CM and NCM modes are enabled, then we should call the combo mode - NewMasterWatchFactory
 			masterWatchFactory, err = factory.NewMasterWatchFactory(ovnClientset.GetMasterClientset())
 			if err != nil {
@@ -460,7 +460,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 		metrics.MetricClusterManagerReadyDuration.Set(time.Since(startTime).Seconds())
 	}
 
-	if runMode.networkControllerManager {
+	if runMode.ovnkubeController {
 		var libovsdbOvnNBClient, libovsdbOvnSBClient libovsdbclient.Client
 
 		if libovsdbOvnNBClient, err = libovsdb.NewNBClient(stopChan); err != nil {
@@ -478,7 +478,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 		}
 		err = cm.Start(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to start network controller manager: %w", err)
+			return fmt.Errorf("failed to start ovnkube controller: %w", err)
 		}
 		defer cm.Stop()
 
@@ -489,11 +489,11 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 	if runMode.node {
 		var nodeWatchFactory factory.NodeWatchFactory
 
-		if runMode.networkControllerManager && runMode.clusterManager {
+		if runMode.ovnkubeController && runMode.clusterManager {
 			// masterWatchFactory would be initialized as NewMasterWatchFactory already, let's use that
 			nodeWatchFactory = masterWatchFactory
-		} else if runMode.networkControllerManager {
-			// masterWatchFactory would be initialized as NewNCMWatchFactory, let's change that
+		} else if runMode.ovnkubeController {
+			// masterWatchFactory would be initialized as NewOVNKubeControllerWatchFactory, let's change that
 			// if Node and NCM modes are enabled, then we should call the combo mode - NewMasterWatchFactory
 			masterWatchFactory, err = factory.NewMasterWatchFactory(ovnClientset.GetMasterClientset())
 			if err != nil {
@@ -516,7 +516,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 		metrics.RegisterNodeMetrics()
 		ncm, err := controllerManager.NewNodeNetworkControllerManager(ovnClientset, nodeWatchFactory, runMode.identity, eventRecorder)
 		if err != nil {
-			return fmt.Errorf("failed to create ovnkube node network controller manager: %w", err)
+			return fmt.Errorf("failed to create ovnkube node ovnkube controller: %w", err)
 		}
 		err = ncm.Start(ctx)
 		if err != nil {
@@ -549,7 +549,7 @@ type ovnkubeMasterMetrics struct {
 }
 
 func (m ovnkubeMasterMetrics) On(string) {
-	if m.runMode.networkControllerManager {
+	if m.runMode.ovnkubeController {
 		metrics.MetricMasterLeader.Set(1)
 	}
 	if m.runMode.clusterManager {
@@ -558,7 +558,7 @@ func (m ovnkubeMasterMetrics) On(string) {
 }
 
 func (m ovnkubeMasterMetrics) Off(string) {
-	if m.runMode.networkControllerManager {
+	if m.runMode.ovnkubeController {
 		metrics.MetricMasterLeader.Set(0)
 	}
 	if m.runMode.clusterManager {

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -239,7 +239,7 @@ type DefaultConfig struct {
 	// the kernel network stack. This requires a new-enough kernel (5.15 or RHEL 8.5).
 	EnableUDPAggregation bool `gcfg:"enable-udp-aggregation"`
 
-	// Zone name to which ovnkube-node/ovnkube-network-controller-manager belongs to
+	// Zone name to which ovnkube-node/ovnkube-controller belongs to
 	Zone string `gcfg:"zone"`
 }
 
@@ -651,15 +651,15 @@ var CommonFlags = []cli.Flag{
 	// Mode flags
 	&cli.StringFlag{
 		Name:  "init-master",
-		Usage: "initialize master (both cluster-manager and network-controller-manager), requires the hostname as argument",
+		Usage: "initialize master (both cluster-manager and ovnkube-controller), requires the hostname as argument",
 	},
 	&cli.StringFlag{
 		Name:  "init-cluster-manager",
-		Usage: "initialize cluster manager (but not network-controller-manager), requires the hostname as argument",
+		Usage: "initialize cluster manager (but not ovnkube-controller), requires the hostname as argument",
 	},
 	&cli.StringFlag{
-		Name:  "init-network-controller-manager",
-		Usage: "initialize network-controller-manager (but not cluster-manager), requires the hostname as argument",
+		Name:  "init-ovnkube-controller",
+		Usage: "initialize ovnkube-controller (but not cluster-manager), requires the hostname as argument",
 	},
 	&cli.StringFlag{
 		Name:  "init-node",
@@ -840,7 +840,7 @@ var CommonFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "zone",
-		Usage:       "zone name to which ovnkube-node/ovnkube-network-controller-manager belongs to",
+		Usage:       "zone name to which ovnkube-node/ovnkube-controller belongs to",
 		Value:       Default.Zone,
 		Destination: &cliConfig.Default.Zone,
 	},

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -155,11 +155,12 @@ var (
 )
 
 // NewMasterWatchFactory initializes a new watch factory for:
-// a) network controller manager + cluster manager or
-// b) network controller manager + node
+// a) ovnkube controller + cluster manager or
+// b) ovnkube controller + node
+// c) all-in-one a.k.a ovnkube controller + cluster-manager + node
 // processes.
 func NewMasterWatchFactory(ovnClientset *util.OVNMasterClientset) (*WatchFactory, error) {
-	wf, err := NewNCMWatchFactory(ovnClientset.GetNetworkControllerManagerClientset())
+	wf, err := NewOVNKubeControllerWatchFactory(ovnClientset.GetOVNKubeControllerClientset())
 	if err != nil {
 		return nil, err
 	}
@@ -173,8 +174,8 @@ func NewMasterWatchFactory(ovnClientset *util.OVNMasterClientset) (*WatchFactory
 	return wf, nil
 }
 
-// NewNCMWatchFactory initializes a new watch factory for the network controller manager process
-func NewNCMWatchFactory(ovnClientset *util.OVNNetworkControllerManagerClientset) (*WatchFactory, error) {
+// NewOVNKubeControllerWatchFactory initializes a new watch factory for the ovnkube controller process
+func NewOVNKubeControllerWatchFactory(ovnClientset *util.OVNKubeControllerClientset) (*WatchFactory, error) {
 	// resync time is 12 hours, none of the resources being watched in ovn-kubernetes have
 	// any race condition where a resync may be required e.g. cni executable on node watching for
 	// events on pods and assuming that an 'ADD' event will contain the annotations put in by

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
@@ -88,7 +88,7 @@ type NetAttachDefinitionController struct {
 	// key is nadName, value is BasicNetInfo
 	perNADNetInfo *syncmap.SyncMap[util.BasicNetInfo]
 	// controller for all networks, key is netName of net-attach-def, value is networkNADInfo
-	// this map is updated either at the very beginning of network controller manager when initializing the
+	// this map is updated either at the very beginning of ovnkube controller when initializing the
 	// default controller or when net-attach-def is added/deleted. All these are serialized by syncmap lock
 	perNetworkNADInfo *syncmap.SyncMap[*networkNADInfo]
 }

--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -177,7 +177,7 @@ func (cm *networkControllerManager) CleanupDeletedNetworks(allControllers []nad.
 	return nil
 }
 
-// NewNetworkControllerManager creates a new OVN controller manager to manage all the controller for all networks
+// NewNetworkControllerManager creates a new ovnkube controller manager to manage all the controller for all networks
 func NewNetworkControllerManager(ovnClient *util.OVNClientset, identity string, wf *factory.WatchFactory,
 	libovsdbOvnNBClient libovsdbclient.Client, libovsdbOvnSBClient libovsdbclient.Client,
 	recorder record.EventRecorder, wg *sync.WaitGroup) (*networkControllerManager, error) {
@@ -296,11 +296,11 @@ func (cm *networkControllerManager) initDefaultNetworkController() error {
 	return nil
 }
 
-// Start the network controller manager
+// Start the ovnkube controller
 func (cm *networkControllerManager) Start(ctx context.Context) error {
-	klog.Info("Starting the network controller manager")
+	klog.Info("Starting the ovnkube controller")
 
-	// Make sure that the NCM zone matches with the Northbound db zone.
+	// Make sure that the ovnkube-controller zone matches with the Northbound db zone.
 	// Wait for 300s before giving up
 	maxTimeout := 300 * time.Second
 	klog.Infof("Waiting up to %s for NBDB zone to match: %s", maxTimeout, config.Default.Zone)
@@ -321,7 +321,7 @@ func (cm *networkControllerManager) Start(ctx context.Context) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to start default network controller - OVN NBDB zone %s does not match the configured zone %q: errors: %v, %v",
+		return fmt.Errorf("failed to start default ovnkube-controller - OVN NBDB zone %s does not match the configured zone %q: errors: %v, %v",
 			zone, config.Default.Zone, err, err1)
 	}
 	klog.Infof("NBDB zone sync took: %s", time.Since(start))

--- a/go-controller/pkg/network-controller-manager/network_controller_manager_suite_test.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestNodeSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Network Controller Manager Suite")
+	RunSpecs(t, "ovnkube controller suite")
 }

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -65,7 +65,7 @@ type OVNMasterClientset struct {
 }
 
 // OVNNetworkControllerManagerClientset
-type OVNNetworkControllerManagerClientset struct {
+type OVNKubeControllerClientset struct {
 	KubeClient               kubernetes.Interface
 	EgressIPClient           egressipclientset.Interface
 	EgressFirewallClient     egressfirewallclientset.Interface
@@ -102,8 +102,8 @@ func (cs *OVNClientset) GetMasterClientset() *OVNMasterClientset {
 	}
 }
 
-func (cs *OVNMasterClientset) GetNetworkControllerManagerClientset() *OVNNetworkControllerManagerClientset {
-	return &OVNNetworkControllerManagerClientset{
+func (cs *OVNMasterClientset) GetOVNKubeControllerClientset() *OVNKubeControllerClientset {
+	return &OVNKubeControllerClientset{
 		KubeClient:               cs.KubeClient,
 		EgressIPClient:           cs.EgressIPClient,
 		EgressFirewallClient:     cs.EgressFirewallClient,
@@ -114,8 +114,8 @@ func (cs *OVNMasterClientset) GetNetworkControllerManagerClientset() *OVNNetwork
 	}
 }
 
-func (cs *OVNClientset) GetNetworkControllerManagerClientset() *OVNNetworkControllerManagerClientset {
-	return &OVNNetworkControllerManagerClientset{
+func (cs *OVNClientset) GetOVNKubeControllerClientset() *OVNKubeControllerClientset {
+	return &OVNKubeControllerClientset{
 		KubeClient:               cs.KubeClient,
 		EgressIPClient:           cs.EgressIPClient,
 		EgressFirewallClient:     cs.EgressFirewallClient,


### PR DESCRIPTION

**- What this PR does and why is it needed**
```
    User Facing change: Rename ncm to ovnkube-controller
    
    Recently we added the network-controller-manager flag
    mode for supporting deployments where master will run
    separately from cluster-manager. From https://github.com/ovn-org/ovn-kubernetes/pull/3366
    we have renamed the container to be more generic: `ovnkube-controller`.
    
    Since we are still early and only merged this flag a few weeks ago,
    let's make sure we stay consistent moving forward and rename
    this flag to ovnkube-controller before bringing this flag downstream
    into CNO.
    
    NOTE: All exisiting internal code can call this
    NetworkControllerManager.
    On a user facing level, I'd like to keep this simple and say
    anything programming ovnkube and OVN DB is the ovnkube-controller
    similar to ovn-controller container. If we don't do this change
    now we are going to end up with confusion and mismatch between
    ncm flag and ovnkube-controller container.
    
    Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

```
**- Special notes for reviewers**
This was discussed in https://github.com/ovn-org/ovn-kubernetes/pull/3632 first and @trozet wanted us to be consistent and also change things internally from NCM -> OVNK-Controller but that might be a bigger refactor and we should let the feature cycle end and then do a nice PR with struct renaming + some golang platuml perhaps because codebase is growing - we must even try to add more developer docs around structNamins, controller creations etc.. to be more consistent.


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->