### PR TITLE
Remove the centos image usages from e2e tests

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -998,7 +998,7 @@ var _ = ginkgo.Describe("e2e non-vxlan external gateway and update validation", 
 		ciWorkerNodeSrc := ovnWorkerNode
 
 		// start the container that will act as an external gateway
-		_, err := runCommand(containerRuntime, "run", "-itd", "--privileged", "--network", externalContainerNetwork, "--name", gwContainerNameAlt1, "centos")
+		_, err := runCommand(containerRuntime, "run", "-itd", "--privileged", "--network", externalContainerNetwork, "--name", gwContainerNameAlt1, agnhostImage)
 		if err != nil {
 			framework.Failf("failed to start external gateway test container %s: %v", gwContainerNameAlt1, err)
 		}
@@ -1071,7 +1071,7 @@ var _ = ginkgo.Describe("e2e non-vxlan external gateway and update validation", 
 			framework.Failf("Failed to ping the first gateway network %s from container %s on node %s: %v", exGWRemoteIpAlt1, ovnContainer, ovnWorkerNode, err)
 		}
 		// start the container that will act as a new external gateway that the tests will be updated to use
-		_, err = runCommand(containerRuntime, "run", "-itd", "--privileged", "--network", externalContainerNetwork, "--name", gwContainerNameAlt2, "centos")
+		_, err = runCommand(containerRuntime, "run", "-itd", "--privileged", "--network", externalContainerNetwork, "--name", gwContainerNameAlt2, agnhostImage)
 		if err != nil {
 			framework.Failf("failed to start external gateway test container %s: %v", gwContainerNameAlt2, err)
 		}


### PR DESCRIPTION
Use the agnhost image used in other tests instead.
This should hopefully help with the following error we started seeing in CI:
```
2023-09-15T09:42:52.5466215Z Sep 15 09:42:52.545: FAIL: failed to start external gateway test container gw-novxlan-test-container-alt1: failed to run "docker run -itd --privileged --network kind --name gw-novxlan-test-container-alt1 centos": exit status 125 (Unable to find image 'centos:latest' locally
2023-09-15T09:42:52.5467433Z latest: Pulling from library/centos
2023-09-15T09:42:52.5468198Z a1d0c7532777: Pulling fs layer
2023-09-15T09:42:52.5468642Z a1d0c7532777: Verifying Checksum
2023-09-15T09:42:52.5468929Z a1d0c7532777: Download complete
2023-09-15T09:42:52.5469364Z docker: failed to register layer: write /usr/lib/locale/C.utf8/LC_COLLATE: no space left on device.
```