### PR TITLE
GW: Ignore headless services in syncServices

### DIFF
--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -728,6 +728,10 @@ func (npw *nodePortWatcher) SyncServices(services []interface{}) error {
 				serviceInterface)
 			continue
 		}
+		// don't process headless service
+		if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
+			continue
+		}
 
 		epSlices, err := npw.watchFactory.GetEndpointSlices(service.Namespace, service.Name)
 		if err != nil {
@@ -1024,6 +1028,10 @@ func (npwipt *nodePortWatcherIptables) SyncServices(services []interface{}) erro
 		if !ok {
 			klog.Errorf("Spurious object in syncServices: %v",
 				serviceInterface)
+			continue
+		}
+		// don't process headless service
+		if !util.ServiceTypeHasClusterIP(service) || !util.IsClusterIPSet(service) {
 			continue
 		}
 		// Add correct iptables rules.


### PR DESCRIPTION

**- What this PR does and why is it needed**
`SyncServices` in gateway code would try and add iptable rules for
headless services resulting in ovnkube-node crashing
```
I0929 16:34:08.992237   17788 iptables.go:35] Chain: "OVN-KUBE-ITP" in table: "mangle" already exists, skipping creation: running [/usr/sbin/iptables -t mangle -N OVN-KUBE-ITP --wait]: exit status 1: iptables: Chain already exists.
I0929 16:34:08.997235   17788 iptables.go:27] Adding rule in table: mangle, chain: OVN-KUBE-ITP with args: "-p TCP -d <nil> --dport 80 -j MARK --set-xmark 0x1745ec" for protocol: 0 
I0929 16:34:08.998672   17788 iptables.go:35] Chain: "OVN-KUBE-ITP" in table: "mangle" already exists, skipping creation: running [/usr/sbin/iptables -t mangle -N OVN-KUBE-ITP --wait]: exit status 1: iptables: Chain already exists.
E0929 16:34:09.000870   17788 factory.go:845] Failed (will retry) while processing existing *v1.Service items: gateway sync services failed: failed to add iptables mangle/OVN-KUBE-ITP rule "-p TCP -d <nil> --dport 80 -j MARK --set-xmark 0x1745ec": running [/usr/sbin/iptables -t mangle -C OVN-KUBE-ITP -p TCP -d <nil> --dport 80 -j MARK --set-xmark 0x1745ec --wait]: exit status 2: iptables v1.8.7 (legacy): host/network `<nil>' not found
```
```
 State:       Running                                                                                                                                          [239/47128]
      Started:   Fri, 29 Sep 2023 18:32:18 +0200                                                                                                                             
    Last State:  Terminated                                                                                                                                                  
      Reason:    Error                                                                                                                                                       
      Message:      9868 reflector.go:293] Stopping reflector *v1.EgressFirewall (0s) from github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressfirewall/v1/apis/inf
ormers/externalversions/factory.go:116                                                                                                                                       
I0929 16:32:04.355513    9868 reflector.go:293] Stopping reflector *v1.EgressIP (0s) from github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressip/v1/apis/informers/
externalversions/factory.go:131                                                                                                                                              
I0929 16:32:04.356755    9868 reflector.go:293] Stopping reflector *v1.EgressQoS (0s) from github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressqos/v1/apis/informer
s/externalversions/factory.go:131                                                                                                                                            
I0929 16:32:04.355627    9868 reflector.go:293] Stopping reflector *v1alpha1.BaselineAdminNetworkPolicy (0s) from sigs.k8s.io/network-policy-api/pkg/client/informers/externa
lversions/factory.go:132                                                                                                                                                     
I0929 16:32:04.355308    9868 handler.go:215] Removed *v1.EgressFirewall event handler 9                                                                                     
I0929 16:32:04.356191    9868 reflector.go:293] Stopping reflector *v1.EgressService (0s) from github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/egressservice/v1/apis/
informers/externalversions/factory.go:131                                                                                                                                    
I0929 16:32:04.356993    9868 reflector.go:293] Stopping reflector *v1.NetworkPolicy (0s) from k8s.io/client-go/informers/factory.go:150                                     
I0929 16:32:04.356233    9868 metrics.go:506] Stopping metrics server 172.19.0.6:9410                                                                                        
I0929 16:32:04.357225    9868 metrics.go:502] Metrics server has stopped serving at address "172.19.0.6:9410"                                                                
I0929 16:32:04.356331    9868 reflector.go:293] Stopping reflector *v1.AdminPolicyBasedExternalRoute (0s) from github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminp
olicybasedroute/v1/apis/informers/externalversions/factory.go:116                                                                                                            
F0929 16:32:04.357564    9868 ovnkube.go:136] failed to start node network manager: failed to start default node network controller: error waiting for node readiness: gatewa
y init failed to start watching services: watchResource for resource *factory.serviceForGateway. Failed addHandlerFunc: context deadline exceeded                            
=============== pid 9868 terminated ==========                                                                                                                               
                                                                                                                                                                             
      Exit Code:    6                                                                                                                                                        
      Started:      Fri, 29 Sep 2023 18:31:03 +0200                                                                                                                          
      Finished:     Fri, 29 Sep 2023 18:32:04 +0200                                                                                                                          
    Ready:          False                                                                                                                                                    
    Restart Count:  2                                                                                                                                                        
    Requests:                                                                                                                                                                
      cpu:      100m                                                                                                                                                         
      memory:   300Mi
    Readiness:  exec [/usr/bin/ovn-kube-util readiness-probe -t ovnkube-node] delay=30s timeout=30s period=60s #success=1 #failure=3
```
This PR ignores headless services on restarts.

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
Tested on KIND, without this fix ovnkube-node pod crashes and doesn't recover.
Note that this is already done for add/delete services, it got missed out in sync services code

**- Description for the changelog**
`Don't process headless services`