### PR TITLE
Delete pod IPs from the global EgressService address set

### DIFF
--- a/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
+++ b/go-controller/pkg/ovn/controller/egressservice/egressservice_zone.go
@@ -858,6 +858,12 @@ func (c *Controller) clearServiceResourcesAndRequeue(key string, svcState *svcSt
 		return err
 	}
 
+	delAddrSetOps, err := c.deletePodIPsFromAddressSetOps(createIPAddressNetSlice(svcState.v4LocalEndpoints.UnsortedList(), svcState.v6LocalEndpoints.UnsortedList()))
+	if err != nil {
+		return err
+	}
+	deleteOps = append(deleteOps, delAddrSetOps...)
+
 	if config.OVNKubernetesFeature.EnableInterconnect {
 		p := func(item *nbdb.LogicalRouterStaticRoute) bool {
 			return item.ExternalIDs[svcExternalIDKey] == key


### PR DESCRIPTION
When an EgressService is deleted the POD IPs added to the global EgressService address set should be removed.

I still need to add unit-tests and some additional cleanup  of the address set in `repair()`