### PR TITLE
[OCPBUGS-18572] clearInitialNodeNetworkUnavailableCondition() called on node update

### DIFF
--- a/go-controller/pkg/clustermanager/network_cluster_controller.go
+++ b/go-controller/pkg/clustermanager/network_cluster_controller.go
@@ -294,6 +294,7 @@ func (h *networkClusterControllerEventHandler) UpdateResource(oldObj, newObj int
 				node.Name, err)
 			return err
 		}
+		h.clearInitialNodeNetworkUnavailableCondition(node)
 	default:
 		return fmt.Errorf("no update function for object type %s", h.objType)
 	}


### PR DESCRIPTION
when this used to be called from a master pod
clearInitialNodeNetworkUnavailableCondtion() was called during both add and update. It seems as though there are some instances where there is a delay between when the node is created and when gcp adds the taint, clearing on unpdate will ensure that the taint is removed.

this was seen in a bug https://issues.redhat.com/browse/OCPBUGS-18572?filter=-1

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->