### PR TITLE
Fixes race in delete legacy hybrid route policies

### DIFF
--- a/go-controller/pkg/ovn/external_gateway_test.go
+++ b/go-controller/pkg/ovn/external_gateway_test.go
@@ -2648,8 +2648,6 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 					},
 				)
 
-				fakeOvn.RunAPBExternalPolicyController()
-
 				finalNB := []libovsdbtest.TestData{
 					&nbdb.LogicalRouterPolicy{
 						UUID:     "501-new-UUID",


### PR DESCRIPTION
This test adds 2 legacy hybrid routes in the old format and then 1 new one and runs the stale cleanup code to verify that legacy ones get removed. By starting APB controller it will also try to run repair and potentially remove the new one becuase it does not match a real pod in the cluster. There is no real value in having APB in this test.

