### PR TITLE
vhost-vDPA support

### DIFF
--- a/go-controller/go.mod
+++ b/go-controller/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/j-keck/arping v1.0.2
-	github.com/k8snetworkplumbingwg/govdpa v0.1.4
+	github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20230926073613-07c1031aea47
 	github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20200914073308-0f33b9190170
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/k8snetworkplumbingwg/sriovnet v1.2.1-0.20230427090635-4929697df2dc

--- a/go-controller/go.sum
+++ b/go-controller/go.sum
@@ -489,8 +489,8 @@ github.com/juju/testing v0.0.0-20200706033705-4c23f9c453cd/go.mod h1:hpGvhGHPVbN
 github.com/juju/utils v0.0.0-20180808125547-9dfc6dbfb02b/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/k8snetworkplumbingwg/govdpa v0.1.4 h1:e6mM7JFZkLVJeMQw3px96EigHAhnb4VUlqhNub/2Psk=
-github.com/k8snetworkplumbingwg/govdpa v0.1.4/go.mod h1:UQR1xu7A+nnRK1dkLEi12OnNL0OiBPpIKOYDuaQQkck=
+github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20230926073613-07c1031aea47 h1:iSncnlC+rtlNOIpPa3fbqQMhpTscGJIlkiWaPl1VcS4=
+github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20230926073613-07c1031aea47/go.mod h1:SPaDIyUmwN03Bgn0u/mhoiE4o/+koeKh11VUsdsUX0U=
 github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20200914073308-0f33b9190170 h1:rtPle+U5e7Fia0j44gm+p5QMgOIXXB3A8GtFeCCh8Kk=
 github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20200914073308-0f33b9190170/go.mod h1:CF9uYILB8GY25A/6Hhi1AWKc29qbyLu8r7Gs+uINGZE=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:VzM3TYHDgqPkettiP6I6q2jOeQFL4nrJM+UcAc4f6Fs=

--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -112,7 +112,7 @@ func (pr *PodRequest) cmdAdd(kubeAuth *KubeAPIAuth, clientset *ClientSet) (*Resp
 	if pr.CNIConf.DeviceID != "" {
 		var err error
 
-		netdevName, err = util.GetNetdevNameFromDeviceId(pr.CNIConf.DeviceID)
+		netdevName, err = util.GetNetdevNameFromDeviceId(pr.CNIConf.DeviceID, pr.deviceInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed in cmdAdd while getting Netdevice name: %v", err)
 		}

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -192,6 +192,7 @@ func cniRequestToPodRequest(cr *Request) (*PodRequest, error) {
 	}
 
 	req.CNIConf = conf
+	req.deviceInfo = cr.DeviceInfo
 	req.timestamp = time.Now()
 	// Match the Kubelet default CRI operation timeout of 2m
 	req.ctx, req.cancel = context.WithTimeout(context.Background(), 2*time.Minute)

--- a/go-controller/pkg/cni/cniserver_test.go
+++ b/go-controller/pkg/cni/cniserver_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
 
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 )
@@ -136,6 +137,29 @@ func TestCNIServer(t *testing.T) {
 					"CNI_ARGS":        makeCNIArgs(namespace, name),
 				},
 				Config: []byte(cniConfig),
+			},
+			result: expectedResult,
+		},
+		// Normal ADD request with DeviceInfo
+		{
+			name: "ADD_WITH_DEVICEINFO",
+			request: &Request{
+				Env: map[string]string{
+					"CNI_COMMAND":     string(CNIAdd),
+					"CNI_CONTAINERID": sandboxID,
+					"CNI_NETNS":       "/path/to/something",
+					"CNI_ARGS":        makeCNIArgs(namespace, name),
+				},
+				Config: []byte(cniConfig),
+				DeviceInfo: nadapi.DeviceInfo{
+					Type:    "vdpa",
+					Version: "1.0.0",
+					Vdpa: &nadapi.VdpaDevice{
+						ParentDevice: "vdpa:0000:65:00.3",
+						Driver:       "vhost",
+						Path:         "/dev/vhost-vdpa-1",
+						PciAddress:   "0000:65:00.3"},
+				},
 			},
 			result: expectedResult,
 		},

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni/types"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 
+	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	kapi "k8s.io/api/core/v1"
 )
 
@@ -79,6 +80,8 @@ type Request struct {
 	Env map[string]string `json:"env,omitempty"`
 	// CNI configuration passed via stdin to the CNI plugin
 	Config []byte `json:"config,omitempty"`
+	// The DeviceInfo struct
+	nadapi.DeviceInfo
 }
 
 // CNIRequestMetrics info to report from CNI shim to CNI server
@@ -157,6 +160,9 @@ type PodRequest struct {
 	// also, need to find the pod annotation, dpu pod connection/status annotations of the given NAD ("default"
 	// for default network).
 	nadName string
+
+	// the DeviceInfo struct
+	deviceInfo nadapi.DeviceInfo
 }
 
 type podRequestFunc func(request *PodRequest, clientset *ClientSet, kubeAuth *KubeAPIAuth) ([]byte, error)

--- a/go-controller/pkg/cni/types/types.go
+++ b/go-controller/pkg/cni/types/types.go
@@ -43,6 +43,11 @@ type NetConf struct {
 	// LogFileMaxAge represents the maximum number
 	// of days to retain old log files
 	LogFileMaxAge int `json:"logfile-maxage"`
+	// Runtime arguments passed by the NPWG implementation (e.g. multus)
+	RuntimeConfig struct {
+		// see https://github.com/k8snetworkplumbingwg/device-info-spec
+		CNIDeviceInfoFile string `json:"CNIDeviceInfoFile,omitempty"`
+	} `json:"runtimeConfig,omitempty"`
 }
 
 // NetworkSelectionElement represents one element of the JSON format

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 
+	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	honode "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
 	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni"
@@ -460,7 +461,7 @@ func handleNetdevResources(resourceName string) (string, error) {
 	} else {
 		return "", fmt.Errorf("insufficient device IDs for resource: %s", resourceName)
 	}
-	netdevice, err := util.GetNetdevNameFromDeviceId(deviceId)
+	netdevice, err := util.GetNetdevNameFromDeviceId(deviceId, v1.DeviceInfo{})
 	if err != nil {
 		return "", err
 	}

--- a/go-controller/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/util.go
+++ b/go-controller/vendor/github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa/util.go
@@ -1,0 +1,22 @@
+package kvdpa
+
+import (
+	"errors"
+	"strings"
+)
+
+// ExtractBusAndMgmtDevice extracts the busName and deviceName from a full device address (e.g. pci)
+// example 1: pci/65:0000.1   -> "pci", "65:0000.1",  nil
+// example 2: vdpa_sim        -> "",    "vdpa_sim",   nil
+// example 3: pci/65:0000.1/1 -> "",    "",           err
+func ExtractBusAndMgmtDevice(fullMgmtDeviceName string) (busName string, mgmtDeviceName string, err error) {
+	numSlashes := strings.Count(fullMgmtDeviceName, "/")
+	if numSlashes > 1 {
+		return "", "", errors.New("expected mgmtDeviceName to be either in the format <mgmtBusName>/<mgmtDeviceName> or <mgmtDeviceName>")
+	} else if numSlashes == 0 {
+		return "", fullMgmtDeviceName, nil
+	} else {
+		values := strings.Split(fullMgmtDeviceName, "/")
+		return values[0], values[1], nil
+	}
+}

--- a/go-controller/vendor/modules.txt
+++ b/go-controller/vendor/modules.txt
@@ -174,7 +174,7 @@ github.com/json-iterator/go
 github.com/juju/errors
 # github.com/juju/testing v0.0.0-20200706033705-4c23f9c453cd
 ## explicit; go 1.14
-# github.com/k8snetworkplumbingwg/govdpa v0.1.4
+# github.com/k8snetworkplumbingwg/govdpa v0.1.5-0.20230926073613-07c1031aea47
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/govdpa/pkg/kvdpa
 # github.com/k8snetworkplumbingwg/multi-networkpolicy v0.0.0-20200914073308-0f33b9190170


### PR DESCRIPTION
The current PR introduces support for vhost-vDPA devices.

There are 2 main changes:

1)  DeviceInfo support on ovn-k
See deviceInfo spec at https://github.com/k8snetworkplumbingwg/device-info-spec
This commit is required for introducing vhost-vdpa

2) vhost-vDPA device support

Please make sure to merge this PR first: https://github.com/ovn-org/ovn-kubernetes/pull/3868
