### PR TITLE
multi network: Support NAD plugin list in addition to single plugin configuration

### DIFF
--- a/go-controller/pkg/util/multi_network_test.go
+++ b/go-controller/pkg/util/multi_network_test.go
@@ -270,7 +270,7 @@ func TestParseNetconf(t *testing.T) {
                 "vlanID": 10,
                 "netAttachDefName": "ns1/nad1"
               }
-            ],
+            ]
     }
 `,
 			expectedNetConf: &ovncnitypes.NetConf{
@@ -278,9 +278,8 @@ func TestParseNetconf(t *testing.T) {
 				NADName:  "ns1/nad1",
 				MTU:      1400,
 				VLANID:   10,
-				NetConf:  cnitypes.NetConf{Name: "tenantred", Type: "ovn-k8s-cni-overlay"},
+				NetConf:  cnitypes.NetConf{Name: "tenantred", CNIVersion: "1.0.0", Type: "ovn-k8s-cni-overlay"},
 			},
-			unsupportedReason: "NetConfList plugin specs are not currently supported. This is the *only* supported configuration type for CNI version >= 1.0.0",
 		},
 	}
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
Starting from CNI 1.0.0, the only accepted configuration format possible features a config list of plugins: https://github.com/containernetworking/cni/blob/main/SPEC.md#configuration-format

Support plugin list, in addition to single plugin configuration.

**- Special notes for reviewers**

**- How to verify it**

**- Description for the changelog**
