### PR TITLE
Remove `google-cloud-sdk` from purge pkg list and match purge list of job `e2e-upgrade`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -426,7 +426,13 @@ jobs:
     steps:
 
     - name: Free up disk space
-      run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
+      run: |
+        sudo eatmydata apt-get purge --auto-remove -y \
+          azure-cli aspnetcore-* dotnet-* ghc-* firefox \
+          google-chrome-stable google-cloud-sdk \
+          llvm-* microsoft-edge-stable mono-* \
+          msbuild mysql-server-core-* php-* php7* \
+          powershell temurin-* zulu-*
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,7 +279,7 @@ jobs:
       run: |
         sudo eatmydata apt-get purge --auto-remove -y \
           azure-cli aspnetcore-* dotnet-* ghc-* firefox \
-          google-chrome-stable google-cloud-sdk \
+          google-chrome-stable \
           llvm-* microsoft-edge-stable mono-* \
           msbuild mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*
@@ -429,7 +429,7 @@ jobs:
       run: |
         sudo eatmydata apt-get purge --auto-remove -y \
           azure-cli aspnetcore-* dotnet-* ghc-* firefox \
-          google-chrome-stable google-cloud-sdk \
+          google-chrome-stable \
           llvm-* microsoft-edge-stable mono-* \
           msbuild mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -126,7 +126,7 @@ jobs:
       run: |
         sudo eatmydata apt-get purge --auto-remove -y \
           azure-cli aspnetcore-* dotnet-* ghc-* firefox \
-          google-chrome-stable google-cloud-sdk \
+          google-chrome-stable \
           llvm-* microsoft-edge-stable mono-* \
           msbuild mysql-server-core-* php-* php7* \
           powershell temurin-* zulu-*

--- a/.github/workflows/test_periodic.yml
+++ b/.github/workflows/test_periodic.yml
@@ -122,6 +122,15 @@ jobs:
         echo "GOPATH=$GOPATH" >> $GITHUB_ENV
         echo "$GOPATH/bin" >> $GITHUB_PATH
 
+    - name: Free up disk space
+      run: |
+        sudo eatmydata apt-get purge --auto-remove -y \
+          azure-cli aspnetcore-* dotnet-* ghc-* firefox \
+          google-chrome-stable google-cloud-sdk \
+          llvm-* microsoft-edge-stable mono-* \
+          msbuild mysql-server-core-* php-* php7* \
+          powershell temurin-* zulu-*
+
     - name: Install KIND
       run: |
         sudo curl -Lo /usr/local/bin/kind https://github.com/aojea/kind/releases/download/dualstack/kind


### PR DESCRIPTION
Match the pkg purge list seen in the `e2e-upgade` job also in jobs `e2e` and `e2e-periodic`

Also, testing to see if upgrade job fails because it cannot find a pkg (google-cloud-sdk) while trying to purge that pkg in-order to free up disk space.
Seen in #3913

