### PR TITLE
Always handle invalid label selectors

### DIFF
--- a/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux.go
+++ b/go-controller/hybrid-overlay/pkg/controller/ovn_node_linux.go
@@ -150,7 +150,7 @@ func nameToCookie(nodeName string) string {
 // hybridOverlayNodeUpdate sets up or tears down VXLAN tunnels to hybrid overlay
 // nodes in the cluster
 func (n *NodeController) hybridOverlayNodeUpdate(node *kapi.Node) error {
-	if !houtil.IsHybridOverlayNode(node) {
+	if !util.NoHostSubnet(node) {
 		return nil
 	}
 
@@ -278,7 +278,7 @@ func (n *NodeController) deleteFlowsByCookie(cookie string) {
 
 // DeleteNode handles node deletions
 func (n *NodeController) DeleteNode(node *kapi.Node) error {
-	if node.Name == n.nodeName || !houtil.IsHybridOverlayNode(node) {
+	if node.Name == n.nodeName || !util.NoHostSubnet(node) {
 		return nil
 	}
 

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -10,6 +10,7 @@ import (
 	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -33,7 +34,11 @@ func ParseHybridOverlayHostSubnet(node *kapi.Node) (*net.IPNet, error) {
 // node which does not participate in the ovn-kubernetes overlay network
 func IsHybridOverlayNode(node *kapi.Node) bool {
 	if config.Kubernetes.NoHostSubnetNodes != nil {
-		nodeSelector, _ := metav1.LabelSelectorAsSelector(config.Kubernetes.NoHostSubnetNodes)
+		nodeSelector, err := metav1.LabelSelectorAsSelector(config.Kubernetes.NoHostSubnetNodes)
+		if err != nil {
+			klog.Errorf("NoHostSubnetNodes label selector is not valid: %v", err)
+			return false
+		}
 		return nodeSelector.Matches(labels.Set(node.Labels))
 	}
 	return false

--- a/go-controller/hybrid-overlay/pkg/util/util.go
+++ b/go-controller/hybrid-overlay/pkg/util/util.go
@@ -5,12 +5,7 @@ import (
 	"net"
 
 	"github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/types"
-	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
-
 	kapi "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
 
@@ -28,20 +23,6 @@ func ParseHybridOverlayHostSubnet(node *kapi.Node) (*net.IPNet, error) {
 			node.Name, types.HybridOverlayNodeSubnet, sub, err)
 	}
 	return subnet, nil
-}
-
-// IsHybridOverlayNode returns true if the node has been labeled as a
-// node which does not participate in the ovn-kubernetes overlay network
-func IsHybridOverlayNode(node *kapi.Node) bool {
-	if config.Kubernetes.NoHostSubnetNodes != nil {
-		nodeSelector, err := metav1.LabelSelectorAsSelector(config.Kubernetes.NoHostSubnetNodes)
-		if err != nil {
-			klog.Errorf("NoHostSubnetNodes label selector is not valid: %v", err)
-			return false
-		}
-		return nodeSelector.Matches(labels.Set(node.Labels))
-	}
-	return false
 }
 
 // SameIPNet returns true if both inputs are nil or if both inputs have the

--- a/go-controller/pkg/clustermanager/node/node_allocator.go
+++ b/go-controller/pkg/clustermanager/node/node_allocator.go
@@ -151,7 +151,7 @@ func (na *NodeAllocator) HandleAddUpdateNodeEvent(node *corev1.Node) error {
 	defer na.recordSubnetCount()
 
 	if util.NoHostSubnet(node) {
-		if na.hasHybridOverlayAllocation() && houtil.IsHybridOverlayNode(node) {
+		if na.hasHybridOverlayAllocation() {
 			annotator := kube.NewNodeAnnotator(na.kube, node.Name)
 			allocatedSubnet, err := na.hybridOverlayNodeEnsureSubnet(node, annotator)
 			if err != nil {
@@ -257,7 +257,7 @@ func (na *NodeAllocator) Sync(nodes []interface{}) error {
 		}
 
 		if util.NoHostSubnet(node) {
-			if na.hasHybridOverlayAllocation() && houtil.IsHybridOverlayNode(node) {
+			if na.hasHybridOverlayAllocation() {
 				// this is a hybrid overlay node so mark as allocated from the hybrid overlay subnet allocator
 				hostSubnet, err := houtil.ParseHybridOverlayHostSubnet(node)
 				if err != nil {

--- a/go-controller/pkg/node/controllers/egressip/namespace.go
+++ b/go-controller/pkg/node/controllers/egressip/namespace.go
@@ -113,7 +113,10 @@ func (c *Controller) getEIPsForNamespaceChange(namespace *corev1.Namespace) (set
 		return nil, err
 	}
 	for _, informerEIP := range informerEIPs {
-		targetNsSel, _ := metav1.LabelSelectorAsSelector(&informerEIP.Spec.NamespaceSelector)
+		targetNsSel, err := metav1.LabelSelectorAsSelector(&informerEIP.Spec.NamespaceSelector)
+		if err != nil {
+			return nil, err
+		}
 		if targetNsSel.Matches(labels.Set(namespace.Labels)) {
 			eIPNames.Insert(informerEIP.Name)
 			continue

--- a/go-controller/pkg/node/controllers/egressip/pod.go
+++ b/go-controller/pkg/node/controllers/egressip/pod.go
@@ -253,8 +253,14 @@ func (c *Controller) getEIPsForPodChange(pod *corev1.Pod) (sets.Set[string], err
 		return nil, err
 	}
 	for _, informerEIP := range informerEIPs {
-		eipNsSel, _ := metav1.LabelSelectorAsSelector(&informerEIP.Spec.NamespaceSelector)
-		eipPodSel, _ := metav1.LabelSelectorAsSelector(&informerEIP.Spec.PodSelector)
+		eipNsSel, err := metav1.LabelSelectorAsSelector(&informerEIP.Spec.NamespaceSelector)
+		if err != nil {
+			return nil, err
+		}
+		eipPodSel, err := metav1.LabelSelectorAsSelector(&informerEIP.Spec.PodSelector)
+		if err != nil {
+			return nil, err
+		}
 		if eipNsSel.Matches(labels.Set(podNs.Labels)) && eipPodSel.Matches(labels.Set(pod.Labels)) {
 			eipNames.Insert(informerEIP.Name)
 		}

--- a/go-controller/pkg/node/default_node_network_controller.go
+++ b/go-controller/pkg/node/default_node_network_controller.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	honode "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/controller"
-	houtil "github.com/ovn-org/ovn-kubernetes/go-controller/hybrid-overlay/pkg/util"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/cni"
 	config "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/config"
 	adminpolicybasedrouteclientset "github.com/ovn-org/ovn-kubernetes/go-controller/pkg/crd/adminpolicybasedroute/v1/apis/clientset/versioned"
@@ -869,7 +868,7 @@ func (nc *DefaultNodeNetworkController) Start(ctx context.Context) error {
 					return false, nil
 				}
 				for _, node := range nodes.Items {
-					if nc.name != node.Name && util.GetNodeZone(&node) != config.Default.Zone && !houtil.IsHybridOverlayNode(&node) {
+					if nc.name != node.Name && util.GetNodeZone(&node) != config.Default.Zone && !util.NoHostSubnet(&node) {
 						nodeSubnets, err := util.ParseNodeHostSubnetAnnotation(&node, types.DefaultNetworkName)
 						if err != nil {
 							if util.IsAnnotationNotSetError(err) {

--- a/go-controller/pkg/ovn/base_network_controller_policy.go
+++ b/go-controller/pkg/ovn/base_network_controller_policy.go
@@ -1064,9 +1064,14 @@ func (bnc *BaseNetworkController) setupGressPolicy(np *networkPolicy, gp *gressP
 		// nil pod selector is equivalent to empty pod selector, which selects all
 		podSelector = &metav1.LabelSelector{}
 	}
-	podSel, _ := metav1.LabelSelectorAsSelector(podSelector)
-	nsSel, _ := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
-
+	podSel, err := metav1.LabelSelectorAsSelector(podSelector)
+	if err != nil {
+		return nil, err
+	}
+	nsSel, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+	if err != nil {
+		return nil, err
+	}
 	if podSel.Empty() && (peer.NamespaceSelector == nil || !nsSel.Empty()) {
 		// namespace-based filtering
 		if peer.NamespaceSelector == nil {
@@ -1439,8 +1444,10 @@ func (bnc *BaseNetworkController) addPeerNamespaceHandler(
 	gress *gressPolicy, np *networkPolicy) error {
 
 	// NetworkPolicy is validated by the apiserver; this can't fail.
-	sel, _ := metav1.LabelSelectorAsSelector(namespaceSelector)
-
+	sel, err := metav1.LabelSelectorAsSelector(namespaceSelector)
+	if err != nil {
+		return err
+	}
 	// start watching namespaces selected by the namespace selector
 	syncFunc := func(objs []interface{}) error {
 		// ignore returned error, since any namespace that wasn't properly handled will be retried individually.

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller.go
@@ -641,14 +641,20 @@ func (m *externalPolicyManager) getPoliciesForNamespaceChange(namespace *v1.Name
 	}
 
 	for _, informerPolicy := range informerPolicies {
-		targetNsSel, _ := metav1.LabelSelectorAsSelector(&informerPolicy.Spec.From.NamespaceSelector)
+		targetNsSel, err := metav1.LabelSelectorAsSelector(&informerPolicy.Spec.From.NamespaceSelector)
+		if err != nil {
+			return nil, err
+		}
 		if targetNsSel.Matches(labels.Set(namespace.Labels)) {
 			policyNames.Insert(informerPolicy.Name)
 			continue
 		}
 
 		for _, hop := range informerPolicy.Spec.NextHops.DynamicHops {
-			gwNsSel, _ := metav1.LabelSelectorAsSelector(&hop.NamespaceSelector)
+			gwNsSel, err := metav1.LabelSelectorAsSelector(&hop.NamespaceSelector)
+			if err != nil {
+				return nil, err
+			}
 			if gwNsSel.Matches(labels.Set(namespace.Labels)) {
 				policyNames.Insert(informerPolicy.Name)
 			}
@@ -690,16 +696,24 @@ func (m *externalPolicyManager) getPoliciesForPodChange(pod *v1.Pod) (sets.Set[s
 	}
 
 	for _, informerPolicy := range informerPolicies {
-		targetNsSel, _ := metav1.LabelSelectorAsSelector(&informerPolicy.Spec.From.NamespaceSelector)
+		targetNsSel, err := metav1.LabelSelectorAsSelector(&informerPolicy.Spec.From.NamespaceSelector)
+		if err != nil {
+			return nil, err
+		}
 		if targetNsSel.Matches(labels.Set(podNs.Labels)) {
 			policyNames.Insert(informerPolicy.Name)
 			continue
 		}
 
 		for _, hop := range informerPolicy.Spec.NextHops.DynamicHops {
-			gwNsSel, _ := metav1.LabelSelectorAsSelector(&hop.NamespaceSelector)
-			gwPodSel, _ := metav1.LabelSelectorAsSelector(&hop.PodSelector)
-
+			gwNsSel, err := metav1.LabelSelectorAsSelector(&hop.NamespaceSelector)
+			if err != nil {
+				return nil, err
+			}
+			gwPodSel, err := metav1.LabelSelectorAsSelector(&hop.PodSelector)
+			if err != nil {
+				return nil, err
+			}
 			if gwNsSel.Matches(labels.Set(podNs.Labels)) && gwPodSel.Matches(labels.Set(pod.Labels)) {
 				policyNames.Insert(informerPolicy.Name)
 			}

--- a/go-controller/pkg/ovn/controller/apbroute/external_controller_policy.go
+++ b/go-controller/pkg/ovn/controller/apbroute/external_controller_policy.go
@@ -341,7 +341,10 @@ func (m *externalPolicyManager) processDynamicHopsGatewayInformation(hops []*adm
 	selectedNamespaces := sets.Set[string]{}
 	selectedPods := sets.Set[ktypes.NamespacedName]{}
 	for _, h := range hops {
-		gwNsSel, _ := metav1.LabelSelectorAsSelector(&h.NamespaceSelector)
+		gwNsSel, err := metav1.LabelSelectorAsSelector(&h.NamespaceSelector)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		gwNamespaces, err := m.namespaceLister.List(gwNsSel)
 		if err != nil {
 			return podsInfo, selectedNamespaces, selectedPods, fmt.Errorf("failed to list namespaces: %w", err)

--- a/go-controller/pkg/ovn/egressip.go
+++ b/go-controller/pkg/ovn/egressip.go
@@ -303,7 +303,10 @@ func (oc *DefaultNetworkController) reconcileEgressIPNamespace(old, new *v1.Name
 		return err
 	}
 	for _, egressIP := range egressIPs {
-		namespaceSelector, _ := metav1.LabelSelectorAsSelector(&egressIP.Spec.NamespaceSelector)
+		namespaceSelector, err := metav1.LabelSelectorAsSelector(&egressIP.Spec.NamespaceSelector)
+		if err != nil {
+			return err
+		}
 		if namespaceSelector.Matches(oldLabels) && !namespaceSelector.Matches(newLabels) {
 			if err := oc.deleteNamespaceEgressIPAssignment(egressIP.Name, egressIP.Status.Items, oldNamespace, egressIP.Spec.PodSelector); err != nil {
 				return err
@@ -370,7 +373,10 @@ func (oc *DefaultNetworkController) reconcileEgressIPPod(old, new *v1.Pod) (err 
 		return err
 	}
 	for _, egressIP := range egressIPs {
-		namespaceSelector, _ := metav1.LabelSelectorAsSelector(&egressIP.Spec.NamespaceSelector)
+		namespaceSelector, err := metav1.LabelSelectorAsSelector(&egressIP.Spec.NamespaceSelector)
+		if err != nil {
+			return err
+		}
 		if namespaceSelector.Matches(namespaceLabels) {
 			// If the namespace the pod belongs to matches this object then
 			// check the if there's a podSelector defined on the EgressIP
@@ -378,7 +384,10 @@ func (oc *DefaultNetworkController) reconcileEgressIPPod(old, new *v1.Pod) (err 
 			// match only a subset of pods in the namespace, and we'll have to
 			// check that. If there is no podSelector: the user intends it to
 			// match all pods in the namespace.
-			podSelector, _ := metav1.LabelSelectorAsSelector(&egressIP.Spec.PodSelector)
+			podSelector, err := metav1.LabelSelectorAsSelector(&egressIP.Spec.PodSelector)
+			if err != nil {
+				return err
+			}
 			if !podSelector.Empty() {
 				newMatches := podSelector.Matches(newPodLabels)
 				oldMatches := podSelector.Matches(oldPodLabels)
@@ -446,7 +455,10 @@ func (oc *DefaultNetworkController) addEgressIPAssignments(name string, statusAs
 func (oc *DefaultNetworkController) addNamespaceEgressIPAssignments(name string, statusAssignments []egressipv1.EgressIPStatusItem, namespace *kapi.Namespace, podSelector metav1.LabelSelector) error {
 	var pods []*kapi.Pod
 	var err error
-	selector, _ := metav1.LabelSelectorAsSelector(&podSelector)
+	selector, err := metav1.LabelSelectorAsSelector(&podSelector)
+	if err != nil {
+		return err
+	}
 	if !selector.Empty() {
 		pods, err = oc.watchFactory.GetPodsBySelector(namespace.Name, podSelector)
 		if err != nil {
@@ -687,7 +699,10 @@ func (oc *DefaultNetworkController) deleteEgressIPAssignments(name string, statu
 func (oc *DefaultNetworkController) deleteNamespaceEgressIPAssignment(name string, statusAssignments []egressipv1.EgressIPStatusItem, namespace *kapi.Namespace, podSelector metav1.LabelSelector) error {
 	var pods []*kapi.Pod
 	var err error
-	selector, _ := metav1.LabelSelectorAsSelector(&podSelector)
+	selector, err := metav1.LabelSelectorAsSelector(&podSelector)
+	if err != nil {
+		return err
+	}
 	if !selector.Empty() {
 		pods, err = oc.watchFactory.GetPodsBySelector(namespace.Name, podSelector)
 		if err != nil {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -5106,6 +5106,7 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				fakeOvn.patchEgressIPObj(node2Name, egressIPName, updatedEgressIP.String(), "::/64")
+				expectedNAT.ExternalIP = updatedEgressIP.String()
 				gomega.Eventually(fakeOvn.nbClient).Should(libovsdbtest.HaveData(expectedDatabaseState))
 
 				gomega.Eventually(func() []string {

--- a/go-controller/pkg/ovn/egressip_test.go
+++ b/go-controller/pkg/ovn/egressip_test.go
@@ -5123,7 +5123,30 @@ var _ = ginkgo.Describe("OVN master EgressIP Operations", func() {
 		})
 
 	})
-
+	ginkgo.Context("on invalid EgressIP selectors", func() {
+		ginkgo.It("reconcileEgressIP should return an error", func() {
+			app.Action = func(ctx *cli.Context) error {
+				eIP := egressipv1.EgressIP{
+					ObjectMeta: newEgressIPMeta(egressIPName),
+					Spec: egressipv1.EgressIPSpec{
+						EgressIPs: []string{"egressIP1"},
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"": ""},
+						},
+						NamespaceSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"": ""},
+						},
+					},
+				}
+				fakeOvn.startWithDBSetup(libovsdbtest.TestSetup{})
+				err := fakeOvn.controller.reconcileEgressIP(&eIP, &eIP)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				return nil
+			}
+			err := app.Run([]string{app.Name})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
 	ginkgo.Context("WatchEgressNodes", func() {
 
 		ginkgo.It("should populated egress node data as they are tagged `egress assignable` with variants of IPv4/IPv6", func() {

--- a/go-controller/pkg/ovn/egressqos.go
+++ b/go-controller/pkg/ovn/egressqos.go
@@ -125,7 +125,10 @@ func (oc *DefaultNetworkController) cloneEgressQoSRule(raw egressqosapi.EgressQo
 func (oc *DefaultNetworkController) createASForEgressQoSRule(podSelector metav1.LabelSelector, namespace string, priority int) (addressset.AddressSet, *sync.Map, error) {
 	var addrSet addressset.AddressSet
 
-	selector, _ := metav1.LabelSelectorAsSelector(&podSelector)
+	selector, err := metav1.LabelSelectorAsSelector(&podSelector)
+	if err != nil {
+		return nil, nil, err
+	}
 	if selector.Empty() { // empty selector means that the rule applies to all pods in the namespace
 		asIndex := getNamespaceAddrSetDbIDs(namespace, oc.controllerName)
 		addrSet, err := oc.addressSetFactory.EnsureAddressSet(asIndex)
@@ -737,7 +740,10 @@ func (oc *DefaultNetworkController) syncEgressQoSPod(key string) error {
 	podLabels := labels.Set(pod.Labels)
 	podMapOps := []mapAndOp{}
 	for _, r := range eq.rules {
-		selector, _ := metav1.LabelSelectorAsSelector(&r.podSelector)
+		selector, err := metav1.LabelSelectorAsSelector(&r.podSelector)
+		if err != nil {
+			return err
+		}
 		if selector.Empty() { // rule applies to all pods in the namespace, no need to modify address set
 			continue
 		}

--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -532,7 +532,7 @@ func (oc *DefaultNetworkController) syncNodes(kNodes []interface{}) error {
 			return fmt.Errorf("spurious object in syncNodes: %v", tmp)
 		}
 
-		if config.HybridOverlay.Enabled && houtil.IsHybridOverlayNode(node) {
+		if config.HybridOverlay.Enabled && util.NoHostSubnet(node) {
 			continue
 		}
 
@@ -723,7 +723,7 @@ func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSy
 		if err != nil {
 			return fmt.Errorf("nodeAdd: error adding noHost subnet for switch %s: %w", node.Name, err)
 		}
-		if config.HybridOverlay.Enabled && houtil.IsHybridOverlayNode(node) {
+		if config.HybridOverlay.Enabled {
 			// Parse the hybrid overlay host subnet for the node to
 			// make sure that cluster manager has allocated the subnet.
 			if _, err := houtil.ParseHybridOverlayHostSubnet(node); err != nil {
@@ -844,7 +844,7 @@ func (oc *DefaultNetworkController) addUpdateLocalNodeEvent(node *kapi.Node, nSy
 
 func (oc *DefaultNetworkController) addUpdateRemoteNodeEvent(node *kapi.Node, syncZoneIC bool) error {
 	// nothing to do for hybrid nodes
-	if houtil.IsHybridOverlayNode(node) {
+	if util.NoHostSubnet(node) {
 		return nil
 	}
 	start := time.Now()
@@ -891,12 +891,12 @@ func (oc *DefaultNetworkController) deleteNodeEvent(node *kapi.Node) error {
 		"various caches", node.Name)
 
 	if config.HybridOverlay.Enabled {
-		if noHostSubnet := util.NoHostSubnet(node); noHostSubnet {
+		if util.NoHostSubnet(node) {
 			// noHostSubnet nodes are different, only remove the switch
 			oc.lsManager.DeleteSwitch(node.Name)
 			return nil
 		}
-		if _, ok := node.Annotations[hotypes.HybridOverlayDRMAC]; ok && !houtil.IsHybridOverlayNode(node) {
+		if _, ok := node.Annotations[hotypes.HybridOverlayDRMAC]; ok {
 			oc.deleteHybridOverlayPort(node)
 		}
 		if err := oc.removeHybridLRPolicySharedGW(node); err != nil {

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -1521,9 +1521,10 @@ var _ = ginkgo.Describe("Default network controller operations", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// Don't create clusterManager so that the node has not subnets allocated.
 
-			config.Kubernetes.NoHostSubnetNodes = &metav1.LabelSelector{
+			config.Kubernetes.NoHostSubnetNodes, err = metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 				MatchLabels: nodeNoHostSubnetAnnotation(),
-			}
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			gomega.Expect(
 				oc.retryNodes.ResourceHandler.AddResource(

--- a/go-controller/pkg/ovn/policy_test.go
+++ b/go-controller/pkg/ovn/policy_test.go
@@ -303,8 +303,10 @@ func getGressACLs(gressIdx int, namespace, policyName string, peerNamespaces []s
 			// nil pod selector is equivalent to empty pod selector, which selects all
 			podSelector = &metav1.LabelSelector{}
 		}
-		podSel, _ := metav1.LabelSelectorAsSelector(peer.PodSelector)
-		nsSel, _ := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+		podSel, err := metav1.LabelSelectorAsSelector(peer.PodSelector)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		nsSel, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		if !((peer.PodSelector == nil || podSel.Empty()) && (peer.NamespaceSelector == nil || !nsSel.Empty())) {
 			peerIndex := getPodSelectorAddrSetDbIDs(getPodSelectorKey(podSelector, peer.NamespaceSelector, namespace), controllerName)
 			asv4, _ := addressset.GetHashNamesForAS(peerIndex)

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -712,7 +712,11 @@ func NoHostSubnet(node *v1.Node) bool {
 		return false
 	}
 
-	nodeSelector, _ := metav1.LabelSelectorAsSelector(config.Kubernetes.NoHostSubnetNodes)
+	nodeSelector, err := metav1.LabelSelectorAsSelector(config.Kubernetes.NoHostSubnetNodes)
+	if err != nil {
+		klog.Errorf("NoHostSubnetNodes label selector is not valid: %v", err)
+		return false
+	}
 	return nodeSelector.Matches(labels.Set(node.Labels))
 }
 

--- a/go-controller/pkg/util/kube.go
+++ b/go-controller/pkg/util/kube.go
@@ -712,12 +712,7 @@ func NoHostSubnet(node *v1.Node) bool {
 		return false
 	}
 
-	nodeSelector, err := metav1.LabelSelectorAsSelector(config.Kubernetes.NoHostSubnetNodes)
-	if err != nil {
-		klog.Errorf("NoHostSubnetNodes label selector is not valid: %v", err)
-		return false
-	}
-	return nodeSelector.Matches(labels.Set(node.Labels))
+	return config.Kubernetes.NoHostSubnetNodes.Matches(labels.Set(node.Labels))
 }
 
 // ForEachEligibleEndpoint iterates through each eligible endpoint in the given endpointslice and applies the input function fn to it.


### PR DESCRIPTION
Instead of ignoring the error returned from `LabelSelectorAsSelector` handle it to avoid using nil values.

Note: NetworkPolicy shouldn't ever have invalid labelselectors since this is verified in the API already, I don't think it hurts to have the error checks though. 

I wasn't able to find out how we could add labelSelector validation to the CRD but if it is possible it doesn't conflict with the proposed changes.
Found in https://issues.redhat.com/browse/OCPBUGS-20210
/cc @tssurya 
