### PR TITLE
IC Dualstack jobs are flaking (try 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -580,6 +580,23 @@ jobs:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
 
+    - name: Export ovn dbs
+      if: ${{ failure() }}
+      run: |
+        mkdir -p /tmp/kind/ovndbs
+        for node in ovn-control-plane ovn-worker ovn-worker2
+        do for db in ovnnb_db.db ovnsb_db.db
+          do docker cp ${node}:/var/lib/openvswitch/${db} /tmp/kind/ovndbs/${node}_${db} ||:
+          done
+        done
+
+    - name: Upload ovn dbs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: kind-ovndbs-${{ env.JOB_NAME }}-${{ github.run_id }}
+        path: /tmp/kind/ovndbs
+
   e2e-periodic:
     name: e2e-periodic
     if: github.event_name == 'schedule'


### PR DESCRIPTION
This is a continuation of https://github.com/ovn-org/ovn-kubernetes/issues/3770

More details on the reproducing of the flake was added [here](https://github.com/ovn-org/ovn-kubernetes/issues/3770#issuecomment-1637204333).

This PR also includes a commit for github workflow that saves the ovn dbs as an artifact when the test fails. Having this was extremely useful for narrowing down on the flake. So I would like to merge that too.

Note: Unit tests for exercising the individual functions were already added via [this commit](https://github.com/ovn-org/ovn-kubernetes/pull/3724/commits/980abd3d7f6f67714d8a7437e4d0b9917c9ed2f9). What we lacked was the logic in `func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj interface{}, inRetryCache bool) error` which is hard to reproduce the race without artificially forcing the annotations. So I'd like to leave that alone. :)
