### PR TITLE
Service E2E: increase timeout while waiting for nginx pods

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -874,7 +874,7 @@ spec:
 	})
 
 	ginkgo.It("Should ensure connectivity works on an external service when mtu changes in intermediate node", func() {
-		err := framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, svcName, 4, time.Second, time.Second*180)
+		err := framework.WaitForServiceEndpointsNum(f.ClientSet, namespaceName, svcName, 4, time.Second, time.Second*240)
 		framework.ExpectNoError(err, fmt.Sprintf("service: %s never had an endpoint, err: %v", svcName, err))
 
 		time.Sleep(time.Second * 5) // buffer to ensure all rules are created correctly


### PR DESCRIPTION
E2E test flaked once for me because 2 nginx pods didnt become ready before `180s`. No pod restarts seen. Increasing timeout to attempt to reduce CI flakes.

See comment [1] in PR #3940 for analysis.
[1] https://github.com/ovn-org/ovn-kubernetes/pull/3940#issuecomment-1740700610
