### PR TITLE
Create egress firewall with one db transaction

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -321,10 +321,12 @@ func GetDbObjsForAS(dbIDs *libovsdbops.DbObjectIDs, ips []net.IP) (*nbdb.Address
 	v4set = buildAddressSet(dbIDs, ipv4InternalID)
 	uniqIPs := ipsToStringUnique(v4IPs)
 	v4set.Addresses = uniqIPs
+	v4set.UUID = v4set.Name + "-UUID"
 	// v6 address set
 	v6set = buildAddressSet(dbIDs, ipv6InternalID)
 	uniqIPs = ipsToStringUnique(v6IPs)
 	v6set.Addresses = uniqIPs
+	v6set.UUID = v6set.Name + "-UUID"
 	return v4set, v6set
 }
 

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -1184,33 +1184,33 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 				config.Gateway.Mode = gwMode
 				app.Action = func(ctx *cli.Context) error {
 					namespace1 := *newNamespace("namespace1")
+					dnsName := "a.b.c"
+					resolvedIP := "2.2.2.2"
 					egressFirewall := newEgressFirewallObject("default", namespace1.Name, []egressfirewallapi.EgressFirewallRule{
 						{
 							Type: "Deny",
 							To: egressfirewallapi.EgressFirewallDestination{
-								CIDRSelector: "1.2.3.4/23",
-							},
-						},
-						{
-							Type: "Deny",
-							To: egressfirewallapi.EgressFirewallDestination{
-								DNSName: "a.b.c",
+								DNSName: dnsName,
 							},
 						},
 					})
-					startOvn(dbSetup, []v1.Namespace{namespace1}, nil)
-
-					// dns-based rule creation will fail, because addressset factory is nil
-					fakeOVN.controller.egressFirewallDNS = &EgressDNS{
-						dnsEntries:        make(map[string]*dnsEntry),
-						addressSetFactory: nil,
-
-						added:    make(chan struct{}, 1),
-						deleted:  make(chan string, 1),
-						stopChan: make(chan struct{}),
+					initialData = []libovsdbtest.TestData{
+						nodeSwitch,
+						joinSwitch,
+						// delete clusterPortGroup to fail db transaction
+						//clusterPortGroup,
+						clusterRouter,
 					}
+					startOvn(libovsdbtest.TestSetup{
+						NBData: initialData}, []v1.Namespace{namespace1}, nil)
 
-					_, err := fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
+					var err error
+					setDNSOpsMock(dnsName, resolvedIP)
+					fakeOVN.controller.egressFirewallDNS, err = NewEgressDNS(fakeOVN.controller.addressSetFactory,
+						fakeOVN.controller.controllerName, fakeOVN.controller.stopChan)
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+					_, err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
 						Create(context.TODO(), egressFirewall, metav1.CreateOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1219,28 +1219,14 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					retry.CheckRetryObjectEventually(efKey, true, fakeOVN.controller.retryEgressFirewalls)
 
-					// check first acl was successfully created
-					asHash, _ := getNsAddrSetHashNames(namespace1.Name)
-					dbIDs := fakeOVN.controller.getEgressFirewallACLDbIDs(egressFirewall.Namespace, 0)
-					acl := libovsdbops.BuildACL(
-						libovsdbutil.GetACLName(dbIDs),
-						nbdb.ACLDirectionToLport,
-						t.EgressFirewallStartPriority,
-						"(ip4.dst == 1.2.3.4/23) && ip4.src == $"+asHash,
-						nbdb.ACLActionDrop,
-						t.OvnACLLoggingMeter,
-						"",
-						false,
-						dbIDs.GetExternalIDs(),
-						nil,
-						t.DefaultACLTier,
-					)
-					acl.UUID = "acl-UUID"
-					clusterPortGroup.ACLs = []string{acl.UUID}
-					expectedDatabaseState := append(initialData, acl)
+					// check dns address set was created
+					addrSet, _ := addressset.GetDbObjsForAS(
+						getEgressFirewallDNSAddrSetDbIDs(dnsName, fakeOVN.controller.controllerName),
+						[]net.IP{net.ParseIP(resolvedIP)})
+					expectedDatabaseState := append(initialData, addrSet)
 					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
-					// delete wrong object
+					// delete failed object
 					err = fakeOVN.fakeClient.EgressFirewallClient.K8sV1().EgressFirewalls(egressFirewall.Namespace).
 						Delete(context.TODO(), egressFirewall.Name, metav1.DeleteOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1249,11 +1235,8 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 						return retry.CheckRetryObj(efKey, fakeOVN.controller.retryEgressFirewalls)
 					}, time.Second).Should(gomega.BeFalse())
 
-					// check created acl will be cleaned up on delete
-					// acl will be dereferenced, but not deleted by the test server
-					clusterPortGroup.ACLs = []string{}
-					expectedDatabaseState = append(initialData, acl)
-					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
+					// check dns address set is cleaned up on delete
+					gomega.Eventually(fakeOVN.nbClient).Should(libovsdbtest.HaveData(initialData))
 					return nil
 				}
 				err := app.Run([]string{app.Name})
@@ -1698,17 +1681,3 @@ var _ = ginkgo.Describe("OVN test basic functions", func() {
 		}
 	})
 })
-
-//helper functions to help test egressfirewallDNS
-
-// Create an EgressDNS object without the Sync function
-// To make it easier to mock EgressFirewall functionality create an egressFirewall
-// without the go routine of the sync function
-
-// GetDNSEntryForTest Gets a dnsEntry from a EgressDNS object for testing
-func (e *EgressDNS) GetDNSEntryForTest(dnsName string) (map[string]struct{}, []net.IP, addressset.AddressSet, error) {
-	if e.dnsEntries[dnsName] == nil {
-		return nil, nil, nil, fmt.Errorf("there is no dnsEntry for dnsName: %s", dnsName)
-	}
-	return e.dnsEntries[dnsName].namespaces, e.dnsEntries[dnsName].dnsResolves, e.dnsEntries[dnsName].dnsAddressSet, nil
-}


### PR DESCRIPTION
This should improve the time it takes to create an egressfirewall.
Transaction size is limited to 8000 acls, which should be fine based on https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/ovn/external_ids_syncer/acl/acl_sync.go#L58-L60
but should be verified for older version is case of backporting

To test, use 8000-rule egressfirewall https://gist.github.com/npinaeva/7af14f6aa3234694c6d0e082e6c58d14 and find ovnkube-master or ovnkube-control-plane log `Creating *v1.EgressFirewall <namespace>/default took: <n>s`

in local testing, before change the result is `31.372159307s`, after change `2.599303302s` (with db logging enabled, which takes extra time)