### PR TITLE
kubevirt: Reserve migrated IPs at add node

### DIFF
--- a/go-controller/pkg/allocator/ip/subnet/allocator.go
+++ b/go-controller/pkg/allocator/ip/subnet/allocator.go
@@ -112,7 +112,6 @@ func (allocator *allocator) AddOrUpdateSubnet(name string, subnets []*net.IPNet,
 			return fmt.Errorf("failed to exclude subnet %s for %s: not contained in any of the subnets", excludeSubnet, name)
 		}
 	}
-
 	return nil
 }
 

--- a/go-controller/pkg/kubevirt/pod.go
+++ b/go-controller/pkg/kubevirt/pod.go
@@ -285,18 +285,3 @@ func AllocateSyncMigratablePodIPsOnZone(watchFactory *factory.WatchFactory, lsMa
 	// We care about the whole zone so we pass the nodeName empty
 	return allocateSyncMigratablePodIPs(watchFactory, lsManager, nadName, "", pod, allocatePodIPsOnSwitch)
 }
-
-// AllocateSyncMigratablePodIPsOnNode will refill ip pool in
-// case the node has take over the vm subnet for live migrated vms
-func AllocateSyncMigratablePodsIPsOnNode(watchFactory *factory.WatchFactory, lsManager *logicalswitchmanager.LogicalSwitchManager, nodeName, nadName string, allocatePodIPsOnSwitch func(*corev1.Pod, *util.PodAnnotation, string, string) (string, error)) error {
-	liveMigratablePods, err := FindLiveMigratablePods(watchFactory)
-	if err != nil {
-		return err
-	}
-	for _, liveMigratablePod := range liveMigratablePods {
-		if _, _, _, err := allocateSyncMigratablePodIPs(watchFactory, lsManager, nodeName, nadName, liveMigratablePod, allocatePodIPsOnSwitch); err != nil {
-			return err
-		}
-	}
-	return nil
-}

--- a/go-controller/pkg/kubevirt/router.go
+++ b/go-controller/pkg/kubevirt/router.go
@@ -75,7 +75,7 @@ func EnsureLocalZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory, 
 	}
 	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadName)
 	if err != nil {
-		return fmt.Errorf("failed reading ovn annotation: %v", err)
+		return fmt.Errorf("failed reading ovn annotation at local zone: %v", err)
 	}
 
 	nodeOwningSubnet, _ := ZoneContainsPodSubnet(lsManager, podAnnotation)
@@ -180,7 +180,7 @@ func EnsureRemoteZonePodAddressesToNodeRoute(controllerName string, watchFactory
 
 	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadName)
 	if err != nil {
-		return fmt.Errorf("failed reading ovn annotation: %v", err)
+		return fmt.Errorf("failed reading ovn annotation at remote zone: %v", err)
 	}
 
 	vmRunningAtNodeOwningSubnet, err := nodeContainsPodSubnet(watchFactory, pod.Spec.NodeName, podAnnotation, nadName)

--- a/go-controller/pkg/kubevirt/router.go
+++ b/go-controller/pkg/kubevirt/router.go
@@ -75,7 +75,7 @@ func EnsureLocalZonePodAddressesToNodeRoute(watchFactory *factory.WatchFactory, 
 	}
 	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadName)
 	if err != nil {
-		return fmt.Errorf("failed reading ovn annotation at local zone: %v", err)
+		return fmt.Errorf("failed reading local pod annotation: %v", err)
 	}
 
 	nodeOwningSubnet, _ := ZoneContainsPodSubnet(lsManager, podAnnotation)
@@ -180,7 +180,7 @@ func EnsureRemoteZonePodAddressesToNodeRoute(controllerName string, watchFactory
 
 	podAnnotation, err := util.UnmarshalPodAnnotation(pod.Annotations, nadName)
 	if err != nil {
-		return fmt.Errorf("failed reading ovn annotation at remote zone: %v", err)
+		return fmt.Errorf("failed reading remote pod annotation: %v", err)
 	}
 
 	vmRunningAtNodeOwningSubnet, err := nodeContainsPodSubnet(watchFactory, pod.Spec.NodeName, podAnnotation, nadName)
@@ -230,7 +230,7 @@ func EnsureRemoteZonePodAddressesToNodeRoute(controllerName string, watchFactory
 			matches := item.IPPrefix == route.IPPrefix && item.Nexthop == route.Nexthop && item.Policy != nil && *item.Policy == *route.Policy
 			return matches
 		}); err != nil {
-			return fmt.Errorf("failed adding static route at remote zone: %v", err)
+			return fmt.Errorf("failed adding static route to remote pod: %v", err)
 		}
 	}
 	return nil

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -407,7 +407,6 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 			return err
 		}
 	}
-
 	// Add the switch to the logical switch cache
 	return bnc.lsManager.AddOrUpdateSwitch(logicalSwitch.Name, hostSubnets)
 }

--- a/go-controller/pkg/ovn/base_network_controller.go
+++ b/go-controller/pkg/ovn/base_network_controller.go
@@ -33,6 +33,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -404,11 +405,16 @@ func (bnc *BaseNetworkController) createNodeLogicalSwitch(nodeName string, hostS
 		err = libovsdbops.AddPortsToPortGroup(bnc.nbClient, bnc.getClusterPortGroupName(types.ClusterRtrPortGroupNameBase), logicalSwitchPort.UUID)
 		if err != nil {
 			klog.Errorf(err.Error())
-			return err
+			return fmt.Errorf("failed adding port to portgroup for multicast: %v", err)
 		}
 	}
 	// Add the switch to the logical switch cache
-	return bnc.lsManager.AddOrUpdateSwitch(logicalSwitch.Name, hostSubnets)
+	migratableIPsByPod, err := bnc.findMigratablePodIPsForSubnets(hostSubnets)
+	if err != nil {
+		return fmt.Errorf("failed finding migratable pod IPs belonging to %s: %v", nodeName, err)
+	}
+
+	return bnc.lsManager.AddOrUpdateSwitch(logicalSwitch.Name, hostSubnets, migratableIPsByPod...)
 }
 
 // UpdateNodeAnnotationWithRetry update node's annotation with the given node annotations.
@@ -806,4 +812,44 @@ func (bnc *BaseNetworkController) nodeZoneClusterChanged(oldNode, newNode *kapi.
 	}
 
 	return false
+}
+
+func (bnc *BaseNetworkController) findMigratablePodIPsForSubnets(subnets []*net.IPNet) ([]*net.IPNet, error) {
+	ipSet := sets.New[string]()
+	ipList := []*net.IPNet{}
+	liveMigratablePods, err := kubevirt.FindLiveMigratablePods(bnc.watchFactory)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, liveMigratablePod := range liveMigratablePods {
+		if util.PodCompleted(liveMigratablePod) {
+			continue
+		}
+		isMigratedSourcePodStale, err := kubevirt.IsMigratedSourcePodStale(bnc.watchFactory, liveMigratablePod)
+		if err != nil {
+			return nil, err
+		}
+		if isMigratedSourcePodStale {
+			continue
+		}
+		podAnnotation, err := util.UnmarshalPodAnnotation(liveMigratablePod.Annotations, bnc.GetNetworkName())
+		if err != nil {
+			return nil, err
+		}
+		for _, podIP := range podAnnotation.IPs {
+			if util.IsContainedInAnyCIDR(podIP, subnets...) {
+				podIPString := podIP.String()
+				// Skip duplicate IPs
+				if !ipSet.Has(podIPString) {
+					ipSet = ipSet.Insert(podIPString)
+					ipList = append(ipList, &net.IPNet{
+						IP:   podIP.IP,
+						Mask: util.GetIPFullMask(podIP.IP),
+					})
+				}
+			}
+		}
+	}
+	return ipList, nil
 }

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -121,7 +121,6 @@ type DefaultNetworkController struct {
 	nodeClusterRouterPortFailed sync.Map
 	hybridOverlayFailed         sync.Map
 	syncZoneICFailed            sync.Map
-	syncMigratablePodsFailed    sync.Map
 
 	// variable to determine if all pods present on the node during startup have been processed
 	// updated atomically
@@ -745,19 +744,15 @@ func (h *defaultNetworkControllerEventHandler) AddResource(obj interface{}, from
 				_, gwSync := h.oc.gatewaysFailed.Load(node.Name)
 				_, hoSync := h.oc.hybridOverlayFailed.Load(node.Name)
 				_, zoneICSync := h.oc.syncZoneICFailed.Load(node.Name)
-				_, syncMigratablePods := h.oc.syncMigratablePodsFailed.Load(node.Name)
 				nodeParams = &nodeSyncs{
 					nodeSync,
 					clusterRtrSync,
 					mgmtSync,
 					gwSync,
 					hoSync,
-					zoneICSync,
-					syncMigratablePods}
+					zoneICSync}
 			} else {
-				nodeHostSubnets, _ := util.ParseNodeHostSubnetAnnotation(node, ovntypes.DefaultNetworkName)
-				syncMigratablePods := nodeHostSubnets != nil
-				nodeParams = &nodeSyncs{true, true, true, true, config.HybridOverlay.Enabled, config.OVNKubernetesFeature.EnableInterconnect, syncMigratablePods}
+				nodeParams = &nodeSyncs{true, true, true, true, config.HybridOverlay.Enabled, config.OVNKubernetesFeature.EnableInterconnect}
 			}
 
 			if err = h.oc.addUpdateLocalNodeEvent(node, nodeParams); err != nil {
@@ -901,21 +896,18 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 				_, hoSync := h.oc.hybridOverlayFailed.Load(newNode.Name)
 				_, syncZoneIC := h.oc.syncZoneICFailed.Load(newNode.Name)
 				syncZoneIC = syncZoneIC || zoneClusterChanged || primaryAddrChanged(oldNode, newNode)
-				_, failed = h.oc.syncMigratablePodsFailed.Load(newNode.Name)
-				syncMigratablePods := failed || nodeSubnetChanged
 				nodeSyncsParam = &nodeSyncs{
 					nodeSync,
 					clusterRtrSync,
 					mgmtSync,
 					gwSync,
 					hoSync,
-					syncZoneIC,
-					syncMigratablePods}
+					syncZoneIC}
 			} else {
 				klog.Infof("Node %s moved from the remote zone %s to local zone.",
 					newNode.Name, util.GetNodeZone(oldNode), util.GetNodeZone(newNode))
 				// The node is now a local zone node.  Trigger a full node sync.
-				nodeSyncsParam = &nodeSyncs{true, true, true, true, true, config.OVNKubernetesFeature.EnableInterconnect, true}
+				nodeSyncsParam = &nodeSyncs{true, true, true, true, true, config.OVNKubernetesFeature.EnableInterconnect}
 			}
 
 			return h.oc.addUpdateLocalNodeEvent(newNode, nodeSyncsParam)


### PR DESCRIPTION
**- What this PR does and why is it needed**
closes https://issues.redhat.com/browse/OCPBUGS-19445


**- Special notes for reviewers**
When the migrated IPs node has being removed and a new node owning the
subnet is added a new pod can be created before the migrated IPs are
stored at ip pool at sync so a duplicate IP can happend. This change
reserve the migrated IPs atomically during subnet registration at ip
pool so new pods will be assigned with different IPs.


**- How to verify it**
Unit test included.

**- Description for the changelog**
Reserver migrated atomically IPs at add node to prevent IP duplication
