### PR TITLE
ovnkube.sh: set northd backoff interval to save CPU

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -795,6 +795,10 @@ nb-ovsdb() {
     echo "=============== nb-ovsdb ========== reconfigured for ipsec"
   }
 
+  # Let ovn-northd sleep and not use so much CPU
+  ovn-nbctl set NB_Global . options:northd-backoff-interval-ms=300
+  echo "=============== nb-ovsdb ========== reconfigured for northd backoff"
+
   ovn-nbctl set NB_Global . name=${ovn_zone}
   ovn-nbctl set NB_Global . options:name=${ovn_zone}
 
@@ -916,6 +920,10 @@ local-nb-ovsdb() {
 
   wait_for_event attempts=3 process_ready ovnnb_db
   echo "=============== nb-ovsdb (unix sockets only) ========== RUNNING"
+
+  # Let ovn-northd sleep and not use so much CPU
+  ovn-nbctl set NB_Global . options:northd-backoff-interval-ms=300
+  echo "=============== nb-ovsdb ========== reconfigured for northd backoff"
 
   ovn-nbctl set NB_Global . name=${K8S_NODE}
   ovn-nbctl set NB_Global . options:name=${K8S_NODE}


### PR DESCRIPTION
23.09 northd has a new option that lets the CMS (ovnkube) set a maximum processing loop time. When this option is enabled, northd will batch updates (but do no processing of them) for the duration of the last processing loop, saving significant CPU.

When the processing loop time exceeds the CMS-configured backoff interval, northd will no longer sleep, trading off CPU usage for responsiveness to changes.

During scale tests we observed that when northd was fed a continous stream of changes from kube-burner -> ovnkube -> NB it was never able to complete work quickly enough to sleep before the next change came in. Until more portions of northd are moved to Incremental Processing (IP) most of the processing time is taken by recomputes of unchanged data. Doing this continuously is pretty pointless.

By making northd sleep and batching updates, northd can do the recomputation once rather than continuously, saving a bunch of CPU.

300ms was chosen as the maximum processing loop time because 120-node density-cni tests showed the loop taking about that time near the end of the test.