### PR TITLE
service controller: use shared InformerFactory

### DIFF
--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -1074,8 +1074,16 @@ func (wf *WatchFactory) ServiceInformer() cache.SharedIndexInformer {
 	return wf.informers[ServiceType].inf
 }
 
+func (wf *WatchFactory) ServiceCoreInformer() v1coreinformers.ServiceInformer {
+	return wf.iFactory.Core().V1().Services()
+}
+
 func (wf *WatchFactory) EndpointSliceInformer() cache.SharedIndexInformer {
 	return wf.informers[EndpointSliceType].inf
+}
+
+func (wf *WatchFactory) EndpointSliceCoreInformer() discoveryinformers.EndpointSliceInformer {
+	return wf.iFactory.Discovery().V1().EndpointSlices()
 }
 
 func (wf *WatchFactory) EgressQoSInformer() egressqosinformer.EgressQoSInformer {

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -1506,7 +1506,6 @@ var _ = ginkgo.Describe("OVN Egress Service Operations", func() {
 })
 
 func (o *FakeOVN) InitAndRunEgressSVCController(tweak ...func(*DefaultNetworkController)) {
-	o.controller.svcFactory.Start(o.stopChan)
 	c, err := o.controller.InitEgressServiceZoneController()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	o.controller.egressSvcController = c

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -299,7 +299,8 @@ var _ = ginkgo.Describe("OVN Namespace Operations", func() {
 			gomega.Expect(nodeHostSubnetAnnotations[0].String()).To(gomega.Equal(node1.NodeSubnet))
 
 			expectedDatabaseState := []libovsdb.TestData{}
-			expectedDatabaseState = addNodeLogicalFlows(expectedDatabaseState, expectedOVNClusterRouter, expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1)
+			expectedDatabaseState = addNodeLogicalFlowsWithServiceController(expectedDatabaseState, expectedOVNClusterRouter,
+				expectedNodeSwitch, expectedClusterRouterPortGroup, expectedClusterPortGroup, &node1, fakeOvn.controller.svcTemplateSupport)
 
 			// Addressset of the host-network namespace was initialized but the node logical switch management port address may or may not
 			// be in the addressset yet, depending on if the host subnets annotation of the node exists in the informer cache. The addressset

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -15,20 +15,13 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	addressset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/address_set"
 	egresssvc_zone "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/egressservice"
-	svccontroller "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/services"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/informers"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/record"
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2"
 )
@@ -403,41 +396,6 @@ func shouldUpdateNode(node, oldNode *kapi.Node) (bool, error) {
 	return true, nil
 }
 
-func newServiceController(client clientset.Interface, nbClient libovsdbclient.Client, recorder record.EventRecorder) (*svccontroller.Controller, informers.SharedInformerFactory, error) {
-	// Create our own informers to start compartmentalizing the code
-	// filter server side the things we don't care about
-	noProxyName, err := labels.NewRequirement("service.kubernetes.io/service-proxy-name", selection.DoesNotExist, nil)
-	if err != nil {
-		panic(err)
-	}
-
-	noHeadlessEndpoints, err := labels.NewRequirement(kapi.IsHeadlessService, selection.DoesNotExist, nil)
-	if err != nil {
-		panic(err)
-	}
-
-	labelSelector := labels.NewSelector()
-	labelSelector = labelSelector.Add(*noProxyName, *noHeadlessEndpoints)
-
-	svcFactory := informers.NewSharedInformerFactoryWithOptions(client, 0,
-		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.LabelSelector = labelSelector.String()
-		}))
-
-	controller, err := svccontroller.NewController(
-		client,
-		nbClient,
-		svcFactory.Core().V1().Services(),
-		svcFactory.Discovery().V1().EndpointSlices(),
-		svcFactory.Core().V1().Nodes(),
-		recorder,
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-	return controller, svcFactory, nil
-}
-
 func (oc *DefaultNetworkController) StartServiceController(wg *sync.WaitGroup, runRepair bool) error {
 	klog.Infof("Starting OVN Service Controller: Using Endpoint Slices")
 	wg.Add(1)
@@ -471,7 +429,7 @@ func (oc *DefaultNetworkController) InitEgressServiceZoneController() (*egresssv
 
 	return egresssvc_zone.NewController(DefaultNetworkControllerName, oc.client, oc.nbClient, oc.addressSetFactory,
 		initClusterEgressPolicies, ensureNodeNoReroutePolicies, deleteLegacyDefaultNoRerouteNodePolicies,
-		oc.stopChan, oc.watchFactory.EgressServiceInformer(), oc.svcFactory.Core().V1().Services(),
-		oc.svcFactory.Discovery().V1().EndpointSlices(),
-		oc.svcFactory.Core().V1().Nodes(), oc.zone)
+		oc.stopChan, oc.watchFactory.EgressServiceInformer(), oc.watchFactory.ServiceCoreInformer(),
+		oc.watchFactory.EndpointSliceCoreInformer(),
+		oc.watchFactory.NodeCoreInformer(), oc.zone)
 }


### PR DESCRIPTION
Update service controller to use sharedInformerFactory from the default controller. It decreases kube-apiserver load and memory footprint, because service controller used to create its own SharedInformerFactory for Nodes, Services and EndpointSlices.
