### PR TITLE
Sync cache with timeout, fix apbroute start

### DIFF
--- a/go-controller/pkg/clustermanager/egressservice/egressservice_cluster.go
+++ b/go-controller/pkg/clustermanager/egressservice/egressservice_cluster.go
@@ -168,20 +168,19 @@ func (c *Controller) Start(threadiness int) error {
 	defer utilruntime.HandleCrash()
 
 	klog.Infof("Starting Egress Services Controller")
-
-	if !cache.WaitForNamedCacheSync("egressservices", c.stopCh, c.egressServiceSynced) {
+	if !util.WaitForNamedCacheSyncWithTimeout("egressservices", c.stopCh, c.egressServiceSynced) {
 		return fmt.Errorf("timed out waiting for egressservice caches to sync")
 	}
 
-	if !cache.WaitForNamedCacheSync("egressservices_services", c.stopCh, c.servicesSynced) {
+	if !util.WaitForNamedCacheSyncWithTimeout("egressservices_services", c.stopCh, c.servicesSynced) {
 		return fmt.Errorf("timed out waiting for caches to sync")
 	}
 
-	if !cache.WaitForNamedCacheSync("egressservices_endpointslices", c.stopCh, c.endpointSlicesSynced) {
+	if !util.WaitForNamedCacheSyncWithTimeout("egressservices_endpointslices", c.stopCh, c.endpointSlicesSynced) {
 		return fmt.Errorf("timed out waiting for caches to sync")
 	}
 
-	if !cache.WaitForNamedCacheSync("egressservices_nodes", c.stopCh, c.nodesSynced) {
+	if !util.WaitForNamedCacheSyncWithTimeout("egressservices_nodes", c.stopCh, c.nodesSynced) {
 		return fmt.Errorf("timed out waiting for caches to sync")
 	}
 

--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
@@ -141,7 +141,7 @@ func (nadController *NetAttachDefinitionController) Start() error {
 
 func (nadController *NetAttachDefinitionController) start() error {
 	nadController.nadFactory.Start(nadController.stopChan)
-	if !cache.WaitForNamedCacheSync(nadController.name, nadController.stopChan, nadController.netAttachDefSynced) {
+	if !util.WaitForNamedCacheSyncWithTimeout(nadController.name, nadController.stopChan, nadController.netAttachDefSynced) {
 		return fmt.Errorf("stop requested while syncing caches")
 	}
 

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -930,18 +930,14 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		nc.wg.Add(1)
-		go func() {
-			defer nc.wg.Done()
-			c.Run(1)
-		}()
+		if err = c.Run(nc.wg, 1); err != nil {
+			return err
+		}
 	}
 	if config.OVNKubernetesFeature.EnableMultiExternalGateway {
-		nc.wg.Add(1)
-		go func() {
-			defer nc.wg.Done()
-			nc.apbExternalRouteNodeController.Run(1)
-		}()
+		if err = nc.apbExternalRouteNodeController.Run(nc.wg, 1); err != nil {
+			return err
+		}
 	}
 
 	nc.wg.Add(1)

--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -265,11 +265,8 @@ var _ = Describe("Egress Service Operations", func() {
 				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
 					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
 				Expect(err).ToNot(HaveOccurred())
-				fakeOvnNode.wg.Add(1)
-				go func() {
-					defer fakeOvnNode.wg.Done()
-					c.Run(1)
-				}()
+				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(err).ToNot(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -377,11 +374,8 @@ var _ = Describe("Egress Service Operations", func() {
 				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
 					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
 				Expect(err).ToNot(HaveOccurred())
-				fakeOvnNode.wg.Add(1)
-				go func() {
-					defer fakeOvnNode.wg.Done()
-					c.Run(1)
-				}()
+				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(err).ToNot(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -524,11 +518,8 @@ var _ = Describe("Egress Service Operations", func() {
 				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
 					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
 				Expect(err).ToNot(HaveOccurred())
-				fakeOvnNode.wg.Add(1)
-				go func() {
-					defer fakeOvnNode.wg.Done()
-					c.Run(1)
-				}()
+				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(err).ToNot(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {
@@ -677,11 +668,8 @@ var _ = Describe("Egress Service Operations", func() {
 				c, err := egressservice.NewController(fakeOvnNode.stopChan, ovnKubeNodeSNATMark, fakeOvnNode.nc.name,
 					wf.EgressServiceInformer(), wf.ServiceInformer(), wf.EndpointSliceInformer())
 				Expect(err).ToNot(HaveOccurred())
-				fakeOvnNode.wg.Add(1)
-				go func() {
-					defer fakeOvnNode.wg.Done()
-					c.Run(1)
-				}()
+				err = c.Run(fakeOvnNode.wg, 1)
+				Expect(err).ToNot(HaveOccurred())
 
 				expectedTables := map[string]util.FakeTable{
 					"nat": {

--- a/go-controller/pkg/node/egress_service_test.go
+++ b/go-controller/pkg/node/egress_service_test.go
@@ -573,14 +573,6 @@ var _ = Describe("Egress Service Operations", func() {
 					Cmd: "ip -4 rule add prio 5000 from 10.128.0.3 table mynetwork",
 					Err: nil,
 				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork",
-					Err: nil,
-				})
-				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
-					Cmd: "ip -4 rule del prio 5000 from 10.128.0.3 table mynetwork",
-					Err: nil,
-				})
 				epPortName := "https"
 				epPortValue := int32(443)
 
@@ -685,12 +677,25 @@ var _ = Describe("Egress Service Operations", func() {
 					return f4.MatchState(expectedTables)
 				}).ShouldNot(HaveOccurred())
 
+				Eventually(func() bool {
+					return fakeOvnNode.fakeExec.CalledMatchesExpected()
+				}).Should(BeTrue())
+
 				err = fakeOvnNode.fakeClient.EgressServiceClient.K8sV1().EgressServices("namespace1").Delete(context.TODO(), "service1", metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() error {
 					return f4.MatchState(expectedTables)
 				}).ShouldNot(HaveOccurred())
+
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule del prio 5000 from 10.129.0.2 table mynetwork",
+					Err: nil,
+				})
+				fakeOvnNode.fakeExec.AddFakeCmd(&ovntest.ExpectedCmd{
+					Cmd: "ip -4 rule del prio 5000 from 10.128.0.3 table mynetwork",
+					Err: nil,
+				})
 
 				Eventually(func() bool {
 					return fakeOvnNode.fakeExec.CalledMatchesExpected()

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -2,6 +2,7 @@ package apbroute
 
 import (
 	"context"
+	"sync"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,6 +41,7 @@ var (
 	externalController *ExternalGatewayMasterController
 	iFactory           *factory.WatchFactory
 	stopChan           chan (struct{})
+	wg                 *sync.WaitGroup
 	initialDB          libovsdbtest.TestSetup
 	nbClient           libovsdbclient.Client
 	nbsbCleanup        *libovsdbtest.Context
@@ -117,9 +119,9 @@ func initController(k8sObjects, routePolicyObjects []runtime.Object) {
 	}
 
 	mgr = externalController.mgr
-	go func() {
-		externalController.Run(5)
-	}()
+	wg = &sync.WaitGroup{}
+	err = externalController.Run(wg, 5)
+	Expect(err).NotTo(HaveOccurred())
 }
 
 var _ = Describe("OVN External Gateway policy", func() {

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -50,19 +50,19 @@ type ExternalGatewayMasterController struct {
 	stopCh               <-chan struct{}
 
 	// route policies
-	routeLister adminpolicybasedroutelisters.AdminPolicyBasedExternalRouteLister
-	routeSynced cache.InformerSynced
-	routeQueue  workqueue.RateLimitingInterface
+	routeLister   adminpolicybasedroutelisters.AdminPolicyBasedExternalRouteLister
+	routeInformer cache.SharedIndexInformer
+	routeQueue    workqueue.RateLimitingInterface
 
 	// Pods
-	podLister corev1listers.PodLister
-	podSynced cache.InformerSynced
-	podQueue  workqueue.RateLimitingInterface
+	podLister   corev1listers.PodLister
+	podInformer cache.SharedIndexInformer
+	podQueue    workqueue.RateLimitingInterface
 
 	// Namespaces
-	namespaceQueue  workqueue.RateLimitingInterface
-	namespaceLister corev1listers.NamespaceLister
-	namespaceSynced cache.InformerSynced
+	namespaceQueue    workqueue.RateLimitingInterface
+	namespaceLister   corev1listers.NamespaceLister
+	namespaceInformer cache.SharedIndexInformer
 
 	// External gateway caches
 	// Make them public so that they can be used by the annotation logic to lock on namespaces and share the same external route information
@@ -111,19 +111,19 @@ func NewExternalMasterController(
 		apbRoutePolicyClient: apbRoutePolicyClient,
 		stopCh:               stopCh,
 		routeLister:          externalRouteInformer.Lister(),
-		routeSynced:          externalRouteInformer.Informer().HasSynced,
+		routeInformer:        externalRouteInformer.Informer(),
 		routeQueue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.NewItemFastSlowRateLimiter(time.Second, 5*time.Second, 5),
 			"adminpolicybasedexternalroutes",
 		),
-		podLister: podInformer.Lister(),
-		podSynced: podInformer.Informer().HasSynced,
+		podLister:   podInformer.Lister(),
+		podInformer: podInformer.Informer(),
 		podQueue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.NewItemFastSlowRateLimiter(time.Second, 5*time.Second, 5),
 			"apbexternalroutepods",
 		),
-		namespaceLister: namespaceInformer.Lister(),
-		namespaceSynced: namespaceInformer.Informer().HasSynced,
+		namespaceLister:   namespaceInformer.Lister(),
+		namespaceInformer: namespaceInformer.Informer(),
 		namespaceQueue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.NewItemFastSlowRateLimiter(time.Second, 5*time.Second, 5),
 			"apbexternalroutenamespaces",
@@ -139,43 +139,41 @@ func NewExternalMasterController(
 			routePolicyFactory.K8s().V1().AdminPolicyBasedExternalRoutes().Lister(),
 			nbCli),
 	}
+	return c, nil
+}
 
-	_, err = namespaceInformer.Informer().AddEventHandler(
+func (c *ExternalGatewayMasterController) Run(wg *sync.WaitGroup, threadiness int) error {
+	defer utilruntime.HandleCrash()
+	klog.V(4).Info("Starting Admin Policy Based Route Controller")
+
+	_, err := c.namespaceInformer.AddEventHandler(
 		factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.onNamespaceAdd,
 			UpdateFunc: c.onNamespaceUpdate,
 			DeleteFunc: c.onNamespaceDelete,
 		}))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	_, err = podInformer.Informer().AddEventHandler(
+	_, err = c.podInformer.AddEventHandler(
 		factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.onPodAdd,
 			UpdateFunc: c.onPodUpdate,
 			DeleteFunc: c.onPodDelete,
 		}))
 	if err != nil {
-		return nil, err
+		return err
 	}
-	_, err = externalRouteInformer.Informer().AddEventHandler(
+	_, err = c.routeInformer.AddEventHandler(
 		factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.onPolicyAdd,
 			UpdateFunc: c.onPolicyUpdate,
 			DeleteFunc: c.onPolicyDelete,
 		}))
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	return c, nil
-
-}
-
-func (c *ExternalGatewayMasterController) Run(wg *sync.WaitGroup, threadiness int) error {
-	defer utilruntime.HandleCrash()
-	klog.V(4).Info("Starting Admin Policy Based Route Controller")
 
 	c.routePolicyFactory.Start(c.stopCh)
 
@@ -185,9 +183,9 @@ func (c *ExternalGatewayMasterController) Run(wg *sync.WaitGroup, threadiness in
 		resourceName string
 		syncFn       cache.InformerSynced
 	}{
-		{"apbexternalroutenamespaces", c.namespaceSynced},
-		{"apbexternalroutepods", c.podSynced},
-		{"adminpolicybasedexternalroutes", c.routeSynced},
+		{"apbexternalroutenamespaces", c.namespaceInformer.HasSynced},
+		{"apbexternalroutepods", c.podInformer.HasSynced},
+		{"adminpolicybasedexternalroutes", c.routeInformer.HasSynced},
 	} {
 		syncWg.Add(1)
 		go func(resourceName string, syncFn cache.InformerSynced) {

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -193,7 +193,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair, useLBGr
 
 	// Wait for the caches to be synced
 	klog.Info("Waiting for informer caches to sync")
-	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.servicesSynced, c.endpointSlicesSynced, c.nodesSynced) {
+	if !util.WaitForNamedCacheSyncWithTimeout(controllerName, stopCh, c.servicesSynced, c.endpointSlicesSynced, c.nodesSynced) {
 		return fmt.Errorf("error syncing cache")
 	}
 

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -488,11 +488,9 @@ func (oc *DefaultNetworkController) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		oc.wg.Add(1)
-		go func() {
-			defer oc.wg.Done()
-			oc.runEgressQoSController(1, oc.stopChan)
-		}()
+		if err = oc.runEgressQoSController(oc.wg, 1, oc.stopChan); err != nil {
+			return err
+		}
 	}
 
 	if config.OVNKubernetesFeature.EnableEgressService {
@@ -501,19 +499,15 @@ func (oc *DefaultNetworkController) Run(ctx context.Context) error {
 			return fmt.Errorf("unable to create new egress service controller while creating new default network controller: %w", err)
 		}
 		oc.egressSvcController = c
-		oc.wg.Add(1)
-		go func() {
-			defer oc.wg.Done()
-			oc.egressSvcController.Run(1)
-		}()
+		if err = oc.egressSvcController.Run(oc.wg, 1); err != nil {
+			return err
+		}
 	}
 
 	if config.OVNKubernetesFeature.EnableMultiExternalGateway {
-		oc.wg.Add(1)
-		go func() {
-			defer oc.wg.Done()
-			oc.apbExternalRouteController.Run(1)
-		}()
+		if err = oc.apbExternalRouteController.Run(oc.wg, 1); err != nil {
+			return err
+		}
 	}
 
 	end := time.Since(start)

--- a/go-controller/pkg/ovn/egressqos_test.go
+++ b/go-controller/pkg/ovn/egressqos_test.go
@@ -820,11 +820,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 func (o *FakeOVN) InitAndRunEgressQoSController() {
 	klog.Warningf("#### [%p] INIT EgressQoS", o)
 	o.controller.initEgressQoSController(o.watcher.EgressQoSInformer(), o.watcher.PodCoreInformer(), o.watcher.NodeCoreInformer())
-	o.egressQoSWg.Add(1)
-	go func() {
-		defer o.egressQoSWg.Done()
-		o.controller.runEgressQoSController(1, o.stopChan)
-	}()
+	o.controller.runEgressQoSController(o.egressQoSWg, 1, o.stopChan)
 }
 
 func createNodeAndLS(fakeOVN *FakeOVN, name, zone string) (*v1.Node, *nbdb.LogicalSwitch, error) {

--- a/go-controller/pkg/ovn/egressservices_test.go
+++ b/go-controller/pkg/ovn/egressservices_test.go
@@ -1513,11 +1513,8 @@ func (o *FakeOVN) InitAndRunEgressSVCController(tweak ...func(*DefaultNetworkCon
 	for _, t := range tweak {
 		t(o.controller)
 	}
-	o.egressSVCWg.Add(1)
-	go func() {
-		defer o.egressSVCWg.Done()
-		o.controller.egressSvcController.Run(1)
-	}()
+	err = o.controller.egressSvcController.Run(o.egressSVCWg, 1)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 }
 
 // creates a logical router static route for egress service

--- a/go-controller/pkg/ovn/external_gateway_apb_test.go
+++ b/go-controller/pkg/ovn/external_gateway_apb_test.go
@@ -3054,9 +3054,6 @@ func deleteNamespace(namespaceName string, fakeClient kubernetes.Interface) {
 
 func (o *FakeOVN) RunAPBExternalPolicyController() {
 	o.controller.apbExternalRouteController.Repair()
-	o.controller.wg.Add(1)
-	go func() {
-		defer o.controller.wg.Done()
-		o.controller.apbExternalRouteController.Run(5)
-	}()
+	err := o.controller.apbExternalRouteController.Run(o.controller.wg, 5)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 }

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -198,4 +198,8 @@ const (
 	// MaxLogicalPortTunnelKey is maximum tunnel key that can be requested for a
 	// Logical Switch or Router Port
 	MaxLogicalPortTunnelKey = 32767
+
+	// InformerSyncTimeout is used to wait from the initial informer cache sync.
+	// It allows ~4 list() retries with the default reflector exponential backoff config
+	InformerSyncTimeout = 20 * time.Second
 )

--- a/go-controller/pkg/util/sync.go
+++ b/go-controller/pkg/util/sync.go
@@ -1,5 +1,13 @@
 package util
 
+import (
+	"time"
+
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
+
+	"k8s.io/client-go/tools/cache"
+)
+
 // GetChildStopChan returns a new channel that doesn't affect parentStopChan, but will be closed when
 // parentStopChan is closed. May be used for child goroutines that may need to be stopped with the main goroutine or
 // separately.
@@ -24,4 +32,27 @@ func GetChildStopChan(parentStopChan <-chan struct{}) chan struct{} {
 		}
 	}()
 	return childStopChan
+}
+
+func GetChildStopChanWithTimeout(parentStopChan <-chan struct{}, duration time.Duration) chan struct{} {
+	childStopChan := make(chan struct{})
+	timer := time.NewTicker(duration)
+	go func() {
+		defer timer.Stop()
+		select {
+		case <-parentStopChan:
+			close(childStopChan)
+			return
+		case <-childStopChan:
+			return
+		case <-timer.C:
+			close(childStopChan)
+			return
+		}
+	}()
+	return childStopChan
+}
+
+func WaitForNamedCacheSyncWithTimeout(controllerName string, stopCh <-chan struct{}, cacheSyncs ...cache.InformerSynced) bool {
+	return cache.WaitForNamedCacheSync(controllerName, GetChildStopChanWithTimeout(stopCh, types.InformerSyncTimeout), cacheSyncs...)
 }


### PR DESCRIPTION
 WaitForCacheSync function takes stopChannel as an argument, and it will
retry syncing cache until it is closed. If we just use ovn-kube stop
channel, it will never return an error (it will never return until
either the cache is synced, or stopChannel is closed).
To fix it, GetChildStopChanWithTimeout and some wrappers functions
passing this channel with timeout were added. The default cache sync
timeout is 20 seconds (with reflector exponential backoff it means 4
list() retries).
If any informer failed to list its resource withing a given time period,
return error to make the problem visible.

To test this change, comment out list permission for any object in
dist/templates/ovn-setup.yaml.j2, run kind cluster and check the
corresponding container fails with message like
"failed to start ovnkube controller: error in syncing cache for
*v1.EndpointSlice informer"

Don't add event handlers for existing informers in constructor.
Do so only if Run() is called, otherwise workqueues will be filled,
but not handled.

I joined these 2 fixes together, because they both add an error to the `Run` method of the apbroute controllers