### PR TITLE
Use variable for kubectl version

### DIFF
--- a/docs/kind.md
+++ b/docs/kind.md
@@ -359,9 +359,9 @@ Download and install latest version of `kubectl`:
 $ K8S_VERSION=v1.26.0
 $ curl -LO https://storage.googleapis.com/kubernetes-release/release/$K8S_VERSION/bin/linux/amd64/kubectl
 $ chmod +x kubectl
-$ sudo mv kubectl /usr/bin/kubectl-v1.18.0
+$ sudo mv kubectl /usr/bin/kubectl-$K8S_VERSION
 $ sudo rm /usr/bin/kubectl
-$ sudo ln -s /usr/bin/kubectl-v1.18.0 /usr/bin/kubectl
+$ sudo ln -s /usr/bin/kubectl-$K8S_VERSION /usr/bin/kubectl
 $ kubectl version --client
 Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:58:59Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
 ```


### PR DESCRIPTION
The kubectl installation instructions define a variable, but it isn't used when renaming and linking the kubectl binary. This fixes the instructions to use the variable, producing a consistent result instead of a hard-coded 1.18.0 binary name.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->