### PR TITLE
Change APB unit test to use multus annotation instead of hostnetwork

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/external_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller.go
@@ -63,9 +63,15 @@ func newRoutePolicyState() *routePolicyState {
 // Equal compares StaticGateways and DynamicGateways elements for every namespace to be exactly the same,
 // including applied status
 func (rp *routePolicyState) Equal(rp2 *routePolicyState) bool {
+	if len(rp2.targetNamespaces) != len(rp.targetNamespaces) {
+		return false
+	}
 	for nsName, nsInfo := range rp.targetNamespaces {
 		nsInfo2, found := rp2.targetNamespaces[nsName]
 		if !found {
+			return false
+		}
+		if len(nsInfo) != len(nsInfo2) {
 			return false
 		}
 		for podName, podInfo := range nsInfo {

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_pod.go
@@ -54,8 +54,8 @@ func getMultusIPsFromNetworkName(pod *v1.Pod, networkName string) (sets.Set[stri
 	var multusNetworks []nettypes.NetworkStatus
 	err := json.Unmarshal([]byte(pod.ObjectMeta.Annotations[nettypes.NetworkStatusAnnot]), &multusNetworks)
 	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshall annotation on pod %s k8s.v1.cni.cncf.io/network-status '%s': %v",
-			pod.Name, pod.ObjectMeta.Annotations[nettypes.NetworkStatusAnnot], err)
+		return nil, fmt.Errorf("unable to unmarshall annotation on pod %s %s '%s': %v",
+			pod.Name, nettypes.NetworkStatusAnnot, pod.ObjectMeta.Annotations[nettypes.NetworkStatusAnnot], err)
 	}
 	for _, multusNetwork := range multusNetworks {
 		if multusNetwork.Name == networkName {

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy.go
@@ -207,13 +207,13 @@ func (m *externalPolicyManager) updateRoutePolicy(existingPolicy *routePolicySta
 				existingTargetPodConfig, found := existingNs[updatedPodNamespacedName]
 				if !found {
 					existingTargetPodConfig = newPodInfo()
-					existingNs[updatedPodNamespacedName] = existingTargetPodConfig
 				}
 				// applyPodConfig will apply changes and update existingTargetPodConfig with the status
 				err := m.applyPodConfig(updatedPod, existingTargetPodConfig, updatedPolicy)
 				if err != nil {
 					return err
 				}
+				existingNs[updatedPodNamespacedName] = existingTargetPodConfig
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy.go
@@ -207,13 +207,13 @@ func (m *externalPolicyManager) updateRoutePolicy(existingPolicy *routePolicySta
 				existingTargetPodConfig, found := existingNs[updatedPodNamespacedName]
 				if !found {
 					existingTargetPodConfig = newPodInfo()
+					existingNs[updatedPodNamespacedName] = existingTargetPodConfig
 				}
 				// applyPodConfig will apply changes and update existingTargetPodConfig with the status
 				err := m.applyPodConfig(updatedPod, existingTargetPodConfig, updatedPolicy)
 				if err != nil {
 					return err
 				}
-				existingNs[updatedPodNamespacedName] = existingTargetPodConfig
 			}
 		}
 	}

--- a/go-controller/pkg/ovn/controller/apbroute/gateway_info/gateway_info.go
+++ b/go-controller/pkg/ovn/controller/apbroute/gateway_info/gateway_info.go
@@ -42,7 +42,7 @@ func (g *GatewayInfoList) Has(gw *GatewayInfo) bool {
 
 func (g *GatewayInfoList) HasWithoutErr(gw *GatewayInfo) bool {
 	for _, i := range g.elems {
-		if i.SameSpec(gw) && i.applied {
+		if i.SameSpec(gw) && !i.failedToApply {
 			return true
 		}
 	}
@@ -82,7 +82,7 @@ func (g *GatewayInfoList) insertOverwrite(gw *GatewayInfo) {
 
 func (g *GatewayInfoList) InsertOverwriteFailed(gws ...*GatewayInfo) {
 	for _, gw := range gws {
-		gw.applied = false
+		gw.failedToApply = true
 	}
 	g.InsertOverwrite(gws...)
 }
@@ -148,9 +148,9 @@ func (g *GatewayInfoList) Equal(g2 *GatewayInfoList) bool {
 }
 
 type GatewayInfo struct {
-	Gateways   sets.Set[string]
-	BFDEnabled bool
-	applied    bool
+	Gateways      sets.Set[string]
+	BFDEnabled    bool
+	failedToApply bool
 }
 
 func (g *GatewayInfo) String() string {
@@ -172,7 +172,7 @@ func (g *GatewayInfo) RemoveIPs(g2 *GatewayInfo) {
 
 // Equal compares all GatewayInfo fields, including BFDEnabled and applied
 func (g *GatewayInfo) Equal(g2 *GatewayInfo) bool {
-	return g.BFDEnabled == g2.BFDEnabled && g.Gateways.Equal(g2.Gateways) && g.applied == g2.applied
+	return g.BFDEnabled == g2.BFDEnabled && g.Gateways.Equal(g2.Gateways) && g.failedToApply == g2.failedToApply
 }
 
 func (g *GatewayInfo) Has(ip string) bool {

--- a/go-controller/pkg/ovn/controller/apbroute/gateway_info/gateway_info_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/gateway_info/gateway_info_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GatewayInfoList", func() {
 			s1 := NewGatewayInfoList(NewGatewayInfo(sets.New("1.1.1.1"), false))
 			s1.InsertOverwriteFailed(NewGatewayInfo(sets.New("1.1.1.1"), false))
 			failedGwInfo := NewGatewayInfo(sets.New("1.1.1.1"), false)
-			failedGwInfo.applied = false
+			failedGwInfo.failedToApply = true
 			Expect(s1.Equal(NewGatewayInfoList(failedGwInfo))).To(BeTrue())
 		})
 


### PR DESCRIPTION
This PR changes the way the APB external route unit tests were run so that the pods don't rely on the `hostNetwork` to avoid skipping running the northBoundDB code stored in network_client.go, and instead they use the multus annotation to retrieve the pod IP.

@npinaeva @trozet @jcaamano PTAL.
