### PR TITLE
[OCPBUGS-17692] Failed to apply APB External Route to a recreated pod

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1035,7 +1035,6 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	if config.HybridOverlay.Enabled {
 		// Not supported with DPUs, enforced in config
 		// TODO(adrianc): Revisit above comment
-		// TODO(jtanenba): LocalPodInformer informs on all pods
 		nodeController, err := honode.NewNode(
 			nc.Kube,
 			nc.name,

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -15,7 +15,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ktypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -38,10 +37,12 @@ import (
 )
 
 const (
-	maxRetries = 15
+	resyncInterval = 0
+	maxRetries     = 15
 )
 
 // Admin Policy Based Route services
+
 type ExternalGatewayMasterController struct {
 	client               kubernetes.Interface
 	apbRoutePolicyClient adminpolicybasedrouteclient.Interface
@@ -62,13 +63,9 @@ type ExternalGatewayMasterController struct {
 	namespaceLister   corev1listers.NamespaceLister
 	namespaceInformer cache.SharedIndexInformer
 
-	// External gateway caches
-	// Make them public so that they can be used by the annotation logic to lock on namespaces and share the same external route information
-	ExternalGWCache map[ktypes.NamespacedName]*ExternalRouteInfo
-	ExGWCacheMutex  *sync.RWMutex
-
-	mgr      *externalPolicyManager
-	nbClient *northBoundClient
+	mgr                      *externalPolicyManager
+	nbClient                 *northBoundClient
+	ExternalGWRouteInfoCache *ExternalGatewayRouteInfoCache
 }
 
 func NewExternalMasterController(
@@ -84,22 +81,20 @@ func NewExternalMasterController(
 	controllerName string,
 ) (*ExternalGatewayMasterController, error) {
 
-	externalGWCache := make(map[ktypes.NamespacedName]*ExternalRouteInfo)
-	exGWCacheMutex := &sync.RWMutex{}
+	externalGWRouteInfo := NewExternalGatewayRouteInfoCache()
 	zone, err := libovsdbutil.GetNBZone(nbClient)
 	if err != nil {
 		return nil, err
 	}
 	nbCli := &northBoundClient{
-		routeLister:       apbRouteInformer.Lister(),
-		nodeLister:        nodeLister,
-		podLister:         podInformer.Lister(),
-		nbClient:          nbClient,
-		addressSetFactory: addressSetFactory,
-		externalGWCache:   externalGWCache,
-		exGWCacheMutex:    exGWCacheMutex,
-		controllerName:    controllerName,
-		zone:              zone,
+		routeLister:              apbRouteInformer.Lister(),
+		nodeLister:               nodeLister,
+		podLister:                podInformer.Lister(),
+		nbClient:                 nbClient,
+		addressSetFactory:        addressSetFactory,
+		controllerName:           controllerName,
+		zone:                     zone,
+		externalGatewayRouteInfo: externalGWRouteInfo,
 	}
 
 	c := &ExternalGatewayMasterController{
@@ -124,9 +119,8 @@ func NewExternalMasterController(
 			workqueue.NewItemFastSlowRateLimiter(time.Second, 5*time.Second, 5),
 			"apbexternalroutenamespaces",
 		),
-		ExternalGWCache: externalGWCache,
-		ExGWCacheMutex:  exGWCacheMutex,
-		nbClient:        nbCli,
+		ExternalGWRouteInfoCache: externalGWRouteInfo,
+		nbClient:                 nbCli,
 		mgr: newExternalPolicyManager(
 			stopCh,
 			podInformer.Lister(),

--- a/go-controller/pkg/ovn/controller/apbroute/node_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/node_controller.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	ktypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -47,11 +46,6 @@ type ExternalGatewayNodeController struct {
 	namespaceQueue    workqueue.RateLimitingInterface
 	namespaceLister   corev1listers.NamespaceLister
 	namespaceInformer cache.SharedIndexInformer
-
-	//external gateway caches
-	//make them public so that they can be used by the annotation logic to lock on namespaces and share the same external route information
-	ExternalGWCache map[ktypes.NamespacedName]*ExternalRouteInfo
-	ExGWCacheMutex  *sync.RWMutex
 
 	mgr *externalPolicyManager
 }

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -28,13 +28,11 @@ import (
 	zoneic "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/ovn/zone_interconnect"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/retry"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/syncmap"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	ovntypes "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
-	ktypes "k8s.io/apimachinery/pkg/types"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -52,8 +50,7 @@ type DefaultNetworkController struct {
 	// cluster's east-west traffic.
 	loadbalancerClusterCache map[kapi.Protocol]string
 
-	externalGWCache map[ktypes.NamespacedName]*apbroutecontroller.ExternalRouteInfo
-	exGWCacheMutex  *sync.RWMutex
+	externalGatewayRouteInfo *apbroutecontroller.ExternalGatewayRouteInfoCache
 
 	// egressFirewalls is a map of namespaces and the egressFirewall attached to it
 	egressFirewalls sync.Map
@@ -206,8 +203,7 @@ func newDefaultNetworkControllerCommon(cnci *CommonNetworkControllerInfo,
 			zoneICHandler:               zoneICHandler,
 			cancelableCtx:               util.NewCancelableContext(),
 		},
-		externalGWCache: apbExternalRouteController.ExternalGWCache,
-		exGWCacheMutex:  apbExternalRouteController.ExGWCacheMutex,
+		externalGatewayRouteInfo: apbExternalRouteController.ExternalGWRouteInfoCache,
 		eIPC: egressIPZoneController{
 			nodeIPUpdateMutex:  &sync.Mutex{},
 			podAssignmentMutex: &sync.Mutex{},
@@ -229,7 +225,7 @@ func newDefaultNetworkControllerCommon(cnci *CommonNetworkControllerInfo,
 	// allocate the first IPs in the join switch subnets.
 	gwLRPIfAddrs, err := oc.getOVNClusterRouterPortToJoinSwitchIfAddrs()
 	if err != nil {
-		return nil, fmt.Errorf("failed to allocate join switch IP address connected to %s: %v", types.OVNClusterRouter, err)
+		return nil, fmt.Errorf("failed to allocate join switch IP address connected to %s: %v", ovntypes.OVNClusterRouter, err)
 	}
 
 	oc.ovnClusterLRPToJoinIfAddrs = gwLRPIfAddrs

--- a/go-controller/pkg/ovn/egressgw.go
+++ b/go-controller/pkg/ovn/egressgw.go
@@ -35,97 +35,6 @@ type gatewayInfo struct {
 	bfdEnabled bool
 }
 
-// ensureRouteInfoLocked either gets the current routeInfo in the cache with a lock, or creates+locks a new one if missing
-func (oc *DefaultNetworkController) ensureRouteInfoLocked(podName ktypes.NamespacedName) (*apbroutecontroller.RouteInfo, error) {
-	// We don't want to hold the cache lock while we try to lock the routeInfo (unless we are creating it, then we know
-	// no one else is using it). This could lead to dead lock. Therefore the steps here are:
-	// 1. Get the cache lock, try to find the routeInfo
-	// 2. If routeInfo existed, release the cache lock
-	// 3. If routeInfo did not exist, safe to hold the cache lock while we create the new routeInfo
-	oc.externalGatewayRouteInfo.ExGWCacheMutex.Lock()
-	routeInfo, ok := oc.externalGatewayRouteInfo.ExternalGWCache[podName]
-	var isDeleted bool
-	if !ok {
-		routeInfo = &apbroutecontroller.RouteInfo{
-			PodExternalRoutes: make(map[string]map[string]string),
-			PodName:           podName,
-		}
-		// we are creating routeInfo and going to set it in podExternalRoutes map
-		// so safe to hold the lock while we create and add it
-		defer oc.externalGatewayRouteInfo.ExGWCacheMutex.Unlock()
-		oc.externalGatewayRouteInfo.ExternalGWCache[podName] = routeInfo
-	} else {
-		// if we found an existing routeInfo, do not hold the cache lock
-		// while waiting for routeInfo to Lock
-		isDeleted = oc.externalGatewayRouteInfo.GetRouteInfoDeletedStatus(podName)
-		oc.externalGatewayRouteInfo.ExGWCacheMutex.Unlock()
-	}
-
-	// 4. Now lock the routeInfo
-	routeInfo.Lock()
-
-	// 5. If routeInfo was deleted between releasing the cache lock and grabbing
-	// the routeInfo lock, return an error so the caller doesn't use it and
-	// retries the operation later
-	if oc.externalGatewayRouteInfo.GetRouteInfoDeletedStatus(podName) {
-		if !isDeleted {
-			// info was modified while waiting for unlock, return error and retry later
-			routeInfo.Unlock()
-			return nil, fmt.Errorf("routeInfo for pod %s, was altered during ensure route info", podName)
-		}
-		// it was already deleted before the lock, so change the status as not deleted
-		oc.externalGatewayRouteInfo.SetRouteInfoDeletedStatus(podName, false)
-	}
-
-	return routeInfo, nil
-}
-
-// getRouteInfosForNamespace returns all routeInfos for a specific namespace
-func (oc *DefaultNetworkController) getRouteInfosForNamespace(namespace string) map[ktypes.NamespacedName]*apbroutecontroller.RouteInfo {
-	oc.externalGatewayRouteInfo.ExGWCacheMutex.RLock()
-	defer oc.externalGatewayRouteInfo.ExGWCacheMutex.RUnlock()
-
-	routes := make(map[ktypes.NamespacedName]*apbroutecontroller.RouteInfo)
-	for namespacedName, routeInfo := range oc.externalGatewayRouteInfo.ExternalGWCache {
-		if namespacedName.Namespace == namespace {
-			routes[namespacedName] = routeInfo
-		}
-	}
-
-	return routes
-}
-
-// deleteRouteInfoLocked removes a routeInfo from the cache, and returns it locked
-func (oc *DefaultNetworkController) deleteRouteInfoLocked(name ktypes.NamespacedName) *apbroutecontroller.RouteInfo {
-	// Attempt to find the routeInfo in the cache, release the cache lock while
-	// we try to lock the routeInfo to avoid any deadlock
-	oc.externalGatewayRouteInfo.ExGWCacheMutex.RLock()
-	routeInfo := oc.externalGatewayRouteInfo.ExternalGWCache[name]
-	oc.externalGatewayRouteInfo.ExGWCacheMutex.RUnlock()
-
-	if routeInfo == nil {
-		return nil
-	}
-	routeInfo.Lock()
-
-	if oc.externalGatewayRouteInfo.GetRouteInfoDeletedStatus(name) {
-		routeInfo.Unlock()
-		return nil
-	}
-
-	oc.externalGatewayRouteInfo.SetRouteInfoDeletedStatus(name, true)
-
-	go func() {
-		oc.externalGatewayRouteInfo.ExGWCacheMutex.Lock()
-		defer oc.externalGatewayRouteInfo.ExGWCacheMutex.Unlock()
-		if newRouteInfo := oc.externalGatewayRouteInfo.ExternalGWCache[name]; routeInfo == newRouteInfo {
-			delete(oc.externalGatewayRouteInfo.ExternalGWCache, name)
-		}
-	}()
-
-	return routeInfo
-}
-
 // addPodExternalGW handles detecting if a pod is serving as an external gateway for namespace(s) and adding routes
 // to all pods in that namespace
 func (oc *DefaultNetworkController) addPodExternalGW(pod *kapi.Pod) error {
@@ -425,68 +334,57 @@ func (oc *DefaultNetworkController) deleteGWRoutesForNamespace(namespace string,
 		return err
 	}
 	policyGWIPs = policyGWIPs.Union(policyStaticGWIPs)
-	for podNsName, routeInfo := range oc.getRouteInfosForNamespace(namespace) {
-		routeInfo.Lock()
-		if oc.externalGatewayRouteInfo.GetRouteInfoDeletedStatus(podNsName) {
-			routeInfo.Unlock()
-			continue
-		}
+	return oc.externalGatewayRouteInfo.CleanupNamespace(namespace, func(routeInfo *apbroutecontroller.RouteInfo) error {
 		for podIP, routes := range routeInfo.PodExternalRoutes {
 			for gw, gr := range routes {
 				if (deleteAll || matchGWs.Has(gw)) && !policyGWIPs.Has(gw) {
 					if err := oc.deletePodGWRoute(routeInfo, podIP, gw, gr); err != nil {
 						// if we encounter error while deleting routes for one pod; we return and don't try subsequent pods
-						routeInfo.Unlock()
 						return fmt.Errorf("delete pod GW route failed: %w", err)
 					}
 					delete(routes, gw)
 				}
 			}
 		}
-		routeInfo.Unlock()
-	}
-	return nil
+		return nil
+	})
 }
 
 // deleteGwRoutesForPod handles deleting all routes to gateways for a pod IP on a specific GR
 func (oc *DefaultNetworkController) deleteGWRoutesForPod(name ktypes.NamespacedName, podIPNets []*net.IPNet) (err error) {
-	routeInfo := oc.deleteRouteInfoLocked(name)
-	if routeInfo == nil {
-		return nil
-	}
-	defer routeInfo.Unlock()
-
-	policyGWIPs, err := oc.apbExternalRouteController.GetDynamicGatewayIPsForTargetNamespace(name.Namespace)
-	if err != nil {
-		return err
-	}
-	policyStaticGWIPs, err := oc.apbExternalRouteController.GetStaticGatewayIPsForTargetNamespace(name.Namespace)
-	if err != nil {
-		return err
-	}
-	policyGWIPs = policyGWIPs.Union(policyStaticGWIPs)
-
-	for _, podIPNet := range podIPNets {
-		podIP := podIPNet.IP.String()
-		routes, ok := routeInfo.PodExternalRoutes[podIP]
-		if !ok {
-			continue
+	return oc.externalGatewayRouteInfo.Cleanup(name, func(routeInfo *apbroutecontroller.RouteInfo) error {
+		policyGWIPs, err := oc.apbExternalRouteController.GetDynamicGatewayIPsForTargetNamespace(name.Namespace)
+		if err != nil {
+			return err
 		}
-		if len(routes) == 0 {
-			delete(routeInfo.PodExternalRoutes, podIP)
-			continue
+		policyStaticGWIPs, err := oc.apbExternalRouteController.GetStaticGatewayIPsForTargetNamespace(name.Namespace)
+		if err != nil {
+			return err
 		}
-		for gw, gr := range routes {
-			if !policyGWIPs.Has(gw) {
-				if err := oc.deletePodGWRoute(routeInfo, podIP, gw, gr); err != nil {
-					// if we encounter error while deleting routes for one pod; we return and don't try subsequent pods
-					return fmt.Errorf("delete pod GW route failed: %w", err)
+		policyGWIPs = policyGWIPs.Union(policyStaticGWIPs)
+
+		for _, podIPNet := range podIPNets {
+			podIP := podIPNet.IP.String()
+			routes, ok := routeInfo.PodExternalRoutes[podIP]
+			if !ok {
+				continue
+			}
+			if len(routes) == 0 {
+				delete(routeInfo.PodExternalRoutes, podIP)
+				continue
+			}
+			for gw, gr := range routes {
+				if !policyGWIPs.Has(gw) {
+					if err := oc.deletePodGWRoute(routeInfo, podIP, gw, gr); err != nil {
+						// if we encounter error while deleting routes for one pod; we return and don't try subsequent pods
+						return fmt.Errorf("delete pod GW route failed: %w", err)
+					}
+					delete(routes, gw)
 				}
-				delete(routes, gw)
 			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // addEgressGwRoutesForPod handles adding all routes to gateways for a pod on a specific GR
@@ -515,63 +413,60 @@ func (oc *DefaultNetworkController) addGWRoutesForPod(gateways []*gatewayInfo, p
 	}
 
 	port := portPrefix + types.GWRouterToExtSwitchPrefix + gr
-	routeInfo, err := oc.ensureRouteInfoLocked(podNsName)
-	if err != nil {
-		return fmt.Errorf("failed to ensure routeInfo for %s, error: %v", podNsName, err)
-	}
-	policyGWIPs, err := oc.apbExternalRouteController.GetDynamicGatewayIPsForTargetNamespace(podNsName.Namespace)
-	if err != nil {
-		return err
-	}
-	policyStaticGWIPs, err := oc.apbExternalRouteController.GetStaticGatewayIPsForTargetNamespace(podNsName.Namespace)
-	if err != nil {
-		return err
-	}
-	policyGWIPs = policyGWIPs.Union(policyStaticGWIPs)
 
-	defer routeInfo.Unlock()
+	return oc.externalGatewayRouteInfo.CreateOrLoad(podNsName, func(routeInfo *apbroutecontroller.RouteInfo) error {
+		policyGWIPs, err := oc.apbExternalRouteController.GetDynamicGatewayIPsForTargetNamespace(podNsName.Namespace)
+		if err != nil {
+			return err
+		}
+		policyStaticGWIPs, err := oc.apbExternalRouteController.GetStaticGatewayIPsForTargetNamespace(podNsName.Namespace)
+		if err != nil {
+			return err
+		}
+		policyGWIPs = policyGWIPs.Union(policyStaticGWIPs)
 
-	for _, podIPNet := range podIfAddrs {
-		for _, gateway := range gateways {
-			// TODO (trozet): use the go bindings here and batch commands
-			// validate the ip and gateway belong to the same address family
-			gws, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(podIPNet.IP), gateway.gws.UnsortedList())
-			if err == nil {
-				podIP := podIPNet.IP.String()
-				for _, gw := range gws {
-					// if route was already programmed, skip it
-					foundGR, ok := routeInfo.PodExternalRoutes[podIP][gw]
-					if (ok && foundGR == gr) || policyGWIPs.Has(gw) {
-						routesAdded++
-						continue
-					}
-					mask := util.GetIPFullMaskString(podIP)
+		for _, podIPNet := range podIfAddrs {
+			for _, gateway := range gateways {
+				// TODO (trozet): use the go bindings here and batch commands
+				// validate the ip and gateway belong to the same address family
+				gws, err := util.MatchAllIPStringFamily(utilnet.IsIPv6(podIPNet.IP), gateway.gws.UnsortedList())
+				if err == nil {
+					podIP := podIPNet.IP.String()
+					for _, gw := range gws {
+						// if route was already programmed, skip it
+						foundGR, ok := routeInfo.PodExternalRoutes[podIP][gw]
+						if (ok && foundGR == gr) || policyGWIPs.Has(gw) {
+							routesAdded++
+							continue
+						}
+						mask := util.GetIPFullMaskString(podIP)
 
-					if err := oc.createBFDStaticRoute(gateway.bfdEnabled, gw, podIP, gr, port, mask); err != nil {
-						return err
-					}
-					if routeInfo.PodExternalRoutes[podIP] == nil {
-						routeInfo.PodExternalRoutes[podIP] = make(map[string]string)
-					}
-					routeInfo.PodExternalRoutes[podIP][gw] = gr
-					routesAdded++
-					if len(routeInfo.PodExternalRoutes[podIP]) == 1 {
-						if err := oc.addHybridRoutePolicyForPod(podIPNet.IP, node); err != nil {
+						if err := oc.createBFDStaticRoute(gateway.bfdEnabled, gw, podIP, gr, port, mask); err != nil {
 							return err
 						}
+						if routeInfo.PodExternalRoutes[podIP] == nil {
+							routeInfo.PodExternalRoutes[podIP] = make(map[string]string)
+						}
+						routeInfo.PodExternalRoutes[podIP][gw] = gr
+						routesAdded++
+						if len(routeInfo.PodExternalRoutes[podIP]) == 1 {
+							if err := oc.addHybridRoutePolicyForPod(podIPNet.IP, node); err != nil {
+								return err
+							}
+						}
 					}
+				} else {
+					klog.Warningf("Address families for the pod address %s and gateway %s did not match", podIPNet.IP.String(), gateway.gws)
 				}
-			} else {
-				klog.Warningf("Address families for the pod address %s and gateway %s did not match", podIPNet.IP.String(), gateway.gws)
 			}
 		}
-	}
-	// if no routes are added return an error
-	if routesAdded < 1 {
-		return fmt.Errorf("gateway specified for namespace %s with gateway addresses %v but no valid routes exist for pod: %s",
-			podNsName.Namespace, podIfAddrs, podNsName.Name)
-	}
-	return nil
+		// if no routes are added return an error
+		if routesAdded < 1 {
+			return fmt.Errorf("gateway specified for namespace %s with gateway addresses %v but no valid routes exist for pod: %s",
+				podNsName.Namespace, podIfAddrs, podNsName.Name)
+		}
+		return nil
+	})
 }
 
 // deletePodSNAT removes per pod SNAT rules towards the nodeIP that are applied to the GR where the pod resides

--- a/go-controller/pkg/syncmap/syncmap.go
+++ b/go-controller/pkg/syncmap/syncmap.go
@@ -27,9 +27,9 @@ func newKeyLock() *keyLock {
 	return &c
 }
 
-// SyncMap is a map with lockable keys. It allows to lock the key regardless of whether the entry for
+// SyncMapComparableKey is a map with lockable keys. It allows to lock the key regardless of whether the entry for
 // given key exists. When key is locked other threads can't read/write the key.
-type SyncMap[T any] struct {
+type SyncMapComparableKey[T1 comparable, T2 any] struct {
 	// keyLocksMutex needs to be locked for every read/write operation with keyLocks.
 	// refCounter should be updated for keyLock before keyLocksMutex lock is released.
 	// to avoid deadlocks make sure no other locks are acquired when keyLocksMutex is locked.
@@ -37,28 +37,28 @@ type SyncMap[T any] struct {
 	// map of key mutexes, should only be accessed with keyLocksMutex lock
 	// keyLock exists for a key that was locked with LockKey and until all threads that called LockKey
 	// execute UnlockKey
-	keyLocks map[string]*keyLock
+	keyLocks map[T1]*keyLock
 	// entriesMutex needs to be locked for every read/write operation with entries
 	// to avoid deadlocks make sure no other locks are acquired when entriesMutex is locked
 	entriesMutex sync.Mutex
 	// cache entries
 	// should only be accessed with entriesMutex, also
 	// read/write for a given key is only allowed with keyLock
-	entries map[string]T
+	entries map[T1]T2
 }
 
-func NewSyncMap[T any]() *SyncMap[T] {
-	c := SyncMap[T]{
+func NewSyncMapComparableKey[T1 comparable, T2 any]() *SyncMapComparableKey[T1, T2] {
+	c := SyncMapComparableKey[T1, T2]{
 		sync.Mutex{},
-		make(map[string]*keyLock),
+		make(map[T1]*keyLock),
 		sync.Mutex{},
-		make(map[string]T),
+		make(map[T1]T2),
 	}
 	return &c
 }
 
 // UnlockKey unlocks previously locked key. Call it when all the operations with the given key are done.
-func (c *SyncMap[T]) UnlockKey(lockedKey string) {
+func (c *SyncMapComparableKey[T1, T2]) UnlockKey(lockedKey T1) {
 	c.keyLocksMutex.Lock()
 	defer c.keyLocksMutex.Unlock()
 	kLock, ok := c.keyLocks[lockedKey]
@@ -82,7 +82,7 @@ func (c *SyncMap[T]) UnlockKey(lockedKey string) {
 // Otherwise, it stores and returns the given value.
 // The loaded result is true if the value was loaded, false if stored.
 // loadOrStoreKeyLock will increase refCounter for returned value
-func (c *SyncMap[T]) loadOrStoreKeyLock(lockedKey string, value *keyLock) (*keyLock, bool) {
+func (c *SyncMapComparableKey[T1, T2]) loadOrStoreKeyLock(lockedKey T1, value *keyLock) (*keyLock, bool) {
 	c.keyLocksMutex.Lock()
 	defer c.keyLocksMutex.Unlock()
 	if kLock, ok := c.keyLocks[lockedKey]; ok {
@@ -99,7 +99,7 @@ func (c *SyncMap[T]) loadOrStoreKeyLock(lockedKey string, value *keyLock) (*keyL
 // it guarantees exclusive access to the key.
 // Unlock(key) should be called once the work for this key is done to unlock other threads
 // After the key is unlocked there are no guarantees for the entry for given key
-func (c *SyncMap[T]) LockKey(key string) {
+func (c *SyncMapComparableKey[T1, T2]) LockKey(key T1) {
 	// if the kLock is not present, we create a new one
 	// lock it before adding, to prevent other threads from getting the key lock after we add it
 	newKLock := newKeyLock()
@@ -120,7 +120,7 @@ func (c *SyncMap[T]) LockKey(key string) {
 
 // Load returns the value stored in the map for a key, or nil if no value is present.
 // The loaded result indicates whether value was found in the map.
-func (c *SyncMap[T]) Load(lockedKey string) (value T, loaded bool) {
+func (c *SyncMapComparableKey[T1, T2]) Load(lockedKey T1) (value T2, loaded bool) {
 	c.entriesMutex.Lock()
 	defer c.entriesMutex.Unlock()
 	entry, ok := c.entries[lockedKey]
@@ -129,7 +129,7 @@ func (c *SyncMap[T]) Load(lockedKey string) (value T, loaded bool) {
 
 // LoadOrStore gets the key value if it's present or creates a new one if it isn't,
 // loaded return value signals if the object was present.
-func (c *SyncMap[T]) LoadOrStore(lockedKey string, newEntry T) (value T, loaded bool) {
+func (c *SyncMapComparableKey[T1, T2]) LoadOrStore(lockedKey T1, newEntry T2) (value T2, loaded bool) {
 	c.entriesMutex.Lock()
 	defer c.entriesMutex.Unlock()
 	if entry, ok := c.entries[lockedKey]; ok {
@@ -142,14 +142,14 @@ func (c *SyncMap[T]) LoadOrStore(lockedKey string, newEntry T) (value T, loaded 
 
 // Store sets the value for a key.
 // If key-value was already present, it will be over-written
-func (c *SyncMap[T]) Store(lockedKey string, newEntry T) {
+func (c *SyncMapComparableKey[T1, T2]) Store(lockedKey T1, newEntry T2) {
 	c.entriesMutex.Lock()
 	defer c.entriesMutex.Unlock()
 	c.entries[lockedKey] = newEntry
 }
 
 // Delete deletes object from the entries map
-func (c *SyncMap[T]) Delete(lockedKey string) {
+func (c *SyncMapComparableKey[T1, T2]) Delete(lockedKey T1) {
 	c.entriesMutex.Lock()
 	defer c.entriesMutex.Unlock()
 	delete(c.entries, lockedKey)
@@ -157,10 +157,10 @@ func (c *SyncMap[T]) Delete(lockedKey string) {
 
 // GetKeys returns a snapshot of all keys from entries map.
 // After this function returns there are no guarantees that the keys in the real entries map are still the same
-func (c *SyncMap[T]) GetKeys() []string {
+func (c *SyncMapComparableKey[T1, T2]) GetKeys() []T1 {
 	c.entriesMutex.Lock()
 	defer c.entriesMutex.Unlock()
-	keys := make([]string, len(c.entries))
+	keys := make([]T1, len(c.entries))
 	i := 0
 	for k := range c.entries {
 		keys[i] = k
@@ -170,8 +170,16 @@ func (c *SyncMap[T]) GetKeys() []string {
 }
 
 // DoWithLock takes care of locking and unlocking key.
-func (c *SyncMap[T]) DoWithLock(key string, f func(key string) error) error {
+func (c *SyncMapComparableKey[T1, T2]) DoWithLock(key T1, f func(key T1) error) error {
 	c.LockKey(key)
 	defer c.UnlockKey(key)
 	return f(key)
+}
+
+type SyncMap[T any] struct {
+	SyncMapComparableKey[string, T]
+}
+
+func NewSyncMap[T any]() *SyncMap[T] {
+	return &SyncMap[T]{*NewSyncMapComparableKey[string, T]()}
 }


### PR DESCRIPTION
Fixes an issue in APB External Route where deleting a pod and recreating it failed due to the Deleted state in the routeInfo. The solution involves getting the status before obtaining the routeInfo lock and comparing it after obtaining lock: if the values differ, return with error. If the values match, there has been no changes and it is safe to reuse the routeInfo in case it was deleted.

@npinaeva @trozet @jcaamano PTAL