### PR TITLE
Ensure conntrack zones are not changing for IC upgrades

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -915,6 +915,9 @@ install_ovn_multiple_nodes_zones() {
   n=1
   for node in $KIND_NODES; do
     zone="zone-${zone_idx}"
+    if [ "${zone}" == "zone-1" ]; then
+      zone="global"
+    fi
     kubectl label node "${node}" k8s.ovn.org/zone-name=${zone} --overwrite
     if [ "${n}" == "1" ]; then
       # Mark 1st node of each zone as zone control plane

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -41,10 +41,10 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: node-role.kubernetes.io/zone-controller
-                    operator: In
-                    values:
-                      - ""
+                  #- key: node-role.kubernetes.io/zone-controller
+                  #  operator: In
+                  #  values:
+                  #    - ""
                   - key: kubernetes.io/os
                     operator: In
                     values:

--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -15,7 +15,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
@@ -306,24 +305,25 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	// controller mode or combined cluster manager and ovnkube-controller modes (the classic
 	// master mode), the master HA config applies. For cluster manager
 	// standalone mode, the cluster manager HA config applies.
-	var haConfig *config.HAConfig
-	var name string
+	//var haConfig *config.HAConfig
+	//var name string
 	switch {
 	case runMode.ovnkubeController && runMode.clusterManager:
 		metrics.RegisterClusterManagerBase()
 		fallthrough
 	case runMode.ovnkubeController:
 		metrics.RegisterOVNKubeControllerBase()
-		haConfig = &config.MasterHA
-		name = networkControllerManagerLockName()
+		//haConfig = &config.MasterHA
+		//name = networkControllerManagerLockName()
 	case runMode.clusterManager:
 		metrics.RegisterClusterManagerBase()
-		haConfig = &config.ClusterMgrHA
-		name = "ovn-kubernetes-cluster-manager"
+		//haConfig = &config.ClusterMgrHA
+		//name = "ovn-kubernetes-cluster-manager"
 	}
 
 	// Set up leader election process. Use lease resource lock as configmap and
 	// endpoint lock support has been removed from leader election library.
+	/*
 	rl, err := resourcelock.New(
 		resourcelock.LeasesResourceLock,
 		config.Kubernetes.OVNConfigNamespace,
@@ -398,6 +398,11 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	ovnKubeStopLock.Lock()
 	ovnKubeStopped = true
 	ovnKubeStopLock.Unlock()
+	*/
+	if err := runOvnKube(ctx.Context, runMode, ovnClientset, eventRecorder); err != nil {
+		klog.Error(err)
+		cancel()
+	}
 
 	return nil
 }

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -982,16 +982,29 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 			}
 		}
 		klog.Infof("Upgrade hack: ovnkube-node %s finished setting DB Auth; took: %v", nc.name, time.Since(start))
-		// Resume ovn-controller
-		_, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "debug/resume")
+		// Enable logs in ovn-controller
+		/*
+			_, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "vlog/set", "dbg:main")
+			if err != nil {
+				klog.Exitf("Upgrade hack: Failed to set logs for ovn-controller %v %q", err, stderr)
+			}
+			// Resume ovn-controller
+
+			_, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "debug/resume")
+			if err != nil {
+				klog.Exitf("Upgrade hack: Failed to resume ovn-controller %v %q", err, stderr)
+			}
+			stdout, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "debug/status")
+			if err != nil && stdout != "running" {
+				klog.Exitf("Upgrade hack: Failed to resume ovn-controller %v %q %v", err, stderr, stdout)
+			}
+			klog.Infof("ovnkube-node %s resumed ovn-controller at %v", nc.name, time.Now())
+		*/
+		stdout, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "exit")
 		if err != nil {
-			klog.Exitf("Upgrade hack: Failed to resume ovn-controller %v %q", err, stderr)
+			klog.Exitf("Upgrade hack: Failed to exit ovn-controller %v %q %v", err, stderr, stdout)
 		}
-		stdout, stderr, err = util.RunOVNAppctlWithTimeout(5, "-t", "ovn-controller", "debug/status")
-		if err != nil && stdout != "running" {
-			klog.Exitf("Upgrade hack: Failed to resume ovn-controller %v %q %v", err, stderr, stdout)
-		}
-		klog.Infof("ovnkube-node %s resumed ovn-controller at %v", nc.name, time.Now())
+		klog.Infof("ovnkube-node %s killed ovn-controller at %v", nc.name, time.Now())
 	}
 	/** HACK END **/
 


### PR DESCRIPTION
When we do IC upgrades, in phase2 we rebuild the DBs from scratch, this causes the UUIDs of the sbdb datapath elements to change which leads to ovn-controller flushing conntrack entries which leads to traffic disruption for workloads.

We know that node reboots will follow phase2 upgrades to conntrack entries will get blown anyway anyways, but for that duration of 5mins we spend in phase2 before reboot we want to ensure we don't break existing traffic.

To avoid conntrack flush, we save the uuids of the datapath bindings in SBDB from the legacy DB in phase1 and then in phase2 we get the zone value from OVS locally and newUUID from the newSBDB and replace the OVS binding values to ensure that ovn-controller doesn't flush any zones.

Equivalent of:

```
sh-5.1# ovs-vsctl get bridge br-int external_ids:ct-zone-b93a6244-449a-4d96-a61b-c21b6631f362_dnat                                                                           
"12" 
sh-5.1# ovn-sbctl --no-leader-only --bare --columns _uuid  find datapath external_ids:name=GR_surya-07-19-2023-dqvtb-master-0.c.openshift-gce-devel.internal                 
a9a78cf9-78d5-4d7b-aded-2b03dd8fff97   
sh-5.1# ovs-vsctl remove bridge br-int external_ids ct-zone-b93a6244-449a-4d96-a61b-c21b6631f362_dnat
sh-5.1# ovs-vsctl set bridge br-int external_ids:ct-zone-a9a78cf9-78d5-4d7b-aded-2b03dd8fff97_dnat=12
```
Tested using https://github.com/trozet/ovn-kubernetes/commit/baee20aff2a98009af1175f2b99c3a3c78030988

PHASE1:

Annotation on nodes look like this in phase:
```
k8s.ovn.org/legacy-sbdb-binding-info: '{"GR_ovn-worker":"3ce1e77c-03d6-4689-a274-dccd6b03404f","ext_ovn-worker":"9dac74fd-9a24-4544-a8d7-006810057a79","join":"15fda5b0-16a5-4e97-ac04-d17c4c53acfe","ovn-worker":"517eedf7-ac38-4f1c-bcff-16cc81ea79bd","ovn_cluster_router":"bf68d02d-2857-4483-9017-f231dde611b7"}'
```
```
[surya@hidden-temple ovn-kubernetes]$ oc logs -n ovn-kubernetes ovnkube-zone-controller-t6p59 ovnkube-controller | grep Upgrade
I0720 19:36:59.555426    2350 default_network_controller.go:586] Upgrade hack: Gathering datapath binding info for each node...
I0720 19:36:59.555756    2350 default_network_controller.go:617] Upgrade hack: Node ovn-control-plane has datapath bindings map[GR_ovn-control-plane:ced5e774-27a1-4d70-886c-5d2cf4744bdf ext_ovn-control-plane:74429399-e140-4712-9d9c-3dc9f6d100c8 join:a5f37e58-3139-45ab-963c-33225368f79a ovn-control-plane:4cea2ff7-85e2-4ff7-98d0-70f2a66bb6f7 ovn_cluster_router:752291c9-10f2-44dd-8f2d-6de8b496e2cb]
I0720 19:36:59.602679    2350 default_network_controller.go:617] Upgrade hack: Node ovn-worker2 has datapath bindings map[GR_ovn-worker2:cf07aa55-e553-4bd0-b8d0-b7f359688190 ext_ovn-worker2:3f63bb70-b777-402d-8098-8102c1f6e934 join:a5f37e58-3139-45ab-963c-33225368f79a ovn-worker2:0ced04de-028a-4dab-aafd-934a30dce759 ovn_cluster_router:752291c9-10f2-44dd-8f2d-6de8b496e2cb]
I0720 19:36:59.670024    2350 default_network_controller.go:617] Upgrade hack: Node ovn-worker has datapath bindings map[GR_ovn-worker:e8fe9bfd-639d-4185-9bce-37128efcfcac ext_ovn-worker:3234ca63-9beb-47bb-b93d-2de152b51ca1 join:a5f37e58-3139-45ab-963c-33225368f79a ovn-worker:e6dccb05-768e-4242-9351-793cb2e33b6f ovn_cluster_router:752291c9-10f2-44dd-8f2d-6de8b496e2cb]
[surya@hidden-temple ovn-kubernetes]$ oc logs -n ovn-kubernetes ovnkube-zone-controller-tsjzh ovnkube-controller | grep Upgrade
I0720 19:37:00.281033    1737 default_network_controller.go:586] Upgrade hack: Gathering datapath binding info for each node...
[surya@hidden-temple ovn-kubernetes]$ oc logs -n ovn-kubernetes ovnkube-zone-controller-qglv4 ovnkube-controller | grep Upgrade
I0720 19:37:00.275355    1732 default_network_controller.go:586] Upgrade hack: Gathering datapath binding info for each node...
```
PHASE2:


