### PR TITLE
Use NodePrimaryIp to set host-addresses in DPU mode

### DIFF
--- a/go-controller/pkg/node/node_ip_handler_linux.go
+++ b/go-controller/pkg/node/node_ip_handler_linux.go
@@ -10,11 +10,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	"github.com/vishvananda/netlink"
+	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -235,7 +238,7 @@ func (c *addressManager) updateNodeAddressAnnotations() error {
 	}
 
 	// update k8s.ovn.org/host-addresses
-	if err = util.SetNodeHostAddresses(c.nodeAnnotator, c.addresses); err != nil {
+	if err = c.updateHostAddresses(node); err != nil {
 		return err
 	}
 
@@ -263,6 +266,21 @@ func (c *addressManager) updateNodeAddressAnnotations() error {
 		return err
 	}
 	return nil
+}
+
+func (c *addressManager) updateHostAddresses(node *kapi.Node) error {
+	if config.OvnKubeNode.Mode == types.NodeModeDPU {
+		// For DPU mode, here we need to use the DPU host's IP address which is the tenant cluster's
+		// host internal IP address instead.
+		nodeAddrStr, err := util.GetNodePrimaryIP(node)
+		if err != nil {
+			return err
+		}
+		nodeAddrSet := sets.New[string](nodeAddrStr)
+		return util.SetNodeHostAddresses(c.nodeAnnotator, nodeAddrSet)
+	}
+
+	return util.SetNodeHostAddresses(c.nodeAnnotator, c.addresses)
 }
 
 func (c *addressManager) assignAddresses(nodeHostAddresses sets.Set[string]) bool {


### PR DESCRIPTION
When running a 2-cluster design in DPU mode, currently host-addresses is set to the IP address of the Infrastructure node (i.e. Bluefield node) running of behalf of the tenant cluster. This will cause all NodePort service to fail in DPU mode.

Instead, we should calculate the host-addresses using the NodePrimaryIP which will set the host-address to the Node IP of the tenant node.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->