### PR TITLE
Register resource max retry failed metric for cluster manager

### DIFF
--- a/go-controller/pkg/metrics/cluster_manager.go
+++ b/go-controller/pkg/metrics/cluster_manager.go
@@ -117,6 +117,11 @@ func RegisterClusterManagerFunctional() {
 		prometheus.MustRegister(metricEgressIPRebalanceCount)
 		prometheus.MustRegister(metricEgressIPCount)
 	}
+	if err := prometheus.Register(MetricResourceRetryFailuresCount); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			panic(err)
+		}
+	}
 }
 
 // RecordSubnetUsage records the number of subnets allocated for nodes


### PR DESCRIPTION
This fixes a regression associated with IC changes because resource_retry_failures_total metric is not registered for cluster manager module, hence it doesn't collect object max retry failures metric associated with control plane pod. So this makes resource_retry_failures_total  metric is registered for cluster manger as well.