### PR TITLE
fake address set: don't check for concurrency on destroy

### DIFF
--- a/go-controller/pkg/ovn/address_set/fake_address_set.go
+++ b/go-controller/pkg/ovn/address_set/fake_address_set.go
@@ -477,7 +477,8 @@ func (as *fakeAddressSet) deleteIP(ip net.IP) ([]ovsdb.Operation, error) {
 }
 
 func (as *fakeAddressSet) destroy() error {
-	gomega.Expect(atomic.LoadUint32(&as.destroyed)).To(gomega.Equal(uint32(0)))
+	// Don't check here if the address set was already destroyed as it should be
+	// a thread safe, idempotent operation anyway.
 	atomic.StoreUint32(&as.destroyed, 1)
 	return nil
 }


### PR DESCRIPTION
Real address sets don't have any concurrency check but specifically deleting an address set twice from different threads at the same time should not be a problem.

We are seeing unit test failing on the fake address set destroy:
```
2023-06-13T22:39:00.4651626Z Your test failed.
2023-06-13T22:39:00.4651925Z Ginkgo panics to prevent subsequent assertions from running.
2023-06-13T22:39:00.4652392Z Normally Ginkgo rescues this panic so you shouldn't see it.
2023-06-13T22:39:00.4652576Z 
2023-06-13T22:39:00.4652842Z But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
2023-06-13T22:39:00.4653164Z To circumvent this, you should call
2023-06-13T22:39:00.4653319Z 
2023-06-13T22:39:00.4653431Z 	defer GinkgoRecover()
2023-06-13T22:39:00.4653572Z 
2023-06-13T22:39:00.4653721Z at the top of the goroutine that caused this panic.
2023-06-13T22:39:00.4653881Z 
2023-06-13T22:39:00.4653989Z goroutine 9900 [running]:
2023-06-13T22:39:00.4654302Z k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2e29de0?, 0x3889210?})
2023-06-13T22:39:00.4655145Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0xe9
2023-06-13T22:39:00.4655598Z k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x4abfa80?})
2023-06-13T22:39:00.4656311Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0xb0
2023-06-13T22:39:00.4656693Z panic({0x2e29de0, 0x3889210})
2023-06-13T22:39:00.4657018Z 	/opt/hostedtoolcache/go/1.18.4/x64/src/runtime/panic.go:844 +0x258
2023-06-13T22:39:00.4657371Z github.com/onsi/ginkgo.Fail({0xc00bc939c0, 0x31}, {0xc00be06a58, 0x1, 0x4a48b7?})
2023-06-13T22:39:00.4657974Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:291 +0x13a
2023-06-13T22:39:00.4658456Z github.com/onsi/gomega/internal.(*Assertion).match(0xc00be14dc0, {0x389d200, 0xc00be78a80}, 0x1, {0x0, 0x0, 0x0})
2023-06-13T22:39:00.4659099Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/gomega/internal/assertion.go:106 +0x2f6
2023-06-13T22:39:00.4659578Z github.com/onsi/gomega/internal.(*Assertion).To(0xc00be14dc0, {0x389d200, 0xc00be78a80}, {0x0, 0x0, 0x0})
2023-06-13T22:39:00.4660223Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/gomega/internal/assertion.go:62 +0x105
2023-06-13T22:39:00.4660845Z github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set.(*fakeAddressSet).destroy(0xc00bbe0660)
2023-06-13T22:39:00.4661463Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set/fake_address_set.go:480 +0xd4
2023-06-13T22:39:00.4662067Z github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set.(*fakeAddressSets).Destroy(0xc00bbd4840)
2023-06-13T22:39:00.4662696Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set/fake_address_set.go:439 +0xcf
2023-06-13T22:39:00.4663482Z github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute.(*northBoundClient).delHybridRoutePolicyForPod(0xc00b46c0a0, {0xc00bd76250, 0x10, 0x10}, {0xc00b40fe1b, 0x5})
2023-06-13T22:39:00.4664214Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute/network_client.go:593 +0x6bf
2023-06-13T22:39:00.4664903Z github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute.(*ExternalGatewayMasterController).repair(0xc00b462680)
2023-06-13T22:39:00.4665589Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute/repair.go:154 +0x1a53
2023-06-13T22:39:00.4666260Z github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute.(*ExternalGatewayMasterController).Run(0xc00b462680, 0x5)
2023-06-13T22:39:00.4666965Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute/master_controller.go:198 +0x545
2023-06-13T22:39:00.4667683Z github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*FakeOVN).RunAPBExternalPolicyController.func1()
2023-06-13T22:39:00.4668337Z 	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/external_gateway_test.go:2889 +0xe5
2023-06-13T22:39:00.4669013Z created by github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn.(*FakeOVN).RunAPBExternalPolicyController
```

I have seen that happen in different places but more frequently now on APBroute unit tests.

```
2023-06-13T22:39:00.4727082Z [91m[1m• Failure [0.568 seconds][0m
2023-06-13T22:39:00.4727362Z OVN Egress Gateway Operations
2023-06-13T22:39:00.4727879Z [90m/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/external_gateway_test.go:36[0m
2023-06-13T22:39:00.4728274Z   hybrid route policy operations in lgw mode
2023-06-13T22:39:00.4728850Z   [90m/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/external_gateway_test.go:2183[0m
2023-06-13T22:39:00.4729661Z     [91m[1mshould reconcile a pod and create/delete the hybridRoutePolicy accordingly [It][0m
2023-06-13T22:39:00.4730364Z     [90m/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/external_gateway_test.go:2240[0m
2023-06-13T22:39:00.4730613Z 
2023-06-13T22:39:00.4730809Z     [91mExpected
2023-06-13T22:39:00.4731054Z         <uint32>: 1
2023-06-13T22:39:00.4731269Z     to equal
2023-06-13T22:39:00.4731537Z         <uint32>: 0[0m
2023-06-13T22:39:00.4731668Z 
2023-06-13T22:39:00.4732187Z     /home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/address_set/fake_address_set.go:480
```
