### PR TITLE
Enable gateway_mtu on rtoe port of GR

### DIFF
--- a/go-controller/pkg/ovn/gateway_init.go
+++ b/go-controller/pkg/ovn/gateway_init.go
@@ -265,7 +265,8 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 		l3GatewayConfig.MACAddress.String(),
 		types.PhysicalNetworkName,
 		l3GatewayConfig.IPAddresses,
-		l3GatewayConfig.VLANID); err != nil {
+		l3GatewayConfig.VLANID,
+		enableGatewayMTU); err != nil {
 		return err
 	}
 
@@ -277,7 +278,8 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 			l3GatewayConfig.EgressGWMACAddress.String(),
 			types.PhysicalNetworkExGwName,
 			l3GatewayConfig.EgressGWIPAddresses,
-			nil); err != nil {
+			nil,
+			enableGatewayMTU); err != nil {
 			return err
 		}
 	}
@@ -480,7 +482,10 @@ func (oc *DefaultNetworkController) gatewayInit(nodeName string, clusterIPSubnet
 
 // addExternalSwitch creates a switch connected to the external bridge and connects it to
 // the gateway router
-func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRouter, macAddress, physNetworkName string, ipAddresses []*net.IPNet, vlanID *uint) error {
+// enableGatewayMTU enables options:gateway_mtu for gateway routers. Setting it on
+// the external ports of the GR will mimic the older behaviour of using br-ex flows
+func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeName, gatewayRouter, macAddress, physNetworkName string,
+	ipAddresses []*net.IPNet, vlanID *uint, enableGatewayMTU bool) error {
 	// Create the GR port that connects to external_switch with mac address of
 	// external interface and that IP address. In the case of `local` gateway
 	// mode, whenever ovnkube-node container restarts a new br-local bridge will
@@ -491,6 +496,12 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 	for _, ip := range ipAddresses {
 		externalRouterPortNetworks = append(externalRouterPortNetworks, ip.String())
 	}
+	var options map[string]string
+	if enableGatewayMTU {
+		options = map[string]string{
+			"gateway_mtu": strconv.Itoa(config.Default.MTU),
+		}
+	}
 	externalLogicalRouterPort := nbdb.LogicalRouterPort{
 		MAC: macAddress,
 		ExternalIDs: map[string]string{
@@ -498,12 +509,14 @@ func (oc *DefaultNetworkController) addExternalSwitch(prefix, interfaceID, nodeN
 		},
 		Networks: externalRouterPortNetworks,
 		Name:     externalRouterPort,
+		Options:  options,
 	}
 	logicalRouter := nbdb.LogicalRouter{Name: gatewayRouter}
 
 	err := libovsdbops.CreateOrUpdateLogicalRouterPort(oc.nbClient, &logicalRouter,
 		&externalLogicalRouterPort, nil, &externalLogicalRouterPort.MAC,
-		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs)
+		&externalLogicalRouterPort.Networks, &externalLogicalRouterPort.ExternalIDs,
+		&externalLogicalRouterPort.Options)
 	if err != nil {
 		return fmt.Errorf("failed to add logical router port %+v to router %s: %v", externalLogicalRouterPort, gatewayRouter, err)
 	}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -192,6 +192,7 @@ func generateGatewayInitExpectedNB(testData []libovsdb.TestData, expectedOVNClus
 			"gateway-physical-ip": "yes",
 		},
 		Networks: networks,
+		Options:  options,
 	})
 
 	natUUIDs := make([]string, 0, len(clusterIPSubnets))

--- a/test/e2e/pod.go
+++ b/test/e2e/pod.go
@@ -1,0 +1,243 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"regexp"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+var _ = ginkgo.Describe("Pod to external server PMTUD", func() {
+	const (
+		echoServerPodNameTemplate = "echo-server-pod-%d"
+		echoClientPodName         = "echo-client-pod"
+		echoServerPodPortMin      = 9800
+		echoServerPodPortMax      = 9899
+		primaryNetworkName        = "kind"
+	)
+
+	f := wrappedTestFramework("pod2external-pmtud")
+	cleanupFn := func() {}
+
+	ginkgo.AfterEach(func() {
+		cleanupFn()
+	})
+
+	// The below series of tests queries a server running as a hostNetwork:true pod on nodeB from a client pod running as hostNetwork:false on nodeA
+	// This traffic scenario mimics a pod2external setup where large packets and needs frag is involved.
+	// for both HTTP and UDP and different ingress and egress payload sizes.
+	// Steps:
+	// * Set up a hostNetwork:false client pod (agnhost echo server) on nodeA
+	// * Set up a hostNetwork:true server pod on nodeB
+	// * Query from client pod to server pod
+	// Traffic Flow:
+	// Req: podA on nodeA -> nodeA switch -> nodeA cluster-route -> nodeA transit switch -> nodeA join switch -> nodeA GR -> nodeA ext switch -> nodeA br-ex -> underlay
+	// underlay -> br-ex on nodeB -> host-networked pod on nodeB
+	// Res: host-networked pod on nodeB sends large packet -> br-ex on nodeB -> underlay
+	// underlay -> br-ex on nodeA -> nodeA ext-switch -> rtoe-GR port sends back needs frag thanks to gateway_mtu option
+	// ICMP needs frag goes back to nodeB's host-networked pod
+	// server now fragments packets correctly.
+	// NOTE: on LGW, the pkt exits via mp0 on nodeA and path is different than what is described above
+	// Frag needed is sent by nodeA using ovn-k8s-mp0 interface mtu and not OVN's GR for flows where services are not involved in LGW
+	ginkgo.When("a client ovnk pod targeting an external server(running on another node) is created", func() {
+		var serverPod *v1.Pod
+		var serverPodNodeName string
+		var serverPodPort int
+		var serverPodName string
+		var serverNode v1.Node
+		var serverNodeInternalIPs []string
+
+		var clientPod *v1.Pod
+		var clientPodNodeName string
+
+		var echoPayloads = map[string]string{
+			"small": fmt.Sprintf("%010d", 1),
+			"large": fmt.Sprintf("%01420d", 1),
+		}
+		var echoMtuRegex = regexp.MustCompile(`cache expires.*mtu.*`)
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Selecting 3 schedulable nodes")
+			nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, 3)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically(">", 2))
+
+			ginkgo.By("Selecting nodes for client pod and server host-networked pod")
+			serverPodNodeName = nodes.Items[0].Name
+			serverNode = nodes.Items[0]
+			clientPodNodeName = nodes.Items[1].Name
+
+			ginkgo.By("Getting all InternalIP addresses of the server node")
+			serverNodeInternalIPs = e2enode.GetAddresses(&serverNode, v1.NodeInternalIP)
+			gomega.Expect(len(serverNodeInternalIPs)).To(gomega.BeNumerically(">", 0))
+
+			ginkgo.By("Creating hostNetwork:false (ovnk) client pod")
+			clientPod = e2epod.NewAgnhostPod(f.Namespace.Name, echoClientPodName, nil, nil, nil)
+			clientPod.Spec.NodeName = clientPodNodeName
+			for k := range clientPod.Spec.Containers {
+				if clientPod.Spec.Containers[k].Name == "agnhost-container" {
+					clientPod.Spec.Containers[k].Command = []string{
+						"sleep",
+						"infinity",
+					}
+				}
+			}
+			f.PodClient().CreateSync(clientPod)
+
+			ginkgo.By("Creating the server pod with hostNetwork:true")
+			// Create the server pod.
+			// Wait for 1 minute and if the pod does not come up, select a different port and try again.
+			// Wait for a max of 5 minutes.
+			gomega.Eventually(func() error {
+				serverPodPort = rand.Intn(echoServerPodPortMax-echoServerPodPortMin) + echoServerPodPortMin
+				serverPodName = fmt.Sprintf(echoServerPodNameTemplate, serverPodPort)
+				framework.Logf("Creating server pod listening on TCP and UDP port %d", serverPodPort)
+				serverPod = e2epod.NewAgnhostPod(f.Namespace.Name, serverPodName, nil, nil, nil, "netexec",
+					"--http-port",
+					fmt.Sprintf("%d", serverPodPort),
+					"--udp-port",
+					fmt.Sprintf("%d", serverPodPort))
+				serverPod.ObjectMeta.Labels = map[string]string{
+					"app": serverPodName,
+				}
+				serverPod.Spec.HostNetwork = true
+				serverPod.Spec.NodeName = serverPodNodeName
+				f.PodClient().Create(serverPod)
+
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, serverPod.Name, f.Namespace.Name, 1*time.Minute)
+				if err != nil {
+					f.PodClient().Delete(context.TODO(), serverPod.Name, metav1.DeleteOptions{})
+					return err
+				}
+				serverPod, err = f.PodClient().Get(context.TODO(), serverPod.Name, metav1.GetOptions{})
+				return err
+			}, 5*time.Minute, 1*time.Second).Should(gomega.Succeed())
+		})
+
+		// Run queries against the server both with a small (10 bytes + overhead for echo service) and
+		// a large (1420 bytes + overhead for echo service) payload.
+		// The payload is transmitted to and echoed from the echo service for both HTTP and UDP tests.
+		ginkgo.When("tests are run towards the agnhost echo server", func() {
+			ginkgo.It("queries to the hostNetworked server pod on another node shall work for TCP", func() {
+				for _, size := range []string{"small", "large"} {
+					for _, serverNodeIP := range serverNodeInternalIPs {
+						ginkgo.By(fmt.Sprintf("Sending TCP %s payload to node IP %s "+
+							"and expecting to receive the same payload", size, serverNodeIP))
+						cmd := fmt.Sprintf("curl --max-time 10 -g -q -s http://%s:%d/echo?msg=%s",
+							serverNodeIP,
+							serverPodPort,
+							echoPayloads[size],
+						)
+						framework.Logf("Testing TCP %s with command %q", size, cmd)
+						stdout, err := framework.RunHostCmdWithRetries(
+							clientPod.Namespace,
+							clientPod.Name,
+							cmd,
+							framework.Poll,
+							60*time.Second)
+						framework.ExpectNoError(err, fmt.Sprintf("Testing TCP with %s payload failed", size))
+						gomega.Expect(stdout).To(gomega.Equal(echoPayloads[size]), fmt.Sprintf("Testing TCP with %s payload failed", size))
+					}
+				}
+			})
+			ginkgo.It("queries to the hostNetworked server pod on another node shall work for UDP", func() {
+				clientNodeIPv4, clientNodeIPv6 := getContainerAddressesForNetwork(clientPodNodeName, primaryNetworkName) // we always want to fetch from primary network
+				clientnodeIP := clientNodeIPv4
+				if IsIPv6Cluster(f.ClientSet) {
+					clientnodeIP = clientNodeIPv6
+				}
+				for _, size := range []string{"small", "large"} {
+					for _, serverNodeIP := range serverNodeInternalIPs {
+						if size == "large" {
+							// Flushing the IP route cache will remove any routes in the cache
+							// that are a result of receiving a "need to frag" packet.
+							ginkgo.By("Flushing the ip route cache")
+							stdout, err := runCommand(containerRuntime, "exec", "-i", serverPodNodeName, "ip", "route", "flush", "cache")
+							framework.ExpectNoError(err, "Flushing the ip route cache failed")
+							framework.Logf("Flushed cache on %s", serverPodNodeName)
+							// List the current IP route cache for informative purposes.
+							cmd := fmt.Sprintf("ip route get %s", clientnodeIP)
+							stdout, err = framework.RunHostCmd(
+								serverPod.Namespace,
+								serverPod.Name,
+								cmd)
+							framework.ExpectNoError(err, "Listing IP route cache")
+							framework.Logf("%s: %s", cmd, stdout)
+						}
+						// We expect the following to fail at least once for large payloads and non-hostNetwork
+						// endpoints: the first request will fail as we have to receive a "need to frag" ICMP
+						// message, subsequent requests then should succeed.
+						gomega.Eventually(func() error {
+							ginkgo.By(fmt.Sprintf("Sending UDP %s payload to server IP %s "+
+								"and expecting to receive the same payload", size, serverNodeIP))
+							// Send payload via UDP.
+							cmd := fmt.Sprintf("echo 'echo %s' | nc -w2 -u %s %d",
+								echoPayloads[size],
+								serverNodeIP,
+								serverPodPort,
+							)
+							framework.Logf("Testing UDP %s with command %q", size, cmd)
+							stdout, err := framework.RunHostCmd(
+								clientPod.Namespace,
+								clientPod.Name,
+								cmd)
+							if err != nil {
+								return err
+							}
+							// Compare received payload vs sent payload.
+							if stdout != echoPayloads[size] {
+								return fmt.Errorf("stdout does not match payloads[%s], %s != %s", size, stdout, echoPayloads[size])
+							}
+							if size == "large" {
+								ginkgo.By("Making sure that the ip route cache contains an MTU route")
+								// Get IP route cache and make sure that it contains an MTU route on the server side.
+								cmd = fmt.Sprintf("ip route get %s", clientnodeIP)
+								stdout, err = framework.RunHostCmd(
+									serverPod.Namespace,
+									serverPod.Name,
+									cmd)
+								if err != nil {
+									return fmt.Errorf("could not list IP route cache using cmd: %s, err: %q", cmd, err)
+								}
+								framework.Logf("Route cache on server pod %s", stdout)
+								if !echoMtuRegex.Match([]byte(stdout)) {
+									return fmt.Errorf("cannot find MTU cache entry in route: %s", stdout)
+								}
+							}
+							return nil
+						}, 60*time.Second, 1*time.Second).Should(gomega.Succeed())
+						// Flushing the IP route cache will remove any routes in the cache
+						// that are a result of receiving a "need to frag" packet. Let's
+						// flush this on all 3 nodes else we will run into the
+						// bug: https://issues.redhat.com/browse/OCPBUGS-7609.
+						// TODO: Revisit this once https://bugzilla.redhat.com/show_bug.cgi?id=2169839 is fixed.
+						ovnKubeNodePods, err := f.ClientSet.CoreV1().Pods(ovnNs).List(context.TODO(), metav1.ListOptions{
+							LabelSelector: "name=ovnkube-node",
+						})
+						if err != nil {
+							framework.Failf("could not get ovnkube-node pods: %v", err)
+						}
+						for _, ovnKubeNodePod := range ovnKubeNodePods.Items {
+							framework.Logf("Flushing the ip route cache on %s", ovnKubeNodePod.Name)
+							containerName := "ovnkube-node"
+							if isInterconnectEnabled() {
+								containerName = "ovnkube-controller"
+							}
+							_, err := framework.RunKubectl(ovnNs, "exec", ovnKubeNodePod.Name, "--container", containerName, "--",
+								"ip", "route", "flush", "cache")
+							framework.ExpectNoError(err, "Flushing the ip route cache failed")
+						}
+					}
+				}
+			})
+		})
+	})
+})

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -362,12 +362,12 @@ var _ = ginkgo.Describe("Services", func() {
 							}
 							for _, ovnKubeNodePod := range ovnKubeNodePods.Items {
 								framework.Logf("Flushing the ip route cache on %s", ovnKubeNodePod.Name)
-								_, err := framework.RunHostCmdWithRetries(
-									ovnNs,
-									ovnKubeNodePod.Name,
-									"ip route flush cache",
-									framework.Poll,
-									60*time.Second)
+								containerName := "ovnkube-node"
+								if isInterconnectEnabled() {
+									containerName = "ovnkube-controller"
+								}
+								_, err := framework.RunKubectl(ovnNs, "exec", ovnKubeNodePod.Name, "--container", containerName, "--",
+									"ip", "route", "flush", "cache")
 								framework.ExpectNoError(err, "Flushing the ip route cache failed")
 							}
 						}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**

1. pod sends request to server outside the cluster
2. server responds back with a large pkt
3. GR sends frag needed when pkt hits rtoj since gateway_mtu is set
4. pkt going out is not SNAT-ed by OVN so it goes out with podIP
5. pkt is dropped by server since it doesn't know what to do
6. server continues to hammer large pkts
7. OVN team doesn't have a nice way to fix this on their side
8. Compromise: On the CMS we configure gateway_mtu on both rtoe and rtoj ports such that needs frag is sent at rtoe itself and this time it will be SNATed to nodeIP

**- Special notes for reviewers**
Also fixes the MTU test flake on IC lanes:

Sep  5 14:00:02.820: INFO: Flushing the ip route cache on ovnkube-node-sc4v8
Sep  5 14:00:02.820: INFO: Running '/usr/local/bin/kubectl --server=https://127.0.0.1:38371 --kubeconfig=/home/surya/ovn.conf --namespace=ovn-kubernetes exec ovnkube-node-sc4v8 -- /bin/sh -x -c ip route flush cache'
Sep  5 14:00:02.947: INFO: stderr: "Defaulted container \"nb-ovsdb\" out of: nb-ovsdb, sb-ovsdb, ovn-northd, ovnkube-controller, ovn-controller, ovs-metrics-exporter\n+ ip route flush cache\nCannot open \"/proc/sys/net/ipv4/route/flush\": Read-only file system\n"

Does this have an impact on service backed by host-net pod case?

**- How to verify it**
UTs have been updated, added a new e2e for pod2external case

**- Description for the changelog**
`Configure gateway_mtu also on rtoe`