### PR TITLE
EgressService: Do not try to remove the chain creation rule on startup

### DIFF
--- a/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
+++ b/go-controller/pkg/node/controllers/egressservice/egressservice_node.go
@@ -498,6 +498,11 @@ func (c *Controller) repairIPTables(v4EpsToServices, v6EpsToServices map[string]
 		// and update the cache accordingly
 		rulesToDel := []string{}
 		for _, rule := range snatRules {
+			if rule == fmt.Sprintf("-N %s", Chain) {
+				// Ignore chain creation rule
+				continue
+			}
+
 			parsed, err := parseIPTRule(rule)
 			if err != nil {
 				// the rule is malformed


### PR DESCRIPTION
The repair function of the EgressService node controller was trying to remove the chain creating rule resulting in the following error:
```
Failed to repair Egress Services entries: running [/usr/sbin/iptables -t nat -D OVN-KUBE-EGRESS-SVC -N OVN-KUBE-EGRESS-SVC --wait]: exit status 2: iptables v1.8.7 (nf_tables): Cannot use -N with -D
```

To address the issue skip that particular rule.

/cc @trozet @oribon 
