### PR TITLE
Remove Network field from EIP status

### DIFF
--- a/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressfirewalls.yaml.j2
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
   name: egressfirewalls.k8s.ovn.org
 spec:
   group: k8s.ovn.org

--- a/dist/templates/k8s.ovn.org_egressips.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressips.yaml.j2
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
   name: egressips.k8s.ovn.org
 spec:
   group: k8s.ovn.org
@@ -168,15 +169,11 @@ spec:
                     egressIP:
                       description: Assigned egress IP
                       type: string
-                    network:
-                      description: Assigned network
-                      type: string
                     node:
                       description: Assigned node name
                       type: string
                   required:
                   - egressIP
-                  - network
                   - node
                   type: object
                 type: array

--- a/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
+++ b/dist/templates/k8s.ovn.org_egressqoses.yaml.j2
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
   name: egressqoses.k8s.ovn.org
 spec:
   group: k8s.ovn.org

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1274,6 +1274,8 @@ func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []
 			// if the EIP is hosted by a non OVN managed network, then restrict the assignable nodes to the set of nodes that
 			// may host the non-OVN managed network
 			if len(assignableNodesWithSecondaryNet) > 0 {
+				klog.V(5).Infof("Restricting the number of assignable nodes from %d to %d because EgressIP %s IP %s "+
+					"is going to be hosted by a non-OVN managed network", len(assignableNodes), len(assignableNodesWithSecondaryNet), name, eIP.String())
 				assignableNodes = assignableNodesWithSecondaryNet
 			}
 		}
@@ -1324,7 +1326,7 @@ func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []
 			})
 			eNode.allocations[eIP.String()] = name
 			assignmentSuccessful = true
-			klog.Infof("Successful assignment of egress IP: %s on node: %+v", egressIP, eNode)
+			klog.Infof("Successful assignment of egress IP: %s to network %s on node: %+v", egressIP, egressIPNetwork, eNode)
 			break
 		}
 	}

--- a/go-controller/pkg/crd/egressip/v1/types.go
+++ b/go-controller/pkg/crd/egressip/v1/types.go
@@ -41,8 +41,6 @@ type EgressIPStatusItem struct {
 	Node string `json:"node"`
 	// Assigned egress IP
 	EgressIP string `json:"egressIP"`
-	// Assigned network
-	Network string `json:"network"`
 }
 
 // EgressIPSpec is a desired state description of EgressIP.

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -537,6 +537,8 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 		if !found {
 			continue
 		}
+		klog.Infof("Generating config for EgressIP %s IP %s which is hosted by a non-OVN managed interface (name %s)",
+			eip.Name, status.EgressIP, link.Attrs().Name)
 		// go through all selected pods and build a config per pod IP. We know there are at least one pod and these the
 		// pod(s) have IP(s).
 		eIPConfig, podIPConfigs = generateEIPConfigForPods(selectedPodIPs, link, eIPNet, isV6)

--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -937,9 +937,6 @@ func isEIPStatusItemValid(status eipv1.EgressIPStatusItem, nodeName string) bool
 	if status.EgressIP == "" {
 		return false
 	}
-	if status.Network == "" {
-		return false
-	}
 	return true
 }
 

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -417,7 +417,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 						if status.Node != node1Name {
 							continue
 						}
-						if status.Network == "" || status.EgressIP == "" {
+						if status.EgressIP == "" {
 							continue
 						}
 						// FIXME: we assume all EIPs are hosted by non-OVN managed network. Skip OVN managed EIPs.
@@ -521,7 +521,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures nothing when EIPs dont select anything",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{},
 			},
 		},
@@ -534,7 +534,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures one EIP and one Pod",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -559,7 +559,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 		// Test pod and namespace selection -
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -590,7 +590,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures one EIP and multiple namespaces and multiple pods",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -623,7 +623,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures one EIP and multiple namespaces and multiple pods",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -655,7 +655,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 	table.Entry("configures multiple EIPs and multiple namespaces and multiple pods",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink1Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -675,7 +675,7 @@ var _ = table.XDescribeTable("EgressIP selectors",
 				},
 			},
 			{
-				newEgressIP(egressIP2Name, egressIP2IP, dummy2IPv4CIDRNetwork, node1Name, namespace2Label, egressPodLabel),
+				newEgressIP(egressIP2Name, egressIP2IP, node1Name, namespace2Label, egressPodLabel),
 				testConfig{ // expected config for EIP
 					getExpectedDefaultRoute(getLinkIndex(dummyLink2Name)),
 					getExpectedLinkAddr(egressIP1IP),
@@ -769,7 +769,7 @@ var _ = table.XDescribeTable("repair node", func(expectedStateFollowingClean []t
 }, table.Entry("should not fail when node is clean and nothing to apply",
 	[]testEIPConfig{
 		{
-			newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+			newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 			testConfig{}, // no expected config
 		},
 	},
@@ -782,7 +782,7 @@ var _ = table.XDescribeTable("repair node", func(expectedStateFollowingClean []t
 	table.Entry("should remove stale route",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{
 					inf: dummyLink2Name,
 				}, // no expected config
@@ -805,7 +805,7 @@ var _ = table.XDescribeTable("repair node", func(expectedStateFollowingClean []t
 	table.XEntry("should remove stale address",
 		[]testEIPConfig{
 			{
-				newEgressIP(egressIP1Name, egressIP1IP, dummy1IPv4CIDRNetwork, node1Name, namespace1Label, egressPodLabel),
+				newEgressIP(egressIP1Name, egressIP1IP, node1Name, namespace1Label, egressPodLabel),
 				testConfig{
 					inf: dummyLink2Name,
 				}, // no expected config
@@ -972,11 +972,7 @@ func newEgressIPMeta(name string) metav1.ObjectMeta {
 	}
 }
 
-func newEgressIP(name, ip, network, node string, namespaceLabels, podLabels map[string]string) egressipv1.EgressIP {
-	_, ipnet, err := net.ParseCIDR(network)
-	if err != nil {
-		panic(err.Error())
-	}
+func newEgressIP(name, ip, node string, namespaceLabels, podLabels map[string]string) egressipv1.EgressIP {
 	return egressipv1.EgressIP{
 		ObjectMeta: newEgressIPMeta(name),
 		Spec: egressipv1.EgressIPSpec{
@@ -992,7 +988,6 @@ func newEgressIP(name, ip, network, node string, namespaceLabels, podLabels map[
 			Items: []egressipv1.EgressIPStatusItem{{
 				node,
 				ip,
-				ipnet.String(),
 			}},
 		},
 	}

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -1348,20 +1348,10 @@ func (e egressStatuses) contains(potentialStatus egressipv1.EgressIPStatusItem) 
 	if _, exists := e.statusMap[potentialStatus]; exists {
 		return true
 	}
-	// handle the case where not network is populated. This may occur if an EIP obj was considered by a cluster
-	// manager egress IP controller that did not support the network field
-	potentialStatus.Network = ""
-	if _, exists := e.statusMap[potentialStatus]; exists {
-		return true
-	}
 	return false
 }
 
 func (e egressStatuses) delete(deleteStatus egressipv1.EgressIPStatusItem) {
-	delete(e.statusMap, deleteStatus)
-	// also remove any keys without networks set. This is may occur when upgrading from a version that didn't set the
-	// network field
-	deleteStatus.Network = ""
 	delete(e.statusMap, deleteStatus)
 }
 

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -45,29 +45,24 @@ var (
 )
 
 const (
-	namespace       = "egressip-namespace"
-	namespace2      = "egressip-namespace2"
-	nodeInternalIP  = "def0::56"
-	v4GatewayIP     = "10.128.0.1"
-	podV4IP         = "10.128.0.15"
-	podV4IP2        = "10.128.0.16"
-	podV4IP3        = "10.128.1.3"
-	podV4IP4        = "10.128.1.4"
-	podV6IP         = "ae70::66"
-	v6GatewayIP     = "ae70::1"
-	v6ClusterSubnet = "ae70::66/64"
-	v6Node1Subnet   = "ae70::66/64"
-	v6Node2Subnet   = "be70::66/64"
-	v4ClusterSubnet = "10.128.0.0/14"
-	v4Node1Subnet   = "10.128.0.0/16"
-	v4Node2Subnet   = "10.90.0.0/16"
-	v4Node3Subnet   = "10.80.0.0/16"
-	v4Node4Subnet   = "10.70.0.0/16"
-	podName         = "egress-pod"
-	podName2        = "egress-pod2"
-	egressIPName    = "egressip"
-	egressIP2Name   = "egressip-2"
-	inspectTimeout  = 4 * time.Second // arbitrary, to avoid failures on github CI
+	namespace      = "egressip-namespace"
+	namespace2     = "egressip-namespace2"
+	podV4IP        = "10.128.0.15"
+	podV4IP2       = "10.128.0.16"
+	podV4IP3       = "10.128.1.3"
+	podV4IP4       = "10.128.1.4"
+	podV6IP        = "ae70::66"
+	v6GatewayIP    = "ae70::1"
+	v6Node1Subnet  = "ae70::66/64"
+	v6Node2Subnet  = "be70::66/64"
+	v4Node1Subnet  = "10.128.0.0/16"
+	v4Node2Subnet  = "10.90.0.0/16"
+	v4Node3Subnet  = "10.80.0.0/16"
+	podName        = "egress-pod"
+	podName2       = "egress-pod2"
+	egressIPName   = "egressip"
+	egressIP2Name  = "egressip-2"
+	inspectTimeout = 4 * time.Second // arbitrary, to avoid failures on github CI
 )
 
 var eipExternalID = map[string]string{
@@ -282,8 +277,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						{
 							Node:     node1Name,
 							EgressIP: egressIP,
-							// blank network
-							Network: "",
 						},
 					},
 				},
@@ -450,8 +443,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						{
 							Node:     node1Name,
 							EgressIP: egressIP,
-							// blank network
-							Network: "",
 						},
 					},
 				},
@@ -625,7 +616,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 								{
 									Node:     node1Name,
 									EgressIP: egressIP,
-									Network:  node1IPv4OVNManagedNet,
 								},
 							},
 						},
@@ -6270,7 +6260,6 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 						{
 							Node:     node1Name,
 							EgressIP: egressIP3,
-							Network:  node1IPv4Net,
 						},
 					}
 					err = fakeOvn.controller.patchReplaceEgressIPStatus(egressIP2Name, status)

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -429,7 +429,6 @@ func (o *FakeOVN) patchEgressIPObj(nodeName, egressIPName, egressIP, network str
 		{
 			Node:     nodeName,
 			EgressIP: egressIP,
-			Network:  network,
 		},
 	}
 	err := o.controller.patchReplaceEgressIPStatus(egressIPName, status)


### PR DESCRIPTION
Reasons for adding this network status field in the first place was to allow users to quickly establish which network an EgressIP IP is assigned to. 

This is a good idea for users.

The original goal can be accomplished without the burden of introducing a new field within EIP IPs status and managing this field during upgrade and for existing assigned EIP IPs isnt trivial. 

Simplify things and reduce the possibility of bugs introduced by this new field.

OVN kube node doesnt depend on this field so its removal is trivial.
Add extra logging to accomplish the original goal.

@trozet 
