### PR TITLE
Stabilize 2 unit tests

### DIFF
--- a/go-controller/pkg/ovn/egressfirewall_dns.go
+++ b/go-controller/pkg/ovn/egressfirewall_dns.go
@@ -64,7 +64,7 @@ func NewEgressDNS(addressSetFactory addressset.AddressSetFactory, controllerName
 		addressSetFactory: addressSetFactory,
 		controllerName:    controllerName,
 
-		added:          make(chan struct{}),
+		added:          make(chan struct{}, 1),
 		deleted:        make(chan string, 1),
 		stopChan:       make(chan struct{}),
 		controllerStop: controllerStop,

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -1182,7 +1182,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						dnsEntries:        make(map[string]*dnsEntry),
 						addressSetFactory: nil,
 
-						added:    make(chan struct{}),
+						added:    make(chan struct{}, 1),
 						deleted:  make(chan string, 1),
 						stopChan: make(chan struct{}),
 					}

--- a/go-controller/pkg/ovn/pod_selector_address_set_test.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set_test.go
@@ -476,6 +476,8 @@ var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
 			MatchLabels: map[string]string{"key": "value"},
 		}
 
+		// let the system settle down before counting goroutines
+		time.Sleep(100 * time.Millisecond)
 		goroutinesNumInit := runtime.NumGoroutine()
 		// namespace selector will be run because it is not empty.
 		// one namespace should match the label and start a pod watchFactory.

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -1869,6 +1869,8 @@ var _ = ginkgo.Describe("OVN NetworkPolicy Operations", func() {
 					}, nil)
 				startOvn(initialDB, []v1.Namespace{namespace1}, nil, nil, nil)
 
+				// let the system settle down before counting goroutines
+				time.Sleep(100 * time.Millisecond)
 				goroutinesNumInit := runtime.NumGoroutine()
 				fmt.Printf("goroutinesNumInit %v", goroutinesNumInit)
 				// network policy will create 1 watchFactory for local pods selector, and 1 peer namespace selector


### PR DESCRIPTION
1.  Fix counting goroutines test: let the system settle down before
counting goroutines.
It used to flake ~ every 1000 iterations.
Verified this fix with 7500 runs.

2.  Fix egressDNS test flake when EgressDNS hasn't started its goroutine
listening to the added channel. If `Add` is called before that,
message won't be sent because the channel didn't have a buffer.