### PR TITLE
Add debug statements to figure out ETP=local flake

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -866,10 +866,12 @@ func pokeIPTableRules(clientContainer, pattern string) int {
 	cmd = append(cmd, ipTCommand...)
 	iptRules, err := runCommand(cmd...)
 	framework.ExpectNoError(err, "failed to get iptable rules from node %s", clientContainer)
+	framework.Logf("DEBUG: Dumping IPTRules %v", iptRules)
 	numOfMatchRules := 0
 	for _, iptRule := range strings.Split(iptRules, "\n") {
 		match := strings.Contains(iptRule, pattern)
 		if match {
+			framework.Logf("DEBUG: Matched rule %s for pattern %s", iptRule, pattern)
 			numOfMatchRules++
 		}
 	}


### PR DESCRIPTION
We had a flake here: https://github.com/ovn-org/ovn-kubernetes/actions/runs/5408009751?pr=3724 for this test and from the logs everything looks good. Unless we print the iptable rules at the given instance its hard to debug this test specially since we don't gather the iptable rules from nodes at a given point.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
This PR tries to debug the flake seen in https://github.com/ovn-org/ovn-kubernetes/pull/3724

**- Special notes for reviewers**
We could revert this when we think we have the test stable. From just looking at the logs in the failed run things look good!
The curl was successful and so my doubt is that the counter in iptables [1:60] was perhaps not right and maybe we matched on more packets? We need to check this and the only way to run into this flake again is by adding these debug statements so that its easier to catch it.

**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->