### PR TITLE
APB External Route: refactored controllers to use a single workqueue to handle policy updates

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/external_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller.go
@@ -231,7 +231,6 @@ func (m *externalPolicyManager) getRoutePolicyFromCache(policyName string) (*adm
 		found, markedForDeletion bool
 	)
 	_ = m.routePolicySyncCache.DoWithLock(policyName, func(policyName string) error {
-		klog.Infof("Getting route %s", policyName)
 		ri, f := m.routePolicySyncCache.Load(policyName)
 		if !f {
 			return nil

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller.go
@@ -2,6 +2,7 @@ package apbroute
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	adminpolicybasedrouteapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1"
@@ -16,6 +17,14 @@ import (
 )
 
 type gatewayInfoList []*gatewayInfo
+
+func (g gatewayInfoList) String() string {
+	ret := []string{}
+	for _, i := range g {
+		ret = append(ret, i.String())
+	}
+	return strings.Join(ret, ", ")
+}
 
 // HasBFDEnabled returns the BFD value for the given IP stored in the gatewayInfoList when found.
 // It also returns a boolean that indicates if the IP was found and an error
@@ -82,6 +91,10 @@ type gatewayInfo struct {
 	BFDEnabled bool
 }
 
+func (g *gatewayInfo) String() string {
+	return fmt.Sprintf("BFDEnabled: %t, Gateways: %+v", g.BFDEnabled, g.Gateways.items)
+}
+
 func newGatewayInfo(items sets.Set[string], bfdEnabled bool) *gatewayInfo {
 	return &gatewayInfo{Gateways: &syncSet{items: items, mux: &sync.Mutex{}}, BFDEnabled: bfdEnabled}
 }
@@ -93,16 +106,7 @@ type syncSet struct {
 
 // Equal compares two gatewayInfo instances and returns true if all the gateway IPs are equal, regardless of the order, as well as the BFDEnabled field value.
 func (g *gatewayInfo) Equal(g2 *gatewayInfo) bool {
-	return g.BFDEnabled == g2.BFDEnabled && g.Gateways.Equal(g2.Gateways)
-}
-
-func (g *syncSet) Equal(s2 *syncSet) bool {
-	s2.mux.Lock()
-	s2items := s2.items.Clone()
-	s2.mux.Unlock()
-	g.mux.Lock()
-	defer g.mux.Unlock()
-	return g.items.Equal(s2items)
+	return g.BFDEnabled == g2.BFDEnabled && len(g.Gateways.Difference(g2.Gateways.items.Clone())) == 0
 }
 
 func (g *syncSet) Has(ip string) bool {
@@ -145,7 +149,6 @@ type namespaceInfo struct {
 	Policies        sets.Set[string]
 	StaticGateways  gatewayInfoList
 	DynamicGateways map[ktypes.NamespacedName]*gatewayInfo
-	markForDelete   bool
 }
 
 func newNamespaceInfo() *namespaceInfo {
@@ -157,8 +160,8 @@ func newNamespaceInfo() *namespaceInfo {
 }
 
 type routeInfo struct {
-	policy          *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute
-	markedForDelete bool
+	policy            *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute
+	markedForDeletion bool
 }
 
 type ExternalRouteInfo struct {
@@ -222,19 +225,20 @@ func newExternalPolicyManager(
 }
 
 // getRoutePolicyFromCache retrieves the cached value of the policy if it exists in the cache, as well as locking the key in case it exists.
-func (m *externalPolicyManager) getRoutePolicyFromCache(policyName string) (adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute, bool, bool) {
+func (m *externalPolicyManager) getRoutePolicyFromCache(policyName string) (*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute, bool, bool) {
 	var (
-		policy                   adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute
+		policy                   *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute
 		found, markedForDeletion bool
 	)
 	_ = m.routePolicySyncCache.DoWithLock(policyName, func(policyName string) error {
+		klog.Infof("Getting route %s", policyName)
 		ri, f := m.routePolicySyncCache.Load(policyName)
 		if !f {
 			return nil
 		}
 		found = f
-		policy = *ri.policy
-		markedForDeletion = ri.markedForDelete
+		markedForDeletion = ri.markedForDeletion
+		policy = ri.policy.DeepCopy()
 		return nil
 	})
 	return policy, found, markedForDeletion
@@ -247,7 +251,7 @@ func (m *externalPolicyManager) storeRoutePolicyInCache(policyInfo *adminpolicyb
 			m.routePolicySyncCache.LoadOrStore(policyName, &routeInfo{policy: policyInfo})
 			return nil
 		}
-		if ri.markedForDelete {
+		if ri.markedForDeletion {
 			return fmt.Errorf("attempting to store policy %s that is in the process of being deleted", policyInfo.Name)
 		}
 		ri.policy = policyInfo
@@ -258,7 +262,7 @@ func (m *externalPolicyManager) storeRoutePolicyInCache(policyInfo *adminpolicyb
 func (m *externalPolicyManager) deleteRoutePolicyFromCache(policyName string) error {
 	return m.routePolicySyncCache.DoWithLock(policyName, func(policyName string) error {
 		ri, found := m.routePolicySyncCache.Load(policyName)
-		if found && !ri.markedForDelete {
+		if found && !ri.markedForDeletion {
 			return fmt.Errorf("attempting to delete route policy %s from cache before it has been marked for deletion", policyName)
 		}
 		m.routePolicySyncCache.Delete(policyName)
@@ -278,7 +282,7 @@ func (m *externalPolicyManager) getAndMarkRoutePolicyForDeletionInCache(policyNa
 		if !found {
 			return nil
 		}
-		ri.markedForDelete = true
+		ri.markedForDeletion = true
 		exists = true
 		routePolicy = *ri.policy
 		return nil
@@ -296,26 +300,8 @@ func (m *externalPolicyManager) getNamespaceInfoFromCache(namespaceName string) 
 	return nsInfo, true
 }
 
-func (m *externalPolicyManager) getAndMarkForDeleteNamespaceInfoFromCache(namespaceName string) (*namespaceInfo, bool) {
-	nsInfo, ok := m.getNamespaceInfoFromCache(namespaceName)
-	if !ok {
-		return nil, false
-	}
-	nsInfo.markForDelete = true
-	return nsInfo, ok
-}
-
-func (m *externalPolicyManager) deleteNamespaceInfoInCache(namespaceName string) {
-	nsInfo, ok := m.namespaceInfoSyncCache.Load(namespaceName)
-	if !ok {
-		klog.Warningf("Failed to retrieve namespace %s for deletion", namespaceName)
-		return
-	}
-	if !nsInfo.markForDelete {
-		klog.Warningf("Attempting to delete namespace %s when it has not been marked for deletion", namespaceName)
-		return
-	}
-	m.namespaceInfoSyncCache.Delete(namespaceName)
+func (m *externalPolicyManager) getAllNamespacesNamesInCache() []string {
+	return m.namespaceInfoSyncCache.GetKeys()
 }
 
 func (m *externalPolicyManager) unlockNamespaceInfoCache(namespaceName string) {

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace.go
@@ -31,6 +31,17 @@ func (m *externalPolicyManager) syncNamespace(namespace *v1.Namespace, routeQueu
 							keysToBeQueued.Insert(policyName)
 						}
 					}
+					for _, hop := range ri.policy.Spec.NextHops.DynamicHops {
+						gwNs, err := m.listNamespacesBySelector(hop.NamespaceSelector)
+						if err != nil {
+							return err
+						}
+						for _, ns := range gwNs {
+							if ns.Name == namespace.Name {
+								keysToBeQueued.Insert(policyName)
+							}
+						}
+					}
 				}
 				return nil
 			})

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace.go
@@ -14,7 +14,7 @@ func (m *externalPolicyManager) syncNamespace(namespace *v1.Namespace, routeQueu
 
 	keysToBeQueued := sets.New[string]()
 
-	// get a copy of all policies at this time and see if they include this namespace
+	// Get a copy of all policies at this time and see if they include this namespace
 	policyKeys := m.routePolicySyncCache.GetKeys()
 
 	for _, policyName := range policyKeys {
@@ -39,7 +39,7 @@ func (m *externalPolicyManager) syncNamespace(namespace *v1.Namespace, routeQueu
 		}
 	}
 
-	// check if this namespace is being tracked by policy in its namespace cache
+	// Check if this namespace is being tracked by policy in its namespace cache
 	cacheInfo, found := m.getNamespaceInfoFromCache(namespace.Name)
 	if found {
 		for policyName := range cacheInfo.Policies {
@@ -56,7 +56,7 @@ func (m *externalPolicyManager) syncNamespace(namespace *v1.Namespace, routeQueu
 	return nil
 }
 
-// must be called with lock on namespaceInfo cache
+// Must be called with lock on namespaceInfo cache
 func (m *externalPolicyManager) applyPolicyToNamespace(namespaceName string, policy *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute, cacheInfo *namespaceInfo) error {
 
 	processedPolicy, err := m.processExternalRoutePolicy(policy)
@@ -70,7 +70,7 @@ func (m *externalPolicyManager) applyPolicyToNamespace(namespaceName string, pol
 	return nil
 }
 
-// must be called with lock on namespaceInfo cache
+// Must be called with lock on namespaceInfo cache
 func (m *externalPolicyManager) removePolicyFromNamespace(targetNamespace string, policy *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute, cacheInfo *namespaceInfo) error {
 	processedPolicy, err := m.processExternalRoutePolicy(policy)
 	if err != nil {
@@ -81,7 +81,7 @@ func (m *externalPolicyManager) removePolicyFromNamespace(targetNamespace string
 		return err
 	}
 
-	klog.Infof("Deleting APB policy %s in namespace cache %s", policy.Name, targetNamespace)
+	klog.V(4).InfoS("Deleting APB policy %s in namespace cache %s", policy.Name, targetNamespace)
 	cacheInfo.Policies = cacheInfo.Policies.Delete(policy.Name)
 	if len(cacheInfo.Policies) == 0 {
 		m.namespaceInfoSyncCache.Delete(targetNamespace)

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace.go
@@ -1,90 +1,62 @@
 package apbroute
 
 import (
-	"fmt"
-
 	adminpolicybasedrouteapi "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 )
 
-// processAddNamespace takes in a namespace and applies the policies that are applicable to the namespace, previously stored in the cacheInfo object argument.
-// The logic goes through all the policies and applies the gateway IPs derived from the static and dynamic hop to all the pods in the namespace.
-// Lastly, it updates the cacheInfo to contain the static and dynamic gateway IPs generated from the previous action to keep track of the gateway IPs applied in the namespace.
-func (m *externalPolicyManager) processAddNamespace(new *v1.Namespace, cacheInfo *namespaceInfo) error {
-	staticGateways, dynamicGateways, err := m.aggregateNamespaceInfo(cacheInfo.Policies)
-	if err != nil {
-		return err
-	}
-	cacheInfo.StaticGateways = staticGateways
-	cacheInfo.DynamicGateways = dynamicGateways
-	return nil
-}
+func (m *externalPolicyManager) syncNamespace(namespace *v1.Namespace, routeQueue workqueue.RateLimitingInterface) error {
+	klog.V(5).Infof("APB processing namespace: %s", namespace)
 
-// processDeleteNamespace processes a delete namespace event by ensuring that no pod is still running in that namespace before deleting the namespace info cache. It also
-// marks the namespace for deletion so that if a new pod event appears targeting the namespace, the operation will be rejected.
-func (m *externalPolicyManager) processDeleteNamespace(namespaceName string) error {
-	_, found := m.getAndMarkForDeleteNamespaceInfoFromCache(namespaceName)
-	if !found {
-		// namespace is not a recipient for policies
-		return nil
-	}
-	defer m.unlockNamespaceInfoCache(namespaceName)
-	podsInNs, err := m.podLister.Pods(namespaceName).List(labels.Everything())
-	if err != nil {
-		return err
-	}
-	if len(podsInNs) != 0 {
-		klog.Infof("Attempting to delete namespace %s with resources still attached to it. Retrying...", namespaceName)
-		return fmt.Errorf("unable to delete namespace %s with resources still attached to it", namespaceName)
-	}
-	m.deleteNamespaceInfoInCache(namespaceName)
-	return nil
-}
+	keysToBeQueued := sets.New[string]()
 
-// processUpdateNamespace takes in a namespace name, current policies applied to the namespace, policies that are now expected to be applied to the namespace and the cache info
-// that contains all the current gateway IPs and policies for that namespace. It follows this logic:
-// * Calculate the difference between current and expected policies and proceed to remove the gateway IPs from the policies that are no longer applicable to this namespace
-// * Calculate the difference between the expected and current ones to determine the new policies to be applied and proceed to apply them.
-// * Update the cache info with the new list of policies, as well as the static and dynamic gateway IPs derived from executing the previous logic.
-func (m *externalPolicyManager) processUpdateNamespace(namespaceName string, currentPolicies, newPolicies sets.Set[string], cacheInfo *namespaceInfo) error {
+	// get a copy of all policies at this time and see if they include this namespace
+	policyKeys := m.routePolicySyncCache.GetKeys()
 
-	// some differences apply, let's figure out if previous policies have been removed first
-	policiesNotValid := currentPolicies.Difference(newPolicies)
-	// iterate through the policies that no longer apply to this namespace
-	for policyName := range policiesNotValid {
-		err := m.removePolicyFromNamespaceWithName(namespaceName, policyName, cacheInfo)
+	for _, policyName := range policyKeys {
+		err := m.routePolicySyncCache.DoWithLock(policyName,
+			func(key string) error {
+				ri, found := m.routePolicySyncCache.Load(policyName)
+				if found {
+					targetNsList, err := m.listNamespacesBySelector(&ri.policy.Spec.From.NamespaceSelector)
+					if err != nil {
+						return err
+					}
+					for _, targetNS := range targetNsList {
+						if targetNS.Name == namespace.Name {
+							keysToBeQueued.Insert(policyName)
+						}
+					}
+				}
+				return nil
+			})
 		if err != nil {
 			return err
 		}
 	}
 
-	// policies that now apply to this namespace
-	newPoliciesDiff := newPolicies.Difference(currentPolicies)
-	for policyName := range newPoliciesDiff {
-		policy, found, markedForDeletion := m.getRoutePolicyFromCache(policyName)
-		if !found {
-			return fmt.Errorf("failed to find external route policy %s in cache", policyName)
+	// check if this namespace is being tracked by policy in its namespace cache
+	cacheInfo, found := m.getNamespaceInfoFromCache(namespace.Name)
+	if found {
+		for policyName := range cacheInfo.Policies {
+			keysToBeQueued.Insert(policyName)
 		}
-		if markedForDeletion {
-			klog.Infof("Skipping route policy %s as it has been marked for deletion", policyName)
-			continue
-		}
-		err := m.applyPolicyToNamespace(namespaceName, &policy, cacheInfo)
-		if err != nil {
-			return err
-		}
+		m.unlockNamespaceInfoCache(namespace.Name)
 	}
-	// at least one policy apply, let's update the cache
-	cacheInfo.Policies = newPolicies
-	return nil
 
+	for policyKey := range keysToBeQueued {
+		klog.V(5).Infof("APB queuing policy: %s for namespace: %s", policyKey, namespace)
+		routeQueue.Add(policyKey)
+	}
+
+	return nil
 }
 
+// must be called with lock on namespaceInfo cache
 func (m *externalPolicyManager) applyPolicyToNamespace(namespaceName string, policy *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute, cacheInfo *namespaceInfo) error {
 
 	processedPolicy, err := m.processExternalRoutePolicy(policy)
@@ -98,15 +70,8 @@ func (m *externalPolicyManager) applyPolicyToNamespace(namespaceName string, pol
 	return nil
 }
 
-func (m *externalPolicyManager) removePolicyFromNamespaceWithName(targetNamespace, policyName string, cacheInfo *namespaceInfo) error {
-	policy, err := m.routeLister.Get(policyName)
-	if err != nil {
-		return err
-	}
-	return m.removePolicyFromNamespace(targetNamespace, policy, cacheInfo)
-}
+// must be called with lock on namespaceInfo cache
 func (m *externalPolicyManager) removePolicyFromNamespace(targetNamespace string, policy *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute, cacheInfo *namespaceInfo) error {
-
 	processedPolicy, err := m.processExternalRoutePolicy(policy)
 	if err != nil {
 		return err
@@ -115,7 +80,13 @@ func (m *externalPolicyManager) removePolicyFromNamespace(targetNamespace string
 	if err != nil {
 		return err
 	}
+
+	klog.Infof("Deleting APB policy %s in namespace cache %s", policy.Name, targetNamespace)
 	cacheInfo.Policies = cacheInfo.Policies.Delete(policy.Name)
+	if len(cacheInfo.Policies) == 0 {
+		m.namespaceInfoSyncCache.Delete(targetNamespace)
+	}
+
 	return nil
 }
 
@@ -130,33 +101,4 @@ func (m *externalPolicyManager) listNamespacesBySelector(selector *metav1.LabelS
 	}
 	return ns, nil
 
-}
-
-func (m *externalPolicyManager) aggregateNamespaceInfo(policies sets.Set[string]) (gatewayInfoList, map[ktypes.NamespacedName]*gatewayInfo, error) {
-
-	static := gatewayInfoList{}
-	dynamic := make(map[ktypes.NamespacedName]*gatewayInfo)
-	for policyName := range policies {
-		externalPolicy, err := m.routeLister.Get(policyName)
-		if err != nil {
-			klog.Warningf("Unable to find route policy %s:%+v", policyName, err)
-			continue
-		}
-		processedPolicy, err := m.processExternalRoutePolicy(externalPolicy)
-		if err != nil {
-			return nil, nil, err
-		}
-		var duplicated sets.Set[string]
-		static, duplicated, err = static.Insert(processedPolicy.staticGateways...)
-		if err != nil {
-			return nil, nil, err
-		}
-		if duplicated.Len() > 0 {
-			klog.Warningf("Found duplicated gateway IP(s) %+s in policy(s) %+s", sets.List(duplicated), sets.List(policies))
-		}
-		for podName, gatewayInfo := range processedPolicy.dynamicGateways {
-			dynamic[podName] = gatewayInfo
-		}
-	}
-	return static, dynamic, nil
 }

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
@@ -100,7 +100,6 @@ func listNamespaceInfo() []string {
 func deepCopyNamespaceInfo(source, destination *namespaceInfo) {
 	destination.Policies = sets.New(source.Policies.UnsortedList()...)
 	destination.StaticGateways = gatewayInfoList{}
-	destination.markForDelete = source.markForDelete
 	for _, gwInfo := range source.StaticGateways {
 		destination.StaticGateways, _, err = destination.StaticGateways.Insert(&gatewayInfo{
 			Gateways: &syncSet{
@@ -311,7 +310,6 @@ var _ = Describe("OVN External Gateway namespace", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			Eventually(func() bool { return len(getNamespaceInfo(namespaceTest.Name).DynamicGateways) > 0 }, 5).Should(BeTrue())
 			deleteNamespace(namespaceTest.Name, fakeClient)
-			Eventually(func() bool { return getNamespaceInfo(namespaceTest.Name).markForDelete }, 5).Should(BeTrue())
 			deletePod(targetPod, fakeClient)
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(0))
 		})
@@ -324,26 +322,20 @@ var _ = Describe("OVN External Gateway namespace", func() {
 			}
 
 			initController([]runtime.Object{namespaceDefault, namespaceTest, targetPod, podGW}, []runtime.Object{dynamicPolicy})
-
+			createNamespace(namespaceTest2)
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			Eventually(func() bool { return len(getNamespaceInfo(namespaceTest.Name).DynamicGateways) > 0 }, 5).Should(BeTrue())
 			By("delete the namespace whilst a pod still remains")
 			deleteNamespace(namespaceTest.Name, fakeClient)
-			Eventually(func() bool { return getNamespaceInfo(namespaceTest.Name).markForDelete }, 5).Should(BeTrue())
 			By("create the namespace test again while it is being deleted")
 			createNamespace(namespaceTest)
 			By("delete the remaining pod in the namespace to proceed on deleting the namespace itself")
 			deletePod(targetPod, fakeClient)
-			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
-			// The new namespace should not be marked for deletion and should contain the same dynamic gateways
-			Eventually(func() bool {
+			Eventually(func() []string { return listNamespaceInfo() }, time.Hour).Should(HaveLen(1))
+			Eventually(func() int {
 				nsInfo := getNamespaceInfo(namespaceTest.Name)
-				if nsInfo != nil {
-					return nsInfo.markForDelete
-				}
-				return true
-			}, time.Hour).Should(BeFalse())
-			Eventually(func() bool { return len(getNamespaceInfo(namespaceTest.Name).DynamicGateways) > 0 }, time.Hour).Should(BeTrue())
+				return len(nsInfo.DynamicGateways)
+			}, 5).Should(Equal(1))
 		})
 
 	})
@@ -385,8 +377,7 @@ var _ = Describe("OVN External Gateway namespace", func() {
 						DynamicGateways: make(map[ktypes.NamespacedName]*gatewayInfo)},
 					cmpOpts...))
 			updateNamespaceLabel(namespaceTest.Name, dynamicPolicyTest2.Spec.From.NamespaceSelector.MatchLabels, fakeClient)
-			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(newNamespaceInfo()))
+			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(0))
 		})
 
 		It("validates that a namespace changes its policies when its labels are changed to match a different policy, resulting in the later on being the only policy applied to the namespace", func() {

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
@@ -30,9 +30,9 @@ func (m *externalPolicyManager) syncPod(pod *v1.Pod, podLister corev1listers.Pod
 	if pErr != nil {
 		return pErr
 	}
-	klog.Infof("Processing gateway pod %s/%s with matching policies %+v", pod.Namespace, pod.Name, policies.UnsortedList())
+	klog.V(4).InfoS("Processing gateway pod %s/%s with matching policies %+v", pod.Namespace, pod.Name, policies.UnsortedList())
 	for policyName := range policies {
-		klog.V(2).InfoS("Queueing policy %s", policyName)
+		klog.V(5).InfoS("Queueing policy %s", policyName)
 		routeQueue.Add(policyName)
 	}
 
@@ -92,13 +92,13 @@ func (m *externalPolicyManager) listPoliciesUsingPodGateway(key ktypes.Namespace
 		return nil, err
 	}
 	for _, p := range policies {
-		klog.Infof("Checking for policy %s to have pod %s", p.Name, key)
+		klog.V(5).InfoS("Checking for policy %s to have pod %s", p.Name, key)
 		pp, err := m.processExternalRoutePolicy(p)
 		if err != nil {
 			return nil, err
 		}
 		if _, found := pp.dynamicGateways[key]; found {
-			klog.Infof("Policy %s has pod %s", p.Name, key)
+			klog.V(5).InfoS("Policy %s has pod %s", p.Name, key)
 			ret = append(ret, p)
 		}
 
@@ -108,7 +108,7 @@ func (m *externalPolicyManager) listPoliciesUsingPodGateway(key ktypes.Namespace
 
 func (m *externalPolicyManager) listPoliciesInNamespacesUsingPodGateway(key ktypes.NamespacedName) (sets.Set[string], error) {
 	policies := sets.New[string]()
-	// iterate through all current namespaces that contain the pod. This is needed in case the pod is deleted from an existing namespace, in which case
+	// Iterate through all current namespaces that contain the pod. This is needed in case the pod is deleted from an existing namespace, in which case
 	// if we iterated applying the namespace selector in the policies, we would miss the fact that a pod was part of a namespace that is no longer
 	// and we'd miss updating that namespace and removing the pod through the reconciliation of the policy in that namespace.
 	nsList := m.listNamespaceInfoCache()
@@ -122,7 +122,7 @@ func (m *externalPolicyManager) listPoliciesInNamespacesUsingPodGateway(key ktyp
 		}
 		m.unlockNamespaceInfoCache(namespaceName)
 	}
-	// list all namespaces that match the policy, for those new namespaces where the pod now applies
+	// List all namespaces that match the policy, for those new namespaces where the pod now applies
 	p, err := m.listPoliciesUsingPodGateway(key)
 	if err != nil {
 		return nil, err

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
@@ -30,6 +30,15 @@ func (m *externalPolicyManager) syncPod(pod *v1.Pod, podLister corev1listers.Pod
 	if pErr != nil {
 		return pErr
 	}
+	if policies.Len() == 0 {
+		// this is not a gateway pod
+		cacheInfo, found := m.getNamespaceInfoFromCache(pod.Namespace)
+		if found {
+			// its namespace is a target for policies.
+			policies = policies.Union(cacheInfo.Policies)
+			m.unlockNamespaceInfoCache(pod.Namespace)
+		}
+	}
 	klog.V(4).InfoS("Processing gateway pod %s/%s with matching policies %+v", pod.Namespace, pod.Name, policies.UnsortedList())
 	for policyName := range policies {
 		klog.V(5).InfoS("Queueing policy %s", policyName)

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
@@ -199,36 +199,36 @@ var _ = Describe("OVN External Gateway policy", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, namespaceTest2, pod1}, []runtime.Object{dynamicPolicyTest2, dynamicPolicy})
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(2))
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
 						{Namespace: pod1.Namespace, Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
-				}))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
+				}, cmpOpts...))
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicyTest2.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
 						{Namespace: pod1.Namespace, Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
-				}))
+				}, cmpOpts...))
 			deletePod(pod1, fakeClient)
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5, 1).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5, 1).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:        sets.New(dynamicPolicy.Name),
 					StaticGateways:  gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
-				}))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
+				}, cmpOpts...))
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:        sets.New(dynamicPolicyTest2.Name),
 					StaticGateways:  gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
-				}))
+				}, cmpOpts...))
 		})
 
 		It("deletes a pod that does not match any policy", func() {
@@ -243,12 +243,12 @@ var _ = Describe("OVN External Gateway policy", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, pod1}, []runtime.Object{noMatchPolicy})
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:        sets.New(noMatchPolicy.Name),
 					StaticGateways:  gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
-				}))
+				}, cmpOpts...))
 			deletePod(pod1, fakeClient)
 			Eventually(func() bool {
 				_, err := fakeClient.CoreV1().Pods(pod1.Namespace).Get(context.Background(), pod1.Name, v1.GetOptions{})
@@ -256,12 +256,12 @@ var _ = Describe("OVN External Gateway policy", func() {
 			}).Should(BeTrue())
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:        sets.New(noMatchPolicy.Name),
 					StaticGateways:  gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
-				}))
+				}, cmpOpts...))
 		})
 
 		It("deletes a pod gateway that is one of two pods that matches two policies to the same target namespace", func() {
@@ -270,14 +270,14 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			deletePod(pod1, fakeClient)
 
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(overlappingPolicy.Name, dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
+						{Namespace: pod2.Namespace, Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
-				}))
+				}, cmpOpts...))
 		})
 	})
 
@@ -287,21 +287,21 @@ var _ = Describe("OVN External Gateway policy", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, unmatchPod}, []runtime.Object{dynamicPolicy})
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:        sets.New(dynamicPolicy.Name),
 					StaticGateways:  gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
-				}))
+				}, cmpOpts...))
 			updatePodLabels(unmatchPod, pod1.Labels, fakeClient)
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: unmatchPod.Name}: newGatewayInfo(sets.New(unmatchPod.Status.PodIPs[0].IP), false),
+						{Namespace: unmatchPod.Namespace, Name: unmatchPod.Name}: newGatewayInfo(sets.New(unmatchPod.Status.PodIPs[0].IP), false),
 					},
-				}))
+				}, cmpOpts...))
 		})
 
 		It("updates an existing pod gateway to match a new policy that targets the same namespace", func() {
@@ -309,37 +309,37 @@ var _ = Describe("OVN External Gateway policy", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, pod2}, []runtime.Object{overlappingPolicy, dynamicPolicy})
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(2))
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name, overlappingPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
+						{Namespace: pod2.Namespace, Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
-				}))
+				}, cmpOpts...))
 			updatePodLabels(pod2, map[string]string{"duplicated": "true"}, fakeClient)
-			// wait for 2 second to ensure that the pod changed have been reconciled. We are doing this because the outcome of the change should not impact the list of dynamic IPs and
+			// Wait for 2 second to ensure that the pod changed have been reconciled. We are doing this because the outcome of the change should not impact the list of dynamic IPs and
 			// there is no way to know which of the policies apply specifically to the pod.
 			Eventually(func() bool {
 				p, err := fakeClient.CoreV1().Pods(pod2.Namespace).Get(context.TODO(), pod2.Name, v1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				return reflect.DeepEqual(p.Labels, map[string]string{"duplicated": "true"})
 			}, 2, 2).Should(BeTrue())
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name, overlappingPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
+						{Namespace: pod2.Namespace, Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
-				}))
+				}, cmpOpts...))
 		})
 
 		It("updates an existing pod gateway to match a new policy that targets a different namespace", func() {
 
 			initController([]runtime.Object{namespaceDefault, namespaceTest, namespaceTest2, pod2, pod3}, []runtime.Object{dynamicPolicyForTest2Only, dynamicPolicy})
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
@@ -347,36 +347,36 @@ var _ = Describe("OVN External Gateway policy", func() {
 						{Namespace: pod2.Namespace, Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 						{Namespace: pod3.Namespace, Name: pod3.Name}: newGatewayInfo(sets.New(pod3.Status.PodIPs[0].IP), false),
 					},
-				}))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
+				}, cmpOpts...))
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:        sets.New(dynamicPolicyForTest2Only.Name),
 					StaticGateways:  gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
-				}))
+				}, cmpOpts...))
 			updatePodLabels(pod2, map[string]string{"duplicated": "true"}, fakeClient)
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
 						{Namespace: pod3.Namespace, Name: pod3.Name}: newGatewayInfo(sets.New(pod3.Status.PodIPs[0].IP), false),
 					},
-				}))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
+				}, cmpOpts...))
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicyForTest2Only.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
 						{Namespace: pod2.Namespace, Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
-				}))
+				}, cmpOpts...))
 		})
 		It("updates an existing pod gateway to match no policies", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, pod1, pod2}, []runtime.Object{dynamicPolicy})
 			Eventually(func() []string { return listRoutePolicyInCache() }, time.Minute).Should(HaveLen(1))
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
@@ -384,52 +384,52 @@ var _ = Describe("OVN External Gateway policy", func() {
 						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
-				}))
+				}, cmpOpts...))
 			updatePodLabels(pod1, map[string]string{}, fakeClient)
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
 						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
-				}))
+				}, cmpOpts...))
 		})
 
 		It("updates a pod to match a policy to a single namespace", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, namespaceTest2, pod1}, []runtime.Object{dynamicPolicyForTest2Only, dynamicPolicy})
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
+						{Namespace: pod1.Namespace, Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
-				}))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
+				}, cmpOpts...))
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicyForTest2Only.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
+						{Namespace: pod1.Namespace, Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
-				}))
+				}, cmpOpts...))
 			updatePodLabels(pod1, map[string]string{"key": "pod"}, fakeClient)
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
 						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
-				}))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
+				}, cmpOpts...))
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies:        sets.New(dynamicPolicyForTest2Only.Name),
 					StaticGateways:  gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{},
-				}))
+				}, cmpOpts...))
 		})
 
 	})

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod_test.go
@@ -204,7 +204,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
+						{Namespace: pod1.Namespace, Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
 				}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
@@ -212,12 +212,12 @@ var _ = Describe("OVN External Gateway policy", func() {
 					Policies:       sets.New(dynamicPolicyTest2.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
+						{Namespace: pod1.Namespace, Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					},
 				}))
 			deletePod(pod1, fakeClient)
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5, 1).Should(Equal(
 				&namespaceInfo{
 					Policies:        sets.New(dynamicPolicy.Name),
 					StaticGateways:  gatewayInfoList{},
@@ -344,8 +344,8 @@ var _ = Describe("OVN External Gateway policy", func() {
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
-						{Namespace: "default", Name: pod3.Name}: newGatewayInfo(sets.New(pod3.Status.PodIPs[0].IP), false),
+						{Namespace: pod2.Namespace, Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
+						{Namespace: pod3.Namespace, Name: pod3.Name}: newGatewayInfo(sets.New(pod3.Status.PodIPs[0].IP), false),
 					},
 				}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
@@ -360,7 +360,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod3.Name}: newGatewayInfo(sets.New(pod3.Status.PodIPs[0].IP), false),
+						{Namespace: pod3.Namespace, Name: pod3.Name}: newGatewayInfo(sets.New(pod3.Status.PodIPs[0].IP), false),
 					},
 				}))
 			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest2.Name) }, 5).Should(Equal(
@@ -368,7 +368,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 					Policies:       sets.New(dynamicPolicyForTest2Only.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
+						{Namespace: pod2.Namespace, Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					},
 				}))
 		})
@@ -386,7 +386,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 					},
 				}))
 			updatePodLabels(pod1, map[string]string{}, fakeClient)
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5, 1).Should(Equal(
+			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(
 				&namespaceInfo{
 					Policies:       sets.New(dynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -2,12 +2,12 @@ package apbroute
 
 import (
 	"context"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -349,7 +349,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(2))
 			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			deletePolicy(staticPolicy.Name, fakeRouteClient)
-			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
+			Eventually(func() []string { return listRoutePolicyInCache() }, 5, 1).Should(HaveLen(1))
 
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest.Name)
@@ -375,15 +375,15 @@ var _ = Describe("OVN External Gateway policy", func() {
 		It("validates that an overlapping IP from another policy will not be deleted when one of the overlaping policies is deleted", func() {
 
 			initController([]runtime.Object{namespaceTest, namespaceDefault, pod1}, []runtime.Object{staticPolicy, duplicatedStatic, dynamicPolicy, duplicatedDynamic})
+			Eventually(func() []string { return listRoutePolicyInCache() }, 5, 1).Should(HaveLen(4))
 
-			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(4))
 			deletePolicy(staticPolicy.Name, fakeRouteClient)
 			deletePolicy(dynamicPolicy.Name, fakeRouteClient)
-			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(2))
+			Eventually(func() []string { return listRoutePolicyInCache() }, 5, 1).Should(HaveLen(2))
 
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest.Name)
-			}, 5).Should(BeComparableTo(
+			}, 5, 1).Should(BeComparableTo(
 				&namespaceInfo{
 					Policies: sets.New(duplicatedStatic.Name, duplicatedDynamic.Name),
 					StaticGateways: gatewayInfoList{
@@ -419,6 +419,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 			p.Spec.From.NamespaceSelector = v1.LabelSelector{MatchLabels: namespaceTest2.Labels}
 			p.Generation++
 			lastUpdate := p.Status.LastTransitionTime
+			klog.Info("TROZET BEFORE UPDATE")
 			_, err = fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Update(context.Background(), p, v1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() v1.Time {
@@ -426,9 +427,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 				Expect(err).NotTo(HaveOccurred())
 				return p.Status.LastTransitionTime
 			}).Should(Not(Equal(lastUpdate)))
-			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(2))
-			Eventually(func() *namespaceInfo { return getNamespaceInfo(namespaceTest.Name) }, 5).Should(Equal(newNamespaceInfo()))
-
+			Eventually(func() []string { return listNamespaceInfo() }, 5).Should(HaveLen(1))
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest2.Name)
 			}, 5).Should(BeComparableTo(expected, cmpOpts...))
@@ -509,7 +508,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 					Policies:       sets.New(singlePodDynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
+						{Namespace: pod1.Namespace, Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
 					}},
 				cmpOpts...))
 
@@ -533,7 +532,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 					Policies:       sets.New(singlePodDynamicPolicy.Name),
 					StaticGateways: gatewayInfoList{},
 					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
-						{Namespace: "default", Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
+						{Namespace: pod2.Namespace, Name: pod2.Name}: newGatewayInfo(sets.New(pod2.Status.PodIPs[0].IP), false),
 					}},
 				cmpOpts...))
 
@@ -663,6 +662,89 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest.Name)
 			}, 5).Should(BeComparableTo(expected, cmpOpts...))
+		})
+
+		It("validates that changing the BFD setting in a static hop will trigger an update", func() {
+			initController([]runtime.Object{namespaceDefault, namespaceTest}, []runtime.Object{staticPolicy})
+			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
+			Eventually(listNamespaceInfo(), 5).Should(HaveLen(1))
+
+			Eventually(func() *namespaceInfo {
+				return getNamespaceInfo(namespaceTest.Name)
+			}, 5).Should(BeComparableTo(
+				&namespaceInfo{
+					Policies: sets.New(staticPolicy.Name),
+					StaticGateways: gatewayInfoList{
+						newGatewayInfo(sets.New(staticHopGWIP), false),
+					},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{}},
+				cmpOpts...))
+
+			By("set BDF to true in the static hop")
+			p, err := fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.Background(), staticPolicy.Name, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			p.Spec.NextHops.StaticHops[0].BFDEnabled = true
+			p.Generation++
+			lastUpdate := p.Status.LastTransitionTime
+			_, err = fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Update(context.Background(), p, v1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() v1.Time {
+				p, err = fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.TODO(), staticPolicy.Name, v1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return p.Status.LastTransitionTime
+			}).Should(Not(Equal(lastUpdate)))
+
+			Eventually(func() *namespaceInfo {
+				return getNamespaceInfo(namespaceTest.Name)
+			}, 5).Should(BeComparableTo(
+				&namespaceInfo{
+					Policies: sets.New(staticPolicy.Name),
+					StaticGateways: gatewayInfoList{
+						newGatewayInfo(sets.New(staticHopGWIP), true),
+					},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{}},
+				cmpOpts...))
+
+		})
+
+		It("validates that changing the BFD setting in a dynamic hop will trigger an update", func() {
+			initController([]runtime.Object{namespaceDefault, namespaceTest, pod1}, []runtime.Object{dynamicPolicy})
+			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
+			Eventually(listNamespaceInfo(), 5).Should(HaveLen(1))
+			Eventually(func() *namespaceInfo {
+				return getNamespaceInfo(namespaceTest.Name)
+			}, 5).Should(BeComparableTo(
+				&namespaceInfo{
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: pod1.Namespace, Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), false),
+					}},
+				cmpOpts...))
+			By("set BDF to true in the dynamic hop")
+			p, err := fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.Background(), dynamicPolicy.Name, v1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			p.Spec.NextHops.DynamicHops[0].BFDEnabled = true
+			p.Generation++
+			lastUpdate := p.Status.LastTransitionTime
+			_, err = fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Update(context.Background(), p, v1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() v1.Time {
+				p, err = fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.TODO(), dynamicPolicy.Name, v1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return p.Status.LastTransitionTime
+			}).Should(Not(Equal(lastUpdate)))
+			Eventually(func() *namespaceInfo {
+				return getNamespaceInfo(namespaceTest.Name)
+			}, 5).Should(BeComparableTo(
+				&namespaceInfo{
+					Policies:       sets.New(dynamicPolicy.Name),
+					StaticGateways: gatewayInfoList{},
+					DynamicGateways: map[types.NamespacedName]*gatewayInfo{
+						{Namespace: pod1.Namespace, Name: pod1.Name}: newGatewayInfo(sets.New(pod1.Status.PodIPs[0].IP), true),
+					}},
+				cmpOpts...))
+
 		})
 	})
 })

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -2,6 +2,7 @@ package apbroute
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -206,9 +207,9 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Eventually(func(g Gomega) {
 				p, found, _ := externalController.mgr.getRoutePolicyFromCache(multipleMatchPolicy.Name)
 				g.Expect(found).To(BeTrue())
-				g.Expect(p.Spec).To(BeEquivalentTo(multipleMatchPolicy.Spec))
+				g.Expect(p.Spec).To(BeComparableTo(multipleMatchPolicy.Spec, cmpOpts...))
 			}, 5).Should(Succeed())
-			Eventually(listNamespaceInfo(), 5).Should(HaveLen(3))
+			Eventually(listNamespaceInfo, 5).Should(HaveLen(3))
 			expected := &namespaceInfo{
 				Policies:       sets.New(multipleMatchPolicy.Name),
 				StaticGateways: gatewayInfoList{newGatewayInfo(sets.New(staticHopGWIP), false)},
@@ -230,7 +231,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 			initController([]runtime.Object{namespaceTest2, namespaceDefault, pod1}, []runtime.Object{dynamicPolicy})
 
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
-			Eventually(listNamespaceInfo(), 5).Should(HaveLen(0))
+			Eventually(listNamespaceInfo, 5).Should(HaveLen(0))
 		})
 
 		It("registers a new policy with multiple dynamic and static GWs and bfd enabled on all gateways", func() {
@@ -245,7 +246,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, pod1, pod2, pod3, pod4, pod5, pod6}, []runtime.Object{staticMultiIPPolicy})
 
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
-			Eventually(listNamespaceInfo(), 5).Should(HaveLen(1))
+			Eventually(listNamespaceInfo, 5).Should(HaveLen(1))
 
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest.Name)
@@ -275,7 +276,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, pod1}, []runtime.Object{staticPolicy, dynamicPolicy})
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).
 				Should(HaveLen(2))
-			Eventually(listNamespaceInfo(), 5).Should(HaveLen(1))
+			Eventually(listNamespaceInfo, 5).Should(HaveLen(1))
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest.Name)
 			}, 5).Should(BeComparableTo(
@@ -307,7 +308,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).
 				Should(HaveLen(4))
-			Eventually(listNamespaceInfo(), 5).Should(HaveLen(1))
+			Eventually(listNamespaceInfo, 5).Should(HaveLen(1))
 
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest.Name)
@@ -548,7 +549,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest}, []runtime.Object{staticMultiIPPolicy})
 
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
-			Eventually(listNamespaceInfo(), 5).Should(HaveLen(1))
+			Eventually(listNamespaceInfo, 5).Should(HaveLen(1))
 
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest.Name)
@@ -615,7 +616,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, pod1, pod2, pod3, pod4, pod5, pod6}, []runtime.Object{staticMultiIPPolicy, staticPolicy})
 
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(2))
-			Eventually(listNamespaceInfo(), 5).Should(HaveLen(1))
+			Eventually(listNamespaceInfo, 5).Should(HaveLen(1))
 			expected := &namespaceInfo{
 				Policies: sets.New(staticMultiIPPolicy.Name, staticPolicy.Name),
 				StaticGateways: gatewayInfoList{
@@ -652,7 +653,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() v1.Time {
-				// retrieve the CR and ensure the last update timestamp is different before comparing it against the slice.
+				// Retrieve the CR and ensure the last update timestamp is different before comparing it against the slice.
 				p, err = fakeRouteClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.TODO(), staticMultiIPPolicy.Name, v1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				return p.Status.LastTransitionTime
@@ -667,7 +668,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 		It("validates that changing the BFD setting in a static hop will trigger an update", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest}, []runtime.Object{staticPolicy})
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
-			Eventually(listNamespaceInfo(), 5).Should(HaveLen(1))
+			Eventually(listNamespaceInfo, 5).Should(HaveLen(1))
 
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest.Name)
@@ -710,7 +711,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 		It("validates that changing the BFD setting in a dynamic hop will trigger an update", func() {
 			initController([]runtime.Object{namespaceDefault, namespaceTest, pod1}, []runtime.Object{dynamicPolicy})
 			Eventually(func() []string { return listRoutePolicyInCache() }, 5).Should(HaveLen(1))
-			Eventually(listNamespaceInfo(), 5).Should(HaveLen(1))
+			Eventually(listNamespaceInfo, 5).Should(HaveLen(1))
 			Eventually(func() *namespaceInfo {
 				return getNamespaceInfo(namespaceTest.Name)
 			}, 5).Should(BeComparableTo(

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_test.go
@@ -14,7 +14,6 @@ var (
 	// Default comparable options to bypass comparing the mux object and define a less function to sort the slices.
 	cmpOpts = []cmp.Option{
 		cmpopts.IgnoreFields(syncSet{}, "mux"),
-		cmpopts.IgnoreFields(namespaceInfo{}, "markForDelete"),
 		cmpopts.SortSlices(func(x, y interface{}) bool {
 			s1, ok1 := x.(*gatewayInfo)
 			s2, ok2 := y.(*gatewayInfo)

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -256,7 +256,7 @@ func (c *ExternalGatewayMasterController) processNextPolicyWorkItem(wg *sync.Wai
 	err = c.updateStatusAPBExternalRoute(policy, err)
 	if err != nil {
 		if c.routeQueue.NumRequeues(key) < maxRetries {
-			klog.V(4).InfoS("Error found while processing policy: %w", err)
+			klog.V(4).InfoS("Error found while processing policy %s: %w", key, err)
 			c.routeQueue.AddRateLimited(key)
 			return true
 		}

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -202,7 +202,6 @@ func (c *ExternalGatewayMasterController) Run(threadiness int) {
 	klog.Infof("Repairing Admin Policy Based External Route Services")
 	c.repair()
 
-	startWg := &sync.WaitGroup{}
 	wg := &sync.WaitGroup{}
 	for i := 0; i < threadiness; i++ {
 		for _, workerFn := range []func(*sync.WaitGroup){
@@ -213,10 +212,8 @@ func (c *ExternalGatewayMasterController) Run(threadiness int) {
 			// detects namespace changes and applies polices that match the namespace selector in the `From` policy field
 			c.runNamespaceWorker,
 		} {
-			startWg.Add(1)
 			wg.Add(1)
 			go func(fn func(*sync.WaitGroup)) {
-				startWg.Done()
 				defer wg.Done()
 				wait.Until(func() {
 					fn(wg)
@@ -224,7 +221,6 @@ func (c *ExternalGatewayMasterController) Run(threadiness int) {
 			}(workerFn)
 		}
 	}
-	startWg.Wait()
 
 	// wait until we're told to stop
 	<-c.stopCh
@@ -245,87 +241,47 @@ func (c *ExternalGatewayMasterController) processNextPolicyWorkItem(wg *sync.Wai
 	wg.Add(1)
 	defer wg.Done()
 
-	obj, shutdown := c.routeQueue.Get()
+	key, shutdown := c.routeQueue.Get()
 
 	if shutdown {
 		return false
 	}
 
-	defer c.routeQueue.Done(obj)
+	defer c.routeQueue.Done(key)
 
-	item := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
-	klog.Infof("Processing policy %s", item.Name)
-	err := c.syncRoutePolicy(item)
+	klog.Infof("Processing policy %s", key)
+	policy, err := c.mgr.syncRoutePolicy(key.(string), c.routeQueue)
 	if err != nil {
-		if c.routeQueue.NumRequeues(item) < maxRetries {
+		klog.Errorf("Failed to sync APB policy %s: %v", key, err)
+	}
+	// capture the error from processing the sync in the statuses message field
+	err = c.updateStatusAPBExternalRoute(policy, err)
+	if err != nil {
+		if c.routeQueue.NumRequeues(key) < maxRetries {
 			klog.V(2).InfoS("Error found while processing policy: %w", err)
-			c.routeQueue.AddRateLimited(item)
+			c.routeQueue.AddRateLimited(key)
 			return true
 		}
-		klog.Warningf("Dropping policy %q out of the queue: %w", item.Name, err)
+		klog.Warningf("Dropping policy %q out of the queue: %w", key, err)
 		utilruntime.HandleError(err)
 	}
-	c.routeQueue.Forget(obj)
+	c.routeQueue.Forget(key)
 	return true
 }
 
-func (c *ExternalGatewayMasterController) syncRoutePolicy(routePolicy *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute) error {
-	_, err := c.routeLister.Get(routePolicy.Name)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	if apierrors.IsNotFound(err) {
-		// DELETE use case
-		klog.Infof("Deleting policy %s", routePolicy.Name)
-		err = c.mgr.processDeletePolicy(routePolicy.Name)
-		if err != nil {
-			return fmt.Errorf("failed to delete Admin Policy Based External Route %s:%w", routePolicy.Name, err)
-		}
-		klog.Infof("Policy %s deleted", routePolicy.Name)
-		return nil
-	}
-	currentPolicy, found, markedForDeletion := c.mgr.getRoutePolicyFromCache(routePolicy.Name)
-	if markedForDeletion {
-		klog.Warningf("Attempting to add or update route policy %s when it has been marked for deletion. Skipping...", routePolicy.Name)
-		return nil
-	}
-	if !found {
-		// ADD use case
-		klog.Infof("Adding policy %s", routePolicy.Name)
-		pp, err := c.mgr.processAddPolicy(routePolicy)
-		newErr := c.updateStatusAPBExternalRoute(routePolicy.Name, pp, err)
-		if err != nil {
-			return fmt.Errorf("failed to create Admin Policy Based External Route %s:%w", routePolicy.Name, err)
-		}
-		if newErr != nil {
-			return fmt.Errorf("failed to update status in Admin Policy Based External Route %s:%w", routePolicy.Name, newErr)
-		}
-		return nil
-	}
-	// UPDATE use case
-	klog.Infof("Updating policy %s", routePolicy.Name)
-	pp, err := c.mgr.processUpdatePolicy(&currentPolicy, routePolicy)
-	newErr := c.updateStatusAPBExternalRoute(routePolicy.Name, pp, err)
-	if err != nil {
-		return fmt.Errorf("failed to update Admin Policy Based External Route %s:%w", routePolicy.Name, err)
-	}
-	if newErr != nil {
-		return fmt.Errorf("failed to update status in Admin Policy Based External Route %s:%w", routePolicy.Name, newErr)
-	}
-	return nil
-}
-
 func (c *ExternalGatewayMasterController) onPolicyAdd(obj interface{}) {
-	policy, ok := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	_, ok := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{}, obj))
 		return
 	}
-	if policy == nil {
-		utilruntime.HandleError(errors.New("invalid Admin Policy Based External Route provided to onPolicyAdd()"))
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
 		return
 	}
-	c.routeQueue.Add(policy)
+	klog.V(4).Infof("Adding policy %s", key)
+	c.routeQueue.Add(key)
 }
 
 func (c *ExternalGatewayMasterController) onPolicyUpdate(oldObj, newObj interface{}) {
@@ -348,26 +304,33 @@ func (c *ExternalGatewayMasterController) onPolicyUpdate(oldObj, newObj interfac
 		return
 	}
 
-	c.routeQueue.Add(newObj)
+	key, err := cache.MetaNamespaceKeyFunc(newObj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", newObj, err))
+	}
+	c.routeQueue.Add(key)
 }
 
 func (c *ExternalGatewayMasterController) onPolicyDelete(obj interface{}) {
-	policy, ok := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	_, ok := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("couldn't get object from tomstone %#v", obj))
 			return
 		}
-		policy, ok = tombstone.Obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+		_, ok = tombstone.Obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an Admin Policy Based External Route %#v", tombstone.Obj))
 			return
 		}
 	}
-	if policy != nil {
-		c.routeQueue.Add(policy)
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		return
 	}
+	c.routeQueue.Add(key)
 }
 
 func (c *ExternalGatewayMasterController) onNamespaceAdd(obj interface{}) {
@@ -441,7 +404,7 @@ func (c *ExternalGatewayMasterController) processNextNamespaceWorkItem(wg *sync.
 
 	defer c.namespaceQueue.Done(obj)
 
-	err := c.syncNamespace(obj.(*v1.Namespace))
+	err := c.mgr.syncNamespace(obj.(*v1.Namespace), c.routeQueue)
 	if err != nil {
 		if c.namespaceQueue.NumRequeues(obj) < maxRetries {
 			klog.V(2).InfoS("Error found while processing namespace %s:%w", obj.(*v1.Namespace), err)
@@ -453,53 +416,6 @@ func (c *ExternalGatewayMasterController) processNextNamespaceWorkItem(wg *sync.
 	}
 	c.namespaceQueue.Forget(obj)
 	return true
-}
-
-func (c *ExternalGatewayMasterController) syncNamespace(namespace *v1.Namespace) error {
-	_, err := c.namespaceLister.Get(namespace.Name)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	if apierrors.IsNotFound(err) || !namespace.DeletionTimestamp.IsZero() {
-		// DELETE use case
-		klog.Infof("Deleting namespace reference %s", namespace.Name)
-		return c.mgr.processDeleteNamespace(namespace.Name)
-	}
-	matches, err := c.mgr.getPoliciesForNamespace(namespace.Name)
-	if err != nil {
-		return err
-	}
-	cacheInfo, found := c.mgr.getNamespaceInfoFromCache(namespace.Name)
-	if !found && len(matches) == 0 {
-		// it's not a namespace being cached already and it is not a target for policies, nothing to do
-		return nil
-	}
-
-	defer c.mgr.unlockNamespaceInfoCache(namespace.Name)
-	if found && cacheInfo.markForDelete {
-		// namespace exists and has been marked for deletion, this means there should be an event to complete deleting the namespace.
-		// wait for the namespace to be deleted before recreating it in the cache.
-		return fmt.Errorf("cannot add namespace %s because it is currently being deleted", namespace.Name)
-	}
-
-	if !found {
-		// ADD use case
-		// new namespace or namespace updated its labels and now match a routing policy
-		cacheInfo = c.mgr.newNamespaceInfoInCache(namespace.Name)
-		cacheInfo.Policies = matches
-		return c.mgr.processAddNamespace(namespace, cacheInfo)
-	}
-
-	if !cacheInfo.Policies.Equal(matches) {
-		// UPDATE use case
-		// policies differ, need to reconcile them
-		err = c.mgr.processUpdateNamespace(namespace.Name, cacheInfo.Policies, matches, cacheInfo)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-	return nil
 }
 
 func (c *ExternalGatewayMasterController) onPodAdd(obj interface{}) {
@@ -580,7 +496,7 @@ func (c *ExternalGatewayMasterController) processNextPodWorkItem(wg *sync.WaitGr
 	defer c.podQueue.Done(obj)
 
 	p := obj.(*v1.Pod)
-	err := c.syncPod(p)
+	err := c.mgr.syncPod(p, c.podLister, c.routeQueue)
 	if err != nil {
 		if c.podQueue.NumRequeues(obj) < maxRetries {
 			klog.V(2).InfoS("Error found while processing pod %s/%s:%w", p.Namespace, p.Name, err)
@@ -595,37 +511,15 @@ func (c *ExternalGatewayMasterController) processNextPodWorkItem(wg *sync.WaitGr
 	return true
 }
 
-func (c *ExternalGatewayMasterController) syncPod(pod *v1.Pod) error {
-
-	_, err := c.podLister.Pods(pod.Namespace).Get(pod.Name)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
+// updateStatusAPBExternalRoute updates the CR with the current status of the CR instance, including errors captured while processing the CR during its lifetime
+func (c *ExternalGatewayMasterController) updateStatusAPBExternalRoute(externalRoutePolicy *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute, processedError error) error {
+	if externalRoutePolicy == nil {
+		// policy doesnt exist anymore, nothing to do
+		return nil
 	}
-	namespaces := c.mgr.filterNamespacesUsingPodGateway(ktypes.NamespacedName{Namespace: pod.Namespace, Name: pod.Name})
-	klog.Infof("Processing pod %s/%s", pod.Namespace, pod.Name)
-	if apierrors.IsNotFound(err) || !pod.DeletionTimestamp.IsZero() {
-		// DELETE case
-		if namespaces.Len() == 0 {
-			// nothing to do, this pod is not a gateway pod
-			return nil
-		}
-		klog.Infof("Deleting pod gateway %s/%s", pod.Namespace, pod.Name)
-		return c.mgr.processDeletePod(pod, namespaces)
-	}
-	if namespaces.Len() == 0 {
-		// ADD case: new pod or existing pod that is not a gateway pod and could now be one.
-		klog.Infof("Adding pod %s/%s", pod.Namespace, pod.Name)
-		return c.mgr.processAddPod(pod)
-	}
-	// UPDATE case
-	klog.Infof("Updating pod gateway %s/%s", pod.Namespace, pod.Name)
-	return c.mgr.processUpdatePod(pod, namespaces)
-}
 
-func (c *ExternalGatewayMasterController) updateStatusAPBExternalRoute(routeName string, processedPolicy *routePolicy, processedError error) error {
-
-	routePolicy, err := c.apbRoutePolicyClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.TODO(), routeName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
+	processedPolicy, err := c.mgr.processExternalRoutePolicy(externalRoutePolicy)
+	if err != nil {
 		return err
 	}
 
@@ -638,12 +532,20 @@ func (c *ExternalGatewayMasterController) updateStatusAPBExternalRoute(routeName
 			gwIPs = gwIPs.Insert(dynamic.Gateways.UnsortedList()...)
 		}
 	}
+	// retrieve the policy for update
+	routePolicy, err := c.apbRoutePolicyClient.K8sV1().AdminPolicyBasedExternalRoutes().Get(context.TODO(), externalRoutePolicy.Name, metav1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return processedError
+	}
+	if err != nil {
+		return err
+	}
 	updateStatus(routePolicy, strings.Join(sets.List(gwIPs), ","), processedError)
 	_, err = c.apbRoutePolicyClient.K8sV1().AdminPolicyBasedExternalRoutes().UpdateStatus(context.TODO(), routePolicy, metav1.UpdateOptions{})
 	if !apierrors.IsNotFound(err) {
 		return err
 	}
-	return nil
+	return processedError
 }
 
 func (c *ExternalGatewayMasterController) GetDynamicGatewayIPsForTargetNamespace(namespaceName string) (sets.Set[string], error) {
@@ -663,5 +565,5 @@ func updateStatus(route *adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute,
 	route.Status.LastTransitionTime = metav1.Time{Time: time.Now()}
 	route.Status.Status = adminpolicybasedrouteapi.SuccessStatus
 	route.Status.Messages = append(route.Status.Messages, fmt.Sprintf("Configured external gateway IPs: %s", gwIPs))
-	klog.Infof("Updating Admin Policy Based External Route %s with Status: %s, Message: %s", route.Name, route.Status.Status, route.Status.Messages[len(route.Status.Messages)-1])
+	// klog.Infof("Updating Admin Policy Based External Route %s with Status: %s, Message: %s", route.Name, route.Status.Status, route.Status.Messages[len(route.Status.Messages)-1])
 }

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -256,7 +256,7 @@ func (nb *northBoundClient) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddr
 	routesAdded := 0
 	portPrefix, err := nb.extSwitchPrefix(node)
 	if err != nil {
-		klog.Infof("Failed to find ext switch prefix for %s %v", node, err)
+		klog.Warningf("Failed to find ext switch prefix for %s %v", node, err)
 		return err
 	}
 
@@ -442,7 +442,7 @@ func (nb *northBoundClient) updateExternalGWInfoCacheForPodIPWithGatewayIP(podIP
 
 	portPrefix, err := nb.extSwitchPrefix(nodeName)
 	if err != nil {
-		klog.Infof("Failed to find ext switch prefix for %s %v", nodeName, err)
+		klog.Warningf("Failed to find ext switch prefix for %s %v", nodeName, err)
 		return err
 	}
 	if bfdEnabled {
@@ -727,7 +727,7 @@ func (c *conntrackClient) deleteGatewayIPs(namespaceName string, _, toBeKept set
 	var wg sync.WaitGroup
 	wg.Add(len(toBeKept))
 	validMACs := sync.Map{}
-	klog.Infof("Keeping conntrack entries in namespace %s with gateway IPs %s", namespaceName, strings.Join(sets.List(toBeKept), ","))
+	klog.V(4).InfoS("Keeping conntrack entries in namespace %s with gateway IPs %s", namespaceName, strings.Join(sets.List(toBeKept), ","))
 	for gwIP := range toBeKept {
 		go func(gwIP string) {
 			defer wg.Done()

--- a/go-controller/pkg/ovn/controller/apbroute/node_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/node_controller.go
@@ -134,25 +134,25 @@ func NewExternalNodeController(
 
 func (c *ExternalGatewayNodeController) Run(threadiness int) {
 	defer utilruntime.HandleCrash()
-	klog.Infof("Starting Admin Policy Based Route Node Controller")
+	klog.V(4).InfoS("Starting Admin Policy Based Route Node Controller")
 
 	c.routePolicyInformer.Start(c.stopCh)
 
 	if !cache.WaitForNamedCacheSync("apbexternalroutenamespaces", c.stopCh, c.namespaceSynced) {
 		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
-		klog.Infof("Synchronization failed")
+		klog.V(4).InfoS("Synchronization failed")
 		return
 	}
 
 	if !cache.WaitForNamedCacheSync("apbexternalroutepods", c.stopCh, c.podSynced) {
 		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
-		klog.Infof("Synchronization failed")
+		klog.V(4).InfoS("Synchronization failed")
 		return
 	}
 
 	if !cache.WaitForNamedCacheSync("adminpolicybasedexternalroutes", c.stopCh, c.routeSynced) {
 		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
-		klog.Infof("Synchronization failed")
+		klog.V(4).InfoS("Synchronization failed")
 		return
 	}
 
@@ -271,11 +271,11 @@ func (c *ExternalGatewayNodeController) processNextPolicyWorkItem(wg *sync.WaitG
 	defer c.routeQueue.Done(key)
 
 	item := key.(string)
-	klog.Infof("Processing policy %s", key)
+	klog.V(4).InfoS("Processing policy %s", key)
 	_, err := c.mgr.syncRoutePolicy(key.(string), c.routeQueue)
 	if err != nil {
 		if c.routeQueue.NumRequeues(item) < maxRetries {
-			klog.V(2).InfoS("Error found while processing policy: %s, error: %v", key, err.Error())
+			klog.V(4).InfoS("Error found while processing policy: %s, error: %v", key, err.Error())
 			c.routeQueue.AddRateLimited(item)
 			return true
 		}
@@ -360,7 +360,7 @@ func (c *ExternalGatewayNodeController) processNextNamespaceWorkItem(wg *sync.Wa
 	err := c.mgr.syncNamespace(obj.(*v1.Namespace), c.routeQueue)
 	if err != nil {
 		if c.namespaceQueue.NumRequeues(obj) < maxRetries {
-			klog.V(2).InfoS("Error found while processing namespace %s:%w", obj.(*v1.Namespace), err)
+			klog.V(4).InfoS("Error found while processing namespace %s:%w", obj.(*v1.Namespace), err)
 			c.namespaceQueue.AddRateLimited(obj)
 			return true
 		}
@@ -451,7 +451,7 @@ func (c *ExternalGatewayNodeController) processNextPodWorkItem(wg *sync.WaitGrou
 	err := c.mgr.syncPod(p, c.podLister, c.routeQueue)
 	if err != nil {
 		if c.podQueue.NumRequeues(obj) < maxRetries {
-			klog.V(2).InfoS("Error found while processing pod %s/%s:%w", p.Namespace, p.Name, err)
+			klog.V(4).InfoS("Error found while processing pod %s/%s:%w", p.Namespace, p.Name, err)
 			c.podQueue.AddRateLimited(obj)
 			return true
 		}

--- a/go-controller/pkg/ovn/controller/apbroute/repair.go
+++ b/go-controller/pkg/ovn/controller/apbroute/repair.go
@@ -27,7 +27,7 @@ type managedGWIPs struct {
 func (c *ExternalGatewayMasterController) repair() {
 	start := time.Now()
 	defer func() {
-		klog.Infof("Syncing exgw routes took %v", time.Since(start))
+		klog.V(4).InfoS("Syncing exgw routes took %v", time.Since(start))
 	}()
 
 	// migration from LGW to SGW mode
@@ -109,19 +109,18 @@ func (c *ExternalGatewayMasterController) repair() {
 		}
 	}
 
-	klog.Infof("OVN ECMP route cache is: %+v", ovnRouteCache)
-	klog.Infof("Cluster ECMP route cache is: %+v", policyGWIPsMap)
+	klog.V(4).InfoS("OVN ECMP route cache is: %+v", ovnRouteCache)
+	klog.V(4).InfoS("Cluster ECMP route cache is: %+v", policyGWIPsMap)
 
 	// iterate through ovn routes and remove any stale entries
 	for podIP, ovnRoutes := range ovnRouteCache {
 		podHasAnyECMPRoutes := false
 		for _, ovnRoute := range ovnRoutes {
 			if !ovnRoute.shouldExist {
-				klog.Infof("Found stale exgw ecmp route, podIP: %s, nexthop: %s, router: %s",
+				klog.V(4).InfoS("Found stale exgw ecmp route, podIP: %s, nexthop: %s, router: %s",
 					podIP, ovnRoute.nextHop, ovnRoute.router)
 				lrsr := nbdb.LogicalRouterStaticRoute{UUID: ovnRoute.uuid}
 				err := c.nbClient.deleteLogicalRouterStaticRoutes(ovnRoute.router, &lrsr)
-				// err :=
 				if err != nil {
 					klog.Errorf("Error deleting static route %s from router %s: %v", ovnRoute.uuid, ovnRoute.router, err)
 				}
@@ -133,7 +132,7 @@ func (c *ExternalGatewayMasterController) repair() {
 				// the default bridge to a new secondary bridge (or vice versa)
 				prefix, err := c.nbClient.extSwitchPrefix(node)
 				if err != nil {
-					// we shouldn't continue in this case, because we cant be sure this is a route we want to remove
+					// We shouldn't continue in this case, because we cant be sure this is a route we want to remove
 					klog.Errorf("Cannot sync exgw bfd: %+v, unable to determine exgw switch prefix: %v",
 						ovnRoute, err)
 				} else {
@@ -188,7 +187,7 @@ func (c *ExternalGatewayMasterController) buildExternalIPGatewaysFromPolicyRules
 				return nil, err
 			}
 			for _, nsPod := range nsPods {
-				// ignore completed pods, host networked pods, pods not scheduled
+				// Ignore completed pods, host networked pods, pods not scheduled
 				if util.PodWantsHostNetwork(nsPod) || util.PodCompleted(nsPod) || !util.PodScheduled(nsPod) {
 					continue
 				}


### PR DESCRIPTION
This PR aims to solve a design flaw in the APB External Route controllers where there were potential situations for race conditions due to all 3 controllers making changes to the impacted resources in parallel and out of sync. 

The new implementation relies only on the route policy controller to handle any updates due to changes to namespaces, pods or policies.

