### PR TITLE
Fix node ip migration encap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -395,6 +395,7 @@ jobs:
           - {"target": "control-plane",     "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "noSnatGW", "second-bridge": "2br", "ic": "ic-single-node-zones"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "node-ip-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv6",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
+          - {"target": "node-ip-migration", "ha": "noHA", "gateway-mode": "shared", "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "compact-mode",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "snatGW",   "second-bridge": "1br", "ic": "ic-disabled"}
           - {"target": "multi-homing",      "ha": "noHA", "gateway-mode": "local",  "ipfamily": "dualstack", "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-single-node-zones"}
           - {"target": "multi-node-zones",  "ha": "noHA", "gateway-mode": "local",  "ipfamily": "ipv4",      "disable-snat-multiple-gws": "SnatGW",   "second-bridge": "1br", "ic": "ic-multi-node-zones", "num-workers": "3", "num-nodes-per-zone": "2"}

--- a/go-controller/pkg/libovsdb/libovsdb.go
+++ b/go-controller/pkg/libovsdb/libovsdb.go
@@ -136,6 +136,10 @@ func NewSBClientWithConfig(cfg config.OvnAuthConfig, promRegistry prometheus.Reg
 	enableMetricsOption := client.WithMetricsRegistryNamespaceSubsystem(promRegistry,
 		"ovnkube", "master_libovsdb")
 
+	dbModel.SetIndexes(map[string][]model.ClientIndex{
+		sbdb.EncapTable: {{Columns: []model.ColumnKey{{Column: "chassis_name"}}}},
+	})
+
 	c, err := newClient(cfg, dbModel, stopCh, enableMetricsOption)
 	if err != nil {
 		return nil, err

--- a/go-controller/pkg/libovsdb/ops/model.go
+++ b/go-controller/pkg/libovsdb/ops/model.go
@@ -245,9 +245,10 @@ func copyIndexes(model model.Model) model.Model {
 		}
 	case *sbdb.Encap:
 		return &sbdb.Encap{
-			UUID: t.UUID,
-			Type: t.Type,
-			IP:   t.IP,
+			UUID:        t.UUID,
+			Type:        t.Type,
+			IP:          t.IP,
+			ChassisName: t.ChassisName,
 		}
 	case *sbdb.PortBinding:
 		return &sbdb.PortBinding{

--- a/go-controller/pkg/libovsdb/ops/model_client.go
+++ b/go-controller/pkg/libovsdb/ops/model_client.go
@@ -140,12 +140,14 @@ operationModel is a struct which uses reflection to determine and perform
 idempotent operations against OVS DB (NB DB by default).
 */
 type operationModel struct {
-	// Model specifies the model to be created, or to look up in the cache
-	// if ModelPredicate is not specified. The values in the fields of the
-	// Model are used for mutations and updates as well. If this Model is
-	// looked up or created, it will have its UUID set after the operation.
+	// Model specifies the model to be created, or to look up in the cache.
+	// The values in the fields of the Model are used for mutations and updates
+	// as well. If this Model is looked up or created, it will have its UUID set
+	// after the operation.
 	Model interface{}
 	// ModelPredicate specifies a predicate to look up models in the cache.
+	// If Model is provided with non-zero index column values, ModelPredicate
+	// will be ignored.
 	ModelPredicate interface{}
 	// ExistingResult is where the results of the look up are added to.
 	// Required when Model is not specified.

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -893,7 +893,7 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 					nodeGatewayMTUSupportChanged(oldNode, newNode))
 				_, hoSync := h.oc.hybridOverlayFailed.Load(newNode.Name)
 				_, syncZoneIC := h.oc.syncZoneICFailed.Load(newNode.Name)
-				syncZoneIC = syncZoneIC || zoneClusterChanged
+				syncZoneIC = syncZoneIC || zoneClusterChanged || primaryAddrChanged(oldNode, newNode)
 				_, failed = h.oc.syncMigratablePodsFailed.Load(newNode.Name)
 				syncMigratablePods := failed || nodeSubnetChanged
 				nodeSyncsParam = &nodeSyncs{
@@ -917,7 +917,7 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 
 			// Check if the node moved from local zone to remote zone and if so syncZoneIC should be set to true.
 			// Also check if node subnet changed, so static routes are properly set
-			syncZoneIC = syncZoneIC || h.oc.isLocalZoneNode(oldNode) || nodeSubnetChanged || zoneClusterChanged
+			syncZoneIC = syncZoneIC || h.oc.isLocalZoneNode(oldNode) || nodeSubnetChanged || zoneClusterChanged || primaryAddrChanged(oldNode, newNode)
 			if syncZoneIC {
 				klog.Infof("Node %s in remote zone %s needs interconnect zone sync up. Zone cluster changed: %v",
 					newNode.Name, util.GetNodeZone(newNode), zoneClusterChanged)

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -394,6 +394,12 @@ func nodeSubnetChanged(oldNode, node *kapi.Node) bool {
 	return !reflect.DeepEqual(oldSubnets, newSubnets)
 }
 
+func primaryAddrChanged(oldNode, newNode *kapi.Node) bool {
+	oldIP, _ := util.GetNodePrimaryIP(oldNode)
+	newIP, _ := util.GetNodePrimaryIP(newNode)
+	return oldIP != newIP
+}
+
 func nodeChassisChanged(oldNode, node *kapi.Node) bool {
 	oldChassis, _ := util.ParseNodeChassisIDAnnotation(oldNode)
 	newChassis, _ := util.ParseNodeChassisIDAnnotation(node)


### PR DESCRIPTION
Fixes node ip migration with IC. Now on primary IP change, IC will call add local/remote zone node, which will properly update the encap for the chassis. Also re-enables node ip migration CI with IC. 1 additional commit to fix some things found along the way.

Closes #3636