### PR TITLE
EIP multi NIC: only match EIP IP family with pod IP family

### DIFF
--- a/go-controller/pkg/node/controllers/egressip/egressip.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip.go
@@ -529,7 +529,7 @@ func (c *Controller) processEIP(eip *eipv1.EgressIP) (*eIPConfig, *podIPConfigLi
 		if util.IsOVNManagedNetwork(parsedNodeEIPConfig, eIPNet.IP) {
 			continue
 		}
-		isV6 := eIPNet.IP.To4() == nil
+		isEIPV6 := utilnet.IsIPv6(eIPNet.IP)
 		found, link, err := findLinkOnSameNetworkAsIP(eIPNet.IP, c.v4, c.v6)
 		if err != nil {
 			return eIPConfig, podIPConfigs, selectedNamespaces, selectedPods, selectedNamespacesPods,
@@ -853,7 +853,7 @@ func (c *Controller) RepairNode() error {
 			if util.IsOVNManagedNetwork(parsedNodeEIPConfig, eIPNet.IP) {
 				continue
 			}
-			isV6 := eIPNet.IP.To4() == nil
+			isEIPV6 := utilnet.IsIPv6(eIPNet.IP)
 			found, link, err := findLinkOnSameNetworkAsIP(eIPNet.IP, c.v4, c.v6)
 			if err != nil {
 				return fmt.Errorf("failed to find a network to host EgressIP %s IP %s: %v", egressIP.Name,

--- a/go-controller/pkg/node/controllers/egressip/egressip_test.go
+++ b/go-controller/pkg/node/controllers/egressip/egressip_test.go
@@ -21,6 +21,7 @@ import (
 	ovniptables "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/iptables"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/node/routemanager"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	utilnet "k8s.io/utils/net"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -461,7 +462,8 @@ var _ = table.XDescribeTable("EgressIP selectors",
 					ips, err := util.DefaultNetworkPodIPs(pod)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					for _, ip := range ips {
-						expectedRules = append(expectedRules, generateIPRule(ip, getLinkIndex(expectedEIPConfig.inf)))
+
+						expectedRules = append(expectedRules, generateIPRule(ip, utilnet.IsIPv6(ip), getLinkIndex(expectedEIPConfig.inf)))
 					}
 				}
 			}


### PR DESCRIPTION
Previous to this change, when we were processing Pod IPs, we didnt check if the pod IP is the same IP family as the EIP.