### PR TITLE
Changes IC chassis update to be a mutate operation

### DIFF
--- a/go-controller/pkg/libovsdb/ops/chassis.go
+++ b/go-controller/pkg/libovsdb/ops/chassis.go
@@ -143,18 +143,17 @@ func CreateOrUpdateChassis(sbClient libovsdbclient.Client, chassis *sbdb.Chassis
 		{
 			Model: encap,
 			DoAfter: func() {
-				encaps := append(chassis.Encaps, encap.UUID)
-				chassis.Encaps = sets.New(encaps...).UnsortedList()
+				chassis.Encaps = []string{encap.UUID}
 			},
 			OnModelUpdates: onModelUpdatesAllNonDefault(),
 			ErrNotFound:    false,
 			BulkOp:         false,
 		},
 		{
-			Model:          chassis,
-			OnModelUpdates: onModelUpdatesAllNonDefault(),
-			ErrNotFound:    false,
-			BulkOp:         false,
+			Model:            chassis,
+			OnModelMutations: []interface{}{&chassis.OtherConfig, &chassis.Encaps},
+			ErrNotFound:      false,
+			BulkOp:           false,
 		},
 	}
 


### PR DESCRIPTION
By updating the chassis with incomplete information, it was causing ovn-controler to rewrite the values in the DB, and furthermore causing northd to rewrite logical flows during ovnkube-master restart. The notable consequence of this would be that access to a service via loadbalancer type (using LB templates) would be momentarily disrupted. This is the root cause for the outage we see in Azure upgrades.

@dceara @numansiddique @tssurya 

Manual way to test/reproduce:
1. launch kind: kind.sh -wk 2 -ic -npz 3 (3 nodes in 1 zone, similar to phase 1)
2. create a loadbalancer service:
```
[trozet@fedora ~]$ cat ~/loadBalancersvc.yml 
apiVersion: v1
kind: Service
metadata:
  name: web-service
spec:
  selector:
   role: webserver
  ports:
    - protocol: TCP
      port: 80
      targetPort: 80
  type: LoadBalancer
```
3. create an endpoint:
 ```
[trozet@fedora ~]$ cat ~/basic.yaml 
---
apiVersion: v1
kind: Pod
metadata:
  name: client
  labels:
    pod-name: client
    role: webserver
      #app: spk-coredns  
spec:
  #hostNetwork: true
  containers:
  - name: client
    image: python
    #command:
    #  - /sbin/init
    command: [ "/bin/bash", "-c", "--" ]
    args: [ "while true; do sleep 3000000; done;" ]
    imagePullPolicy: IfNotPresent
    ports:
      - name: dns-tcp
        containerPort: 53
        protocol: TCP  
      - name: dns-udp
        containerPort: 9999
        protocol: UDP
          # securityContext:
          #sysctls:
          #- name: net.ipv6.route.max_size
          #value: 2048    
          #  securityContext:

          #   sysctls:

        #    - name: net.ipv4.tcp_sack
#      value: "0"
  nodeSelector:
    kubernetes.io/hostname: ovn-worker
```
4. assign a loadbalancer IP to the service. I use a python script:
```
[trozet@fedora ~]$ cat lb_ingress.py 
from kubernetes import client, config
import sys

# Obtain the namespace, the service name  and the lb ip as the arguments
if len(sys.argv) != 4:
    print ("Usage: lb.py namespace service_name ip")
    sys.exit(1)

ns = sys.argv[1]
name = sys.argv[2]
service_ip = sys.argv[3]
field='metadata.name='+name
config.load_kube_config()

v1 = client.CoreV1Api()
# Check if the service existe
ret = v1.list_namespaced_service(ns, watch=False, field_selector=field)
service = ret.items[0]
if service.status.load_balancer.ingress:
    print ("The load balancer has already an ingress ip")
    sys.exit(0)
# Add an ingress ip to the service
lb_ip = list()
lb_ip.append(client.V1LoadBalancerIngress(ip=service_ip))
lb_ingress = client.V1LoadBalancerStatus( ingress = lb_ip )
service.status.load_balancer = lb_ingress
print ("set ingress ip")
v1.patch_namespaced_service_status(name, ns, service)
```
python lb_ingress.py default webserver 1.1.1.1

5. Run a http server from the client... python -m http.server 80
6. Start an external docker container: docker run --network kind --privileged -it fedora /bin/bash
7. In external docker container ip route add 1.1.1.1 via <worker ip>
8. Run curl loop that will break if a curl fails:
while $(curl -vv 1.1.1.1:80 &>/dev/null); do ((counter=counter+1)) && echo "success attempt $counter"; done
9. Go to ovnkube-controller, kill the main ovnkube-controller process
10. without the fix the curl will be interrupted, with the fix it does not get interrupted
11. you can also tail the sbdb, and see that without the fix, logical flows are re-rendered by northd