### PR TITLE
IC/ICNI: Remove the need for k8s.ovn.org/external-gw-pod-ips annotation in

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -1079,15 +1079,22 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 	}
 
 	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
-		util.SetARPTimeout()
-		err := nc.WatchNamespaces()
-		if err != nil {
-			return fmt.Errorf("failed to watch namespaces: %w", err)
+		// If interconnect is disabled OR interconnect is running in single-zone-mode,
+		// the ovnkube-master is responsible for patching ICNI managed namespaces with
+		// "k8s.ovn.org/external-gw-pod-ips". In that case, we need ovnkube-node to flush
+		// conntrack on every node. In multi-zone-interconnect case, we will handle the flushing
+		// directly on the ovnkube-controller code to avoid an extra namespace annotation
+		if !config.OVNKubernetesFeature.EnableInterconnect || sbZone == types.OvnDefaultZone {
+			util.SetARPTimeout()
+			err := nc.WatchNamespaces()
+			if err != nil {
+				return fmt.Errorf("failed to watch namespaces: %w", err)
+			}
+			// every minute cleanup stale conntrack entries if any
+			go wait.Until(func() {
+				nc.checkAndDeleteStaleConntrackEntries()
+			}, time.Minute*1, nc.stopChan)
 		}
-		// every minute cleanup stale conntrack entries if any
-		go wait.Until(func() {
-			nc.checkAndDeleteStaleConntrackEntries()
-		}, time.Minute*1, nc.stopChan)
 		err = nc.WatchEndpointSlices()
 		if err != nil {
 			return fmt.Errorf("failed to watch endpointSlices: %w", err)

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -239,6 +239,19 @@ func (c *ExternalGatewayMasterController) processNextPolicyWorkItem(wg *sync.Wai
 	return true
 }
 
+func (c *ExternalGatewayMasterController) GetAdminPolicyBasedExternalRouteIPsForTargetNamespace(namespaceName string) (sets.Set[string], error) {
+	gwIPs, err := c.mgr.getDynamicGatewayIPsForTargetNamespace(namespaceName)
+	if err != nil {
+		return nil, err
+	}
+	tmpIPs, err := c.mgr.getStaticGatewayIPsForTargetNamespace(namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return gwIPs.Union(tmpIPs), nil
+}
+
 func (c *ExternalGatewayMasterController) onPolicyAdd(obj interface{}) {
 	_, ok := obj.(*adminpolicybasedrouteapi.AdminPolicyBasedExternalRoute)
 	if !ok {

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -33,6 +33,7 @@ import (
 
 	kapi "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -529,6 +530,17 @@ func (oc *DefaultNetworkController) Run(ctx context.Context) error {
 	if config.OVNKubernetesFeature.EnableMultiExternalGateway {
 		if err = oc.apbExternalRouteController.Run(oc.wg, 1); err != nil {
 			return err
+		}
+		// If interconnect is enabled and it is a multi-zone setup, then we flush conntrack
+		// on ovnkube-controller side and not on ovnkube-node side, since they are run in the
+		// same process. TODO(tssurya): In upstream ovnk, its possible to run these as different processes
+		// in which case this flushing feature is not supported.
+		if config.OVNKubernetesFeature.EnableInterconnect && oc.zone != ovntypes.OvnDefaultZone {
+			util.SetARPTimeout()
+			// every minute cleanup stale conntrack entries if any
+			go wait.Until(func() {
+				oc.checkAndDeleteStaleConntrackEntries()
+			}, time.Minute*1, oc.stopChan)
 		}
 	}
 

--- a/test/e2e/external_gateways.go
+++ b/test/e2e/external_gateways.go
@@ -512,12 +512,14 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				}
 
 				// ensure the conntrack deletion tracker annotation is updated
-				ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
-				err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-					ns := getNamespace(f, f.Namespace.Name)
-					return (ns.Annotations[externalGatewayPodIPsAnnotation] == fmt.Sprintf("%s,%s", addresses.gatewayIPs[0], addresses.gatewayIPs[1])), nil
-				})
-				framework.ExpectNoError(err, "Check if the k8s.ovn.org/external-gw-pod-ips got updated, failed: %v", err)
+				if !isInterconnectEnabled() {
+					ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
+					err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+						ns := getNamespace(f, f.Namespace.Name)
+						return (ns.Annotations[externalGatewayPodIPsAnnotation] == fmt.Sprintf("%s,%s", addresses.gatewayIPs[0], addresses.gatewayIPs[1])), nil
+					})
+					framework.ExpectNoError(err, "Check if the k8s.ovn.org/external-gw-pod-ips got updated, failed: %v", err)
+				}
 
 				setupIperf3Client := func(container, address string, port int) {
 					// note iperf3 even when using udp also spawns tcp connection first; so we indirectly also have the tcp connection when using "-u" flag
@@ -547,12 +549,14 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				annotatePodForGateway(gatewayPodName2, servingNamespace, "", addresses.gatewayIPs[1], false)
 
 				// ensure the conntrack deletion tracker annotation is updated
-				ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
-				err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-					ns := getNamespace(f, f.Namespace.Name)
-					return (ns.Annotations[externalGatewayPodIPsAnnotation] == addresses.gatewayIPs[0]), nil
-				})
-				framework.ExpectNoError(err, "Check if the k8s.ovn.org/external-gw-pod-ips got updated, failed: %v", err)
+				if !isInterconnectEnabled() {
+					ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
+					err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+						ns := getNamespace(f, f.Namespace.Name)
+						return (ns.Annotations[externalGatewayPodIPsAnnotation] == addresses.gatewayIPs[0]), nil
+					})
+					framework.ExpectNoError(err, "Check if the k8s.ovn.org/external-gw-pod-ips got updated, failed: %v", err)
+				}
 
 				ginkgo.By("Check if conntrack entries for ECMP routes are removed for the deleted external gateway if traffic is UDP")
 				podConnEntriesWithMACLabelsSet = pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
@@ -569,12 +573,14 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				annotatePodForGateway(gatewayPodName1, servingNamespace, "", addresses.gatewayIPs[0], false)
 
 				// ensure the conntrack deletion tracker annotation is updated
-				ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
-				err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-					ns := getNamespace(f, f.Namespace.Name)
-					return (ns.Annotations[externalGatewayPodIPsAnnotation] == ""), nil
-				})
-				framework.ExpectNoError(err, "Check if the k8s.ovn.org/external-gw-pod-ips got updated, failed: %v", err)
+				if !isInterconnectEnabled() {
+					ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
+					err = wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+						ns := getNamespace(f, f.Namespace.Name)
+						return (ns.Annotations[externalGatewayPodIPsAnnotation] == ""), nil
+					})
+					framework.ExpectNoError(err, "Check if the k8s.ovn.org/external-gw-pod-ips got updated, failed: %v", err)
+				}
 
 				ginkgo.By("Check if conntrack entries for ECMP routes are removed for the deleted external gateway if traffic is UDP")
 				podConnEntriesWithMACLabelsSet = pokeConntrackEntries(nodeName, addresses.srcPodIP, protocol, macAddressGW)
@@ -2205,12 +2211,14 @@ var _ = ginkgo.Describe("External Gateway", func() {
 				}
 				createAPBExternalRouteCRWithDynamicHop(defaultPolicyName, f.Namespace.Name, servingNamespace, false, addressesv4.gatewayIPs)
 				// ensure the conntrack deletion tracker annotation is updated
-				ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
-				err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-					ns := getNamespace(f, f.Namespace.Name)
-					return (ns.Annotations[externalGatewayPodIPsAnnotation] == fmt.Sprintf("%s,%s", addresses.gatewayIPs[0], addresses.gatewayIPs[1])), nil
-				})
-				framework.ExpectNoError(err, "Check if the k8s.ovn.org/external-gw-pod-ips got updated, failed: %v", err)
+				if !isInterconnectEnabled() {
+					ginkgo.By("Check if the k8s.ovn.org/external-gw-pod-ips got updated for the app namespace")
+					err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+						ns := getNamespace(f, f.Namespace.Name)
+						return (ns.Annotations[externalGatewayPodIPsAnnotation] == fmt.Sprintf("%s,%s", addresses.gatewayIPs[0], addresses.gatewayIPs[1])), nil
+					})
+					framework.ExpectNoError(err, "Check if the k8s.ovn.org/external-gw-pod-ips got updated, failed: %v", err)
+				}
 				annotatePodForGateway(gatewayPodName2, servingNamespace, "", addresses.gatewayIPs[1], false)
 				annotatePodForGateway(gatewayPodName1, servingNamespace, "", addresses.gatewayIPs[0], false)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
Currently in legacy ICNI, we use the `k8s.ovn.org/external-gw-pod-ips` as a way for communicating the change in an ICNI gateway pod's status (add/delete/update) from the ovnkube-controller (ovnkube-master in nonIC) to ovnkube-node. In IC multi-zone since the ovnkube-controller and ovnkube-node run as the same process, this is not needed. We can remove dependeny on the extra annotation update we do for IC multizone deployments. We flush the conntrack on ovnkube-controller directly.

On nonIC and IC with single zone we still use the annotation approach for flushing.

**- Special notes for reviewers**
Review the namespace update bits carefully.


**- How to verify it**
E2Es present for signalling issues. Ran v6 ones locally since CI does not run it. Need to dust off https://github.com/ovn-org/ovn-kubernetes/pull/3512 because some of the v6 ones are failing on the setup parts :/ so TODO to fix that in future, but as of now v4 ones pass and v6 should follow the same logic as far as code is concerned. 


**- Description for the changelog**
`Remove the need for k8s.ovn.org/external-gw-pod-ips annotation in IC/ICNI`