### PR TITLE
Fix push image permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   GO_VERSION: 1.19.6


### PR DESCRIPTION
Fixes this error on the ovn-docker-images workflow which has been preventing us to upload new images from quite some time
```
buildx failed with: ERROR: failed to solve: failed to push ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master: unexpected status from POST request to https://ghcr.io/v2/ovn-org/ovn-kubernetes/ovn-kube-f/blobs/uploads/: 403 Forbidden
```

Fixes: https://github.com/ovn-org/ovn-kubernetes/pull/3607