### PR TITLE
Remove ginkgo deprecated APIs from e2e test

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -4,12 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/config"
-	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/onsi/gomega"
 	"github.com/ovn-org/ovn-kubernetes/test/e2e/diagnostics"
 	"k8s.io/client-go/tools/clientcmd"
@@ -81,20 +78,14 @@ func TestMain(m *testing.M) {
 }
 
 func TestE2E(t *testing.T) {
-	// Run tests through the Ginkgo runner with output to console + JUnit for reporting
-	var r []ginkgo.Reporter
+	if testing.Short() {
+		return
+	}
 	if framework.TestContext.ReportDir != "" {
-		klog.Infof("Saving reports to %s", framework.TestContext.ReportDir)
-		// TODO: we should probably only be trying to create this directory once
-		// rather than once-per-Ginkgo-node.
 		if err := os.MkdirAll(framework.TestContext.ReportDir, 0755); err != nil {
 			klog.Errorf("Failed creating report directory: %v", err)
-		} else {
-			defaultReporterConfigType := config.DeprecatedGinkgoConfigType{}
-			r = append(r, reporters.NewJUnitReporter(path.Join(framework.TestContext.ReportDir,
-				fmt.Sprintf("junit_%v%02d.xml", framework.TestContext.ReportPrefix, defaultReporterConfigType.ParallelNode))))
 		}
 	}
 	gomega.RegisterFailHandler(framework.Fail)
-	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "E2e Suite", r)
+	ginkgo.RunSpecs(t, "E2E Suite")
 }

--- a/test/scripts/conformance.sh
+++ b/test/scripts/conformance.sh
@@ -4,7 +4,7 @@ set -ex
 
 # setting this env prevents ginkgo e2e from trying to run provider setup
 export KUBERNETES_CONFORMANCE_TEST=y
-export KUBECONFIG=${HOME}/ovn.conf
+export KUBECONFIG=${KUBECONFIG:-${HOME}/ovn.conf}
 
 # setting these is required to make RuntimeClass tests work ... :/
 export KUBE_CONTAINER_RUNTIME=remote

--- a/test/scripts/e2e-cp.sh
+++ b/test/scripts/e2e-cp.sh
@@ -4,7 +4,7 @@ set -ex
 
 # setting this env prevents ginkgo e2e from trying to run provider setup
 export KUBERNETES_CONFORMANCE_TEST=y
-export KUBECONFIG=${HOME}/ovn.conf
+export KUBECONFIG=${KUBECONFIG:-${HOME}/ovn.conf}
 
 # Skip tests which are not IPv6 ready yet (see description of https://github.com/ovn-org/ovn-kubernetes/pull/2276)
 # (Note that netflow v5 is IPv4 only)
@@ -180,11 +180,6 @@ export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
 export KUBE_CONTAINER_RUNTIME_NAME=containerd
 export NUM_NODES=2
 
-# Silence deprecations warnings at the end of test result.
-# Custom Ginkgo test reporters which are deprecated in Ginkgo 2.0.
-# For a migration path https://onsi.github.io/ginkgo/MIGRATING_TO_V2#removed-custom-reporters.
-export ACK_GINKGO_DEPRECATIONS=2.4.0
-
 FOCUS=$(echo ${@:1} | sed 's/ /\\s/g')
 
 pushd e2e
@@ -196,9 +191,9 @@ go test -test.timeout 180m -v . \
         -ginkgo.timeout 3h \
         -ginkgo.flake-attempts ${FLAKE_ATTEMPTS:-2} \
         -ginkgo.skip="${SKIPPED_TESTS}" \
+        -ginkgo.junit-report=${E2E_REPORT_DIR}/junit_${E2E_REPORT_PREFIX}report.xml \
         -provider skeleton \
         -kubeconfig ${KUBECONFIG} \
         ${NUM_NODES:+"--num-nodes=${NUM_NODES}"} \
-        ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"} \
-        ${E2E_REPORT_PREFIX:+"--report-prefix=${E2E_REPORT_PREFIX}"}
+        ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"}
 popd

--- a/test/scripts/upgrade-ovn.sh
+++ b/test/scripts/upgrade-ovn.sh
@@ -3,7 +3,7 @@
 # always exit on errors
 set -ex
 
-export KUBECONFIG=${HOME}/ovn.conf
+export KUBECONFIG=${KUBECONFIG:-${HOME}/ovn.conf}
 export OVN_IMAGE=${OVN_IMAGE:-ovn-daemonset-f:pr}
 
 kubectl_wait_pods() {


### PR DESCRIPTION
This PR replaces remaining usage of deprecated ginkgo v2.4.0 APIs in the e2e test modules.