### PR TITLE
Handle tombstone of type cache.DeletedFinalStateUnknown while deleting net-attach-def

### DIFF
--- a/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
+++ b/go-controller/pkg/network-attach-def-controller/network_attach_def_controller.go
@@ -317,14 +317,21 @@ func (nadController *NetAttachDefinitionController) onNetworkAttachDefinitionUpd
 }
 
 func (nadController *NetAttachDefinitionController) onNetworkAttachDefinitionDelete(obj interface{}) {
-	nad := obj.(*nettypes.NetworkAttachmentDefinition)
-	if nad == nil {
-		utilruntime.HandleError(fmt.Errorf("invalid net-attach-def provided to onNetworkAttachDefinitionDelete()"))
-		return
+	nad, ok := obj.(*nettypes.NetworkAttachmentDefinition)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		nad, ok = tombstone.Obj.(*nettypes.NetworkAttachmentDefinition)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a NetworkAttachmentDefinition object %#v", obj))
+			return
+		}
 	}
-
 	klog.V(4).Infof("%s: Deleting net-attach-def %s/%s", nadController.name, nad.Namespace, nad.Name)
-	nadController.queueNetworkAttachDefinition(obj)
+	nadController.queueNetworkAttachDefinition(nad)
 }
 
 // getAllNetworkControllers returns a snapshot of all managed NAD associated network controllers.


### PR DESCRIPTION
**- What this PR does and why is it needed**
This change is to prevent Type Assertion panic in case the object has already been removed but was put into tombstone of type cache.DeletedFinalStateUnknown which contains the deleted key and object.

**- Special notes for reviewers**
JIRA: https://issues.redhat.com/browse/OCPBUGS-19961

**- How to verify it**
It is hard to reproduce .

**- Description for the changelog**
- Raise error and return if the object is neither of type NetworkAttachmentDefinition nor of type cache.DeletedFinalStateUnknown.
- Raise error and return if the object in tombstone is not of type NetworkAttachmentDefinition.
- Continue normally if none of the above condition matches.