### PR TITLE
EIP multi NIC: ensure we exclude ovn managed networks when CM is assigning EIP

### DIFF
--- a/go-controller/pkg/util/slice.go
+++ b/go-controller/pkg/util/slice.go
@@ -1,0 +1,22 @@
+package util
+
+// RemoveIndexFromSliceUnstable attempts to remove slice index specified by parameter i. Slice order is not preserved.
+func RemoveIndexFromSliceUnstable[T comparable](slice []T, i int) []T {
+	var t T
+	sliceLen := len(slice)
+	slice[i] = slice[sliceLen-1]
+	slice[sliceLen-1] = t // zero out the copied last element to have it garbage collected
+	return slice[:sliceLen-1]
+}
+
+// RemoveItemFromSliceUnstable attempts to remove an item from a slice specified by parameter candidate. Slice order is not preserved.
+func RemoveItemFromSliceUnstable[T comparable](slice []T, candidate T) []T {
+	for i := 0; i < len(slice); {
+		if slice[i] == candidate {
+			slice = RemoveIndexFromSliceUnstable(slice, i)
+			continue
+		}
+		i++
+	}
+	return slice
+}

--- a/go-controller/pkg/util/slice_test.go
+++ b/go-controller/pkg/util/slice_test.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestRemoveIndexFromSliceUnstableFunc(t *testing.T) {
+	var tcs = []struct {
+		input    []int
+		index    int
+		expected []int
+	}{
+
+		{
+			[]int{1, 2, 3},
+			0,
+			[]int{2, 3},
+		},
+		{
+			[]int{1, 2, 3},
+			1,
+			[]int{1, 3},
+		},
+		{
+			[]int{1, 2, 3},
+			2,
+			[]int{1, 2},
+		},
+	}
+
+	for _, tc := range tcs {
+		inputCopy := make([]int, len(tc.input))
+		copy(inputCopy, tc.input)
+		result := RemoveIndexFromSliceUnstable(inputCopy, tc.index)
+		if !equalIntSliceUnstable(result, tc.expected) {
+			t.Errorf("RemoveIndexFromSliceUnstable(%v, %d) = %v, want %v", tc.input, tc.index, result, tc.expected)
+		}
+	}
+}
+
+func TestRemoveItemFromSliceUnstableFunc(t *testing.T) {
+	var tcs = []struct {
+		input    []int
+		remove   int
+		expected []int
+	}{
+		{
+			[]int{},
+			0,
+			[]int{},
+		},
+		{
+			[]int{1, 2, 3},
+			0,
+			[]int{1, 2, 3},
+		},
+		{
+			[]int{1, 2, 3},
+			2,
+			[]int{1, 3},
+		},
+		{
+			[]int{1, 2, 2},
+			2,
+			[]int{1},
+		},
+	}
+
+	for _, tc := range tcs {
+		inputCopy := make([]int, len(tc.input))
+		copy(inputCopy, tc.input)
+		result := RemoveItemFromSliceUnstable(inputCopy, tc.remove)
+		if !equalIntSliceUnstable(result, tc.expected) {
+			t.Errorf("RemoveItemFromSliceUnstable(%v, %d) = %v, want %v", tc.input, tc.remove, result, tc.expected)
+		}
+	}
+}
+
+func equalIntSliceUnstable(sliceA, sliceB []int) bool {
+	if len(sliceA) != len(sliceB) {
+		return false
+	}
+	sliceACopy := make([]int, len(sliceA))
+	sliceBCopy := make([]int, len(sliceB))
+	copy(sliceACopy, sliceA)
+	copy(sliceBCopy, sliceB)
+	sort.Ints(sliceACopy)
+	sort.Ints(sliceBCopy)
+	return reflect.DeepEqual(sliceACopy, sliceBCopy)
+}


### PR DESCRIPTION
I am not sure how this happened during #3749 but it somehow got excluded..

When cluster manager is attempting to find out if an EIP IP can be hosted by a non-OVN managed network, we dont exclude OVN managed networks.
