### PR TITLE
APB: make namespaceSelector in dynamic hops mandatory

### DIFF
--- a/dist/templates/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
+++ b/dist/templates/k8s.ovn.org_adminpolicybasedexternalroutes.yaml.j2
@@ -227,6 +227,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       required:
+                      - namespaceSelector
                       - podSelector
                       type: object
                     type: array

--- a/go-controller/pkg/crd/adminpolicybasedroute/v1/types.go
+++ b/go-controller/pkg/crd/adminpolicybasedroute/v1/types.go
@@ -91,9 +91,9 @@ type DynamicHop struct {
 	// +required
 	PodSelector metav1.LabelSelector `json:"podSelector"`
 	// NamespaceSelector defines a selector to filter the namespaces where the pod gateways are located.
-	// +kubebuilder:validation:Optional
-	// +optional
-	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector"`
+	// +kubebuilder:validation:Required
+	// +required
+	NamespaceSelector metav1.LabelSelector `json:"namespaceSelector"`
 	// NetworkAttachmentName determines the multus network name to use when retrieving the pod IPs that will be used as the gateway IP.
 	// When this field is empty, the logic assumes that the pod is configured with HostNetwork and is using the node's IP as gateway.
 	// +optional

--- a/go-controller/pkg/crd/adminpolicybasedroute/v1/zz_generated.deepcopy.go
+++ b/go-controller/pkg/crd/adminpolicybasedroute/v1/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -130,11 +129,7 @@ func (in *AdminPolicyBasedRouteStatus) DeepCopy() *AdminPolicyBasedRouteStatus {
 func (in *DynamicHop) DeepCopyInto(out *DynamicHop) {
 	*out = *in
 	in.PodSelector.DeepCopyInto(&out.PodSelector)
-	if in.NamespaceSelector != nil {
-		in, out := &in.NamespaceSelector, &out.NamespaceSelector
-		*out = new(metav1.LabelSelector)
-		(*in).DeepCopyInto(*out)
-	}
+	in.NamespaceSelector.DeepCopyInto(&out.NamespaceSelector)
 	return
 }
 

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller.go
@@ -181,11 +181,7 @@ func (m *externalPolicyManager) getPoliciesForNamespaceChange(namespace *v1.Name
 		}
 
 		for _, hop := range informerPolicy.Spec.NextHops.DynamicHops {
-			// if NamespaceSelector is not set, it means all namespaces
-			gwNsSel := labels.Everything()
-			if hop.NamespaceSelector != nil {
-				gwNsSel, _ = metav1.LabelSelectorAsSelector(hop.NamespaceSelector)
-			}
+			gwNsSel, _ := metav1.LabelSelectorAsSelector(&hop.NamespaceSelector)
 			if gwNsSel.Matches(labels.Set(namespace.Labels)) {
 				policyNames.Insert(informerPolicy.Name)
 			}
@@ -234,11 +230,7 @@ func (m *externalPolicyManager) getPoliciesForPodChange(pod *v1.Pod) (sets.Set[s
 		}
 
 		for _, hop := range informerPolicy.Spec.NextHops.DynamicHops {
-			// if NamespaceSelector is not set, it means all namespaces
-			gwNsSel := labels.Everything()
-			if hop.NamespaceSelector != nil {
-				gwNsSel, _ = metav1.LabelSelectorAsSelector(hop.NamespaceSelector)
-			}
+			gwNsSel, _ := metav1.LabelSelectorAsSelector(&hop.NamespaceSelector)
 			gwPodSel, _ := metav1.LabelSelectorAsSelector(&hop.PodSelector)
 
 			if gwNsSel.Matches(labels.Set(podNs.Labels)) && gwPodSel.Matches(labels.Set(pod.Labels)) {

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
@@ -46,7 +46,7 @@ func newPolicy(policyName string, fromNSSelector *v1.LabelSelector, staticHopsGW
 	}
 	if dynamicHopsNSSelector != nil && dynamicHopsPodSelector != nil {
 		p.Spec.NextHops.DynamicHops = []*adminpolicybasedrouteapi.DynamicHop{
-			{NamespaceSelector: dynamicHopsNSSelector,
+			{NamespaceSelector: *dynamicHopsNSSelector,
 				PodSelector: *dynamicHopsPodSelector,
 				BFDEnabled:  bfdEnabled},
 		}

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy.go
@@ -335,11 +335,7 @@ func (m *externalPolicyManager) processDynamicHopsGatewayInformation(hops []*adm
 	selectedNamespaces := sets.Set[string]{}
 	selectedPods := sets.Set[ktypes.NamespacedName]{}
 	for _, h := range hops {
-		gwNsSel := labels.Everything()
-		if h.NamespaceSelector != nil {
-			gwNsSel, _ = metav1.LabelSelectorAsSelector(h.NamespaceSelector)
-		}
-
+		gwNsSel, _ := metav1.LabelSelectorAsSelector(&h.NamespaceSelector)
 		gwNamespaces, err := m.namespaceLister.List(gwNsSel)
 		if err != nil {
 			return podsInfo, selectedNamespaces, selectedPods, fmt.Errorf("failed to list namespaces: %w", err)

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -362,7 +362,7 @@ var _ = Describe("OVN External Gateway policy", func() {
 			)
 			duplicatedDynamic.Spec.NextHops.DynamicHops = append(duplicatedDynamic.Spec.NextHops.DynamicHops,
 				&adminpolicybasedrouteapi.DynamicHop{
-					NamespaceSelector: &v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
+					NamespaceSelector: v1.LabelSelector{MatchLabels: gatewayNamespaceMatch},
 					PodSelector:       v1.LabelSelector{MatchLabels: map[string]string{"key": "duplicated"}},
 					BFDEnabled:        false,
 				})

--- a/go-controller/pkg/ovn/external_gateway_apb_test.go
+++ b/go-controller/pkg/ovn/external_gateway_apb_test.go
@@ -3000,7 +3000,7 @@ func newPolicy(policyName string, fromNSSelector *metav1.LabelSelector, staticHo
 	}
 	if dynamicHopsNSSelector != nil && dynamicHopsPodSelector != nil {
 		p.Spec.NextHops.DynamicHops = []*adminpolicybasedrouteapi.DynamicHop{
-			{NamespaceSelector: dynamicHopsNSSelector,
+			{NamespaceSelector: *dynamicHopsNSSelector,
 				PodSelector:           *dynamicHopsPodSelector,
 				NetworkAttachmentName: networkAttachementName,
 				BFDEnabled:            bfdDynamic},
@@ -3026,7 +3026,7 @@ func updatePolicy(policyName string, fromNSSelector *metav1.LabelSelector, stati
 	if dynamicHopsNSSelector != nil && dynamicHopsPodSelector != nil {
 		p.Spec.NextHops.DynamicHops = append(p.Spec.NextHops.DynamicHops,
 			&adminpolicybasedrouteapi.DynamicHop{
-				NamespaceSelector:     dynamicHopsNSSelector,
+				NamespaceSelector:     *dynamicHopsNSSelector,
 				PodSelector:           *dynamicHopsPodSelector,
 				NetworkAttachmentName: networkAttachementName,
 				BFDEnabled:            bfdDynamic},


### PR DESCRIPTION
Implements changes to the APB External Route [PR](https://github.com/openshift/enhancements/pull/1377) that makes the namespace selector in the dynamic hop as mandatory. The motivation is that it did not make sense to have a dynamic hop that scoped all the pods in the cluster (if namespace selector is empty, then fetch all pods in all namespaces). 


@trozet @npinaeva @tssurya @jcaamano PTAL.
