### PR TITLE
Do not reconcile egressIPPod objects that are being deleted when the namespace no longer exists

### DIFF
--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -327,6 +327,12 @@ func (oc *DefaultNetworkController) reconcileEgressIPPod(old, new *v1.Pod) (err 
 		oldPod = old
 		namespace, err = oc.watchFactory.GetNamespace(oldPod.Namespace)
 		if err != nil {
+			// when the whole namespace gets removed, we can ignore the NotFound error here
+			// any potential configuration will get removed in reconcileEgressIPNamespace
+			if new == nil && apierrors.IsNotFound(err) {
+				klog.V(5).Infof("Namespace %s no longer exists for the deleted pod: %s", oldPod.Namespace, oldPod.Name)
+				return nil
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
When a namespace with pods gets removed and the pod removal event is handled after the namespace is already gone, we should ignore the NotFound error in reconcileEgressIPPod. Any potential configuration will get removed in reconcileEgressIPNamespace.

Found in downstream CI, tracked in https://issues.redhat.com/browse/OCPBUGS-15804
Example error:
```
I0707 01:15:21.862524       1 namespace.go:260] [e2e-netpol-z-1913] deleting namespace
...
E0707 01:15:21.894356       1 obj_retry.go:680] Failed to delete *factory.egressIPPod e2e-netpol-z-1913/b, error: namespace "e2e-netpol-z-1913" not found
I0707 01:15:21.894452       1 pods.go:100] Deleting pod: e2e-netpol-z-1913/b
E0707 01:15:21.904170       1 obj_retry.go:680] Failed to delete *factory.egressIPPod e2e-netpol-z-1913/c, error: namespace "e2e-netpol-z-1913" not found
I0707 01:15:21.904206       1 pods.go:100] Deleting pod: e2e-netpol-z-1913/c
```

/cc @tssurya @jcaamano 
