### PR TITLE
Allow hostNetwork ingress for network policies with empty namespace selector

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -1085,6 +1085,13 @@ func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressP
 		}
 		gp.addPeerAddressSets(ipv4as, ipv6as)
 	}
+	if podSel.Empty() && nsSel.Empty() && config.Kubernetes.HostNetworkNamespace != "" {
+		// all namespaces selector, add hostnetwork address set
+		_, err := gp.addNamespaceAddressSet(config.Kubernetes.HostNetworkNamespace, bnc.addressSetFactory)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add namespace address set for gress policy: %w", err)
+		}
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
The previous version used shared address sets for empty namespace
selector to reuse the address set, but it didn't include a special
config.Kubernetes.HostNetworkNamespace that only has an address set,
but no pods. This difference may break existing network policies for
hostNetwork pods, therefore we explicitly add this address sets for an
empty namespace selector.