### PR TITLE
EIP: Fix CPIP updates on cloud environments

### DIFF
--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -224,6 +224,11 @@ func (eIPC *egressIPClusterController) executeCloudPrivateIPConfigOps(egressIPNa
 			// if the object already exists and the request is for a different node, that's an error
 		} else if op.toAdd != "" {
 			if err == nil {
+				// Do not add if object is being deleted; either retry the add (if this was an update) OR (if this was a perm-delete)
+				// we will retry till we exhaust our retry count
+				if cloudPrivateIPConfig.GetDeletionTimestamp() != nil && !cloudPrivateIPConfig.GetDeletionTimestamp().IsZero() {
+					return fmt.Errorf("cloud update request failed, CloudPrivateIPConfig: %s is being deleted", cloudPrivateIPConfigName)
+				}
 				if op.toAdd == cloudPrivateIPConfig.Spec.Node {
 					klog.Infof("CloudPrivateIPConfig: %s already assigned to node: %s", cloudPrivateIPConfigName, cloudPrivateIPConfig.Spec.Node)
 					continue

--- a/go-controller/pkg/clustermanager/egressip_controller.go
+++ b/go-controller/pkg/clustermanager/egressip_controller.go
@@ -635,7 +635,10 @@ func checkEgressNodesReachabilityIterate(eIPC *egressIPClusterController) {
 			}
 		} else {
 			klog.Infof("Node: %s is detected as reachable and ready again, adding it to egress assignment", nodeName)
-			if err := eIPC.addEgressNode(nodeName); err != nil {
+			nodeToAdd, err := eIPC.watchFactory.GetNode(nodeName)
+			if err != nil {
+				klog.Errorf("Node: %s is detected as reachable and ready again, but could not re-assign egress IPs, err: %v", nodeName, err)
+			} else if err := eIPC.retryEgressNodes.AddRetryObjWithAddNoBackoff(nodeToAdd); err != nil {
 				klog.Errorf("Node: %s is detected as reachable and ready again, but could not re-assign egress IPs, err: %v", nodeName, err)
 			}
 		}

--- a/go-controller/pkg/clustermanager/egressip_controller_test.go
+++ b/go-controller/pkg/clustermanager/egressip_controller_test.go
@@ -1554,6 +1554,8 @@ var _ = ginkgo.Describe("OVN cluster-manager EgressIP Operations", func() {
 				// egress IP should get assigned on the next checkEgressNodesReachabilityIterate call
 				// explicitly call check reachability, periodic checker is not active
 				checkEgressNodesReachabilityIterate(fakeClusterManagerOVN.eIPC)
+				// this will trigger an immediate add retry for the node which we need to simulate for this test
+				fakeClusterManagerOVN.eIPC.retryEgressNodes.RequestRetryObjs()
 				gomega.Eventually(getEgressIPStatusLen(eIP1.Name)).Should(gomega.Equal(1))
 
 				return nil


### PR DESCRIPTION
**- What this PR does and why is it needed**
The EIP controller being event driven means we don't
have control over the order of events that we get.

There is a bug around the ordering of event processing currently:

- When a node goes offline, 
- cluster-manager calls deleteEgressNode based on healthchecks and then patches the EIP to reflect that on the status by deleting the node immediately from the status
- this causes zone-controller to take action and do tear down of OVN setup for this EIP in the respective zone
- the CPIP also reacts and starts deleting the CPIP for this EIP (On clouds like azure this is very slow)
- node now comes back online - no control on the amount of time its down
- cluster-manager is super fast in IC as its asynchronous and tries to re-add this egressNode
- CM calls addEgressNode -> reconcileEIP -> executeCloudPrivateIPConfigOps -> and then we return with `CloudPrivateIPConfig: %s already assigned to node: %s", cloudPrivateIPConfigName, cloudPrivateIPConfig.Spec.Node` because the deletion for CPIP takes time and its still in `CloudResponsePending Deleting IP addres` phase.

```
W0925 18:55:30.984193       1 egressip_healthcheck.go:145] Health checking using insecure connection
I0925 18:55:30.987283       1 egressip_healthcheck.go:168] Connected to huirwang-0925c-8tdq2-worker-westus-85ljx (10.131.0.2:9107)
I0925 18:55:30.987309       1 egressip_controller.go:631] Node: huirwang-0925c-8tdq2-worker-westus-85ljx is detected as reachable and ready again, adding it to egress assignment
I0925 18:55:30.989470       1 egressip_controller.go:1320] Successful assignment of egress IP: 10.0.128.100 on node: &{egressIPConfig:0xc000cee000 mgmtIPs:[[10 131 0 2]] allocations:map[] healthClient:0xc000c3b7d0 isReady:true isReachable:true isEgressAssignable:true name:huirwang-0925c-8tdq2-worker-westus-85ljx}
I0925 18:55:30.989510       1 egressip_controller.go:228] CloudPrivateIPConfig: 10.0.128.100 already assigned to node: huirwang-0925c-8tdq2-worker-westus-85ljx
```

- Now we get the request for CPIP delete completed and the object goes away but the add is also considered successful as per above set of events which is bad.
- This is detrimental since setup won't be done in zone-controller without getting that add patch again.

This PR fixes this by firstly fixing the CPIP config add logic to explicitly fail to add something if the object is currently being deleted. This is the same thing we do for updates. The next thing this PR does is to fix the retries around node's becoming online and offline. If the node add/delete fails, we do not retry, I think we should.

**- Special notes for reviewers**
Currently I added retry only for when node comes back online, if we want we can also add retries for when node goes offline?
Long term solution: Become level driven

**- How to verify it**
Tested on cloud env, we are blind here u/s. Not easy to reproduce the ordering of events via a test.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->