### PR TITLE
Remove unregister metrics from cluster manager

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -450,6 +450,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 		if err != nil {
 			return fmt.Errorf("failed to create new cluster manager: %w", err)
 		}
+		metrics.RegisterClusterManagerFunctional()
 		err = cm.Start(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to start cluster manager: %w", err)

--- a/go-controller/pkg/clustermanager/clustermanager.go
+++ b/go-controller/pkg/clustermanager/clustermanager.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/metrics"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
 
@@ -115,7 +114,6 @@ func NewClusterManager(ovnClient *util.OVNClusterManagerClientset, wf *factory.W
 // Start the cluster manager.
 func (cm *ClusterManager) Start(ctx context.Context) error {
 	klog.Info("Starting the cluster manager")
-	metrics.RegisterClusterManagerFunctional()
 
 	// Start and sync the watch factory to begin listening for events
 	if err := cm.wf.Start(); err != nil {
@@ -165,5 +163,4 @@ func (cm *ClusterManager) Stop() {
 	if config.OVNKubernetesFeature.EnableEgressService {
 		cm.egressServiceController.Stop()
 	}
-	metrics.UnregisterClusterManagerFunctional()
 }

--- a/go-controller/pkg/metrics/cluster_manager.go
+++ b/go-controller/pkg/metrics/cluster_manager.go
@@ -119,18 +119,6 @@ func RegisterClusterManagerFunctional() {
 	}
 }
 
-func UnregisterClusterManagerFunctional() {
-	prometheus.Unregister(metricV4HostSubnetCount)
-	prometheus.Unregister(metricV6HostSubnetCount)
-	prometheus.Unregister(metricV4AllocatedHostSubnetCount)
-	prometheus.Unregister(metricV6AllocatedHostSubnetCount)
-	if config.OVNKubernetesFeature.EnableEgressIP {
-		prometheus.Unregister(metricEgressIPNodeUnreacheableCount)
-		prometheus.Unregister(metricEgressIPRebalanceCount)
-		prometheus.Unregister(metricEgressIPCount)
-	}
-}
-
 // RecordSubnetUsage records the number of subnets allocated for nodes
 func RecordSubnetUsage(v4SubnetsAllocated, v6SubnetsAllocated float64) {
 	metricV4AllocatedHostSubnetCount.Set(v4SubnetsAllocated)


### PR DESCRIPTION
There is no point in unregistering metrics from Prometheus when cluster manager is stopped. Hence removing associated methods handling unregister metrics.