### PR TITLE
fix: build-go.sh capture k8s.io/client-go version to use in build tag

### DIFF
--- a/go-controller/hack/build-go.sh
+++ b/go-controller/hack/build-go.sh
@@ -9,6 +9,7 @@ source "$(dirname "${BASH_SOURCE}")/init.sh"
 build_binaries() {
     # Check for `go` binary and set ${GOPATH}.
     setup_env
+    echo ${OVN_KUBE_ROOT}
     cd "${OVN_KUBE_ROOT}"
 
     mkdir -p "${OVN_KUBE_OUTPUT_BINPATH}"
@@ -19,7 +20,7 @@ build_binaries() {
     GIT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
     BUILD_USER=$(whoami)
     BUILD_DATE=$(date +"%Y-%m-%d")
-    K8S_CLIENT_VERSION=$(grep 'k8s.io/client-go' ${OVN_KUBE_GO_PACKAGE}/go.sum | head -1 |cut -f2 -d' ')
+    K8S_CLIENT_VERSION=$(grep 'k8s.io/client-go' ${OVN_KUBE_ROOT}/go.mod | head -1 |cut -f2 -d' ')
 
     set -x
     for bin in "$@"; do


### PR DESCRIPTION
Fixes a small issue in the `build-go.sh` where the script failed to extract the `k8s.io/client-go` version from the `go.sum` due to 2 factors:
* Wrong path: The file `go.sum` is located inside the `go-controller` directory from the main project, the current variable prefix used to point the path `$OVN_KUBE_GO_PACKAGE` won't find the file because the script runs already in `$OVN_KUBE_ROOT`. So in essence it's trying to run this command:
```
grep 'k8s.io/client-go' github.com/ovn-org/ovn-kubernetes/go-controller/go.sum
```
Inside `$OVN_KUBE_ROOT`, which is the full path to the `go-controller` directory. In my case:
```bash
$> echo $OVN_KUBE_ROOT 
/home/jgil/go/src/github.com/ovn-org/ovn-kubernetes/go-controller
```

* Possibly the wrong file to check to extract this value: Checking the contents of `go.sum` shows that the list of entries that match the `k8s.io/client-go` criteria are multiple:
```bash
$> grep 'k8s.io/client-go' go.sum 
k8s.io/client-go v0.18.8/go.mod h1:HqFqMllQ5NnQJNwjro9k5zMyfhZlOwpuTLVrxjkYSxU=
k8s.io/client-go v0.20.1/go.mod h1:/zcHdt1TeWSd5HoUe6elJmHSQ6uLLgp4bIJHVEuy+/Y=
k8s.io/client-go v0.20.4/go.mod h1:LiMv25ND1gLUdBeYxBIwKpkSC5IsozMMmOOeSJboP+k=
k8s.io/client-go v0.20.6/go.mod h1:nNQMnOvEUEsOzRRFIIkdmYOjAZrC8bgq0ExboWSU1I0=
k8s.io/client-go v0.27.1 h1:oXsfhW/qncM1wDmWBIuDzRHNS2tLhK3BZv512Nc59W8=
k8s.io/client-go v0.27.1/go.mod h1:f8LHMUkVb3b9N8bWturc+EDtVVVwZ7ueTVquFAJb2vA=
``` 
   Whereas `go.mod` contains only one entry:
```zsh
$>grep k8s.io/client-go go.mod
k8s.io/client-go v0.27.1
```

The difference is that without this fix, the `make build` shows this error in the first lines of execution:
```
$> make build
hack/build-go.sh cmd/ovnkube cmd/ovn-k8s-cni-overlay cmd/ovn-kube-util hybrid-overlay/cmd/hybrid-overlay-node cmd/ovndbchecker cmd/ovnkube-trace
grep: github.com/ovn-org/ovn-kubernetes/go-controller/go.sum: No such file or directory
...
...
+ env CGO_ENABLED=0 go build -v -mod vendor -gcflags '' -ldflags '
...
...
-X k8s.io/client-go/pkg/version.gitVersion=
```
And with this change, the tag
```
$> make build
hack/build-go.sh cmd/ovnkube cmd/ovn-k8s-cni-overlay cmd/ovn-kube-util hybrid-overlay/cmd/hybrid-overlay-node cmd/ovndbchecker cmd/ovnkube-trace
...
...
+ env CGO_ENABLED=0 go build -v -mod vendor -gcflags '' -ldflags 
...
...
-X k8s.io/client-go/pkg/version.gitVersion=v0.27.1 		'
```