### PR TITLE
APB: remove init policy cache in repair.go

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/repair.go
+++ b/go-controller/pkg/ovn/controller/apbroute/repair.go
@@ -173,11 +173,6 @@ func (c *ExternalGatewayMasterController) buildExternalIPGatewaysFromPolicyRules
 		if err != nil {
 			return nil, err
 		}
-		// store the policy manifest in the routePolicy cache to avoid hitting the informer every time the annotation logic recalls all the gw IPs from the CRs.
-		err = c.mgr.storeRoutePolicyInCache(policy)
-		if err != nil {
-			return nil, err
-		}
 		nsList, err := c.mgr.listNamespacesBySelector(p.targetNamespacesSelector)
 		if err != nil {
 			return nil, err
@@ -213,8 +208,6 @@ func (c *ExternalGatewayMasterController) buildExternalIPGatewaysFromPolicyRules
 		}
 
 	}
-	// flag the route policy cache as populated so that the logic to retrieve the dynamic and static gw IPs from the annotation side can use the cache instead of hitting the informer.
-	c.mgr.setRoutePolicyCacheAsPopulated()
 	return clusterRouteCache, nil
 }
 


### PR DESCRIPTION
Remove the policy cache initialization in the repair.go. The reason is because the repair only takes care of removing inconsistencies, but does not tackle adding the differences. And when policy is again processed right after the repair is completed, the logic will not find any difference between the one cached and the one coming from the informer and will do nothing to reconcile the potentially missing additions that were not tackled in the repair.

The cache was mean to avoid hitting the informer every time it was required to recalculate all the gateway IPs of a given namespace so that the legacy/annotated logic could identify overlapping IPs.

@trozet PTAL. 