### PR TITLE
Replace using k8s node IP addr with EncapIP annotation for chassis encap-ip

### DIFF
--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -821,6 +821,15 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to set node zone annotation for node %s: %w", nc.name, err)
 	}
 
+	// NOTE: An assumption we make here is that `setupOVNNode(node)` has already ran above
+	// and updated the `config.Default.EncapIP` configuration.
+	if config.OvnKubeNode.Mode != types.NodeModeDPUHost {
+		klog.Infof("Setting EncapIp %s in node annotation", config.Default.EncapIP)
+		if err = util.SetNodeEncapIp(nodeAnnotator, config.Default.EncapIP); err != nil {
+			return err
+		}
+	}
+
 	if err := nodeAnnotator.Run(); err != nil {
 		return fmt.Errorf("failed to set node %s annotations: %w", nc.name, err)
 	}

--- a/go-controller/pkg/ovn/default_network_controller.go
+++ b/go-controller/pkg/ovn/default_network_controller.go
@@ -880,6 +880,7 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 		newNodeIsLocalZoneNode := h.oc.isLocalZoneNode(newNode)
 		zoneClusterChanged := h.oc.nodeZoneClusterChanged(oldNode, newNode, newNodeIsLocalZoneNode)
 		nodeSubnetChanged := nodeSubnetChanged(oldNode, newNode)
+		encapIpChanged := util.NodeEncapIpAnnotationChanged(oldNode, newNode)
 		if newNodeIsLocalZoneNode {
 			var nodeSyncsParam *nodeSyncs
 			if h.oc.isLocalZoneNode(oldNode) {
@@ -895,7 +896,7 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 					nodeGatewayMTUSupportChanged(oldNode, newNode))
 				_, hoSync := h.oc.hybridOverlayFailed.Load(newNode.Name)
 				_, syncZoneIC := h.oc.syncZoneICFailed.Load(newNode.Name)
-				syncZoneIC = syncZoneIC || zoneClusterChanged || primaryAddrChanged(oldNode, newNode)
+				syncZoneIC = syncZoneIC || zoneClusterChanged || encapIpChanged || primaryAddrChanged(oldNode, newNode)
 				nodeSyncsParam = &nodeSyncs{
 					nodeSync,
 					clusterRtrSync,
@@ -916,7 +917,7 @@ func (h *defaultNetworkControllerEventHandler) UpdateResource(oldObj, newObj int
 
 			// Check if the node moved from local zone to remote zone and if so syncZoneIC should be set to true.
 			// Also check if node subnet changed, so static routes are properly set
-			syncZoneIC = syncZoneIC || h.oc.isLocalZoneNode(oldNode) || nodeSubnetChanged || zoneClusterChanged || primaryAddrChanged(oldNode, newNode)
+			syncZoneIC = syncZoneIC || h.oc.isLocalZoneNode(oldNode) || nodeSubnetChanged || zoneClusterChanged || encapIpChanged || primaryAddrChanged(oldNode, newNode)
 			if syncZoneIC {
 				klog.Infof("Node %s in remote zone %s needs interconnect zone sync up. Zone cluster changed: %v",
 					newNode.Name, util.GetNodeZone(newNode), zoneClusterChanged)

--- a/go-controller/pkg/ovn/zone_interconnect/chassis_handler.go
+++ b/go-controller/pkg/ovn/zone_interconnect/chassis_handler.go
@@ -133,10 +133,11 @@ func (zch *ZoneChassisHandler) createOrUpdateNodeChassis(node *corev1.Node, isRe
 			node.Name, parsedErr)
 	}
 
-	nodePrimaryIp, err := util.GetNodePrimaryIP(node)
+	encapIp, err := util.GetNodeEncapIp(node)
 	if err != nil {
-		return fmt.Errorf("failed to parse node %s primary IP %w", node.Name, err)
+		return fmt.Errorf("failed to parse node %s encap IP %w", node.Name, err)
 	}
+	klog.V(5).Infof("Found Encap IP %v for node %s from node annotation", encapIp, node.Name)
 
 	chassis := sbdb.Chassis{
 		Name:     chassisID,
@@ -148,7 +149,7 @@ func (zch *ZoneChassisHandler) createOrUpdateNodeChassis(node *corev1.Node, isRe
 
 	encap := sbdb.Encap{
 		ChassisName: chassisID,
-		IP:          nodePrimaryIp,
+		IP:          encapIp,
 		Type:        "geneve",
 		Options:     map[string]string{"csum": "true"},
 	}

--- a/go-controller/pkg/ovn/zone_interconnect/chassis_handler_test.go
+++ b/go-controller/pkg/ovn/zone_interconnect/chassis_handler_test.go
@@ -53,8 +53,11 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 
 		testNode1 = corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "node1",
-				Annotations: map[string]string{"k8s.ovn.org/node-chassis-id": "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6"},
+				Name: "node1",
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-chassis-id": "cb9ec8fa-b409-4ef3-9f42-d9283c47aac6",
+					"k8s.ovn.org/encap-ip":        "10.0.0.10",
+				},
 			},
 			Status: corev1.NodeStatus{
 				Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.10"}},
@@ -62,8 +65,11 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 		}
 		testNode2 = corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "node2",
-				Annotations: map[string]string{"k8s.ovn.org/node-chassis-id": "cb9ec8fa-b409-4ef3-9f42-d9283c47aac7"},
+				Name: "node2",
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-chassis-id": "cb9ec8fa-b409-4ef3-9f42-d9283c47aac7",
+					"k8s.ovn.org/encap-ip":        "10.0.0.11",
+				},
 			},
 			Status: corev1.NodeStatus{
 				Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.11"}},
@@ -71,8 +77,11 @@ var _ = ginkgo.Describe("Zone Interconnect Chassis Operations", func() {
 		}
 		testNode3 = corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "node3",
-				Annotations: map[string]string{"k8s.ovn.org/node-chassis-id": "cb9ec8fa-b409-4ef3-9f42-d9283c47aac8"},
+				Name: "node3",
+				Annotations: map[string]string{
+					"k8s.ovn.org/node-chassis-id": "cb9ec8fa-b409-4ef3-9f42-d9283c47aac8",
+					"k8s.ovn.org/encap-ip":        "10.0.0.12",
+				},
 			},
 			Status: corev1.NodeStatus{
 				Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.12"}},

--- a/go-controller/pkg/ovnwebhook/nodeadmission.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission.go
@@ -31,6 +31,7 @@ var commonNodeAnnotationChecks = map[string]checkNodeAnnot{
 	util.OvnNodeIfAddr:                   nil,
 	util.OvnNodeGatewayMtuSupport:        nil,
 	util.OvnNodeManagementPort:           nil,
+	util.OvnNodeEncapIp:                  nil,
 	util.OvnNodeChassisID: func(v annotationChange, nodeName string) error {
 		if v.action == removed {
 			return fmt.Errorf("%s cannot be removed", util.OvnNodeChassisID)

--- a/go-controller/pkg/ovnwebhook/nodeadmission_test.go
+++ b/go-controller/pkg/ovnwebhook/nodeadmission_test.go
@@ -270,6 +270,25 @@ func TestNodeAdmission_ValidateUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "ovnkube-node can set util.OvnNodeEncapIp",
+			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
+				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{
+					Username: userName,
+				}},
+			}),
+			oldObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+			newObj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{util.OvnNodeEncapIp: "192.168.122.156"},
+				},
+			},
+		},
+		{
 			name: "ovnkube-node can set util.OvnNodeGatewayMtuSupport",
 			ctx: admission.NewContextWithRequest(context.TODO(), admission.Request{
 				AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{


### PR DESCRIPTION
Assuming the k8s node IP address is the encap-ip does not work in all cases, specifically:
1) If ovn-k was started with the "--encap-ip" argument
2) In the case of the DPU, where the DPU runs the OVN/OVN-K stack on behalf of the host.

Thus introducing this encap-ip annotation decouples the encap-ip from the k8s node IP address and couples it correctly with ovn-kube's config parameter "config.Default.EncapIP".