### PR TITLE
NIT: EIP: Healthchecks have moved to ovnkube-controller

### DIFF
--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -461,12 +461,6 @@ func (oc *DefaultNetworkController) Run(ctx context.Context) error {
 		if err := WithSyncDurationMetric("egress ip", oc.WatchEgressIP); err != nil {
 			return err
 		}
-		if config.OVNKubernetesFeature.EgressIPReachabiltyTotalTimeout == 0 {
-			klog.V(2).Infof("EgressIP node reachability check disabled")
-		} else if config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort != 0 {
-			klog.Infof("EgressIP node reachability enabled and using gRPC port %d",
-				config.OVNKubernetesFeature.EgressIPNodeHealthCheckPort)
-		}
 	}
 
 	if config.OVNKubernetesFeature.EnableEgressFirewall {


### PR DESCRIPTION
These logs are already moved to cluster-manager

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->