### PR TITLE
e2e, multihoming: Add localnet MultiNetworkPolicy test

### DIFF
--- a/test/e2e/multihoming_utils.go
+++ b/test/e2e/multihoming_utils.go
@@ -324,6 +324,36 @@ func multiNetIngressLimitingIPBlockPolicy(
 	}
 }
 
+func multiNetEgressLimitingIPBlockPolicy(
+	policyName string,
+	policyFor string,
+	appliesFor metav1.LabelSelector,
+	allowForIPBlock mnpapi.IPBlock,
+) *mnpapi.MultiNetworkPolicy {
+	return &mnpapi.MultiNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+			Annotations: map[string]string{
+				PolicyForAnnotation: policyFor,
+			},
+		},
+
+		Spec: mnpapi.MultiNetworkPolicySpec{
+			PodSelector: appliesFor,
+			Egress: []mnpapi.MultiNetworkPolicyEgressRule{
+				{
+					To: []mnpapi.MultiNetworkPolicyPeer{
+						{
+							IPBlock: &allowForIPBlock,
+						},
+					},
+				},
+			},
+			PolicyTypes: []mnpapi.MultiPolicyType{mnpapi.PolicyTypeEgress},
+		},
+	}
+}
+
 func doesPolicyFeatAnIPBlock(policy *mnpapi.MultiNetworkPolicy) bool {
 	for _, rule := range policy.Spec.Ingress {
 		for _, peer := range rule.From {


### PR DESCRIPTION
**- What this PR does and why is it needed**
The test uses IPBlock to block egress traffic from matching pods.
Verify that without the policy we can reach a service running
on the underlay, and that once we create the blocking
policy, we can't anymore.

**- Special notes for reviewers**

**- How to verify it**

**- Description for the changelog**
