### PR TITLE
Skip adding service flows to gateway bridge when no uplink in the bridge

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -129,6 +129,10 @@ func (npw *nodePortWatcher) updateGatewayIPs(addressManager *addressManager) {
 // `add` parameter indicates if the flows should exist or be removed from the cache
 // `hasLocalHostNetworkEp` indicates if at least one host networked endpoint exists for this service which is local to this node.
 func (npw *nodePortWatcher) updateServiceFlowCache(service *kapi.Service, add, hasLocalHostNetworkEp bool) error {
+	if config.Gateway.Mode == config.GatewayModeLocal && config.Gateway.AllowNoUplink && npw.ofportPhys == "" {
+		// if LGW mode and no uplink gateway bridge, ingress traffic enters host from node physical interface instead of the breth0. Skip adding these service flows to br-ex.
+		return nil
+	}
 	npw.gatewayIPLock.Lock()
 	defer npw.gatewayIPLock.Unlock()
 	var cookie, key string


### PR DESCRIPTION

**- What this PR does and why is it needed**
If ovnkube runs in LGW mode with no uplink gateway bridge, ingress traffic enters the host from node's physical interface instead of the breth0. It makes no sense to configure the servcie flows in the gateway bridge.


**- Special notes for reviewers**

As the no uplink gateway bridge is only used by microshift, the `externalTrafficPolicy` is useless when only one node is in the cluster.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->