### PR TITLE
Fix BANP unit test flake

### DIFF
--- a/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
@@ -478,7 +478,6 @@ var _ = ginkgo.Describe("OVN BANP Operations", func() {
 				banpPeerPod.Labels = peerAllowLabel // pod is now in namespace {house: slytherin} && pod {house: hufflepuff}
 				_, err = fakeOVN.fakeClient.KubeClient.CoreV1().Pods(banpPeerPod.Namespace).Update(context.TODO(), &banpPeerPod, metav1.UpdateOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 				// ingressRule AddressSets - podIP should stay in deny rule's address-set since deny rule matcheS only on nsSelector which has not changed
 				// egressRule AddressSets - podIP should now be present in both deny and allow rule's address-sets
 				expectedDatabaseState[len(expectedDatabaseState)-4].(*nbdb.AddressSet).Addresses = []string{t2.podIP} // podIP should be added to v4 allow address-set


### PR DESCRIPTION
The test is expecting on DB data before actually updating what it is supposed to expect on and expecting again after.