### PR TITLE
Fix unidling test panic after not waiting to be done

### DIFF
--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -212,6 +212,7 @@ var _ = ginkgo.Describe("Unidling", func() {
 			framework.ExpectNoError(err)
 
 			var wg sync.WaitGroup
+			done := make(chan struct{})
 			wg.Add(1)
 			go func() {
 				defer ginkgo.GinkgoRecover()
@@ -219,11 +220,13 @@ var _ = ginkgo.Describe("Unidling", func() {
 
 				time.Sleep(time.Second)
 				createBackend(f, serviceName, namespace, node, jig.Labels, port)
+				close(done)
 			}()
 			wg.Wait()
 
 			// Connecting to the service should work at the first attempt
 			gomega.Expect(checkService(clientPod, cmd)).To(gomega.Equal(works))
+			<-done
 		})
 	})
 


### PR DESCRIPTION
Test was done and the framework was being de-allocated while still in createBackend

Fixes
```
2023-06-28T13:58:03.0137137Z   [91m[1mTest Panicked[0m
2023-06-28T13:58:03.0138811Z   [91mruntime error: invalid memory address or nil pointer dereference[0m
2023-06-28T13:58:03.0141144Z   /opt/hostedtoolcache/go/1.19.6/x64/src/runtime/panic.go:884
2023-06-28T13:58:03.0143776Z 
2023-06-28T13:58:03.0144764Z   [91mFull Stack Trace[0m
2023-06-28T13:58:03.0145429Z   panic({0x1a54e20, 0x2e71ba0})
2023-06-28T13:58:03.0146179Z   	/opt/hostedtoolcache/go/1.19.6/x64/src/runtime/panic.go:884 +0x212
2023-06-28T13:58:03.0147433Z   github.com/ovn-org/ovn-kubernetes/test/e2e.createBackend(0xc000477080, {0xc0009e33e0, 0x10}, {0xc0009e2aa0, 0xc}, {0xc000b41db8, 0x11}, 0xc000f3d260, 0x50)
2023-06-28T13:58:03.0148407Z   	/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/unidling.go:329 +0x209
2023-06-28T13:58:03.0150308Z   github.com/ovn-org/ovn-kubernetes/test/e2e.glob..func28.3.6.2()
2023-06-28T13:58:03.0151107Z   	/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/unidling.go:221 +0xdf
2023-06-28T13:58:03.0152296Z   created by github.com/ovn-org/ovn-kubernetes/test/e2e.glob..func28.3.6
2023-06-28T13:58:03.0153146Z   	/home/runner/work/ovn-kubernetes/ovn-kubernetes/test/e2e/unidling.go:216 +0x158
```

@zeeke PTAL