### PR TITLE
Add additonal certificate acceptance condition feature in ovnkube-identity

### DIFF
--- a/go-controller/pkg/csrapprover/approver.go
+++ b/go-controller/pkg/csrapprover/approver.go
@@ -3,8 +3,10 @@ package csrapprover
 import (
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -12,7 +14,6 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
@@ -30,37 +31,83 @@ const (
 	MaxDuration    = time.Hour * 24 * 365
 )
 
-var (
-	Organization = []string{"system:ovn-nodes"}
-	Groups       = sets.New[string]("system:nodes", "system:ovn-nodes", "system:authenticated")
-	UserPrefixes = sets.New[string]("system:node", NamePrefix)
-	Usages       = sets.New[certificatesv1.KeyUsage](
-		certificatesv1.UsageDigitalSignature,
-		certificatesv1.UsageClientAuth)
-)
-
-// OVNKubeCSRController approves certificate signing requests (CSRs) by applying the following conditions:
-// - CSRs with a CommonName that does not start with "commonNamePrefix" are ignored
+// CSRAcceptanceCondition specifies conditions which CSRs are approved by csrapprover.
+// csrapprover will check these condition and decide to approve by following rules:
+// - CSRs with a CommonName that does not start with "CommonNamePrefix" are ignored
 // - CSRs with .Spec.SignerName not equal to kubernetes.io/kube-apiserver-client are ignored
-// - CSRs .Spec.Username has a format of <prefix>:<nodeName> where <prefix> must exist in "userPrefixes"
+// - CSRs .Spec.Username has a format of <prefix>:<nodeName> where <prefix> must exist in "UserPrefixes"
 // - The node name extracted from .Spec.Username is a valid DNS subdomain
 // - The .Spec.Usages in the CSR matches the "usages" value in the controller
-// - All elements in .Spec.Groups in the CSR exist in the "groups"
+// - All elements in .Spec.Groups in the CSR exist in the "Groups"
 // - The .Spec.ExpirationSeconds is set and is not higher than "maxDuration"
 // - The parsed CSR in .Spec.Request has a .Subject.Organization equal to "organization"
 // - The parsed CSR in .Spec.Request has a .Subject.CommonName in the format of "<commonNamePrefix>:<nodeName>",
 // where the nodeName value is extracted from .Spec.Username.
-type OVNKubeCSRController struct {
-	name               string
-	commonNamePrefixes string
-	organization       []string
-	groups             sets.Set[string]
-	userPrefixes       sets.Set[string]
-	usages             sets.Set[certificatesv1.KeyUsage]
-	maxDuration        time.Duration
+type CSRAcceptanceCondition struct {
+	// CommonNamePrefix specifies common name in target CSRs
+	CommonNamePrefix string `json:"commonNamePrefix"`
+	// Organization specifies Organization in target CSRs
+	Organizations []string `json:"organizations"`
+	// Groups specifies groups in target CSRs
+	Groups []string `json:"groups"`
+	// UserPrefixes specifies prefix of user field in target CSRs
+	UserPrefixes []string `json:"userPrefixes"`
+	// Default should be true if the target CSR is for ovn-node
+	Default bool
+	// groupsSet contains Groups value as sets.Set[]
+	groupsSet sets.Set[string]
+	// userPrefixesSet contains UserPrefixes value as sets.Set[]
+	userPrefixesSet sets.Set[string]
+}
 
-	client   crclient.Client
-	recorder record.EventRecorder
+// InitCSRAcceptanceConditions initializes CSRAcceptanceCondition: Load json from fileName and
+// add default CSRAcceptanceCondition
+func InitCSRAcceptanceConditions(fileName string) (conditions []CSRAcceptanceCondition, err error) {
+	if fileName != "" {
+		file, err := os.ReadFile(fileName)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = json.Unmarshal(file, &conditions); err != nil {
+			return nil, err
+		}
+	}
+
+	conditions = append([]CSRAcceptanceCondition{DefaultCSRAcceptanceCondition}, conditions...)
+	// initialize Sets from slices
+	for i, v := range conditions {
+		conditions[i].groupsSet = sets.New[string](v.Groups...)
+		conditions[i].userPrefixesSet = sets.New[string](v.UserPrefixes...)
+	}
+
+	return conditions, nil
+}
+
+var (
+	DefaultCSRAcceptanceCondition = CSRAcceptanceCondition{
+		CommonNamePrefix: NamePrefix,
+		Organizations:    []string{"system:ovn-nodes"},
+		Groups:           []string{"system:nodes", "system:ovn-nodes", "system:authenticated"},
+		UserPrefixes:     []string{"system:node", NamePrefix},
+		Default:          true,
+	}
+	Usages = sets.New[certificatesv1.KeyUsage](
+		certificatesv1.UsageDigitalSignature,
+		certificatesv1.UsageClientAuth)
+)
+
+// OVNKubeCSRController approves certificate signing requests (CSRs) by applying the conditions, which is defined
+// in CSRAcceptanceCondition.
+type OVNKubeCSRController struct {
+	name                    string
+	csrAcceptanceConditions []CSRAcceptanceCondition
+	maxDuration             time.Duration
+	usages                  sets.Set[certificatesv1.KeyUsage]
+
+	commonNamePrefixes []string
+	client             crclient.Client
+	recorder           record.EventRecorder
 }
 
 var Predicate = predicate.Funcs{
@@ -78,51 +125,45 @@ var Predicate = predicate.Funcs{
 
 // NewController creates a new OVNKubeCSRController
 func NewController(client crclient.Client,
-	commonNamePrefixes string,
-	organization []string,
-	groups, userPrefixes sets.Set[string],
+	csrAcceptanceConditions []CSRAcceptanceCondition,
 	usages sets.Set[certificatesv1.KeyUsage],
 	maxDuration time.Duration,
 	recorder record.EventRecorder) *OVNKubeCSRController {
-	c := &OVNKubeCSRController{
-		name:               ControllerName,
-		client:             client,
-		commonNamePrefixes: commonNamePrefixes,
-		organization:       organization,
-		groups:             groups,
-		usages:             usages,
-		userPrefixes:       userPrefixes,
-		maxDuration:        maxDuration,
-		recorder:           recorder,
+
+	commonNamePrefixes := []string{}
+
+	// create commonNamePrefixes from csrAcceptanceConditions
+	for _, v := range csrAcceptanceConditions {
+		commonNamePrefixes = append(commonNamePrefixes, v.CommonNamePrefix)
 	}
-	return c
+
+	return &OVNKubeCSRController{
+		name:                    ControllerName,
+		client:                  client,
+		csrAcceptanceConditions: csrAcceptanceConditions,
+		commonNamePrefixes:      commonNamePrefixes,
+		usages:                  usages,
+		maxDuration:             maxDuration,
+		recorder:                recorder,
+	}
 }
 
-func (c *OVNKubeCSRController) filterCSR(csr *certificatesv1.CertificateSigningRequest) bool {
-	nsn := types.NamespacedName{Namespace: csr.Namespace, Name: csr.Name}
-	csrPEM, _ := pem.Decode(csr.Spec.Request)
-	if csrPEM == nil {
-		klog.Errorf("Failed to PEM-parse the CSR block in .spec.request: no CSRs were found in %s", nsn)
-		return false
+func (c *OVNKubeCSRController) filterCSR(csr *certificatesv1.CertificateSigningRequest, x509CSR *x509.CertificateRequest) bool {
+	for _, v := range c.commonNamePrefixes {
+		if strings.HasPrefix(x509CSR.Subject.CommonName, v) {
+			return csr.Spec.SignerName == certificatesv1.KubeAPIServerClientSignerName
+		}
 	}
-
-	x509CSR, err := x509.ParseCertificateRequest(csrPEM.Bytes)
-	if err != nil {
-		klog.Errorf("Failed to parse the CSR .spec.request of %q: %v", nsn, err)
-		return false
-	}
-
-	return strings.HasPrefix(x509CSR.Subject.CommonName, c.commonNamePrefixes) &&
-		csr.Spec.SignerName == certificatesv1.KubeAPIServerClientSignerName
+	return false
 }
 
-func (c *OVNKubeCSRController) denyCSR(ctx context.Context, csr *certificatesv1.CertificateSigningRequest, message string) error {
+func (c *OVNKubeCSRController) denyCSR(ctx context.Context, csr *certificatesv1.CertificateSigningRequest, message error) error {
 	csr.Status.Conditions = append(csr.Status.Conditions,
 		certificatesv1.CertificateSigningRequestCondition{
 			Type:    certificatesv1.CertificateDenied,
 			Status:  corev1.ConditionTrue,
 			Reason:  "CSRDenied",
-			Message: message,
+			Message: message.Error(),
 		},
 	)
 
@@ -170,7 +211,17 @@ func (c *OVNKubeCSRController) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
-	if !c.filterCSR(req) {
+	csrPEM, _ := pem.Decode(req.Spec.Request)
+	if csrPEM == nil {
+		return reconcile.Result{}, fmt.Errorf("failed to decode %q PEM block in .spec.request: no CSRs were found", request.Name)
+	}
+
+	x509CSR, err := x509.ParseCertificateRequest(csrPEM.Bytes)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to parse %s PEM bytes: %v", request.Name, err)
+	}
+
+	if !c.filterCSR(req, x509CSR) {
 		klog.V(5).Infof("Ignoring CSR %s", req.Name)
 		return reconcile.Result{}, nil
 	}
@@ -189,57 +240,73 @@ func (c *OVNKubeCSRController) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, nil
 	}
 
-	csrPEM, _ := pem.Decode(req.Spec.Request)
-	if csrPEM == nil {
-		return reconcile.Result{}, fmt.Errorf("failed to PEM-parse the CSR block in .spec.request: no CSRs were found")
-	}
-
-	x509CSR, err := x509.ParseCertificateRequest(csrPEM.Bytes)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to parse the CSR bytes: %v", err)
-	}
-
-	// expected format: userPrefix:nodeName
+	// expected common name format: userPrefix:nodeName
 	// example: system:ovn-node:ovn-worker2
-	i := strings.LastIndex(req.Spec.Username, ":")
-	if i == -1 || i == len(req.Spec.Username)-1 {
-		return reconcile.Result{}, fmt.Errorf("failed to parse the username: %s", req.Spec.Username)
+	i := strings.LastIndex(x509CSR.Subject.CommonName, ":")
+	if i == -1 || i == len(x509CSR.Subject.CommonName)-1 {
+		return reconcile.Result{}, fmt.Errorf("failed to parse the common name: %s", x509CSR.Subject.CommonName)
 	}
 
-	prefix := req.Spec.Username[:i]
-	nodeName = req.Spec.Username[i+1:]
-	if !c.userPrefixes.Has(prefix) {
-		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Sprintf("CSR %q was created by an unexpected user: %q", req.Name, req.Spec.Username))
+	matched := false
+	prefix := x509CSR.Subject.CommonName[:i]
+	nodeName = x509CSR.Subject.CommonName[i+1:]
+	for _, v := range c.csrAcceptanceConditions {
+		if prefix == v.CommonNamePrefix {
+			matched = true
+			if err := v.validateCSR(req, x509CSR, c.usages); err != nil {
+				return reconcile.Result{}, c.denyCSR(ctx, req, err)
+			}
+		}
 	}
 
-	if errs := validation.IsDNS1123Subdomain(nodeName); len(errs) != 0 {
-		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Sprintf("extracted node name %q is not a valid DNS subdomain %v", nodeName, errs))
-	}
-
-	if usages := sets.New[certificatesv1.KeyUsage](req.Spec.Usages...); !usages.Equal(c.usages) {
-		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Sprintf("CSR %q was created with unexpected usages: %v", req.Name, usages.UnsortedList()))
-	}
-
-	if !c.groups.HasAll(req.Spec.Groups...) {
-		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Sprintf("CSR %q was created by a user with unexpected groups: %v", req.Name, req.Spec.Groups))
-	}
-
-	expectedSubject := fmt.Sprintf("%s:%s", c.commonNamePrefixes, nodeName)
-	if x509CSR.Subject.CommonName != expectedSubject {
-		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Sprintf("expected the CSR's commonName to be %q, but it is %q", expectedSubject, x509CSR.Subject.CommonName))
-	}
-
-	if !reflect.DeepEqual(x509CSR.Subject.Organization, c.organization) {
-		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Sprintf("expected the CSR's organization to be %v, but it is %v", c.organization, x509CSR.Subject.Organization))
+	if !matched {
+		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Errorf("CSR %q was created with unexpected common name: %q", req.Name, x509CSR.Subject.CommonName))
 	}
 
 	if req.Spec.ExpirationSeconds == nil {
-		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Sprintf("CSR %q was created without specyfying the expirationSeconds", req.Name))
+		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Errorf("CSR %q was created without specyfying the expirationSeconds", req.Name))
 	}
 
 	if csr.ExpirationSecondsToDuration(*req.Spec.ExpirationSeconds) > c.maxDuration {
-		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Sprintf("CSR %q was created with invalid expirationSeconds value: %d", req.Name, *req.Spec.ExpirationSeconds))
+		return reconcile.Result{}, c.denyCSR(ctx, req, fmt.Errorf("CSR %q was created with invalid expirationSeconds value: %d", req.Name, *req.Spec.ExpirationSeconds))
 	}
 
 	return reconcile.Result{}, c.approveCSR(ctx, req)
+}
+
+func (c *CSRAcceptanceCondition) validateCSR(req *certificatesv1.CertificateSigningRequest, x509CSR *x509.CertificateRequest, acceptUsages sets.Set[certificatesv1.KeyUsage]) error {
+
+	// expected username format: userPrefix:nodeName
+	// example: system:ovn-node:ovn-worker2
+	i := strings.LastIndex(req.Spec.Username, ":")
+	if i == -1 || i == len(req.Spec.Username)-1 {
+		return fmt.Errorf("failed to parse the username: %s", req.Spec.Username)
+	}
+	prefix := req.Spec.Username[:i]
+	nodeName := req.Spec.Username[i+1:]
+	if !c.userPrefixesSet.Has(prefix) {
+		return fmt.Errorf("CSR %q was created by an unexpected user: %q", req.Name, req.Spec.Username)
+	}
+
+	if errs := validation.IsDNS1123Subdomain(nodeName); len(errs) != 0 {
+		return fmt.Errorf("extracted node name %q is not a valid DNS subdomain %v", nodeName, errs)
+	}
+
+	if usages := sets.New[certificatesv1.KeyUsage](req.Spec.Usages...); !usages.Equal(acceptUsages) {
+		return fmt.Errorf("CSR %q was created with unexpected usages: %v", req.Name, usages.UnsortedList())
+	}
+
+	if !c.groupsSet.HasAll(req.Spec.Groups...) {
+		return fmt.Errorf("CSR %q was created by a user with unexpected groups: %v", req.Name, req.Spec.Groups)
+	}
+
+	expectedSubject := fmt.Sprintf("%s:%s", c.CommonNamePrefix, nodeName)
+	if x509CSR.Subject.CommonName != expectedSubject {
+		return fmt.Errorf("expected the CSR's commonName to be %q, but it is %q", expectedSubject, x509CSR.Subject.CommonName)
+	}
+
+	if !reflect.DeepEqual(x509CSR.Subject.Organization, c.Organizations) {
+		return fmt.Errorf("expected the CSR's organization to be %v, but it is %v", c.Organizations, x509CSR.Subject.Organization)
+	}
+	return nil
 }

--- a/go-controller/pkg/ovnwebhook/nodeadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission_test.go
@@ -59,6 +59,8 @@ func TestNewNodeAdmissionWebhook(t *testing.T) {
 
 var nodeName = "fakeNode"
 var userName = fmt.Sprintf("%s:%s", csrapprover.NamePrefix, nodeName)
+var additionalNamePrefix = "system:foobar"
+var additionalUserName = fmt.Sprintf("%s:%s", additionalNamePrefix, nodeName)
 
 func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 	adm := NewNodeAdmissionWebhook(false, false)

--- a/go-controller/pkg/ovnwebhook/podadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/podadmission_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -361,11 +362,76 @@ func TestPodAdmission_ValidateUpdate(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("ovnkube-node on node: %q is not allowed to modify anything other than annotations", nodeName),
 		},
+		// additional acceptance conditions
+		{
+			name: "additonal acceptance conditions valid",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: additionalUserName,
+				}},
+			}),
+			oldObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{"pod-annotation-valid1": "old"},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+			newObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{"pod-annotation-valid1": "new"},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+		},
+		{
+			name: "additonal acceptance conditions invalid",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: additionalUserName,
+				}},
+			}),
+			oldObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{"pod-annotation-invalid1": "old"},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+			newObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        podName,
+					Annotations: map[string]string{"pod-annotation-invalid1": "new"},
+				},
+				Spec: corev1.PodSpec{NodeName: nodeName},
+			},
+			expectedErr: fmt.Errorf("%s node: %q is not allowed to set the following annotations on pod: \"testpod\": [pod-annotation-invalid1]", additionalNamePrefix, nodeName),
+		},
+	}
+
+	allowedPodAnnotations := []string{"pod-annotation-valid1"}
+	additionalPodAdmissions := PodAdmissionConditionOption{
+		CommonNamePrefix:         additionalNamePrefix,
+		AllowedPodAnnotations:    allowedPodAnnotations,
+		AllowedPodAnnotationKeys: sets.New[string](allowedPodAnnotations...),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			padm := NewPodAdmissionWebhook(&fakeNodeLister{
 				nodes: map[string]*corev1.Node{tt.node.Name: tt.node},
+			}, []PodAdmissionConditionOption{
+				additionalPodAdmissions,
 			})
 			_, err := padm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
 			if !reflect.DeepEqual(err, tt.expectedErr) {
@@ -443,10 +509,19 @@ func TestPodAdmission_ValidateUpdateExtraUsers(t *testing.T) {
 			expectedErr: fmt.Errorf("user: %q is not allowed to set %s on pod %q: the annotation is not allowed on host networked pods", extraUser, util.OvnPodAnnotationName, podName),
 		},
 	}
+
+	allowedPodAnnotations := []string{"pod-annotation-valid1"}
+	additionalPodAdmissions := PodAdmissionConditionOption{
+		CommonNamePrefix:         additionalNamePrefix,
+		AllowedPodAnnotations:    allowedPodAnnotations,
+		AllowedPodAnnotationKeys: sets.New[string](allowedPodAnnotations...),
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			padm := NewPodAdmissionWebhook(&fakeNodeLister{
 				nodes: map[string]*corev1.Node{tt.node.Name: tt.node},
+			}, []PodAdmissionConditionOption{
+				additionalPodAdmissions,
 			}, extraUser)
 			_, err := padm.ValidateUpdate(tt.ctx, tt.oldObj, tt.newObj)
 			if !reflect.DeepEqual(err, tt.expectedErr) {


### PR DESCRIPTION
This change introduces additional certificate acceptance condition so that other components reuse ovnkube-identity.

**- What this PR does and why is it needed**
This change introduces add command line options in ovnkube-identity to support to reuse this feature (csrapprove and pod webhook) to other components.