### PR TITLE
Support for separate libovsdb logs via lumberjack

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -103,6 +103,7 @@ usage() {
     echo "                 [-dbl|--dbchecker-loglevel <num>] [-ndl|--ovn-loglevel-northd <loglevel>]"
     echo "                 [-nbl|--ovn-loglevel-nb <loglevel>] [-sbl|--ovn-loglevel-sb <loglevel>]"
     echo "                 [-cl |--ovn-loglevel-controller <loglevel>] [-me|--multicast-enabled]"
+    echo "                 [-lcl|--libovsdb-client-logfile <logfile>]"
     echo "                 [-ep |--experimental-provider <name>] |"
     echo "                 [-eb |--egress-gw-separate-bridge] |"
     echo "                 [-lr |--local-kind-registry |"
@@ -155,6 +156,7 @@ usage() {
     echo "-nbl | --ovn-loglevel-nb            Log config for northbound DB DEFAULT: '-vconsole:info -vfile:info'."
     echo "-sbl | --ovn-loglevel-sb            Log config for southboudn DB DEFAULT: '-vconsole:info -vfile:info'."
     echo "-cl  | --ovn-loglevel-controller    Log config for ovn-controller DEFAULT: '-vconsole:info'."
+    echo "-lcl | --libovsdb-client-logfile    Separate logs for libovsdb client into provided file. DEFAULT: do not separate."
     echo "-ep  | --experimental-provider      Use an experimental OCI provider such as podman, instead of docker. DEFAULT: Disabled."
     echo "-eb  | --egress-gw-separate-bridge  The external gateway traffic uses a separate bridge."
     echo "-lr  | --local-kind-registry        Configure kind to use a local docker registry rather than manually loading images"
@@ -304,6 +306,9 @@ parse_args() {
             -cl  | --ovn-loglevel-controller )  shift
                                                 OVN_LOG_LEVEL_CONTROLLER=$1
                                                 ;;
+            -lcl | --libovsdb-client-logfile )  shift
+                                                LIBOVSDB_CLIENT_LOGFILE=$1
+                                                ;;
             -hns | --host-network-namespace )   OVN_HOST_NETWORK_NAMESPACE=$1
                                                 ;;
             -lr | --local-kind-registry )       KIND_LOCAL_REGISTRY=true
@@ -398,6 +403,7 @@ print_params() {
      echo "OVN_LOG_LEVEL_SB = $OVN_LOG_LEVEL_SB"
      echo "OVN_LOG_LEVEL_CONTROLLER = $OVN_LOG_LEVEL_CONTROLLER"
      echo "OVN_LOG_LEVEL_NBCTLD = $OVN_LOG_LEVEL_NBCTLD"
+     echo "LIBOVSDB_CLIENT_LOGFILE = $LIBOVSDB_CLIENT_LOGFILE"
      echo "OVN_HOST_NETWORK_NAMESPACE = $OVN_HOST_NETWORK_NAMESPACE"
      echo "OVN_ENABLE_EX_GW_NETWORK_BRIDGE = $OVN_ENABLE_EX_GW_NETWORK_BRIDGE"
      echo "OVN_EX_GW_NETWORK_INTERFACE = $OVN_EX_GW_NETWORK_INTERFACE"
@@ -534,6 +540,7 @@ set_default_params() {
   OVN_LOG_LEVEL_SB=${OVN_LOG_LEVEL_SB:-"-vconsole:info -vfile:info"}
   OVN_LOG_LEVEL_CONTROLLER=${OVN_LOG_LEVEL_CONTROLLER:-"-vconsole:info"}
   OVN_LOG_LEVEL_NBCTLD=${OVN_LOG_LEVEL_NBCTLD:-"-vconsole:info"}
+  LIBOVSDB_CLIENT_LOGFILE=${LIBOVSDB_CLIENT_LOGFILE:-}
   OVN_ENABLE_EX_GW_NETWORK_BRIDGE=${OVN_ENABLE_EX_GW_NETWORK_BRIDGE:-false}
   OVN_EX_GW_NETWORK_INTERFACE=""
   if [ "$OVN_ENABLE_EX_GW_NETWORK_BRIDGE" == true ]; then
@@ -854,6 +861,7 @@ create_ovn_kube_manifests() {
     --ovn-loglevel-nb="${OVN_LOG_LEVEL_NB}" \
     --ovn-loglevel-sb="${OVN_LOG_LEVEL_SB}" \
     --ovn-loglevel-controller="${OVN_LOG_LEVEL_CONTROLLER}" \
+    --ovnkube-libovsdb-client-logfile="${LIBOVSDB_CLIENT_LOGFILE}" \
     --ovnkube-config-duration-enable=true \
     --egress-ip-enable=true \
     --egress-ip-healthcheck-port="${OVN_EGRESSIP_HEALTHCHECK_PORT}" \

--- a/dist/images/daemonset.sh
+++ b/dist/images/daemonset.sh
@@ -47,6 +47,7 @@ OVN_LOGLEVEL_NBCTLD=""
 OVNKUBE_LOGFILE_MAXSIZE=""
 OVNKUBE_LOGFILE_MAXBACKUPS=""
 OVNKUBE_LOGFILE_MAXAGE=""
+OVNKUBE_LIBOVSDB_CLIENT_LOGFILE=""
 OVN_ACL_LOGGING_RATE_LIMIT=""
 OVN_MASTER_COUNT=""
 OVN_REMOTE_PROBE_INTERVAL=""
@@ -179,6 +180,9 @@ while [ "$1" != "" ]; do
     ;;
   --ovnkube-logfile-maxage)
     OVNKUBE_LOGFILE_MAXAGE=$VALUE
+    ;;
+  --ovnkube-libovsdb-client-logfile)
+    OVNKUBE_LIBOVSDB_CLIENT_LOGFILE=$VALUE
     ;;
   --acl-logging-rate-limit)
     OVN_ACL_LOGGING_RATE_LIMIT=$VALUE
@@ -369,6 +373,8 @@ ovnkube_logfile_maxbackups=${OVNKUBE_LOGFILE_MAXBACKUPS:-"5"}
 echo "ovnkube_logfile_maxbackups: ${ovnkube_logfile_maxbackups}"
 ovnkube_logfile_maxage=${OVNKUBE_LOGFILE_MAXAGE:-"5"}
 echo "ovnkube_logfile_maxage: ${ovnkube_logfile_maxage}"
+ovnkube_libovsdb_client_logfile=${OVNKUBE_LIBOVSDB_CLIENT_LOGFILE}
+echo "ovnkube_libovsdb_client_logfile: ${ovnkube_libovsdb_client_logfile}"
 ovn_acl_logging_rate_limit=${OVN_ACL_LOGGING_RATE_LIMIT:-"20"}
 echo "ovn_acl_logging_rate_limit: ${ovn_acl_logging_rate_limit}"
 ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE}
@@ -551,6 +557,7 @@ ovn_image=${ovnkube_image} \
   ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
   ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
   ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
+  ovnkube_libovsdb_client_logfile=${ovnkube_libovsdb_client_logfile} \
   ovnkube_config_duration_enable=${ovnkube_config_duration_enable} \
   ovnkube_metrics_scale_enable=${ovnkube_metrics_scale_enable} \
   ovn_acl_logging_rate_limit=${ovn_acl_logging_rate_limit} \
@@ -653,6 +660,7 @@ ovn_image=${ovnkube_image} \
   ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
   ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
   ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
+  ovnkube_libovsdb_client_logfile=${ovnkube_libovsdb_client_logfile} \
   ovnkube_config_duration_enable=${ovnkube_config_duration_enable} \
   ovnkube_metrics_scale_enable=${ovnkube_metrics_scale_enable} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
@@ -705,6 +713,7 @@ ovn_image=${ovnkube_image} \
   ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
   ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
   ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
+  ovnkube_libovsdb_client_logfile=${ovnkube_libovsdb_client_logfile} \
   ovnkube_config_duration_enable=${ovnkube_config_duration_enable} \
   ovnkube_metrics_scale_enable=${ovnkube_metrics_scale_enable} \
   ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \

--- a/dist/templates/ovnkube-master.yaml.j2
+++ b/dist/templates/ovnkube-master.yaml.j2
@@ -208,6 +208,8 @@ spec:
           value: "{{ ovnkube_logfile_maxbackups }}"
         - name: OVNKUBE_LOGFILE_MAXAGE
           value: "{{ ovnkube_logfile_maxage }}"
+        - name: OVNKUBE_LIBOVSDB_CLIENT_LOGFILE
+          value: "{{ ovnkube_libovsdb_client_logfile }}"
         - name: OVNKUBE_CONFIG_DURATION_ENABLE
           value: "{{ ovnkube_config_duration_enable }}"
         - name: OVNKUBE_METRICS_SCALE_ENABLE

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -277,6 +277,8 @@ spec:
           value: "{{ ovnkube_logfile_maxbackups }}"
         - name: OVNKUBE_LOGFILE_MAXAGE
           value: "{{ ovnkube_logfile_maxage }}"
+        - name: OVNKUBE_LIBOVSDB_CLIENT_LOGFILE
+          value: "{{ ovnkube_libovsdb_client_logfile }}"
         - name: OVNKUBE_CONFIG_DURATION_ENABLE
           value: "{{ ovnkube_config_duration_enable }}"
         - name: OVN_NET_CIDR

--- a/dist/templates/ovnkube-zone-controller.yaml.j2
+++ b/dist/templates/ovnkube-zone-controller.yaml.j2
@@ -293,6 +293,8 @@ spec:
           value: "{{ ovnkube_logfile_maxbackups }}"
         - name: OVNKUBE_LOGFILE_MAXAGE
           value: "{{ ovnkube_logfile_maxage }}"
+        - name: OVNKUBE_LIBOVSDB_CLIENT_LOGFILE
+          value: "{{ ovnkube_libovsdb_client_logfile }}"
         - name: OVNKUBE_CONFIG_DURATION_ENABLE
           value: "{{ ovnkube_config_duration_enable }}"
         - name: OVN_NET_CIDR

--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/containernetworking/plugins v1.2.0
 	github.com/coreos/go-iptables v0.6.0
 	github.com/fsnotify/fsnotify v1.6.0
+	github.com/go-logr/logr v1.2.4
+	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
@@ -63,8 +65,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -74,6 +74,7 @@ var (
 	Logging = LoggingConfig{
 		File:                "", // do not log to a file by default
 		CNIFile:             "",
+		LibovsdbFile:        "",
 		Level:               4,
 		LogFileMaxSize:      100, // Size in Megabytes
 		LogFileMaxBackups:   5,
@@ -251,9 +252,11 @@ type LoggingConfig struct {
 	File string `gcfg:"logfile"`
 	// CNIFile is the path of the file for the CNI shim to log to
 	CNIFile string `gcfg:"cnilogfile"`
+	// LibovsdbFile is the path of the file for the libovsdb client to log to
+	LibovsdbFile string `gcfg:"libovsdblogfile"`
 	// Level is the logging verbosity level
 	Level int `gcfg:"loglevel"`
-	// LogFileMaxSize is the maximum size in bytes of the logfile
+	// LogFileMaxSize is the maximum size in megabytes of the logfile
 	// before it gets rolled.
 	LogFileMaxSize int `gcfg:"logfile-maxsize"`
 	// LogFileMaxBackups represents the the maximum number of old log files to retain
@@ -818,6 +821,11 @@ var CommonFlags = []cli.Flag{
 		Usage:       "path of a file to direct log from cni shim to output to (default: /var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log)",
 		Destination: &cliConfig.Logging.CNIFile,
 		Value:       "/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log",
+	},
+	&cli.StringFlag{
+		Name:        "libovsdblogfile",
+		Usage:       "path of a file to direct log from libovsdb client to output to (default is to use same as --logfile)",
+		Destination: &cliConfig.Logging.LibovsdbFile,
 	},
 	// Logfile rotation parameters
 	&cli.IntFlag{

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -942,7 +942,7 @@ func (oc *DefaultNetworkController) addUpdateRemoteNodeEvent(node *kapi.Node, sy
 			oc.syncZoneICFailed.Delete(node.Name)
 		}
 	}
-	klog.Infof("Creating Interconnect resources for node %v took: %s", node.Name, time.Since(start))
+	klog.V(5).Infof("Creating Interconnect resources for node %v took: %s", node.Name, time.Since(start))
 	return err
 }
 

--- a/go-controller/pkg/retry/obj_retry.go
+++ b/go-controller/pkg/retry/obj_retry.go
@@ -512,7 +512,7 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 						r.increaseFailedAttemptsCounter(retryObj)
 						return
 					}
-					klog.Infof("Creating %s %s took: %v", r.ResourceHandler.ObjType, key, time.Since(start))
+					klog.V(5).Infof("Creating %s %s took: %v", r.ResourceHandler.ObjType, key, time.Since(start))
 					// delete retryObj if handling was successful
 					r.DeleteRetryObj(key)
 					r.ResourceHandler.RecordSuccessEvent(obj)
@@ -560,7 +560,7 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 					// This only applies to pod watchers (pods + dynamic network policy handlers watching pods).
 					if kerrors.IsNotFound(err) {
 						if r.ResourceHandler.IsObjectInTerminalState(newer) {
-							klog.Warningf("%s %s is in terminal state but no longer exists in informer cache, removing",
+							klog.V(5).Infof("%s %s is in terminal state but no longer exists in informer cache, removing",
 								r.ResourceHandler.ObjType, newKey)
 							r.DoWithLock(newKey, func(key string) {
 								r.processObjectInTerminalState(newer, newKey, resourceEventUpdate)
@@ -620,7 +620,7 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 						if found {
 							existingCacheEntry = retryEntryOrNil.config
 						}
-						klog.Infof("Deleting old %s of type %s during update", oldKey, r.ResourceHandler.ObjType)
+						klog.V(5).Infof("Deleting old %s of type %s during update", oldKey, r.ResourceHandler.ObjType)
 						if err := r.ResourceHandler.DeleteResource(old, existingCacheEntry); err != nil {
 							klog.Errorf("Failed to delete %s %s, during update: %v",
 								r.ResourceHandler.ObjType, oldKey, err)
@@ -646,7 +646,7 @@ func (r *RetryFramework) WatchResourceFiltered(namespaceForFilteredHandler strin
 									r.ResourceHandler.ObjType, oldKey, newKey, err)
 								r.ResourceHandler.RecordErrorEvent(latest, "ErrorUpdatingResource", err)
 							} else {
-								klog.Infof("Failed to update %s, old=%s, new=%s, error: %v",
+								klog.V(5).Infof("Failed to update %s, old=%s, new=%s, error: %v",
 									r.ResourceHandler.ObjType, oldKey, newKey, err)
 							}
 							var retryEntry *retryObjEntry


### PR DESCRIPTION
This PR enables the libovsdb client to use a separate log file to prevent ovn transactions
from filling up ovnkube controller logs. By default, this feature is disabled, and the logs will
only be separated when the new flag is provided:

--libovsdblogfile /path/to/log.log

When this flag is used, the log's verbosity and rotation will follow the existing flags for such
purposes. See  https://github.com/ovn-org/ovn-kubernetes/pull/1458