### PR TITLE
switch-manager: Remove ippool duplicate call

### DIFF
--- a/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
+++ b/go-controller/pkg/ovn/logical_switch_manager/logical_switch_manager.go
@@ -34,10 +34,6 @@ func NewL2SwitchManager() *LogicalSwitchManager {
 // AddOrUpdateSwitch adds/updates a switch to the logical switch manager for subnet
 // and IPAM management.
 func (manager *LogicalSwitchManager) AddOrUpdateSwitch(switchName string, hostSubnets []*net.IPNet, excludeSubnets ...*net.IPNet) error {
-	err := manager.allocator.AddOrUpdateSubnet(switchName, hostSubnets)
-	if err != nil {
-		return err
-	}
 	if manager.reserveIPs {
 		for _, hostSubnet := range hostSubnets {
 			for _, ip := range []*net.IPNet{util.GetNodeGatewayIfAddr(hostSubnet), util.GetNodeManagementIfAddr(hostSubnet)} {


### PR DESCRIPTION
**- What this PR does and why is it needed**
There is a duplicated call to addOrUpdateSubnet at switch manager. This change remove that.

**- Description for the changelog**
switch-manager: Remove ippool duplicate call