### PR TITLE
APB: Add check for nil when retrieving number of dynamic hops in tests

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
@@ -334,7 +334,10 @@ var _ = Describe("OVN External Gateway namespace", func() {
 			Eventually(func() []string { return listNamespaceInfo() }, time.Hour).Should(HaveLen(1))
 			Eventually(func() int {
 				nsInfo := getNamespaceInfo(namespaceTest.Name)
-				return len(nsInfo.DynamicGateways)
+				if nsInfo != nil {
+					return len(nsInfo.DynamicGateways)
+				}
+				return 0
 			}, 5).Should(Equal(1))
 		})
 


### PR DESCRIPTION
Fixes this scenario:
```
2023-06-29T12:37:36.2845679Z     github.com/onsi/gomega/internal.(*AsyncAssertion).buildActualPoller.func3.1()
2023-06-29T12:37:36.2846810Z     	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/vendor/github.com/onsi/gomega/internal/async_assertion.go:321 +0x397
2023-06-29T12:37:36.2847525Z     panic({0x285b340, 0x3f2c890})
2023-06-29T12:37:36.2848328Z     	/opt/hostedtoolcache/go/1.19.6/x64/src/runtime/panic.go:890 +0x262
2023-06-29T12:37:36.2849115Z     github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute.glob..func1.4.4.4()
2023-06-29T12:37:36.2850141Z     	/home/runner/work/ovn-kubernetes/ovn-kubernetes/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go:337 +0x55
```
https://pipelines.actions.githubusercontent.com/serviceHosts/420fda10-250e-4b5e-ad0c-d969a2d4a803/_apis/pipelines/1/runs/111881/signedlogcontent/4?urlExpires=2023-07-05T08%3A25%3A21.8009273Z&urlSigningMethod=HMACV1&urlSignature=juuRZbUIAiBfWscb6UrwTDcXfM2nAfQXoEm%2BeRl4v5M%3D

@tssurya @npinaeva @jcaamano FYI.