### PR TITLE
EIP: fix how we detect primary interface EIP configuration

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -1657,9 +1657,6 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 
 		table.DescribeTable("should be able to allocate several EgressIPs and avoid the same node", func(egressIP1, egressIP2 string) {
 			app.Action = func(ctx *cli.Context) error {
-				//
-				//egressIP1 := "0:0:0:0:0:feff:c0a8:8e0d"
-				//egressIP2 := "0:0:0:0:0:feff:c0a8:8e0f"
 				node1IPv4OVNManaged := ""
 				node1IPv6OVNManaged := "0:0:0:0:0:feff:c0a8:8e0c/64"
 				node1IPv6NonOVNManaged := "0:0:1:0:0:feff:c0a8:8e0c/64"
@@ -1722,8 +1719,8 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 					&egressipv1.EgressIPList{Items: []egressipv1.EgressIP{eIP}},
 				)
 
-				egressNode1 := setupNode(node1Name, []string{node1IPv6OVNManaged, node1IPv6NonOVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
-				egressNode2 := setupNode(node2Name, []string{node2IPv6OVNManaged, node2IPv6NonOVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+				egressNode1 := setupNode(node1Name, []string{node1IPv6OVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				egressNode2 := setupNode(node2Name, []string{node2IPv6OVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
 
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode2.name] = &egressNode2
@@ -1807,8 +1804,8 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 					&egressipv1.EgressIPList{Items: []egressipv1.EgressIP{eIP}},
 				)
 
-				egressNode1 := setupNode(node1Name, []string{node1IPv4OVNManaged, node1IPv6NonOVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
-				egressNode2 := setupNode(node2Name, []string{node2IPv4OVNManaged, node2IPv6NonOVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+				egressNode1 := setupNode(node1Name, []string{node1IPv4OVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				egressNode2 := setupNode(node2Name, []string{node2IPv4OVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
 
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode2.name] = &egressNode2
@@ -1901,8 +1898,8 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 					&egressipv1.EgressIPList{Items: []egressipv1.EgressIP{eIP}},
 				)
 
-				egressNode1 := setupNode(node1Name, []string{node1IPv4OVNManaged, node1IPv6NonOVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
-				egressNode2 := setupNode(node2Name, []string{node2IPv4OVNManaged, node2IPv6NonOVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+				egressNode1 := setupNode(node1Name, []string{node1IPv4OVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				egressNode2 := setupNode(node2Name, []string{node2IPv4OVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
 
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode2.name] = &egressNode2
@@ -1987,8 +1984,8 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 					&egressipv1.EgressIPList{Items: []egressipv1.EgressIP{eIP}},
 				)
 
-				egressNode1 := setupNode(node1Name, []string{node1IPv4OVNManaged, node1IPv6NonOVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
-				egressNode2 := setupNode(node2Name, []string{node2IPv4OVNManaged, node2IPv6NonOVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
+				egressNode1 := setupNode(node1Name, []string{node1IPv4OVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e32": "bogus1", "0:0:0:0:0:feff:c0a8:8e1e": "bogus2"})
+				egressNode2 := setupNode(node2Name, []string{node2IPv4OVNManaged}, map[string]string{"0:0:0:0:0:feff:c0a8:8e23": "bogus3"})
 
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode1.name] = &egressNode1
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode2.name] = &egressNode2

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -3852,7 +3852,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				)
 
 				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode1.name] = &egressNode1
-				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode1.name] = &egressNode2
+				fakeClusterManagerOVN.eIPC.allocator.cache[egressNode2.name] = &egressNode2
 
 				_, err := fakeClusterManagerOVN.eIPC.WatchEgressIP()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -13,7 +13,6 @@ import (
 	kapi "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilnet "k8s.io/utils/net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/kube"
@@ -600,6 +599,23 @@ func ParseNodeTransitSwitchPortAddrs(node *kapi.Node) ([]*net.IPNet, error) {
 	return parsePrimaryIfAddrAnnotation(node, ovnTransitSwitchPortAddr)
 }
 
+// GetNodeEIPConfig attempts to generate EIP configuration from a nodes annotations.
+// If the platform is running in the cloud, retrieve config info from node obj annotation added by Cloud Network Config
+// Controller (CNCC). If not on a cloud platform (i.e. baremetal), retrieve from the node obj primary interface annotation.
+func GetNodeEIPConfig(node *kapi.Node) (*ParsedNodeEgressIPConfiguration, error) {
+	var parsedEgressIPConfig *ParsedNodeEgressIPConfiguration
+	var err error
+	if PlatformTypeIsEgressIPCloudProvider() {
+		parsedEgressIPConfig, err = ParseCloudEgressIPConfig(node)
+	} else {
+		parsedEgressIPConfig, err = ParseNodePrimaryIfAddr(node)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate egress IP config for node %s: %w", node.Name, err)
+	}
+	return parsedEgressIPConfig, nil
+}
+
 // ParseCloudEgressIPConfig returns the cloud's information concerning the node's primary network interface
 func ParseCloudEgressIPConfig(node *kapi.Node) (*ParsedNodeEgressIPConfiguration, error) {
 	egressIPConfigAnnotation, ok := node.Annotations[cloudEgressIPConfigAnnotationKey]
@@ -782,25 +798,18 @@ func IsNonOVNManagedNetworkContainingIP(node *v1.Node, ip net.IP) (bool, error) 
 	return true, nil
 }
 
-// GetEgressIPNetwork attempts to retrieve a network that contains EgressIP. It first checks the primary OVN managed network,
-// otherwise searches through non-OVN managed networks
-func GetEgressIPNetwork(node *v1.Node, eIP net.IP) (string, error) {
-	primaryNetworks, err := getNodeIfAddrAnnotation(node)
-	if err != nil {
-		return "", fmt.Errorf("failed to get node address annotation for node %s: %v", node.Name, err)
+// GetEgressIPNetwork attempts to retrieve a network that contains EgressIP. Check the OVN managed network first as
+// represented by parameter eIPConfig, and if no match is found, and if not in a cloud environment, check non-OVN managed networks.
+func GetEgressIPNetwork(node *v1.Node, eIPConfig *ParsedNodeEgressIPConfiguration, eIP net.IP) (string, error) {
+	if eIPConfig.V4.Net != nil && eIPConfig.V4.Net.Contains(eIP) {
+		return eIPConfig.V4.Net.String(), nil
 	}
-	primaryNetwork := primaryNetworks.IPv4
-	if utilnet.IsIPv6(eIP) {
-		primaryNetwork = primaryNetworks.IPv6
+	if eIPConfig.V6.Net != nil && eIPConfig.V6.Net.Contains(eIP) {
+		return eIPConfig.V6.Net.String(), nil
 	}
-	if primaryNetwork != "" {
-		_, primaryNet, err := net.ParseCIDR(primaryNetwork)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse CIDR %s for node %s: %v", primaryNetwork, node.Name, err)
-		}
-		if primaryNet.Contains(eIP) {
-			return primaryNet.String(), nil
-		}
+	// Do not attempt to check if a non-OVN managed network may host an EIP if we are in a cloud environment
+	if PlatformTypeIsEgressIPCloudProvider() {
+		return "", nil
 	}
 	network, err := GetNonOVNNetworkContainingIP(node, eIP)
 	if err != nil {
@@ -811,46 +820,14 @@ func GetEgressIPNetwork(node *v1.Node, eIP net.IP) (string, error) {
 
 // IsOVNManagedNetwork attempts to detect if the argument IP can be hosted by a network managed by OVN. Currently, this is
 // only the primary OVN network
-func IsOVNManagedNetwork(node *v1.Node, ip net.IP) (bool, error) {
-	if ip == nil {
-		return false, fmt.Errorf("empty IP is not valid")
+func IsOVNManagedNetwork(eIPConfig *ParsedNodeEgressIPConfiguration, ip net.IP) bool {
+	if eIPConfig.V4.Net != nil && eIPConfig.V4.Net.Contains(ip) {
+		return true
 	}
-	if node == nil {
-		return false, fmt.Errorf("unable to determine if IP %s is OVN managed because node argument is nil", ip.String())
+	if eIPConfig.V6.Net != nil && eIPConfig.V6.Net.Contains(ip) {
+		return true
 	}
-	isIPV6 := utilnet.IsIPv6(ip)
-	primaryNetworks, err := getNodeIfAddrAnnotation(node)
-	if err != nil {
-		return false, fmt.Errorf("failed to determine if IP %s is OVN managed: %v", ip.String(), err)
-	}
-	if isIPV6 {
-		if primaryNetworks.IPv6 != "" {
-			_, primaryIPv6IPNet, err := net.ParseCIDR(primaryNetworks.IPv6)
-			if err != nil {
-				return false, fmt.Errorf("failed to parse IPv6 IP CIDR %s and therefore unable to detect if "+
-					"IP %s is OVN managed: %v", primaryNetworks.IPv6, ip.String(), err)
-			}
-			if primaryIPv6IPNet.Contains(ip) {
-				return true, nil
-			} else {
-				return false, nil
-			}
-		}
-	} else {
-		if primaryNetworks.IPv4 != "" {
-			_, primaryIPv4IPNet, err := net.ParseCIDR(primaryNetworks.IPv4)
-			if err != nil {
-				return false, fmt.Errorf("failed to parse IPv4 IP CIDR %s and therefore unable to detect if "+
-					"IP %s is OVN managed: %v", primaryNetworks.IPv4, ip.String(), err)
-			}
-			if primaryIPv4IPNet.Contains(ip) {
-				return true, nil
-			} else {
-				return false, nil
-			}
-		}
-	}
-	return false, fmt.Errorf("unable to determine if IP %s is within the OVN managed network for node %s", ip.String(), node.Name)
+	return false
 }
 
 // GetNonOVNNetworkContainingIP attempts to find a non OVN managed network to host the argument IP


### PR DESCRIPTION
Ready for review. See commits for details. 
Essentially this is a revert to previous behaviour that was introduced by EIP multi NIC PR.

In the original EIP multi NIC PR, I erroneously thought we get the IP + subnet for the primary OVN managed node network from annotation `k8s.ovn.org/node-primary-ifaddr` in both cloud and non cloud env.

I missed the distinction that in the cloud we get the IP from that annotation but we get the subnet from CNCCs annotation `cloud.network.openshift.io/egress-ipconfig`. This PR reverts to this behaviour.

On GCP cloud, the subnet seen on the `node-primary-ifaddr` is different to what is seen in the CNCC subnet and this error was found there.
