### PR TITLE
Adds cast check when getting object from queue in APB logic

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -2,6 +2,7 @@ package apbroute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -312,13 +313,22 @@ func (c *ExternalGatewayMasterController) syncRoutePolicy(routePolicy *adminpoli
 }
 
 func (c *ExternalGatewayMasterController) onPolicyAdd(obj interface{}) {
-	c.routeQueue.Add(obj)
+	policy := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if policy == nil {
+		utilruntime.HandleError(errors.New("invalid Admin Policy Based External Route provided to onPolicyAdd()"))
+		return
+	}
+	c.routeQueue.Add(policy)
 }
 
 func (c *ExternalGatewayMasterController) onPolicyUpdate(oldObj, newObj interface{}) {
 	oldRoutePolicy := oldObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
 	newRoutePolicy := newObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
 
+	if oldRoutePolicy == nil || newRoutePolicy == nil {
+		utilruntime.HandleError(errors.New("invalid Admin Policy Based External Route provided to onPolicyUpdate()"))
+		return
+	}
 	if oldRoutePolicy.Generation == newRoutePolicy.Generation ||
 		!newRoutePolicy.GetDeletionTimestamp().IsZero() {
 		return
@@ -328,25 +338,64 @@ func (c *ExternalGatewayMasterController) onPolicyUpdate(oldObj, newObj interfac
 }
 
 func (c *ExternalGatewayMasterController) onPolicyDelete(obj interface{}) {
-	c.routeQueue.Add(obj)
+	policy, ok := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tomstone %#v", obj))
+			return
+		}
+		policy, ok = tombstone.Obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an Admin Policy Based External Route %#v", tombstone.Obj))
+			return
+		}
+	}
+	if policy != nil {
+		c.routeQueue.Add(policy)
+	}
 }
 
 func (c *ExternalGatewayMasterController) onNamespaceAdd(obj interface{}) {
-	c.namespaceQueue.Add(obj)
+	ns := obj.(*v1.Namespace)
+	if ns == nil {
+		utilruntime.HandleError(errors.New("invalid Namespace provided to onNamespaceAdd()"))
+		return
+	}
+	c.namespaceQueue.Add(ns)
 }
 
 func (c *ExternalGatewayMasterController) onNamespaceUpdate(oldObj, newObj interface{}) {
 	oldNamespace := oldObj.(*v1.Namespace)
 	newNamespace := newObj.(*v1.Namespace)
 
+	if oldNamespace == nil || newNamespace == nil {
+		utilruntime.HandleError(errors.New("invalid Namespace provided to onNamespaceUpdate()"))
+		return
+	}
 	if oldNamespace.ResourceVersion == newNamespace.ResourceVersion || !newNamespace.GetDeletionTimestamp().IsZero() {
 		return
 	}
-	c.namespaceQueue.Add(newObj)
+	c.namespaceQueue.Add(newNamespace)
 }
 
 func (c *ExternalGatewayMasterController) onNamespaceDelete(obj interface{}) {
-	c.namespaceQueue.Add(obj)
+	ns, ok := obj.(*v1.Namespace)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		ns, ok = tombstone.Obj.(*v1.Namespace)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Namespace: %#v", tombstone.Obj))
+			return
+		}
+	}
+	if ns != nil {
+		c.namespaceQueue.Add(ns)
+	}
 }
 
 func (c *ExternalGatewayMasterController) runNamespaceWorker(wg *sync.WaitGroup) {
@@ -429,13 +478,27 @@ func (c *ExternalGatewayMasterController) syncNamespace(namespace *v1.Namespace)
 }
 
 func (c *ExternalGatewayMasterController) onPodAdd(obj interface{}) {
-	c.podQueue.Add(obj)
+	pod := obj.(*v1.Pod)
+	if pod == nil {
+		utilruntime.HandleError(errors.New("invalid Pod provided to onPodAdd()"))
+		return
+	}
+	// if the pod does not have IPs AND there are no multus network status annotations found, skip it
+	if len(pod.Status.PodIPs) == 0 && len(pod.Annotations[nettypes.NetworkStatusAnnot]) == 0 {
+		return
+	}
+	c.podQueue.Add(pod)
 }
 
 func (c *ExternalGatewayMasterController) onPodUpdate(oldObj, newObj interface{}) {
 	o := oldObj.(*v1.Pod)
 	n := newObj.(*v1.Pod)
-	// if labels AND assigned Pod IPs AND networkStatus annotations are the same, skip processing changes to the pod.
+
+	if o == nil || n == nil {
+		utilruntime.HandleError(errors.New("invalid Pod provided to onPodUpdate()"))
+		return
+	}
+	// if labels AND assigned Pod IPs AND the multus network status annotations are the same, skip processing changes to the pod.
 	if reflect.DeepEqual(o.Labels, n.Labels) &&
 		reflect.DeepEqual(o.Status.PodIPs, n.Status.PodIPs) &&
 		reflect.DeepEqual(o.Annotations[nettypes.NetworkStatusAnnot], n.Annotations[nettypes.NetworkStatusAnnot]) {
@@ -445,7 +508,22 @@ func (c *ExternalGatewayMasterController) onPodUpdate(oldObj, newObj interface{}
 }
 
 func (c *ExternalGatewayMasterController) onPodDelete(obj interface{}) {
-	c.podQueue.Add(obj)
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		pod, ok = tombstone.Obj.(*v1.Pod)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod: %#v", tombstone.Obj))
+			return
+		}
+	}
+	if pod != nil {
+		c.podQueue.Add(pod)
+	}
 }
 
 func (c *ExternalGatewayMasterController) runPodWorker(wg *sync.WaitGroup) {

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -313,7 +313,11 @@ func (c *ExternalGatewayMasterController) syncRoutePolicy(routePolicy *adminpoli
 }
 
 func (c *ExternalGatewayMasterController) onPolicyAdd(obj interface{}) {
-	policy := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	policy, ok := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{}, obj))
+		return
+	}
 	if policy == nil {
 		utilruntime.HandleError(errors.New("invalid Admin Policy Based External Route provided to onPolicyAdd()"))
 		return
@@ -322,9 +326,16 @@ func (c *ExternalGatewayMasterController) onPolicyAdd(obj interface{}) {
 }
 
 func (c *ExternalGatewayMasterController) onPolicyUpdate(oldObj, newObj interface{}) {
-	oldRoutePolicy := oldObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
-	newRoutePolicy := newObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
-
+	oldRoutePolicy, ok := oldObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{}, oldObj))
+		return
+	}
+	newRoutePolicy, ok := newObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{}, newObj))
+		return
+	}
 	if oldRoutePolicy == nil || newRoutePolicy == nil {
 		utilruntime.HandleError(errors.New("invalid Admin Policy Based External Route provided to onPolicyUpdate()"))
 		return
@@ -357,7 +368,11 @@ func (c *ExternalGatewayMasterController) onPolicyDelete(obj interface{}) {
 }
 
 func (c *ExternalGatewayMasterController) onNamespaceAdd(obj interface{}) {
-	ns := obj.(*v1.Namespace)
+	ns, ok := obj.(*v1.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Namespace{}, obj))
+		return
+	}
 	if ns == nil {
 		utilruntime.HandleError(errors.New("invalid Namespace provided to onNamespaceAdd()"))
 		return
@@ -366,9 +381,16 @@ func (c *ExternalGatewayMasterController) onNamespaceAdd(obj interface{}) {
 }
 
 func (c *ExternalGatewayMasterController) onNamespaceUpdate(oldObj, newObj interface{}) {
-	oldNamespace := oldObj.(*v1.Namespace)
-	newNamespace := newObj.(*v1.Namespace)
-
+	oldNamespace, ok := oldObj.(*v1.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Namespace{}, oldObj))
+		return
+	}
+	newNamespace, ok := newObj.(*v1.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Namespace{}, newObj))
+		return
+	}
 	if oldNamespace == nil || newNamespace == nil {
 		utilruntime.HandleError(errors.New("invalid Namespace provided to onNamespaceUpdate()"))
 		return
@@ -478,7 +500,11 @@ func (c *ExternalGatewayMasterController) syncNamespace(namespace *v1.Namespace)
 }
 
 func (c *ExternalGatewayMasterController) onPodAdd(obj interface{}) {
-	pod := obj.(*v1.Pod)
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Pod{}, obj))
+		return
+	}
 	if pod == nil {
 		utilruntime.HandleError(errors.New("invalid Pod provided to onPodAdd()"))
 		return
@@ -491,9 +517,16 @@ func (c *ExternalGatewayMasterController) onPodAdd(obj interface{}) {
 }
 
 func (c *ExternalGatewayMasterController) onPodUpdate(oldObj, newObj interface{}) {
-	o := oldObj.(*v1.Pod)
-	n := newObj.(*v1.Pod)
-
+	o, ok := oldObj.(*v1.Pod)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Pod{}, o))
+		return
+	}
+	n, ok := newObj.(*v1.Pod)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Pod{}, n))
+		return
+	}
 	if o == nil || n == nil {
 		utilruntime.HandleError(errors.New("invalid Pod provided to onPodUpdate()"))
 		return

--- a/go-controller/pkg/ovn/controller/apbroute/node_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/node_controller.go
@@ -203,7 +203,11 @@ func (c *ExternalGatewayNodeController) Run(threadiness int) {
 }
 
 func (c *ExternalGatewayNodeController) onNamespaceAdd(obj interface{}) {
-	ns := obj.(*v1.Namespace)
+	ns, ok := obj.(*v1.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Namespace{}, obj))
+		return
+	}
 	if ns == nil {
 		utilruntime.HandleError(errors.New("invalid Namespace provided to onNamespaceAdd()"))
 		return
@@ -212,8 +216,16 @@ func (c *ExternalGatewayNodeController) onNamespaceAdd(obj interface{}) {
 }
 
 func (c *ExternalGatewayNodeController) onNamespaceUpdate(oldObj, newObj interface{}) {
-	oldNamespace := oldObj.(*v1.Namespace)
-	newNamespace := newObj.(*v1.Namespace)
+	oldNamespace, ok := oldObj.(*v1.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Namespace{}, oldObj))
+		return
+	}
+	newNamespace, ok := newObj.(*v1.Namespace)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Namespace{}, newObj))
+		return
+	}
 
 	if oldNamespace == nil || newNamespace == nil {
 		utilruntime.HandleError(errors.New("invalid Namespace provided to onNamespaceUpdate()"))
@@ -316,7 +328,11 @@ func (c *ExternalGatewayNodeController) syncRoutePolicy(routePolicy *adminpolicy
 }
 
 func (c *ExternalGatewayNodeController) onPolicyAdd(obj interface{}) {
-	policy := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	policy, ok := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{}, obj))
+		return
+	}
 	if policy == nil {
 		utilruntime.HandleError(errors.New("invalid Admin Policy Based External Route provided to onPolicyAdd()"))
 		return
@@ -325,8 +341,16 @@ func (c *ExternalGatewayNodeController) onPolicyAdd(obj interface{}) {
 }
 
 func (c *ExternalGatewayNodeController) onPolicyUpdate(oldObj, newObj interface{}) {
-	oldRoutePolicy := oldObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
-	newRoutePolicy := newObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	oldRoutePolicy, ok := oldObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{}, oldObj))
+		return
+	}
+	newRoutePolicy, ok := newObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute{}, newObj))
+		return
+	}
 
 	if oldRoutePolicy == nil || newRoutePolicy == nil {
 		utilruntime.HandleError(errors.New("invalid Admin Policy Based External Route provided to onPolicyUpdate()"))
@@ -440,7 +464,11 @@ func (c *ExternalGatewayNodeController) syncNamespace(namespace *v1.Namespace) e
 }
 
 func (c *ExternalGatewayNodeController) onPodAdd(obj interface{}) {
-	pod := obj.(*v1.Pod)
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Pod{}, obj))
+		return
+	}
 	if pod == nil {
 		utilruntime.HandleError(errors.New("invalid Pod provided to onPodAdd()"))
 		return
@@ -453,8 +481,16 @@ func (c *ExternalGatewayNodeController) onPodAdd(obj interface{}) {
 }
 
 func (c *ExternalGatewayNodeController) onPodUpdate(oldObj, newObj interface{}) {
-	o := oldObj.(*v1.Pod)
-	n := newObj.(*v1.Pod)
+	o, ok := oldObj.(*v1.Pod)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Pod{}, o))
+		return
+	}
+	n, ok := newObj.(*v1.Pod)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expecting %T but received %T", &v1.Pod{}, n))
+		return
+	}
 
 	if o == nil || n == nil {
 		utilruntime.HandleError(errors.New("invalid Pod provided to onPodUpdate()"))

--- a/go-controller/pkg/ovn/controller/apbroute/node_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/node_controller.go
@@ -1,6 +1,7 @@
 package apbroute
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -202,21 +203,45 @@ func (c *ExternalGatewayNodeController) Run(threadiness int) {
 }
 
 func (c *ExternalGatewayNodeController) onNamespaceAdd(obj interface{}) {
-	c.namespaceQueue.Add(obj)
+	ns := obj.(*v1.Namespace)
+	if ns == nil {
+		utilruntime.HandleError(errors.New("invalid Namespace provided to onNamespaceAdd()"))
+		return
+	}
+	c.namespaceQueue.Add(ns)
 }
 
 func (c *ExternalGatewayNodeController) onNamespaceUpdate(oldObj, newObj interface{}) {
 	oldNamespace := oldObj.(*v1.Namespace)
 	newNamespace := newObj.(*v1.Namespace)
 
+	if oldNamespace == nil || newNamespace == nil {
+		utilruntime.HandleError(errors.New("invalid Namespace provided to onNamespaceUpdate()"))
+		return
+	}
 	if oldNamespace.ResourceVersion == newNamespace.ResourceVersion || !newNamespace.GetDeletionTimestamp().IsZero() {
 		return
 	}
-	c.namespaceQueue.Add(newObj)
+	c.namespaceQueue.Add(newNamespace)
 }
 
 func (c *ExternalGatewayNodeController) onNamespaceDelete(obj interface{}) {
-	c.namespaceQueue.Add(obj)
+	ns, ok := obj.(*v1.Namespace)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		ns, ok = tombstone.Obj.(*v1.Namespace)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Namespace: %#v", tombstone.Obj))
+			return
+		}
+	}
+	if ns != nil {
+		c.namespaceQueue.Add(ns)
+	}
 }
 
 func (c *ExternalGatewayNodeController) runPolicyWorker(wg *sync.WaitGroup) {
@@ -291,13 +316,22 @@ func (c *ExternalGatewayNodeController) syncRoutePolicy(routePolicy *adminpolicy
 }
 
 func (c *ExternalGatewayNodeController) onPolicyAdd(obj interface{}) {
-	c.routeQueue.Add(obj)
+	policy := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if policy == nil {
+		utilruntime.HandleError(errors.New("invalid Admin Policy Based External Route provided to onPolicyAdd()"))
+		return
+	}
+	c.routeQueue.Add(policy)
 }
 
 func (c *ExternalGatewayNodeController) onPolicyUpdate(oldObj, newObj interface{}) {
 	oldRoutePolicy := oldObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
 	newRoutePolicy := newObj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
 
+	if oldRoutePolicy == nil || newRoutePolicy == nil {
+		utilruntime.HandleError(errors.New("invalid Admin Policy Based External Route provided to onPolicyUpdate()"))
+		return
+	}
 	if oldRoutePolicy.Generation == newRoutePolicy.Generation ||
 		!newRoutePolicy.GetDeletionTimestamp().IsZero() {
 		return
@@ -307,7 +341,22 @@ func (c *ExternalGatewayNodeController) onPolicyUpdate(oldObj, newObj interface{
 }
 
 func (c *ExternalGatewayNodeController) onPolicyDelete(obj interface{}) {
-	c.routeQueue.Add(obj)
+	policy, ok := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tomstone %#v", obj))
+			return
+		}
+		policy, ok = tombstone.Obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an Admin Policy Based External Route %#v", tombstone.Obj))
+			return
+		}
+	}
+	if policy != nil {
+		c.routeQueue.Add(policy)
+	}
 }
 
 func (c *ExternalGatewayNodeController) runNamespaceWorker(wg *sync.WaitGroup) {
@@ -391,18 +440,26 @@ func (c *ExternalGatewayNodeController) syncNamespace(namespace *v1.Namespace) e
 }
 
 func (c *ExternalGatewayNodeController) onPodAdd(obj interface{}) {
-	o := obj.(*v1.Pod)
-	// if the pod does not have IPs AND there are no multus network status annotations found, skip it
-	if len(o.Status.PodIPs) == 0 && len(o.Annotations[nettypes.NetworkStatusAnnot]) == 0 {
+	pod := obj.(*v1.Pod)
+	if pod == nil {
+		utilruntime.HandleError(errors.New("invalid Pod provided to onPodAdd()"))
 		return
 	}
-	c.podQueue.Add(obj)
+	// if the pod does not have IPs AND there are no multus network status annotations found, skip it
+	if len(pod.Status.PodIPs) == 0 && len(pod.Annotations[nettypes.NetworkStatusAnnot]) == 0 {
+		return
+	}
+	c.podQueue.Add(pod)
 }
 
 func (c *ExternalGatewayNodeController) onPodUpdate(oldObj, newObj interface{}) {
 	o := oldObj.(*v1.Pod)
 	n := newObj.(*v1.Pod)
 
+	if o == nil || n == nil {
+		utilruntime.HandleError(errors.New("invalid Pod provided to onPodUpdate()"))
+		return
+	}
 	// if labels AND assigned Pod IPs AND the multus network status annotations are the same, skip processing changes to the pod.
 	if reflect.DeepEqual(o.Labels, n.Labels) &&
 		reflect.DeepEqual(o.Status.PodIPs, n.Status.PodIPs) &&
@@ -413,7 +470,22 @@ func (c *ExternalGatewayNodeController) onPodUpdate(oldObj, newObj interface{}) 
 }
 
 func (c *ExternalGatewayNodeController) onPodDelete(obj interface{}) {
-	c.podQueue.Add(obj)
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		pod, ok = tombstone.Obj.(*v1.Pod)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod: %#v", tombstone.Obj))
+			return
+		}
+	}
+	if pod != nil {
+		c.podQueue.Add(pod)
+	}
 }
 
 func (c *ExternalGatewayNodeController) runPodWorker(wg *sync.WaitGroup) {


### PR DESCRIPTION
Adds a cast check when retrieving the objects from the event queues to avoid cases where the object retrieved in the delete use case is of type `cache.DeletedFinalStateUnknown`. 
It also adds checks for nil to avoid queuing nil objects.