### PR TITLE
kubevirt: pre pull fedora coreos image

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1045,6 +1045,28 @@ install_metallb() {
   sleep 30
 }
 
+# The "stable" tag is a moving tag let's pre-load it so the sha256 do not
+# disappear
+install_fedora_coreos_image() {
+  local fedora_coreos_image="quay.io/fedora/fedora-coreos:stable"
+  # If local registry is being used push image there for consumption by kind cluster
+  if [ "$KIND_LOCAL_REGISTRY" == true ]; then
+    echo "TODO"
+  else
+    ${OCI_BIN} pull "${fedora_coreos_image}"
+    if [ "$OCI_BIN" == "podman" ]; then
+      # podman: cf https://github.com/kubernetes-sigs/kind/issues/2027
+      rm -f /tmp/fedora-coreos.tar
+      podman save -o /tmp/fedora-cores.tar "${fedora_coreos_image}"
+      kind load image-archive /tmp/ovn-kube-f.tar --name "${KIND_CLUSTER_NAME}"
+    else
+      kind load docker-image "${fedora_coreos_image}" --name "${KIND_CLUSTER_NAME}"
+    fi
+  fi
+}
+
+
+
 install_plugins() {
   git clone https://github.com/containernetworking/plugins.git
   pushd plugins
@@ -1369,5 +1391,6 @@ if [ "$KIND_INSTALL_PLUGINS" == true ]; then
   install_plugins
 fi
 if [ "$KIND_INSTALL_KUBEVIRT" == true ]; then
+  install_fedora_coreos_image
   install_kubevirt
 fi


### PR DESCRIPTION
**- What this PR does and why is it needed**
The fedora coreos quay.io image tag "stable" is a moving tag so quay.io remove the old image after the tag is moving. This change pre-load that image at kind so it's present after quay.io has remove it.

closes https://github.com/ovn-org/ovn-kubernetes/issues/3855


**- Description for the changelog**
Pre pull fedora coreos image