### PR TITLE
Allocate completed pods on startup

### DIFF
--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -158,6 +158,11 @@ type BaseNetworkController struct {
 	// Interconnect resources are Transit switch and logical ports connecting this transit switch
 	// to the cluster router. Please see zone_interconnect/interconnect_handler.go for more details.
 	zoneICHandler *zoneic.ZoneInterconnectHandler
+
+	// releasedPodsBeforeStartup tracks pods per NAD (map of NADs to pods UIDs)
+	// might have been already be released on startup
+	releasedPodsBeforeStartup  map[string]sets.Set[string]
+	releasedPodsOnStartupMutex sync.Mutex
 }
 
 // BaseSecondaryNetworkController structure holds per-network fields and network specific

--- a/go-controller/pkg/ovn/base_network_controller_pods_test.go
+++ b/go-controller/pkg/ovn/base_network_controller_pods_test.go
@@ -1,0 +1,234 @@
+package ovn
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	ovntest "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/testing"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestBaseNetworkController_trackPodsReleasedBeforeStartup(t *testing.T) {
+	tests := []struct {
+		name           string
+		podAnnotations map[*corev1.Pod]map[string]*util.PodAnnotation
+		expected       map[string]sets.Set[string]
+	}{
+		{
+			name: "a scheduled/running annotated pod should not be considered released",
+			podAnnotations: map[*corev1.Pod]map[string]*util.PodAnnotation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "running",
+					},
+				}: {
+					"default": {
+						IPs: []*net.IPNet{ovntest.MustParseIPNet("192.168.0.1/24")},
+					},
+				},
+			},
+			expected: map[string]sets.Set[string]{},
+		},
+		{
+			name: "a completed annotated pod should not be considered released",
+			podAnnotations: map[*corev1.Pod]map[string]*util.PodAnnotation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "running",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+					},
+				}: {
+					"default": {
+						IPs: []*net.IPNet{ovntest.MustParseIPNet("192.168.0.1/24")},
+					},
+				},
+			},
+			expected: map[string]sets.Set[string]{},
+		},
+		{
+			// consider dual-stack IPs individually but only track at the pod level based
+			// on a couple of assumptions:
+			// - while the same pair of IPs released for a pod will most likely be
+			//   assigned to a different pod, assume that one of those IPs might be
+			//   assigned to a pod and the other IP to a different pod. This is easy to
+			//   handle so better take a safe approach
+			// - assume that there is no error path leading to one of the IPs of the
+			//   pair to be released while the other is not. This is based on the fact
+			//   that both IPs are released in block.
+			name: "a completed pod sharing at least one IP with a running Pod should be considered released",
+			podAnnotations: map[*corev1.Pod]map[string]*util.PodAnnotation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "completed",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+					},
+				}: {
+					"default": {
+						IPs: []*net.IPNet{
+							ovntest.MustParseIPNet("192.168.0.1/24"),
+							ovntest.MustParseIPNet("fd11::1/64"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "running",
+					},
+				}: {
+					"default": {
+						IPs: []*net.IPNet{
+							ovntest.MustParseIPNet("192.168.0.2/24"),
+							ovntest.MustParseIPNet("fd11::1/64"),
+						},
+					},
+				},
+			},
+			expected: map[string]sets.Set[string]{
+				"default": sets.New("completed"),
+			},
+		},
+		{
+			name: "only the last completed pod of multiple completed pods sharing at least one IP should not be considered released",
+			podAnnotations: map[*corev1.Pod]map[string]*util.PodAnnotation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "completed-third",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+						Conditions: []corev1.PodCondition{
+							{
+								Type: corev1.PodInitialized,
+								LastTransitionTime: metav1.Time{
+									Time: time.Time{}.Add(time.Second * 2),
+								},
+							},
+						},
+					},
+				}: {
+					"default": {
+						IPs: []*net.IPNet{
+							ovntest.MustParseIPNet("192.168.0.1/24"),
+							ovntest.MustParseIPNet("fd11::1/64"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "completed-first",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+						Conditions: []corev1.PodCondition{
+							{
+								Type: corev1.PodInitialized,
+								LastTransitionTime: metav1.Time{
+									Time: time.Time{},
+								},
+							},
+						},
+					},
+				}: {
+					"default": {
+						IPs: []*net.IPNet{
+							ovntest.MustParseIPNet("192.168.0.1/24"),
+							ovntest.MustParseIPNet("fd11::2/64"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "completed-second",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+						Conditions: []corev1.PodCondition{
+							{
+								Type: corev1.PodInitialized,
+								LastTransitionTime: metav1.Time{
+									Time: time.Time{}.Add(time.Second),
+								},
+							},
+						},
+					},
+				}: {
+					"default": {
+						IPs: []*net.IPNet{
+							ovntest.MustParseIPNet("192.168.0.2/24"),
+							ovntest.MustParseIPNet("fd11::1/64"),
+						},
+					},
+				},
+			},
+			expected: map[string]sets.Set[string]{
+				"default": sets.New("completed-first", "completed-second"),
+			},
+		},
+		{
+			name: "a completed pod sharing at least one IP from nad1 with a running Pod on nad2 should be considered released on nad1",
+			podAnnotations: map[*corev1.Pod]map[string]*util.PodAnnotation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "completed",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+					},
+				}: {
+					"nad1": {
+						IPs: []*net.IPNet{
+							ovntest.MustParseIPNet("192.168.0.1/24"),
+							ovntest.MustParseIPNet("fd11::1/64"),
+						},
+					},
+					"nad2": {
+						IPs: []*net.IPNet{
+							ovntest.MustParseIPNet("192.168.0.2/24"),
+							ovntest.MustParseIPNet("fd11::2/64"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "running",
+					},
+				}: {
+					"nad1": {
+						IPs: []*net.IPNet{
+							ovntest.MustParseIPNet("192.168.0.3/24"),
+							ovntest.MustParseIPNet("fd11::3/64"),
+						},
+					},
+					"nad2": {
+						IPs: []*net.IPNet{
+							ovntest.MustParseIPNet("192.168.0.4/24"),
+							ovntest.MustParseIPNet("fd11::1/64"),
+						},
+					},
+				},
+			},
+			expected: map[string]sets.Set[string]{
+				"nad1": sets.New("completed"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			bnc := &BaseNetworkController{}
+
+			bnc.trackPodsReleasedBeforeStartup(tt.podAnnotations)
+
+			g.Expect(bnc.releasedPodsBeforeStartup).To(gomega.Equal(tt.expected))
+		})
+	}
+}

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -230,7 +230,13 @@ func (oc *DefaultNetworkController) removePod(pod *kapi.Pod, portInfo *lpInfo) e
 		}
 	}
 
-	return kubevirt.CleanUpLiveMigratablePod(oc.nbClient, oc.watchFactory, pod)
+	err := kubevirt.CleanUpLiveMigratablePod(oc.nbClient, oc.watchFactory, pod)
+	if err != nil {
+		return err
+	}
+
+	oc.forgetPodReleasedBeforeStartup(string(pod.UID), ovntypes.DefaultNetworkName)
+	return nil
 }
 
 // removeLocalZonePod tries to tear down a local zone pod. It returns nil on success and error on failure;

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -23,6 +23,7 @@ import (
 
 func (oc *DefaultNetworkController) syncPods(pods []interface{}) error {
 	annotatedLocalPods := map[*kapi.Pod]map[string]*util.PodAnnotation{}
+	var allHostSubnets []*net.IPNet
 
 	// get the list of logical switch ports (equivalent to pods). Reserve all existing Pod IPs to
 	// avoid subsequent new Pods getting the same duplicate Pod IP.
@@ -54,6 +55,26 @@ func (oc *DefaultNetworkController) syncPods(pods []interface{}) error {
 		}
 
 		if annotations == nil {
+			continue
+		}
+
+		// We track which pods are allocated on startup to check which might
+		// have already been released. We track local non-migratable pods and
+		// live migratable pods that have an IP allocation from a local subnet
+		// (assigned to a node belonging to this zone) or from an unassigned
+		// subnet (previously assigned to a node that has been since removed)
+		var zoneContainsPodSubnetOrUntracked bool
+		if kubevirt.IsPodLiveMigratable(pod) {
+			allHostSubnets, zoneContainsPodSubnetOrUntracked, err = kubevirt.ZoneContainsPodSubnetOrUntracked(
+				oc.watchFactory,
+				oc.lsManager,
+				allHostSubnets,
+				annotations)
+			if err != nil {
+				return err
+			}
+		}
+		if kubevirt.IsPodLiveMigratable(pod) && !zoneContainsPodSubnetOrUntracked {
 			continue
 		}
 		annotatedLocalPods[pod] = map[string]*util.PodAnnotation{ovntypes.DefaultNetworkName: annotations}

--- a/go-controller/pkg/util/subnet_annotations.go
+++ b/go-controller/pkg/util/subnet_annotations.go
@@ -195,3 +195,17 @@ func GetNodeSubnetAnnotationNetworkNames(node *kapi.Node) ([]string, error) {
 
 	return nodeNetworks, nil
 }
+
+// ParseNodesHostSubnetAnnotation parses parses the "k8s.ovn.org/node-subnets" annotation
+// for all the provided nodes
+func ParseNodesHostSubnetAnnotation(nodes []*kapi.Node, netName string) ([]*net.IPNet, error) {
+	allSubnets := []*net.IPNet{}
+	for _, node := range nodes {
+		subnets, err := ParseNodeHostSubnetAnnotation(node, netName)
+		if err != nil {
+			return nil, err
+		}
+		allSubnets = append(allSubnets, subnets...)
+	}
+	return allSubnets, nil
+}


### PR DESCRIPTION
There is a race condition on startup when a scheduled pod is allocated
an IP that is also annotated on a completed pod by which the delete flow
of the completed pod will check if any other pods are using that IP just
before the scheduled pod is annotated, missing that and thus
de-allocating the IP, leading to the possibility of a third pod being
allocated that same IP and ending up with duplicate IPs for two different
pods.

By allocating the IPs of completed pods on startup, we prevent other
scheduled pods from being allocated the same IPs.

However, on startup, multiple pods might be annotated with the same IP as long as
just one of them is running. Thus, we cannot release the IPs for the
completed ones as that would de-allocate the IP which the running pod is
using.

To avoid that, track which pods are annotated with the same IPs on
startup and make sure that those IPs are only released with the
appropriate pods, that is, with a running pod or with the last completed
pod if there is no running pod sharing that IP. Do this tracking per
NAD to cover the corner case where a pod might be released for one NAD
but not others in error cases.

A live migrated pod might have an IP annotated from a subnet assigned 
to a different node than the one is running on or even to a node that has
since been deleted and not re-assigned to another node. We also need to
track the IPs of these pods in case they are shared among completed pods
or running pods to make sure they are released for the correct pod.

