### PR TITLE
Fix pod delete perf

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1411,6 +1411,12 @@ ovnkube-controller() {
   fi
   echo "ovnkube_enable_multi_external_gateway_flag=${ovnkube_enable_multi_external_gateway_flag}"
 
+  ovnkube_metrics_scale_enable_flag=
+  if [[ ${ovnkube_metrics_scale_enable} == "true" ]]; then
+    ovnkube_metrics_scale_enable_flag="--metrics-enable-scale"
+  fi
+  echo "ovnkube_metrics_scale_enable_flag: ${ovnkube_metrics_scale_enable_flag}"
+
   echo "=============== ovnkube-controller ========== MASTER ONLY"
   /usr/bin/ovnkube --init-ovnkube-controller ${K8S_NODE} \
     ${anp_enabled_flag} \
@@ -1430,6 +1436,7 @@ ovnkube-controller() {
     ${ovnkube_config_duration_enable_flag} \
     ${ovnkube_enable_interconnect_flag} \
     ${ovnkube_enable_multi_external_gateway_flag} \
+    ${ovnkube_metrics_scale_enable_flag} \
     ${ovnkube_metrics_tls_opts} \
     ${ovn_encap_port_flag} \
     ${ovn_master_ssl_opts} \
@@ -1764,6 +1771,11 @@ ovnkube-controller-with-node() {
   fi
   echo "ovn_v6_masquerade_subnet_opt=${ovn_v6_masquerade_subnet_opt}"
 
+  ovnkube_metrics_scale_enable_flag=
+  if [[ ${ovnkube_metrics_scale_enable} == "true" ]]; then
+    ovnkube_metrics_scale_enable_flag="--metrics-enable-scale"
+  fi
+  echo "ovnkube_metrics_scale_enable_flag: ${ovnkube_metrics_scale_enable_flag}"
 
   echo "=============== ovnkube-controller-with-node --init-ovnkube-controller-with-node=========="
   /usr/bin/ovnkube --init-ovnkube-controller ${K8S_NODE} --init-node ${K8S_NODE} \
@@ -1798,6 +1810,7 @@ ovnkube-controller-with-node() {
     ${ovnkube_config_duration_enable_flag} \
     ${ovnkube_enable_interconnect_flag} \
     ${ovnkube_enable_multi_external_gateway_flag} \
+    ${ovnkube_metrics_scale_enable_flag} \
     ${ovnkube_metrics_tls_opts} \
     ${ovnkube_node_mgmt_port_netdev_flag} \
     ${ovnkube_node_mode_flag} \

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -1149,7 +1149,7 @@ ovn-master() {
 
   ovnkube_metrics_scale_enable_flag=
   if [[ ${ovnkube_metrics_scale_enable} == "true" ]]; then
-    ovnkube_metrics_scale_enable_flag="--metrics-enable-scale"
+    ovnkube_metrics_scale_enable_flag="--metrics-enable-scale --metrics-enable-pprof"
   fi
   echo "ovnkube_metrics_scale_enable_flag: ${ovnkube_metrics_scale_enable_flag}"
   
@@ -1413,7 +1413,7 @@ ovnkube-controller() {
 
   ovnkube_metrics_scale_enable_flag=
   if [[ ${ovnkube_metrics_scale_enable} == "true" ]]; then
-    ovnkube_metrics_scale_enable_flag="--metrics-enable-scale"
+    ovnkube_metrics_scale_enable_flag="--metrics-enable-scale --metrics-enable-pprof"
   fi
   echo "ovnkube_metrics_scale_enable_flag: ${ovnkube_metrics_scale_enable_flag}"
 
@@ -1773,7 +1773,7 @@ ovnkube-controller-with-node() {
 
   ovnkube_metrics_scale_enable_flag=
   if [[ ${ovnkube_metrics_scale_enable} == "true" ]]; then
-    ovnkube_metrics_scale_enable_flag="--metrics-enable-scale"
+    ovnkube_metrics_scale_enable_flag="--metrics-enable-scale --metrics-enable-pprof"
   fi
   echo "ovnkube_metrics_scale_enable_flag: ${ovnkube_metrics_scale_enable_flag}"
 

--- a/dist/templates/ovnkube-single-node-zone.yaml.j2
+++ b/dist/templates/ovnkube-single-node-zone.yaml.j2
@@ -310,6 +310,8 @@ spec:
           value: "{{ ovnkube_libovsdb_client_logfile }}"
         - name: OVNKUBE_CONFIG_DURATION_ENABLE
           value: "{{ ovnkube_config_duration_enable }}"
+        - name: OVNKUBE_METRICS_SCALE_ENABLE
+          value: "{{ ovnkube_metrics_scale_enable }}"
         - name: OVN_NET_CIDR
           valueFrom:
             configMapKeyRef:

--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -64,7 +64,7 @@ func (oc *DefaultNetworkController) cleanupStalePodSNATs(nodeName string, nodeIP
 			continue
 		}
 		if util.PodCompleted(&pod) {
-			collidingPod, err := oc.findPodWithIPAddresses([]net.IP{utilnet.ParseIPSloppy(pod.Status.PodIP)}) //even if a pod is completed we should still delete the nat if the ip is not in use anymore
+			collidingPod, err := oc.findPodWithIPAddresses([]net.IP{utilnet.ParseIPSloppy(pod.Status.PodIP)}, "") //even if a pod is completed we should still delete the nat if the ip is not in use anymore
 			if err != nil {
 				return fmt.Errorf("lookup for pods with same ip as %s %s failed: %w", pod.Namespace, pod.Name, err)
 			}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -181,14 +181,13 @@ func (oc *DefaultNetworkController) ensureLocalZonePod(oldPod, pod *kapi.Pod, ad
 //
 // It returns nil on success and error on failure; failure indicates the pod set up should be retried later.
 func (oc *DefaultNetworkController) ensureRemoteZonePod(oldPod, pod *kapi.Pod, addPort bool) error {
-	podIfAddrs, err := util.GetPodCIDRsWithFullMask(pod, oc.NetInfo)
-	if err != nil {
-		// not finding pod IPs on a remote pod is common until the other node wires the pod, suppress it
-		return fmt.Errorf("failed to obtain IPs to add remote pod %s/%s: %w",
-			pod.Namespace, pod.Name, ovntypes.NewSuppressedError(err))
-	}
-
 	if (addPort || (oldPod != nil && len(pod.Status.PodIPs) != len(oldPod.Status.PodIPs))) && !util.PodWantsHostNetwork(pod) {
+		podIfAddrs, err := util.GetPodCIDRsWithFullMask(pod, oc.NetInfo)
+		if err != nil {
+			// not finding pod IPs on a remote pod is common until the other node wires the pod, suppress it
+			return fmt.Errorf("failed to obtain IPs to add remote pod %s/%s: %w",
+				pod.Namespace, pod.Name, ovntypes.NewSuppressedError(err))
+		}
 		if err := oc.addRemotePodToNamespace(pod.Namespace, podIfAddrs); err != nil {
 			return fmt.Errorf("failed to add remote pod %s/%s to namespace: %w", pod.Namespace, pod.Name, err)
 		}

--- a/go-controller/pkg/util/multi_network.go
+++ b/go-controller/pkg/util/multi_network.go
@@ -98,7 +98,8 @@ func (nInfo *DefaultNetInfo) CompareNetInfo(netBasicInfo BasicNetInfo) bool {
 
 // TopologyType returns the defaultNetConfInfo's topology type which is empty
 func (nInfo *DefaultNetInfo) TopologyType() string {
-	return ""
+	// TODO(trozet): optimize other checks using this function after changing default network type from "" -> L3
+	return types.Layer3Topology
 }
 
 // MTU returns the defaultNetConfInfo's MTU value


### PR DESCRIPTION
- Enables scale metrics correctly in KIND with single zone per node
- Enables pprof when enabling metrics with KIND
- Prefers to use IPs provided in pod status IPs, and falls back to annotation when needed
- For searching for colliding pods, restrict the search to only pods on the node where the original pod lived, as long as the topology is layer 3, and the pods are not affected by live migration.

