### PR TITLE
Disable gofmt check for register.go and factory.go CRD autogenerated files

### DIFF
--- a/go-controller/hack/verify-gofmt.sh
+++ b/go-controller/hack/verify-gofmt.sh
@@ -9,6 +9,8 @@ PKGS=${PKGS:-.}
 find_files="find ${PKGS} -not \( \
       \( \
         -wholename '*/vendor/*' \
+        -o -wholename './pkg/crd/*/register.go' \
+        -o -wholename './pkg/crd/*/factory.go' \
         -o -wholename '*/_output/*' \
       \) -prune \
     \) -name '*.go'"


### PR DESCRIPTION
Errors are popping up in the [build PR](https://github.com/ovn-org/ovn-kubernetes/actions/runs/5324874363/jobs/9644797735?pr=3674#step:6:47) lane due to invalid formatting to the egressservice pkg/crd/ autogenerated files.
This PR filters out these 2 files from all the CRD autogenerated code.