### PR TITLE
Rename GetDbObjsForAS to GetTestDbAddrSets 

### DIFF
--- a/go-controller/pkg/ovn/address_set/address_set.go
+++ b/go-controller/pkg/ovn/address_set/address_set.go
@@ -312,9 +312,9 @@ func GetHashNamesForAS(dbIDs *libovsdbops.DbObjectIDs) (string, string) {
 		buildAddressSet(dbIDs, ipv6InternalID).Name
 }
 
-// GetDbObjsForAS returns nbdb.AddressSet objects both for ipv4 and ipv6, regardless of current config.
-// May be used for testing and cleanup.
-func GetDbObjsForAS(dbIDs *libovsdbops.DbObjectIDs, ips []net.IP) (*nbdb.AddressSet, *nbdb.AddressSet) {
+// GetTestDbAddrSets returns nbdb.AddressSet objects both for ipv4 and ipv6, regardless of current config.
+// May only be used for testing.
+func GetTestDbAddrSets(dbIDs *libovsdbops.DbObjectIDs, ips []net.IP) (*nbdb.AddressSet, *nbdb.AddressSet) {
 	var v4set, v6set *nbdb.AddressSet
 	v4IPs, v6IPs := splitIPsByFamily(ips)
 	// v4 address set

--- a/go-controller/pkg/ovn/address_set/address_set_test.go
+++ b/go-controller/pkg/ovn/address_set/address_set_test.go
@@ -20,7 +20,7 @@ func getDbAddrSets(dbIDs *libovsdbops.DbObjectIDs, ipFamily string, ips []string
 	for _, ip := range ips {
 		parsedIPs = append(parsedIPs, net.ParseIP(ip))
 	}
-	asv4, asv6 := GetDbObjsForAS(dbIDs, parsedIPs)
+	asv4, asv6 := GetTestDbAddrSets(dbIDs, parsedIPs)
 	if ipFamily == ipv4InternalID {
 		asv4.UUID = asv4.Name + "-UUID"
 		return asv4

--- a/go-controller/pkg/ovn/admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/admin_network_policy_test.go
@@ -204,14 +204,9 @@ func getACLsForANPRules(anp *anpapi.AdminNetworkPolicy) []*nbdb.ACL {
 }
 
 func buildANPAddressSets(anp *anpapi.AdminNetworkPolicy, index int32, ips []net.IP, gressPrefix libovsdbutil.ACLDirection) (*nbdb.AddressSet, *nbdb.AddressSet) {
-	priority := getANPRulePriority(getBaseRulePriority(anp.Spec.Priority), index)
 	asIndex := anpovn.GetANPPeerAddrSetDbIDs(anp.Name, string(gressPrefix),
 		fmt.Sprintf("%d", index), DefaultNetworkControllerName, false)
-	v4set, v6set := addressset.GetDbObjsForAS(asIndex, ips)
-
-	v4set.UUID = fmt.Sprintf("%s-%d-%s-ipv4-addrSet", anp.Name, priority, gressPrefix)
-	v6set.UUID = fmt.Sprintf("%s-%d-%s-ipv6-addrSet", anp.Name, priority, gressPrefix)
-	return v4set, v6set
+	return addressset.GetTestDbAddrSets(asIndex, ips)
 }
 
 var _ = ginkgo.Describe("OVN ANP Operations", func() {

--- a/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
+++ b/go-controller/pkg/ovn/baseline_admin_network_policy_test.go
@@ -62,14 +62,9 @@ func getACLsForBANPRules(banp *anpapi.BaselineAdminNetworkPolicy) []*nbdb.ACL {
 }
 
 func buildBANPAddressSets(banp *anpapi.BaselineAdminNetworkPolicy, index int32, ips []net.IP, gressPrefix libovsdbutil.ACLDirection) (*nbdb.AddressSet, *nbdb.AddressSet) {
-	priority := getBANPRulePriority(index)
 	asIndex := anpovn.GetANPPeerAddrSetDbIDs(banp.Name, string(gressPrefix),
 		fmt.Sprintf("%d", index), DefaultNetworkControllerName, true)
-	v4set, v6set := addressset.GetDbObjsForAS(asIndex, ips)
-
-	v4set.UUID = fmt.Sprintf("%s-%d-%s-ipv4-addrSet", banp.Name, priority, gressPrefix)
-	v6set.UUID = fmt.Sprintf("%s-%d-%s-ipv6-addrSet", banp.Name, priority, gressPrefix)
-	return v4set, v6set
+	return addressset.GetTestDbAddrSets(asIndex, ips)
 }
 
 var _ = ginkgo.Describe("OVN BANP Operations", func() {

--- a/go-controller/pkg/ovn/egressfirewall_test.go
+++ b/go-controller/pkg/ovn/egressfirewall_test.go
@@ -1220,7 +1220,7 @@ var _ = ginkgo.Describe("OVN EgressFirewall Operations", func() {
 					retry.CheckRetryObjectEventually(efKey, true, fakeOVN.controller.retryEgressFirewalls)
 
 					// check dns address set was created
-					addrSet, _ := addressset.GetDbObjsForAS(
+					addrSet, _ := addressset.GetTestDbAddrSets(
 						getEgressFirewallDNSAddrSetDbIDs(dnsName, fakeOVN.controller.controllerName),
 						[]net.IP{net.ParseIP(resolvedIP)})
 					expectedDatabaseState := append(initialData, addrSet)

--- a/go-controller/pkg/ovn/egressqos_test.go
+++ b/go-controller/pkg/ovn/egressqos_test.go
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					ExternalIDs: map[string]string{"EgressQoS": "staleNS"},
 					UUID:        "staleQoS-UUID",
 				}
-				staleAddrSet, _ := addressset.GetDbObjsForAS(
+				staleAddrSet, _ := addressset.GetTestDbAddrSets(
 					getEgressQosAddrSetDbIDs("staleNS", "1000", controllerName),
 					[]net.IP{net.ParseIP("1.2.3.4")})
 
@@ -242,7 +242,7 @@ var _ = ginkgo.Describe("OVN EgressQoS Operations", func() {
 					ExternalIDs: map[string]string{"EgressQoS": "staleNS"},
 					UUID:        "staleQoS-UUID",
 				}
-				staleAddrSet, _ := addressset.GetDbObjsForAS(
+				staleAddrSet, _ := addressset.GetTestDbAddrSets(
 					getEgressQosAddrSetDbIDs("staleNS", "1000", controllerName),
 					[]net.IP{net.ParseIP("1.2.3.4")})
 

--- a/go-controller/pkg/ovn/namespace_test.go
+++ b/go-controller/pkg/ovn/namespace_test.go
@@ -71,11 +71,7 @@ func getNsAddrSetHashNames(ns string) (string, string) {
 }
 
 func buildNamespaceAddressSets(namespace string, ips []net.IP) (*nbdb.AddressSet, *nbdb.AddressSet) {
-	v4set, v6set := addressset.GetDbObjsForAS(getNamespaceAddrSetDbIDs(namespace, "default-network-controller"), ips)
-
-	v4set.UUID = fmt.Sprintf("%s-ipv4-addrSet", namespace)
-	v6set.UUID = fmt.Sprintf("%s-ipv6-addrSet", namespace)
-	return v4set, v6set
+	return addressset.GetTestDbAddrSets(getNamespaceAddrSetDbIDs(namespace, "default-network-controller"), ips)
 }
 
 var _ = ginkgo.Describe("OVN Namespace Operations", func() {

--- a/go-controller/pkg/ovn/pod_selector_address_set_test.go
+++ b/go-controller/pkg/ovn/pod_selector_address_set_test.go
@@ -299,14 +299,11 @@ var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
 		namespaceName := "namespace1"
 		policyName := "networkpolicy1"
 		staleNetpolIDs := getStaleNetpolAddrSetDbIDs(namespaceName, policyName, "ingress", "0", DefaultNetworkControllerName)
-		staleNetpolAS, _ := addressset.GetDbObjsForAS(staleNetpolIDs, []net.IP{net.ParseIP("1.1.1.1")})
-		staleNetpolAS.UUID = staleNetpolAS.Name + "-UUID"
+		staleNetpolAS, _ := addressset.GetTestDbAddrSets(staleNetpolIDs, []net.IP{net.ParseIP("1.1.1.1")})
 		unusedPodSelIDs := getPodSelectorAddrSetDbIDs("pasName", DefaultNetworkControllerName)
-		unusedPodSelAS, _ := addressset.GetDbObjsForAS(unusedPodSelIDs, []net.IP{net.ParseIP("1.1.1.2")})
-		unusedPodSelAS.UUID = unusedPodSelAS.Name + "-UUID"
+		unusedPodSelAS, _ := addressset.GetTestDbAddrSets(unusedPodSelIDs, []net.IP{net.ParseIP("1.1.1.2")})
 		refNetpolIDs := getStaleNetpolAddrSetDbIDs(namespaceName, policyName, "egress", "0", DefaultNetworkControllerName)
-		refNetpolAS, _ := addressset.GetDbObjsForAS(refNetpolIDs, []net.IP{net.ParseIP("1.1.1.3")})
-		refNetpolAS.UUID = refNetpolAS.Name + "-UUID"
+		refNetpolAS, _ := addressset.GetTestDbAddrSets(refNetpolIDs, []net.IP{net.ParseIP("1.1.1.3")})
 		netpolACL := libovsdbops.BuildACL(
 			"netpolACL",
 			nbdb.ACLDirectionFromLport,
@@ -324,8 +321,7 @@ var _ = ginkgo.Describe("OVN PodSelectorAddressSet", func() {
 		)
 		netpolACL.UUID = "netpolACL-UUID"
 		refPodSelIDs := getPodSelectorAddrSetDbIDs("pasName2", DefaultNetworkControllerName)
-		refPodSelAS, _ := addressset.GetDbObjsForAS(refPodSelIDs, []net.IP{net.ParseIP("1.1.1.4")})
-		refPodSelAS.UUID = refPodSelAS.Name + "-UUID"
+		refPodSelAS, _ := addressset.GetTestDbAddrSets(refPodSelIDs, []net.IP{net.ParseIP("1.1.1.4")})
 		podSelACL := libovsdbops.BuildACL(
 			"podSelACL",
 			nbdb.ACLDirectionFromLport,


### PR DESCRIPTION
as it should be used only for
testing. This is a follow-up to the 2c252f11344c80718fc1b291d0e0921e2afb4e41 where I added UUID generation for address sets, which can only be used for testing.

Thanks to @jcaamano for pointing this out