### PR TITLE
Use the old leadership lock name for global zone

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -315,7 +315,7 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	case runMode.networkControllerManager:
 		metrics.RegisterMasterBase()
 		haConfig = &config.MasterHA
-		name = "ovn-kubernetes-master-" + config.Default.Zone
+		name = networkControllerManagerLockName()
 	case runMode.clusterManager:
 		metrics.RegisterClusterManagerBase()
 		haConfig = &config.ClusterMgrHA
@@ -572,4 +572,13 @@ type ovnkubeMetricsProvider struct {
 
 func (p ovnkubeMetricsProvider) NewLeaderMetric() leaderelection.SwitchMetric {
 	return &ovnkubeMasterMetrics{p.runMode}
+}
+
+func networkControllerManagerLockName() string {
+	// keep the same old lock name unless we are owners of a specific zone
+	name := "ovn-kubernetes-master"
+	if config.Default.Zone != types.OvnDefaultZone {
+		name = name + "-" + config.Default.Zone
+	}
+	return name
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -586,7 +586,7 @@ var _ = ginkgo.Describe("e2e control plane", func() {
 			controlPlaneLeaseName = "ovn-kubernetes-master-ovn-control-plane"
 		} else {
 			controlPlanePodName = "ovnkube-master"
-			controlPlaneLeaseName = "ovn-kubernetes-master-global"
+			controlPlaneLeaseName = "ovn-kubernetes-master"
 		}
 
 		controlPlanePods, err := f.ClientSet.CoreV1().Pods("ovn-kubernetes").List(context.Background(), metav1.ListOptions{


### PR DESCRIPTION
Otherwise on upgrade there will be two leaders done the same things, the
old ovn-kubernetes-master leader and the new
ovn-kubernetes-master-global leader.