### PR TITLE
APB: return error if the target pod is in Pending phase when adding the GW IPs

### DIFF
--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_namespace_test.go
@@ -106,7 +106,6 @@ func newNamespaceWithPods(nsName string, pods ...*corev1.Pod) *namespaceWithPods
 		pods:   pods,
 	}
 }
-
 func expectedPolicyStateAndRefs(targetNamespaces []*namespaceWithPods, staticGWIPs []string,
 	dynamicGws []*namespaceWithPods, bfdEnabled bool) (*routePolicyState, *policyReferencedObjects) {
 	routeState := newRoutePolicyState()

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy_test.go
@@ -28,15 +28,22 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func newPod(podName, namespace, hostIP string, labels map[string]string) *corev1.Pod {
-	return &corev1.Pod{
+func newPod(podName, namespace, podIP string, labels map[string]string) *corev1.Pod {
+	return newPodWithPhaseAndIP(podName, namespace, corev1.PodRunning, podIP, labels)
+}
+
+func newPodWithPhaseAndIP(podName, namespace string, phase corev1.PodPhase, podIP string, labels map[string]string) *corev1.Pod {
+	p := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{Name: podName, Namespace: namespace,
-			Labels:      labels,
-			Annotations: map[string]string{nettypes.NetworkStatusAnnot: fmt.Sprintf(network_status, hostIP)},
-		},
+			Labels: labels},
 		Spec:   corev1.PodSpec{NodeName: "node"},
-		Status: corev1.PodStatus{PodIPs: []corev1.PodIP{{IP: hostIP}}, Phase: corev1.PodRunning},
+		Status: corev1.PodStatus{Phase: phase},
 	}
+	if len(podIP) > 0 {
+		p.Annotations = map[string]string{nettypes.NetworkStatusAnnot: fmt.Sprintf(network_status, podIP)}
+		p.Status.PodIPs = []corev1.PodIP{{IP: podIP}}
+	}
+	return p
 }
 
 func listRoutePolicyInCache() []string {

--- a/go-controller/pkg/ovn/controller/apbroute/gateway_info/gateway_info.go
+++ b/go-controller/pkg/ovn/controller/apbroute/gateway_info/gateway_info.go
@@ -154,7 +154,7 @@ type GatewayInfo struct {
 }
 
 func (g *GatewayInfo) String() string {
-	return fmt.Sprintf("BFDEnabled: %t, Gateways: %+v", g.BFDEnabled, g.Gateways)
+	return fmt.Sprintf("BFDEnabled: %t, Gateways: %+v, failedToApply: %t", g.BFDEnabled, g.Gateways, g.failedToApply)
 }
 
 func NewGatewayInfo(items sets.Set[string], bfdEnabled bool) *GatewayInfo {

--- a/go-controller/pkg/ovn/controller/apbroute/master_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/master_controller.go
@@ -228,11 +228,11 @@ func (c *ExternalGatewayMasterController) processNextPolicyWorkItem(wg *sync.Wai
 	}
 	if err != nil {
 		if c.routeQueue.NumRequeues(key) < maxRetries {
-			klog.V(4).Infof("Error found while processing policy %s: %w", key, err)
+			klog.V(4).Infof("Error found while processing policy %s: %v", key, err)
 			c.routeQueue.AddRateLimited(key)
 			return true
 		}
-		klog.Warningf("Dropping policy %q out of the queue: %w", key, err)
+		klog.Warningf("Dropping policy %q out of the queue: %v", key, err)
 		utilruntime.HandleError(err)
 	}
 	c.routeQueue.Forget(key)


### PR DESCRIPTION
Currently, when adding a new pod to a cluster with an APB CR, the controller will process the pod before it reaches the `Running` phase, which is before the target pod has an [IP allocated](https://github.com/ovn-org/ovn-kubernetes/blob/91046e8892e603822cbae2c5ff1351b703664da8/go-controller/pkg/ovn/controller/apbroute/network_client.go#L168-L170). This leads to the situation where the pod information cache is [initialized](https://github.com/ovn-org/ovn-kubernetes/blob/91046e8892e603822cbae2c5ff1351b703664da8/go-controller/pkg/ovn/controller/apbroute/network_client.go#L168-L170) with the GW IPs presumably added in the nbDB, when in truth nothing happened because the pod didn't have an IP to link to. When the event where the pod reaches the `Running` phase is generated, the logic checks that the pod has already been initialized with the GW IP and [avoids](https://github.com/ovn-org/ovn-kubernetes/blob/2ac88df3d2d757688ab1a1d7bb55ddf296ebe894/go-controller/pkg/ovn/controller/apbroute/external_controller_policy.go#L246) hitting the nbDB.

This problem occurs because initially the code in the network client to add the GW IP did not incorporate a cache, so the pod always hit the `addGatewayIPs` logic on each event change. With the inclusion of a cache to avoid hitting the nbDB unnecessarily, the `addGatewayIPs` logic requires a new approach to return an error when there are no IPs allocated in the pod so that it will keep retrying on each generated event.

@trozet @npinaeva  PTAL.