### PR TITLE
e2e, localnet: Align case of all localnet tests

### DIFF
--- a/test/e2e/multihoming.go
+++ b/test/e2e/multihoming.go
@@ -529,7 +529,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			table.Entry(
-				"can communicate over an Localnet secondary network when the pods are scheduled on different nodes",
+				"can communicate over an localnet secondary network when the pods are scheduled on different nodes",
 				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",
@@ -549,7 +549,7 @@ var _ = Describe("Multi Homing", func() {
 				},
 			),
 			table.Entry(
-				"can communicate over an Localnet secondary network without IPAM when the pods are scheduled on different nodes",
+				"can communicate over an localnet secondary network without IPAM when the pods are scheduled on different nodes",
 				networkAttachmentConfigParams{
 					name:     secondaryNetworkName,
 					topology: "localnet",

--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"strings"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -11,8 +14,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	"net"
-	"strings"
 
 	mnpapi "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"


### PR DESCRIPTION
**- What this PR does and why is it needed**
Some were `Localnet` and some were `localnet`, align all to `localnet`.
This allows running all of them using:
`ENABLE_MULTI_NET=true make -C test control-plane WHAT=".*localnet.*"`
Before this change, 2 out of 5 were not selected.

Additional small change:
Rearrange imports

**- Special notes for reviewers**

**- How to verify it**

**- Description for the changelog**
