### PR TITLE
Ensure ovnkube-controller does not go remote->local (cont.)

### DIFF
--- a/go-controller/pkg/network-controller-manager/network_controller_manager.go
+++ b/go-controller/pkg/network-controller-manager/network_controller_manager.go
@@ -340,6 +340,10 @@ func (cm *networkControllerManager) Start(ctx context.Context) error {
 			klog.Errorf("Unable to get nodes from informer while waiting for node zone sync")
 			return false, nil
 		}
+		if len(nodes) == 0 {
+			klog.Infof("No nodes in cluster: waiting for a node to have %q zone is not needed", config.Default.Zone)
+			return true, nil
+		}
 		for _, node := range nodes {
 			if util.GetNodeZone(node) == config.Default.Zone {
 				return true, nil


### PR DESCRIPTION
This is a continuation of commit 5e6787d187a77d837b7bddade57e93c6fb199116 . While waiting for a node in the default zone, introduced logic must factor in cases when there are no nodes in the cluster at the time controller starts.

Related PR: https://github.com/ovn-org/ovn-kubernetes/pull/3735


Reported-at: https://issues.redhat.com/browse/OCPBUGS-16767
