### PR TITLE
gh workflow test: save ovn dbs when e2e-dual-conversion fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -575,6 +575,23 @@ jobs:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
 
+    - name: Export ovn dbs
+      if: ${{ failure() }}
+      run: |
+        mkdir -p /tmp/kind/ovndbs
+        for node in ovn-control-plane ovn-worker ovn-worker2
+        do for db in ovnnb_db.db ovnsb_db.db
+          do docker cp ${node}:/var/lib/openvswitch/${db} /tmp/kind/ovndbs/${node}_${db} ||:
+          done
+        done
+
+    - name: Upload ovn dbs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: kind-ovndbs-${{ env.JOB_NAME }}-${{ github.run_id }}
+        path: /tmp/kind/ovndbs
+
   e2e-periodic:
     name: e2e-periodic
     if: github.event_name == 'schedule'


### PR DESCRIPTION
Reproducing the flake locally has been a real challenge. In the process of finding out why the e2e-dual-conversion is flaking, this commit will keep the ovn dbs as part of the artifacts.
