### PR TITLE
Don't enable multicast querier on transit switches.

### DIFF
--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -274,6 +274,7 @@ func (zic *ZoneInterconnectHandler) createLocalZoneNodeResources(node *corev1.No
 			"interconn-ts":             zic.networkTransitSwitchName,
 			"requested-tnl-key":        strconv.Itoa(transitSwitchTunnelKey),
 			"mcast_snoop":              "true",
+			"mcast_querier":            "false",
 			"mcast_flood_unregistered": "true",
 		},
 	}
@@ -346,6 +347,7 @@ func (zic *ZoneInterconnectHandler) createRemoteZoneNodeResources(node *corev1.N
 			"interconn-ts":             zic.networkTransitSwitchName,
 			"requested-tnl-key":        strconv.Itoa(transitSwitchTunnelKey),
 			"mcast_snoop":              "true",
+			"mcast_querier":            "false",
 			"mcast_flood_unregistered": "true",
 		},
 	}


### PR DESCRIPTION
It's enabled by default when snooping is enabled but it's not really needed and we don't configure a source IP for it anyway.  This was causing ovn-controller to continuously log the mis-configuration and effectively disable the querier, e.g.:

  pinctrl|WARN|IGMP Querier enabled without a valid IPv4 or IPv6 address
