### PR TITLE
Cluster manager: fix consumption of CM HA config file overrides

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -579,6 +579,7 @@ func init() {
 	savedOvnSouth = OvnSouth
 	savedGateway = Gateway
 	savedMasterHA = MasterHA
+	savedClusterMgrHA = ClusterMgrHA
 	savedHybridOverlay = HybridOverlay
 	savedOvnKubeNode = OvnKubeNode
 	savedClusterManager = ClusterManager
@@ -2103,6 +2104,7 @@ func initConfigWithPath(ctx *cli.Context, exec kexec.Interface, saPath string, d
 		OvnSouth:             savedOvnSouth,
 		Gateway:              savedGateway,
 		MasterHA:             savedMasterHA,
+		ClusterMgrHA:         savedClusterMgrHA,
 		HybridOverlay:        savedHybridOverlay,
 		OvnKubeNode:          savedOvnKubeNode,
 		ClusterManager:       savedClusterManager,


### PR DESCRIPTION
Prior to this, we dont consume config file options for CM HA, specifically to configure LE.

Also, in our current code when you run ovnkubecontroller & cluster manager together, we use cluster managers HAs options to set the HA defaults but they arent being consumed from the `kube-config.conf` override file:

```go
	var haConfig *config.HAConfig
	var name string
	switch {
	case runMode.ovnkubeController && runMode.clusterManager:
		metrics.RegisterClusterManagerBase()
		fallthrough <==== fall through here
	case runMode.ovnkubeController:
		metrics.RegisterOVNKubeControllerBase()
		haConfig = &config.MasterHA
		name = networkControllerManagerLockName()
	case runMode.clusterManager:
		metrics.RegisterClusterManagerBase()
		haConfig = &config.ClusterMgrHA  <=== cluster manager ends up setting the haConfig overriding any MasterHA
		name = "ovn-kubernetes-master"
	}
```

cc @numansiddique 