### PR TITLE
Forward ICMP packets to OVN loadbalancer

### DIFF
--- a/go-controller/pkg/node/gateway_localnet_linux_test.go
+++ b/go-controller/pkg/node/gateway_localnet_linux_test.go
@@ -1173,11 +1173,13 @@ var _ = Describe("Node Operations", func() {
 				expectedLBIngressFlows := []string{
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=5.5.5.5, actions=output:LOCAL",
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, tcp, nw_dst=5.5.5.5, tp_dst=8080, actions=output:patch-breth0_ov",
+					"cookie=0x10c6b89e483ea111, priority=110, in_port=eth0, icmp, nw_dst=5.5.5.5, icmp_type=3, icmp_code=4, actions=output:patch-breth0_ov",
 					"cookie=0x10c6b89e483ea111, priority=110, in_port=patch-breth0_ov, tcp, nw_src=5.5.5.5, tp_src=8080, actions=output:eth0",
 				}
 				expectedLBExternalIPFlows := []string{
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, arp, arp_op=1, arp_tpa=1.1.1.1, actions=output:LOCAL",
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, tcp, nw_dst=1.1.1.1, tp_dst=8080, actions=output:patch-breth0_ov",
+					"cookie=0x71765945a31dc2f1, priority=110, in_port=eth0, icmp, nw_dst=1.1.1.1, icmp_type=3, icmp_code=4, actions=output:patch-breth0_ov",
 					"cookie=0x71765945a31dc2f1, priority=110, in_port=patch-breth0_ov, tcp, nw_src=1.1.1.1, tp_src=8080, actions=output:eth0",
 				}
 

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -321,6 +321,11 @@ func (npw *nodePortWatcher) createLbAndExternalSvcFlows(service *kapi.Service, s
 			fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_dst=%d, "+
 				"actions=%s",
 				cookie, npw.ofportPhys, flowProtocol, nwDst, externalIPOrLBIngressIP, svcPort.Port, actions),
+			// we send any ICMP destination unreachable, fragmentation needed to the OVN pipeline too so that
+			// path MTU discovery continues to work
+			fmt.Sprintf("cookie=%s, priority=110, in_port=%s, icmp, %s=%s, icmp_type=3, icmp_code=4, "+
+				"actions=%s",
+				cookie, npw.ofportPhys, nwDst, externalIPOrLBIngressIP, actions),
 			// table=0, matches on return traffic from service externalIP or LB ingress and sends it out to primary node interface (br-ex)
 			fmt.Sprintf("cookie=%s, priority=110, in_port=%s, %s, %s=%s, tp_src=%d, "+
 				"actions=output:%s",


### PR DESCRIPTION
Forward the Destination unreachable (Fragmentation needed) ICMP packets to OVN so that path MTU discovery works.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
This lets the ICMP packets "Destination unreachable, fragmentation needed" go through from the external network back to an OVN loadbalancer. It should be the last step needed to complete the work for

https://bugzilla.redhat.com/show_bug.cgi?id=2126083 /   https://bugzilla.redhat.com/show_bug.cgi?id=2041746 / https://github.com/submariner-io/submariner/issues/1022 etc.

It attempts at addressing 1 particular use case, in IPv4  with a LoadBalancer service with externalTrafficPolicy=Local (also I have "mode":"shared" on the k8s.ovn.org/l3-gateway-config annotation of the nodes, and chassis have ovn-ct-lb-related="true". ovn and ovs run versions containing the various fixes developed for this use case)

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

This is case 03367857 at Red Hat, I think someone wanted information on how to reproduce.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->

This is how I verified this. It is similar to what is provided on https://gist.github.com/karampok/805588c5f1f14bc6600935caf221ca5f

1- I run the kind installation with podman, within a VM. Everything interface has MTU=1500 configured
2- install metallb from https://github.com/metallb/metallb/blob/main/config/manifests/metallb-frr.yaml
3- run a pod with 
```kubectl run --port 80 --expose --image nginx myserver```
4- change the service to have type: LoadBalancer and externalTrafficPolicy: Local
5- apply the following so to have metallb give the service an external IP with
```
apiVersion: metallb.io/v1beta1
kind: IPAddressPool
metadata:
  name: first-pool
  namespace: metallb-system
spec:
  addresses:
  - 10.123.99.0-10.123.99.12
```
In my example, external IP will be 10.123.99.0, pod myserver runs on ovn-worker with IP 10.89.0.7. My VM is connected to the host on bridge virbr1 and has IP 10.224.123.151/24
6- set-up the routing. On host side
```
ip route add 10.123.99.0 via 10.224.123.151 mtu 1500
```
On VM side
```
ip route add 10.123.99.0 via 10.89.0.7
```
7- we lower the MTU on the VM (```ip link set eth0 mtu 400```) and host (```ip link set virbr1 mtu 400```). Do this only after the myserver pod runs fine, because downloading a container image with this mtu will cause trouble.

8- test with ```curl 10.123.99.0``` from the host. On the VM a ```tcpdump -i podman1``` should show ICMP packets, however the node just sends the packet back with the same source and destination IP, the curl never completes.

9- apply the patch (or by hand, the equivalent
```ovs-ofctl add-flow breth0 priority=110,icmp,in_port=1,nw_dst=10.123.99.0,icmp_type=3,icmp_code=4,actions=output:2```). The curl completes and runs fine.
Note that once the MTU of the path is discovered, it is then cached, so one needs to run an ```ip route flush cache``` within the pod network namespace, to clear the discovered MTU (or you won't see those ICMP packets anymore for some time)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix path MTU Discovery