### PR TITLE
OVNK/GW: Use openflow13 flow formats

### DIFF
--- a/docs/design/host_to_services_OpenFlow.md
+++ b/docs/design/host_to_services_OpenFlow.md
@@ -171,8 +171,8 @@ With the new implementation comes new OpenFlow rules in the shared gateway bridg
  cookie=0xdeff105, duration=793.273s, table=0, n_packets=0, n_bytes=0, priority=500,ip,in_port=LOCAL,nw_dst=10.96.0.0/16 actions=ct(commit,table=2,zone=64001,nat(src=169.254.169.2))
  cookie=0xdeff105, duration=793.273s, table=0, n_packets=0, n_bytes=0, priority=500,ip,in_port="patch-breth0_ov",nw_src=10.96.0.0/16,nw_dst=169.254.169.2 actions=ct(table=3,zone=64001,nat)
 
- cookie=0xdeff105, duration=5.507s, table=2, n_packets=0, n_bytes=0, actions=mod_dl_dst:02:42:ac:12:00:03,output:"patch-breth0_ov"
- cookie=0xdeff105, duration=5.507s, table=3, n_packets=0, n_bytes=0, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],mod_dl_dst:02:42:ac:12:00:03,LOCAL
+ cookie=0xdeff105, duration=5.507s, table=2, n_packets=0, n_bytes=0, actions=set_field:02:42:ac:12:00:03->eth_dst,output:"patch-breth0_ov"
+ cookie=0xdeff105, duration=5.507s, table=3, n_packets=0, n_bytes=0, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],set_field:02:42:ac:12:00:03->eth_dst,LOCAL
  cookie=0xdeff105, duration=793.273s, table=4, n_packets=0, n_bytes=0, ip actions=ct(commit,table=3,zone=64002,nat(src=169.254.169.1))
  cookie=0xdeff105, duration=793.273s, table=5, n_packets=0, n_bytes=0, ip actions=ct(commit,table=2,zone=64001,nat)
 
@@ -204,7 +204,7 @@ cookie=0xdeff105, duration=1136.261s, table=0, n_packets=12, n_bytes=884, priori
 ```
 4. In table 2, the destination MAC address is modified to be the MAC of the OVN GR. Note, although the source MAC is the host's, OVN does not care so this is left unmodified.
 ```text
-cookie=0xdeff105, duration=1.486s, table=2, n_packets=12, n_bytes=884, actions=mod_dl_dst:02:42:ac:12:00:03,output:"patch-breth0_ov"
+cookie=0xdeff105, duration=1.486s, table=2, n_packets=12, n_bytes=884, actions=set_field:02:42:ac:12:00:03->eth_dst,output:"patch-breth0_ov"
 ```
 CT Entry:
 ```text
@@ -231,7 +231,7 @@ cookie=0xdeff105, duration=1136.261s, table=0, n_packets=11, n_bytes=1670, prior
 ```
 This flow will unDNAT the packet, and send to table 3:
 ```text
-cookie=0xdeff105, duration=1.486s, table=3, n_packets=11, n_bytes=1670, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],mod_dl_dst:02:42:ac:12:00:03,LOCAL
+cookie=0xdeff105, duration=1.486s, table=3, n_packets=11, n_bytes=1670, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],set_field:02:42:ac:12:00:03->eth_dst,LOCAL
 ```
 This flow will move the dest MAC (next hop MAC) to be the source, and set the new dest MAC to be the MAC of the host.
 This ensures the Linux host thinks it is still talking to the external next hop. The packet is then delivered to the host.
@@ -352,7 +352,7 @@ cookie=0xdeff105, duration=2877.527s, table=5, n_packets=12, n_bytes=1736, ip ac
 ```
 Here the packet will be unDNAT'ed and sent towards table 2:
 ```text
-cookie=0xdeff105, duration=5.520s, table=2, n_packets=47, n_bytes=4314, actions=mod_dl_dst:02:42:ac:12:00:03,output:"patch-breth0_ov"
+cookie=0xdeff105, duration=5.520s, table=2, n_packets=47, n_bytes=4314, actions=set_field:02:42:ac:12:00:03->eth_dst,output:"patch-breth0_ov"
 ```
 Table 2 will modify the MAC accordingly and sent it back into OVN GR. OVN GR will then unSNAT, unDNAT and send the packet back to breth0 in the same fashion as the previous example.
 

--- a/docs/design/service_traffic_policy.md
+++ b/docs/design/service_traffic_policy.md
@@ -293,7 +293,7 @@ cookie=0xdeff105, duration=3189.786s, table=0, n_packets=11, n_bytes=814, priori
 6. In `table2` we have a flow that forwards this to patch port that takes the traffic in OVN:
 
 ```
-cookie=0xdeff105, duration=6.308s, table=2, n_packets=11, n_bytes=814, actions=mod_dl_dst:02:42:ac:12:00:03,output:"patch-breth0_ov"
+cookie=0xdeff105, duration=6.308s, table=2, n_packets=11, n_bytes=814, actions=set_field:02:42:ac:12:00:03->eth_dst,output:"patch-breth0_ov"
 ```
 
 7. Traffic enters the GR on the worker node and hits the load-balancer where we DNAT it correctly to the local backends.
@@ -317,7 +317,7 @@ vips                : {"10.96.115.103:80"="172.19.0.3:8080", "172.19.0.3:31339"=
 ```
   cookie=0xdeff105, duration=839.789s, table=0, n_packets=6, n_bytes=484, priority=175,tcp,in_port="patch-breth0_ov",nw_src=172.19.0.3 actions=ct(table=4,zone=64001)
   cookie=0xdeff105, duration=2334.510s, table=4, n_packets=18, n_bytes=1452, ip actions=ct(commit,table=3,zone=64002,nat(src=169.254.169.1))
-  cookie=0xdeff105, duration=1.612s, table=3, n_packets=10, n_bytes=892, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],mod_dl_dst:02:42:ac:13:00:03,LOCAL
+  cookie=0xdeff105, duration=1.612s, table=3, n_packets=10, n_bytes=892, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],set_field:02:42:ac:13:00:03->eth_dst,LOCAL
 ```
 
 9. The routes in the host send this back to breth0:
@@ -353,7 +353,7 @@ cookie=0xdeff105, duration=3189.786s, table=0, n_packets=99979, n_bytes=29802921
 ```
  cookie=0xdeff105, duration=2334.510s, table=0, n_packets=14, n_bytes=1356, priority=500,ip,in_port=LOCAL,nw_dst=169.254.169.1 actions=ct(table=5,zone=64002,nat)
  cookie=0xdeff105, duration=2334.510s, table=5, n_packets=14, n_bytes=1356, ip actions=ct(commit,table=2,zone=64001,nat)
- cookie=0xdeff105, duration=0.365s, table=2, n_packets=33, n_bytes=2882, actions=mod_dl_dst:02:42:ac:13:00:03,output:"patch-breth0_ov"
+ cookie=0xdeff105, duration=0.365s, table=2, n_packets=33, n_bytes=2882, actions=set_field:02:42:ac:13:00:03->eth_dst,output:"patch-breth0_ov"
 ```
 
 4. From OVN it gets sent back to host and then back from host into breth0 and into the wire:
@@ -361,7 +361,7 @@ cookie=0xdeff105, duration=3189.786s, table=0, n_packets=99979, n_bytes=29802921
 ```
   cookie=0xdeff105, duration=2334.510s, table=0, n_packets=18, n_bytes=1452, priority=175,ip,in_port="patch-breth0_ov",nw_src=172.19.0.4 actions=ct(table=4,zone=64001,nat)
   cookie=0xdeff105, duration=2334.510s, table=4, n_packets=18, n_bytes=1452, ip actions=ct(commit,table=3,zone=64002,nat(src=169.254.169.1))
-  cookie=0xdeff105, duration=0.365s, table=3, n_packets=32, n_bytes=2808, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],mod_dl_dst:02:42:ac:13:00:03,LOCAL
+  cookie=0xdeff105, duration=0.365s, table=3, n_packets=32, n_bytes=2808, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],set_field:02:42:ac:13:00:03->eth_dst,LOCAL
   cookie=0xdeff105, duration=2334.510s, table=0, n_packets=7611, n_bytes=754388, priority=100,ip,in_port=LOCAL actions=ct(commit,zone=64000,exec(load:0x2->NXM_NX_CT_MARK[])),output:eth0
 ```
 
@@ -436,7 +436,7 @@ cookie=0xdeff105, duration=3189.786s, table=0, n_packets=11, n_bytes=814, priori
 6. In `table2` we have a flow that forwards this to patch port that takes the traffic in OVN:
 
 ```
-cookie=0xdeff105, duration=6.308s, table=2, n_packets=11, n_bytes=814, actions=mod_dl_dst:02:42:ac:12:00:03,output:"patch-breth0_ov"
+cookie=0xdeff105, duration=6.308s, table=2, n_packets=11, n_bytes=814, actions=set_field:02:42:ac:12:00:03->eth_dst,output:"patch-breth0_ov"
 ```
 
 7. Traffic enters the GR on the worker node and hits the load-balancer where we DNAT it correctly to the local backends.
@@ -466,7 +466,7 @@ cookie=0xdeff105, duration=3189.786s, table=0, n_packets=10, n_bytes=540, priori
 8. In `table3`, we send it to host:
 
 ```
-cookie=0xdeff105, duration=6.308s, table=3, n_packets=10, n_bytes=540, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],mod_dl_dst:02:42:ac:12:00:03,LOCAL
+cookie=0xdeff105, duration=6.308s, table=3, n_packets=10, n_bytes=540, actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],set_field:02:42:ac:12:00:03->eth_dst,LOCAL
 ```
 
 9. From host we send it back to breth0 using:

--- a/go-controller/pkg/node/gateway_shared_intf.go
+++ b/go-controller/pkg/node/gateway_shared_intf.go
@@ -1327,12 +1327,12 @@ func flowsForDefaultBridge(bridge *bridgeConfiguration, extraIPs []net.IP) ([]st
 	// table 2, dispatch from Host -> OVN
 	dftFlows = append(dftFlows,
 		fmt.Sprintf("cookie=%s, table=2, "+
-			"actions=mod_dl_dst=%s,output:%s", defaultOpenFlowCookie, bridgeMacAddress, ofPortPatch))
+			"actions=set_field:%s->eth_dst,output:%s", defaultOpenFlowCookie, bridgeMacAddress, ofPortPatch))
 
 	// table 3, dispatch from OVN -> Host
 	dftFlows = append(dftFlows,
 		fmt.Sprintf("cookie=%s, table=3, "+
-			"actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],mod_dl_dst=%s,output:%s",
+			"actions=move:NXM_OF_ETH_DST[]->NXM_OF_ETH_SRC[],set_field:%s->eth_dst,output:%s",
 			defaultOpenFlowCookie, bridgeMacAddress, ofPortHost))
 
 	// table 4, hairpinned pkts that need to go from OVN -> Host


### PR DESCRIPTION
syncFlows synchronizes the flow table with "ovs-ofctl replace -Oopenflow13", "mod_dl_dst" is openflow10 format, and "set_field ->eth_dst" is openflow13, "ovs-ofctl replace -Oopenflow13" considers "mod_dl_dst" and "set_field" are not equal, leading to periodic changes in the flow table on brphy.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->