### PR TITLE
ovn-ic: node update missing static routes

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -892,8 +892,13 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 			return h.oc.addUpdateLocalNodeEvent(newNode, nodeSyncsParam)
 		} else {
 			_, syncZoneIC := h.oc.syncZoneICFailed.Load(newNode.Name)
-			// Check if the node moved from local zone to remote zone and if so syncZoneIC should be set to true
-			syncZoneIC = syncZoneIC || h.oc.isLocalZoneNode(oldNode)
+			// Check if the node moved from local zone to remote zone and if so syncZoneIC should be set to true.
+			// Also check if node subnet changed, so static routes are properly set
+			syncZoneIC = syncZoneIC || h.oc.isLocalZoneNode(oldNode) || nodeSubnetChanged(oldNode, newNode)
+			if syncZoneIC {
+				klog.Infof("Node %s in remote zone %s needs interconnect zone sync up.",
+					newNode.Name, util.GetNodeZone(newNode))
+			}
 			return h.oc.addUpdateRemoteNodeEvent(newNode, syncZoneIC)
 		}
 


### PR DESCRIPTION
When node from a remote zone is updated, we only perform the actual update when necessary. This commit improved the logic for doing the remote update in cases where the subnets of the remote node change. That is particularly needed when node changes from ipv4 to dual stack (ipv4 + ipv6)

Reported-at: https://issues.redhat.com/browse/SDN-3993
