### PR TITLE
libovsdb: give monitor setup time to process than normal transactions

### DIFF
--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -98,7 +98,7 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout*2)
 	go func() {
 		<-stopCh
 		cancel()
@@ -166,7 +166,7 @@ func NewNBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), types.OVSDBTimeout*2)
 	go func() {
 		<-stopCh
 		cancel()


### PR DESCRIPTION
In certain scaling situations, it may take longer than types.OVSDBTimeout for the monitoring of OVSDB tables to be set up. This change is a follow-up to commit da9408d3b1d1c1fd376e365f9cb2836444e2523b, accounting for cases where ovnkube-master has a lot of startup data. The timeout for monitoring introduced in commit 6ae4edb8d8575e86c4e4519ee45e11ffecc5d239 did not account for that.

Reported-at: [OCPBUGS-17147](https://issues.redhat.com/browse/OCPBUGS-17147)