### PR TITLE
Enable multi-homing e2e tests for localnet with IC

### DIFF
--- a/test/e2e/localnet-underlay.go
+++ b/test/e2e/localnet-underlay.go
@@ -156,8 +156,6 @@ func defaultNetworkBridgeMapping() BridgeMapping {
 }
 
 func bridgeMapping(physnet, ovsBridge string) BridgeMapping {
-	physnet = strings.ReplaceAll(physnet, "-", ".")
-	physnet = strings.ReplaceAll(physnet, "/", ".")
 	return BridgeMapping{
 		physnet:   physnet,
 		ovsBridge: ovsBridge,

--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -60,7 +60,7 @@ var _ = Describe("Multi Homing", func() {
 		table.DescribeTable("is able to get to the Running phase", func(netConfigParams networkAttachmentConfigParams, podConfig podConfiguration) {
 			netConfig := newNetworkAttachmentConfig(netConfigParams)
 
-			if netConfig.topology != "layer3" {
+			if netConfig.topology == "layer2" {
 				if isInterconnectEnabled() {
 					e2eskipper.Skipf(
 						"Secondary network with topology %s is not yet supported with multiple zones interconnect deployment", netConfig.topology,
@@ -275,8 +275,8 @@ var _ = Describe("Multi Homing", func() {
 			func(netConfigParams networkAttachmentConfigParams, clientPodConfig podConfiguration, serverPodConfig podConfiguration) {
 				netConfig := newNetworkAttachmentConfig(netConfigParams)
 
-				// Skip the test if the netConfig topology is not layer3 and the deployment is multi zone
-				if netConfig.topology != "layer3" {
+				// Skip the test if the netConfig topology is layer2 and the deployment is multi zone
+				if netConfig.topology == "layer2" {
 					if isInterconnectEnabled() {
 						e2eskipper.Skipf(
 							"Secondary network with topology %s is not yet supported with multiple zones interconnect deployment", netConfig.topology,
@@ -694,8 +694,8 @@ var _ = Describe("Multi Homing", func() {
 				func(netConfigParams networkAttachmentConfigParams, allowedClientPodConfig podConfiguration, blockedClientPodConfig podConfiguration, serverPodConfig podConfiguration, policy *mnpapi.MultiNetworkPolicy) {
 					netConfig := newNetworkAttachmentConfig(netConfigParams)
 
-					// Skip the test if the netConfig topology is not layer3 and the deployment is multi zone
-					if netConfig.topology != "layer3" {
+					// Skip the test if the netConfig topology is layer2 and the deployment is multi zone
+					if netConfig.topology == "layer2" {
 						if isInterconnectEnabled() {
 							e2eskipper.Skipf(
 								"Secondary network with topology %s is not yet supported with multiple zones interconnect deployment", netConfig.topology,


### PR DESCRIPTION
Enable e2e tests for localnet but there was another issue that needed
a fix.

PR#3609 removed the suffix `_br-localnet` from the localnet network
name used in the bridge mappings, but also inadvertedly removed the
replacement of `-` and `/` characters form the controller code but not
from the tests.

Let's remove them from tests as well as they don't look troublesome
neither as network name in the logical switch port options nor in the
OVS bridge mappings.