### PR TITLE
[DO NOT MERGE/DO NOT REVIEW] Add log create pod in e2e

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -49,14 +49,57 @@ var (
 	err                error
 )
 
+func createTestNBGlobal(nbClient libovsdbclient.Client, zone string) error {
+	nbGlobal := &nbdb.NBGlobal{Name: zone}
+	ops, err := nbClient.Create(nbGlobal)
+	if err != nil {
+		return err
+	}
+
+	_, err = nbClient.Transact(context.Background(), ops...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deleteTestNBGlobal(nbClient libovsdbclient.Client, zone string) error {
+	p := func(nbGlobal *nbdb.NBGlobal) bool {
+		return true
+	}
+
+	ops, err := nbClient.WhereCache(p).Delete()
+	if err != nil {
+		return err
+	}
+
+	_, err = nbClient.Transact(context.Background(), ops...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func initController(k8sObjects, routePolicyObjects []runtime.Object) {
+	var nbZoneFailed bool
 	stopChan = make(chan struct{})
 	fakeClient = fake.NewSimpleClientset(k8sObjects...)
 	fakeRouteClient = adminpolicybasedrouteclient.NewSimpleClientset(routePolicyObjects...)
 	iFactory, err = factory.NewMasterWatchFactory(&util.OVNMasterClientset{KubeClient: fakeClient})
 	Expect(err).NotTo(HaveOccurred())
 	iFactory.Start()
-	externalController, err = NewExternalMasterController(fakeClient,
+	// Try to get the NBZone.  If there is an error, create NB_Global record.
+	// Otherwise NewController() will return error since it
+	// calls util.GetNBZone().
+	_, err = util.GetNBZone(nbClient)
+	if err != nil {
+		nbZoneFailed = true
+		err = createTestNBGlobal(nbClient, "global")
+		Expect(err).NotTo(HaveOccurred())
+	}
+	externalController, err = NewExternalMasterController(controllerName, fakeClient,
 		fakeRouteClient,
 		stopChan,
 		iFactory.PodCoreInformer(),
@@ -65,6 +108,14 @@ func initController(k8sObjects, routePolicyObjects []runtime.Object) {
 		nbClient,
 		addressset.NewFakeAddressSetFactory(apbControllerName))
 	Expect(err).NotTo(HaveOccurred())
+
+	if nbZoneFailed {
+		// Delete the NBGlobal row as this function created it.  Otherwise many tests would fail while
+		// checking the expectedData in the NBDB.
+		err = deleteTestNBGlobal(nbClient, "global")
+		Expect(err).NotTo(HaveOccurred())
+	}
+
 	mgr = externalController.mgr
 	go func() {
 		externalController.Run(5)

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -99,7 +99,7 @@ func initController(k8sObjects, routePolicyObjects []runtime.Object) {
 		err = createTestNBGlobal(nbClient, "global")
 		Expect(err).NotTo(HaveOccurred())
 	}
-	externalController, err = NewExternalMasterController(controllerName, fakeClient,
+	externalController, err = NewExternalMasterController(fakeClient,
 		fakeRouteClient,
 		stopChan,
 		iFactory.PodCoreInformer(),

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -103,6 +103,7 @@ func NewExternalMasterController(
 		externalGWCache:   externalGWCache,
 		exGWCacheMutex:    exGWCacheMutex,
 		zone:              zone,
+		controllerName:    apbControllerName,
 	}
 
 	c := &ExternalGatewayMasterController{

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -31,6 +31,7 @@ import (
 	adminpolicybasedroutelisters "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/listers/adminpolicybasedroute/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
 const (
@@ -89,14 +90,19 @@ func NewExternalMasterController(
 	externalRouteInformer := routePolicyInformer.K8s().V1().AdminPolicyBasedExternalRoutes()
 	externalGWCache := make(map[ktypes.NamespacedName]*ExternalRouteInfo)
 	exGWCacheMutex := &sync.RWMutex{}
+	zone, err := util.GetNBZone(nbClient)
+	if err != nil {
+		return nil, err
+	}
 	nbCli := &northBoundClient{
 		routeLister:       externalRouteInformer.Lister(),
 		nodeLister:        nodeLister,
+		podLister:         podInformer.Lister(),
 		nbClient:          nbClient,
 		addressSetFactory: addressSetFactory,
 		externalGWCache:   externalGWCache,
 		exGWCacheMutex:    exGWCacheMutex,
-		controllerName:    apbControllerName,
+		zone:              zone,
 	}
 
 	c := &ExternalGatewayMasterController{
@@ -133,7 +139,7 @@ func NewExternalMasterController(
 			nbCli),
 	}
 
-	_, err := namespaceInformer.Informer().AddEventHandler(
+	_, err = namespaceInformer.Informer().AddEventHandler(
 		factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.onNamespaceAdd,
 			UpdateFunc: c.onNamespaceUpdate,

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -45,8 +45,8 @@ type northBoundClient struct {
 	addressSetFactory addressset.AddressSetFactory
 	externalGWCache   map[ktypes.NamespacedName]*ExternalRouteInfo
 	exGWCacheMutex    *sync.RWMutex
-
-	zone string
+	controllerName    string
+	zone              string
 }
 
 type conntrackClient struct {

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -207,6 +207,14 @@ func (nb *northBoundClient) addGatewayIPs(pod *v1.Pod, egress gatewayInfoList) e
 // if allSNATs flag is set, then all the SNATs (including against egressIPs if any) for that pod will be deleted
 // used when disableSNATMultipleGWs=true
 func (nb *northBoundClient) deletePodSNAT(nodeName string, extIPs, podIPNets []*net.IPNet) error {
+	node, err := nb.nodeLister.Get(nodeName)
+	if err != nil {
+		return err
+	}
+	if util.GetNodeZone(node) != nb.zone {
+		klog.V(4).InfoS("Node %s is not in the local zone %s", nodeName, nb.zone)
+		return nil
+	}
 	nats, err := buildPodSNAT(extIPs, podIPNets)
 	if err != nil {
 		return err

--- a/go-controller/pkg/ovn/controller/apbroute/network_client.go
+++ b/go-controller/pkg/ovn/controller/apbroute/network_client.go
@@ -37,6 +37,7 @@ type networkClient interface {
 type northBoundClient struct {
 	routeLister adminpolicybasedroutelisters.AdminPolicyBasedExternalRouteLister
 	nodeLister  corev1listers.NodeLister
+	podLister   corev1listers.PodLister
 	// NorthBound client interface
 	nbClient libovsdbclient.Client
 
@@ -44,7 +45,8 @@ type northBoundClient struct {
 	addressSetFactory addressset.AddressSetFactory
 	externalGWCache   map[ktypes.NamespacedName]*ExternalRouteInfo
 	exGWCacheMutex    *sync.RWMutex
-	controllerName    string
+
+	zone string
 }
 
 type conntrackClient struct {
@@ -60,6 +62,15 @@ func (nb *northBoundClient) deleteLogicalRouterStaticRoutes(routerName string, l
 
 func (nb *northBoundClient) findLogicalRoutersWithPredicate(p func(item *nbdb.LogicalRouter) bool) ([]*nbdb.LogicalRouter, error) {
 	return libovsdbops.FindLogicalRoutersWithPredicate(nb.nbClient, p)
+}
+
+// When IC is enabled, isNodeInLocalZone returns whether the provided node is in a zone local to the zone controller
+func (nb *northBoundClient) isPodInLocalZone(pod *v1.Pod) (bool, error) {
+	node, err := nb.nodeLister.Get(pod.Spec.NodeName)
+	if err != nil {
+		return false, err
+	}
+	return util.GetNodeZone(node) == nb.zone, nil
 }
 
 // delAllHybridRoutePolicies deletes all the 501 hybrid-route-policies that
@@ -117,6 +128,17 @@ func (nb *northBoundClient) deleteGatewayIPs(namespace string, toBeDeletedGWIPs,
 		if routeInfo.Deleted {
 			routeInfo.Unlock()
 			continue
+		}
+		pod, err := nb.podLister.Pods(routeInfo.PodName.Namespace).Get(routeInfo.PodName.Name)
+		if err == nil {
+			local, err := nb.isPodInLocalZone(pod)
+			if err != nil {
+				return err
+			}
+			if !local {
+				klog.V(4).InfoS("Pod %s is not in the local zone %s", routeInfo.PodName, nb.zone)
+				return nil
+			}
 		}
 		for podIP, routes := range routeInfo.PodExternalRoutes {
 			for gw, gr := range routes {
@@ -214,6 +236,17 @@ func (nb *northBoundClient) addGWRoutesForPod(gateways []*gatewayInfo, podIfAddr
 	routeInfo, err := nb.ensureRouteInfoLocked(podNsName)
 	if err != nil {
 		return fmt.Errorf("failed to ensure routeInfo for %s, error: %v", podNsName, err)
+	}
+	pod, err := nb.podLister.Pods(routeInfo.PodName.Namespace).Get(routeInfo.PodName.Name)
+	if err != nil {
+		return err
+	}
+	local, err := nb.isPodInLocalZone(pod)
+	if err != nil {
+		return err
+	}
+	if !local {
+		return nil
 	}
 	defer routeInfo.Unlock()
 	for _, podIPNet := range podIfAddrs {

--- a/go-controller/pkg/ovn/egressgw_test.go
+++ b/go-controller/pkg/ovn/egressgw_test.go
@@ -2685,7 +2685,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Name: "node1",
 					},
 				}
-				err = deletePodSNAT(fakeOvn.controller.nbClient, nodeName, extIPs, []*net.IPNet{fullMaskPodNet})
+				err = fakeOvn.controller.deletePodSNAT(nodeName, extIPs, []*net.IPNet{fullMaskPodNet})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil

--- a/go-controller/pkg/ovn/external_gateway_test.go
+++ b/go-controller/pkg/ovn/external_gateway_test.go
@@ -2786,7 +2786,7 @@ var _ = ginkgo.Describe("OVN Egress Gateway Operations", func() {
 						Name: "node1",
 					},
 				}
-				err = deletePodSNAT(fakeOvn.controller.nbClient, nodeName, extIPs, []*net.IPNet{fullMaskPodNet})
+				err = fakeOvn.controller.deletePodSNAT(nodeName, extIPs, []*net.IPNet{fullMaskPodNet})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(finalNB))
 				return nil

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -187,7 +187,7 @@ func (oc *DefaultNetworkController) updateNamespace(old, newer *kapi.Namespace) 
 					if len(ips) > 0 {
 						if extIPs, err := getExternalIPsGR(oc.watchFactory, pod.Spec.NodeName); err != nil {
 							errors = append(errors, err)
-						} else if err = deletePodSNAT(oc.nbClient, pod.Spec.NodeName, extIPs, ips); err != nil {
+						} else if err = oc.deletePodSNAT(pod.Spec.NodeName, extIPs, ips); err != nil {
 							errors = append(errors, err)
 						}
 					}

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -117,7 +117,7 @@ func (oc *DefaultNetworkController) deleteLogicalPort(pod *kapi.Pod, portInfo *l
 	}
 
 	if config.Gateway.DisableSNATMultipleGWs {
-		if err := deletePodSNAT(oc.nbClient, pInfo.logicalSwitch, []*net.IPNet{}, pInfo.ips); err != nil {
+		if err := oc.deletePodSNAT(pInfo.logicalSwitch, []*net.IPNet{}, pInfo.ips); err != nil {
 			return fmt.Errorf("cannot delete GR SNAT for pod %s: %w", podDesc, err)
 		}
 	}

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -1033,11 +1033,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			f := wrappedTestFramework(svcname)
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
@@ -1184,11 +1179,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			var addressesv4, addressesv6 gatewayTestIPs
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				// retrieve worker node names
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
 				framework.ExpectNoError(err)
@@ -1335,11 +1325,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			)
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err = e2enode.GetBoundedReadySchedulableNodes(clientSet, 3)
@@ -1561,11 +1546,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 				f := wrappedTestFramework(svcname)
 
 				ginkgo.BeforeEach(func() {
-					if isInterconnectEnabled() {
-						skipper.Skipf(
-							"APB External Route is not yet supported with multiple zones interconnect deployment",
-						)
-					}
 					clientSet = f.ClientSet // so it can be used in AfterEach
 					// retrieve worker node names
 					nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
@@ -1766,11 +1746,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 				var addressesv4, addressesv6 gatewayTestIPs
 
 				ginkgo.BeforeEach(func() {
-					if isInterconnectEnabled() {
-						skipper.Skipf(
-							"APB External Route is not yet supported with multiple zones interconnect deployment",
-						)
-					}
 					nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
 					framework.ExpectNoError(err)
 					if len(nodes.Items) < 3 {
@@ -1978,11 +1953,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			f := wrappedTestFramework(svcname)
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
@@ -2133,11 +2103,6 @@ var _ = ginkgo.Describe("External Gateway test suite", func() {
 			)
 
 			ginkgo.BeforeEach(func() {
-				if isInterconnectEnabled() {
-					skipper.Skipf(
-						"APB External Route is not yet supported with multiple zones interconnect deployment",
-					)
-				}
 				clientSet = f.ClientSet // so it can be used in AfterEach
 				// retrieve worker node names
 				nodes, err = e2enode.GetBoundedReadySchedulableNodes(clientSet, 3)


### PR DESCRIPTION
Adds verbosity to wait for pod to be running. The reason is because in https://github.com/ovn-org/ovn-kubernetes/pull/3674 it's timing out in some tests after 5 minutes to validate the pod running, 28 occurrences in that run, and at the end the run times out as it goes beyond the 3h limit.
DO NOT MERGE / DO NOT REVIEW.