### PR TITLE
kind: Allow redeploy multi-network-enable OVN-K

### DIFF
--- a/contrib/kind.sh
+++ b/contrib/kind.sh
@@ -1221,7 +1221,7 @@ docker_create_second_disconnected_interface() {
 
   KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
   for n in $KIND_NODES; do
-    "$OCI_BIN" network connect "$bridge_name" "$n"
+    "$OCI_BIN" network connect "$bridge_name" "$n" || true
   done
 }
 


### PR DESCRIPTION
**- What this PR does and why is it needed**
This fixes `multi-network-enable` redeploy flow on existing kind cluster. 
Use `./kind.sh -mne` to create the cluster
and then `./kind.sh -mne --deploy` to redeploy OVN-K, reusing the same cluster.

**- Special notes for reviewers**

**- How to verify it**

**- Description for the changelog**
