### PR TITLE
Add Interconnect support in APB External Route controller

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -387,6 +387,8 @@ jobs:
           - {"target": "compact-mode",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "multi-node-zones",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-multi-node-zones", "num-workers": "3", "num-nodes-per-zone": "2"}
+          - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
+          - {"target": "external-gateway",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "1br", "ic": "ic-single-node-zones"}
     needs: [ build-pr ]
     env:
       JOB_NAME: "${{ matrix.target }}-${{ matrix.ha }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily }}-${{ matrix.disable-snat-multiple-gws }}-${{ matrix.second-bridge }}"
@@ -453,8 +455,8 @@ jobs:
 
     - name: Run Tests
       # e2e tests take ~60 minutes normally, 120 should be more than enough
-      # set 2 1/2 hours for control-plane tests as these might take a while
-      timeout-minutes: ${{ matrix.target == 'control-plane' && 180 || 120 }}
+      # set 3 hours for control-plane tests as these might take a while
+      timeout-minutes: ${{ matrix.target == 'control-plane' && 180 || matrix.target == 'external-gateway' && 180 || 120 }}
       run: |
         if [ "${{ matrix.target }}" == "multi-homing" ]; then
           make -C test control-plane WHAT="Multi Homing"
@@ -464,6 +466,8 @@ jobs:
           SINGLE_NODE_CLUSTER="true" make -C test shard-network
         elif [ "${{ matrix.target }}" == "multi-node-zones" ]; then
           make -C test control-plane WHAT="Multi node zones interconnect"
+        elif [ "${{ matrix.target }}" == "external-gateway" ]; then
+          make -C test control-plane WHAT="External Gateway"
         else
           make -C test ${{ matrix.target }}
         fi

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -49,13 +49,56 @@ var (
 	err                error
 )
 
+func createTestNBGlobal(nbClient libovsdbclient.Client, zone string) error {
+	nbGlobal := &nbdb.NBGlobal{Name: zone}
+	ops, err := nbClient.Create(nbGlobal)
+	if err != nil {
+		return err
+	}
+
+	_, err = nbClient.Transact(context.Background(), ops...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deleteTestNBGlobal(nbClient libovsdbclient.Client, zone string) error {
+	p := func(nbGlobal *nbdb.NBGlobal) bool {
+		return true
+	}
+
+	ops, err := nbClient.WhereCache(p).Delete()
+	if err != nil {
+		return err
+	}
+
+	_, err = nbClient.Transact(context.Background(), ops...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func initController(k8sObjects, routePolicyObjects []runtime.Object) {
+	var nbZoneFailed bool
 	stopChan = make(chan struct{})
 	fakeClient = fake.NewSimpleClientset(k8sObjects...)
 	fakeRouteClient = adminpolicybasedrouteclient.NewSimpleClientset(routePolicyObjects...)
 	iFactory, err = factory.NewMasterWatchFactory(&util.OVNMasterClientset{KubeClient: fakeClient})
 	Expect(err).NotTo(HaveOccurred())
 	iFactory.Start()
+	// Try to get the NBZone.  If there is an error, create NB_Global record.
+	// Otherwise NewController() will return error since it
+	// calls util.GetNBZone().
+	_, err = util.GetNBZone(nbClient)
+	if err != nil {
+		nbZoneFailed = true
+		err = createTestNBGlobal(nbClient, "global")
+		Expect(err).NotTo(HaveOccurred())
+	}
 	externalController, err = NewExternalMasterController(fakeClient,
 		fakeRouteClient,
 		stopChan,
@@ -65,6 +108,14 @@ func initController(k8sObjects, routePolicyObjects []runtime.Object) {
 		nbClient,
 		addressset.NewFakeAddressSetFactory(apbControllerName))
 	Expect(err).NotTo(HaveOccurred())
+
+	if nbZoneFailed {
+		// Delete the NBGlobal row as this function created it.  Otherwise many tests would fail while
+		// checking the expectedData in the NBDB.
+		err = deleteTestNBGlobal(nbClient, "global")
+		Expect(err).NotTo(HaveOccurred())
+	}
+
 	mgr = externalController.mgr
 	go func() {
 		externalController.Run(5)

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -31,6 +31,7 @@ import (
 	adminpolicybasedroutelisters "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/listers/adminpolicybasedroute/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 const (
@@ -89,14 +90,20 @@ func NewExternalMasterController(
 	externalRouteInformer := routePolicyInformer.K8s().V1().AdminPolicyBasedExternalRoutes()
 	externalGWCache := make(map[ktypes.NamespacedName]*ExternalRouteInfo)
 	exGWCacheMutex := &sync.RWMutex{}
+	zone, err := util.GetNBZone(nbClient)
+	if err != nil {
+		return nil, err
+	}
 	nbCli := &northBoundClient{
 		routeLister:       externalRouteInformer.Lister(),
 		nodeLister:        nodeLister,
+		podLister:         podInformer.Lister(),
 		nbClient:          nbClient,
 		addressSetFactory: addressSetFactory,
 		externalGWCache:   externalGWCache,
 		exGWCacheMutex:    exGWCacheMutex,
 		controllerName:    apbControllerName,
+		zone:              zone,
 	}
 
 	c := &ExternalGatewayMasterController{
@@ -133,7 +140,7 @@ func NewExternalMasterController(
 			nbCli),
 	}
 
-	_, err := namespaceInformer.Informer().AddEventHandler(
+	_, err = namespaceInformer.Informer().AddEventHandler(
 		factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.onNamespaceAdd,
 			UpdateFunc: c.onNamespaceUpdate,

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -125,37 +125,43 @@ func (nb *northBoundClient) delAllLegacyHybridRoutePolicies() error {
 // are given, all routes for the namespace are deleted.
 func (nb *northBoundClient) deleteGatewayIPs(namespace string, toBeDeletedGWIPs, _ sets.Set[string]) error {
 	for _, routeInfo := range nb.getRouteInfosForNamespace(namespace) {
-		routeInfo.Lock()
-		if routeInfo.Deleted {
-			routeInfo.Unlock()
-			continue
+		// if we encounter error while deleting routes for one pod; we return and don't try subsequent pods
+		if err := nb.deletePodGWRoutes(routeInfo, toBeDeletedGWIPs); err != nil {
+			return err
 		}
-		pod, err := nb.podLister.Pods(routeInfo.PodName.Namespace).Get(routeInfo.PodName.Name)
-		if err == nil {
-			local, err := nb.isPodInLocalZone(pod)
-			if err != nil {
-				return err
-			}
-			if !local {
-				klog.V(4).InfoS("Pod %s is not in the local zone %s", routeInfo.PodName, nb.zone)
-				return nil
-			}
+	}
+	return nil
+}
+
+// deletePodGWRoutes removes known exgw routes for a pod via routeInfo for a list of given GW IPs
+func (nb *northBoundClient) deletePodGWRoutes(routeInfo *ExternalRouteInfo, toBeDeletedGWIPs sets.Set[string]) error {
+	routeInfo.Lock()
+	defer routeInfo.Unlock()
+	if routeInfo.Deleted {
+		return nil
+	}
+	pod, err := nb.podLister.Pods(routeInfo.PodName.Namespace).Get(routeInfo.PodName.Name)
+	if err == nil {
+		local, err := nb.isPodInLocalZone(pod)
+		if err != nil {
+			return err
 		}
-		for podIP, routes := range routeInfo.PodExternalRoutes {
-			for gw, gr := range routes {
-				if toBeDeletedGWIPs.Has(gw) {
-					// we cannot delete an external gateway IP from the north bound if it's also being provided by an external gateway annotation or if it is also
-					// defined by a coexisting policy in the same namespace
-					if err := nb.deletePodGWRoute(routeInfo, podIP, gw, gr); err != nil {
-						// if we encounter error while deleting routes for one pod; we return and don't try subsequent pods
-						routeInfo.Unlock()
-						return fmt.Errorf("delete pod GW route failed: %w", err)
-					}
-					delete(routes, gw)
+		if !local {
+			klog.V(4).InfoS("APB will not delete exgw routes for pod %s not in the local zone %s", routeInfo.PodName, nb.zone)
+			return nil
+		}
+	}
+	for podIP, routes := range routeInfo.PodExternalRoutes {
+		for gw, gr := range routes {
+			if toBeDeletedGWIPs.Has(gw) {
+				// we cannot delete an external gateway IP from the north bound if it's also being provided by an external gateway annotation or if it is also
+				// defined by a coexisting policy in the same namespace
+				if err := nb.deletePodGWRoute(routeInfo, podIP, gw, gr); err != nil {
+					return fmt.Errorf("APB delete pod GW route failed: %w", err)
 				}
+				delete(routes, gw)
 			}
 		}
-		routeInfo.Unlock()
 	}
 	return nil
 }
@@ -232,6 +238,19 @@ func (nb *northBoundClient) deletePodSNAT(nodeName string, extIPs, podIPNets []*
 
 // addEgressGwRoutesForPod handles adding all routes to gateways for a pod on a specific GR
 func (nb *northBoundClient) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddrs []*net.IPNet, podNsName ktypes.NamespacedName, node string) error {
+	pod, err := nb.podLister.Pods(podNsName.Namespace).Get(podNsName.Name)
+	if err != nil {
+		return err
+	}
+	local, err := nb.isPodInLocalZone(pod)
+	if err != nil {
+		return err
+	}
+	if !local {
+		klog.V(4).InfoS("APB will not add exgw routes for pod %s not in the local zone %s", podNsName, nb.zone)
+		return nil
+	}
+
 	gr := util.GetGatewayRouterFromNode(node)
 
 	routesAdded := 0
@@ -245,17 +264,6 @@ func (nb *northBoundClient) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddr
 	routeInfo, err := nb.ensureRouteInfoLocked(podNsName)
 	if err != nil {
 		return fmt.Errorf("failed to ensure routeInfo for %s, error: %v", podNsName, err)
-	}
-	pod, err := nb.podLister.Pods(routeInfo.PodName.Namespace).Get(routeInfo.PodName.Name)
-	if err != nil {
-		return err
-	}
-	local, err := nb.isPodInLocalZone(pod)
-	if err != nil {
-		return err
-	}
-	if !local {
-		return nil
 	}
 	defer routeInfo.Unlock()
 	for _, podIPNet := range podIfAddrs {

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -208,6 +208,14 @@ func (nb *northBoundClient) addGatewayIPs(pod *v1.Pod, egress gatewayInfoList) e
 // if allSNATs flag is set, then all the SNATs (including against egressIPs if any) for that pod will be deleted
 // used when disableSNATMultipleGWs=true
 func (nb *northBoundClient) deletePodSNAT(nodeName string, extIPs, podIPNets []*net.IPNet) error {
+	node, err := nb.nodeLister.Get(nodeName)
+	if err != nil {
+		return err
+	}
+	if util.GetNodeZone(node) != nb.zone {
+		klog.V(4).InfoS("Node %s is not in the local zone %s", nodeName, nb.zone)
+		return nil
+	}
 	nats, err := buildPodSNAT(extIPs, podIPNets)
 	if err != nil {
 		return err

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -2687,7 +2687,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Name: "node1",
 					},
 				}
-				err = deletePodSNAT(fakeOvn.controller.nbClient, nodeName, extIPs, []*net.IPNet{fullMaskPodNet})
+				err = fakeOvn.controller.deletePodSNAT(nodeName, extIPs, []*net.IPNet{fullMaskPodNet})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil

--- a/go-controller/pkg/ovn/external_gateway_test.go
+++ b/go-controller/pkg/ovn/external_gateway_test.go
@@ -2790,7 +2790,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Name: "node1",
 					},
 				}
-				err = deletePodSNAT(fakeOvn.controller.nbClient, nodeName, extIPs, []*net.IPNet{fullMaskPodNet})
+				err = fakeOvn.controller.deletePodSNAT(nodeName, extIPs, []*net.IPNet{fullMaskPodNet})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -187,7 +187,7 @@ func (oc *DefaultNetworkController) updateNamespace(old, newer *kapi.Namespace) 
 					if len(ips) > 0 {
 						if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
 							errors = append(errors, err)
-						} else if err = deletePodSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, ips); err != nil {
+						} else if err = oc.deletePodSNAT(pod.Spec.NodeName, extIPs, ips); err != nil {
 							errors = append(errors, err)
 						}
 					}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -117,7 +117,7 @@ func (oc *DefaultNetworkController) deleteLogicalPort(pod *kapi.Pod, portInfo *l
 	}
 
 	if config.Gateway.DisableSNATMultipleGWs {
-		if err := deletePodSNAT(oc.nbClient, pInfo.logicalSwitch, []*net.IPNet{}, pInfo.ips); err != nil {
+		if err := oc.deletePodSNAT(pInfo.logicalSwitch, []*net.IPNet{}, pInfo.ips); err != nil {
 			return fmt.Errorf("cannot delete GR SNAT for pod %s: %w", podDesc, err)
 		}
 	}

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -61,7 +61,7 @@ func init() {
 	}
 }
 
-// gatewayTestIPs collects all the addresses required for a external gateway
+// gatewayTestIPs collects all the addresses required for an external gateway
 // test.
 type gatewayTestIPs struct {
 	gatewayIPs []string
@@ -70,7 +70,7 @@ type gatewayTestIPs struct {
 	targetIPs  []string
 }
 
-var _ = ginkgo.Describe("External Gateway test suite", func() {
+var _ = ginkgo.Describe("External Gateway", func() {
 
 	var _ = ginkgo.Context("With annotations", func() {
 

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -1033,11 +1033,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			f := wrappedTestFramework(svcname)
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
@@ -1184,11 +1179,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			var addressesv4, addressesv6 gatewayTestIPs
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				// retrieve worker node names
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
 				framework.ExpectNoError(err)
@@ -1335,11 +1325,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			)
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err = e2enode.GetBoundedReadySchedulableNodes(clientSet, 3)
@@ -1561,11 +1546,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 				f := wrappedTestFramework(svcname)
 
 				ginkgo.BeforeEach(func() {
-					if isInterconnectEnabled() {
-						skipper.Skipf(
-							"APB External Route is not yet supported with multiple zones interconnect deployment",
-						)
-					}
 					clientSet = f.ClientSet // so it can be used in AfterEach
 					// retrieve worker node names
 					nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
@@ -1766,11 +1746,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 				var addressesv4, addressesv6 gatewayTestIPs
 
 				ginkgo.BeforeEach(func() {
-					if isInterconnectEnabled() {
-						skipper.Skipf(
-							"APB External Route is not yet supported with multiple zones interconnect deployment",
-						)
-					}
 					nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
 					framework.ExpectNoError(err)
 					if len(nodes.Items) < 3 {
@@ -1978,11 +1953,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			f := wrappedTestFramework(svcname)
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
@@ -2133,11 +2103,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			)
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err = e2enode.GetBoundedReadySchedulableNodes(clientSet, 3)

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -96,6 +96,16 @@ if [ "${WHAT}" != "${MULTI_NODE_ZONES_TESTS}" ]; then
   SKIPPED_TESTS+="Multi node zones interconnect"
 fi
 
+# Only run external gateway tests if they are explicitly requested
+EXTERNAL_GATEWAY_TESTS="External Gateway"
+if [ "${WHAT}" != "${EXTERNAL_GATEWAY_TESTS}" ]; then
+  if [ "$SKIPPED_TESTS" != "" ]; then
+	SKIPPED_TESTS+="|"
+  fi
+  SKIPPED_TESTS+="External Gateway"
+fi
+
+
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote
 export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
* Added changes in the master APB External Controller to be IC aware and avoid hitting the NB when adding pods that are not in the same zone as the controller.

* It reverts the commit to disable interconnect in the e2e tests for APB use cases.

@trozet PTAL. I'm missing adding unit tests, hence a WIP for now, but I'd be grateful if you could take a look at what it's done and give me the thumbs up in the meanwhile.