### PR TITLE
Setting custom n-handler-threads is not supported in per-cpu mode

### DIFF
--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -665,6 +665,11 @@ ovs-server() {
   /usr/share/openvswitch/scripts/ovs-ctl start --no-ovs-vswitchd \
     --system-id=random ${ovs_options} ${USER_ARGS} "$@"
 
+  # Reduce stack size to 2M from default 8M as per below commit on Openvswitch
+  # https://github.com/openvswitch/ovs/commit/b82a90e266e1246fe2973db97c95df22558174ea
+  # added while troubleshooting on https://bugzilla.redhat.com/show_bug.cgi?id=1572797
+  ulimit -s 2048
+
   /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server \
     --system-id=random ${ovs_options} ${USER_ARGS} "$@"
 

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -665,14 +665,6 @@ ovs-server() {
   /usr/share/openvswitch/scripts/ovs-ctl start --no-ovs-vswitchd \
     --system-id=random ${ovs_options} ${USER_ARGS} "$@"
 
-  # Restrict the number of pthreads ovs-vswitchd creates to reduce the
-  # amount of RSS it uses on hosts with many cores
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1571379
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1572797
-  if [[ $(nproc) -gt 12 ]]; then
-    ovs-vsctl --no-wait set Open_vSwitch . other_config:n-revalidator-threads=4
-    ovs-vsctl --no-wait set Open_vSwitch . other_config:n-handler-threads=10
-  fi
   /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server \
     --system-id=random ${ovs_options} ${USER_ARGS} "$@"
 

--- a/dist/images/ovnkube.sh
+++ b/dist/images/ovnkube.sh
@@ -668,6 +668,10 @@ ovs-server() {
   /usr/share/openvswitch/scripts/ovs-ctl start --no-ovsdb-server \
     --system-id=random ${ovs_options} ${USER_ARGS} "$@"
 
+  if [[ $(nproc) -gt 32 ]]; then
+    echo "Warning: Higher memory allocation by ovs-vswitchd is expected due to high number of n-handler-threads and n-revalidator-threads"
+  fi
+
   tail --follow=name ${OVS_LOGDIR}/ovs-vswitchd.log ${OVS_LOGDIR}/ovsdb-server.log &
   ovs_tail_pid=$!
   sleep 10

--- a/dist/templates/ovs-node.yaml.j2
+++ b/dist/templates/ovs-node.yaml.j2
@@ -86,8 +86,8 @@ spec:
             cpu: 100m
             memory: 300Mi
           limits:
-            cpu: 200m
-            memory: 400Mi
+            cpu: 500m
+            memory: 500Mi
         env:
         - name: OVN_DAEMONSET_VERSION
           value: "3"


### PR DESCRIPTION
**- What this PR does and why is it needed**

Function[1] sets n_handler to maximum number of CPUs available on the node and in turn overrides n-handler-threads while setting[2] up threads. So, right now there is no point in setting n-handler-threads to 10 when number of CPUs are more than 12. Limiting n-revalidator-threads to 4 also not at per with the best practices in per-cpu mode.
[1] - https://github.com/openvswitch/ovs/blob/master/lib/dpif-netlink.c#L2570-L2591
[2] - https://github.com/openvswitch/ovs/blob/master/ofproto/ofproto-dpif-upcall.c#L650


**- Special notes for reviewers**

Currently n-revalidator-threads can be limited by setting n-revalidator-threads other_config but that is not suitable in per-cpu mode and its best to create default(n-handler-threads/4+1) number of threads for revalidator.
closes #3842



**- How to verify it**
Check ovs-vswitchd log


**- Description for the changelog**
- Removing code block to disable setting custom n-handler-threads and n-revalidator-threads when number of CPUs are more than 12.
- Adding a warning message to notify high memory allocation due to creation of high number of threads in a node with high number of CPUs.
- Increasing CPU and memory limit of ovs-node daemonset to prevent OOM caused by high memory allocation per threads.
- Limiting stack size to 2M as per below commit on Openvswitch
  https://github.com/openvswitch/ovs/commit/b82a90e266e1246fe2973db97c95df22558174ea