### PR TITLE
Refactor fake address set factory to detect concurrency issues

### DIFF
--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -431,3 +431,13 @@ func GetNBZone(nbClient libovsdbclient.Client) (string, error) {
 
 	return nbGlobal.Name, nil
 }
+
+// StringSlice converts to a slice of the string representation of the input
+// items
+func StringSlice[T fmt.Stringer](items []T) []string {
+	s := make([]string, len(items))
+	for i := range items {
+		s[i] = items[i].String()
+	}
+	return s
+}


### PR DESCRIPTION
It basically detects if an IP address that is added or removed to an address set has been operated with concurrently by someone else (typically, other goroutine). It assumes that all address set operations happen through a single factory as before. It also assumes that a single goroutine does not hold multiple references to the same address set at the same time, which may cause false positives.

Also cleans up synchonization fixing some issues and aligns other behavior to how the real factory/address sets would behave: deleting an address set that doesn't exist is idempotent, otherwise operating with an address set that does not exist may return an error.
