### PR TITLE
Fix removal of address from link manager

### DIFF
--- a/go-controller/pkg/node/linkmanager/link_network_manager.go
+++ b/go-controller/pkg/node/linkmanager/link_network_manager.go
@@ -189,7 +189,7 @@ func (c *Controller) delAddressFromStore(linkName string, address netlink.Addr) 
 	temp := addressesSaved[:0]
 	for _, addressSaved := range addressesSaved {
 		if !addressSaved.Equal(address) {
-			temp = append(temp, address)
+			temp = append(temp, addressSaved)
 		}
 	}
 	c.store[linkName] = temp


### PR DESCRIPTION
Wasnt caught earlier because:
- No unit tests for link manager
- E2Es didnt catch it because no coverage for multiple non-OVN managed EIPs on a single node
