### PR TITLE
Trivial: Improve CloudPrivateIPConfig logs when it cannot be assigned.

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -228,7 +228,8 @@ func (eIPC *egressIPClusterController) executeCloudPrivateIPConfigOps(egressIPNa
 					klog.Infof("CloudPrivateIPConfig: %s already assigned to node: %s", cloudPrivateIPConfigName, cloudPrivateIPConfig.Spec.Node)
 					continue
 				}
-				return fmt.Errorf("cloud create request failed for CloudPrivateIPConfig: %s, err: item exists", cloudPrivateIPConfigName)
+				return fmt.Errorf("cloud request failed for CloudPrivateIPConfig: %s, err: cannot be assigned to node %s because cloud has it in node %s",
+					cloudPrivateIPConfigName, op.toAdd, cloudPrivateIPConfig.Spec.Node)
 			}
 			cloudPrivateIPConfig := ocpcloudnetworkapi.CloudPrivateIPConfig{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
If the cloud provider is still working on de-associating an egress IP from a node, it is possible that a following association will be stopped. This commit implements a better log explaining this scenario.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-18647