### PR TITLE
netdev can't be moved to pod namespace

### DIFF
--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 
+	"crypto/rand"
+
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -355,4 +357,22 @@ func StringSlice[T fmt.Stringer](items []T) []string {
 		s[i] = items[i].String()
 	}
 	return s
+}
+
+var chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-"
+
+// GenerateId returns a random id as a string with the requested length
+func GenerateId(length int) string {
+	charsLength := len(chars)
+	b := make([]byte, length)
+	_, err := rand.Read(b) // generates len(b) random bytes
+	if err != nil {
+		klog.Errorf("can't generate a random ID: ", err)
+		return ""
+	}
+
+	for i := 0; i < length; i++ {
+		b[i] = chars[int(b[i])%charsLength]
+	}
+	return string(b)
 }

--- a/go-controller/pkg/util/util_unit_test.go
+++ b/go-controller/pkg/util/util_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -237,4 +238,11 @@ func TestFilterIPsSlice(t *testing.T) {
 			assert.Equal(t, tc.want, actual)
 		})
 	}
+}
+
+func TestGenerateId(t *testing.T) {
+	id := GenerateId(10)
+	assert.Equal(t, 10, len(id))
+	matchesPattern, _ := regexp.MatchString("([a-zA-Z0-9-]*)", id)
+	assert.True(t, matchesPattern)
 }


### PR DESCRIPTION
This is a fix for issue [#3867](https://github.com/ovn-org/ovn-kubernetes/issues/3867).  This happens mainly for SR-IOV/vDPA interfaces when enabling the ovn-k secondary interface, sometimes the netdev can't be moved from the host to the pod namespace.

This is the faulty scenario:
- netdev in the host to be moved to pod namespace is called eth0
- the pod has already an interface called eth0 (primary interface)
- when the user creates a new pod (planning to use the interface above), the pod creation fails with the message "file exists"
