### PR TITLE
EIP: fix entry of EIP into validated EIP set

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -1318,9 +1318,9 @@ func (eIPC *egressIPClusterController) assignEgressIPs(name string, egressIPs []
 				EgressIP: eIP.String(),
 				Network:  egressIPNetwork,
 			})
-			klog.Infof("Successful assignment of egress IP: %s on node: %+v", egressIP, eNode)
 			eNode.allocations[eIP.String()] = name
 			assignmentSuccessful = true
+			klog.Infof("Successful assignment of egress IP: %s on node: %+v", egressIP, eNode)
 			break
 		}
 	}
@@ -1367,7 +1367,7 @@ func (eIPC *egressIPClusterController) validateEgressIPSpec(name string, egressI
 			eIPC.recorder.Eventf(&eIPRef, v1.EventTypeWarning, "InvalidEgressIP", "egress IP: %s for object EgressIP: %s is not a valid IP address", egressIP, name)
 			return nil, fmt.Errorf("unable to parse provided EgressIP: %s, invalid", egressIP)
 		}
-		validatedEgressIPs.Insert(egressIP)
+		validatedEgressIPs.Insert(ip.String())
 	}
 	return validatedEgressIPs, nil
 }

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -3061,7 +3061,7 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 								Network:  "192.168.0.0/16",
 							},
 							{
-								EgressIP: egressIPv6,
+								EgressIP: net.ParseIP(egressIPv6).String(),
 								Node:     egressNode1.name,
 								Network:  "::/64",
 							},


### PR DESCRIPTION
This error was introduced in eip multi nic feature.

Revert to how it was previously.

For IPv6, this may cause reassignment of 'compressed' IPv6s.
