### PR TITLE
Wait for APB controller's clean external gateway ECMP routes before resuming default net controller startup

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -197,9 +197,6 @@ func (c *ExternalGatewayMasterController) Run(threadiness int) {
 	}
 	syncWg.Wait()
 
-	klog.V(4).InfoS("Repairing Admin Policy Based External Route Services")
-	c.repair()
-
 	wg := &sync.WaitGroup{}
 	for i := 0; i < threadiness; i++ {
 		for _, workerFn := range []func(*sync.WaitGroup){

--- a/go-controller/pkg/ovn/controller/apbroute/repair.go
+++ b/go-controller/pkg/ovn/controller/apbroute/repair.go
@@ -24,7 +24,7 @@ type managedGWIPs struct {
 	gwList         gatewayInfoList
 }
 
-func (c *ExternalGatewayMasterController) repair() {
+func (c *ExternalGatewayMasterController) Repair() {
 	start := time.Now()
 	defer func() {
 		klog.V(4).InfoS("Syncing exgw routes took %v", time.Since(start))

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -391,7 +391,10 @@ func (oc *DefaultNetworkController) Init() error {
 		klog.Errorf("Failed to setup master (%v)", err)
 		return err
 	}
-
+	// Sync external gateway routes. External gateway are set via Admin Policy Based External Route CRs.
+	// So execute an individual sync method at startup to cleanup any difference
+	klog.V(4).InfoS("Cleaning External Gateway ECMP routes")
+	WithSyncDurationMetricNoError("external gateway routes", oc.apbExternalRouteController.Repair)
 	return nil
 }
 

--- a/go-controller/pkg/ovn/external_gateway_test.go
+++ b/go-controller/pkg/ovn/external_gateway_test.go
@@ -3042,6 +3042,7 @@ func deleteNamespace(namespaceName string, fakeClient kubernetes.Interface) {
 }
 
 func (o *FakeOVN) RunAPBExternalPolicyController() {
+	o.controller.apbExternalRouteController.Repair()
 	o.controller.wg.Add(1)
 	go func() {
 		defer o.controller.wg.Done()


### PR DESCRIPTION
Add logic to wait for APB controller's clean external gateway ECMP routes to be finished in the default network controller before resuming the execution of the `Run()` method.

Also moved the initialization of the APB controller to be the first thing to do to ensure the north bound information is updated before all other controllers kickoff.

@jcaamano PTAL.