### PR TITLE
kubevirtl: Replace node only at migration tests

### DIFF
--- a/go-controller/pkg/ovn/kubevirt_test.go
+++ b/go-controller/pkg/ovn/kubevirt_test.go
@@ -736,7 +736,6 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				lrpNetworks:         []string{nodeByName[node1].lrpNetworkIPv4},
 				dnsServiceIPs:       []string{dnsServiceIPv4},
 				testVirtLauncherPod: virtLauncher1(node1, vm1, "ipv4"),
-				replaceNode:         node1,
 				expectedDhcpv4: []testDHCPOptions{{
 					cidr:     nodeByName[node1].subnetIPv4,
 					dns:      dnsServiceIPv4,
@@ -748,7 +747,6 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				lrpNetworks:         []string{nodeByName[node1].lrpNetworkIPv4},
 				dnsServiceIPs:       []string{dnsServiceIPv4},
 				testVirtLauncherPod: virtLauncher1(node1, vm1, "ipv4"),
-				replaceNode:         node1,
 				expectedDhcpv4: []testDHCPOptions{{
 					cidr:     nodeByName[node1].subnetIPv4,
 					dns:      dnsServiceIPv4,
@@ -761,13 +759,11 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				lrpNetworks:         []string{nodeByName[node1].lrpNetworkIPv4},
 				dnsServiceIPs:       []string{dnsServiceIPv4},
 				testVirtLauncherPod: virtLauncher1(node1, vm1, "ipv4"),
-				replaceNode:         node1,
 			}),
 			Entry("for single stack ipv6 at global zone", testData{
 				lrpNetworks:         []string{nodeByName[node1].lrpNetworkIPv6},
 				dnsServiceIPs:       []string{dnsServiceIPv6},
 				testVirtLauncherPod: virtLauncher1(node1, vm1, "ipv6"),
-				replaceNode:         node1,
 				expectedDhcpv6: []testDHCPOptions{{
 					cidr:     nodeByName[node1].subnetIPv6,
 					dns:      dnsServiceIPv6,
@@ -779,7 +775,6 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				dnsServiceIPs:       []string{dnsServiceIPv6},
 				interconnected:      true,
 				testVirtLauncherPod: virtLauncher1(node1, vm1, "ipv6"),
-				replaceNode:         node1,
 				expectedDhcpv6: []testDHCPOptions{{
 					cidr:     nodeByName[node1].subnetIPv6,
 					dns:      dnsServiceIPv6,
@@ -792,13 +787,11 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				interconnected:      true,
 				remoteNodes:         []string{node1},
 				testVirtLauncherPod: virtLauncher1(node1, vm1, "ipv6"),
-				replaceNode:         node1,
 			}),
 			Entry("for dual stack at global zone", testData{
 				lrpNetworks:         []string{nodeByName[node1].lrpNetworkIPv4, nodeByName[node1].lrpNetworkIPv6},
 				dnsServiceIPs:       []string{dnsServiceIPv4, dnsServiceIPv6},
 				testVirtLauncherPod: virtLauncher1(node1, vm1, "dualstack"),
-				replaceNode:         node1,
 				expectedDhcpv4: []testDHCPOptions{{
 					cidr:     nodeByName[node1].subnetIPv4,
 					dns:      dnsServiceIPv4,
@@ -815,7 +808,6 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				lrpNetworks:         []string{nodeByName[node1].lrpNetworkIPv4, nodeByName[node1].lrpNetworkIPv6},
 				dnsServiceIPs:       []string{dnsServiceIPv4, dnsServiceIPv6},
 				testVirtLauncherPod: virtLauncher1(node1, vm1, "dualstack"),
-				replaceNode:         node1,
 				expectedDhcpv4: []testDHCPOptions{{
 					cidr:     nodeByName[node1].subnetIPv4,
 					dns:      dnsServiceIPv4,
@@ -833,7 +825,6 @@ var _ = Describe("OVN Kubevirt Operations", func() {
 				lrpNetworks:         []string{nodeByName[node1].lrpNetworkIPv4, nodeByName[node1].lrpNetworkIPv6},
 				dnsServiceIPs:       []string{dnsServiceIPv4, dnsServiceIPv6},
 				testVirtLauncherPod: virtLauncher1(node1, vm1, "dualstack"),
-				replaceNode:         node1,
 			}),
 
 			Entry("for pre-copy live migration at global zone", testData{


### PR DESCRIPTION
**- What this PR does and why is it needed**
After live migrating a VM the original node can be shutdown and a new one can appear taking over the node subnet. There were some unit tets for that but they exercise this part for non live migration scenarios creating a race condition between cleanup and addLogicalPort.

This change run that part of the tests only for live-migration scenarios.

This is the race condition log 
```
2023-07-20T19:21:44.7804051Z ^[[1mSTEP^[[0m: Replace vm node with newNode at the logical switch manager
2023-07-20T19:21:44.7804518Z I0720 19:21:44.780096   23041 master.go:789] Adding or Updating Node "newNode1"
2023-07-20T19:21:44.7811187Z I0720 19:21:44.780889   23041 pods.go:181] [namespace1/virt-launcher-1] addLogicalPort took 20.236766ms, libovsdb time 6.815389ms
2023-07-20T19:21:44.7817461Z I0720 19:21:44.781542   23041 model_client.go:363] Create operations generated as: [{Op:insert Table:Logical_Router_Static_Route Row:map[ip_prefix:10.128.0.0/16 nexthop:100.64.0.4 policy:{GoSet:[src-ip]}] Rows:[] Columns:[] Mutations:[] Timeout:<nil> Where:[] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName:u1272052859}]
2023-07-20T19:21:44.7822052Z I0720 19:21:44.781982   23041 model_client.go:388] Mutate operations generated as: [{Op:mutate Table:Logical_Router Row:map[] Rows:[] Columns:[] Mutations:[{Column:static_routes Mutator:insert Value:{GoSet:[{GoUUID:u1272052859}]}}] Timeout:<nil> Where:[where column _uuid == {3017c32e-929c-4f1c-8577-716bffe0a07f}] Until: Durable:<nil> Comment:<nil> Lock:<nil> UUID: UUIDName:}]
```

Closes https://github.com/ovn-org/ovn-kubernetes/issues/3788

**- How to verify it**
Running `go test --ginkgo.focus ".*Kubevirt.*" at ./pkg/ovn multiple times should not fail.

**- Description for the changelog**
Run replace node unit test only at live migration scenarios