### PR TITLE
subnetallocator: fix and clean up used vs. count confusion

### DIFF
--- a/go-controller/pkg/clustermanager/subnetallocator/host_subnet_allocator.go
+++ b/go-controller/pkg/clustermanager/subnetallocator/host_subnet_allocator.go
@@ -81,7 +81,7 @@ func (sna *HostSubnetAllocator) hasHybridOverlayAllocation() bool {
 func (sna *HostSubnetAllocator) recordSubnetCount() {
 	// only for the default network
 	if !sna.netInfo.IsSecondary() {
-		v4count, _, v6count, _ := sna.clusterSubnetAllocator.Usage()
+		v4count, v6count := sna.clusterSubnetAllocator.Count()
 		metrics.RecordSubnetCount(float64(v4count), float64(v6count))
 	}
 }
@@ -89,8 +89,8 @@ func (sna *HostSubnetAllocator) recordSubnetCount() {
 func (sna *HostSubnetAllocator) recordSubnetUsage() {
 	// only for the default network
 	if !sna.netInfo.IsSecondary() {
-		v4count, _, v6count, _ := sna.clusterSubnetAllocator.Usage()
-		metrics.RecordSubnetUsage(float64(v4count), float64(v6count))
+		v4used, v6used := sna.clusterSubnetAllocator.Usage()
+		metrics.RecordSubnetUsage(float64(v4used), float64(v6used))
 	}
 }
 

--- a/go-controller/pkg/clustermanager/subnetallocator/host_subnet_allocator_test.go
+++ b/go-controller/pkg/clustermanager/subnetallocator/host_subnet_allocator_test.go
@@ -303,7 +303,7 @@ func TestController_allocateNodeSubnets_ReleaseOnError(t *testing.T) {
 	}
 
 	// test network allocation works correctly
-	_, v4usedBefore, _, v6usedBefore := sna.clusterSubnetAllocator.Usage()
+	v4usedBefore, v6usedBefore := sna.clusterSubnetAllocator.Usage()
 	got, allocated, err := sna.allocateNodeSubnets(sna.clusterSubnetAllocator, "testNode", nil, true, true)
 	if err == nil {
 		t.Fatalf("allocateNodeSubnets() expected error but got success")
@@ -315,7 +315,7 @@ func TestController_allocateNodeSubnets_ReleaseOnError(t *testing.T) {
 		t.Fatalf("allocateNodeSubnets() expected no allocated subnets, got %v", allocated)
 	}
 
-	_, v4usedAfter, _, v6usedAfter := sna.clusterSubnetAllocator.Usage()
+	v4usedAfter, v6usedAfter := sna.clusterSubnetAllocator.Usage()
 	if v4usedAfter != v4usedBefore {
 		t.Fatalf("Expected %d v4 allocated subnets, but got %d", v4usedBefore, v4usedAfter)
 	}


### PR DESCRIPTION
The original Usage() returned both used and available subnets for the allocator, which is confusing and error prone. The fixed commit used the "count" (eg used+unused) for both count and usage, leading to OpenShift alerts about subnets exceeded because (usage / count) = 1.

Instead, break the API into two separate calls with clear meaning. Usage() returns how many subnets are allocated, and Count() returns how many are possible/available.

```
{  fail [github.com/openshift/origin/test/extended/prometheus/prometheus.go:587]: Unexpected error:
    <errors.aggregate | len:1, cap:1>:
    promQL query returned unexpected results:
    ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|PrometheusRemoteWriteDesiredShards|KubeJobFailed|Watchdog|KubePodNotReady|etcdMembersDown|etcdMembersDown|etcdGRPCRequestsSlow|etcdGRPCRequestsSlow|etcdHighNumberOfFailedGRPCRequests|etcdHighNumberOfFailedGRPCRequests|etcdMemberCommunicationSlow|etcdMemberCommunicationSlow|etcdNoLeader|etcdNoLeader|etcdHighFsyncDurations|etcdHighFsyncDurations|etcdHighCommitDurations|etcdHighCommitDurations|etcdInsufficientMembers|etcdInsufficientMembers|etcdHighNumberOfLeaderChanges|etcdHighNumberOfLeaderChanges|KubeAPIErrorBudgetBurn|KubeAPIErrorBudgetBurn|KubeClientErrors|KubeClientErrors|KubePersistentVolumeErrors|KubePersistentVolumeErrors|MCDDrainError|MCDDrainError|KubeMemoryOvercommit|KubeMemoryOvercommit|MCDPivotError|MCDPivotError|PrometheusOperatorWatchErrors|PrometheusOperatorWatchErrors|OVNKubernetesResourceRetryFailure|OVNKubernetesResourceRetryFailure|RedhatOperatorsCatalogError|RedhatOperatorsCatalogError|VSphereOpenshiftNodeHealthFail|VSphereOpenshiftNodeHealthFail|SamplesImagestreamImportFailing|SamplesImagestreamImportFailing",alertstate="firing",severity!="info"} >= 1
    [
      {
        "metric": {
          "__name__": "ALERTS",
          "alertname": "V4SubnetAllocationThresholdExceeded",
          "alertstate": "firing",
          "container": "kube-rbac-proxy",
          "endpoint": "metrics",
          "instance": "10.0.0.4:9102",
          "job": "ovnkube-master",
          "namespace": "openshift-ovn-kubernetes",
          "pod": "ovnkube-master-hjp2x",
          "prometheus": "openshift-monitoring/k8s",
          "service": "ovn-kubernetes-master",
          "severity": "warning"
        },
        "value": [
     `     1689091264.978,
          "1"
        ]
      }
    ]
    [
        <*errors.errorString | 0xc00194d430>{
            s: "promQL query returned unexpected results:\nALERTS{alertname!~\"Watchdog|AlertmanagerReceiversNotConfigured|PrometheusRemoteWriteDesiredShards|KubeJobFailed|Watchdog|KubePodNotRead|etcdMembersDown|etcdMembersDown|etcdGRPCRequestsSlow|etcdGRPCRequestsSlow|etcdHighNumberOfFailedGRPCRequests|etcdHighNumberOfFailedGRPCRequests|etcdMemberCommunicationSlow|etcdMemberCommunicationSlow|etcdNoLeader|etcdNoLeader|etcdHighFsyncDurations|etcdHighFsyncDurations|etcdHighCommitDurations|etcdHighCommitDurations|etcdInsufficientMembers|etcdInsufficientMembers|etcdHighNumberOfLeaderChanges|etcdHighNumberOfLeaderChanges|KubeAPIErrorBudgetBurn|KubeAPIErrorBudgetBurn|KubeClientErrors|KubeClientErrors|KubePersistentVolumeErrors|KubePersistentVolumeErrors|MCDDrainError|MCDDrainError|KubeMemoryOvercommit|KubeMemoryOvercommit|MCDPivotError|MCDPivotError|PrometheusOperatorWatchErrors|PrometheusOperatorWatchErrors|OVNKubernetesResourceRetryFailure|OVNKubernetesResourceRetryFailure|RedhatOperatorsCatalogError|RedhatOperatorsCatalogError|VSphereOpenshiftNodeHealthFail|VSphereOpenshiftNodeHealthFail|SamplesImagestreamImportFailing|SamplesImagestreamImportFailing\",alertstate=\"firing\",severity!=\"info\"} >= 1\n[\n  {\n    \"metric\": {\n      \"__name__\": \"ALERTS\",\n      \"alertname\": \"V4SubnetAllocationThresholdExceeded\",\n      \"alertstate\": \"firing\",\n      \"container\": \"kube-rbac-proxy\",\n      \"endpoint\": \"metrics\",\n      \"instance\": \"10.0.0.4:9102\",\n      \"job\": \"ovnkube-master\",\n      \"namespace\": \"openshift-ovn-kubernetes\",\n      \"pod\": \"ovnkube-master-hjp2x\",\n      \"prometheus\": \"openshift-monitoring/k8s\",\n      \"service\": \"ovn-kubernetes-master\",\n      \"severity\": \"warning\"\n    },\n    \"value\": [\n      1689091264.978,\n      \"1\"\n    ]\n  }\n]",
        },
    ]
occurred
```

Fixes: d86604bf2074 ("Move subnet handling out of network cluster controller")

@jcaamano 