### PR TITLE
Fixes control plane shared gateway jobs

### DIFF
--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -63,7 +63,7 @@ if [ "$OVN_GATEWAY_MODE" == "shared" ]; then
   if [ "$SKIPPED_TESTS" != "" ]; then
     SKIPPED_TESTS+="|"
   fi
-  SKIPPED_TESTS+="Should ensure load balancer service|[LGW]"
+  SKIPPED_TESTS+="Should ensure load balancer service|LGW"
 fi
 
 # skipping the egress ip legacy health check test because it requires two


### PR DESCRIPTION
The jobs were not actually executing any tests becuase of a bad regexp introduced in:
de40f0ffeb17e4991005677aa6684eaf30cee4b6

@oribon fyi