### PR TITLE
Allow ovnkube-node to set util.OvnNodeManagementPort

### DIFF
--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -29,6 +29,7 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OvnNodeL3GatewayConfig:          nil,
 	util.OvnNodeManagementPortMacAddress: nil,
 	util.OvnNodeIfAddr:                   nil,
+	util.OvnNodeGatewayMtuSupport:        nil,
 	util.OvnNodeChassisID: func(v annotationChange, nodeName string) error {
 		if v.action == removed {
 			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)

--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -30,6 +30,7 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OvnNodeManagementPortMacAddress: nil,
 	util.OvnNodeIfAddr:                   nil,
 	util.OvnNodeGatewayMtuSupport:        nil,
+	util.OvnNodeManagementPort:           nil,
 	util.OvnNodeChassisID: func(v annotationChange, nodeName string) error {
 		if v.action == removed {
 			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)

--- a/go-controller/pkg/ovnwebhook/nodeadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission_test.go
@@ -251,6 +251,44 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "ovnkube-node can set util.OvnNodeManagementPort",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: userName,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OvnNodeManagementPort: `{"PfId":1,"FuncId":1}`},
+				},
+			},
+		},
+		{
+			name: "ovnkube-node can set util.OvnNodeGatewayMtuSupport",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: userName,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OvnNodeGatewayMtuSupport: "false"},
+				},
+			},
+		},
+		{
 			name: "ovnkube-node can add util.OvnNodeZoneName with <nodeName> value",
 			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
 				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -56,8 +56,8 @@ const (
 	// OvnDefaultNetworkGateway captures L3 gateway config for default OVN network interface
 	ovnDefaultNetworkGateway = "default"
 
-	// ovnNodeManagementPort is the constant string representing the annotation key
-	ovnNodeManagementPort = "k8s.ovn.org/node-mgmt-port"
+	// OvnNodeManagementPort is the constant string representing the annotation key
+	OvnNodeManagementPort = "k8s.ovn.org/node-mgmt-port"
 
 	// OvnNodeManagementPortMacAddress is the constant string representing the annotation key
 	OvnNodeManagementPortMacAddress = "k8s.ovn.org/node-mgmt-port-mac-address"
@@ -371,14 +371,14 @@ func SetNodeManagementPortAnnotation(nodeAnnotator kube.Annotator, PfId int, Fun
 	if err != nil {
 		return fmt.Errorf("failed to marshal mgmtPortDetails with PfId '%v', FuncId '%v'", PfId, FuncId)
 	}
-	return nodeAnnotator.Set(ovnNodeManagementPort, string(bytes))
+	return nodeAnnotator.Set(OvnNodeManagementPort, string(bytes))
 }
 
-// ParseNodeManagementPort returns the parsed host addresses living on a node
+// ParseNodeManagementPortAnnotation returns the parsed host addresses living on a node
 func ParseNodeManagementPortAnnotation(node *kapi.Node) (int, int, error) {
-	mgmtPortAnnotation, ok := node.Annotations[ovnNodeManagementPort]
+	mgmtPortAnnotation, ok := node.Annotations[OvnNodeManagementPort]
 	if !ok {
-		return -1, -1, newAnnotationNotSetError("%s annotation not found for node %q", ovnNodeManagementPort, node.Name)
+		return -1, -1, newAnnotationNotSetError("%s annotation not found for node %q", OvnNodeManagementPort, node.Name)
 	}
 
 	cfg := ManagementPortDetails{}

--- a/go-controller/pkg/util/node_annotations.go
+++ b/go-controller/pkg/util/node_annotations.go
@@ -50,8 +50,8 @@ const (
 	// OvnNodeL3GatewayConfig is the constant string representing the l3 gateway annotation key
 	OvnNodeL3GatewayConfig = "k8s.ovn.org/l3-gateway-config"
 
-	// ovnNodeGatewayMtuSupport determines if option:gateway_mtu shall be set for GR router ports.
-	ovnNodeGatewayMtuSupport = "k8s.ovn.org/gateway-mtu-support"
+	// OvnNodeGatewayMtuSupport determines if option:gateway_mtu shall be set for GR router ports.
+	OvnNodeGatewayMtuSupport = "k8s.ovn.org/gateway-mtu-support"
 
 	// OvnDefaultNetworkGateway captures L3 gateway config for default OVN network interface
 	ovnDefaultNetworkGateway = "default"
@@ -301,16 +301,16 @@ func SetL3GatewayConfig(nodeAnnotator kube.Annotator, cfg *L3GatewayConfig) erro
 // this node.
 func SetGatewayMTUSupport(nodeAnnotator kube.Annotator, set bool) error {
 	if set {
-		nodeAnnotator.Delete(ovnNodeGatewayMtuSupport)
+		nodeAnnotator.Delete(OvnNodeGatewayMtuSupport)
 		return nil
 	}
-	return nodeAnnotator.Set(ovnNodeGatewayMtuSupport, "false")
+	return nodeAnnotator.Set(OvnNodeGatewayMtuSupport, "false")
 }
 
 // ParseNodeGatewayMTUSupport parses annotation "k8s.ovn.org/gateway-mtu-support". The default behavior should be true,
 // therefore only an explicit string of "false" will make this function return false.
 func ParseNodeGatewayMTUSupport(node *kapi.Node) bool {
-	return node.Annotations[ovnNodeGatewayMtuSupport] != "false"
+	return node.Annotations[OvnNodeGatewayMtuSupport] != "false"
 }
 
 // ParseNodeL3GatewayAnnotation returns the parsed l3-gateway-config annotation


### PR DESCRIPTION
Allow ovnkube-node to set util.OvnNodeManagementPort.
Based on https://github.com/ovn-org/ovn-kubernetes/pull/3927.

/cc @wizhaoredhat @tssurya @jcaamano 