### PR TITLE
Fix race condition between encap row update and retrieval

### DIFF
--- a/go-controller/cmd/ovnkube/ovnkube.go
+++ b/go-controller/cmd/ovnkube/ovnkube.go
@@ -505,6 +505,7 @@ func runOvnKube(ctx context.Context, runMode *ovnkubeRunMode, ovnClientset *util
 			err = cm.Start(ctx)
 			if err != nil {
 				ovnkubeControllerStartErr = fmt.Errorf("failed to start ovnkube controller: %w", err)
+				klog.Error(ovnkubeControllerStartErr)
 				return
 			}
 			// record delay until ready

--- a/go-controller/pkg/node/default_node_network_controller_test.go
+++ b/go-controller/pkg/node/default_node_network_controller_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -315,8 +316,7 @@ var _ = Describe("Node", func() {
 				_, err = config.InitConfig(ctx, fexec, nil)
 				Expect(err).NotTo(HaveOccurred())
 				config.Default.EncapPort = encapPort
-
-				err = setEncapPort()
+				err = setEncapPort(context.Background())
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fexec.CalledMatchesExpected()).To(BeTrue(), fexec.ErrorDesc)


### PR DESCRIPTION
This PR makes default network controller to wait for Encap entry to be created because in some cases local node add event is received a bit later than network controller and it looks up for encap entry and giving up on starting ovnkube controller.