### PR TITLE
Wait for other SBDB objects

### DIFF
--- a/go-controller/pkg/libovsdbops/portbinding.go
+++ b/go-controller/pkg/libovsdbops/portbinding.go
@@ -32,3 +32,22 @@ func UpdatePortBindingSetChassis(sbClient libovsdbclient.Client, portBinding *sb
 	_, err = m.CreateOrUpdate(opModel)
 	return err
 }
+
+// GetPortBinding looks up a portBinding in SBDB
+func GetPortBinding(sbClient libovsdbclient.Client, portBinding *sbdb.PortBinding) (*sbdb.PortBinding, error) {
+	found := []*sbdb.PortBinding{}
+	opModel := operationModel{
+		Model:          portBinding,
+		ExistingResult: &found,
+		ErrNotFound:    true,
+		BulkOp:         false,
+	}
+
+	m := newModelClient(sbClient)
+	err := m.Lookup(opModel)
+	if err != nil {
+		return nil, err
+	}
+
+	return found[0], nil
+}

--- a/go-controller/pkg/util/ovn.go
+++ b/go-controller/pkg/util/ovn.go
@@ -4,10 +4,14 @@ package util
 // Eventually these should all be migrated to go-ovn bindings
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"time"
 
 	ocpconfigapi "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
@@ -19,9 +23,20 @@ func CreateMACBinding(sbClient libovsdbclient.Client, logicalPort, datapathName 
 	p := func(item *sbdb.DatapathBinding) bool {
 		return item.ExternalIDs["name"] == datapathName
 	}
-	datapath, err := libovsdbops.GetDatapathBindingWithPredicate(sbClient, p)
+
+	// It could take some time for the datapath to propagate to SBDB, wait for some time
+	maxTimeout := 10 * time.Second
+	var datapath *sbdb.DatapathBinding
+	var err1 error
+	err := wait.PollUntilContextTimeout(context.TODO(), 50*time.Millisecond, maxTimeout, true, func(ctx context.Context) (bool, error) {
+		if datapath, err1 = libovsdbops.GetDatapathBindingWithPredicate(sbClient, p); err1 != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+
 	if err != nil {
-		return fmt.Errorf("error getting datapath %s: %v", datapathName, err)
+		return fmt.Errorf("failed to find datpath: %s, after %s: %w, %v", datapathName, maxTimeout, err, err1)
 	}
 
 	// find Create mac_binding if needed


### PR DESCRIPTION
There are other objects that we update in SBDB that depend on an object being created by northd and may race. Failures here can further delay node add by 30 seconds.

Ideally we should lower the retry mechanism interval from 30 seconds to something much smaller (now that we use a per key locked syncmap), however that could have even greater implications. So for now, just add in path delays for SBDB objects.

