### PR TITLE
Replace centos/tools image with agnhostImage

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -2488,7 +2488,8 @@ var _ = ginkgo.Describe("e2e ingress gateway traffic validation", func() {
 		}
 
 		// start the first container that will act as an external gateway
-		_, err := runCommand(containerRuntime, "run", "-itd", "--privileged", "--network", externalContainerNetwork, "--name", gwContainer, "centos/tools")
+		_, err := runCommand(containerRuntime, "run", "-itd", "--privileged", "--network", externalContainerNetwork,
+			"--name", gwContainer, agnhostImage)
 		if err != nil {
 			framework.Failf("failed to start external gateway test container %s: %v", gwContainer, err)
 		}


### PR DESCRIPTION
 in the only test that was using it. Downloading an extra image for one test doesn't make a lot of sense, and can cause test failures like
"docker: failed to register layer: ApplyLayer exit status 1 stdout: stderr: write /usr/lib64/dyninst/libparseAPI.so.9.3.1: no space left on device."

Failure example https://github.com/ovn-org/ovn-kubernetes/actions/runs/5665620434/job/15351462559?pr=3582