### PR TITLE
fix race condition in hybrid overlay.

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -247,13 +247,14 @@ func (n *NodeController) hybridOverlayNodeUpdate(node *kapi.Node) error {
 func (n *NodeController) AddNode(node *kapi.Node) error {
 	klog.Info("Add Node ", node.Name)
 	var err error
+
 	if n.drIP == nil {
 		hybridOverlayDRIP, ok := node.Annotations[hotypes.HybridOverlayDRIP]
 		if !ok {
 			return fmt.Errorf("hybrid overlay not initialized on %s, it was not assigned an interface address", node.Name)
 		}
-		n.drIP = net.ParseIP(hybridOverlayDRIP)
-		if n.drIP == nil {
+		drIP := net.ParseIP(hybridOverlayDRIP)
+		if drIP == nil {
 			return fmt.Errorf("hybrid overlay not initialized on %s, the the annotation %s = %s is not an IP address", node.Name, hotypes.HybridOverlayDRIP, hybridOverlayDRIP)
 		}
 	}


### PR DESCRIPTION
at the beginning of AddNode() we checked if the hybrid annotation had been set on the node being added as a quick way to determine if we should continue. It turns out we also set the nodes drIP to whatever the annotation of the added node is.

Turns out this does not effect the operation too much because we never change the flows associated with the drIP except when nodeName being added is equal to the nodeName of the controller but the internal representation is wrong without this patch.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->