### PR TITLE
Correct the operation of the hybrid overlay

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node.go
@@ -83,6 +83,7 @@ func podChanged(old, new interface{}) bool {
 }
 
 // NewNode Returns a new Node
+// TODO(jtanenba) the localPodInformer no longer selects only local pods
 func NewNode(
 	kube kube.Interface,
 	nodeName string,
@@ -124,6 +125,9 @@ func NewNode(
 			pod, ok := obj.(*kapi.Pod)
 			if !ok {
 				return fmt.Errorf("object is not a pod")
+			}
+			if pod.Spec.NodeName != nodeName {
+				return nil
 			}
 			return n.controller.AddPod(pod)
 		},

--- a/go-controller/pkg/factory/factory.go
+++ b/go-controller/pkg/factory/factory.go
@@ -421,6 +421,10 @@ func (wf *WatchFactory) Start() error {
 
 // NewNodeWatchFactory initializes a watch factory with significantly fewer
 // informers to save memory + bandwidth. It is to be used by the node-only process.
+//
+// TODO(jtanenba) originally the pod selector was only supposed to select pods local to the node
+// commit 91046e889... changed that and pod selector selects all pods in the cluster fix the naming
+// of the localPodSelector or figure out how to deal with selecting all pods everywhere.
 func NewNodeWatchFactory(ovnClientset *util.OVNNodeClientset, nodeName string) (*WatchFactory, error) {
 	wf := &WatchFactory{
 		iFactory:             informerfactory.NewSharedInformerFactory(ovnClientset.KubeClient, resyncInterval),

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1034,6 +1034,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	if config.HybridOverlay.Enabled {
 		// Not supported with DPUs, enforced in config
 		// TODO(adrianc): Revisit above comment
+		// TODO(jtanenba): LocalPodInformer informs on all pods
 		nodeController, err := honode.NewNode(
 			nc.Kube,
 			nc.name,


### PR DESCRIPTION
Nodes running hybrid overlay only care about routing traffic from pods local to the node into the hybrid overlay's vxlan tunnel. Commit 91046e... changed how the LocalPodLister worked and it grabs all pods in the cluster. Change the filtering of the handler for hybrid overlay to only select pods local to the node so the right ovs flows are created. 

This will correct the operation for hybrid overlay while working to correct the WatchFactory
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->