### PR TITLE
Fix log spam caused by IC

### DIFF
--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -183,7 +183,9 @@ func (oc *DefaultNetworkController) ensureLocalZonePod(oldPod, pod *kapi.Pod, ad
 func (oc *DefaultNetworkController) ensureRemoteZonePod(oldPod, pod *kapi.Pod, addPort bool) error {
 	podIfAddrs, err := util.GetPodCIDRsWithFullMask(pod, oc.NetInfo)
 	if err != nil {
-		return fmt.Errorf("failed to obtain IPs to add remote pod %s/%s: %w", pod.Namespace, pod.Name, err)
+		// not finding pod IPs on a remote pod is common until the other node wires the pod, suppress it
+		return fmt.Errorf("failed to obtain IPs to add remote pod %s/%s: %w",
+			pod.Namespace, pod.Name, ovntypes.NewSuppressedError(err))
 	}
 
 	if (addPort || (oldPod != nil && len(pod.Status.PodIPs) != len(oldPod.Status.PodIPs))) && !util.PodWantsHostNetwork(pod) {

--- a/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/zone_ic_handler.go
@@ -211,7 +211,7 @@ func (zic *ZoneInterconnectHandler) AddLocalZoneNode(node *corev1.Node) error {
 	return nil
 }
 
-// AddRemoteZoneNode creates the interconnect resources in OVN NB DB for the remote zone node.
+// AddRemoteZoneNode creates the interconnect resources in OVN NBDB and SBDB for the remote zone node.
 // // See createRemoteZoneNodeResources() below for more details.
 func (zic *ZoneInterconnectHandler) AddRemoteZoneNode(node *corev1.Node) error {
 	klog.Infof("Creating interconnect resources for remote zone node %s for the network %s", node.Name, zic.GetNetworkName())
@@ -225,7 +225,7 @@ func (zic *ZoneInterconnectHandler) AddRemoteZoneNode(node *corev1.Node) error {
 	// Get the chassis id.
 	chassisId, err := util.ParseNodeChassisIDAnnotation(node)
 	if err != nil {
-		return fmt.Errorf("failed to parse node chassis-id for node - %s, error: %w", node.Name, err)
+		return fmt.Errorf("failed to parse node chassis-id for node - %s, error: %w", node.Name, types.NewSuppressedError(err))
 	}
 
 	if err := zic.createRemoteZoneNodeResources(node, nodeID, chassisId); err != nil {
@@ -369,7 +369,7 @@ func (zic *ZoneInterconnectHandler) createLocalZoneNodeResources(node *corev1.No
 //   - creates a logical port of type "remote" in the transit switch with the name as - <network_name>.tstor.<node_name>
 //     Eg. if the node name is ovn-worker and the network is default, the name would be - tstor.ovn-worker
 //     if the node name is ovn-worker and the network name is blue, the logical port name would be - blue.tstor.ovn-worker
-//   - binds the remote port to the node remote chassis
+//   - binds the remote port to the node remote chassis in SBDB
 //   - adds static routes for the remote node via the remote port ip in the ovn_cluster_router
 func (zic *ZoneInterconnectHandler) createRemoteZoneNodeResources(node *corev1.Node, nodeID int, chassisId string) error {
 	nodeTransitSwitchPortIPs, err := util.ParseNodeTransitSwitchPortAddrs(node)

--- a/go-controller/pkg/types/errors.go
+++ b/go-controller/pkg/types/errors.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+)
+
+type SuppressedError struct {
+	Inner error
+}
+
+func (e *SuppressedError) Error() string {
+	return fmt.Sprintf("suppressed error logged: %v", e.Inner.Error())
+}
+
+func (e *SuppressedError) Unwrap() error {
+	return e.Inner
+}
+
+func NewSuppressedError(err error) error {
+	return &SuppressedError{
+		Inner: err,
+	}
+}
+
+func IsSuppressedError(err error) bool {
+	var suppressedError *SuppressedError
+	return errors.As(err, &suppressedError)
+}


### PR DESCRIPTION
This PR adds a new type of SuppressedError which can be used by different components to indicate errors that should only be logged as error on their final failure (since we implement retry framework). This is needed because with IC, we rely on the remote node to update some information on the pod/node/resource before we can process it. Currently we spam errors everytime we get an event and do not see that information. The error is necessary so that our retry framework will know to retry, but we do not need to log these as errors.

The PR focuses on pod ips set by remote nodes, as well as chassis information for nodes set by remote nodes or OVN.

When I launch a cluster with this PR most of the log spam is gone. There is still spam from egress qos:

E0628 10:28:09.135010    4186 egressqos.go:890] ip-10-0-164-61.ec2.internal failed with : object not found

but I presume that will be fixed by:

https://github.com/ovn-org/ovn-kubernetes/pull/3666
