### PR TITLE
e2e: Avoid test panic if unidling test fails

### DIFF
--- a/test/e2e/unidling.go
+++ b/test/e2e/unidling.go
@@ -223,10 +223,10 @@ var _ = ginkgo.Describe("Unidling", func() {
 				close(done)
 			}()
 			wg.Wait()
+			defer func() { <-done }()
 
 			// Connecting to the service should work at the first attempt
 			gomega.Expect(checkService(clientPod, cmd)).To(gomega.Equal(works))
-			<-done
 		})
 	})
 


### PR DESCRIPTION
If the test fails an assertion, the `createBackend(...)` gorotine is still running after the test end, as the reading from `done` channel is skipped.
Moving that wait to a `defer ...` routine avoids spanning test execution across multiple cases, that can cause panics.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->


**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

fixes #3882 

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

cc @martinkennelly , @oribon , @jcaamano 


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->