### PR TITLE
Various fixes to hybrid overlay

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/node_linux.go
@@ -16,6 +16,7 @@ import (
 // This controller is running in ovnkube-node binary. It's responsible for local
 // node configuration and annotation.
 type NodeController struct {
+	sync.RWMutex
 	nodeName  string
 	initState hotypes.HybridInitState
 	drMAC     net.HardwareAddr


### PR DESCRIPTION
Changes-Include:
 - Fixes data race where properties of the hybrid controller are read during node add, but may also be being written to at the same time (like n.drIP). Now there is a mutex on the controller, which is write locked when the local node add happens and the controller properties may be updated. On remote node or pod add, the controller is read locked.
 - During *every* node add, the code would attempt to add *every* pod in the cluster to this node's hybrid overlay. Modified this behavior so that this only happens when the state of our node is not PodsInitialized, as well as filtered out only pods local to our node.
 - During node add, if setting up hybrid overlay failed, we would still try to add pods. Additionally if adding a pod failed, we would not return error and then set the controller state to PodsInitialized. Modified this behavior so that errors are returned immediately and controller state is not updated upon failure.

Closes: #3924

