### PR TITLE
Move the UnidledAt controller to cluster-manager

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1468,6 +1468,12 @@ ovn-cluster-manager() {
   fi
   echo "ovnkube_enable_multi_external_gateway_flag=${ovnkube_enable_multi_external_gateway_flag}"
 
+  empty_lb_events_flag=
+  if [[ ${ovn_empty_lb_events} == "true" ]]; then
+      empty_lb_events_flag="--ovn-empty-lb-events"
+  fi
+  echo "empty_lb_events_flag=${empty_lb_events_flag}"
+
   echo "=============== ovn-cluster-manager ========== MASTER ONLY"
   /usr/bin/ovnkube \
     --init-cluster-manager ${K8S_NODE} \
@@ -1476,6 +1482,7 @@ ovn-cluster-manager() {
     --logfile-maxsize=${ovnkube_logfile_maxsize} \
     --logfile-maxbackups=${ovnkube_logfile_maxbackups} \
     --logfile-maxage=${ovnkube_logfile_maxage} \
+    ${empty_lb_events_flag} \
     ${hybrid_overlay_flags} \
     ${ovn_v4_join_subnet_opt} \
     ${ovn_v6_join_subnet_opt} \

--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/clustermanager/egressservice"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/controller/unidling"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/healthcheck"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -99,6 +101,11 @@ func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.W
 
 		cm.egressServiceController, err = egressservice.NewController(ovnClient, wf, isReachable)
 		if err != nil {
+			return nil, err
+		}
+	}
+	if config.Kubernetes.OVNEmptyLbEvents {
+		if _, err := unidling.NewUnidledAtController(&kube.Kube{KClient: ovnClient.KubeClient}, wf.ServiceInformer()); err != nil {
 			return nil, err
 		}
 	}

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -538,11 +538,6 @@ func (oc *DefaultNetworkController) Run(ctx context.Context) error {
 			defer oc.wg.Done()
 			unidlingController.Run(oc.stopChan)
 		}()
-
-		_, err = unidling.NewUnidledAtController(oc.kube, oc.watchFactory.ServiceInformer())
-		if err != nil {
-			return err
-		}
 	}
 
 	// Master is fully running and resource handlers have synced, update Topology version in OVN and the ConfigMap


### PR DESCRIPTION
UnidledAtController sets informational annotations on idled/unidled services.
Without the proposed changes every node will try to set/remove the `UnidledAtAnnotation` on a service that changed the idle state.

Additionally, this is the only place where ovnkube-node requires `services/status` permissions so it would be good if we could get rid of it.

Before:
```
oc logs -lapp=ovnkube-node -c ovnkube-controller --tail -1 | grep -i "setting.*unidled"                                                                                                                                                                                                                                                                                                           
I0807 12:33:43.879576    4125 kube.go:173] Setting annotations map[k8s.ovn.org/unidled-at:2023-08-07T12:33:43Z] on service default/nginx
I0807 12:33:43.878253   14637 kube.go:173] Setting annotations map[k8s.ovn.org/unidled-at:2023-08-07T12:33:43Z] on service default/nginx
I0807 12:33:43.879238    3920 kube.go:173] Setting annotations map[k8s.ovn.org/unidled-at:2023-08-07T12:33:43Z] on service default/nginx
I0807 12:33:43.858909    3898 kube.go:173] Setting annotations map[k8s.ovn.org/unidled-at:2023-08-07T12:33:43Z] on service default/nginx
I0807 12:33:43.878780   13136 kube.go:173] Setting annotations map[k8s.ovn.org/unidled-at:2023-08-07T12:33:43Z] on service default/nginx
I0807 12:33:43.878141   11974 kube.go:173] Setting annotations map[k8s.ovn.org/unidled-at:2023-08-07T12:33:43Z] on service default/nginx
```

After:
```
oc logs -lapp=ovnkube-control-plane -c ovnkube-cluster-manager  --tail -1 | grep -i "setting.*unidled"                                                                     
I0807 12:49:39.401637       1 kube.go:173] Setting annotations map[k8s.ovn.org/unidled-at:2023-08-07T12:49:39Z] on service default/nginx
oc logs -lapp=ovnkube-node -c ovnkube-controller --tail -1 | grep -i "setting.*unidled"                                                                                           
<NO OUTPUT>
```


Using `OVNEmptyLbEvents` config flag means we need to pass `ovn-empty-lb-events` to cluster-manager. 

/cc @tssurya @trozet  