### PR TITLE
Egressfirewall use port groups

### DIFF
--- a/go-controller/pkg/libovsdb/ops/portgroup.go
+++ b/go-controller/pkg/libovsdb/ops/portgroup.go
@@ -141,7 +141,7 @@ func DeletePortsFromPortGroupOps(nbClient libovsdbclient.Client, ops []libovsdb.
 	opModel := operationModel{
 		Model:            &pg,
 		OnModelMutations: []interface{}{&pg.Ports},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 
@@ -229,7 +229,7 @@ func DeleteACLsFromPortGroupOps(nbClient libovsdbclient.Client, ops []libovsdb.O
 	opModel := operationModel{
 		Model:            &pg,
 		OnModelMutations: []interface{}{&pg.ACLs},
-		ErrNotFound:      true,
+		ErrNotFound:      false,
 		BulkOp:           false,
 	}
 

--- a/go-controller/pkg/ovn/base_network_controller_secondary.go
+++ b/go-controller/pkg/ovn/base_network_controller_secondary.go
@@ -548,7 +548,10 @@ func (bsnc *BaseSecondaryNetworkController) updateNamespaceForSecondaryNetwork(o
 func (bsnc *BaseSecondaryNetworkController) deleteNamespace4SecondaryNetwork(ns *kapi.Namespace) error {
 	klog.Infof("[%s] deleting namespace for network %s", ns.Name, bsnc.GetNetworkName())
 
-	nsInfo := bsnc.deleteNamespaceLocked(ns.Name)
+	nsInfo, err := bsnc.deleteNamespaceLocked(ns.Name)
+	if err != nil {
+		return err
+	}
 	if nsInfo == nil {
 		return nil
 	}

--- a/go-controller/pkg/ovn/ovn_test.go
+++ b/go-controller/pkg/ovn/ovn_test.go
@@ -183,7 +183,7 @@ func (o *FakeOVN) init(nadList []nettypes.NetworkAttachmentDefinition) {
 		o.nbClient, o.sbClient,
 		o.fakeRecorder, o.wg)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	o.controller.multicastSupport = true
+	o.controller.multicastSupport = config.EnableMulticast
 	o.controller.clusterLoadBalancerGroupUUID = types.ClusterLBGroupName + "-UUID"
 	o.controller.switchLoadBalancerGroupUUID = types.ClusterSwitchLBGroupName + "-UUID"
 	o.controller.routerLoadBalancerGroupUUID = types.ClusterRouterLBGroupName + "-UUID"

--- a/go-controller/pkg/util/batching/batch.go
+++ b/go-controller/pkg/util/batching/batch.go
@@ -2,6 +2,7 @@ package batching
 
 import "fmt"
 
+// Batch splits values in `data` in batches of size `batchSize`, and calls `eachFn` for each batch.
 func Batch[T any](batchSize int, data []T, eachFn func([]T) error) error {
 	if batchSize < 1 {
 		return fmt.Errorf("batchSize should be > 0, got %d", batchSize)
@@ -18,6 +19,52 @@ func Batch[T any](batchSize int, data []T, eachFn func([]T) error) error {
 			return err
 		}
 		start = end
+	}
+	return nil
+}
+
+// BatchMap splits values in `data` in batches of size `batchSize`, and calls `eachFn` for each batch.
+// Values of a specific key may be split into different batches, make sure `eachFn` can handle that case.
+func BatchMap[T any](batchSize int, data map[string][]T, eachFn func(map[string][]T) error) error {
+	if batchSize < 1 {
+		return fmt.Errorf("batchSize should be > 0, got %d", batchSize)
+	}
+	batchCounter := 0
+	batchMap := map[string][]T{}
+
+	for key, value := range data {
+		// a given value may need to be split into multiple batches.
+		// allElemsBatched is true when all value elements are added to the batchMap.
+		allElemsBatched := false
+		for !allElemsBatched {
+			if batchCounter+len(value) >= batchSize {
+				leftSpace := batchSize - batchCounter
+				batchMap[key] = value[:leftSpace]
+
+				err := eachFn(batchMap)
+				if err != nil {
+					return err
+				}
+				// reset batch
+				batchMap = map[string][]T{}
+				batchCounter = 0
+
+				// update value to what's left
+				value = value[leftSpace:]
+				allElemsBatched = len(value) == 0
+			} else {
+				batchMap[key] = value
+				batchCounter += len(value)
+				allElemsBatched = true
+			}
+		}
+	}
+	if len(batchMap) > 0 {
+		// process last batch
+		err := eachFn(batchMap)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/go-controller/pkg/util/batching/batch_test.go
+++ b/go-controller/pkg/util/batching/batch_test.go
@@ -13,7 +13,6 @@ type batchTestData struct {
 	name      string
 	batchSize int
 	data      []int
-	result    []int
 	expectErr string
 }
 
@@ -76,6 +75,152 @@ func TestBatch(t *testing.T) {
 		// tCase.data/tCase.batchSize round up
 		expectedBatchNum := (len(tCase.data) + tCase.batchSize - 1) / tCase.batchSize
 		g.Expect(batchNum).To(gomega.Equal(expectedBatchNum))
+		g.Expect(result).To(gomega.Equal(tCase.data))
+	}
+}
+
+type batchMapTestData struct {
+	name               string
+	batchSize          int
+	data               map[string][]int
+	expectErr          string
+	expectedBatchesNum int
+}
+
+func TestBatchMap(t *testing.T) {
+	tt := []batchMapTestData{
+		{
+			name:      "batch size should be > 0",
+			batchSize: 0,
+			data:      map[string][]int{"a": {1, 2, 3}},
+			expectErr: "batchSize should be > 0",
+		},
+		{
+			name:      "batchSize = 1",
+			batchSize: 1,
+			data: map[string][]int{
+				"a": {1},
+				"b": {2},
+				"c": {3},
+			},
+			expectedBatchesNum: 3,
+		},
+		{
+			name:      "batchSize = 1, nil value",
+			batchSize: 1,
+			data: map[string][]int{
+				"a": nil,
+				"b": nil,
+			},
+			expectedBatchesNum: 1,
+		},
+		{
+			name:      "batchSize = 1, empty value",
+			batchSize: 1,
+			data: map[string][]int{
+				"a": {},
+				"b": {},
+			},
+			expectedBatchesNum: 1,
+		},
+		{
+			name:      "batchSize = 1, len(value) > 1",
+			batchSize: 1,
+			data: map[string][]int{
+				"a": {1, 2, 3},
+				"b": {4},
+			},
+			expectedBatchesNum: 4,
+		},
+		{
+			name:      "batchSize > 1",
+			batchSize: 2,
+			data: map[string][]int{
+				"a": {1},
+				"b": {2},
+				"c": {3},
+			},
+			expectedBatchesNum: 2,
+		},
+		{
+			name:               "number of batches = 0",
+			batchSize:          2,
+			data:               map[string][]int{},
+			expectedBatchesNum: 0,
+		},
+		{
+			name:      "number of batches = 1, same key",
+			batchSize: 2,
+			data: map[string][]int{
+				"a": {1, 2},
+			},
+			expectedBatchesNum: 1,
+		},
+		{
+			name:      "number of batches = 1, different keys",
+			batchSize: 2,
+			data: map[string][]int{
+				"a": {1},
+				"b": {2},
+			},
+			expectedBatchesNum: 1,
+		},
+		{
+			name:      "number of batches > 1, different keys",
+			batchSize: 2,
+			data: map[string][]int{
+				"a": {1, 2},
+				"b": {3},
+				"c": {4},
+			},
+			expectedBatchesNum: 2,
+		},
+		{
+			name:      "number of batches > 2, different keys",
+			batchSize: 3,
+			data: map[string][]int{
+				"a": {1, 2},
+				"b": {3, 4, 5},
+				"c": {6, 7},
+			},
+			expectedBatchesNum: 3,
+		},
+		{
+			name:      "number of batches = 2, split values",
+			batchSize: 3,
+			data: map[string][]int{
+				"a": {1, 2},
+				"b": {3, 4, 5},
+				"c": {6},
+			},
+			expectedBatchesNum: 2,
+		},
+	}
+
+	for _, tCase := range tt {
+		g := gomega.NewGomegaWithT(t)
+		ginkgo.By(tCase.name)
+		result := map[string][]int{}
+		batchNum := 0
+		err := BatchMap[int](tCase.batchSize, tCase.data, func(l map[string][]int) error {
+			batchNum += 1
+			for key, value := range l {
+				// this is needed to handle empty list vs nil, since appending empty list to a nil returns nil.
+				if len(value) == 0 {
+					result[key] = value
+				} else {
+					result[key] = append(result[key], value...)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			if tCase.expectErr != "" && strings.Contains(err.Error(), tCase.expectErr) {
+				continue
+			}
+			t.Fatal(fmt.Sprintf("test %s failed: %v", tCase.name, err))
+		}
+		g.Expect(batchNum).To(gomega.Equal(tCase.expectedBatchesNum))
 		g.Expect(result).To(gomega.Equal(tCase.data))
 	}
 }


### PR DESCRIPTION
We already have namespace port groups that are created by multicast and updated by pod handlers. That implementation has some races because port group is created conditionally. First commit changes that to create namespace port groups similar to namespace address sets on namespace initialization and update multicast handler to use that.
Second commit updates egress firewall to use namespaced port group instead of cluster port group + address set match to reduce the number of OVS flows.

Namespace port groups can be created conditionally, but that would require namespace locking for every port group-related operation, and may be worse for performance than 1 extra port group per namespace