### PR TITLE
Fixes service controller + node tracker start up race

### DIFF
--- a/go-controller/pkg/ovn/controller/services/node_tracker.go
+++ b/go-controller/pkg/ovn/controller/services/node_tracker.go
@@ -104,8 +104,8 @@ func newNodeTracker(zone string, resyncFn func(nodes []nodeInfo)) *nodeTracker {
 	}
 }
 
-func (nt *nodeTracker) Start(nodeInformer coreinformers.NodeInformer) error {
-	_, err := nodeInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
+func (nt *nodeTracker) Start(nodeInformer coreinformers.NodeInformer) (cache.ResourceEventHandlerRegistration, error) {
+	return nodeInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			node, ok := obj.(*v1.Node)
 			if !ok {
@@ -160,7 +160,6 @@ func (nt *nodeTracker) Start(nodeInformer coreinformers.NodeInformer) error {
 			nt.removeNodeWithServiceReSync(node.Name)
 		},
 	}))
-	return err
 
 }
 
@@ -278,6 +277,7 @@ func (nt *nodeTracker) updateNode(node *v1.Node) {
 
 // getZoneNodes returns a list of all nodes (and their relevant information)
 // which belong to the nodeTracker 'zone'
+// MUST be called with nt locked
 func (nt *nodeTracker) getZoneNodes() []nodeInfo {
 	out := make([]nodeInfo, 0, len(nt.nodes))
 	for _, node := range nt.nodes {

--- a/go-controller/pkg/ovn/controller/services/services_controller.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller.go
@@ -42,7 +42,8 @@ const (
 	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
 	maxRetries = 15
 
-	controllerName = "ovn-lb-controller"
+	controllerName     = "ovn-lb-controller"
+	nodeControllerName = "node-tracker-controller"
 )
 
 var NoServiceLabelError = fmt.Errorf("endpointSlice missing %s label", discovery.LabelServiceName)
@@ -66,10 +67,8 @@ func NewController(client clientset.Interface,
 		nodeIPv6Templates:     NewNodeIPsTemplates(v1.IPv6Protocol),
 		serviceInformer:       serviceInformer,
 		serviceLister:         serviceInformer.Lister(),
-		servicesSynced:        serviceInformer.Informer().HasSynced,
 		endpointSliceInformer: endpointSliceInformer,
 		endpointSliceLister:   endpointSliceInformer.Lister(),
-		endpointSlicesSynced:  endpointSliceInformer.Informer().HasSynced,
 		eventRecorder:         recorder,
 		repair:                newRepair(serviceInformer.Lister(), nbClient),
 		nodeInformer:          nodeInformer,
@@ -101,17 +100,11 @@ type Controller struct {
 	serviceInformer coreinformers.ServiceInformer
 	// serviceLister is able to list/get services and is populated by the shared informer passed to
 	serviceLister corelisters.ServiceLister
-	// servicesSynced returns true if the service shared informer has been synced at least once.
-	servicesSynced cache.InformerSynced
 
 	endpointSliceInformer discoveryinformers.EndpointSliceInformer
 	// endpointSliceLister is able to list/get endpoint slices and is populated
 	// by the shared informer passed to NewController
 	endpointSliceLister discoverylisters.EndpointSliceLister
-	// endpointSlicesSynced returns true if the endpoint slice shared informer
-	// has been synced at least once. Added as a member to the struct to allow
-	// injection for testing.
-	endpointSlicesSynced cache.InformerSynced
 
 	nodesSynced cache.InformerSynced
 
@@ -169,8 +162,18 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair, useLBGr
 	klog.Infof("Starting controller %s", controllerName)
 	defer klog.Infof("Shutting down controller %s", controllerName)
 
+	nodeHandler, err := c.nodeTracker.Start(c.nodeInformer)
+	if err != nil {
+		return err
+	}
+	// We need node cache to be synced first, as we rely on it to properly reprogram initial per node load balancers
+	klog.Info("Waiting for node tracker caches to sync")
+	if !util.WaitForNamedCacheSyncWithTimeout(nodeControllerName, stopCh, nodeHandler.HasSynced) {
+		return fmt.Errorf("error syncing cache")
+	}
+
 	klog.Info("Setting up event handlers for services")
-	_, err := c.serviceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
+	svcHandler, err := c.serviceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onServiceAdd,
 		UpdateFunc: c.onServiceUpdate,
 		DeleteFunc: c.onServiceDelete,
@@ -180,7 +183,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair, useLBGr
 	}
 
 	klog.Info("Setting up event handlers for endpoint slices")
-	_, err = c.endpointSliceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
+	endpointHandler, err := c.endpointSliceInformer.Informer().AddEventHandler(factory.WithUpdateHandlingForObjReplace(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onEndpointSliceAdd,
 		UpdateFunc: c.onEndpointSliceUpdate,
 		DeleteFunc: c.onEndpointSliceDelete,
@@ -189,14 +192,9 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}, runRepair, useLBGr
 		return err
 	}
 
-	err = c.nodeTracker.Start(c.nodeInformer)
-	if err != nil {
-		return err
-	}
-
 	// Wait for the caches to be synced
-	klog.Info("Waiting for informer caches to sync")
-	if !util.WaitForNamedCacheSyncWithTimeout(controllerName, stopCh, c.servicesSynced, c.endpointSlicesSynced, c.nodesSynced) {
+	klog.Info("Waiting for service and endpoint caches to sync")
+	if !util.WaitForNamedCacheSyncWithTimeout(controllerName, stopCh, svcHandler.HasSynced, endpointHandler.HasSynced) {
 		return fmt.Errorf("error syncing cache")
 	}
 

--- a/go-controller/pkg/ovn/controller/services/services_controller_test.go
+++ b/go-controller/pkg/ovn/controller/services/services_controller_test.go
@@ -85,8 +85,6 @@ func newControllerWithDBSetup(dbSetup libovsdbtest.TestSetup) (*serviceControlle
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
 
-	controller.servicesSynced = alwaysReady
-	controller.endpointSlicesSynced = alwaysReady
 	controller.initTopLevelCache()
 	controller.useLBGroups = true
 	controller.useTemplates = true


### PR DESCRIPTION
When service controller starts up along side node tracker, it is possible that it attempts to sync a service without having all of the nodes in the cluster. In new installations this is fine, but in a steady state cluster where a new ovnkube-controller takes over, or is restarted it can cause service outage.

This happens because there may already be a load balancer configured for a specific node in OVN, then when the ovnk pod is restarted, it may sync the service before it has rebuilt its node cache. The consequence is the LB will be removed from OVN for a period of time, causing traffic disruption. This was noticed in a downstream OCP CI run.

This commit fixes the problem by ensuring that the node tracker has synced its initial objects first, before allowing services and endpoint handlers to be added and their respective workers to be started.

