### PR TITLE
Fixes panic with delete NAT operations

### DIFF
--- a/go-controller/pkg/libovsdbops/router.go
+++ b/go-controller/pkg/libovsdbops/router.go
@@ -1005,7 +1005,10 @@ func GetRouterNATs(nbClient libovsdbclient.Client, router *nbdb.LogicalRouter) (
 	nats := []*nbdb.NAT{}
 	for _, uuid := range r.Nat {
 		nat, err := GetNAT(nbClient, &nbdb.NAT{UUID: uuid})
-		if err != nil && err != libovsdbclient.ErrNotFound {
+		if err == libovsdbclient.ErrNotFound {
+			continue
+		}
+		if err != nil {
 			return nil, fmt.Errorf("failed to lookup NAT entry with uuid: %s, error: %w", uuid, err)
 		}
 		nats = append(nats, nat)


### PR DESCRIPTION
Regression introduced by:
25d892cc9e318d19738d9519e0e20fbab28f7eae

Would end up appending a nil NAT and causing an NPE when trying to execute EquivalentNAT:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x178ea7b]

goroutine 140 [running]:
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops.isEquivalentNAT(0x0, 0xc002e6cea0)
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/libovsdbops/router.go:935 +0x9b
github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops.DeleteNATsOps({0x24aa068, 0xc0008c0fc0}, {0x0, 0x0, 0x0}, 0xc002e1a4e0, {0xc000130c48, 0x1, 0xc00106f6f8?})
	/go/src/github.com/openshift/ovn-kubernetes/go-controller/pkg/libovsdbops/router.go:1087 +0x728

Seen downstream:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_ovn-kubernetes/1726/pull-ci-openshift-ovn-kubernetes-master-e2e-metal-ipi-ovn-ipv6/1673751230423240704/artifacts/e2e-metal-ipi-ovn-ipv6/gather-extra/artifacts/pods/openshift-ovn-kubernetes_ovnkube-master-fb52f_ovnkube-master_previous.log