### PR TITLE
LB: Use OVN's conntrack flush

### DIFF
--- a/go-controller/pkg/ovn/controller/services/loadbalancer.go
+++ b/go-controller/pkg/ovn/controller/services/loadbalancer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/klog/v2"
@@ -357,6 +358,10 @@ func buildLB(lb *LB) *templateLoadBalancer {
 		"skip_snat":          skipSNAT,
 		"neighbor_responder": "none",
 		"hairpin_snat_ip":    fmt.Sprintf("%s %s", config.Gateway.MasqueradeIPs.V4OVNServiceHairpinMasqueradeIP.String(), config.Gateway.MasqueradeIPs.V6OVNServiceHairpinMasqueradeIP.String()),
+	}
+
+	if lb.Protocol == string(v1.ProtocolUDP) {
+		options["ct_flush"] = "true"
 	}
 
 	// Session affinity


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
OVN did a per-LB flush config option (https://github.com/ovn-org/ovn/commit/89fc85fa7f2b) a while ago and reverted the global flush option since OVNK requested we only want to flush for UDP: https://bugzilla.redhat.com/show_bug.cgi?id=2178962#c0, like we do today in OVNK. This PR attempts to take a stab at this.

We need to discuss a few things:

1. backwards compatibility u/s newer ovnk versus older ovn?
2. need to wait for https://patchwork.ozlabs.org/project/ovn/list/?series=374952 to land because apparently this flush is not working on router LBs because OVN doesn't sync LR LBs to SBDB :( before we can make OVNK stop flushing conntrack on endpoints deletion for UDP on node side
3. Figure out the `LB Merge` logic for ensuring name change doesn't delete and create LBs. Double check OVNK's updates to LB's (flush on ovn happens if vip changes, vip port changes, backend ips changes, backend ports change, protocol changes, lb is deleted)

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->