### PR TITLE
Run node certificate manager in hybrid overlay

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -278,7 +278,7 @@ func startOvnKube(ctx *cli.Context, cancel context.CancelFunc) error {
 	}()
 
 	if config.Kubernetes.BootstrapKubeconfig != "" {
-		if err := util.StartNodeCertificateManager(ctx.Context, ovnKubeStartWg, &config.Kubernetes); err != nil {
+		if err := util.StartNodeCertificateManager(ctx.Context, ovnKubeStartWg, os.Getenv("K8S_NODE"), &config.Kubernetes); err != nil {
 			return fmt.Errorf("failed to start the node certificate manager: %w", err)
 		}
 	}


### PR DESCRIPTION
`hybrid-overlay-node` runs on windows nodes and should be able to set the same annotations as ovnkube-node.
This means that it requires also requires a per-node certificate.

/cc @jcaamano @JacobTanenbaum 
