### PR TITLE
Allow a node switching between OVN node and hybrid overlay node

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node.go
@@ -60,7 +60,8 @@ func nodeChanged(old, new interface{}) bool {
 	newCidr, newNodeIP, newDrMAC, _ := getNodeDetails(newNode)
 
 	return !reflect.DeepEqual(oldCidr, newCidr) || !reflect.DeepEqual(oldNodeIP, newNodeIP) || !reflect.DeepEqual(oldDrMAC, newDrMAC) ||
-		!reflect.DeepEqual(newNode.Annotations[hotypes.HybridOverlayDRIP], oldNode.Annotations[hotypes.HybridOverlayDRIP])
+		!reflect.DeepEqual(newNode.Annotations[hotypes.HybridOverlayDRIP], oldNode.Annotations[hotypes.HybridOverlayDRIP]) ||
+		util.NoHostSubnet(oldNode) != util.NoHostSubnet(newNode)
 }
 
 // podChanged returns true if any relevant pod attributes changed

--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -16,6 +16,7 @@ import (
 // This controller is running in ovnkube-node binary. It's responsible for local
 // node configuration and annotation.
 type NodeController struct {
+	kube kube.Interface
 	sync.RWMutex
 	nodeName  string
 	initState hotypes.HybridInitState

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -91,7 +91,8 @@ func (na *NodeAllocator) Init() error {
 }
 
 func (na *NodeAllocator) hasHybridOverlayAllocation() bool {
-	return config.HybridOverlay.Enabled && !na.netInfo.IsSecondary()
+	// When config.HybridOverlay.ClusterSubnets is empty, assume the subnet allocation will be managed by an external component.
+	return config.HybridOverlay.Enabled && !na.netInfo.IsSecondary() && len(config.HybridOverlay.ClusterSubnets) > 0
 }
 
 func (na *NodeAllocator) recordSubnetCount() {

--- a/go-controller/pkg/ovn/hybrid.go
+++ b/go-controller/pkg/ovn/hybrid.go
@@ -1,11 +1,13 @@
 package ovn
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
 	"sync/atomic"
 
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	hotypes "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
 	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
@@ -93,7 +95,7 @@ func (oc *DefaultNetworkController) handleHybridOverlayPort(node *kapi.Node, ann
 	// we need to setup a reroute policy for hybrid overlay subnet
 	// this is so hybrid pod -> service -> hybrid endpoint will reroute to the DR IP
 	if err := oc.setupHybridLRPolicySharedGw(subnets, node.Name, portMAC, drIP); err != nil {
-		return fmt.Errorf("unable to setup Hybrid Subnet Logical Route Policy for node: %s, error: %v",
+		return fmt.Errorf("unable to setup Hybrid Subnet Logical Route Policy for node: %s, error: %w",
 			node.Name, err)
 	}
 
@@ -161,8 +163,10 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 				return err
 			}
 			for _, node := range nodes.Items {
-				if subnet, _ := houtil.ParseHybridOverlayHostSubnet(&node); subnet != nil {
-					hybridCIDRs = append(hybridCIDRs, subnet)
+				if util.NoHostSubnet(&node) {
+					if subnet, _ := houtil.ParseHybridOverlayHostSubnet(&node); subnet != nil {
+						hybridCIDRs = append(hybridCIDRs, subnet)
+					}
 				}
 			}
 		}
@@ -189,9 +193,10 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 
 			if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, &logicalRouterPolicy, func(item *nbdb.LogicalRouterPolicy) bool {
 				return item.Priority == logicalRouterPolicy.Priority &&
-					item.ExternalIDs["name"] == logicalRouterPolicy.ExternalIDs["name"]
+					item.ExternalIDs["name"] == logicalRouterPolicy.ExternalIDs["name"] &&
+					item.Match == matchStr
 			}, &logicalRouterPolicy.Nexthops, &logicalRouterPolicy.Match, &logicalRouterPolicy.Action); err != nil {
-				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
+				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %w", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
 			}
 
 			smb := &nbdb.StaticMACBinding{
@@ -218,7 +223,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 			grLogicalRouterPolicy := nbdb.LogicalRouterPolicy{
 				Priority: ovntypes.HybridOverlaySubnetPriority,
 				ExternalIDs: map[string]string{
-					"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
+					"name": ovntypes.HybridSubnetPrefix + nodeName + ovntypes.HybridOverlayGRSubfix,
 				},
 				Action:   nbdb.LogicalRouterPolicyActionReroute,
 				Nexthops: []string{drIP.String()},
@@ -229,7 +234,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 				return item.Priority == grLogicalRouterPolicy.Priority &&
 					item.ExternalIDs["name"] == grLogicalRouterPolicy.ExternalIDs["name"]
 			}, &grLogicalRouterPolicy.Nexthops, &grLogicalRouterPolicy.Match, &grLogicalRouterPolicy.Action); err != nil {
-				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %v", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
+				return fmt.Errorf("failed to add policy route '%s' for host %q on %s , error: %w", matchStr, nodeName, ovntypes.OVNClusterRouter, err)
 			}
 			klog.Infof("Created hybrid overlay logical route policies for node %s", nodeName)
 
@@ -249,7 +254,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 						item.ExternalIDs["name"] == clusterRouterStaticRoutes.ExternalIDs["name"] &&
 						libovsdbops.PolicyEqualPredicate(clusterRouterStaticRoutes.Policy, item.Policy)
 				}, &clusterRouterStaticRoutes.Nexthop); err != nil {
-				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v",
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %w",
 					clusterRouterStaticRoutes.IPPrefix, clusterRouterStaticRoutes.Nexthop,
 					ovntypes.GWRouterPrefix+nodeName, err)
 			}
@@ -268,7 +273,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 				IPPrefix: hybridCIDR.String(),
 				Nexthop:  drLRPIfAddr.IP.String(),
 				ExternalIDs: map[string]string{
-					"name": ovntypes.HybridSubnetPrefix + nodeName + "-gr",
+					"name": ovntypes.HybridSubnetPrefix + nodeName + ovntypes.HybridOverlayGRSubfix,
 				},
 			}
 			if err := libovsdbops.CreateOrReplaceLogicalRouterStaticRouteWithPredicate(oc.nbClient,
@@ -278,7 +283,7 @@ func (oc *DefaultNetworkController) setupHybridLRPolicySharedGw(nodeSubnets []*n
 						item.ExternalIDs["name"] == nodeGWRouterStaticRoutes.ExternalIDs["name"] &&
 						libovsdbops.PolicyEqualPredicate(nodeGWRouterStaticRoutes.Policy, item.Policy)
 				}, &nodeGWRouterStaticRoutes.Nexthop); err != nil {
-				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %v",
+				return fmt.Errorf("failed to add policy route static '%s %s' for on %s , error: %w",
 					nodeGWRouterStaticRoutes.IPPrefix, nodeGWRouterStaticRoutes.Nexthop,
 					ovntypes.GWRouterPrefix+nodeName, err)
 			}
@@ -293,20 +298,20 @@ func (oc *DefaultNetworkController) removeHybridLRPolicySharedGW(node *kapi.Node
 	name := ovntypes.HybridSubnetPrefix + nodeName
 
 	if err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterPolicy) bool {
-		return item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName || item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName+"-gr"
-	}); err != nil {
-		return fmt.Errorf("failed to delete policy %s from %s, error: %v", name, ovntypes.OVNClusterRouter, err)
+		return item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName || item.ExternalIDs["name"] == ovntypes.HybridSubnetPrefix+nodeName+ovntypes.HybridOverlayGRSubfix
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete policy %s from %s, error: %w", name, ovntypes.OVNClusterRouter, err)
 	}
 
 	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterStaticRoute) bool {
 		return item.ExternalIDs["name"] == name
-	}); err != nil {
-		return fmt.Errorf("failed to delete static route %s from %s, error: %v", name, ovntypes.OVNClusterRouter, err)
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete static route %s from %s, error: %w", name, ovntypes.OVNClusterRouter, err)
 	}
 	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.GWRouterPrefix+nodeName, func(item *nbdb.LogicalRouterStaticRoute) bool {
-		return item.ExternalIDs["name"] == name+"-gr"
-	}); err != nil {
-		return fmt.Errorf("failed to delete static route %s from %s, error: %v", name+"gr", ovntypes.GWRouterPrefix+nodeName, err)
+		return item.ExternalIDs["name"] == name+ovntypes.HybridOverlayGRSubfix
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete static route %s from %s, error: %w", name+"gr", ovntypes.GWRouterPrefix+nodeName, err)
 	}
 
 	if node.Annotations[hotypes.HybridOverlayDRIP] != "" {
@@ -351,5 +356,58 @@ func (oc *DefaultNetworkController) allocateHybridOverlayDRIP(node *kapi.Node) e
 		return fmt.Errorf("cannot set hybrid annotation on node %s: %v", node.Name, err)
 	}
 
+	return nil
+}
+
+func (oc *DefaultNetworkController) removeRoutesToHONodeSubnet(nodeSubnet *net.IPNet) error {
+	klog.Infof("Delete hybrid overlay policy and static routes to %s", nodeSubnet.String())
+
+	// Delete policy to HO subnet from the cluster router
+	if err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterPolicy) bool {
+		return strings.Contains(item.Match, nodeSubnet.String())
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete policy route to %s from %s, error: %w", nodeSubnet, ovntypes.OVNClusterRouter, err)
+	}
+
+	// Delete routes to HO subnet from the cluster router
+	if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.OVNClusterRouter, func(item *nbdb.LogicalRouterStaticRoute) bool {
+		name, ok := item.ExternalIDs["name"]
+		if !ok {
+			return false
+		}
+		if !strings.Contains(name, ovntypes.HybridSubnetPrefix) || strings.Contains(name, ovntypes.HybridOverlayGRSubfix) {
+			return false
+		}
+		return item.IPPrefix == nodeSubnet.String() && item.Policy == nil
+	}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+		return fmt.Errorf("failed to delete static route to %s from %s, error: %w", nodeSubnet, ovntypes.OVNClusterRouter, err)
+	}
+
+	// Delete routes to HO subnet from GRs
+	nodes, err := oc.kube.GetNodes()
+	if err != nil {
+		return err
+	}
+	for _, node := range nodes.Items {
+		// Check existence of Gateway Router before removing the static route from it.
+		if _, err := libovsdbops.GetLogicalRouter(oc.nbClient, &nbdb.LogicalRouter{Name: ovntypes.GWRouterPrefix + node.Name}); err != nil {
+			if err == libovsdbclient.ErrNotFound {
+				continue
+			}
+			return fmt.Errorf("failed to get logical router %s, error: %w", ovntypes.GWRouterPrefix+node.Name, err)
+		}
+		if err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(oc.nbClient, ovntypes.GWRouterPrefix+node.Name, func(item *nbdb.LogicalRouterStaticRoute) bool {
+			name, ok := item.ExternalIDs["name"]
+			if !ok {
+				return false
+			}
+			if name != ovntypes.HybridSubnetPrefix+node.Name+ovntypes.HybridOverlayGRSubfix {
+				return false
+			}
+			return item.IPPrefix == nodeSubnet.String() && item.Policy == nil
+		}); err != nil && !errors.Is(err, libovsdbclient.ErrNotFound) {
+			return fmt.Errorf("failed to delete static route to %s from %s, error: %w", nodeSubnet, ovntypes.GWRouterPrefix+node.Name, err)
+		}
+	}
 	return nil
 }

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -456,6 +456,10 @@ func (oc *DefaultNetworkController) deleteStaleNodeChassis(node *kapi.Node) erro
 			return fmt.Errorf("node %s is now with a new chassis ID. Its stale chassis template vars are still in the NBDB", node.Name)
 		}
 		if err = libovsdbops.DeleteChassisWithPredicate(oc.sbClient, p); err != nil {
+			if err == libovsdbclient.ErrNotFound {
+				klog.Infof("deleteStaleNodeChassis: chassis %s not found", node.Name)
+				return nil
+			}
 			// Send an event and Log on failure
 			oc.recorder.Eventf(node, kapi.EventTypeWarning, "ErrorMismatchChassis",
 				"Node %s is now with a new chassis ID. Its stale chassis entry is still in the SBDB",
@@ -889,14 +893,17 @@ func (oc *DefaultNetworkController) addUpdateRemoteNodeEvent(node *kapi.Node, sy
 func (oc *DefaultNetworkController) deleteNodeEvent(node *kapi.Node) error {
 	klog.V(5).Infof("Deleting Node %q. Removing the node from "+
 		"various caches", node.Name)
-
-	if config.HybridOverlay.Enabled {
-		if util.NoHostSubnet(node) {
-			// noHostSubnet nodes are different, only remove the switch
-			oc.lsManager.DeleteSwitch(node.Name)
-			return nil
+	if config.HybridOverlay.Enabled && util.NoHostSubnet(node) {
+		if err := oc.deleteHoNodeEvent(node); err != nil {
+			return err
 		}
-		if _, ok := node.Annotations[hotypes.HybridOverlayDRMAC]; ok {
+	}
+	return oc.deleteOVNNodeEvent(node)
+}
+
+func (oc *DefaultNetworkController) deleteOVNNodeEvent(node *kapi.Node) error {
+	if config.HybridOverlay.Enabled {
+		if _, ok := node.Annotations[hotypes.HybridOverlayDRMAC]; ok && !util.NoHostSubnet(node) {
 			oc.deleteHybridOverlayPort(node)
 		}
 		if err := oc.removeHybridLRPolicySharedGW(node); err != nil {
@@ -956,4 +963,60 @@ func (oc *DefaultNetworkController) getOVNClusterRouterPortToJoinSwitchIfAddrs()
 	}
 
 	return gwLRPIPs, nil
+}
+
+// addUpdateHoNodeEvent reconsile ovn nodes when a hybrid overlay node is added.
+func (oc *DefaultNetworkController) addUpdateHoNodeEvent(node *kapi.Node) error {
+	if subnets, _ := util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName); len(subnets) > 0 {
+		klog.Infof("Node %q is used to be a OVN-K managed node, deleting it from OVN topology", node.Name)
+		if err := oc.deleteOVNNodeEvent(node); err != nil {
+			return err
+		}
+	}
+
+	err := oc.lsManager.AddNoHostSubnetSwitch(node.Name)
+	if err != nil {
+		return fmt.Errorf("nodeAdd: error adding no hostsubnet for switch %s: %w", node.Name, err)
+	}
+
+	// Parse the hybrid overlay host subnet annotation of the node to
+	// make sure that the subnet is allocated.
+	if _, err := houtil.ParseHybridOverlayHostSubnet(node); err != nil {
+		return err
+	}
+
+	nodes, err := oc.kube.GetNodes()
+	if err != nil {
+		return err
+	}
+	annotator := kube.NewNodeAnnotator(oc.kube, node.Name)
+
+	for _, node := range nodes.Items {
+		// reconcile hybrid overlay subnets for local zone nodes.
+		if !util.NoHostSubnet(&node) && oc.isLocalZoneNode(&node) {
+			if err := oc.handleHybridOverlayPort(&node, annotator); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (oc *DefaultNetworkController) deleteHoNodeEvent(node *kapi.Node) error {
+	if oc.lsManager.IsNonHostSubnetSwitch(node.Name) {
+		klog.Infof("Delete hybrid overlay node switch %s", node.Name)
+		oc.lsManager.DeleteSwitch(node.Name)
+	}
+	if subnet, ok := node.Annotations[hotypes.HybridOverlayNodeSubnet]; ok {
+		// Delete the routes and policies for this HO node
+		_, nodeSubnet, err := net.ParseCIDR(subnet)
+		if err != nil {
+			return fmt.Errorf("failed to parse hybridOverlay node subnet for node %s: %w", node.Name, err)
+		}
+		err = oc.removeRoutesToHONodeSubnet(nodeSubnet)
+		if err != nil {
+			return fmt.Errorf("failed to remove hybrid overlay static routes and route policy: %w", err)
+		}
+	}
+	return nil
 }

--- a/go-controller/pkg/ovn/namespace.go
+++ b/go-controller/pkg/ovn/namespace.go
@@ -326,6 +326,10 @@ func (oc *DefaultNetworkController) getAllHostNamespaceAddresses() []net.IP {
 	} else {
 		ips = make([]net.IP, 0, len(existingNodes))
 		for _, node := range existingNodes {
+			if config.HybridOverlay.Enabled && util.NoHostSubnet(node) {
+				// skip hybrid overlay nodes
+				continue
+			}
 			hostSubnets, err := util.ParseNodeHostSubnetAnnotation(node, types.DefaultNetworkName)
 			if err != nil {
 				klog.Warningf("Error parsing host subnet annotation for node %s (%v)",

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -125,6 +125,12 @@ func (oc *DefaultNetworkController) ensurePod(oldPod, pod *kapi.Pod, addPort boo
 		return nil
 	}
 
+	// skip the pods on no host subnet nodes
+	switchName := pod.Spec.NodeName
+	if oc.lsManager.IsNonHostSubnetSwitch(switchName) {
+		return nil
+	}
+
 	if oc.isPodScheduledinLocalZone(pod) {
 		klog.V(5).Infof("Ensuring zone local for Pod %s/%s in node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
 		return oc.ensureLocalZonePod(oldPod, pod, addPort)
@@ -435,10 +441,6 @@ func shouldUpdateNode(node, oldNode *kapi.Node) (bool, error) {
 
 	if oldNoHostSubnet && newNoHostSubnet {
 		return false, nil
-	} else if oldNoHostSubnet && !newNoHostSubnet {
-		return false, fmt.Errorf("error updating node %s, cannot remove assigned hostsubnet, please delete node and recreate.", node.Name)
-	} else if !oldNoHostSubnet && newNoHostSubnet {
-		return false, fmt.Errorf("error updating node %s, cannot assign a hostsubnet to already created node, please delete node and recreate.", node.Name)
 	}
 
 	return true, nil

--- a/go-controller/pkg/types/const.go
+++ b/go-controller/pkg/types/const.go
@@ -4,9 +4,10 @@ import "time"
 
 const (
 	// Default network name
-	DefaultNetworkName  = "default"
-	K8sPrefix           = "k8s-"
-	HybridOverlayPrefix = "int-"
+	DefaultNetworkName    = "default"
+	K8sPrefix             = "k8s-"
+	HybridOverlayPrefix   = "int-"
+	HybridOverlayGRSubfix = "-gr"
 
 	// K8sMgmtIntfName name to be used as an OVS internal port on the node
 	K8sMgmtIntfName = "ovn-k8s-mp0"


### PR DESCRIPTION

**- What this PR does and why is it needed**
With this patch, when hybrid overlay is enabled, a node can dynamically be switched from a OVN node to a hybrid overlay node or versa vice.

When the node is switched to a ovn node, OVN-K will treat it as adding a new OVN node, and try to remove the HO static routes and policies like a HO node is removed.

When the node is switched to a HO node, OVN-K will treat it as deleting a existing OVN node, and adding a HO node.

**- Special notes for reviewers**
This patch is primary for the SDN live migration use case of OpenShift


**- How to verify it**


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->